### PR TITLE
Added g++ dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ Urbit depends on:
 
 ####Ubuntu or Debian
 
-    sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev git make exuberant-ctags automake autoconf libtool
+    sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev git make exuberant-ctags automake autoconf libtool g++
 
 ####Fedora
 


### PR DESCRIPTION
On initial compilation, I get an error message that is solved by installing g++:

```
make[1]: Entering directory `/home/amos/urbit/outside/re2'
g++ -o obj/util/arena.o  -Wall -O3 -g -pthread  -Wno-sign-compare -c -I.    -DNDEBUG util/arena.cc
make[1]: g++: Command not found
make[1]: *** [obj/util/arena.o] Error 127
make[1]: Leaving directory `/home/amos/urbit/outside/re2'
make: *** [outside/re2/obj/libre2.a] Error 2
```
