### PR TITLE
Add libtool dependency to code snippet for OSX

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,7 @@ Otherwise, install XCode: `https://developer.apple.com/xcode/`, with the command
 
 To install dependencies pick either one of Homebrew or Macports, but not both:  
   Homebrew -  
-  `brew install git gmp libsigsegv openssl`  
+  `brew install git gmp libsigsegv openssl libtool`  
 
   Macports -  
   `sudo port install git gmp libsigsegv openssl`


### PR DESCRIPTION
I don't know if it was previously the case that libtool was a dependency of one of the other tools, but you must now explicitly install it when using Homebrew for urbit to compile.
