### PR TITLE
add autoconf and automake to OSX build instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,10 +51,10 @@ Otherwise, install XCode: `https://developer.apple.com/xcode/`, with the command
 
 To install dependencies pick either one of Homebrew or Macports, but not both:  
   Homebrew -  
-  `brew install git gmp libsigsegv openssl libtool`  
+  `brew install git gmp libsigsegv openssl libtool autoconf automake`  
 
   Macports -  
-  `sudo port install git gmp libsigsegv openssl`
+  `sudo port install git gmp libsigsegv openssl autoconf automake`
 
 Although automake/autoconf/libtool are generally installed by default, some
 have reported needing to uninstall and reinstall those three packages, at least


### PR DESCRIPTION
OSX 10.9 does not come with automake installed by default (even after installing Xcode's command line tools), so this pr adds them to the `brew install ...` and `port install ...` line in the readme.
