### PR TITLE
Use standard format specifiers for 64bit ints

### DIFF
--- a/i/c/portable.h
+++ b/i/c/portable.h
@@ -17,6 +17,7 @@
   *** C file.
   **/
 #   if defined(U3_OS_linux)
+#     include <inttypes.h>
 #     include <stdlib.h>
 #     include <string.h>
 #     include <stdarg.h>
@@ -32,6 +33,7 @@
 #     include <sys/mman.h>
 
 #   elif defined(U3_OS_osx)
+#     include <inttypes.h>
 #     include <stdlib.h>
 #     include <string.h>
 #     include <stdarg.h>
@@ -48,6 +50,7 @@
 #     include <sys/mman.h>
 
 #   elif defined(U3_OS_bsd)
+#     include <inttypes.h>
 #     include <stdlib.h>
 #     include <string.h>
 #     include <stdarg.h>

--- a/j/a/mod.c
+++ b/j/a/mod.c
@@ -14,7 +14,7 @@
   {
 #if 0
     if ( b == 3 && a == 2684227708 ) {
-      printf("dword at 0x27ff84ff8 is %llu\r\n", *(c3_d *)0x27ff84ff8);
+      printf("dword at 0x27ff84ff8 is %" PRIu64 "\r\n", *(c3_d *)0x27ff84ff8);
       *(c3_d *)0x27ff84ff8 = 25;
       printf("see, we modified it\r\n");
     }

--- a/n/e.c
+++ b/n/e.c
@@ -201,7 +201,7 @@ _ce_image_open(u3e_image* img_u, c3_o nuu_o)
       }
       else { 
         if ( siz_d != (pgs_d << (c3_d)(u3a_page + 2)) ) {
-          fprintf(stderr, "%s: corrupt size %llx\r\n", ful_c, siz_d);
+          fprintf(stderr, "%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
           return c3n;
         }
         img_u->pgs_w = (c3_w) pgs_d;

--- a/n/j.c
+++ b/n/j.c
@@ -237,7 +237,7 @@ _cj_warm_hump(c3_l jax_l, u3_noun huc)
       if ( '.' == *(jet_u->fcs_c) ) {
         c3_d axe_d = 0;
 
-        if ( (1 != sscanf(jet_u->fcs_c+1, "%llu", &axe_d)) ||
+        if ( (1 != sscanf(jet_u->fcs_c+1, "%" SCNu64, &axe_d)) ||
              axe_d >> 32ULL ||
              ((1 << 31) & (axe_l = (c3_w)axe_d)) ||
              (axe_l < 2) )

--- a/v/raft.c
+++ b/v/raft.c
@@ -453,7 +453,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
   red_i += sizeof(c3_d);
 
   if ( msg_u->len_d < 4 ) {
-    uL(fprintf(uH, "raft: length too short (a) %llu\n", ( unsigned long long int) msg_u->len_d));
+    uL(fprintf(uH, "raft: length too short (a) %" PRIu64 "\n", msg_u->len_d));
     return -1;
   }
 
@@ -464,7 +464,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
   }
 
   if ( ben_d < red_i + 2 * sizeof(c3_w) ) {
-    uL(fprintf(uH, "raft: length too short (b) %llu\n", (unsigned long long int) msg_u->len_d));
+    uL(fprintf(uH, "raft: length too short (b) %" PRIu64 "\n", msg_u->len_d));
     return -1;
   }
   memcpy(&msg_u->tem_w, buf_u->buf_y + red_i, sizeof(c3_w));
@@ -479,7 +479,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
     }
     case c3__rasp: {
       if ( ben_d < red_i + sizeof(c3_w) ) {
-        uL(fprintf(uH, "raft: length too short (c) %llu\n", ( unsigned long long int)msg_u->len_d));
+        uL(fprintf(uH, "raft: length too short (c) %" PRIu64 "\n", msg_u->len_d));
         return -1;
       }
       memcpy(&msg_u->rasp.suc_w, buf_u->buf_y + red_i, sizeof(c3_w));
@@ -488,7 +488,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
     }
     case c3__apen: case c3__revo: {
       if ( ben_d < red_i + sizeof(c3_d) + 2 * sizeof(c3_w) ) {
-        uL(fprintf(uH, "raft: length too short (d) %llu\n", ( unsigned long long int)msg_u->len_d));
+        uL(fprintf(uH, "raft: length too short (d) %" PRIu64 "\n", msg_u->len_d));
         return -1;
       }
       memcpy(&msg_u->rest.lai_d, buf_u->buf_y + red_i, sizeof(c3_d));
@@ -499,7 +499,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
       red_i += sizeof(c3_w);
 
       if ( ben_d < red_i + 4 * msg_u->rest.nam_w ) {
-        uL(fprintf(uH, "raft: length too short (e) %llu\n", ( unsigned long long int)msg_u->len_d));
+        uL(fprintf(uH, "raft: length too short (e) %" PRIu64 "\n", msg_u->len_d));
         return -1;
       }
       msg_u->rest.nam_c = c3_malloc(4 * msg_u->rest.nam_w);
@@ -511,7 +511,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
 
   if ( c3__apen == msg_u->typ_w ) {
     if ( ben_d < red_i + 2 * sizeof(c3_d) ) {
-      uL(fprintf(uH, "raft: length too short (f) %llu\n", ( unsigned long long int)msg_u->len_d));
+      uL(fprintf(uH, "raft: length too short (f) %" PRIu64 "\n", msg_u->len_d));
       red_i = -1;
       goto fail;
     }
@@ -528,7 +528,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
 
       for ( i_d = 0; i_d < msg_u->rest.apen.ent_d; i_d++ ) {
         if ( ben_d < red_i + 3 * sizeof(c3_w) ) {
-          uL(fprintf(uH, "raft: length too short (g) %llu\n", ( unsigned long long int)msg_u->len_d));
+          uL(fprintf(uH, "raft: length too short (g) %" PRIu64 "\n", msg_u->len_d));
           red_i = -1;
           goto fail;
         }
@@ -539,7 +539,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
         memcpy(&ent_u[i_d].len_w, buf_u->buf_y + red_i, sizeof(c3_w));
         red_i += sizeof(c3_w);
         if ( ben_d < red_i + 4 * ent_u[i_d].len_w ) {
-          uL(fprintf(uH, "raft: length too short (h) %llu\n", ( unsigned long long int)msg_u->len_d));
+          uL(fprintf(uH, "raft: length too short (h) %" PRIu64 "\n", msg_u->len_d));
           red_i = -1;
           goto fail;
         }
@@ -551,7 +551,7 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
   }
 
   if ( red_i != ben_d ) {
-    uL(fprintf(uH, "raft: sizes don't match r:%ld w:%llu\n", (long int) red_i, ( unsigned long long int)ben_d));
+    uL(fprintf(uH, "raft: sizes don't match r:%zd w:%" PRIu64 "\n", red_i, ben_d));
     red_i = -1;
     goto fail;
   }
@@ -642,7 +642,7 @@ _raft_rmsg_send(u3_rcon* ron_u, const u3_rmsg* msg_u)
     }
   }
 
-  //uL(fprintf(uH, "raft: sent %llu (%llu) [%x]\n",
+  //uL(fprintf(uH, "raft: sent %" PRIu64 " (%" PRIu64 ") [%x]\n",
   //               len_d, msg_u->len_d, msg_u->typ_w));
   c3_assert(len_d == 4 * msg_u->len_d);
 }

--- a/v/save.c
+++ b/v/save.c
@@ -30,7 +30,7 @@ _save_time_cb(uv_timer_t* tim_u)
   }
 
   if ( u3A->ent_d > sav_u->ent_d ) {
-    // uL(fprintf(uH, "autosaving... ent_d %llu\n", u3A->ent_d));
+    // uL(fprintf(uH, "autosaving... ent_d %" PRIu64 "\n", u3A->ent_d));
 
     // u3e_grab("save", u3_none);
 

--- a/v/sist.c
+++ b/v/sist.c
@@ -59,7 +59,7 @@ u3_sist_pack(c3_w tem_w, c3_w typ_w, c3_w* bob_w, c3_w len_w)
     c3_assert(0);
   }
 #if 0
-  uL(fprintf(uH, "sist_pack: write %llu, %llu: lar ent %llu, len %d, mug %x\n",
+  uL(fprintf(uH, "sist_pack: write %" PRIu64 ", %" PRIu64 ": lar ent %" PRIu64 ", len %d, mug %x\n",
                  lug_u->len_d,
                  tar_d,
                  lar_u.ent_d,
@@ -932,7 +932,7 @@ _sist_rest()
     ent_d = 0;
 
     if ( -1 == lseek64(fid_i, 4ULL * end_d, SEEK_SET) ) {
-      fprintf(stderr, "end_d %llu\n", end_d);
+      fprintf(stderr, "end_d %" PRIu64 "\n", end_d);
       perror("lseek");
       uL(fprintf(uH, "record (%s) is corrupt (c)\n", ful_c));
       u3_lo_bail();
@@ -944,7 +944,7 @@ _sist_rest()
       c3_w*   img_w;
       u3_noun ron;
 
-      // uL(fprintf(uH, "rest: reading event at %llx\n", end_d));
+      // uL(fprintf(uH, "rest: reading event at %" PRIx64 "\n", end_d));
 
       if ( -1 == lseek64(fid_i, 4ULL * tar_d, SEEK_SET) ) {
         uL(fprintf(uH, "record (%s) is corrupt (d)\n", ful_c));
@@ -974,7 +974,7 @@ _sist_rest()
       }
 
 #if 0
-      uL(fprintf(uH, "log: read: at %d, %d: lar ent %llu, len %d, mug %x\n",
+      uL(fprintf(uH, "log: read: at %d, %d: lar ent %" PRIu64 ", len %d, mug %x\n",
                       (tar_w - lar_u.len_w),
                       tar_w,
                       lar_u.ent_d,
@@ -987,7 +987,7 @@ _sist_rest()
       else {
         if ( lar_u.ent_d != (ent_d - 1ULL) ) {
           uL(fprintf(uH, "record (%s) is corrupt (g)\n", ful_c));
-          uL(fprintf(uH, "lar_u.ent_d %llx, ent_d %llx\n", lar_u.ent_d, ent_d));
+          uL(fprintf(uH, "lar_u.ent_d %" PRIx64 ", ent_d %" PRIx64 "\n", lar_u.ent_d, ent_d));
           u3_lo_bail();
         }
         ent_d -= 1ULL;
@@ -1051,7 +1051,7 @@ _sist_rest()
     //
     c3_assert(u3A->ent_d == old_d);
     if ( las_d + 1 != old_d ) {
-      uL(fprintf(uH, "checkpoint and log disagree! las:%llu old:%llu\n",
+      uL(fprintf(uH, "checkpoint and log disagree! las:%" PRIu64 " old:%" PRIu64 "\n",
                      las_d + 1, old_d));
       uL(fprintf(uH, "Some events appear to be missing from the log.\n"
                      "Please contact the authorities, "
@@ -1065,7 +1065,7 @@ _sist_rest()
 
     //  Execute the fscking things.  This is pretty much certain to crash.
     //
-    uL(fprintf(uH, "rest: replaying through event %llu\n", las_d));
+    uL(fprintf(uH, "rest: replaying through event %" PRIu64 "\n", las_d));
     fprintf(uH, "---------------- playback starting----------------\n");
 
     xno_w = 0;

--- a/v/unix.c
+++ b/v/unix.c
@@ -121,7 +121,7 @@ u3_unix_acquire(c3_c* pax_c)
   FILE* loq_u;
 
   if ( NULL != (loq_u = fopen(paf_c, "r")) ) {
-    if ( 1 != fscanf(loq_u, "%u", &pid_w) ) {
+    if ( 1 != fscanf(loq_u, "%" SCNu32, &pid_w) ) {
       uL(fprintf(uH, "lockfile %s is corrupt!\n", paf_c));
       kill(getpid(), SIGTERM);
       sleep(1); c3_assert(0);


### PR DESCRIPTION
This fixes a bunch of stupid warnings.

It may also be worth considering the 16- and 32-bit versions for _w and
_s, but I didn't do them because it would've taken more than a 5-minute
search-and-replace to sort out which was which.

It may also be a good idea to come up with an urbit-standard name for
these rather than the ones given by inttypes.h. In that case, it's
easier to get there via search-and-replace if the standard ones are
already there.
