### PR TITLE
Fix off-by ones in UTF-8 parsing in terminal

### DIFF
--- a/v/term.c
+++ b/v/term.c
@@ -828,9 +828,9 @@ _term_io_suck_char(u3_utty* uty_u, c3_y cay_y)
       tat_u->fut.len_w = 1;
       tat_u->fut.syb_y[0] = cay_y;
 
-      if ( cay_y <= 224 ) {
+      if ( cay_y < 224 ) {
         tat_u->fut.wid_w = 2;
-      } else if ( cay_y <= 240 ) {
+      } else if ( cay_y < 240 ) {
         tat_u->fut.wid_w = 3;
       } else tat_u->fut.wid_w = 4;
     }


### PR DESCRIPTION
- 11100000 (224) was misinterpreted as 2-byte sequence, whereas it defines a 3-byte
- 11110000 (240) was misinterpreted as 3-byte sequence, whereas it defines a 4-byte

Makes it possible to type characters from the Supplementary Multilingual Plane such as 𐎒 and 𝄐.
