### PR TITLE
Add a checkpoint save before exiting

### DIFF
--- a/v/loop.c
+++ b/v/loop.c
@@ -477,6 +477,8 @@ u3_lo_shut(c3_o inn)
     u3t_damp();
     u3_lo_exit();
 
+    //  save a checkpoint before exiting
+    u3e_save();
     exit(u3_Host.xit_i);
   }
   else {


### PR DESCRIPTION
Adds a u3e_save() to u3_lo_shut() to save a checkpoint before exiting. Should be save as it is only called on the exit case, when u3Host.liv is c3n.
