### PR TITLE
Ignore unused return values for functions that care.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ CWFLAGS=-Wall \
         -Wno-sign-compare \
         -Wno-unused-parameter \
         -Wno-missing-field-initializers \
-	-Werror
+        -Wno-error=unused-result \
+        -Werror
 
 ifdef NO_SILENT_RULES
 %.o: %.c $(CORE)


### PR DESCRIPTION
This unbreaks the linux build again.
