### PR TITLE
ruthlessly amputate extraneous arms

### DIFF
--- a/urb/zod/arvo/ames.hoon
+++ b/urb/zod/arvo/ames.hoon
@@ -546,11 +546,6 @@
           ?~  dyv  ~
           [~ u.dyv ..kuch]
         ::
-        ++  trox                                        ::    trox:lax:as:go
-          |=  [now=@da]                                 ::  expire by date
-          ^+  +>
-          +>    ::  XX
-        ::
         ++  wasc                                        ::    wasc:lax:as:go
           |=  key=code                                  ::  hear foreign code
           ^+  +>

--- a/urb/zod/arvo/eyre.hoon
+++ b/urb/zod/arvo/eyre.hoon
@@ -133,7 +133,6 @@
   ==                                                    ::
 ++  dual  ,[p=@ud q=(each ,[p=ship q=hole] ship)]       ::  request handle
 ++  dude  ,[p=@tas q=@]                                 ::  client identity
-++  loco  ,[p=? q=(unit ,@tas) r=path]                  ::  logical construct
 ++  pest                                                ::  request in progress
   $|  $?  %new                                          ::  virgin
           %way                                          ::  waiting

--- a/urb/zod/arvo/ford.hoon
+++ b/urb/zod/arvo/ford.hoon
@@ -151,16 +151,6 @@
   ^-  cafe                                              ::
   [(grom p.a p.b) (grum q.a q.b)]                       ::
 ::                                                      ::
-++  colt                                                ::  reduce to save
-  |=  lex=axle                                          ::
-  ^-  axle
-  %=    lex
-      pol
-    %-  ~(run by pol.lex)
-    |=  bay=baby
-    bay(jav ~)
-  ==
-::
 ++  faun  |=([a=cafe b=vase] (fine a `cage`noun/b))     ::  vase to cage
 ++  feel  |=([a=cafe b=cage] (fine a q.b))              ::  cage to vase
 ++  fest  |*([a=cafe b=*] (fine a [~ u=b]))             ::  bolt to unit

--- a/urb/zod/arvo/gall.hoon
+++ b/urb/zod/arvo/gall.hoon
@@ -71,7 +71,6 @@
               $:  @tas                                  ::  to any
           $%  [%meta p=vase]                            ::
           ==  ==  ==                                    ::
-++  rapt  |*(a=$+(* *) (qual path path ,@da a))         ::  versioned result
 ++  rave                                                ::  see %clay
           $%  [& p=mood]                                ::  single request
               [| p=moat]                                ::  change range
@@ -158,16 +157,6 @@
 ++  toil  (pair duct knob)                              ::  work in progress
 --  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 |%  ::::::::::::::::::::::::::::::::::::::::::::::::::::::  functions
-++  byby                                                ::  double bind
-  |*  [a=(unit (unit)) b=$+(* *)]
-  ?~  a  ~
-  ?~  u.a  [~ u=~]
-  [~ u=[~ u=(b u.u.a)]]
-::                                                      ::
-++  colt                                                ::  reduce to save
-  |=  all=axle                                          ::
-  all
-::
 ++  read                                                ::  read permission
   |=  law=(unit cuff)
   ^-  (unit (set monk))

--- a/urb/zod/arvo/hoon.hoon
+++ b/urb/zod/arvo/hoon.hoon
@@ -62,9 +62,6 @@
 ++  cord  ,@t                                           ::  text atom (UTF-8)
 ++  date  ,[[a=? y=@ud] m=@ud t=tarp]                   ::  parsed date
 ++  dime  ,[p=@ta q=@]                                  ::
-++  dram  $%  [| p=(map ,@tas dram)]                    ::  simple unix dir
-              [& p=@ud q=@]                             ::
-          ==                                            ::
 ++  each  |*([a=$+(* *) b=$+(* *)] $%([& p=a] [| p=b])) ::  either a or b
 ++  edge  ,[p=hair q=(unit ,[p=* q=nail])]              ::  parsing output
 ++  foot  $%  [%ash p=twig]                             ::  dry arm, geometric
@@ -726,13 +723,6 @@
     +<+.b
   $(a t.a, b b(+<+ (b i.a +<+.b)))
 ::
-++  skid                                                ::  separate
-  |*  [a=(list) b=$+(* ?)]
-  |-  ^+  [p=a q=a]
-  ?~  a  [~ ~]
-  =+  c=$(a t.a)
-  ?:((b i.a) [[i.a p.c] q.c] [p.c [i.a q.c]])
-::
 ++  skim                                                ::  only
   ~/  %skim
   |*  [a=(list) b=_|=(p=* .?(p))]
@@ -1383,9 +1373,6 @@
   ::  black magic values
   ++  vl
     |%
-    ++  uzer  |=  [b=@u p=@u]
-              (szer b p %.y)
-
     ++  szer  |=  [b=@u p=@u s=?]
               [s=s e=`@s`(dec (^mul b 2)) a=(lia p 0b1)]
 
@@ -4451,22 +4438,6 @@
     $(hol t.hol, +> (merg (flop `(list ,@ud)`?~(guy ~ u.guy))))
   --
 ::
-++  locz                                                ::  trivial algorithm
-  |=  [hel=tape hev=tape]
-  ^-  tape
-  =+  [leh=(lent hel) veh=(lent hev)]
-  =-  (flop q.yun)
-  ^=  yun
-  |-  ^-  [p=@ud q=tape]
-  ~+
-  ?:  |(=(0 leh) =(0 veh))  [0 ~]
-  =+  [dis=(snag (dec leh) hel) dat=(snag (dec veh) hev)]
-  ?:  =(dis dat)
-    =+  say=$(leh (dec leh), veh (dec veh))
-    [+(p.say) [dis q.say]]
-  =+  [lef=$(leh (dec leh)) rig=$(veh (dec veh))]
-  ?:((gth p.lef p.rig) lef rig)
-::
 ++  lore                                                ::  atom to line list
   ~/  %lore
   |=  lub=@
@@ -6023,10 +5994,6 @@
   |=  vax=vase  ^-  tape
   ~(ram re (sell vax))
 ::
-++  loot                                                ::  cord pretty-print
-  |=  vax=vase  ^-  @ta
-  (rap 3 (pave vax))
-::
 ++  slam                                                ::  slam a gate
   |=  [gat=vase sam=vase]  ^-  vase
   =+  :-  ^=  typ  ^-  type
@@ -6074,15 +6041,6 @@
     [%wtgr [%wtts [%leaf %tas -.q.vax] [%$ 2]~] [%$ 1]]
   (~(fuse ut p.vax) [%cell %noun %noun])
 ::
-++  slew                                                ::  get axis in vase
-  |=  [axe=@ vax=vase]  ^-  (unit vase)
-  ?.  |-  ^-  ?
-      ?:  =(1 axe)  &
-      ?.  ?=(^ q.vax)  |
-      $(axe (mas axe), q.vax .*(q.vax [0 (cap axe)]))
-    ~
-  `[(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]
-::
 ++  slab                                                
   |=  [cog=@tas typ=type]
   !=(~ q:(~(fino ut typ) 0 %free cog))
@@ -6098,16 +6056,6 @@
 ++  slot                                                ::  got axis in vase
   |=  [axe=@ vax=vase]  ^-  vase
   [(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]
-::
-++  slum
-  |=  [vax=vase wad=(map term vase)]  ^-  vase
-  ?-  wad
-    ~        vax
-    [* ~ ~]  [[%cell p.vax [%face p.n.wad p.q.n.wad]] [q.vax q.q.n.wad]]
-    [* ~ *]  $(wad [n.wad ~ ~], vax $(wad r.wad))
-    [* * ~]  $(wad [n.wad ~ ~], vax $(wad l.wad))
-    [* * *]  $(wad [n.wad ~ r.wad], vax $(wad l.wad))
-  ==
 ::
 ++  wash                                                ::  render tank at width
   |=  [[tab=@ edg=@] tac=tank]  ^-  wall
@@ -6881,7 +6829,6 @@
     ==
   ::
   ++  dank  |=(pax=path ^-(tank (dish [~ %path] pax)))
-  ++  dart  |=(pax=path ^-(tape ~(ram re (dank pax))))
   ++  deal  |=(lum=* (dish dole lum))
   ++  dial
     |=  ham=calf
@@ -9231,7 +9178,7 @@
     ++  expq  |.(;~(gunk rope loaf loaf))               ::  wing and two twigs
     ++  expr  |.(;~(gunk loaf wisp))                    ::  twig and core tail
     ++  exps  |.((butt hank))                           ::  closed gapped twigs
-    ++  expt  |.((butt ;~(gunk loaf race)))             ::  twig, [tile twig]s
+    ::  expt
     ++  expu  |.(;~(gunk lobe wisp))                    ::  tile, core tail
     ++  expv  |.(lobe)                                  ::  tile
     ++  expw  |.(;~(gunk lobe teak))                    ::  tile and tiki
@@ -9239,8 +9186,6 @@
     ++  expy  |.((butt ;~(gunk teak loaf race)))        :: tiki twig [tile twig]s
     ++  expz  |.(loaf(bug &))                           ::  twig with tracing
     ::    Hint syntaces  (nock 10)
-    ++  hina  |.                                        ::  unused
-              ;~(gunk (ifix [sel ser] ;~(gunk dem dem)) loaf)
     ++  hinb  |.(;~(gunk bont loaf))                    ::  hint and twig
     ++  hinc  |.                                        ::  optional =en, twig
               ;~(pose ;~(gunk bony loaf) ;~(plug (easy ~) loaf))
@@ -9613,7 +9558,6 @@
           ==                                            ::
 ++  curd  ,[p=@tas q=*]                                 ::  typeless card
 ++  duct  (list wire)                                   ::  causal history
-++  herd  (hypo curd)                                   ::  typed card
 ++  hide                                                ::  standard app state
         $:  $:  our=ship                                ::  owner/operator
                 app=term                                ::  app identity
@@ -9626,7 +9570,6 @@
                 eny=@uvI                                ::  entropy
                 lat=@da                                 ::  date of last tick
         ==  ==                                          ::
-++  hilt  ?(0 1 2)                                      ::  lead iron gold
 ++  hypo  |*(a=$+(* *) (pair type a))                   ::  type associated
 ++  hobo  |*  a=$+(* *)                                 ::  kiss wrapper
           $?  $%  [%soft p=*]                           ::

--- a/urb/zod/arvo/zuse.hoon
+++ b/urb/zod/arvo/zuse.hoon
@@ -997,10 +997,6 @@
   =+  buf=(rap 3 (turn wol |=(a=tape (crip (weld a `tape`[`@`10 ~])))))
   [(met 3 buf) buf]
 ::
-::
-++  txml                                                ::  string to xml
-    |=  tep=tape  ^-  mars
-    [[%$ [%$ tep] ~] ~]
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::                section 3bE, tree sync                ::
 ::
@@ -2004,11 +2000,6 @@
       ==
   [p.one [%& [*cart (weld q.q.q.one q.q.q.two)]]]
 ::
-++  meat                                                ::  kite to .^ path
-  |=  kit=kite
-  ^-  path
-  [(cat 3 'c' p.kit) (scot %p r.kit) s.kit (scot `dime`q.kit) t.kit]
-::
 ++  tame                                                ::  parse kite path
   |=  hap=path
   ^-  (unit kite)
@@ -2064,16 +2055,6 @@
   ?~  raf
     [~ [i.rax ~]]
   [q.u.raf [p.u.raf ~]]
-::
-++  fain                                                ::  path restructure
-  |=  [hom=path raw=path]
-  =+  bem=(need (tome raw))
-  =+  [mer=(flop s.bem) moh=(flop hom)]
-  |-  ^-  (pair beam path)
-  ?~  moh
-    [bem(s hom) (flop mer)]
-  ?>  &(?=(^ mer) =(i.mer i.moh))
-  $(mer t.mer, moh t.moh)
 ::
 ++  fuel                                                ::  parse fcgi
   |=  [bem=beam but=path]
@@ -2701,7 +2682,6 @@
               q=(unit ,[p=cash q=*])                    ::  file
               r=(map ,@ta ankh)                         ::  folders
           ==                                            ::
-++  ankz  ,[p=@ (map ,@ta ankz)]                        ::  trimmed ankh
 ++  apex  ,[p=@uvI q=(map ,@ta ,@uvI) r=(map ,@ta ,~)]  ::  node report (old)
 ++  ares  (unit ,[p=term q=(list tank)])                ::  possible error
 ++  ball  ,@uw                                          ::  statement payload
@@ -2832,7 +2812,6 @@
               ton=town                                  ::  security
               zac=(map ship corn)                       ::  flows by server
           ==                                            ::
-++  frog  ,[p=@da q=nori]                               ::  time and change
 ++  gank  (each vase (list tank))                       ::  abstract result
 ++  gift                                                ::  one-way effect
           $%  [%$ p=vase]                               ::  trivial output
@@ -2945,10 +2924,6 @@
               [%n p=@ta]                                ::  number
               [%s p=@t]                                 ::  string
           ==                                            ::
-++  jsot                                                ::  strict json top
-          $%  [%a p=(list json)]                        ::  array
-              [%o p=(map ,@t json)]                     ::  object
-          ==                                            ::
 ++  lamb                                                ::  short path
           $%  [& p=@tas]                                ::  auto
               [| p=twig]                                ::  manual
@@ -2978,10 +2953,8 @@
               [%wan p=wain]                             ::  text lines
               [%zap p=@ud q=(list tank)]                ::  status/error
           ==                                            ::
-++  luge  ,[p=mark q=*]                                 ::  fully typed content
 ++  maki  ,[p=@ta q=@ta r=@ta s=path]                   ::
 ++  mace  (list ,[p=life q=ring])                       ::  private secrets
-++  marv  ?(%da %tas %ud)                               ::  release form
 ++  math  (map ,@t (list ,@t))                          ::  semiparsed headers
 ++  meal                                                ::  payload
           $%  [%back p=cape q=flap r=@dr]               ::  acknowledgment
@@ -3143,7 +3116,6 @@
 ++  step  ,[p=bray q=gens r=pass]                       ::  identity stage
 ++  tako  ,@                                            ::  yaki ref
 ++  tart  $+([@da path note] bowl)                      ::  process core
-++  taxi  ,[p=lane q=rock]                              ::  routed packet
 ++  tick  ,@ud                                          ::  process id
 ++  toro  ,[p=@ta q=nori]                               ::  general change
 ++  town                                                ::  all security state
@@ -3168,6 +3140,5 @@
               [%chan (list $|(@ud [p=@ud q=@ud]))]      ::
 ++  wund  (list ,[p=life q=ring r=acru])                ::  mace in action
 ++  will  (list deed)                                   ::  certificate
-++  worm  ,*                                            ::  vase of tart
 ++  zuse  %314                                          ::  hoon/zuse kelvin
 --


### PR DESCRIPTION
Handy summary of what's removed, with roughly the commits where they were last used, and also any that I ignored, with reasons.
At some point the docs will need to be cleaned accordingly.

Tested with :reset and :reload

Removed
========
%ames
----
* ++trox
 * 5c894854ff770b663b5cae2588496478555d367c:jupiter/sys/192/arvo/ames.hoon:            ^+  ..trox

%eyre
----
* ++loco
 * 1eb32f5ee46f3b910da0bf701cde814c12129d60:urb/zod/arvo/eyre.hoon:      ^-  (list ,[p=path q=path r=loco])

%ford
----
* ++colt
 * a1c776ada1e1b65917c39ffcbab763efddb820ae:urb/zod/arvo/ford.hoon:  `vase`!>((colt `axle`+>-.$))

%gall
----
* ++colt
 * a1c776ada1e1b65917c39ffcbab763efddb820ae:urb/zod/arvo/gall.hoon:    ++  stay  `vase`!>((colt `axle`+>-.$))
* ++rapt
 * a1c776ada1e1b65917c39ffcbab763efddb820ae:urb/zod/arvo/gall.hoon:           [%barn p=(rapt (disk))]                   ::  %v report
* ++byby

%hoon
----
* ++dart
 * 1c1bc43ba201924d3979fe4ed959ea4ce902b1de:urb/zod/try/bin/write.hoon:%+  pomp  "appending to {(dart:ut loc)}..."
* ++dram
 * 1eb32f5ee46f3b910da0bf701cde814c12129d60:urb/zod/arvo/zuse.hoon:              [%dire p=@tas q=dram]                     ::  apply directory
* ++expt
 * 988e3c5b36899085b764656331814de2a3d6df3f:urb/zod/arvo/hoon.hoon:                    ['-' (rune hep %wthp expt)]
* ++herd
 * 4b7b058d191c663120132fabb5bbaf5d0c81445c:urb/zod/arvo/hoon.hoon:++  muse  ,[p=@tas q=duct r=(mold herd herd)]           ::  sourced move
* ++hilt
 * 39189ac799cc5d80d68a2080c995a15063435e66:urb/zod/arvo/hoon.hoon:::    |=  hem=helm  ^-  hilt
* ++hina
 * 988e3c5b36899085b764656331814de2a3d6df3f:urb/zod/arvo/hoon.hoon:                    [':' (rune col %sgcl hina)]
* ++locz
 * ee82f0f17634e2071df1adeb7a392308a7d3a152:urb/zod/main/pub/src/doc/ref/vol/2eP.md:++ locz
* ++loot
 * 1eb32f5ee46f3b910da0bf701cde814c12129d60:urb/zod/arvo/eyre.hoon:      =+  lot=(loot pax ?:(syn ~ [~ for]))
* ++skid
 * 2d800684fe666ec39420abd9abf9c2198eb72492:urb/zod/arvo/zuse.hoon:    =+  stu=(skid s.sab (clen who des))
* ++slew
 * 5723991352367c23cea85ea4398d53b6e6bfff1a:reference/hoon/library/1.md:Consumed by `++slew`, `++slot`, and section 2fC
* ++slum
 * 5c894854ff770b663b5cae2588496478555d367c:jupiter/sys/195/junk/born.watt:  ++  meat  (slum vax env)
* ++uzer

%zuse
----
* ++ankz
 * a91bfbd28c302061c6fae4ad73b3871442f795e2:urb/zod/arvo/zuse.hoon:  ^-  ankz
* ++fain
 * 1c1bc43ba201924d3979fe4ed959ea4ce902b1de:urb/zod/try/syn/web/template/htmn.hoon:      (yax (fuel (fain hom raw)))
* ++frog
 * f121b628043ef897ef86fa328f85ab922950525a:urb/zod/arvo/clay.hoon:          ::=+  fud=(flop (scag (sub let.dom u.nab) `(list frog)`hit.dom))
* ++jsot
* ++luge
 * 4b7b058d191c663120132fabb5bbaf5d0c81445c:urb/zod/arvo/gall.hoon:  ++  peek  |+(lira *(unit (unit luge)))                ::  see
* ++marv
* ++meat
 * 1c1bc43ba201924d3979fe4ed959ea4ce902b1de:urb/zod/arvo/batz.hoon:          %_(+>.$ ..ra (warn (spud (meat kit))), s.orb [%r ~])
* ++taxe
* ++txml
* ++worm
 * 1c1bc43ba201924d3979fe4ed959ea4ce902b1de:urb/zod/arvo/batz.hoon:              [%r p=(unit worm)]                        ::  running/done

Ignored
=====
%ames
----
* ++bike
 * could probably go

%ford
----
* ++faun
 * symmetrical with ++feel

%hoon
----
* ++qad
 * just a constant, could be useful

%lunt
----
* ++bulb
 * because %lunt is nascent

%zuse
-----
* ++fuel
 * needed for %ford
* ++trua
* ++trub
 * tests seem useful
* ++urld
 * symmetrical with ++urle
* ++wear
 * symmetrical with ++hail

misc.
-----
* main/app/talk/core.hook main/mar/radio-command/door.hook: ++peach
* main/lib/twitter/core.hook: ++geoo
* main/lib/twitter/core.hook: ++twir
* main/mar/down/parse.hoon: ++enrule
* main/mar/down/parse.hoon: ++parseb
