### PR TITLE
Use pwd command, not PWD env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ENDIAN=little
 #
 BIN=bin
 
-LIB=$(PWD)/urb
+LIB=$(shell pwd)/urb
 
 RM=rm -f
 CC=gcc


### PR DESCRIPTION
So, sometimes PWD isn't exported. Like if you're in some kind of
weird sudo login session or something.

I don't know. It was broken for me. This fixed it.