### PR TITLE
emacs tweak, ford doc tweak

### DIFF
--- a/extras/hoon-mode.el/hoon-mode.el
+++ b/extras/hoon-mode.el/hoon-mode.el
@@ -132,33 +132,44 @@
 ;      translation: "do not sharpen chainsaw while it is running"
 ;   4) the commands that are executed when the DSL is interpreted are likewise written in C
 ;
-; The upshot is ... this:
+; The upshot is... 
+;
+; WAIT. A better way exists. Instead of hacking the mode-line format,
+; just invoke 'rename-buffer, which also lives down in the C
+; underbelly. Everything falls out nicely.
 
 (defvar hoon-buffer-string "")
 (make-variable-buffer-local 'hoon-buffer-string)
 
 (defun hoon-mode-hack-the-modeline ()
-  (setq mode-line-format
-		'("%e" 
-		  mode-line-front-space
-		  mode-line-mule-info
-		  mode-line-client
-		  mode-line-modified
-		  mode-line-remote
-		  mode-line-frame-identification
-		  hoon-buffer-string
-		  "   "
-		  mode-line-position
-		  (vc-mode vc-mode)
-		  "  "
-		  mode-line-modes
-		  mode-line-misc-info
-		  mode-line-end-spaces))
-  (setq hoon-buffer-string 
+  ;; (setq mode-line-format
+  ;; 		'("%e" 
+  ;; 		  mode-line-front-space
+  ;; 		  mode-line-mule-info
+  ;; 		  mode-line-client
+  ;; 		  mode-line-modified
+  ;; 		  mode-line-remote
+  ;; 		  mode-line-frame-identification
+  ;; 		  hoon-buffer-string
+  ;; 		  "   "
+  ;; 		  mode-line-position
+  ;; 		  (vc-mode vc-mode)
+  ;; 		  "  "
+  ;; 		  mode-line-modes
+  ;; 		  mode-line-misc-info
+  ;; 		  mode-line-end-spaces))
+  ;; (setq hoon-buffer-string 
+  ;; 		(concat
+  ;; 		 (nth 1 (reverse (split-string (file-name-directory (buffer-file-name)) "/")))
+  ;; 		 "/"
+  ;; 		 (file-name-nondirectory (buffer-file-name))))
+
+  (rename-buffer
 		(concat
 		 (nth 1 (reverse (split-string (file-name-directory (buffer-file-name)) "/")))
 		 "/"
-		 (file-name-nondirectory (buffer-file-name)))))
+		 (file-name-nondirectory (buffer-file-name))))
+)
 
 (add-hook 'hoon-mode-hook 'hoon-mode-hack-the-modeline)
 

--- a/urb/zod/docs/pub/doc/guide/a-ford.md
+++ b/urb/zod/docs/pub/doc/guide/a-ford.md
@@ -597,8 +597,9 @@ generating html, it's a `.hook`, and our source file is just a `.hoon`.
 In order to find our file one level up we need two `%%` to get to
 `/pub/fab/guide/exercise/9/`. Adding `lib` resolve to our neighboring
 file. You can read more about how `%clay` paths are parsed in the
-[`%clay` overview](link). It's also pretty easy to try them out using
-`:cd` and `:ls` in your `%arvo` terminal.
+[`%clay` overview](link). It's also pretty easy to try them out using 
+`/=main=`, `/=try`, `/try/a/b/c/d`, etc.
+and `:ls` in your `%arvo` terminal.
 
 <hr>
 </hr>


### PR DESCRIPTION
Smarter approach to emacs mode.

Fix obsolete ford docs; ":cd" does not exist.