### PR TITLE
Proper :talk instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -442,7 +442,7 @@ To start chatting, simply press `^X` to switch to the `:talk` app
 
     ~waclux-tomwyc:talk()
 
-and type `;join /urbit-meta` to join our main chat room.
+and type `;join ~doznec/urbit-meta` to join our main chat room.
 
 Most of us are hanging out on `:talk` regularly. We can answer any questions you might have and help you get oriented in this new environment.
 


### PR DESCRIPTION
Doing a `;join /urbit-meta` from the initial :talk prompt only works if you are running a destroyer. Since this is the readme and it claims they aren't giving out destroyers (;D), there is a good chance the reader is running a sub, which need the full path for the room to join.