### PR TITLE
runnable <pre urb:exec=""> examples

### DIFF
--- a/urb/zod/base/lib/react/core.hook
+++ b/urb/zod/base/lib/react/core.hook
@@ -18,13 +18,38 @@
     %pattern  %polygon  %polyline  %radial-gradient  %rect  %stop  %svg
     %text  %tspan
   ==
-++  react-vale  
+++  react-vale
   ~(has in react-elems)
 ++  react-to-tape
   |=  src=manx  ^-  tape
   ?:  (~(has by (mo a.g.src)) [%urb %codemirror])
     ?>  ?=([[%pre *] _:/(**) ~] src)
     $(src ;codemirror(value "{v.i.a.g.i.c.src}");)
+  ?:  (~(has by (mo a.g.src)) [%urb %exec])           ::  runnable code attribute tag
+    ?>  ?=([[%pre *] _:/(**) ~] src)                  ::  verify its only a text node
+    =*  code  v.i.a.g.i.c.src
+    =+  ^=  result
+      (mule |.((slap !>(.) (ream (crip code)))))      ::  compile and run safely
+    ?:  ?=(%.y -.result)                              ::  it was ok
+        =+  ^=  new
+          ;div(class "rancode")
+                ;pre:"{code}"
+                ;code:"{~(ram re (sell p.result))}"
+            ==
+        $(src new)
+    =+  ^=  error
+      ;div(class "failedcode")
+        ;pre:"{code}"
+        ;pre
+          ;div:"error"
+          ;*  %+  turn
+                (scag (dec (lent p.result)) p.result) ::  hide react trace
+              |=  a=tank
+              ^-  manx
+              ;div:"{~(ram re a)}"
+        ==
+      ==
+    $(src error)
   ;:  weld
     "React.createElement("
     =*  tan  n.g.src
@@ -41,7 +66,7 @@
     ", "
     ::
     =<  ~(ram re %rose [", " "[" "]"] (turn c.src .))
-    |=  a=manx 
+    |=  a=manx
     ?:  ?=(_:/(**) a)
       leaf/(pojo (jape v.i.a.g.a))
     leaf/^$(src a)


### PR DESCRIPTION
This adds a React processing rule, making any \<pre urb:exec=""\> tags have their contents evaluated and added below the tag. It includes handling crashing code.

I'm not that sure how safe this is, however - should the `++slap` have a different context without access to the vanes? Although right now this should only be used for `:tree` library examples, if `:talk` gets a markdown message type it would also be able to use it. That would be a problem, and so it needs to be reasonably secure, both with no `%clay` access and no infinite-runtime code.