### PR TITLE
Fixes to the command to install dependencies on Fedora

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ urbit depends on:
 *note: http requests are not supported on either debian wheezy or jessie due to an ssl issue*
 #### Fedora
 
-    sudo yum install gcc gcc-c++ git gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool ragel cmake re2c
+    sudo dnf install gcc gcc-c++ git gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool ragel cmake re2c
 
 #### AWS
 

--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ urbit depends on:
 *note: http requests are not supported on either debian wheezy or jessie due to an ssl issue*
 #### Fedora
 
-    sudo yum install gcc gcc-c++ git gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool cmake re2c
+    sudo yum install gcc gcc-c++ git gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool ragel cmake re2c
 
 #### AWS
 


### PR DESCRIPTION
This adds a dependency missing in the command to install the dependencies on Fedora and changes the command to use DNF instead of Yum since the latter is no longer part of the base system in the stable version of Fedora.