### PR TITLE
debian build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: urbit
 Section: unknown
 Priority: extra
 Maintainer: Urbit <urbit@urbit.org>
-Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev, ragel
+Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev, ragel, cmake
 Standards-Version: 3.9.3
 Homepage: http://urbit.org/
 


### PR DESCRIPTION
cmake is a build-time dependency and has been for some time