### PR TITLE
optional sig

### DIFF
--- a/vere/main.c
+++ b/vere/main.c
@@ -86,7 +86,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         break;
       }
       case 'I': {
-        u3_Host.ops_u.imp_c = strdup(optarg);
+        u3_Host.ops_u.imp_c = _main_presig(optarg);
         break;
       }
       case 'w': {


### PR DESCRIPTION
Makes the `~` part of `./bin/urbit -F -I ~zod -c fake_zod` optional. Should be able to cleanup the CONTRIBUTING.md file a little bit to remove the disclaimer, and not require a \ under zsh.