### PR TITLE
Thread the nock interpreter using computed gotos.

### DIFF
--- a/noun/nock.c
+++ b/noun/nock.c
@@ -133,212 +133,208 @@ _n_nock_on(u3_noun bus, u3_noun fol)
       u3a_lose(fol);
       return u3i_cell(poz, riv);
     }
-    else switch ( hib ) {
-      default: return u3m_bail(c3__exit);
+    else {
+      static void* lut[] = {
+	&&l0, &&l1, &&l2, &&l3, &&l4, &&l5, 
+	&&l6, &&l7, &&l8, &&l9, &&l10, &&l11
+      };
 
-      case 0: {
-        if ( c3n == u3r_ud(gal) ) {
-          return u3m_bail(c3__exit);
-        }
-        else {
-          u3_noun pro = u3k(u3at(gal, bus));
+      goto *lut[hib];
+    
+      {
+      l0: {
+	  if ( c3n == u3r_ud(gal) ) {
+	    return u3m_bail(c3__exit);
+	  }
+	  else {
+	    u3_noun pro = u3k(u3at(gal, bus));
 
-          u3a_lose(bus); u3a_lose(fol);
-          return pro;
-        }
-      }
-      c3_assert(!"not reached");
+	    u3a_lose(bus); u3a_lose(fol);
+	    return pro;
+	  }
+	}
 
-      case 1: {
-        u3_noun pro = u3k(gal);
+      l1: {
+	  u3_noun pro = u3k(gal);
 
-        u3a_lose(bus); u3a_lose(fol);
-        return pro;
-      }
-      c3_assert(!"not reached");
+	  u3a_lose(bus); u3a_lose(fol);
+	  return pro;
+	}
 
-      case 2: {
-        u3_noun nex = _n_nock_on(u3k(bus), u3k(u3t(gal)));
-        u3_noun seb = _n_nock_on(bus, u3k(u3h(gal)));
+      l2: {
+	  u3_noun nex = _n_nock_on(u3k(bus), u3k(u3t(gal)));
+	  u3_noun seb = _n_nock_on(bus, u3k(u3h(gal)));
 
-        u3a_lose(fol);
-        bus = seb;
-        fol = nex;
-        continue;
-      }
-      c3_assert(!"not reached");
+	  u3a_lose(fol);
+	  bus = seb;
+	  fol = nex;
+	  continue;
+	}
 
-      case 3: {
-        u3_noun gof, pro;
+      l3: {
+	  u3_noun gof, pro;
 
-        gof = _n_nock_on(bus, u3k(gal));
-        pro = u3r_du(gof);
+	  gof = _n_nock_on(bus, u3k(gal));
+	  pro = u3r_du(gof);
 
-        u3a_lose(gof); u3a_lose(fol);
-        return pro;
-      }
-      c3_assert(!"not reached");
+	  u3a_lose(gof); u3a_lose(fol);
+	  return pro;
+	}
 
-      case 4: {
-        u3_noun gof, pro;
+      l4: {
+	  u3_noun gof, pro;
 
-        gof = _n_nock_on(bus, u3k(gal));
-        pro = u3i_vint(gof);
+	  gof = _n_nock_on(bus, u3k(gal));
+	  pro = u3i_vint(gof);
 
-        u3a_lose(fol);
-        return pro;
-      }
-      c3_assert(!"not reached");
+	  u3a_lose(fol);
+	  return pro;
+	}
 
-      case 5: {
-        u3_noun wim = _n_nock_on(bus, u3k(gal));
-        u3_noun pro = u3r_sing(u3h(wim), u3t(wim));
+      l5: {
+	  u3_noun wim = _n_nock_on(bus, u3k(gal));
+	  u3_noun pro = u3r_sing(u3h(wim), u3t(wim));
 
-        u3a_lose(wim); u3a_lose(fol);
-        return pro;
-      }
-      c3_assert(!"not reached");
+	  u3a_lose(wim); u3a_lose(fol);
+	  return pro;
+	}
 
-      case 6: {
-        u3_noun b_gal, c_gal, d_gal;
+      l6: {
+	  u3_noun b_gal, c_gal, d_gal;
 
-        u3x_trel(gal, &b_gal, &c_gal, &d_gal);
-        {
-          u3_noun tys = _n_nock_on(u3k(bus), u3k(b_gal));
-          u3_noun nex;
+	  u3x_trel(gal, &b_gal, &c_gal, &d_gal);
+	  {
+	    u3_noun tys = _n_nock_on(u3k(bus), u3k(b_gal));
+	    u3_noun nex;
 
-          if ( 0 == tys ) {
-            nex = u3k(c_gal);
-          } else if ( 1 == tys ) {
-            nex = u3k(d_gal);
-          } else return u3m_bail(c3__exit);
+	    if ( 0 == tys ) {
+	      nex = u3k(c_gal);
+	    } else if ( 1 == tys ) {
+	      nex = u3k(d_gal);
+	    } else return u3m_bail(c3__exit);
 
-          u3a_lose(fol);
-          fol = nex;
-          continue;
-        }
-      }
-      c3_assert(!"not reached");
+	    u3a_lose(fol);
+	    fol = nex;
+	    continue;
+	  }
+	}
 
-      case 7: {
-        u3_noun b_gal, c_gal;
+      l7: {
+	  u3_noun b_gal, c_gal;
 
-        u3x_cell(gal, &b_gal, &c_gal);
-        {
-          u3_noun bod = _n_nock_on(bus, u3k(b_gal));
-          u3_noun nex = u3k(c_gal);
+	  u3x_cell(gal, &b_gal, &c_gal);
+	  {
+	    u3_noun bod = _n_nock_on(bus, u3k(b_gal));
+	    u3_noun nex = u3k(c_gal);
 
-          u3a_lose(fol);
-          bus = bod;
-          fol = nex;
-          continue;
-        }
-      }
-      c3_assert(!"not reached");
+	    u3a_lose(fol);
+	    bus = bod;
+	    fol = nex;
+	    continue;
+	  }
+	}
 
-      case 8: {
-        u3_noun b_gal, c_gal;
+      l8: {
+	  u3_noun b_gal, c_gal;
 
-        u3x_cell(gal, &b_gal, &c_gal);
-        {
-          u3_noun heb = _n_nock_on(u3k(bus), u3k(b_gal));
-          u3_noun bod = u3nc(heb, bus);
-          u3_noun nex = u3k(c_gal);
+	  u3x_cell(gal, &b_gal, &c_gal);
+	  {
+	    u3_noun heb = _n_nock_on(u3k(bus), u3k(b_gal));
+	    u3_noun bod = u3nc(heb, bus);
+	    u3_noun nex = u3k(c_gal);
 
-          u3a_lose(fol);
-          bus = bod;
-          fol = nex;
-          continue;
-        }
-      }
-      c3_assert(!"not reached");
+	    u3a_lose(fol);
+	    bus = bod;
+	    fol = nex;
+	    continue;
+	  }
+	}
 
-      case 9: {
-        u3_noun b_gal, c_gal;
+      l9: {
+	  u3_noun b_gal, c_gal;
 
-        u3x_cell(gal, &b_gal, &c_gal);
-        {
-          u3_noun seb = _n_nock_on(bus, u3k(c_gal));
-          u3_noun pro;
+	  u3x_cell(gal, &b_gal, &c_gal);
+	  {
+	    u3_noun seb = _n_nock_on(bus, u3k(c_gal));
+	    u3_noun pro;
          
-          u3t_off(noc_o);
-          pro = u3j_kick(seb, b_gal);
-          u3t_on(noc_o);
+	    u3t_off(noc_o);
+	    pro = u3j_kick(seb, b_gal);
+	    u3t_on(noc_o);
 
-          if ( u3_none != pro ) {
-            u3a_lose(fol);
-            return pro;
-          }
-          else {
-            if ( c3n == u3r_ud(b_gal) ) {
-              return u3m_bail(c3__exit);
-            }
-            else {
-              u3_noun nex = u3k(u3at(b_gal, seb));
+	    if ( u3_none != pro ) {
+	      u3a_lose(fol);
+	      return pro;
+	    }
+	    else {
+	      if ( c3n == u3r_ud(b_gal) ) {
+		return u3m_bail(c3__exit);
+	      }
+	      else {
+		u3_noun nex = u3k(u3at(b_gal, seb));
 
-              u3a_lose(fol);
-              bus = seb;
-              fol = nex;
-              continue;
-            }
-          }
-        }
+		u3a_lose(fol);
+		bus = seb;
+		fol = nex;
+		continue;
+	      }
+	    }
+	  }
+	}
+
+      l10: {
+	  u3_noun p_gal, q_gal;
+
+	  u3x_cell(gal, &p_gal, &q_gal);
+	  {
+	    u3_noun zep, hod, nex;
+
+	    if ( c3y == u3r_du(p_gal) ) {
+	      u3_noun b_gal = u3h(p_gal);
+	      u3_noun c_gal = u3t(p_gal);
+	      u3_noun d_gal = q_gal;
+
+	      zep = u3k(b_gal);
+	      hod = _n_nock_on(u3k(bus), u3k(c_gal));
+	      nex = u3k(d_gal);
+	    }
+	    else {
+	      u3_noun b_gal = p_gal;
+	      u3_noun c_gal = q_gal;
+
+	      zep = u3k(b_gal);
+	      hod = u3_nul;
+	      nex = u3k(c_gal);
+	    }
+
+	    u3a_lose(fol);
+	    return _n_hint(zep, hod, bus, nex);
+	  }
+	}
+
+      l11: {
+	  u3_noun gof = _n_nock_on(bus, u3k(gal));
+	  u3_noun val;
+
+	  u3t_off(noc_o);
+	  val = u3m_soft_esc(u3k(gof));
+	  u3t_on(noc_o);
+
+	  if ( !_(u3du(val)) ) {
+	    u3m_bail(u3nt(1, gof, 0));
+	  } 
+	  else {
+	    u3_noun pro;
+
+	    u3z(gof);
+	    u3z(fol);
+	    pro = u3k(u3t(val));
+	    u3z(val);
+
+	    return pro;
+	  }
+	}  
       }
-      c3_assert(!"not reached");
-
-      case 10: {
-        u3_noun p_gal, q_gal;
-
-        u3x_cell(gal, &p_gal, &q_gal);
-        {
-          u3_noun zep, hod, nex;
-
-          if ( c3y == u3r_du(p_gal) ) {
-            u3_noun b_gal = u3h(p_gal);
-            u3_noun c_gal = u3t(p_gal);
-            u3_noun d_gal = q_gal;
-
-            zep = u3k(b_gal);
-            hod = _n_nock_on(u3k(bus), u3k(c_gal));
-            nex = u3k(d_gal);
-          }
-          else {
-            u3_noun b_gal = p_gal;
-            u3_noun c_gal = q_gal;
-
-            zep = u3k(b_gal);
-            hod = u3_nul;
-            nex = u3k(c_gal);
-          }
-
-          u3a_lose(fol);
-          return _n_hint(zep, hod, bus, nex);
-        }
-      }
-
-      case 11: {
-        u3_noun gof = _n_nock_on(bus, u3k(gal));
-        u3_noun val;
-
-        u3t_off(noc_o);
-        val = u3m_soft_esc(u3k(gof));
-        u3t_on(noc_o);
-
-        if ( !_(u3du(val)) ) {
-          u3m_bail(u3nt(1, gof, 0));
-        } 
-        else {
-          u3_noun pro;
-
-          u3z(gof);
-          u3z(fol);
-          pro = u3k(u3t(val));
-          u3z(val);
-
-          return pro;
-        }
-      }  
-      c3_assert(!"not reached");
     }
   }
 }

--- a/noun/nock.c
+++ b/noun/nock.c
@@ -139,6 +139,10 @@ _n_nock_on(u3_noun bus, u3_noun fol)
 	&&l6, &&l7, &&l8, &&l9, &&l10, &&l11
       };
 
+      if(hib > 11) {
+	return u3m_bail(c3__exit);
+      }
+
       goto *lut[hib];
     
       {


### PR DESCRIPTION
Rather than use a switch statement in what looked to be the main loop of the nock interpreter, use computed gotos instead.  This should speed things up and is a typical pattern for interpreters.