### PR TITLE
Ask for ticket, close #366

### DIFF
--- a/vere/main.c
+++ b/vere/main.c
@@ -163,6 +163,13 @@ _main_getopt(c3_i argc, c3_c** argv)
     return c3n;
   }
 
+  if ( u3_Host.ops_u.tic_c == 0 && u3_Host.ops_u.who_c != 0 ) {
+      c3_c tic_c[29];
+      printf("your ticket: ~");
+      scanf("%28s",tic_c);
+      u3_Host.ops_u.tic_c = _main_presig(tic_c);
+  }
+
   if ( c3y == u3_Host.ops_u.bat ) {
     u3_Host.ops_u.dem = c3y;
     u3_Host.ops_u.nuu = c3y;


### PR DESCRIPTION
28 is the length of a ticket plus a leading sig, should anyone enter it.
If you enter an invalid ticket, it will panic later while setting up the pier, but with a nice "ticket: invalid secret '~foobar'" error message instead of the current bail.

I fired up a fakezod, +ticket'd ~doznec, and was able to run ./bin/urbit -F -c fake_doznec -w doznec and enter the ticket, so I assume it's all working fine.