### PR TITLE
Check if directory already exists when using -c

### DIFF
--- a/vere/main.c
+++ b/vere/main.c
@@ -322,6 +322,14 @@ main(c3_i   argc,
     return 1;
   }
 
+  if ( c3y == u3_Host.ops_u.nuu ) {
+    struct stat s;
+    if ( !stat(u3_Host.dir_c, &s) ) {
+      fprintf(stderr, "used -c but %s already exists\n", u3_Host.dir_c);
+      exit(1);
+    }
+   }
+
   u3_ve_sysopt();
 
   printf("~\n");


### PR DESCRIPTION
We've had an ugly unexplained segfault when you try to -c a pier that already exists. This adds a quick existence check.