### PR TITLE
Change moon name rendering in talk

### DIFF
--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -1719,7 +1719,12 @@
         %czar  (weld "          " raw)
         %king  (weld "       " raw)
         %duke  raw
-        %earl  :(welp (scag 7 raw) "^" (scag 6 (slag 22 raw)))
+        %earl  ;:  welp
+                 (scag 1 raw)
+                 (scag 6 (slag 15 raw))
+                 "^"
+                 (scag 6 (slag 22 raw))
+               ==
         %pawn  :(welp (scag 7 raw) "_" (scag 6 (slag 51 raw)))
     ==
   ::


### PR DESCRIPTION
There was a suggestion by ~matfeb-sablud to change the rendering of moon names on talk. This change now renders moons (say, ~sampel-sipnym-matwyc-sablud) as ~matwyc^sablud in the console talk.

Discussion?

Obviously this would make it difficult to discern different moons from the same planet in chat, but if moons are meant to be closely bound to planets, is that such a problem?