### PR TITLE
Talk nicknames

### DIFF
--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -982,9 +982,20 @@
         |=  [her=(unit ship) nym=(unit cord)]
         ^+  ..sh-work
         ?:  ?=([~ ~] +<)
-          (sh-note "display all associations")
+          %+  sh-fact  %mor
+          %+  turn  (~(tap by folks))
+          |=  [p=ship q=human]
+          :-  %txt
+          ?~  hand.q
+            "{<p>}:"
+          "{<p>}: {<u.hand.q>}"
         ?~  nym
-          (sh-note "display one assocation")
+          ?>  ?=(^ her)
+          =+  asc=(~(get by folks) u.her)
+          %+  sh-fact  %txt
+          ?~  asc  "{<u.her>} unbound"
+          ?~  hand.u.asc  "{<u.her>}:"
+          "{<u.her>}: {<u.hand.u.asc>}"
         ?~  her
           (sh-note "display reverse association")
         %=  ..sh-work

--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -107,7 +107,7 @@
           [%banish p=span q=(list partner)]             ::  blacklist add
           [%block p=span q=(list partner)]              ::  blacklist add
           [%author p=span q=(list partner)]             ::  whitelist add
-          [%nick ~]                                     ::
+          [%nick p=(unit ship) q=(unit cord)]           ::
           [%target p=where q=(unit work)]               ::  set active targets
           ::  [%destroy p=span]                         ::
           [%create p=posture q=span r=cord]             ::
@@ -215,6 +215,7 @@
           ==
         ==
       ::
+      ++  nick  (cook crip (stun [1 14] low))           ::  nickname
       ++  text  (cook crip (star (shim ' ' '~')))       ::  bullets separating
       ++  glyph  (mask "/\\\{(<!?{(zing glyphs)}")      ::  station postfix
       ++  work
@@ -239,7 +240,16 @@
           ;~((glue ace) (perk %join ~) parz)
           ;~((glue ace) (perk %what ~) ;~(pose parz glyph))
         ::
-          ;~(plug (perk %nick ~) (easy ~))
+          ;~  plug  (perk %nick ~)
+            ;~  pose
+              (cook some ;~(pfix ace ship))
+              (easy ~)
+            ==
+            ;~  pose
+              (cook some ;~(pfix ace nick))
+              (easy ~)
+            ==
+          ==
         ::
           ;~(plug (perk %help ~) (easy ~))
           (stag %number nump)
@@ -846,7 +856,7 @@
           %author  (author +.job)
           %block   (block +.job)
           %create  (create +.job)
-          %nick    (nick)
+          %nick    (nick +.job)
           %target  (target +.job)
           %probe   (probe +.job)
           %help    (help)
@@ -969,9 +979,10 @@
         (join [[%& our.hid nom] ~ ~])
       ::
       ++  nick
-        |=  *
+        |=  [her=(unit ship) nym=(unit cord)]
         ^+  ..sh-work
-        !!
+        ~&  [her nym]
+        ..sh-work
       ::
       ++  target                                        ::  %target
         |=  [lix=?((set partner) char) woe=(unit ^work)]

--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -978,11 +978,18 @@
             [por ~]
         (join [[%& our.hid nom] ~ ~])
       ::
-      ++  nick
+      ++  nick                                          ::  %nick
         |=  [her=(unit ship) nym=(unit cord)]
         ^+  ..sh-work
-        ~&  [her nym]
-        ..sh-work
+        ?:  ?=([~ ~] +<)
+          (sh-note "display all associations")
+        ?~  nym
+          (sh-note "display one assocation")
+        ?~  her
+          (sh-note "display reverse association")
+        %=  ..sh-work
+          folks  (~(put by folks) u.her [true=~ hand=nym])
+        ==
       ::
       ++  target                                        ::  %target
         |=  [lix=?((set partner) char) woe=(unit ^work)]

--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -978,6 +978,15 @@
             [por ~]
         (join [[%& our.hid nom] ~ ~])
       ::
+      ++  reverse-folks
+        |=  nym=span
+        ^-  (list ship)
+        %+  murn  (~(tap by folks))
+        |=  [p=ship q=human]
+        ?~  hand.q  ~
+        ?.  =(u.hand.q nym)  ~
+        [~ u=p]
+      ::
       ++  nick                                          ::  %nick
         |=  [her=(unit ship) nym=(unit cord)]
         ^+  ..sh-work
@@ -997,7 +1006,10 @@
           ?~  hand.u.asc  "{<u.her>}:"
           "{<u.her>}: {<u.hand.u.asc>}"
         ?~  her
-          (sh-note "display reverse association")
+          %+  sh-fact  %mor
+          %+  turn  (reverse-folks u.nym)
+          |=  p=ship
+          [%txt "{<p>}: {<u.nym>}"]
         %=  ..sh-work
           folks  (~(put by folks) u.her [true=~ hand=nym])
         ==

--- a/urb/zod/ape/talk.hoon
+++ b/urb/zod/ape/talk.hoon
@@ -107,6 +107,7 @@
           [%banish p=span q=(list partner)]             ::  blacklist add
           [%block p=span q=(list partner)]              ::  blacklist add
           [%author p=span q=(list partner)]             ::  whitelist add
+          [%nick ~]                                     ::
           [%target p=where q=(unit work)]               ::  set active targets
           ::  [%destroy p=span]                         ::
           [%create p=posture q=span r=cord]             ::
@@ -237,6 +238,8 @@
           ;~(plug (perk %bind ~) ;~(pfix ace glyph) (punt ;~(pfix ace parz)))
           ;~((glue ace) (perk %join ~) parz)
           ;~((glue ace) (perk %what ~) ;~(pose parz glyph))
+        ::
+          ;~(plug (perk %nick ~) (easy ~))
         ::
           ;~(plug (perk %help ~) (easy ~))
           (stag %number nump)
@@ -843,6 +846,7 @@
           %author  (author +.job)
           %block   (block +.job)
           %create  (create +.job)
+          %nick    (nick)
           %target  (target +.job)
           %probe   (probe +.job)
           %help    (help)
@@ -857,7 +861,7 @@
         sh-prod(active.she `tr-pals:tay)
       ::
       ++  help  |=(~ (sh-fact %mor talk-doc))           ::  %help
-      ++  nick
+      ++  glyph
         |=  idx=@
         =<  cha.ole
         %+  reel  glyphs
@@ -875,7 +879,7 @@
         =.  ..sh-work
           =+  (~(get by nik) lix)
           ?^  -  (sh-note "has glyph {<u>}")
-          =+  cha=(nick (mug lix))
+          =+  cha=(glyph (mug lix))
           =:  nik  (~(put by nik) lix cha)
               nak  (~(put ju nak) cha lix)
             ==
@@ -963,6 +967,11 @@
               (end 3 64 txt)
             [por ~]
         (join [[%& our.hid nom] ~ ~])
+      ::
+      ++  nick
+        |=  *
+        ^+  ..sh-work
+        !!
       ::
       ++  target                                        ::  %target
         |=  [lix=?((set partner) char) woe=(unit ^work)]


### PR DESCRIPTION
Barebones nicknaming functionality in console talk.

Further extension required:
 
- completion (per talk spec)
- removing nickname entries
- displaying nicknames if available
- webtalk support