### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,48 +209,6 @@ To start your comet again, omit the `-c` flag:
 Learn these two control keys first: ^D to quit Urbit (from either
 of the two core applications), 
 
-Or just talk
-------------
-
-Use `^X` to get into `:talk`, and 
-From `:talk`, 
-
-    ~
-
-Doing more
-----------
-
-To test the dojo, run 
-Doing more
-
-
-From either of the core 
-
-directory.  Your pier (all Urbit state, log and checkpoint) will
-be in `./fintud-macrep`.  The format is portable.  Doing `rm -r
-fintud-macrep/.urb/chk` will delete the checkpoint, meaning all
-your events need to be recomputed, but making the image smaller.
-
-
-    bin/urbit fintud-macrep
-
-Basics
-------
-
-`^v` will switch between the task manager and the focussed process. `^x`
-will switch between processes.
-
-To start a process that is not yet started, run `*proc` from the task
-manager.
-
-To connect your console to a process that has already been started, run
-`+proc` from the task manager. Note that the process must be one that
-supports console access, such as dojo and talk.
-
-`^d` will exit the pier from the task manager. No matter how you shut
-your urbit down you'll be returned to exactly the same state as when you
-turned it off.
-
 Talk
 ----
 
@@ -280,6 +238,31 @@ clipped.
 
 `;<target>` sets the target for your messages, such as `;~urbit-name`
 for a private message.
+
+Basics
+------
+
+`^x` will switch between processes. To start a process that is not yet
+started, run `*proc` from the task manager.
+
+To connect your console to a process that has already been started, run
+`+proc` from the task manager. Note that the process must be one that
+supports console access, such as dojo and talk.
+
+`^d` will exit the pier from the task manager. No matter how you shut
+your urbit down you'll be returned to exactly the same state as when you
+turned it off.
+
+Doing more
+----------
+
+Your pier (all Urbit state, log and checkpoint) will be in
+`./fintud-macrep`.  The format is portable.  Doing `rm -r
+fintud-macrep/.urb/chk` will delete the checkpoint, meaning all
+your events need to be recomputed, but making the image smaller.
+
+    bin/urbit fintud-macrep
+
 
 Filesystem Sync
 ---------------
@@ -342,8 +325,12 @@ Your urbit is a web server. localhost:8080 is the default. If that is
 taken, you may want to try localhost:8081.
 
 If you're running on AWS or another cloud service, this port may
-be firewalled; go to the firewall configuration to open it.  In a
+be firewalled; go to the firewall configuration to open it. In a
 last resort, you can use our server, doznec.urbit.org.
+
+Try going to http://localhost:8080/home/pub/talk/fab to talk via
+a web interface. Note that for the time being,, the login code is
+output to your console, it's not the same as your planet ticket.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -186,17 +186,28 @@ the prompt.
 
 `^D` from any default appliance exits the urbit process.
 
-Learn more
-----------
+Run (without a network invitation)
+----------------------------------
 
-Your urbit is a web server, so the best place to read about it 
-is in your browser. localhost:8080 is the default. If that is
-taken, you may want to try localhost:8081.
+To create a comet (128-bit urbit) in the Unix directory 
+`mycomet`:
 
-If you're running on AWS or another cloud
-service, this port may be firewalled; go to the firewall
-configuration to open it.  In a last resort, you can use our
-server, doznec.urbit.org.
+    bin/urbit -c mycomet
+
+This will take a little while.  Go smoke a bowl.
+
+This process can only read and write files within `mycomet`.
+
+To quit Urbit (without destroying any data, since Urbit is a
+database): ^D.
+
+To start your comet again, omit the `-c` flag:
+
+    bin/urbit mypier
+
+
+Learn these two control keys first: ^D to quit Urbit (from either
+of the two core applications), 
 
 Or just talk
 ------------
@@ -222,29 +233,6 @@ your events need to be recomputed, but making the image smaller.
 
 
     bin/urbit fintud-macrep
-
-Run (without a network invitation)
-----------------------------------
-
-To create a comet (128-bit urbit) in the Unix directory 
-`mycomet`:
-
-    bin/urbit -c mycomet
-
-This will take a little while.  Go smoke a bowl.
-
-This process can only read and write files within `mycomet`.
-
-To quit Urbit (without destroying any data, since Urbit is a
-database): ^D.
-
-To start your comet again, omit the `-c` flag:
-
-    bin/urbit mypier
-
-
-Learn these two control keys first: ^D to quit Urbit (from either
-of the two core applications), 
 
 Basics
 ------
@@ -346,6 +334,16 @@ continuity of our crypto.
 
 When this happens you'll need to back up your data and start a fresh
 pier. Your original ticket will still work.
+
+Web server
+----------
+
+Your urbit is a web server. localhost:8080 is the default. If that is
+taken, you may want to try localhost:8081.
+
+If you're running on AWS or another cloud service, this port may
+be firewalled; go to the firewall configuration to open it.  In a
+last resort, you can use our server, doznec.urbit.org.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ be firewalled; go to the firewall configuration to open it. In a
 last resort, you can use our server, doznec.urbit.org.
 
 Try going to http://localhost:8080/home/pub/talk/fab to talk via
-a web interface. Note that for the time being,, the login code is
+a web interface. Note that for the time being, the login code is
 output to your console, it's not the same as your planet ticket.
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -329,8 +329,9 @@ be firewalled; go to the firewall configuration to open it. In a
 last resort, you can use our server, doznec.urbit.org.
 
 Try going to http://localhost:8080/home/pub/talk/fab to talk via
-a web interface. Note that for the time being, the login code is
-output to your console, it's not the same as your planet ticket.
+a web interface. Note that for the time being the login code is
+output to your console (e.g. `code='laslyt-mocwyd-hobmyn-rolbyl'`)
+it's not the same as your planet ticket.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -190,13 +190,10 @@ Learn more
 ----------
 
 Your urbit is a web server, so the best place to read about it 
-is in your browser.
+is in your browser. localhost:8080 is the default. If that is
+taken, you may want to try localhost:8081.
 
-Urbit prints the HTTP port it's serving when it starts up:
-
-    http: live (insecure) on 8080
-
-8080 is the default.  If you're running on AWS or another cloud
+If you're running on AWS or another cloud
 service, this port may be firewalled; go to the firewall
 configuration to open it.  In a last resort, you can use our
 server, doznec.urbit.org.


### PR DESCRIPTION
I rearranged some sections, removed some things that felt incomplete, and pointed new users in the direction the web-based talk UI. I removed a phrase "the best place to read about it 
is in your browser" from the section about the web server because I still haven't discovered where these docs can be found. (Where can they be found?)