### PR TITLE
#writing fix

### DIFF
--- a/urb/zod/pub/talk/src/css/main.css
+++ b/urb/zod/pub/talk/src/css/main.css
@@ -534,6 +534,8 @@ a {
 #writing {
   min-height: 1.6rem;
   min-width: 1.3rem;
+  max-width: 32rem;
+  line-height: 2rem;
   outline: none;
   padding: 0.3rem 0.1rem;
   margin-top: -0.3rem;

--- a/urb/zod/pub/talk/src/css/main.styl
+++ b/urb/zod/pub/talk/src/css/main.styl
@@ -488,6 +488,8 @@ a
 #writing
   min-height 1.6rem
   min-width 1.3rem
+  max-width 32rem
+  line-height 2rem
   outline none
   padding .3rem .1rem
   margin-top -.3rem


### PR DESCRIPTION
This just keeps the writing box in `:talk` from causing crazy things to happen when you put a lot of text in it. 