### PR TITLE
<pre> fix

### DIFF
--- a/urb/zod/pub/tree/src/css/main.css
+++ b/urb/zod/pub/tree/src/css/main.css
@@ -155,7 +155,7 @@ pre {
   background-color: #f5f5f5;
   padding: 0.3rem;
   margin-left: -0.3rem;
-  white-space: pre-line;
+  overflow-y: scroll;
 }
 code {
   line-height: 1.2rem;

--- a/urb/zod/pub/tree/src/css/main.styl
+++ b/urb/zod/pub/tree/src/css/main.styl
@@ -85,7 +85,7 @@ pre
   background-color #f5f5f5
   padding .3rem
   margin-left -.3rem
-  white-space pre-line
+  overflow-y scroll
 
 code
   line-height 1.2rem


### PR DESCRIPTION
Thanks @chc4. This fixes the whitespace mangling of codeblocks in the tree. 