### PR TITLE
Add command line option to report urbit build info.

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -542,6 +542,7 @@
         c3_o    qui;                        //  -q, quiet
         c3_o    vno;                        //  -V, turn on +verb
         c3_o    mem;                        //  -M, memory madness
+        c3_o    rep;                        //  -R, report build info
       } u3_opts;
 
     /* u3_host: entire host.

--- a/vere/main.c
+++ b/vere/main.c
@@ -17,6 +17,7 @@
 #include <termios.h>
 #include <term.h>
 #include <dirent.h>
+#include <openssl/ssl.h>
 
 #define U3_GLOBAL
 #define C3_GLOBAL
@@ -78,9 +79,10 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.qui = c3n;
   u3_Host.ops_u.nuu = c3n;
   u3_Host.ops_u.mem = c3n;
+  u3_Host.ops_u.rep = c3n;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
-  while ( (ch_i=getopt(argc, argv,"I:w:t:f:k:l:n:p:r:LabcdgqvxFMPDX")) != -1 ) {
+  while ( (ch_i=getopt(argc, argv,"I:w:t:f:k:l:n:p:r:LabcdgqvxFMPDXR")) != -1 ) {
     switch ( ch_i ) {
       case 'M': {
         u3_Host.ops_u.mem = c3y;
@@ -139,6 +141,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       case 'r': {
         u3_Host.ops_u.raf_c = strdup(optarg);
         break;
+      }
+      case 'R': {
+        u3_Host.ops_u.rep = c3y;
+        return c3y;
       }
       case 'L': { u3_Host.ops_u.loh = c3y; break; }
       case 'F': {
@@ -235,6 +241,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-M            Memory madness\n",
     "-f            Fuzz testing\n",
     "-k stage      Start at Hoon kernel version stage\n",
+    "-R            Report urbit build info\n",
     "-Xwtf         Skip last event\n"};
   c3_i i;
   for ( i=0; i < sizeof(use_c)/sizeof(c3_c*); i++ ) {
@@ -339,6 +346,17 @@ interrupt_handler(int x)
 
 #define GRAB
 
+static void
+report(void)
+{
+  printf("---------\nLibraries\n---------\n");
+  printf("gmp: %s\n", gmp_version);
+  printf("sigsegv: %d.%d\n", (libsigsegv_version >> 8) & 0xff, libsigsegv_version & 0xff);
+  printf("openssl: %s\n", SSLeay_version(SSLEAY_VERSION));
+  printf("curses: %s\n", curses_version());
+  //  libuv -- add when it becomes an external dependency
+}
+
 c3_i
 main(c3_i   argc,
      c3_c** argv)
@@ -348,6 +366,11 @@ main(c3_i   argc,
   if ( c3n == _main_getopt(argc, argv) ) {
     u3_ve_usage(argc, argv);
     return 1;
+  }
+
+  if ( c3y == u3_Host.ops_u.rep ) {
+    report();
+    return 0;
   }
 
   if ( c3y == u3_Host.ops_u.nuu ) {

--- a/vere/main.c
+++ b/vere/main.c
@@ -354,7 +354,7 @@ report(void)
   printf("sigsegv: %d.%d\n", (libsigsegv_version >> 8) & 0xff, libsigsegv_version & 0xff);
   printf("openssl: %s\n", SSLeay_version(SSLEAY_VERSION));
   printf("curses: %s\n", curses_version());
-  //  libuv -- add when it becomes an external dependency
+  printf("libuv: %s\n", uv_version_string());
 }
 
 c3_i


### PR DESCRIPTION
This patch adds a command line option to report urbit build info.

	bin/urbit -R
	---------
	Libraries
	---------
	gmp: 6.0.0
	sigsegv: 2.10
	openssl: OpenSSL 1.0.2d 9 Jul 2015
	curses: ncurses 6.0.20150808

I can make changes (rename/move stuff, change the flag option/processing, etc) if needed.
