### PR TITLE
 Re-add normal urbit usage instructions to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Launch
 ======
 
 An urbit is a persistent server on the `%ames` P2P network. You'll
-create one of these servers now. 
+create one of these servers now.
 
 If you have an invitation, it's a planet like `~fintud-macrep` and a
 ticket like `~fortyv-tombyt-tabsen-sonres`. Run
@@ -163,14 +163,24 @@ over Urbit itself. Go get a cup of coffee. Or a beer.
 
 Wait until you see a prompt, something like
 
-      ~fintud-macrep:talk() 
+      ~fintud-macrep:talk()
 
 or
 
-      ~fintud-macrep:dojo> 
+      ~fintud-macrep:dojo>
 
 Your urbit is launched! Ladies and gentlemen, we are floating in
 space.
+
+### Relaunch
+
+To use Urbit normally after creating your planet or comet:
+
+    urbit fintud-macrep
+
+or
+
+    urbit mycomet
 
 Docs
 ====
@@ -208,4 +218,4 @@ The first step in contributing to urbit is to come and join us on
 `:talk`.
 
 For more detailed instructions check out
-[`contributing.md`](https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md).
+[`CONTRIBUTING.md`](https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md).

--- a/vere/main.c
+++ b/vere/main.c
@@ -377,6 +377,7 @@ main(c3_i   argc,
     struct stat s;
     if ( !stat(u3_Host.dir_c, &s) ) {
       fprintf(stderr, "tried to create, but %s already exists\n", u3_Host.dir_c);
+      fprintf(stderr, "normal usage: %s %s\n", argv[0], u3_Host.dir_c);
       exit(1);
     }
   }


### PR DESCRIPTION
This PR addresses https://github.com/urbit/urbit/issues/537

There are two commits.
The first one changes `README.md`.
The second one changes `vere/main.c`.
I can squash these commits if you want.

`README.md` notes:
* My editor deleted some trailing spaces.  I can put them back.
* I changed `contributing.md` to `CONTRIBUTING.md`.  I can change it back.

My preference would be to not change them back.

The change to `README.md` (at least) should be in `master` sooner rather than later.
I can send a PR against `master` if you want.
