### PR TITLE
Sublime highlighting fixes

### DIFF
--- a/extras/hoonSublime/hoon.YAML-tmLanguage
+++ b/extras/hoonSublime/hoon.YAML-tmLanguage
@@ -21,10 +21,12 @@ patterns:
 - comment: tape
   name: string.double.hoon
   begin: \"
+  patterns: [{match: '\\.|[^"]'}]
   end: \"
 - comment: cord
   name: string.single.hoon
   begin: \'
+  patterns: [{match: "\\\\.|[^']"}]
   end: \'
 - comment: arm
   name: constant.character.hoon

--- a/extras/hoonSublime/hoon.YAML-tmLanguage
+++ b/extras/hoonSublime/hoon.YAML-tmLanguage
@@ -32,8 +32,9 @@ patterns:
   name: constant.character.hoon
   match: "[a-z]([a-z0-9-]*[a-z0-9])?/"
 - comment: arm
-  name: entity.name.function.hoon
-  match: "\\+\\+  [a-z]([a-z0-9-]*[a-z0-9])?"
+  contentName: entity.name.function.hoon
+  begin: "\\+[-+]  (?=[a-z]([a-z0-9-]*[a-z0-9])?)"
+  end: "(?![a-z0-9-])"
 - comment: cube
   name: constant.character.hoon
   match: "%[a-z]([a-z0-9-]*[a-z0-9])?"

--- a/extras/hoonSublime/hoon.tmLanguage
+++ b/extras/hoonSublime/hoon.tmLanguage
@@ -50,6 +50,13 @@
 			<string>\"</string>
 			<key>name</key>
 			<string>string.double.hoon</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.|[^"]</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -60,6 +67,13 @@
 			<string>\'</string>
 			<key>name</key>
 			<string>string.single.hoon</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.|[^']</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>comment</key>

--- a/extras/hoonSublime/hoon.tmLanguage
+++ b/extras/hoonSublime/hoon.tmLanguage
@@ -84,12 +84,14 @@
 			<string>constant.character.hoon</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>\+[-+]  (?=[a-z]([a-z0-9-]*[a-z0-9])?)</string>
 			<key>comment</key>
 			<string>arm</string>
-			<key>match</key>
-			<string>\+\+  [a-z]([a-z0-9-]*[a-z0-9])?</string>
-			<key>name</key>
+			<key>contentName</key>
 			<string>entity.name.function.hoon</string>
+			<key>end</key>
+			<string>(?![a-z0-9-])</string>
 		</dict>
 		<dict>
 			<key>comment</key>


### PR DESCRIPTION
Fixes runaway quote highlighting and tweaks the arm pattern to enable "Goto Definition" for arms under the cursor.