### PR TITLE
Inaccuracy in core layout

### DIFF
--- a/urb/zod/pub/docs/dev/hoon/principles/3-program.mdy
+++ b/urb/zod/pub/docs/dev/hoon/principles/3-program.mdy
@@ -134,11 +134,11 @@ data]` pair.  Our new `span` mold:
 
 ### Structure of a core
 
-The core is a cell `[battery payload]`.  The payload is data, the
-battery is code -- a tree of Nock formulas.
+The core is a cell `[battery payload]`.  The battery is code,
+the payload is data-- a tree of Nock formulas.
 
-In the `%core` span, the payload is described by an arbitrary
-span.  The battery is described by a map of symbol to twig.
+In the `%core` span, the battery is described by an arbitrary
+span.  The payload is described by a map of symbol to twig.
 
 > Yes, the span contains the complete AST of the whole core.
 This is a very different approach from most typed languages,


### PR DESCRIPTION
I read over the 3rd chapter and noticed that the description of cores doesn't seem correct. It says the a core is `[code data]`, a core is `[%core p=span q=(map ,@tas twig)]`, a core is `[battery payload]`...but then goes on and says "In the `%core` span, the payload is described by an arbitrary
span.  The battery is described by a map of symbol to twig.". Something doesn't follow.

Unfortunately, I'm not sure the fix in this commit is correct. The sentence "we pull one formula from the battery" doesn't seem right to me if the battery is an arbitrary span, for example. This part is pretty important, so someone read over that section for if it makes sense.