### PR TITLE
Add "Equivalent to" sections to selected rune docs.

### DIFF
--- a/urb/zod/pub/docs/dev/hoon/runes/cn/cndt.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/cn/cndt.md
@@ -55,3 +55,8 @@ Here we add `2` to the product of `2` and `20`, and use `%.` to
 decrement our result. As you can see, `%.` is most useful for code
 organization, when you need to compute intermediate products for your
 final result.
+
+Equivalent to
+-------------
+
+    %-(q p)

--- a/urb/zod/pub/docs/dev/hoon/runes/cn/cnkt.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/cn/cnkt.md
@@ -39,3 +39,8 @@ None
 
 Examples
 --------
+
+Equivalent to
+-------------
+
+    %-(p [q r s])

--- a/urb/zod/pub/docs/dev/hoon/runes/cn/cnls.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/cn/cnls.md
@@ -52,3 +52,8 @@ First we set a shell variable `a` to be a gate that takes two arguments
 and produces their sum. Then we use `%+` to pass values to our gate.
 `%+` is most useful for code organization, when you need to compute
 intermediate products for your final computation.
+
+Equivalent to
+-------------
+
+    %-(p [q r])

--- a/urb/zod/pub/docs/dev/hoon/runes/kt/kthp.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/kt/kthp.md
@@ -63,3 +63,8 @@ In this case we see a very common use of `^-`, at the top of a [gate]().
 This pattern is considered good hoon style for two reasons: it gives the
 reader a clear pattern for understanding what your code produces, and it
 helps ensure type-safety.
+
+Equivalent to
+-------------
+
+    ^+(*p q)

--- a/urb/zod/pub/docs/dev/hoon/runes/kt/ktls.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/kt/ktls.md
@@ -73,3 +73,8 @@ the sum of the latter two as the second, and the differene as the third.
 In the first call you can see that our type information is lost, and we
 produce our cord as an atom. By adding a `^+  a` we cast the result to
 our input, and type information is retained.
+
+Equivalent to
+-------------
+
+    ^-(_p q)

--- a/urb/zod/pub/docs/dev/hoon/runes/ts/tsbr.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/ts/tsbr.md
@@ -48,3 +48,8 @@ Here we use `=|` to generate the default value of a `@p`, which is
 
 Here we add the bunt of `a=[b=@ c=@]` and perform a very basic operation
 on it.
+
+Equivalent to
+-------------
+
+    =+(*p q)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtdt.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtdt.md
@@ -51,3 +51,8 @@ Examples
 Here we see two common cases of `?.` in the wide form, one uses an
 expression `gth` that produces a loobean and the other [`?=`]() to
 produce one of its cases.
+
+Equivalent to
+-------------
+
+    ?:(p r q)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtgl.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtgl.md
@@ -45,3 +45,8 @@ Examples
     %foo
     ~zod/try=> ?<(=(0x1 1) %foo)
     ! exit
+
+Equivalent to
+-------------
+
+    ?:(p !! q)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtgr.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtgr.md
@@ -45,3 +45,8 @@ Examples
     %foo
     ~zod/try=> ?>(=(0x1 0) %foo)
     ! exit
+
+Equivalent to
+-------------
+
+    ?.(p !! q)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wthp.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wthp.md
@@ -94,6 +94,6 @@ defined type for which all of the cases are covered. We create a core,
 
 Here we can see a common failure case with `?-`. In the first example
 all of our possible input cases are not covered when we pass in a `@t`,
-so we fail with `mint-vain` – a parsing error. When we construct a well
+so we fail with `mint-vain` – a compilation error. When we construct a well
 typed input and select a case from it `?-` in fact has all of the cases
 covered and produces correct output.

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtkt.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtkt.md
@@ -63,3 +63,8 @@ Here we show that `*@tas`, the bunt of `@tas` is equivalent to the empty
 
 Similar to the above case, we show the bunt of a [`++unit`](), which is
 `~`, and test against it.
+
+Equivalent to
+-------------
+
+    ?:(?=(^ p) q r)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtls.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtls.md
@@ -103,3 +103,13 @@ covered, or the default.
 
 This example shows how `?+` can fail. Our input icon must match the icon
 of our cases.
+
+Equivalent to
+-------------
+
+    ?-  p
+      p.i.r      q.i.r
+      p.i.t.r    q.i.t.r
+      p.i.t.t.r  q.i.t.t.r
+      *          q
+    ==

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtls.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtls.md
@@ -101,5 +101,5 @@ covered, or the default.
           ==
     0
 
-This example shows how `?-` can fail. Our input icon must match the icon
+This example shows how `?+` can fail. Our input icon must match the icon
 of our cases.

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtpt.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtpt.md
@@ -52,3 +52,8 @@ Examples
     ! exit
     ~zod/try=> ?@(`*`[1 1] 1 2)
     2 
+
+Equivalent to
+-------------
+
+    ?:(?=(@ p) q r)

--- a/urb/zod/pub/docs/dev/hoon/runes/wt/wtsg.md
+++ b/urb/zod/pub/docs/dev/hoon/runes/wt/wtsg.md
@@ -43,3 +43,8 @@ Examples
     1
     ~zod/try=> ?~((sub 20 20) 1 2)
     1
+
+Equivalent to
+-------------
+
+    ?:(?=(~ p) q r)


### PR DESCRIPTION
For runes with straightforward translations to semantically equivalent forms (like `^-(p q)` / `^+(*p q)`), this makes the equivalent form explicit in the reference docs.

It probably doesn't cover all the runes it should, just the ones that I knew of obvious translations for.