### PR TITLE
Fix stack overflow handling in Linux?

### DIFF
--- a/noun/events.c
+++ b/noun/events.c
@@ -113,6 +113,11 @@ _ce_mapfree(void* map_v)
 c3_i
 u3e_fault(void* adr_v, c3_i ser_i)
 {
+  //  Let the stack overflow handler run.
+  if ( 0 == ser_i ) {
+    return 0;
+  }
+
   c3_w* adr_w = (c3_w*) adr_v;
 
   if ( (adr_w < u3_Loom) || (adr_w >= (u3_Loom + u3a_words)) ) {


### PR DESCRIPTION
Seems to work. I haven't worked with libsigsegv before, but according to [this](http://git.savannah.gnu.org/cgit/libsigsegv.git/tree/src/sigsegv.h.in#n64), `u3e_fault` should return 0 when `ser_i` is 0 in order to give the stack overflow handler a chance to run.