### PR TITLE
Update the whitepaper digraphs to match tutorial.

### DIFF
--- a/urb/zod/pub/docs/theory/whitepaper.md
+++ b/urb/zod/pub/docs/theory/whitepaper.md
@@ -1070,10 +1070,10 @@ A few digraphs also have irregular sounds:
     ==  stet
     --  shed
     ++  slus
-    ->  dart
-    -<  dusk
-    +>  lark
-    +<  lush
+    ->  lark
+    -<  lush
+    +>  dark
+    +<  dush
 
 Hoon defines over 100 digraph ideograms (like `|=`). Ideograms
 (or *runes*) have consistent internal structure; for instance,


### PR DESCRIPTION
The ones on [this tutorial](http://urbit.org/docs/dev/hoon/principles/2-syntax) seem to be newer. If that's backwards, my bad.