### PR TITLE
adds term support for meta-. and meta-backspace

### DIFF
--- a/include/c/motes.h
+++ b/include/c/motes.h
@@ -315,6 +315,7 @@
 #   define c3__door   c3_s4('d','o','o','r')
 #   define c3__dorn   c3_s4('d','o','r','n')
 #   define c3__dost   c3_s4('d','o','s','t')
+#   define c3__dot    c3_s3('d','o','t')
 #   define c3__drag   c3_s4('d','r','a','g')
 #   define c3__draz   c3_s4('d','r','a','z')
 #   define c3__drib   c3_s4('d','r','i','b')

--- a/vere/term.c
+++ b/vere/term.c
@@ -838,6 +838,14 @@ _term_io_suck_char(u3_utty* uty_u, c3_y cay_y)
         tat_u->esc.ape = c3n;
         _term_io_belt(uty_u, u3nc(c3__met, cay_y));
       }
+      else if ( '.' == cay_y ) {
+        tat_u->esc.ape = c3n;
+        _term_io_belt(uty_u, u3nc(c3__met, c3__dot));
+      }
+      else if ( 8 == cay_y || 127 == cay_y ) {
+        tat_u->esc.ape = c3n;
+        _term_io_belt(uty_u, u3nc(c3__met, c3__bac));
+      }
       else if ( ('[' == cay_y) || ('O' == cay_y) ) {
         tat_u->esc.bra = c3y;
       }


### PR DESCRIPTION
and a new mote: `c3__dot`

this supports the implementations in urbit/arvo#192