### PR TITLE
Fix jet discrepancies on ill-typed identity cases.

### DIFF
--- a/jets/a/add.c
+++ b/jets/a/add.c
@@ -15,6 +15,9 @@
 
       return u3i_words(1, &c);
     }
+    else if ( 0 == a ) {
+      return u3k(b);
+    }
     else {
       mpz_t a_mp, b_mp;
 
@@ -34,7 +37,7 @@
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
          (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
+         (c3n == u3ud(b) && a != 0) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/a/lth.c
+++ b/jets/a/lth.c
@@ -13,6 +13,12 @@
     if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
       return __(a < b);
     }
+    else if ( 0 == a ) {
+      return c3y;
+    }
+    else if ( 0 == b ) {
+      return c3n;
+    }
     else {
       mpz_t   a_mp, b_mp;
       u3_noun cmp;
@@ -34,8 +40,8 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
+         (c3n == u3ud(b) && a != 0) ||
+         (c3n == u3ud(a) && b != 0) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/a/mul.c
+++ b/jets/a/mul.c
@@ -15,6 +15,9 @@
 
       return u3i_chubs(1, &c);
     }
+    else if ( 0 == a ) {
+      return 0;
+    }
     else {
       mpz_t a_mp, b_mp;
 
@@ -34,7 +37,7 @@
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
          (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
+         (c3n == u3ud(b) && a != 0) )
     {
       return u3m_bail(c3__exit);
     } else {
@@ -42,7 +45,7 @@
     }
   }
   u3_noun
-  u3ka_mul(u3_noun a, 
+  u3ka_mul(u3_noun a,
            u3_noun b)
   {
     u3_noun c = u3qa_mul(a, b);

--- a/jets/a/sub.c
+++ b/jets/a/sub.c
@@ -16,6 +16,9 @@
       }
       else return (a - b);
     }
+    else if ( 0 == b ) {
+      return u3k(a);
+    }
     else {
       mpz_t a_mp, b_mp;
 
@@ -41,8 +44,8 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
+         (c3n == u3ud(b)) ||
+         (c3n == u3ud(a) && b != 0) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/b/scag.c
+++ b/jets/b/scag.c
@@ -10,7 +10,10 @@
   u3qb_scag(u3_atom a,
             u3_noun b)
   {
-    if ( !_(u3a_is_cat(a)) ) {
+    if ( u3_nul == b ) {
+      return u3_nul;
+    }
+    else if ( !_(u3a_is_cat(a)) ) {
       return u3m_bail(c3__fail);
     }
     else {
@@ -39,7 +42,7 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) )
+         (c3n == u3ud(a) && u3_nul != b) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/b/slag.c
+++ b/jets/b/slag.c
@@ -9,7 +9,10 @@
   u3_noun
   u3qb_slag(u3_atom a, u3_noun b)
   {
-    if ( !_(u3a_is_cat(a)) ) {
+    if ( u3_nul == b ) {
+      return u3_nul;
+    }
+    else if ( !_(u3a_is_cat(a)) ) {
       return u3m_bail(c3__fail);
     }
     else {
@@ -31,7 +34,7 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) )
+         (c3n == u3ud(a) && u3_nul != b) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/c/met.c
+++ b/jets/c/met.c
@@ -10,10 +10,11 @@
   u3qc_met(u3_atom a,
            u3_atom b)
   {
-    if ( !_(u3a_is_cat(a)) || (a >= 32) ) {
-      if ( 0 == b ) {
-        return 0;
-      } else return 1;
+    if ( 0 == b ) {
+      return 0;
+    }
+    else if ( !_(u3a_is_cat(a)) || (a >= 32) ) {
+      return 1;
     }
     else {
       c3_w met_w = u3r_met(a, b);
@@ -30,8 +31,8 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
+         (c3n == u3ud(b)) ||
+         (c3n == u3ud(a) && 0 != b) )
     {
       return u3m_bail(c3__exit);
     } else {

--- a/jets/c/peg.c
+++ b/jets/c/peg.c
@@ -10,6 +10,10 @@
   u3qc_peg(u3_atom a,
            u3_atom b)
   {
+    if ( 1 == b ) {
+      return u3k(a);
+    }
+
     u3_atom c, d, e, f, g, h;
 
     c = u3r_met(0, b);
@@ -33,10 +37,10 @@
     u3_noun a, b;
 
     if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) ||
          (0 == a) ||
-         (0 == b) )
+         (0 == b) ||
+         (c3n == u3ud(b)) ||
+         (c3n == u3ud(a) && b != 1) )
     {
       return u3m_bail(c3__exit);
     } else {


### PR DESCRIPTION
Some of the core jets observably break Nock semantics by soft-failing on ill-typed samples that the compiled Nock lets through untouched. Because the discrepancies involve soft failures, they're observable via ++mink:

```
> =jet-fails  =/  kick  [9 2 0 1]
              =/  bad-jet
                |=  {gat/* sam/*}
                =.  +6.gat  sam
                =/  gut   gat(+2 [7 [0 1] +2.gat])
                !=((mack gat kick) (mack gut kick))
              =+  [a b]=[[[0 0] 0] [0 [0 0]]]
              |.
              =-  [(levy tests bad-jet) (lien tests bad-jet)]
              ^=  tests
              %-  ly
              :~  [add b]
                  [sub a]
                  [mul b]
                  [lth a]
                  [lth b]
                  [peg a(+ 1)]
                  [scag a]
                  [slag a]
                  [met a]
              ==
> (jet-fails)
[%.y %.y]
```

With this patch:

```
> (jet-fails)
[%.n %.n]
```