### PR TITLE
Prevent ++burn:ut jet from zeroing non-constants.

### DIFF
--- a/jets/f/ut_burn.c
+++ b/jets/f/ut_burn.c
@@ -58,7 +58,7 @@
     if ( c3n == u3du(sut) ) switch ( sut ) {
       default: return u3m_bail(c3__fail);
 
-      case c3__noun: return u3nc(u3_nul, 0);
+      case c3__noun: return 0;
       case c3__void: {
         return u3_nul;
       }
@@ -68,11 +68,7 @@
 
       case c3__atom: u3x_cell(u3t(sut), &p_sut, &q_sut);
       {
-        if ( c3y == u3du(q_sut) ) {
-          return u3nc(u3_nul, u3k(u3t(q_sut)));
-        } else {
-          return u3nc(u3_nul, 0);
-        }
+        return u3k(q_sut);
       }
       case c3__cell: u3x_cell(u3t(sut), &p_sut, &q_sut);
       {
@@ -148,17 +144,7 @@
   _cqfu_burn(u3_noun van,
              u3_noun sut)
   {
-    u3_noun unt = _burn_in(van, sut, u3_nul);
-
-    if ( u3_nul == unt ) {
-      return u3m_error("burn");
-    } 
-    else {
-      u3_noun ret = u3k(u3t(unt));
-
-      u3z(unt);
-      return ret;
-    }
+    return _burn_in(van, sut, u3_nul);
   }
 
   u3_noun

--- a/jets/f/ut_mint.c
+++ b/jets/f/ut_mint.c
@@ -98,7 +98,7 @@
   {
     if ( 0 == u3h(nug) ) {
       return u3k(u3t(nug));
-    } 
+    }
     else if ( 10 == u3h(nug) ) {
       return _mint_coke(u3t(u3t(nug)));
     }
@@ -239,10 +239,10 @@
     u3_noun von = u3i_molt(u3k(van), u3x_sam, u3k(sut), 0);
     u3_noun gat = u3j_hook(von, "emin");
 
-    return u3n_kick_on(u3i_molt(gat, 
-                                u3x_sam_2, 
-                                u3k(gol), 
-                                u3x_sam_6, 
+    return u3n_kick_on(u3i_molt(gat,
+                                u3x_sam_2,
+                                u3k(gol),
+                                u3x_sam_6,
                                 u3k(hyp),
                                 u3x_sam_7,
                                 u3k(rig),
@@ -333,8 +333,8 @@
     {
       if ( (c3n == _mint_vet(van))
            || ((c3y == u3du(gen)) &&
-               ((c3__zpfs == u3h(gen)) || 
-                (c3__lost == u3h(gen)) || 
+               ((c3__zpfs == u3h(gen)) ||
+                (c3__lost == u3h(gen)) ||
                 (c3__fail == u3h(gen)) ||
                 (c3__zpzp == u3h(gen)))) )
       {
@@ -501,11 +501,11 @@
         u3_noun nog = u3nc(c3__bunt, u3k(p_gen));
         u3_noun nef = _mint_in(van, sut, gol, nog);
         u3_noun viz = _mint_in(van, sut, c3__noun, q_gen);
-       
-        ret = u3nc(u3k(u3h(nef)), 
+
+        ret = u3nc(u3k(u3h(nef)),
                    u3nt(11, u3nc(1, u3nc(151, u3k(u3h(nef)))), u3k(u3t(viz))));
 
-        u3z(viz); 
+        u3z(viz);
         u3z(nef);
         u3z(nog);
         return ret;

--- a/jets/f/ut_mint.c
+++ b/jets/f/ut_mint.c
@@ -615,7 +615,12 @@
 
         {
           u3_noun cag = u3qfu_burn(van, sut);
-          u3_noun wim = u3n_nock_an(cag, u3k(q_nef));
+          u3_noun wim;
+          if ( 0 == cag ) {
+            wim = u3nc(2, 0);
+          } else {
+            wim = u3n_nock_an(u3k(u3t(cag)), u3k(q_nef));
+          }
 
           if ( 0 == u3h(wim) ) {
             fom = u3nc(1, u3k(u3t(wim)));


### PR DESCRIPTION
Fixes #663. Jet for urbit/arvo#238.