### PR TITLE
Use `U3_OS_LoomBits` To Set Reserved Memory Size

### DIFF
--- a/include/noun/allocate.h
+++ b/include/noun/allocate.h
@@ -23,7 +23,7 @@
   **/
     /* u3a_bits: number of bits in word-addressed pointer.  29 == 2GB.
     */
-#     define u3a_bits  29
+#     define u3a_bits  U3_OS_LoomBits
 
     /* u3a_page: number of bits in word-addressed page.  12 == 16Kbyte page.
     */


### PR DESCRIPTION
The size and starting position of Urbit's reserved memory block is set by `U3_OS_LoomBits` and `U3_OS_LoomBase` in `include/c/portable.h`.

`U3_OS_LoomBase` is referenced in `include/noun/allocate.h` and sets the position in memory of u3_Loom.  This is good.

However, `U3_OS_LoomBits` is not actually used to set the size of the reserved memory block.  Instead:

in `include/noun/allocate.h`,
 - `u3a_bits` is defined
 - `u3a_bits` → `u3a_bytes`
 
in `noun/manage.c`, 
 - `u3a_bytes` → `len_w` in `_cm_init()`
 - `len_w` sets the reserved memory block size

This proposal puts `U3_OS_LoomBits` back to work by defining `u3a_bits` with it.