### PR TITLE
removes obsolete history-eating bug-fix from _term_it_show_clear()

### DIFF
--- a/vere/term.c
+++ b/vere/term.c
@@ -572,7 +572,7 @@ _term_it_show_clear(u3_utty* uty_u)
 {
   if ( uty_u->tat_u.siz.col_l ) {
     _term_it_write_str(uty_u, "\r");
-    _term_it_write_txt(uty_u, uty_u->ufo_u.out.ed_y);
+    _term_it_write_txt(uty_u, uty_u->ufo_u.out.el_y);
 
     uty_u->tat_u.mir.len_w = 0;
     uty_u->tat_u.mir.cus_w = 0;

--- a/vere/term.c
+++ b/vere/term.c
@@ -570,26 +570,12 @@ _term_it_show_wide(u3_utty* uty_u, c3_w len_w, c3_w* txt_w)
 static void
 _term_it_show_clear(u3_utty* uty_u)
 {
-  u3_utat* tat_u = &uty_u->tat_u;
-
-  if ( tat_u->siz.col_l ) {
-    c3_w     ful_w = tat_u->mir.cus_w / tat_u->siz.col_l;
-
-    if ( 0 != tat_u->mir.cus_w &&
-         ful_w * tat_u->siz.col_l == tat_u->mir.cus_w )
-    {
-      ful_w--;
-    }
-
-    while ( ful_w-- ) {
-      _term_it_write_txt(uty_u, uty_u->ufo_u.out.cuu1_y);
-    }
-
+  if ( uty_u->tat_u.siz.col_l ) {
     _term_it_write_str(uty_u, "\r");
     _term_it_write_txt(uty_u, uty_u->ufo_u.out.ed_y);
 
-    tat_u->mir.len_w = 0;
-    tat_u->mir.cus_w = 0;
+    uty_u->tat_u.mir.len_w = 0;
+    uty_u->tat_u.mir.cus_w = 0;
   }
 }
 


### PR DESCRIPTION
I'm not sure of the exact details of the bug this code was fixing, but the buffer adjustments in `drum` (`++se-just`) definitely make it unnecessary. It's also the cause of the current issue blocking urbit/arvo#216.

Just thought I should throw it up here for clarity and easy testing. I don't know how or when you'd like to merge/release this.