### PR TITLE
Fix ++mull:ut's handling of $tune.

### DIFF
--- a/jets/f/ut_mull.c
+++ b/jets/f/ut_mull.c
@@ -570,11 +570,11 @@
         u3z(vat);
         return ret;
       }
-      
+
       case c3__tune: p_gen = u3t(gen);
       _mull_used();
       {
-        return u3nc(u3qf_face(p_gen, sut), u3qf_face(p_gen, sut));
+        return u3nc(u3qf_face(p_gen, sut), u3qf_face(p_gen, dox));
       }
 
       case c3__burn: p_gen = u3t(gen);


### PR DESCRIPTION
arvo's sys/hoon.hoon defines the $tune case as:

      {$tune *}
    [(face p.gen sut) (face p.gen dox)]

Fix the C jet so that it doesn't use sut on both spans.