### PR TITLE
removes the argument from the tap jet

### DIFF
--- a/include/jets/k.h
+++ b/include/jets/k.h
@@ -68,7 +68,7 @@
   /* u3kdi_tap(): map/set convert to list.  (solves by_tap also.)
   */
     u3_noun
-    u3kdi_tap(u3_noun a, u3_noun b);
+    u3kdi_tap(u3_noun a);
 
   /* u3kdi_put(): put in set.
   */
@@ -80,7 +80,7 @@
     u3_noun 
     u3kdi_uni(u3_noun a, u3_noun b);
 
-#   define u3kdb_tap(a, b) u3kdi_tap(a, b)
+#   define u3kdb_tap(a) u3kdi_tap(a)
 
 /* u3ke: tier 5 functions
 */

--- a/include/jets/q.h
+++ b/include/jets/q.h
@@ -88,7 +88,7 @@
     u3_noun u3qdi_int(u3_noun, u3_noun);
     u3_noun u3qdi_mer(u3_noun, u3_noun);
     u3_noun u3qdi_put(u3_noun, u3_noun);
-    u3_noun u3qdi_tap(u3_noun, u3_noun);
+    u3_noun u3qdi_tap(u3_noun);
     u3_noun u3qdi_uni(u3_noun, u3_noun);
     u3_noun u3qdi_wyt(u3_noun);
 

--- a/jets/d/in_tap.c
+++ b/jets/d/in_tap.c
@@ -27,31 +27,29 @@
   }
 
   u3_noun
-  u3qdi_tap(u3_noun a,
-            u3_noun b)
+  u3qdi_tap(u3_noun a)
   {
-    return _tap_in(a, u3k(b));
+    return _tap_in(a, u3_nul);
   }
   u3_noun
   u3wdi_tap(u3_noun cor)
   {
-    u3_noun a, b;
+    u3_noun a;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, 0) ) {
+    if ( c3n == u3r_mean(cor, u3x_con_sam, &a, 0) ) {
       return u3m_bail(c3__exit);
     } else {
-      return u3qdi_tap(a, b);
+      return u3qdi_tap(a);
     }
   }
   u3_noun
-  u3kdi_tap(u3_noun a,
-            u3_noun b)
+  u3kdi_tap(u3_noun a)
   {
-    u3_weak c = u3qdi_tap(a, b);
+    u3_weak b = u3qdi_tap(a);
 
-    u3z(a); u3z(b);
-    if ( u3_none == c ) {
+    u3z(a);
+    if ( u3_none == b ) {
       return u3m_bail(c3__exit);
     }
-    else return c;
+    else return b;
   }

--- a/jets/f/ut_burn.c
+++ b/jets/f/ut_burn.c
@@ -119,7 +119,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = _burn_fork(van, yed, gil);
 
         u3z(yed);

--- a/jets/f/ut_crop.c
+++ b/jets/f/ut_crop.c
@@ -152,7 +152,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = u3kf_fork(_crop_dext_fork(van, yed, ref, bix));
 
         u3z(yed);
@@ -202,7 +202,7 @@
       }
       case c3__fork: p_ref = u3t(ref);
       {
-        u3_noun yed = u3qdi_tap(p_ref, u3_nul);
+        u3_noun yed = u3qdi_tap(p_ref);
         u3_noun ret = _crop_sint_fork(van, sut, yed, bix);
 
         u3z(yed);

--- a/jets/f/ut_find.c
+++ b/jets/f/ut_find.c
@@ -385,7 +385,7 @@
                   u3_noun gil)
   {
     u3_noun p_sut = u3t(sut);
-    u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+    u3_noun yed = u3qdi_tap(p_sut);
     u3_noun wiz;
     u3_noun ret;
 

--- a/jets/f/ut_fish.c
+++ b/jets/f/ut_fish.c
@@ -101,7 +101,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = _fish_fork(van, yed, axe, vit);
 
         u3z(yed);

--- a/jets/f/ut_fuse.c
+++ b/jets/f/ut_fuse.c
@@ -134,7 +134,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = u3kf_fork(_fuse_in_fork(van, yed, ref, bix));
 
         u3z(yed);

--- a/jets/f/ut_nest.c
+++ b/jets/f/ut_nest.c
@@ -271,7 +271,7 @@
         }
 
         {
-          u3_noun dey = u3qdi_tap(p_sut, u3_nul);
+          u3_noun dey = u3qdi_tap(p_sut);
           u3_noun yed = dey;
 
           while ( u3_nul != yed ) {
@@ -418,7 +418,7 @@
         }
         case c3__fork: p_ref = u3t(ref);
         {
-          u3_noun dey = u3qdi_tap(p_ref, u3_nul);
+          u3_noun dey = u3qdi_tap(p_ref);
           u3_noun yed = dey;
 
           while ( u3_nul != yed ) {

--- a/jets/f/ut_peek.c
+++ b/jets/f/ut_peek.c
@@ -137,7 +137,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = u3kf_fork(_peek_fork(van, yed, way, axe, gil));
 
         u3z(yed);

--- a/jets/f/ut_rest.c
+++ b/jets/f/ut_rest.c
@@ -26,7 +26,7 @@
                 u3_noun gar)
   {
     u3_noun gun = u3qdi_gas(u3_nul, gar);
-    u3_noun yed = u3qdi_tap(gun, u3_nul);
+    u3_noun yed = u3qdi_tap(gun);
 
     u3z(gun);
     return yed;

--- a/jets/f/ut_wrap.c
+++ b/jets/f/ut_wrap.c
@@ -50,7 +50,7 @@
       }
       case c3__fork: p_sut = u3t(sut);
       {
-        u3_noun yed = u3qdi_tap(p_sut, u3_nul);
+        u3_noun yed = u3qdi_tap(p_sut);
         u3_noun ret = u3kf_fork(_wrap_fork(van, yed, yoz));
 
         u3z(yed);

--- a/vere/fuse.c
+++ b/vere/fuse.c
@@ -311,7 +311,7 @@ _inode_load(u3_fnod* nod_u)
         if ( u3_nul == u3h(ark) ) {
           nod_u->typ_e = u3_fuse_type_directory;
           nod_u->dir_u = _inode_fill_directory
-            (nod_u, u3qdb_tap(u3t(ark), u3_nul));
+            (nod_u, u3qdb_tap(u3t(ark)));
         }
         else {
           u3_noun dat;


### PR DESCRIPTION
... and indirects through a "rap" jet.

pairs with urbit/arvo#352

I have no problem with the first three commits here. I can add the new "rap" jet, replace all calls to `*_tap()` with `*_rap()`, and everything works without issue. Adding printfs confirms that the correct jet is being called at the right time. The problem comes with the last commit, when I try to remove the tap gate jet and replace it with a renamed rap loop jet. When I do that, I get an immediate core dump. Here's the backtrace:

```
(lldb) bt
* thread #1: tid = 0x0000, 0x00007fff9399ff06 libsystem_kernel.dylib`__pthread_kill + 10, stop reason = signal SIGSTOP
  * frame #0: 0x00007fff9399ff06 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff8da7a4ec libsystem_pthread.dylib`pthread_kill + 90
    frame #2: 0x00007fff9306d6df libsystem_c.dylib`abort + 129
    frame #3: 0x000000010621829e urbit`u3m_bail(how=1953069157) + 62 at manage.c:583
    frame #4: 0x00000001062254d4 urbit`u3x_at(axe=20, som=0) + 52 at xtract.c:25
    frame #5: 0x000000010622606d urbit`_cv_nock_wish(txt=1802465133) + 61 at vortex.c:14
    frame #6: 0x0000000106225f5f urbit`u3v_wish(str_c="mook") + 127 at vortex.c:188
    frame #7: 0x0000000106226948 urbit`u3v_do(txt_c="mook", sam=3221225611) + 24 at vortex.c:362
    frame #8: 0x000000010621a964 urbit`u3m_soft(sec_w=0, fun_f=(urbit`u3v_lite at vortex.c:66), arg=2147483787) + 1412 at manage.c:1171
    frame #9: 0x0000000106225aee urbit`u3v_boot_lite(lit=2147483787) + 30 at vortex.c:111
    frame #10: 0x0000000106278bd5 urbit`u3_pier_boot(pax_c="tmp-zod", sys_c="working-m.pill") + 85 at pier.c:1836
    frame #11: 0x000000010625dbc2 urbit`main(argc=9, argv=0x00007fff599fe208) + 770 at main.c:548
    frame #12: 0x00007fff980755ad libdyld.dylib`start + 1
    frame #13: 0x00007fff980755ad libdyld.dylib`start + 1
```

Is this as simple as replacing `ivory.c`? How is that file generated?
