### PR TITLE
Don't kill self with corrupt Lockfile

### DIFF
--- a/vere/unix.c
+++ b/vere/unix.c
@@ -1356,7 +1356,7 @@ u3_unix_acquire(c3_c* pax_c)
       kill(getpid(), SIGTERM);
       sleep(1); c3_assert(0);
     }
-    else {
+    else if (pid_w != getpid()) {
       c3_w i_w;
 
       if ( -1 != kill(pid_w, SIGTERM) ) {


### PR DESCRIPTION
When running in docker for example, urbit always runs as pid 1. If it crashes / is killed too hard, it will try to kill itself on the next start, not cleaning up after itself again, resulting in a bricked pier / restart loop.

Since normal behavior would be to kill the old process, and there cannot be another process if the process' own pid is in the lockfile (even though it's a faulty/unexpected occurence), this should be safe to do.