### PR TITLE
Added function noun/xtract.c:u3x_hext().

### DIFF
--- a/include/noun/xtract.h
+++ b/include/noun/xtract.h
@@ -117,3 +117,16 @@
                    u3_noun* d,
                    u3_noun* e,
                    u3_noun* f);
+
+      /* u3x_hext():
+      **
+      **   Divide `a` as a hextuple `[b c d e f g]`.
+      */
+        void
+        u3x_hext(u3_noun  a,
+                   u3_noun* b,
+                   u3_noun* c,
+                   u3_noun* d,
+                   u3_noun* e,
+                   u3_noun* f,
+                   u3_noun* g);

--- a/noun/xtract.c
+++ b/noun/xtract.c
@@ -88,3 +88,21 @@ u3x_quil(u3_noun  a,
   }
 }
 
+/* u3x_hext():
+**
+**   Divide `a` as a hextuple `[b c d e f g]`.
+*/
+void
+u3x_hext(u3_noun  a,
+           u3_noun* b,
+           u3_noun* c,
+           u3_noun* d,
+           u3_noun* e,
+           u3_noun* f,
+           u3_noun* g)
+{
+  if ( c3n == u3r_hext(a, b, c, d, e, f, g) ) {
+    u3m_bail(c3__exit);
+  }
+}
+


### PR DESCRIPTION
Wraps `noun/retrieve.c:u3r_hext()` like the others.

Obviously not used since it didn't exist but I'm using it for jet exploration.  Seems to work.

If you want this patch do you want it for `master` too?
