### PR TITLE
Remove hard-coded default HTTP request 'Accept: */*' header from cttp.c

### DIFF
--- a/vere/cttp.c
+++ b/vere/cttp.c
@@ -1509,7 +1509,7 @@ _cttp_ccon_fire(u3_ccon* coc_u, u3_creq* ceq_u)
   _cttp_ccon_fire_str(coc_u, ceq_u->url_c);
   _cttp_ccon_fire_str(coc_u, " HTTP/1.1\r\n");
   _cttp_ccon_fire_str(coc_u, "User-Agent: urbit/vere.0.2\r\n");
-  _cttp_ccon_fire_str(coc_u, "Accept: */*\r\n");
+  // _cttp_ccon_fire_str(coc_u, "Accept: */*\r\n");
   //  XX it's more painful than it's worth to deal with SSL+Keepalive
   if ( c3n == coc_u->sec ) {
     _cttp_ccon_fire_str(coc_u, "Connection: Keep-Alive\r\n");

--- a/vere/cttp.c
+++ b/vere/cttp.c
@@ -1509,7 +1509,6 @@ _cttp_ccon_fire(u3_ccon* coc_u, u3_creq* ceq_u)
   _cttp_ccon_fire_str(coc_u, ceq_u->url_c);
   _cttp_ccon_fire_str(coc_u, " HTTP/1.1\r\n");
   _cttp_ccon_fire_str(coc_u, "User-Agent: urbit/vere.0.2\r\n");
-  // _cttp_ccon_fire_str(coc_u, "Accept: */*\r\n");
   //  XX it's more painful than it's worth to deal with SSL+Keepalive
   if ( c3n == coc_u->sec ) {
     _cttp_ccon_fire_str(coc_u, "Connection: Keep-Alive\r\n");


### PR DESCRIPTION
This is a solution to urbit/arvo#442, thanks to @joemfb for doing the digging. Just a single line deleted.

This should be safe because HTTP requests require only `Host` according to [this source](https://serverfault.com/questions/163511/what-is-the-mandatory-information-a-http-request-header-must-contain) and [HTTP 1.1 - RFC 2616](http://tools.ietf.org/html/rfc2616). Additionally: 
> Content-Length or Transfer-Encoding are only mandatory if an entity is delivered with the request or response, and in many cases a request or response will lack an entity (like a GET request, or a 302 response).

Thus, we are in the clear for removing a default `Accept` header. @belisarius222 suggested that we might want to add one at the Hoon level.