### PR TITLE
Process one event at a time

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1104,7 +1104,12 @@
         void
         u3_raft_init(void);
 
-      /* u3_raft_work(): poke, kick, and push pending events.
+      /* u3_raft_play(): synchronously poke, kick, and push pending events.
+      */
+        void
+        u3_raft_play(void);
+
+      /* u3_raft_work(): asynchronously poke, kick, and push pending events.
       */
         void
         u3_raft_work(void);

--- a/vere/loop.c
+++ b/vere/loop.c
@@ -442,6 +442,7 @@ u3_lo_shut(c3_o inn)
   if ( c3n == u3_Host.liv ) {
     //  direct save and die
     //
+    u3_raft_play();
     // u3_lo_grab("lo_exit", u3_none);
     // u3_loom_save(u3A->ent_d);
     // u3_loom_exit();

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1476,7 +1476,7 @@ _raft_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 
 /* _raft_lame(): handle an application failure.
 */
-static u3_weak
+static u3_noun
 _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
 {
   u3_noun bov, gon;
@@ -1551,7 +1551,7 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
 
 /* _raft_punk(): insert and apply an input ovum (unprotected).
 */
-static u3_weak
+static u3_noun
 _raft_punk(u3_noun ovo)
 {
 #ifdef GHETTO
@@ -1631,7 +1631,8 @@ _raft_punk(u3_noun ovo)
   //  free(txt_c);
 }
 
-
+/* _raft_push(): save an event
+*/
 static c3_d
 _raft_push(u3_raft* raf_u, c3_w* bob_w, c3_w len_w)
 {
@@ -1947,6 +1948,26 @@ _raft_crop(void)
   }
 }
 
+/* _raft_pop_roe(): pop the next [(list effects) event] pair of the queue
+*/
+static u3_weak
+_raft_pop_roe(void)
+{
+  if ( u3_nul == u3A->roe ) {
+    return u3_none;
+  }
+
+  u3_noun ovo;
+
+  {
+    u3_noun ova = u3kb_flop(u3A->roe);
+    u3A->roe    = u3qb_flop(u3t(ova));
+    ovo         = u3k(u3h(ova));
+    u3z(ova);
+  }
+
+  return ovo;
+}
 
 /* _raft_poke(): Poke pending events, leaving the poked events
  * and errors on u3A->roe.
@@ -1954,41 +1975,44 @@ _raft_crop(void)
 static void
 _raft_poke(void)
 {
-  u3_noun ova, nex;
-
   if ( 0 == u3Z->lug_u.len_d ) {
     return;
   }
-  ova = u3kb_flop(u3A->roe);
-  u3A->roe = u3_nul;
 
-  u3_noun hed = (u3_nul == ova) ? u3_nul : u3h(ova);
+  c3_o bee_o  = c3n;
+  u3_noun oer = u3_nul;
+  u3_weak rus;
 
-  if ( u3_nul != hed ) {
-    u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3k(hed)), u3_nul));
-  }
+  while ( u3_none != (rus = _raft_pop_roe()) ) {
+    u3_noun ovo, vir, sur;
 
-  while ( u3_nul != ova ) {
-    u3_noun sur = _raft_punk(u3k(u3t(u3h(ova))));
-    if ( u3_nul != sur) {
-      u3A->roe = u3nc(sur, u3A->roe);
+    if ( c3n == bee_o ) {
+      u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3k(rus)), u3_nul));
+      bee_o = c3y;
     }
-    c3_assert(u3_nul == u3h(u3h(ova)));
 
-    nex = u3k(u3t(ova));
-    u3z(ova); ova = nex;
+    u3x_cell(rus, &vir, &ovo);
+    c3_assert( u3_nul == vir );
+
+    sur = _raft_punk(u3k(ovo));
+    u3z(rus);
+
+    if ( u3_nul != sur) {
+      oer = u3nc(sur, oer);
+    }
   }
 
-  if ( u3_nul != hed ) {
+  u3A->roe = oer;
+
+  if ( c3y == bee_o ) {
     u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3_nul), u3_nul));
   }
 }
 
-
 /* _raft_pump(): Cartify, jam, and save an ovum, then perform its effects.
 */
 static void
-_raft_pump(ovo, vir)
+_raft_pump(u3_noun ovo, u3_noun vir)
 {
   u3v_cart*     egg_u = u3a_malloc(sizeof(*egg_u));
   u3p(u3v_cart) egg_p = u3of(u3v_cart, egg_u);
@@ -2029,7 +2053,6 @@ _raft_pump(ovo, vir)
   egg_u->vir = 0;
 }
 
-
 /* u3_raft_work(): work.
 */
 void
@@ -2055,25 +2078,18 @@ u3_raft_work(void)
     //  Cartify, jam, and encrypt this batch of events. Take a number, Raft will
     //  be with you shortly.
     {
-      u3_noun ova;
-      u3_noun ovo;
-      u3_noun vir;
-      u3_noun nex;
+      u3_weak rus;
 
-      ova = u3kb_flop(u3A->roe);
-      u3A->roe = u3_nul;
-
-      while ( u3_nul != ova ) {
-        ovo = u3k(u3t(u3h(ova)));
-        vir = u3k(u3h(u3h(ova)));
-        nex = u3k(u3t(ova));
-        u3z(ova); ova = nex;
+      while ( u3_none != (rus = _raft_pop_roe()) ) {
+        u3_noun ovo, vir;
+        u3x_cell(rus, &vir, &ovo);
 
         if ( u3_nul != ovo ) {
-          _raft_pump(ovo, vir);
-
-          _raft_grab(ova);
+          _raft_pump(u3k(ovo), u3k(vir));
+          _raft_grab(u3A->roe);
         }
+
+        u3z(rus);
       }
     }
   }

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1922,6 +1922,69 @@ _raft_grab(u3_noun ova)
 
 int FOO;
 
+/* _raft_crop(): Delete finished events.
+*/
+static void
+_raft_crop(void)
+{
+  while ( u3A->ova.egg_p ) {
+    u3p(u3v_cart) egg_p = u3A->ova.egg_p;
+    u3v_cart*     egg_u = u3to(u3v_cart, u3A->ova.egg_p);
+
+    if ( c3y == egg_u->did ) {
+      if ( egg_p == u3A->ova.geg_p ) {
+        c3_assert(egg_u->nex_p == 0);
+        u3A->ova.geg_p = u3A->ova.egg_p = 0;
+      }
+      else {
+        c3_assert(egg_u->nex_p != 0);
+        u3A->ova.egg_p = egg_u->nex_p;
+      }
+      egg_u->cit = c3y;
+      u3a_free(egg_u);
+    }
+    else break;
+  }
+}
+
+
+/* _raft_poke(): Poke pending events, leaving the poked events
+ * and errors on u3A->roe.
+*/
+static void
+_raft_poke(void)
+{
+  u3_noun ova, nex;
+
+  if ( 0 == u3Z->lug_u.len_d ) {
+    return;
+  }
+  ova = u3kb_flop(u3A->roe);
+  u3A->roe = u3_nul;
+
+  u3_noun hed = (u3_nul == ova) ? u3_nul : u3h(ova);
+
+  if ( u3_nul != hed ) {
+    u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3k(hed)), u3_nul));
+  }
+
+  while ( u3_nul != ova ) {
+    u3_noun sur = _raft_punk(u3k(u3t(u3h(ova))));
+    if ( u3_nul != sur) {
+      u3A->roe = u3nc(sur, u3A->roe);
+    }
+    c3_assert(u3_nul == u3h(u3h(ova)));
+
+    nex = u3k(u3t(ova));
+    u3z(ova); ova = nex;
+  }
+
+  if ( u3_nul != hed ) {
+    u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3_nul), u3_nul));
+  }
+}
+
+
 /* u3_raft_work(): work.
 */
 void
@@ -1936,63 +1999,13 @@ u3_raft_work(void)
     }
   }
   else {
-    u3_noun  ova;
-    u3_noun  vir;
-    u3_noun  nex;
-
     //  Delete finished events.
     //
-    while ( u3A->ova.egg_p ) {
-      u3p(u3v_cart) egg_p = u3A->ova.egg_p;
-      u3v_cart*     egg_u = u3to(u3v_cart, u3A->ova.egg_p);
-
-      if ( c3y == egg_u->did ) {
-        vir = egg_u->vir;
-
-        if ( egg_p == u3A->ova.geg_p ) {
-          c3_assert(egg_u->nex_p == 0);
-          u3A->ova.geg_p = u3A->ova.egg_p = 0;
-        }
-        else {
-          c3_assert(egg_u->nex_p != 0);
-          u3A->ova.egg_p = egg_u->nex_p;
-        }
-        egg_u->cit = c3y;
-        u3a_free(egg_u);
-      }
-      else break;
-    }
+    _raft_crop();
 
     //  Poke pending events, leaving the poked events and errors on u3A->roe.
     //
-    {
-      if ( 0 == u3Z->lug_u.len_d ) {
-        return;
-      }
-      ova = u3kb_flop(u3A->roe);
-      u3A->roe = u3_nul;
-
-      u3_noun hed = (u3_nul == ova) ? u3_nul : u3h(ova);
-
-      if ( u3_nul != hed ) {
-        u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3k(hed)), u3_nul));
-      }
-
-      while ( u3_nul != ova ) {
-        u3_noun sur = _raft_punk(u3k(u3t(u3h(ova))));
-        if ( u3_nul != sur) {
-          u3A->roe = u3nc(sur, u3A->roe);
-        }
-        c3_assert(u3_nul == u3h(u3h(ova)));
-
-        nex = u3k(u3t(ova));
-        u3z(ova); ova = nex;
-      }
-
-      if ( u3_nul != hed ) {
-        u3_term_ef_blit(0, u3nc(u3nc(c3__bee, u3_nul), u3_nul));
-      }
-    }
+    _raft_poke();
 
     //  Cartify, jam, and encrypt this batch of events. Take a number, Raft will
     //  be with you shortly.
@@ -2000,8 +2013,11 @@ u3_raft_work(void)
       c3_d    bid_d;
       c3_w    len_w;
       c3_w*   bob_w;
-      u3_noun ron;
+      u3_noun ova;
       u3_noun ovo;
+      u3_noun vir;
+      u3_noun nex;
+      u3_noun ron;
 
       ova = u3kb_flop(u3A->roe);
       u3A->roe = u3_nul;

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1985,6 +1985,51 @@ _raft_poke(void)
 }
 
 
+/* _raft_pump(): Cartify, jam, and save an ovum, then perform its effects.
+*/
+static void
+_raft_pump(ovo, vir)
+{
+  u3v_cart*     egg_u = u3a_malloc(sizeof(*egg_u));
+  u3p(u3v_cart) egg_p = u3of(u3v_cart, egg_u);
+  u3_noun       ron;
+  c3_d          bid_d;
+  c3_w          len_w;
+  c3_w*         bob_w;
+
+  egg_u->nex_p = 0;
+  egg_u->cit = c3n;
+  egg_u->did = c3n;
+  egg_u->vir = vir;
+
+  ron = u3ke_jam(u3nc(u3k(u3A->now), ovo));
+  c3_assert(u3A->key);
+  // don't encrypt for the moment, bootstrapping
+  // ron = u3dc("en:crua", u3k(u3A->key), ron);
+
+  len_w = u3r_met(5, ron);
+  bob_w = c3_malloc(len_w * 4L);
+  u3r_words(0, len_w, bob_w, ron);
+  u3z(ron);
+
+  bid_d = _raft_push(u3Z, bob_w, len_w);
+  egg_u->ent_d = bid_d;
+
+  if ( 0 == u3A->ova.geg_p ) {
+    c3_assert(0 == u3A->ova.egg_p);
+    u3A->ova.geg_p = u3A->ova.egg_p = egg_p;
+  }
+  else {
+    c3_assert(0 == u3to(u3v_cart, u3A->ova.geg_p)->nex_p);
+    u3to(u3v_cart, u3A->ova.geg_p)->nex_p = egg_p;
+    u3A->ova.geg_p = egg_p;
+  }
+  _raft_kick_all(vir);
+  egg_u->did = c3y;
+  egg_u->vir = 0;
+}
+
+
 /* u3_raft_work(): work.
 */
 void
@@ -2010,14 +2055,10 @@ u3_raft_work(void)
     //  Cartify, jam, and encrypt this batch of events. Take a number, Raft will
     //  be with you shortly.
     {
-      c3_d    bid_d;
-      c3_w    len_w;
-      c3_w*   bob_w;
       u3_noun ova;
       u3_noun ovo;
       u3_noun vir;
       u3_noun nex;
-      u3_noun ron;
 
       ova = u3kb_flop(u3A->roe);
       u3A->roe = u3_nul;
@@ -2029,39 +2070,7 @@ u3_raft_work(void)
         u3z(ova); ova = nex;
 
         if ( u3_nul != ovo ) {
-          u3v_cart*     egg_u = u3a_malloc(sizeof(*egg_u));
-          u3p(u3v_cart) egg_p = u3of(u3v_cart, egg_u);
-
-          egg_u->nex_p = 0;
-          egg_u->cit = c3n;
-          egg_u->did = c3n;
-          egg_u->vir = vir;
-
-          ron = u3ke_jam(u3nc(u3k(u3A->now), ovo));
-          c3_assert(u3A->key);
-          // don't encrypt for the moment, bootstrapping
-          // ron = u3dc("en:crua", u3k(u3A->key), ron);
-
-          len_w = u3r_met(5, ron);
-          bob_w = c3_malloc(len_w * 4L);
-          u3r_words(0, len_w, bob_w, ron);
-          u3z(ron);
-
-          bid_d = _raft_push(u3Z, bob_w, len_w);
-          egg_u->ent_d = bid_d;
-
-          if ( 0 == u3A->ova.geg_p ) {
-            c3_assert(0 == u3A->ova.egg_p);
-            u3A->ova.geg_p = u3A->ova.egg_p = egg_p;
-          }
-          else {
-            c3_assert(0 == u3to(u3v_cart, u3A->ova.geg_p)->nex_p);
-            u3to(u3v_cart, u3A->ova.geg_p)->nex_p = egg_p;
-            u3A->ova.geg_p = egg_p;
-          }
-          _raft_kick_all(vir);
-          egg_u->did = c3y;
-          egg_u->vir = 0;
+          _raft_pump(ovo, vir);
 
           _raft_grab(ova);
         }

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -2070,26 +2070,38 @@ u3_raft_chip(void)
   }
 }
 
-/* u3_raft_work(): work, either synchronously or asynchronously.
+/* u3_raft_play(): synchronously process events.
+*/
+void
+u3_raft_play(void)
+{
+  c3_assert( u3Z->typ_e == u3_raty_lead );
+
+  u3_raft_chip();
+
+  if ( u3_nul != u3A->roe ) {
+    u3_raft_play();
+  }
+}
+
+/* _raft_work_cb(): callback to recurse into u3_raft_work().
+*/
+static void
+_raft_work_cb(uv_timer_t* tim_u)
+{
+  u3_raft_work();
+}
+
+/* u3_raft_work(): asynchronously process events.
 */
 void
 u3_raft_work(void)
 {
-  if ( u3Z->typ_e != u3_raty_lead ) {
-    c3_assert(u3A->ova.egg_p == 0);
-    if ( u3_nul != u3A->roe ) {
-      uL(fprintf(uH, "raft: dropping roe!!\n"));
-      u3z(u3A->roe);
-      u3A->roe = u3_nul;
-    }
-  }
-  else {
+  c3_assert( u3Z->typ_e == u3_raty_lead );
 
-    //  Cartify, jam, and encrypt this batch of events.
-    //  Take a number, Raft will be with you shortly.
-    //
-    while ( u3_nul != u3A->roe ) {
-      u3_raft_chip();
-    }
+  u3_raft_chip();
+
+  if ( u3_nul != u3A->roe ) {
+    uv_timer_start(&u3Z->tim_u, _raft_work_cb, 0, 0);
   }
 }

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1445,17 +1445,19 @@ u3_raft_init()
 
 /* _raft_sure(): apply and save an input ovum and its result.
 */
-static void
+static u3_noun
 _raft_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 {
   //  Whatever worked, save it.  (XX - should be concurrent with execute.)
   //  We'd like more events that don't change the state but need work here.
   {
+    u3_noun ret;
+
     u3r_mug(cor);
     u3r_mug(u3A->roc);
 
     if ( c3n == u3r_sing(cor, u3A->roc) ) {
-      u3A->roe = u3nc(u3nc(vir, ovo), u3A->roe);
+      ret = u3nc(vir, ovo);
 
       u3z(u3A->roc);
       u3A->roc = cor;
@@ -1464,19 +1466,21 @@ _raft_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
       u3z(ovo);
 
       // push a new event into queue
-      u3A->roe = u3nc(u3nc(vir, u3_nul), u3A->roe);
+      ret = u3nc(vir, u3_nul);
 
       u3z(cor);
     }
+    return ret;
   }
 }
 
 /* _raft_lame(): handle an application failure.
 */
-static void
+static u3_weak
 _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
 {
   u3_noun bov, gon;
+  u3_noun ret;
 
 #if 0
   {
@@ -1509,10 +1513,12 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
   gon = u3m_soft(0, u3v_poke, u3k(bov));
 
   if ( u3_blip == u3h(gon) ) {
-    _raft_sure(bov, u3k(u3h(u3t(gon))), u3k(u3t(u3t(gon))));
+    ret = _raft_sure(bov, u3k(u3h(u3t(gon))), u3k(u3t(u3t(gon))));
 
     u3z(tan);
     u3z(gon);
+
+    return ret;
   }
   else {
     u3z(gon);
@@ -1522,9 +1528,11 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
       u3_noun nog = u3m_soft(0, u3v_poke, u3k(vab));
 
       if ( u3_blip == u3h(nog) ) {
-        _raft_sure(vab, u3k(u3h(u3t(nog))), u3k(u3t(u3t(nog))));
+        ret = _raft_sure(vab, u3k(u3h(u3t(nog))), u3k(u3t(u3t(nog))));
         u3z(tan);
         u3z(nog);
+
+        return ret;
       }
       else {
         u3z(nog);
@@ -1534,6 +1542,8 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
         u3_lo_punt(2, u3kb_flop(u3k(tan)));
         uL(fprintf(uH, "crude: punted\n"));
         // c3_assert(!"crud");
+
+        return u3_nul;
       }
     }
   }
@@ -1541,7 +1551,7 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
 
 /* _raft_punk(): insert and apply an input ovum (unprotected).
 */
-static void
+static u3_weak
 _raft_punk(u3_noun ovo)
 {
 #ifdef GHETTO
@@ -1592,7 +1602,7 @@ _raft_punk(u3_noun ovo)
     u3_noun tan = u3k(u3t(gon));
 
     u3z(gon);
-    _raft_lame(ovo, why, tan);
+    return _raft_lame(ovo, why, tan);
   }
   else {
     u3_noun vir = u3k(u3h(u3t(gon)));
@@ -1607,14 +1617,14 @@ _raft_punk(u3_noun ovo)
       u3_noun tan = u3k(u3t(nug));
 
       u3z(nug);
-      _raft_lame(ovo, why, tan);
+      return _raft_lame(ovo, why, tan);
     }
     else {
       vir = u3k(u3h(u3t(nug)));
       cor = u3k(u3t(u3t(nug)));
 
       u3z(nug);
-      _raft_sure(ovo, vir, cor);
+      return _raft_sure(ovo, vir, cor);
     }
   }
   //  uL(fprintf(uH, "punk oot %s\n", txt_c));
@@ -1969,7 +1979,10 @@ u3_raft_work(void)
       }
 
       while ( u3_nul != ova ) {
-        _raft_punk(u3k(u3t(u3h(ova))));
+        u3_noun sur = _raft_punk(u3k(u3t(u3h(ova))));
+        if ( u3_nul != sur) {
+          u3A->roe = u3nc(sur, u3A->roe);
+        }
         c3_assert(u3_nul == u3h(u3h(ova)));
 
         nex = u3k(u3t(ova));

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1952,7 +1952,10 @@ _raft_crop(void)
   }
 }
 
-/* _raft_pop_roe(): pop the next [(list effects) event] pair of the queue
+/* _raft_pop_roe(): pop the next [~ event] off the queue.
+**
+**  effects are no longer stored on u3A->roe; the head of
+**  each pair is always null.
 */
 static u3_weak
 _raft_pop_roe(void)
@@ -1973,17 +1976,16 @@ _raft_pop_roe(void)
   return ovo;
 }
 
-/* _raft_poke(): Peel one ovum off u3A->roe and poke Arvo with it.
+/* _raft_poke(): poke Arvo with the next queued event.
 */
 static u3_weak
 _raft_poke(void)
 {
   u3_weak rus;
 
-  //  XX what is this condition?
+  //  defer event processing until storage is initialized
   //
   if ( 0 == u3Z->lug_u.len_d ) {
-    fprintf(stderr, "_raft_poke ret early\r\n");
     return u3_none;
   }
 

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1622,35 +1622,6 @@ _raft_punk(u3_noun ovo)
 }
 
 
-static void
-_raft_comm(c3_d bid_d)
-{
-  u3p(u3v_cart) egg_p;
-
-  u3_lo_open();
-
-  egg_p = u3A->ova.egg_p;
-  while ( egg_p ) {
-    u3v_cart* egg_u = u3to(u3v_cart, egg_p);
-
-    if ( egg_u->ent_d <= bid_d ) {
-      egg_u->cit = c3y;
-    } else break;
-
-    egg_p = egg_u->nex_p;
-  }
-  u3_lo_shut(c3y);
-}
-
-static void
-_raft_comm_cb(uv_timer_t* tim_u)
-{
-  u3_raft* raf_u = tim_u->data;
-
-  _raft_comm(raf_u->ent_d);
-}
-
-
 static c3_d
 _raft_push(u3_raft* raf_u, c3_w* bob_w, c3_w len_w)
 {
@@ -1664,8 +1635,17 @@ _raft_push(u3_raft* raf_u, c3_w* bob_w, c3_w len_w)
     u3t_event_trace("Recording", 'e');
     raf_u->lat_w = raf_u->tem_w;  //  XX
 
-    if ( !uv_is_active((uv_handle_t*)&raf_u->tim_u) ) {
-      uv_timer_start(&raf_u->tim_u, _raft_comm_cb, 0, 0);
+    u3p(u3v_cart) egg_p;
+
+    egg_p = u3A->ova.egg_p;
+    while ( egg_p ) {
+      u3v_cart* egg_u = u3to(u3v_cart, egg_p);
+
+      if ( egg_u->ent_d <= raf_u->ent_d ) {
+        egg_u->cit = c3y;
+      } else break;
+
+      egg_p = egg_u->nex_p;
     }
 
     return raf_u->ent_d;

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1456,6 +1456,9 @@ _raft_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
     u3r_mug(cor);
     u3r_mug(u3A->roc);
 
+    //  XX review this, and confirm it's actually an optimization
+    //  Seems like it could be very expensive in some cases
+    //
     if ( c3n == u3r_sing(cor, u3A->roc) ) {
       ret = u3nc(vir, ovo);
 
@@ -1465,7 +1468,8 @@ _raft_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
     else {
       u3z(ovo);
 
-      // push a new event into queue
+      //  we return ~ in place of the event ovum to skip persistence
+      //
       ret = u3nc(vir, u3_nul);
 
       u3z(cor);
@@ -1669,10 +1673,10 @@ _raft_push(u3_raft* raf_u, c3_w* bob_w, c3_w len_w)
 }
 
 
-/* _raft_kick_all(): kick a list of events, transferring.
+/* _raft_kick(): kick a list of effects, transferring.
 */
 static void
-_raft_kick_all(u3_noun vir)
+_raft_kick(u3_noun vir)
 {
   while ( u3_nul != vir ) {
     u3_noun ovo = u3k(u3h(vir));
@@ -2001,10 +2005,10 @@ _raft_poke(void)
   return rus;
 }
 
-/* _raft_pump(): Cartify, jam, and save an ovum, then perform its effects.
+/* _raft_pump(): Cartify, jam, and save an ovum.
 */
 static void
-_raft_pump(u3_noun ovo, u3_noun vir)
+_raft_pump(u3_noun ovo)
 {
   u3v_cart*     egg_u = u3a_malloc(sizeof(*egg_u));
   u3p(u3v_cart) egg_p = u3of(u3v_cart, egg_u);
@@ -2016,7 +2020,7 @@ _raft_pump(u3_noun ovo, u3_noun vir)
   egg_u->nex_p = 0;
   egg_u->cit = c3n;
   egg_u->did = c3n;
-  egg_u->vir = vir;
+  egg_u->vir = 0;
 
   ron = u3ke_jam(u3nc(u3k(u3A->now), ovo));
   c3_assert(u3A->key);
@@ -2040,9 +2044,8 @@ _raft_pump(u3_noun ovo, u3_noun vir)
     u3to(u3v_cart, u3A->ova.geg_p)->nex_p = egg_p;
     u3A->ova.geg_p = egg_p;
   }
-  _raft_kick_all(vir);
+
   egg_u->did = c3y;
-  egg_u->vir = 0;
 }
 
 /* u3_raft_chip(): chip one event off for processing.
@@ -2059,12 +2062,11 @@ u3_raft_chip(void)
     u3x_cell(rus, &vir, &ovo);
 
     if ( u3_nul != ovo ) {
-      _raft_pump(u3k(ovo), u3k(vir));
-
-      //  XX should be vir
-      //
-      _raft_grab(u3A->roe);
+      _raft_pump(u3k(ovo));
     }
+
+    _raft_kick(u3k(vir));
+    _raft_grab(vir);
 
     u3z(rus);
   }

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -595,7 +595,8 @@ _sist_zest()
   }
 
   //  Work through the boot events.
-  u3_raft_work();
+  //
+  u3_raft_play();
 }
 
 /* _sist_rest_nuu(): upgrade log from previous format.
@@ -1223,8 +1224,9 @@ u3_sist_boot(void)
       u3C.wag_w |= u3o_hashless;
     }
 
-    // process pending events
-    u3_raft_work();
+    //  process pending events
+    //
+    u3_raft_play();
   }
   else {
     u3_noun pig, who;


### PR DESCRIPTION
Augmented the code that processed all the outstanding Urbit events at once with new logic that processes a single event at a time, then schedules the next Urbit event to be processed in a later libuv event.

During normal runtime the events are processed asynchronously one at a time. On boot and shutdown, all events are processed synchronously.

I had originally written this using libuv's "idler" pattern, but that caused pathological changes to the control flow in libuv's event loop and 100% CPU usage, so I abandoned that approach. Instead, I repurposed the timer in the u3Z raft struct to trigger the processing of the next event.

Initial unscientific testing suggests this might feel slightly more responsive in the dojo; certainly pasted text starts appearing much faster. We should test the web publishing performance before merging. Also note that there used to be a garbage collection pass after each event was processed. That's no longer called, since I wasn't entirely sure where it should be called with this new code.