### PR TITLE
Enforce -F / -N network options in Ames

### DIFF
--- a/vere/ames.c
+++ b/vere/ames.c
@@ -210,6 +210,10 @@ u3_ames_ef_send(u3_noun lan, u3_noun pac)
 
     u3r_bytes(0, len_w, buf_y, pac);
 
+    if ( c3n == u3_Host.ops_u.net && 0x7f000001 != pip_w) {
+      return;  //  remote sending disabled
+    }
+
     if ( 0 == pip_w ) {
       pip_w = 0x7f000001;
       por_s = u3_Host.sam_u.por_s;
@@ -349,7 +353,9 @@ u3_ames_io_init()
 
     memset(&add_u, 0, sizeof(add_u));
     add_u.sin_family = AF_INET;
-    add_u.sin_addr.s_addr = htonl(INADDR_ANY);
+    add_u.sin_addr.s_addr = _(u3_Host.ops_u.net) ?
+                              htonl(INADDR_ANY) :
+                              htonl(INADDR_LOOPBACK);
     add_u.sin_port = htons(por_s);
 
     int ret;


### PR DESCRIPTION
Prevent Ames from sending and receiving remote packets if networking is disabled.