### PR TITLE
Runtime overflows

### DIFF
--- a/include/noun/allocate.h
+++ b/include/noun/allocate.h
@@ -291,6 +291,22 @@
           void*
           u3a_wealloc(void* lag_v, c3_w len_w);
 
+        /* u3a_push(): allocate space on the road stack
+        */
+          void*
+          u3a_push(c3_w len_w);
+
+        /* u3a_pop(): deallocate space on the road stack
+        */
+          void
+          u3a_pop(c3_w len_w);
+
+        /* u3a_peek(): examine the top of the road stack
+        */
+          void*
+          u3a_peek(c3_w len_w);
+
+
       /* C-style aligned allocation - *not* compatible with above.
       */
         /* u3a_malloc(): aligned storage measured in bytes.

--- a/jets/e/jam.c
+++ b/jets/e/jam.c
@@ -3,32 +3,19 @@
 */
 #include "all.h"
 
-
 /* functions
 */
-  static u3_noun
-  _jam_in(u3p(u3h_root) har_p, u3_atom, u3_atom, u3_noun);
 
   static u3_noun
-  _jam_in_pair(u3p(u3h_root) har_p,
-               u3_atom       h_a,
-               u3_atom       t_a,
-               u3_atom       b,
-               u3_noun       l)
+  _jam_pair(u3_noun x, u3_noun d, u3_noun e)
   {
-    u3_noun w = u3nc(u3nc(2, 1), u3k(l));
-    u3_noun x = u3qa_add(2, b);
-    u3_noun d = _jam_in(har_p, h_a, x, w);
-    u3_noun p_d, q_d, r_d;
-    u3_noun r;
-
-    u3r_trel(d, &p_d, &q_d, &r_d);
+    u3_noun r, p_d, q_d, r_d;
+    u3x_trel(d, &p_d, &q_d, &r_d);
     {
       u3_noun y = u3qa_add(x, p_d);
-      u3_noun e = _jam_in(har_p, t_a, y, q_d);
       u3_noun p_e, q_e, r_e;
 
-      u3r_trel(e, &p_e, &q_e, &r_e);
+      u3x_trel(e, &p_e, &q_e, &r_e);
       {
         u3_noun z = u3qa_add(p_d, p_e);
 
@@ -36,20 +23,16 @@
 
         u3z(z);
       }
-      u3z(e);
       u3z(y);
     }
-    u3z(d);
     u3z(x);
-    u3z(w);
-
+    u3z(d);
+    u3z(e);
     return r;
   }
 
   static u3_noun
-  _jam_in_flat(u3p(u3h_root) har_p,
-               u3_atom       a,
-               u3_noun       l)
+  _jam_flat(u3_atom a, u3_noun l)
   {
     u3_noun d = u3qe_mat(a);
     u3_noun x = u3qa_add(1, u3h(d));
@@ -62,9 +45,7 @@
   }
 
   static u3_noun
-  _jam_in_ptr(u3p(u3h_root) har_p,
-              u3_atom       u_c,
-              u3_noun       l)
+  _jam_ptr(u3_atom u_c, u3_noun l)
   {
     u3_noun d = u3qe_mat(u_c);
     u3_atom x = u3qc_lsh(0, 2, u3t(d));
@@ -78,45 +59,97 @@
     return z;
   }
 
-  static u3_noun
-  _jam_in(u3p(u3h_root) har_p,
-          u3_noun       a,
-          u3_atom       b,
-          u3_noun       l)
+  typedef struct {
+    u3_noun  a;
+    u3_noun  b;
+    u3_noun  l;
+    u3_noun* r;
+    u3_noun hed;
+    u3_noun tel;
+  } jamframe;
+
+  static inline void
+  _jam_push(u3_noun a, u3_noun b, u3_noun l, u3_noun *r)
   {
-    u3_noun c = u3h_get(har_p, a);
-    u3_noun x;
+    jamframe* fam = u3a_push(sizeof(jamframe));
+    fam->a   = a;
+    fam->b   = b;
+    fam->l   = l;
+    fam->r   = r;
+    fam->hed = u3_none;
+    fam->tel = u3_none;
+  }
 
-    if ( u3_none == c ) {
-        u3h_put(har_p, a, u3k(b));
+  static inline void
+  _jam_pop()
+  {
+    u3a_pop(sizeof(jamframe));
+  }
 
-      if ( c3y == u3ud(a) ) {
-        x = _jam_in_flat(har_p, a, l);
-      } else {
-        x = _jam_in_pair(har_p, u3h(a), u3t(a), b, l);
-      }
-    }
-    else {
-      if ( c3y == u3ud(a) && u3r_met(0, a) <= u3r_met(0, c) ) {
-        x = _jam_in_flat(har_p, a, l);
-      }
-      else {
-        x = _jam_in_ptr(har_p, c, l);
-      }
-    }
-    return x;
+  static inline jamframe*
+  _jam_peek()
+  {
+    return (jamframe*) u3a_peek(sizeof(jamframe));
   }
 
   u3_noun
   u3qe_jam(u3_atom a)
   {
     u3p(u3h_root) har_p = u3h_new();
+    u3p(jamframe) empty = u3R->cap_p;
+    jamframe* fam;
+    u3_noun out, c, x, q, r;
 
-    u3_noun x = _jam_in(har_p, a, 0, u3_nul);
-    u3_noun q = u3qb_flop(u3h(u3t(x)));
-    u3_noun r = u3qc_can(0, q);
+    _jam_push(a, 0, u3_nul, &out);
+    while ( empty != u3R->cap_p ) {
+      fam  = _jam_peek();
+      if ( u3_none != fam->tel ) {
+        u3_noun z = u3qa_add(2, fam->b);
+        x = _jam_pair(z, fam->hed, fam->tel);
+      }
+      else if ( u3_none != fam->hed ) {
+        u3_noun p_d, q_d, r_d;
+        u3x_trel(fam->hed, &p_d, &q_d, &r_d);
+        {
+          u3_noun z = u3qa_add(2, fam->b);
+          u3_noun y = u3qa_add(z, p_d);
+          _jam_push(u3t(fam->a), y, q_d, &(fam->tel));
+          u3z(z);
+          continue;
+        }
+      }
+      else {
+        a = fam->a;
+        c = u3h_get(har_p, a);
+        if ( u3_none != c ) {
+          if ( (c3y == u3ud(a)) && u3r_met(0, a) <= u3r_met(0, c) ) {
+            x = _jam_flat(a, fam->l);
+          }
+          else {
+            x = _jam_ptr(c, fam->l);
+          }
+        }
+        else {
+          u3h_put(har_p, a, u3k(fam->b));
+          if ( c3y == u3ud(a) ) {
+            x = _jam_flat(a, fam->l);
+          }
+          else {
+            u3_noun z = u3qa_add(2, fam->b);
+            u3_noun w = u3nc(u3nc(2, 1), u3k(fam->l));
+            _jam_push(u3h(a), z, w, &(fam->hed));
+            continue;
+          }
+        }
+      }
+      *(fam->r) = x;
+      u3z(fam->b);
+      _jam_pop();
+    }
 
-    u3z(x);
+    q = u3qb_flop(u3h(u3t(out)));
+    r = u3qc_can(0, q);
+    u3z(out);
     u3z(q);
     u3h_free(har_p);
     return r;

--- a/noun/allocate.c
+++ b/noun/allocate.c
@@ -576,6 +576,65 @@ u3a_wealloc(void* lag_v, c3_w len_w)
     }
   }
 }
+/* u3a_push(): allocate space on the road stack
+*/
+void*
+u3a_push(c3_w len_w)
+{
+  void *cur, *top = u3to(void, u3R->cap_p);
+  if ( c3y == u3a_is_north(u3R) ) {
+    top -= len_w;
+    cur = top;
+    u3R->cap_p = u3of(void, top);
+    if ( (u3R->cap_p <= u3R->hat_p) ) {
+      u3m_bail(c3__fail);
+    }
+    else {
+      return cur;
+    }
+  }
+  else {
+    cur = top;
+    top += len_w;
+    u3R->cap_p = u3of(void, top);
+    if (u3R->cap_p >= u3R->hat_p) {
+      u3m_bail(c3__fail);
+    }
+    else {
+      return cur;
+    }
+  }
+}
+
+/* u3a_pop(): deallocate space on the road stack
+*/
+void
+u3a_pop(c3_w len_w)
+{
+  void* top = u3to(void, u3R->cap_p);
+  if ( c3y == u3a_is_north(u3R) ) {
+    top += len_w;
+    u3R->cap_p = u3of(void, top);
+    if ( u3R->cap_p > u3R->mat_p ) {
+      u3m_bail(c3__fail);
+    }
+  }
+  else {
+    top -= len_w;
+    u3R->cap_p = u3of(void, top);
+    if ( u3R->cap_p < u3R->mat_p ) {
+      u3m_bail(c3__fail);
+    }
+  }
+}
+
+/* u3a_peek(): examine the top of the road stack
+*/
+void*
+u3a_peek(c3_w len_w)
+{
+  return u3to(void, u3R->cap_p) - (c3y == u3a_is_north(u3R) ? 0 : len_w);
+}
 
 /* u3a_wfree(): free storage.
 */

--- a/noun/allocate.c
+++ b/noun/allocate.c
@@ -585,24 +585,19 @@ u3a_push(c3_w len_w)
   if ( c3y == u3a_is_north(u3R) ) {
     top -= len_w;
     cur = top;
-    u3R->cap_p = u3of(void, top);
-    if ( (u3R->cap_p <= u3R->hat_p) ) {
-      u3m_bail(c3__fail);
-    }
-    else {
-      return cur;
-    }
+    u3p(void) cap_p = u3R->cap_p = u3of(void, top);
+    c3_assert(cap_p < u3R->mat_p);
+    c3_assert(cap_p > u3R->hat_p);
+    return cur;
   }
   else {
     cur = top;
     top += len_w;
     u3R->cap_p = u3of(void, top);
-    if (u3R->cap_p >= u3R->hat_p) {
-      u3m_bail(c3__fail);
-    }
-    else {
-      return cur;
-    }
+    u3p(void) cap_p = u3R->cap_p = u3of(void, top);
+    c3_assert(cap_p > u3R->mat_p);
+    c3_assert(cap_p < u3R->hat_p);
+    return cur;
   }
 }
 
@@ -614,17 +609,15 @@ u3a_pop(c3_w len_w)
   void* top = u3to(void, u3R->cap_p);
   if ( c3y == u3a_is_north(u3R) ) {
     top += len_w;
-    u3R->cap_p = u3of(void, top);
-    if ( u3R->cap_p > u3R->mat_p ) {
-      u3m_bail(c3__fail);
-    }
+    u3p(void) cap_p = u3R->cap_p = u3of(void, top);
+    c3_assert(cap_p <= u3R->mat_p);
+    c3_assert(cap_p > u3R->hat_p);
   }
   else {
     top -= len_w;
-    u3R->cap_p = u3of(void, top);
-    if ( u3R->cap_p < u3R->mat_p ) {
-      u3m_bail(c3__fail);
-    }
+    u3p(void) cap_p = u3R->cap_p = u3of(void, top);
+    c3_assert(cap_p >= u3R->mat_p);
+    c3_assert(cap_p < u3R->hat_p);
   }
 }
 

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -606,8 +606,8 @@ _sang_x(u3_noun a, u3_noun b)
             _eq_no;
           }
           else {
-            _eq_push(a_u->hed, b_u->hed);
             _eq_push(a_u->tel, b_u->tel);
+            _eq_push(a_u->hed, b_u->hed);
             fam->returning = 1;
           }
         }
@@ -775,8 +775,8 @@ _sung_x(u3_noun a, u3_noun b)
             _eq_no;
           }
           else {
-            _eq_push(a_u->hed, b_u->hed);
             _eq_push(a_u->tel, b_u->tel);
+            _eq_push(a_u->hed, b_u->hed);
             fam->returning = 1;
           }
         }
@@ -864,8 +864,8 @@ _sing_x(u3_noun a,
             _eq_no;
           }
           else {
-            _eq_push(a_u->hed, b_u->hed);
             _eq_push(a_u->tel, b_u->tel);
+            _eq_push(a_u->hed, b_u->hed);
             fam->returning = 1;
           }
         }

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -622,7 +622,7 @@ _sung_one(u3_noun* a, u3_noun* b)
 }
 
 static inline c3_o
-_song_atom(u3_atom(a), u3_atom(b))
+_song_atom(u3_atom a, u3_atom b)
 {
   u3a_atom* a_u = u3a_to_ptr(a);
 

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -533,9 +533,6 @@ _eq_pop()
   u3a_pop(sizeof(eqframe));
 }
 
-#define _eq_yes  _eq_pop(); continue
-#define _eq_no   u3R->cap_p = empty; return c3n
-
 /* _sung_one(): pick a unified pointer for identical (a) and (b).
 **
 **  Assumes exclusive access to noun memory.


### PR DESCRIPTION
Fix stack overflows in jam and unifying equals, and use memoize-by-offset cache when doing equality checks for large nouns.