### PR TITLE
Typo in 4k Nock spec

### DIFF
--- a/Spec/nock/4.txt
+++ b/Spec/nock/4.txt
@@ -19,8 +19,8 @@ nock(a)             *a
 /a                  /a
 
 #[1 a b]            a
-#[(a + a) b c]      #[a [b /[(a + a + 1) c]]]
-#[(a + a + 1) b c]  #[a [/[(a + a) c] b]]
+#[(a + a) b c]      #[a [b /[(a + a + 1) c]] c]
+#[(a + a + 1) b c]  #[a [/[(a + a) c] b] c]
 #a                  #a
 
 *[a [b c] d]        [*[a b c] *[a d]]


### PR DESCRIPTION
Ted's correction somehow didn't make it in!

Just to reiterate, however, on typo version of the spec, `#[2 b c]` reduces to b, which clearly isn't right.  I noticed this, complained in urbit-meta, and Ted pointed me to the github discussion.