### PR TITLE
Fixed bug of comparing a non-zero address to a null pointer when comp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,8 @@
 *.swp
 *.o
 /outside/**/*.a
-/outside/re2/obj
 # build
-/bin/urbit
-/bin/test_hash
+/bin/
 /vere.pkg
 .tags
 .etags

--- a/outside/commonmark/src/html/html.c
+++ b/outside/commonmark/src/html/html.c
@@ -160,7 +160,7 @@ static void node_to_html(strbuf *html, cmark_node *node)
 			info = &cur->as.code.info;
 			cr(html);
 
-			if (&cur->as.code.fence_length == 0
+			if (cur->as.code.fence_length == 0
 			    || strbuf_len(info) == 0) {
 				strbuf_puts(html, "<pre><code>");
 			}


### PR DESCRIPTION
…aring an integer to 0 was intended.  Bonus .gitignore cleanup.

This fixes this clang warning (and was a bug):

```
commonmark/src/html/html.c:166:22: warning: comparison of address of 'cur->as.code.fence_length' equal to a
      null pointer is always false [-Wtautological-pointer-compare]
                        if (&cur->as.code.fence_length == 0
                             ~~~~~~~~~~~~~^~~~~~~~~~~~    ~
```
