### PR TITLE
remove well-intentioned equality profile breakage

### DIFF
--- a/noun/trace.c
+++ b/noun/trace.c
@@ -361,12 +361,7 @@ u3t_damp(void)
 void _ct_sigaction(c3_i x_i) 
 { 
   // fprintf(stderr, "itimer!\r\n"); abort();
-
-  // sampling mid-equality can break without this
-  c3_o meq_o = u3T.euq_o;
-  u3T.euq_o  = c3n;
   u3t_samp();
-  u3T.euq_o  = meq_o;
 }
 
 /* u3t_init(): initialize tracing layer.


### PR DESCRIPTION
process sampling already takes care to turn off cpu profiling during its
sampling. this "fix" for mid-equality sampling was masking another bug
at an earlier point in the debugging process for the unifying equality
changes. I realized upon reflection that it was incorrect.