### PR TITLE
prints backtrace on bail

### DIFF
--- a/noun/manage.c
+++ b/noun/manage.c
@@ -8,6 +8,10 @@
 #include <sigsegv.h>
 #include <curl/curl.h>
 
+#if defined(U3_OS_linux) || defined(U3_OS_osx)
+#include <execinfo.h>
+#endif
+
 #include "all.h"
 
 #undef NO_OVERFLOW
@@ -603,6 +607,27 @@ u3m_bail(u3_noun how)
       u3m_p("bail", u3t(how));
     }
   }
+
+#if defined(U3_OS_linux) || defined(U3_OS_osx)
+  {
+    void* tac_u[11]; // stack addresses
+    c3_c** str_c;    // trace strings
+    c3_w tac_w;      // stack size
+    c3_w len_w;
+
+    tac_w = backtrace(tac_u, 11);
+    str_c = backtrace_symbols(tac_u, tac_w);
+
+    // skip ourselves
+    len_w = 1;
+
+    fprintf(stderr, "\r\nbacktrace:\r\n");
+    while (len_w < tac_w) {
+      fprintf(stderr, "%s\r\n", str_c[len_w++]);
+    }
+    fprintf(stderr, "\r\n");
+  }
+#endif
 
   switch ( how ) {
     case c3__fail:


### PR DESCRIPTION
This should help with bug reports and the typical `urbit-meta` troubleshooting conversation.

Example:

```
> |mount /=kids=
>=
```

From outside, `rm -rf fake-zod/kids`:

```
error opening directory bailzod/kids: No such file or directory
~zod:dojo> 
bail: oops

backtrace:
1   urbit                               0x000000010b82e0fe c3_cooked + 14
2   urbit                               0x000000010b86c4ad _unix_update_dir + 1453
3   urbit                               0x000000010b869768 u3_unix_ef_look + 120
4   urbit                               0x000000010b85d86f u3_lo_shut + 63
5   urbit                               0x000000010b87c4d5 uv__run_timers + 21
6   urbit                               0x000000010b870af3 uv_run + 195
7   urbit                               0x000000010b8574e5 main + 2565
8   libdyld.dylib                       0x00007fff8540f5ad start + 1

bailing out
Assertion failed: (0), function u3m_bail, file noun/manage.c, line 652.
                                                                       Abort trap: 6 (core dumped)
```

To enable on BSD, urbit would need to depend on libexecinfo.

Should this be limited to a subset of the bail motes?