### PR TITLE
README should recommend `ninja -C`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ On macos, you need to make sure `pkg-config` uses the correct homebrew path.
 2. `git submodule init` in the urbit repository
 3. `git submodule update`
 4. `meson ./build`
-5. If the last step was successful, type `cd ./build` followed by `ninja`
-   to compile urbit.
+5. If the last step was successful, type `ninja -C build` to compile urbit.
 6. The executable should appear in `./build` directory.
 
 ### Using meson & ninja


### PR DESCRIPTION
`ninja -C` was made specifically for this case, so users don't have to cd into and out of their build output directory all the time.