### PR TITLE
fix -F local networking

### DIFF
--- a/vere/ames.c
+++ b/vere/ames.c
@@ -210,15 +210,11 @@ u3_ames_ef_send(u3_noun lan, u3_noun pac)
 
     u3r_bytes(0, len_w, buf_y, pac);
 
-    if ( c3n == u3_Host.ops_u.net && 0x7f000001 != pip_w) {
-      return;  //  remote sending disabled
-    }
-
     if ( 0 == pip_w ) {
       pip_w = 0x7f000001;
       por_s = u3_Host.sam_u.por_s;
     }
-    {
+    if ( !(c3n == u3_Host.ops_u.net && 0x7f000001 != pip_w) ) {
       struct sockaddr_in add_u;
 
       if ( (0 == (pip_w >> 16)) && (1 == (pip_w >> 8)) ) {


### PR DESCRIPTION
Closes https://github.com/urbit/urbit/issues/935

The -N option is the inverse of the old -L option. If you boot a ship with fake keys using -F (note that -F only does something on first boot, so we might want to restrict its use to that case), then by default, networking is set to localhost-only. If you want your fake ship to be able to communicate with other machines over Ames, then add the -N flag.

This change fixes a couple bugs:
- it was checking for localhost before a normalization
- early return was causing a refcount bug

I've tested the localhost behavior on my machine. I have not tested the multi-machine case.