### PR TITLE
ignores AddressSanitizer errors in jets.c

### DIFF
--- a/noun/imprison.c
+++ b/noun/imprison.c
@@ -334,6 +334,7 @@ u3i_list(u3_weak one, ...);
     return cut_t ? cut_w : i_w;
   }
 
+  __attribute__((no_sanitize("address")))
   static u3_noun                            //  transfer
   _molt_apply(u3_noun            som,       //  retain
               c3_w               len_w,
@@ -358,6 +359,8 @@ u3i_list(u3_weak one, ...);
       }
     }
   }
+
+__attribute__((no_sanitize("address")))
 u3_noun 
 u3i_molt(u3_noun som, ...)
 {

--- a/noun/jets.c
+++ b/noun/jets.c
@@ -5,7 +5,8 @@
 
   /* _cj_count(): count and link dashboard entries.
   */
-  static c3_w 
+  __attribute__((no_sanitize("address")))
+  static c3_w
   _cj_count(u3j_core* par_u, u3j_core* dev_u)
   {
     c3_w len_l = 0;
@@ -23,6 +24,7 @@
   }
   /* _cj_install(): install dashboard entries.
   */
+  __attribute__((no_sanitize("address")))
   static c3_w
   _cj_install(u3j_core* ray_u, c3_w jax_l, u3j_core* dev_u)
   {
@@ -268,6 +270,7 @@ _cj_warm_hump(c3_l jax_l, u3_noun huc)
 **
 ** XX bat is used only for printing, remove.
 */
+__attribute__((no_sanitize("address")))
 static c3_l
 _cj_hot_mean(c3_l par_l, u3_noun mop, u3_noun bat)
 {

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -155,6 +155,7 @@ u3r_at(u3_atom a, u3_noun b)
     }
   }
 
+__attribute__((no_sanitize("address")))
 c3_o
 u3r_mean(u3_noun som,
         ...)


### PR DESCRIPTION
AddressSanitizer doesn't like the iterator/terminator pattern in `tree.c` and `jets.c`, and claims that it constitutes a global buffer overflow. I'm not qualified to adjudicate that claim, so I'm just excluding the relevant functions from AddressSanitizer.

This PR supersedes #915. The build changes are no longer necessary (`meson -Db_sanitize=address $BUILD_DIR`), and the CI integration should be discussed separately (ubuntu on travis is really old).