### PR TITLE
[WIP] Get vere working on ppc64le

### DIFF
--- a/include/noun/allocate.h
+++ b/include/noun/allocate.h
@@ -16,7 +16,11 @@
 
     /* u3a_page: number of bits in word-addressed page.  12 == 16Kbyte page.
     */
+#ifdef __PPC64__
+#     define u3a_page   16
+#else
 #     define u3a_page   12
+#endif
 
     /* u3a_pages: number of pages in memory.
     */

--- a/jets/tree.c
+++ b/jets/tree.c
@@ -624,6 +624,8 @@ static u3j_core _143_two_d[] =
 
     { "by", 0, _143_two__by_d },
     { "in", 0, _143_two__in_d },
+
+    {}
   };
 
 

--- a/meson.build
+++ b/meson.build
@@ -306,12 +306,30 @@ softfloat3_dep = dependency('softfloat3', version: '>=3.0.0', fallback: ['softfl
 libuv_dep = dependency('libuv', version: '>=1.8.0', fallback:['libuv', 'libuv_dep'])
 libh2o_dep = dependency('libh2o', version: '>=0.13.3', fallback: ['libh2o', 'libh2o_dep'])
 
+profiler_deps = []
+if get_option('profile')
+
+  if(legacy_meson)
+    profiler_dep = find_library('profiler')
+  else
+    profiler_dep = meson.get_compiler('c').find_library('profiler')
+  endif
+
+  # Ubuntu sets library pruning by default. Ugh.
+  if osdet == 'linux'
+    os_link_flags = os_link_flags + ['-Wl,--no-as-needed']
+  endif
+
+  profiler_deps = profiler_deps + [profiler_dep]
+endif
+
 executable('urbit',
 sources : sources,
 include_directories : incdir,
 c_args : os_c_flags,
 link_args: os_link_flags,
-dependencies: [openssl_dep,
+dependencies: profiler_deps +
+              [openssl_dep,
                curl_dep,
                libuv_dep,
                libh2o_dep,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('profile', type:'boolean', value: false)

--- a/noun/manage.c
+++ b/noun/manage.c
@@ -413,7 +413,7 @@ _pave_north(c3_w* mem_w, c3_w siz_w, c3_w len_w)
 {
   c3_w*    rut_w = mem_w;
   c3_w*    hat_w = rut_w;
-  c3_w*    mat_w = ((mem_w + len_w) - siz_w);
+  c3_w*    mat_w = ((mem_w + len_w) - (4 * siz_w));
   c3_w*    cap_w = mat_w;
   u3_road* rod_u = (void*) mat_w;
 


### PR DESCRIPTION
- [x] Use 64k pages instead of 4k pages on PPC64.
- [x] Fix _pave_north() so it doesn't write outside of the loom. (#979)
- [x] Make sure jet entries are null terminated; otherwise goes into an infinite loop.

With the above, I'm able to boot a fakezod! However, things are very slow. It's taking 7.5 minutes from start to prompt on a chip that's supposed to be a competitor to a high end Xeon. There's probably something wrong there. (It takes ~2 minutes on my MacBook Pro.)

However, I'm not able to boot a moon. So next:

- [ ] Get a moon booting on the live network.
  - [ ] Figure out the dig: over

I'm able to start booting a moon, talk to ~zod, become a comet, and do the first part of talking to my planet. However, the event which causes a `%dill-init` eventually causes a `dig: over` after chewing on a `%vega-start-hoon` for awhile.

Iterating will be hard since it takes about 25 minutes from starting a moon to `dig: over`.

```
; ~littel-ponnys not responding still trying
[%dill-init ~rivhus-lidnet-littel-ponnys %hood]
activated sync from %kids on ~littel-ponnys to %base
activated sync from %base on ~rivhus-lidnet-littel-ponnys to %home
sync succeeded from %base on ~rivhus-lidnet-littel-ponnys to %home
>> [%mo-not-running %talk %peer]
>> [%mo-not-running %dojo %peer]
'initial merge succeeded'
[ %vega-start-hoon
  /~rivhus-lidnet-littel-ponnys/home/~2018.5.19..23.46.21..4c6c/sys/hoon
]
/«ames»ng hood, this may take a few minutes>
recover: dig: over
over
/~rivhus-lidnet-littel-ponnys/home/~2018.5.19..23.46.21..4c6c/sys/hoon
[%dill-init ~rivhus-lidnet-littel-ponnys %hood]
activated sync from %kids on ~littel-ponnys to %base
activated sync from %base on ~rivhus-lidnet-littel-ponnys to %home
sync succeeded from %base on ~rivhus-lidnet-littel-ponnys to %home
>> [%mo-not-running %talk %peer]
>> [%mo-not-running %dojo %peer]
'initial merge succeeded'
[ %vega-start-hoon
  /~rivhus-lidnet-littel-ponnys/home/~2018.5.19..23.50.59..cd41/sys/hoon
]
/«ames»ng hood, this may take a few minutes>
recover: dig: over
over
``` 

While this patch can be merged as is, I'd like to get a real moon booting before declaring victory.