### PR TITLE
Use smaller heap allocations on libuv i/o reads

### DIFF
--- a/vere/ames.c
+++ b/vere/ames.c
@@ -30,8 +30,11 @@ _ames_alloc(uv_handle_t* had_u,
             uv_buf_t* buf
             )
 {
-  void* ptr_v = c3_malloc(len_i);
-  *buf = uv_buf_init(ptr_v, len_i);
+  //  we allocate 2K, which gives us plenty of space
+  //  for a single ames packet (max size 1060 bytes)
+  //
+  void* ptr_v = c3_malloc(2048);
+  *buf = uv_buf_init(ptr_v, 2048);
 }
 
 /* _ames_free(): contrasting free.

--- a/vere/term.c
+++ b/vere/term.c
@@ -41,14 +41,19 @@ _term_msc_out_host()
   return 1000000ULL * tim_tv.tv_sec + tim_tv.tv_usec;
 }
 
+/* _term_alloc(): libuv buffer allocator.
+*/
 static void
 _term_alloc(uv_handle_t* had_u,
             size_t len_i,
             uv_buf_t* buf
             )
 {
-  void* ptr_v = c3_malloc(len_i);
-  *buf = uv_buf_init(ptr_v, len_i);
+  //  this read can range from a single byte to a paste buffer
+  //  32 bytes has been chosen heuristically
+  //
+  void* ptr_v = c3_malloc(32);
+  *buf = uv_buf_init(ptr_v, 32);
 }
 
 


### PR DESCRIPTION
Upon reading from a stream, libuv *always* asks for 64K bytes. We've been helpfully complying, in ames, the terminal, and raft (follower mode). This adjusts the first two, giving constant buffer sizes that seem appropriate (I don't think anyone is using that raft implementation).

Running locally with these changes, I don't see noticeable performance improvements. But I owe to you all to measure more carefully, and will return with details.