### PR TITLE
Bump Vere version to version 0.6.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-urbit (0.5-1) unstable; urgency=medium
+urbit (0.6-0) unstable; urgency=high
 
-  * hoon %143; new boot sequence; %jael support
+  * Memory-allocation bug fix in _box_slot in Vere. Breaking change.
 
- -- Ted Blackman <ted@tlon.io>  Thu, 12 Oct 2017 17:11:53 -0700
+ -- Keaton Dunsford <keaton@tlon.io>  Fri, 8 Jun 2018 14:31:08 -0700

--- a/meson.build
+++ b/meson.build
@@ -222,7 +222,7 @@ endforeach
 incdir = include_directories('include/')
 
 conf_data = configuration_data()
-conf_data.set('URBIT_VERSION', '"0.5.1"')
+conf_data.set('URBIT_VERSION', '"0.6.0"')
 
 osdet = build_machine.system()
 os_c_flags = ['-funsigned-char','-ffast-math']


### PR DESCRIPTION
The breaking change here is urbit/urbit#987, commit 762638ac, changing
the memory allocation size of _box_slot. This introduced urbit/urbit
issue #990 and has required a continuity breach. The version bump here
is mostly to signal to users that they need to update to the new Vere
version to prevent a future ship crash. Though, we can't enforce this,
and if this happens, we have a couple imperfect fixes that may or may
not revive the crashed ship.