### PR TITLE
Version the bootstrap.urbit.org boot pill URL

### DIFF
--- a/vere/main.c
+++ b/vere/main.c
@@ -255,7 +255,7 @@ _main_getopt(c3_i argc, c3_c** argv)
            && u3_Host.ops_u.url_c == 0
            && u3_Host.ops_u.git == c3n ) {
 
-    u3_Host.ops_u.url_c = "https://bootstrap.urbit.org/latest.pill";
+    u3_Host.ops_u.url_c = "https://bootstrap.urbit.org/urbit-" URBIT_VERSION ".pill";
 
   } else if ( u3_Host.ops_u.nuu == c3y
            && u3_Host.ops_u.url_c == 0


### PR DESCRIPTION
This way, between continuity breaches, we can update the old pills,
adding printf's to them that will trigger upon `~zod is not responding`
messages such as urbit/arvo@c83fb6e23e903a7239187478612dff06c22a3c16,
telling people to pull the latest Vere. And upon breaches, we
can update these bootstrap links. This is a simple/hacky yet reasonably
effective way to help get more people on the same page as it relates to
handling users running different Veres with breaking changes.