### PR TITLE
Remove unused paths from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@
 /outside/**/*.a
 /outside/re2/obj
 # build
-/bin/urbit
-/bin/test_hash
 /vere.pkg
 .tags
 .etags


### PR DESCRIPTION
We're no longer putting the binary into `/bin` (now into `/build` instead),
so we don't need to ignore it anymore.