### PR TITLE
adds an http request timer to ensure connections are always closed

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -50,6 +50,7 @@
         h2o_req_t*       rec_u;             //  h2o request
         c3_w             seq_l;             //  sequence within connection
         u3_rsat          sat_e;             //  request state
+        uv_timer_t*      tim_u;             //  timeout
         struct _u3_hcon* hon_u;             //  connection backlink
         struct _u3_hreq* nex_u;             //  next in connection's list
       } u3_hreq;


### PR DESCRIPTION
H2O stops listening on a socket after it parses a complete request, since the client could pipeline multiple requests. It doesn't notice that a client has prematurely closed the connection until it tries to write a response. When we're proxying requests over %ames, it's not unusual for responses to be greatly delayed (if a ship is offline, for instance), so sockets pile up in CLOSE_WAIT. This PR adds a request timeout, which resolves the resource leak.

Thanks to @ramrunner for identifying the issue!

/cc @keatondunsford 