### PR TITLE
Fix issue with trimming >4 character jet names

### DIFF
--- a/noun/jets.c
+++ b/noun/jets.c
@@ -382,11 +382,11 @@ _cj_kick_z(u3_noun cor, u3j_core* cop_u, u3j_harm* ham_u, u3_atom axe)
     c3_w cod_w;
 
     {
-      char soc_c[6];
+      char soc_c[5];
 
-      memset(soc_c, 0, 6);
-      strncpy(soc_c, cop_u->cos_c, 5);
-      soc_c[5] = 0;
+      memset(soc_c, 0, 5);
+      strncpy(soc_c, cop_u->cos_c, 4);
+      soc_c[4] = 0;
       cod_w = u3i_string(soc_c);
 
       cod_w = u3a_lush(cod_w);


### PR DESCRIPTION
Special thanks to @frodwith for figuring this out after I hit this.

While working on jets and doing memory testing, I was getting a leak that persisted even if I reduced my jet code to `return 0;`. Turns out the fact that I was using jet names longer than four character was giving trouble, only in the specific case of doing memory testing.

As explained by @frodwith:

> so what's happening is
> u3a_lush expects to get a c3_w (referred to elsewhere as cod_w)
> it's the code that prints during leak push
> which, if you're running a jet, is set to the name of the jet
> now, the thing that trims up the cos_c (the name from tree.c) very helpfully trims to a 5-character name
> ....VERY HELPFULLY, since it needs to be a 4-character name to fit in a c3_w
> so we get an indirect atom for cod_w, and never free it, hence the leak