### PR TITLE
Disable terminal echo on passcode entry

### DIFF
--- a/vere/sist.c
+++ b/vere/sist.c
@@ -295,14 +295,28 @@ _sist_cask(c3_c* dir_c, u3_noun nun)
 {
   c3_c   paw_c[60];
   u3_noun key;
+  u3_utty* uty_u = calloc(1, sizeof(u3_utty));
+  uty_u->fid_i = 0;
 
   uH;
+
+  // disable terminal echo when typing in passcode
+  if ( 0 != tcgetattr(uty_u->fid_i, &uty_u->bak_u) ) {
+    c3_assert(!"init-tcgetattr");
+  }
+  uty_u->raw_u = uty_u->bak_u;
+  uty_u->raw_u.c_lflag &= ~ECHO;
+  if ( 0 != tcsetattr(uty_u->fid_i, TCSADRAIN, &uty_u->raw_u) ) {
+    c3_assert(!"init-tcsetattr");
+  }
+
   while ( 1 ) {
     printf("passcode for %s%s? ~", dir_c, (c3y == nun) ? " [none]" : "");
 
     paw_c[0] = 0;
     c3_fpurge(stdin);
     fgets(paw_c, 59, stdin);
+    printf("\n");
 
     if ( '\n' == paw_c[0] ) {
       if ( c3y == nun ) {
@@ -334,6 +348,10 @@ _sist_cask(c3_c* dir_c, u3_noun nun)
       break;
     }
   }
+  if ( 0 != tcsetattr(uty_u->fid_i, TCSADRAIN, &uty_u->bak_u) ) {
+    c3_assert(!"init-tcsetattr");
+  }
+  free(uty_u);
   uL(0);
   return key;
 }


### PR DESCRIPTION
Hiya martians :alien: :v:

In my experimentation with moving my planet to a different machine, I decided to follow the advice of the `for real security, write it down and delete the file...` line and remove the `*.code` file before copying dirs around. When I remove the file, urbit prompts me to type in the code instead.

But when entering the code, its printed onto the screen. This might be a small security issue if I'm showing urbit to someone IRL or in a livestream and they can see my planet's code as I type it in, or if i accidentally pastebin the boot output without retracting the code.

This PR makes it so your passcode is not displayed on the screen while you type it in, similar to how the password entry for many other unix programs works.

The logic for this comes from the [getpass libc docs](https://www.gnu.org/software/libc/manual/html_node/getpass.html), where it gives example code for a simple DIY implementation. I then tried to adapt it to vere-style by using the `u3_utty` struct defined in `include/vere/vere.h`, and using it similarly to how its used in `vere/term.c`.

This is my first time working with the urbit codebase, so I'm very willing to do this a different way if you'd prefer :slightly_smiling_face: 
