### PR TITLE
fix memory leaks, add gc and profile build options

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -11,5 +11,6 @@
 #mesondefine U3_OS_ENDIAN_big
 
 #mesondefine U3_MEMORY_DEBUG
+#mesondefine U3_CPU_DEBUG
 
 #endif /*CONFIG_H*/

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -10,4 +10,6 @@
 #mesondefine U3_OS_ENDIAN_little
 #mesondefine U3_OS_ENDIAN_big
 
+#mesondefine U3_MEMORY_DEBUG
+
 #endif /*CONFIG_H*/

--- a/include/noun/allocate.h
+++ b/include/noun/allocate.h
@@ -2,12 +2,6 @@
 **
 ** This file is in the public domain.
 */
-  /**  Options.
-  **/
-    /* U3_MEMORY_DEBUG: add debugging information to heap.  Breaks image.
-    */
-#     undef U3_MEMORY_DEBUG
-
   /**  Constants.
   **/
     /* u3a_bits: number of bits in word-addressed pointer.  29 == 2GB.

--- a/include/noun/trace.h
+++ b/include/noun/trace.h
@@ -2,12 +2,6 @@
 **
 ** This file is in the public domain.
 */
-  /**  Options.
-  **/
-    /* U3_CPU_DEBUG: activate profiling.
-    */
-#     undef U3_CPU_DEBUG
-
   /** Data structures.
   **/
     /* u3t_trace: fast execution flags.

--- a/meson.build
+++ b/meson.build
@@ -264,6 +264,7 @@ incdir = include_directories('include/')
 
 conf_data = configuration_data()
 conf_data.set('URBIT_VERSION', '"0.6.0"')
+conf_data.set('U3_MEMORY_DEBUG', get_option('gc'))
 
 osdet = build_machine.system()
 os_c_flags = ['-funsigned-char','-ffast-math']

--- a/meson.build
+++ b/meson.build
@@ -265,6 +265,7 @@ incdir = include_directories('include/')
 conf_data = configuration_data()
 conf_data.set('URBIT_VERSION', '"0.6.0"')
 conf_data.set('U3_MEMORY_DEBUG', get_option('gc'))
+conf_data.set('U3_CPU_DEBUG', get_option('prof'))
 
 osdet = build_machine.system()
 os_c_flags = ['-funsigned-char','-ffast-math']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('gc', type : 'boolean', value : false,
+  description : 'Add debugging information to heap. Run with -g. Breaks image.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('gc', type : 'boolean', value : false,
   description : 'Add debugging information to heap. Run with -g. Breaks image.')
+option('prof', type : 'boolean', value : false,
+  description : 'Activate profiling. Run with -P.')

--- a/vere/http.c
+++ b/vere/http.c
@@ -1383,7 +1383,8 @@ _http_serv_start_all(void)
 
   c3_assert( 0 != for_u );
 
-  u3_lo_open();
+  // disabled, as this causes a memory leak
+  // u3_lo_open();
 
   // if the SSL_CTX existed, it'll be freed with the servers
   u3_Host.tls_u = 0;
@@ -1444,7 +1445,8 @@ _http_serv_start_all(void)
   _http_write_ports_file(u3_Host.dir_c);
   _http_form_free();
 
-  u3_lo_shut(c3y);
+  // disabled, see above
+  // u3_lo_shut(c3y);
 }
 
 /* _http_serv_restart(): gracefully shutdown, then start servers.

--- a/vere/http.c
+++ b/vere/http.c
@@ -1501,15 +1501,26 @@ _http_form_free(void)
 void
 u3_http_ef_form(u3_noun fig)
 {
-  // XX validate / test axes?
-  u3_noun sec = u3h(fig);
-  u3_noun lob = u3t(fig);
+  u3_noun sec, pro, log, red;
+
+  if ( (c3n == u3r_qual(fig, &sec, &pro, &log, &red) ) ||
+       // confirm sec is a valid (unit ^)
+       !( u3_nul == sec || ( c3y == u3du(sec) &&
+                             c3y == u3du(u3t(sec)) &&
+                             u3_nul == u3h(sec) ) ) ||
+       // confirm valid flags ("loobeans")
+       !( c3y == pro || c3n == pro ) ||
+       !( c3y == log || c3n == log ) ||
+       !( c3y == red || c3n == red ) ) {
+    uL(fprintf(uH, "http: form: invalid card\n"));
+    u3z(fig);
+    return;
+  }
 
   u3_form* for_u = c3_malloc(sizeof(*for_u));
-
-  for_u->pro = (c3_o)u3h(lob);
-  for_u->log = (c3_o)u3h(u3t(lob));
-  for_u->red = (c3_o)u3t(u3t(lob));
+  for_u->pro = (c3_o)pro;
+  for_u->log = (c3_o)log;
+  for_u->red = (c3_o)red;
 
   if ( u3_nul != sec ) {
     u3_noun key = u3h(u3t(sec));
@@ -2813,15 +2824,13 @@ _proxy_serv_start(u3_prox* lis_u)
 void
 u3_http_ef_that(u3_noun tat)
 {
-  u3_noun sip = u3h(tat);
-  u3_noun por = u3h(u3t(tat));
-  u3_noun sec = u3h(u3t(u3t(tat)));
-  u3_noun non = u3t(u3t(u3t(tat)));
+  u3_noun sip, por, sec, non;
 
-  if( c3n == u3ud(sip) ||
-      c3n == u3a_is_cat(por) ||
-      !( c3y == sec || c3n == sec ) ||
-      c3n == u3ud(non) ) {
+  if ( ( c3n == u3r_qual(tat, &sip, &por, &sec, &non) ) ||
+       ( c3n == u3ud(sip) ) ||
+       ( c3n == u3a_is_cat(por) ) ||
+       !( c3y == sec || c3n == sec ) ||
+       ( c3n == u3ud(non) ) ) {
     uL(fprintf(uH, "http: that: invalid card\n"));
     u3z(tat);
     return;

--- a/vere/http.c
+++ b/vere/http.c
@@ -2861,6 +2861,7 @@ u3_http_ef_that(u3_noun tat)
   if ( c3n == u3_Host.ops_u.net ) {
     cli_u->ipf_w = INADDR_LOOPBACK;
     _proxy_ward_connect(cli_u);
+    u3z(tat);
     return;
   }
 


### PR DESCRIPTION
This PR fixes two memory leaks on the release-candidate (introduced by yours truly).

Additionally, it moves the optional definitions of `U3_MEMORY_DEBUG` and `U3_CPU_DEBUG` into the generated `config.h` header, to be set by the custom meson options `-Dgc=true|false` and `-Dprof=true|false` (in the `meson` build generation, not the `ninja` compilation).

These options should be enabled in CI, probably as separate entries in a build matrix. And I think that should happen here, not on the Arvo build that's already heavily burdened. But that means we need a URL for a suitable pill stored in this repo. I'm happy to wire that up if it's deemed worthwhile.

Thoughts?

/cc @eglaysher @belisarius222 @frodwith 