### PR TITLE
converting iron and zinc cores to lead bug

### DIFF
--- a/jets/f/ut_wrap.c
+++ b/jets/f/ut_wrap.c
@@ -41,8 +41,9 @@
         if ( c3n == u3r_trel(pq_sut, &ppq_sut, &qpq_sut, &rpq_sut) ) {
           return u3m_bail(c3__fail);
         }
-        else if ( c3__gold != rpq_sut ) {
-          return u3m_error("wrap-gold");
+        else if ( (c3__gold != rpq_sut) &&
+                  (c3__lead != yoz) ) {
+          return u3m_error("wrap-metal");
         }
         else {
           return u3nt(c3__core,


### PR DESCRIPTION
In the current release candidate, this happens:

```
> ^?(^|(add))
wrap-gold
ford: %slim failed: 
ford: %ride failed to compute type:
```

This is a jet mismatch from `+wrap`, I believe:

https://github.com/urbit/arvo/blob/release-candidate/sys/hoon.hoon#L11139

You should be able to convert iron and zinc cores to lead.