### PR TITLE
zinc gate casting bug

### DIFF
--- a/jets/f/ut_play.c
+++ b/jets/f/ut_play.c
@@ -358,7 +358,7 @@
         return pro;
       }
 
-      case c3__ktpm: p_gen = u3t(gen);
+      case c3__ktpd: p_gen = u3t(gen);
       _play_used();
       {
         u3_noun boc = _play_x(van, sut, p_gen);


### PR DESCRIPTION
Casting with a `^&` rune example fails because of a minor jet typo:

```
> ^+(^&(|=(@ 15)) |=(@ 15))
-gene.[%ktpd %brts [%base %atom 0] %sand %ud 15]
play-open-z
ford: %slim failed: 
ford: %ride failed to compute type:
```

The above cast should go through.  This fix makes that happen.