### PR TITLE
Fix un-jetted arm profiles

### DIFF
--- a/noun/jets.c
+++ b/noun/jets.c
@@ -1471,10 +1471,7 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u, c3_o lok_o)
   c3_o jet_o  = sit_u->jet_o;
   c3_o pof_o  =  __(u3C.wag_w & u3o_debug_cpu);
   if ( c3n == pof_o ) {
-    if ( c3n == jet_o ) {
-      pro = u3_none;
-    }
-    else {
+    if ( c3y == jet_o ) {
       u3t_off(glu_o);
       pro = _cj_kick_z(cor, sit_u->cop_u, sit_u->ham_u, sit_u->axe);
       u3t_on(glu_o);

--- a/noun/jets.c
+++ b/noun/jets.c
@@ -1465,7 +1465,7 @@ _cj_burn(u3p(u3n_prog) pog_p, u3_noun cor)
 **                      (no validity checks).
 */
 static u3_weak
-_cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u)
+_cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u, c3_o lok_o)
 {
   u3_weak pro = u3_none;
   c3_o jet_o  = sit_u->jet_o;
@@ -1480,7 +1480,9 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u)
       u3t_on(glu_o);
     }
     if ( u3_none == pro ) {
-      _cj_site_lock(loc, cor, sit_u);
+      if ( c3y == lok_o ) {
+        _cj_site_lock(loc, cor, sit_u);
+      }
     }
   }
   else {
@@ -1491,7 +1493,9 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u)
       u3t_on(glu_o);
     }
     if ( u3_none == pro ) {
-      _cj_site_lock(loc, cor, sit_u);
+      if ( c3y == lok_o ) {
+        _cj_site_lock(loc, cor, sit_u);
+      }
       pro = _cj_burn(sit_u->pog_p, cor);
     }
     if ( c3y == pof_o ) {
@@ -1513,9 +1517,7 @@ _cj_site_kick(u3_noun cor, u3j_site* sit_u)
   if ( u3_none != sit_u->loc ) {
     if ( c3y == _cj_fine(cor, sit_u->fin_p) ) {
       loc = sit_u->loc;
-      if ( c3y == sit_u->jet_o ) {
-        pro = _cj_site_kick_hot(loc, cor, sit_u);
-      }
+      pro = _cj_site_kick_hot(loc, cor, sit_u, c3y);
     }
   }
 
@@ -1537,15 +1539,9 @@ _cj_site_kick(u3_noun cor, u3j_site* sit_u)
       sit_u->loc   = loc;
       sit_u->fin_p = _cj_cast(cor, loc);
       sit_u->fon_o = c3y;
-      if ( c3y ==
-        (sit_u->jet_o = _cj_nail(loc, sit_u->axe,
-            &(sit_u->lab), &(sit_u->cop_u), &(sit_u->ham_u))) )
-      {
-        pro = _cj_site_kick_hot(loc, cor, sit_u);
-      }
-      else {
-        pro = u3_none;
-      }
+      sit_u->jet_o = _cj_nail(loc, sit_u->axe,
+          &(sit_u->lab), &(sit_u->cop_u), &(sit_u->ham_u));
+      pro = _cj_site_kick_hot(loc, cor, sit_u, c3y);
 
       if ( u3_none != lod ) {
         u3z(lod);
@@ -1674,8 +1670,8 @@ u3j_gate_slam(u3j_site* sit_u, u3_noun sam)
   cor = u3nt(u3k(u3h(sit_u->bat)),
              sam,
              u3k(u3t(u3t(sit_u->bat))));
-  if ( (u3_none != sit_u->loc) && (c3y == sit_u->jet_o) ) {
-    pro = _cj_site_kick_hot(sit_u->loc, cor, sit_u);
+  if ( u3_none != sit_u->loc ) {
+    pro = _cj_site_kick_hot(sit_u->loc, cor, sit_u, c3n);
   }
   if ( u3_none == pro ) {
     pro = _cj_burn(sit_u->pog_p, cor);


### PR DESCRIPTION
There were two issues in hashboard preventing the profiling of hinted-but-unjetted arms:

- `_cj_site_kick_hot()` was being called much less than it should have been.
- `_cj_site_kick_hot()` needed to be specialized to accommodate the `u3j_site` usage pattern in `u3j_gate_slam`.

Thanks to @frodwith!