### PR TITLE
[CI] fix deploy phase, move coredump backtrace to a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,6 @@ language: node_js
 node_js:
 - 4
 
-script:
-  - meson . ./build --buildtype=debugoptimized -Dgc=true -Dprof=true
-  - cd ./build
-  - ninja
-  - sudo ninja install
-  - cd ../.travis
-  - ulimit -c unlimited -S
-  - npm install
-  # || true so we continue
-  - npm run -s test || RESULT=$?
-  - if [[ ${RESULT} -eq 0 ]]; then exit 0; else for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb urbit core* -ex "thread apply all bt" -ex "set pagination 0" -batch; done; fi;
-  - echo "build failed with status code $RESULT"
-  - exit $RESULT
-
 # Uncomment me if this gets annoying
 #
 # notifications:
@@ -33,6 +19,16 @@ install:
   - cd ./arvo
   - git checkout $(cat ../.travis/pin-arvo-commit.txt)
   - cd ..
+
+script:
+  - meson . ./build --buildtype=debugoptimized -Dgc=true -Dprof=true
+  - cd ./build
+  - ninja
+  - sudo ninja install
+  - cd ../.travis
+  - npm install
+  - ulimit -c unlimited -S
+  - npm run -s test; bash print-core-backtrace.sh $?
 
 addons:
   apt:

--- a/.travis/print-core-backtrace.sh
+++ b/.travis/print-core-backtrace.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+RESULT=$1
+
+if [[ ${RESULT} -eq 0 ]]; then
+  exit 0
+else
+  for i in $(find ./ -maxdepth 1 -name 'core*' -print)
+  do
+    gdb urbit core* -ex "thread apply all bt" -ex "set pagination 0" -batch
+  done
+fi
+
+echo "build failed with status code $RESULT"
+exit $RESULT


### PR DESCRIPTION
We're not currently using the CI deploy phase, but we may someday. My changes in #1051 broke it, as I learned in urbit/arvo#884. Applying the same fix here.