### PR TITLE
restores -H for overriding ames galaxy domain

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -580,6 +580,7 @@
     */
       typedef struct _u3_opts {
         c3_c*   arv_c;                      //  -A, initial sync from
+        c3_c*   dns_c;                      //  -H, ames bootstrap domain
         c3_c*   gen_c;                      //  -G, czar generator
         c3_c*   nam_c;                      //  -n, unix hostname
         c3_c*   pil_c;                      //  -B, bootstrap from

--- a/vere/main.c
+++ b/vere/main.c
@@ -92,7 +92,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.veb = c3n;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
-  while ( (ch_i=getopt(argc, argv,"G:B:K:A:w:u:e:E:f:F:k:l:n:p:r:NabcdgqstvxMPDXRS")) != -1 ) {
+  while ( (ch_i=getopt(argc, argv,"G:B:K:A:H:w:u:e:E:f:F:k:l:n:p:r:NabcdgqstvxMPDXRS")) != -1 ) {
     switch ( ch_i ) {
       case 'M': {
         u3_Host.ops_u.mem = c3y;
@@ -108,6 +108,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 'A': {
         u3_Host.ops_u.arv_c = strdup(optarg);
+        break;
+      }
+      case 'H': {
+        u3_Host.ops_u.dns_c = strdup(optarg);
         break;
       }
       case 'e': {
@@ -262,6 +266,11 @@ _main_getopt(c3_i argc, c3_c** argv)
   if ( c3y == u3_Host.ops_u.bat ) {
     u3_Host.ops_u.dem = c3y;
     u3_Host.ops_u.nuu = c3y;
+  }
+
+  if ( u3_Host.ops_u.nuu != c3y && u3_Host.ops_u.dns_c != 0) {
+    fprintf(stderr, "-H only makes sense when bootstrapping a new instance\n");
+    return c3n;
   }
 
   if ( u3_Host.ops_u.nuu != c3y && u3_Host.ops_u.pil_c != 0) {

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -1296,6 +1296,34 @@ _sist_dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
   u3_lo_bail();
 }
 
+/* _sist_dawn_turf(): override contract domains with -H
+*/
+static u3_noun
+_sist_dawn_turf(c3_c* dns_c)
+{
+  u3_noun tuf;
+
+  u3_noun par = u3v_wish("thos:de-purl:html");
+  u3_noun dns = u3i_string(dns_c);
+  u3_noun rul = u3dc("rush", u3k(dns), u3k(par));
+
+  if ( (u3_nul == rul) || (c3n == u3h(u3t(rul))) ) {
+    fprintf(stderr, "boot: invalid domain specified with -H %s\r\n", dns_c);
+    // bails, won't return
+    u3_lo_bail();
+    return u3_none;
+  }
+  else {
+    fprintf(stderr, "boot: overriding network domains with %s\r\n", dns_c);
+    u3_noun dom = u3t(u3t(rul));
+    tuf = u3nc(u3k(dom), u3_nul);
+  }
+
+  u3z(par); u3z(dns); u3z(rul);
+
+  return tuf;
+}
+
 /* _sist_dawn(): produce %dawn boot card - validate keys and query contract
 */
 static u3_noun
@@ -1440,7 +1468,13 @@ _sist_dawn(u3_noun sed)
   {
     if ( c3y == u3_Host.ops_u.etn ) {
       zar = u3do("czar:snap:dawn", u3k(u3t(sap)));
-      tuf = u3do("turf:snap:dawn", u3k(u3t(sap)));
+
+      if ( 0 != u3_Host.ops_u.dns_c ) {
+        tuf = _sist_dawn_turf(u3_Host.ops_u.dns_c);
+      }
+      else {
+        tuf = u3do("turf:snap:dawn", u3k(u3t(sap)));
+      }
     }
     else {
       {
@@ -1454,7 +1488,10 @@ _sist_dawn(u3_noun sed)
         u3z(oct); u3z(raz);
       }
 
-      {
+      if ( 0 != u3_Host.ops_u.dns_c ) {
+        tuf = _sist_dawn_turf(u3_Host.ops_u.dns_c);
+      }
+      else {
         fprintf(stderr, "boot: retrieving network domains\r\n");
 
         // (list turf): ames domains


### PR DESCRIPTION
The pre-boot validation process constructs a priority-order list of domains by reading from the Ships contract, which is a part of the %dawn boot event. This PR re-enables specifying a custom %ames domain with `-H`, by prepending the specified domain to that list (if it's not already in the list).