### PR TITLE
fixes race in tcp proxy resource cleanup

### DIFF
--- a/vere/http.c
+++ b/vere/http.c
@@ -2140,7 +2140,6 @@ _proxy_ward_free(uv_handle_t* han_u)
   u3_ward* rev_u = han_u->data;
 
   u3z(rev_u->sip);
-  _proxy_ward_unlink(rev_u);
   free(rev_u->non_u.base);
   free(rev_u);
 }
@@ -2160,6 +2159,8 @@ _proxy_ward_close_timer(uv_handle_t* han_u)
 static void
 _proxy_ward_close(u3_ward* rev_u)
 {
+  _proxy_ward_unlink(rev_u);
+
   while ( 0 != rev_u->won_u ) {
     _proxy_wcon_close(rev_u->won_u);
     rev_u->won_u = rev_u->won_u->nex_u;


### PR DESCRIPTION
If the ship-specific proxy listener (`u3_ward`) is closed by a timer, the proxy-connection (`u3_pcon`) to which it is linked is closed at the same time. The unlinking of these structs cannot be asynchronous, or there will be a race ...

Note: the memory lifecycle of these proxy structs is overly complicated and should be generally cleaned up. It was written this way to allow the proxy implementation to be polymorphic, but I'm starting to suspect it's just not worth it. I'm not tackling this at the moment, as there are other proxy improvements that should be queued up too.

/cc @vvisigoth 