### PR TITLE
Fix README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ are included as git submodules. To build urbit from source, perform the followin
 4. The executable should appear in `./build` directory.
 
 ### Using meson & ninja
-To configure project, enter the build directory and enter
-`meson configure`. Without any arguments this command will display available
-options. For example, to compile debug build of urbit, use
+
+To configure the project, enter the build directory and enter
+`meson configure -Dbuildtype=release`.  To compile a debug build of urbit, use
 `meson configure -Dbuildtype=debug`.
-To set the prefix for installation use
-`meson configure -Dprefix=/usr`, and so on.
+To set a prefix for installation use
+`meson configure -Dprefix=/usr`.
 
 ## Configuration & compilation for legacy meson
 


### PR DESCRIPTION
supersedes #1039, removing subproject changes. (and `-S` is already on by default for fake ships)