### PR TITLE
reap call sites before reaping the warm dashboard

### DIFF
--- a/noun/jets.c
+++ b/noun/jets.c
@@ -1996,8 +1996,11 @@ void
 u3j_reap(u3p(u3h_root) cod_p, u3p(u3h_root) war_p, u3p(u3h_root) han_p, u3p(u3h_root) bas_p)
 {
   u3h_walk(cod_p, _cj_cold_reap);
-  u3h_walk(war_p, _cj_warm_reap);
+
+  // call sites must be reaped before the warm dashboard, because they may
+  // contain references to labels on this road
   u3h_walk(han_p, _cj_hank_reap);
+  u3h_walk(war_p, _cj_warm_reap);
   u3h_walk(bas_p, _cj_bash_reap);
 }
 

--- a/noun/manage.c
+++ b/noun/manage.c
@@ -830,8 +830,9 @@ u3m_love(u3_noun pro)
 
     pro = u3a_take(pro);
 
-    u3j_reap(cod_p, war_p, han_p, bas_p);
+    // call sites first: see u3j_reap().
     u3n_reap(byc_p);
+    u3j_reap(cod_p, war_p, han_p, bas_p);
 
     u3R->cap_p = u3R->ear_p;
     u3R->ear_p = 0;


### PR DESCRIPTION
if the warm dashboard is reaped before call sites, the activation
(and thus the label inside the activation) can be freed (during u3h_put)
while a call site in the junior still points to the label (but doesn't hold
a reference to it, since it is on a senior road). trying to take that label
during call site reap then results in a bail: foul.

the solution is to always reap call sites before reaping the warm dashboard.