### PR TITLE
Shrink preallocation of cells from 262.144 cells to 4.096

### DIFF
--- a/noun/allocate.c
+++ b/noun/allocate.c
@@ -772,7 +772,7 @@ u3a_celloc(void)
       return u3a_walloc(c3_wiseof(u3a_cell));
     } 
     else {
-      if ( c3n == u3a_cellblock(256 << 10) ) {
+      if ( c3n == u3a_cellblock(4096) ) {
         return u3a_walloc(c3_wiseof(u3a_cell));
       }
       cel_p = u3R->all.cel_p;


### PR DESCRIPTION
Everytime a new road is constructed, a new bank of cells is
allocated and initialized. This lead to over three megabytes of
memory being allocated and accessed on each road change. This takes
more than 1ms to complete.

Road changes occur on each virtualization call. Each +soft happens
virtualized; so each +soft call incurs a 1ms delay. The metavase
machinery does at least two (and usually three) softs per card move
meaning sending a card move through arvo usually incurs a 3ms delay.

Before this patch, the following line took six seconds to execute.
Now it is imperceivable:

```
~:(turn (gulf 0 10.000) |=(a=@ud (mule |.(a))))
```