### PR TITLE
Jet +jab:by, which is used extensively in ford.

### DIFF
--- a/include/jets/w.h
+++ b/include/jets/w.h
@@ -84,6 +84,7 @@
     u3_noun u3wdb_get(u3_noun);
     u3_noun u3wdb_has(u3_noun);
     u3_noun u3wdb_int(u3_noun);
+    u3_noun u3wdb_jab(u3_noun);
     u3_noun u3wdb_put(u3_noun);
 #   define u3wdb_tap u3wdi_tap
     u3_noun u3wdb_uni(u3_noun);

--- a/jets/d/by_jab.c
+++ b/jets/d/by_jab.c
@@ -1,0 +1,56 @@
+/* j/4/by_jab.c
+**
+*/
+#include "all.h"
+
+
+/* functions
+*/
+  u3_noun
+  u3qdb_jab(u3_noun a,
+            u3_noun key,
+            u3_noun fun)
+  {
+    if ( u3_nul == a ) {
+      return u3m_bail(c3__exit);
+    }
+    else {
+      u3_noun l_a, n_a, r_a;
+      u3_noun pn_a, qn_a;
+
+      if ( (c3n == u3r_trel(a, &n_a, &l_a, &r_a)) ||
+           (c3n == u3r_cell(n_a, &pn_a, &qn_a) ) )
+      {
+        return u3m_bail(c3__exit);
+      }
+      else {
+        if ( (c3y == u3r_sing(key, pn_a)) ) {
+          u3_noun value = u3n_slam_on(u3k(fun), u3k(qn_a));
+          return u3nc(u3nc(u3k(pn_a), value), u3k(u3t(a)));
+        }
+        else {
+          if ( c3y == u3qc_gor(key, pn_a) ) {
+            return u3nt(u3k(n_a), u3qdb_jab(l_a, key, fun), u3k(r_a));
+          }
+          else {
+            return u3nt(u3k(n_a), u3k(l_a), u3qdb_jab(r_a, key, fun));
+          }
+        }
+      }
+    }
+  }
+
+  u3_noun
+  u3wdb_jab(u3_noun cor)
+  {
+    u3_noun a, key, fun;
+
+    if ( c3n == u3r_mean(cor, u3x_sam_2,   &key,
+                              u3x_sam_3,   &fun,
+                              u3x_con_sam, &a, 0) ) {
+      return u3m_bail(c3__exit);
+    } else {
+      u3_noun n = u3qdb_jab(a, key, fun);
+      return n;
+    }
+  }

--- a/jets/tree.c
+++ b/jets/tree.c
@@ -922,6 +922,8 @@ static c3_c* _141_two__in_ha[] = {0};
   // static u3j_harm _141_two__by_int_a[] = {{".2", u3wdb_int, c3y}, {}};
   // static c3_c* _141_two__by_int_ha[] = {0};
 
+  static u3j_harm _141_two__by_jab_a[] = {{".2", u3wdb_jab, c3y}, {}};
+  static c3_c* _141_two__by_jab_ha[] = {0};
   static u3j_harm _141_two__by_put_a[] = {{".2", u3wdb_put, c3y}, {}};
   static c3_c* _141_two__by_put_ha[] = {0};
   static u3j_harm _141_two__by_tap_a[] = {{".2", u3wdb_tap, c3y}, {}};
@@ -938,6 +940,7 @@ static u3j_core _141_two__by_d[] =
     { "get", 7, _141_two__by_get_a, 0, _141_two__by_get_ha },
     { "has", 7, _141_two__by_has_a, 0, _141_two__by_has_ha },
     // { "int", 7, _141_two__by_int_a, 0, _141_two__by_int_ha },
+    { "jab", 7, _141_two__by_jab_a, 0, _141_two__by_jab_ha },
     { "put", 7, _141_two__by_put_a, 0, _141_two__by_put_ha },
     { "tap", 7, _141_two__by_tap_a, 0, _141_two__by_tap_ha },
     // { "uni", 7, _141_two__by_uni_a, 0, _141_two__by_uni_ha },

--- a/meson.build
+++ b/meson.build
@@ -94,6 +94,7 @@ jets_d_src = [
 'jets/d/by_get.c',
 'jets/d/by_has.c',
 'jets/d/by_int.c',
+'jets/d/by_jab.c',
 'jets/d/by_put.c',
 'jets/d/by_uni.c',
 'jets/d/by_bif.c',


### PR DESCRIPTION
+jab:by showed up in profiling traces when running ford, which makes sense since it is used extensively. 

This is my first de-novo jet that I've worked on. I am unsure about the reference counting here. What's the process for checking that it's all correct?