### PR TITLE
fix core nest jet mismatch

### DIFF
--- a/jets/f/ut_nest.c
+++ b/jets/f/ut_nest.c
@@ -150,9 +150,6 @@
       else if ( c3__wet == qpq_sut ) {
         return u3r_sing(qrq_sut, qrq_ref);
       }
-      else if ( c3y == u3r_sing(qrq_sut, qrq_ref) ) {
-        return c3y;
-      }
       else {
         u3_noun hud = u3nc(u3k(sut), u3k(ref));
 


### PR DESCRIPTION
There is a variance bug such that the following cast is allowed to go through:

```
> =a 12

> =core1 ^?  |=(b=@ a)

> =a "hello"

> =core2 ^?  |=(b=@ a)

> ^+(core1 core2)
```

This should not be!  The code in `hoon.hoon` is correct -- it turns out that the jet is wrong however.  It falsely returns "yes" for a nest in which two cores have identical code.  Obviously that's not enough to guarantee sameness of type.  So I've removed the offending lines.