### PR TITLE
Add support for trace_event files.

### DIFF
--- a/include/noun/allocate.h
+++ b/include/noun/allocate.h
@@ -146,6 +146,7 @@
           c3_d    nox_d;                      //  nock steps
           c3_d    cel_d;                      //  cell allocations
           u3_noun don;                        //  (list batt)
+          u3_noun trace;                      //  (list trace)
           u3_noun day;                        //  doss, only in u3H (moveme)
         } pro;
 

--- a/include/noun/options.h
+++ b/include/noun/options.h
@@ -25,7 +25,8 @@
         u3o_verbose =       0x10,             //  be remarkably wordy
         u3o_dryrun =        0x20,             //  don't touch checkpoint
         u3o_quiet =         0x40,             //  disable ~&
-        u3o_hashless =      0x80              //  disable hashboard
+        u3o_hashless =      0x80,             //  disable hashboard
+        u3o_trace =         0x100             //  enables trace dumping
       };
 
   /** Globals.

--- a/include/noun/trace.h
+++ b/include/noun/trace.h
@@ -83,6 +83,27 @@
       void
       u3t_flee(void);
 
+    /* u3t_trace_open(): opens the path for writing tracing information.
+    */
+      void
+      u3t_trace_open(c3_c*);
+
+    /* u3t_nock_trace_push(): pushes a frame ont o the trace stack;
+    *  return yes if active push.
+    */
+      c3_o
+      u3t_nock_trace_push(u3_noun lab);
+
+    /* u3t_nock_trace_pop(): pop off trace stack.
+    */
+      void
+      u3t_nock_trace_pop();
+
+    /* u3t_even_trace(): record a lifecycle event.
+    */
+      void
+      u3t_event_trace(const char* name, char type);
+
     /* u3t_damp(): print and clear profile data.
     */
       void

--- a/include/noun/trace.h
+++ b/include/noun/trace.h
@@ -88,7 +88,12 @@
       void
       u3t_trace_open(c3_c*);
 
-    /* u3t_nock_trace_push(): pushes a frame ont o the trace stack;
+    /* u3t_trace_close(): closes the trace file. optional.
+    */
+      void
+      u3t_trace_close();
+
+    /* u3t_nock_trace_push(): pushes a frame onto the trace stack;
     *  return yes if active push.
     */
       c3_o
@@ -99,7 +104,7 @@
       void
       u3t_nock_trace_pop();
 
-    /* u3t_even_trace(): record a lifecycle event.
+    /* u3t_event_trace(): record a lifecycle event.
     */
       void
       u3t_event_trace(const char* name, char type);

--- a/include/noun/trace.h
+++ b/include/noun/trace.h
@@ -107,7 +107,7 @@
     /* u3t_event_trace(): record a lifecycle event.
     */
       void
-      u3t_event_trace(const char* name, char type);
+      u3t_event_trace(const c3_c* name, c3_c type);
 
     /* u3t_damp(): print and clear profile data.
     */

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -632,7 +632,7 @@
         c3_o       liv;                     //  if u3_no, shut down
         c3_i       xit_i;                   //  exit code for shutdown
         void*      tls_u;                   //  server SSL_CTX*
-        FILE*      trace_file;              //  trace file to write to
+        FILE*      trace_file_u;            //  trace file to write to
       } u3_host;                            //  host == computer == process
 
 #     define u3L  u3_Host.lup_u             //  global event loop

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -591,6 +591,7 @@
         c3_c*   gen_c;                      //  -G, czar generator
         c3_o    gab;                        //  -g, test garbage collection
         c3_c*   dns_c;                      //  -H, ames bootstrap domain
+        c3_c*   json_file_c;                //  -j, json trace
         c3_w    kno_w;                      //  -K, kernel version
         c3_c*   key_c;                      //  -k, private key file
         c3_o    net;                        //  -L, local-only networking
@@ -631,6 +632,7 @@
         c3_o       liv;                     //  if u3_no, shut down
         c3_i       xit_i;                   //  exit code for shutdown
         void*      tls_u;                   //  server SSL_CTX*
+        FILE*      trace_file;              //  trace file to write to
       } u3_host;                            //  host == computer == process
 
 #     define u3L  u3_Host.lup_u             //  global event loop

--- a/noun/jets.c
+++ b/noun/jets.c
@@ -1243,18 +1243,27 @@ u3j_kick(u3_noun cor, u3_noun axe)
       u3x_qual(act, &jax_l, &hap, &bal, &jit);
 
       if ( u3_none == (inx = u3kdb_get(u3k(hap), u3k(axe))) ) {
-        u3t_off(glu_o); 
+        u3t_off(glu_o);
         {
           c3_o pof_o = __(u3C.wag_w & u3o_debug_cpu);
+          c3_o trc_o = __(u3C.wag_w & u3o_trace);
 
           if ( _(pof_o) ) {
             pof_o = u3t_come(bal);
           }
+          if ( _(trc_o) ) {
+            trc_o = u3t_nock_trace_push(bal);
+          }
           u3z(act);
-          if ( _(pof_o) ) {
+          if ( _(pof_o) || _(trc_o) ) {
             u3_noun pro = _cj_sink(cor, u3k(axe));
 
-            u3t_flee();
+            if (_(pof_o)) {
+              u3t_flee();
+            }
+            if ( _(trc_o) ) {
+              u3t_nock_trace_pop();
+            }
             return pro;
           }
           else {
@@ -1267,27 +1276,38 @@ u3j_kick(u3_noun cor, u3_noun axe)
         c3_l      inx_l = inx;
         u3j_harm* ham_u = &cop_u->arm_u[inx_l];
         c3_o      pof_o = __(u3C.wag_w & u3o_debug_cpu);
+        c3_o      trc_o = __(u3C.wag_w & u3o_trace);
         u3_noun   pro;
 
         if ( _(pof_o) ) {
           pof_o = u3t_come(bal);
         }
+        if ( _(trc_o) ) {
+          trc_o = u3t_nock_trace_push(bal);
+        }
         u3z(act);
         u3t_off(glu_o);
         pro = _cj_kick_z(cor, cop_u, ham_u, axe);
- 
+
         if ( u3_none == pro ) {
-          if ( _(pof_o) ) {
+          if ( _(pof_o) || _(trc_o) ) {
             pro = _cj_sink(cor, u3k(axe));
 
-            u3t_flee();
-            return pro;
-          } 
-          else return u3_none;
+            if (_(pof_o)) {
+              u3t_flee();
+            }
+            if ( _(trc_o) ) {
+              u3t_nock_trace_pop();
+            }
+          }
+          return pro;
         }
         else {
           if ( _(pof_o) ) {
             u3t_flee();
+          }
+          if ( _(trc_o) ) {
+            u3t_nock_trace_pop();
           }
           return pro;
         }
@@ -1470,7 +1490,9 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u, c3_o lok_o)
   u3_weak pro = u3_none;
   c3_o jet_o  = sit_u->jet_o;
   c3_o pof_o  =  __(u3C.wag_w & u3o_debug_cpu);
-  if ( c3n == pof_o ) {
+  c3_o trc_o  =  __(u3C.wag_w & u3o_trace);
+
+  if ( c3n == pof_o && c3n == trc_o ) {
     if ( c3y == jet_o ) {
       u3t_off(glu_o);
       pro = _cj_kick_z(cor, sit_u->cop_u, sit_u->ham_u, sit_u->axe);
@@ -1483,7 +1505,13 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u, c3_o lok_o)
     }
   }
   else {
-    pof_o = u3t_come(sit_u->lab);
+    if ( _(pof_o) ) {
+      pof_o = u3t_come(sit_u->lab);
+    }
+    if ( _(trc_o) ) {
+      trc_o = u3t_nock_trace_push(sit_u->lab);
+    }
+
     if ( c3y == jet_o ) {
       u3t_off(glu_o);
       pro = _cj_kick_z(cor, sit_u->cop_u, sit_u->ham_u, sit_u->axe);
@@ -1495,10 +1523,15 @@ _cj_site_kick_hot(u3_noun loc, u3_noun cor, u3j_site* sit_u, c3_o lok_o)
       }
       pro = _cj_burn(sit_u->pog_p, cor);
     }
+
     if ( c3y == pof_o ) {
       u3t_flee();
     }
+    if ( c3y == trc_o ) {
+      u3t_nock_trace_pop();
+    }
   }
+
   return pro;
 }
 

--- a/noun/manage.c
+++ b/noun/manage.c
@@ -500,6 +500,7 @@ u3m_mark(void)
   tot_w += u3a_mark_noun(u3R->bug.tax);
   tot_w += u3a_mark_noun(u3R->bug.mer);
   tot_w += u3a_mark_noun(u3R->pro.don);
+  tot_w += u3a_mark_noun(u3R->pro.trace);
   tot_w += u3a_mark_noun(u3R->pro.day);
   tot_w += u3h_mark(u3R->cax.har_p);
   return tot_w;
@@ -1014,6 +1015,7 @@ u3m_soft_run(u3_noun gul,
   {
     u3R->ski.gul = u3nc(gul, u3to(u3_road, u3R->par_p)->ski.gul);
     u3R->pro.don = u3to(u3_road, u3R->par_p)->pro.don;
+    u3R->pro.trace = u3to(u3_road, u3R->par_p)->pro.trace;
     u3R->bug.tax = 0;
   }
   u3t_on(coy_o);
@@ -1107,6 +1109,7 @@ u3m_soft_esc(u3_noun ref, u3_noun sam)
   {
     u3R->ski.gul = u3t(u3to(u3_road, u3R->par_p)->ski.gul);
     u3R->pro.don = u3to(u3_road, u3R->par_p)->pro.don;
+    u3R->pro.trace = u3to(u3_road, u3R->par_p)->pro.trace;
     u3R->bug.tax = 0;
   }
 

--- a/noun/trace.c
+++ b/noun/trace.c
@@ -351,7 +351,7 @@ u3t_trace_close()
 
 /*  u3t_trace_time(): microsecond clock
 */
-uint64_t u3t_trace_time()
+c3_d u3t_trace_time()
 {
   struct timeval tim_tv;
   gettimeofday(&tim_tv, 0);
@@ -448,7 +448,7 @@ u3t_nock_trace_pop()
   c3_d start_time = u3r_chub(0, u3t(item));
 
   // 33microseconds (a 30th of a millisecond).
-  uint64_t duration = u3t_trace_time() - start_time;
+  c3_d duration = u3t_trace_time() - start_time;
   if (duration > 33) {
     c3_c* name = trace_pretty(lab);
 

--- a/noun/trace.c
+++ b/noun/trace.c
@@ -470,7 +470,7 @@ u3t_nock_trace_pop()
 /* u3t_event_trace(): dumps a simple event from outside nock.
 */
 void
-u3t_event_trace(const char* name, char type)
+u3t_event_trace(const c3_c* name, c3_c type)
 {
   if (!trace_file_u)
     return;

--- a/noun/vortex.c
+++ b/noun/vortex.c
@@ -93,6 +93,7 @@ u3v_start(u3_noun now)
 u3_noun
 u3v_wish(const c3_c* str_c)
 {
+  u3t_event_trace("u3v_wish", 'b');
   u3_noun txt = u3i_string(str_c);
   u3_weak exp = u3kdb_get(u3k(u3A->yot), u3k(txt));
 
@@ -106,6 +107,8 @@ u3v_wish(const c3_c* str_c)
       u3A->yot = u3kdb_put(u3A->yot, u3k(txt), u3k(exp));
     }
   }
+
+  u3t_event_trace("u3v_wish", 'e');
 
   u3z(txt);
   return exp;

--- a/vere/loop.c
+++ b/vere/loop.c
@@ -252,6 +252,11 @@ u3_lo_exit(void)
   cod_l = u3a_lush(c3__behn);
   u3_behn_io_exit();
   u3a_lop(cod_l);
+
+  if ( c3y == __(u3C.wag_w & u3o_trace) ) {
+    printf("saving trace file.\r\n");
+    u3t_trace_close();
+  }
 }
 
 #if 0

--- a/vere/main.c
+++ b/vere/main.c
@@ -94,7 +94,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.raf_c = 0;
   u3_Host.ops_u.nam_c = 0;
 
-  while ( (ch_i=getopt(argc, argv,"G:B:K:A:H:w:u:e:E:f:F:k:p:LabcdgqstvxPDRS")) != -1 ) {
+  while ( (ch_i=getopt(argc, argv,"G:B:K:A:H:w:u:j:e:E:f:F:k:p:LabcdgqstvxPDRS")) != -1 ) {
     switch ( ch_i ) {
       case 'B': {
         u3_Host.ops_u.pil_c = strdup(optarg);
@@ -131,6 +131,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 'u': {
         u3_Host.ops_u.url_c = strdup(optarg);
+        break;
+      }
+      case 'j': {
+        u3_Host.ops_u.json_file_c = strdup(optarg);
         break;
       }
       case 'x': {
@@ -335,6 +339,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-F ship       Fake keys; also disables networking\n",
     "-f            Fuzz testing\n",
     "-g            Set GC flag\n",
+    "-j file       Create json trace file\n",
     "-K stage      Start at Hoon kernel version stage\n",
     "-k keys       Private key file\n",
     "-L            local networking only\n",
@@ -597,6 +602,13 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.has) ) {
         u3C.wag_w |= u3o_hashless;
+      }
+
+      /*  Set tracing flag
+      */
+      if ( u3_Host.ops_u.json_file_c ) {
+        u3C.wag_w |= u3o_trace;
+        u3t_trace_open(u3_Host.ops_u.json_file_c);
       }
     }
     u3m_boot(u3_Host.ops_u.nuu,

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1567,7 +1567,10 @@ _raft_punk(u3_noun ovo)
   }
 #endif
 
+  // TODO: Embed event number here?
+  u3t_event_trace("Running", 'b');
   gon = u3m_soft(sec_w, u3v_poke, u3k(ovo));
+  u3t_event_trace("Running", 'e');
 
 #ifdef GHETTO
   c3_w ms_w;
@@ -1656,7 +1659,9 @@ _raft_push(u3_raft* raf_u, c3_w* bob_w, c3_w len_w)
 
   if ( 1 == raf_u->pop_w ) {
     c3_assert(u3_raty_lead == raf_u->typ_e);
+    u3t_event_trace("Recording", 'b');
     raf_u->ent_d = u3_sist_pack(raf_u->tem_w, c3__ov, bob_w, len_w);
+    u3t_event_trace("Recording", 'e');
     raf_u->lat_w = raf_u->tem_w;  //  XX
 
     if ( !uv_is_active((uv_handle_t*)&raf_u->tim_u) ) {

--- a/vere/reck.c
+++ b/vere/reck.c
@@ -365,6 +365,7 @@ _reck_kick_norm(u3_noun pox, u3_noun fav)
 void
 u3_reck_kick(u3_noun ovo)
 {
+  u3t_event_trace("Effect", 'b');
   if ( (c3n == _reck_kick_spec(u3k(u3h(ovo)), u3k(u3t(ovo)))) &&
        (c3n == _reck_kick_norm(u3k(u3h(ovo)), u3k(u3t(ovo)))) )
   {
@@ -399,4 +400,5 @@ u3_reck_kick(u3_noun ovo)
 #endif
   }
   u3z(ovo);
+  u3t_event_trace("Effect", 'e');
 }


### PR DESCRIPTION
This adds a -j parameter which writes traces of your Urbit's function call
stack to a json file, readable by Chrome's about://tracing or the standalone
trace-viewer webapp.

---

An example of the output (both screenshotted and raw JSON) is in urbit/arvo#905, where I used this tracer to figure out a problem in the kernel.

Right now, this is more a request for comments instead of a real patch since I'm unsure about how I added this to vere. I put in a parallel `trace` to `don`, because I want this to be runnable in normal builds when the user hasn't compiled in `-Dprof=true`. This lets us tell users who are having performance issues to simply restart their urbits for a few moments with another command line flag instead of telling them to recompile their Urbit binary.

manually cc @frodwith because github isn't letting me request a review.