### PR TITLE
update old %behn declarations in vere.h

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1024,15 +1024,15 @@
 
     /**  behn, just a timer.
     **/
-      /* u2_behn_io_init(): initialize behn timer.
+      /* u3_behn_io_init(): initialize behn timer.
       */
         void
-        u2_behn_io_init(void);
+        u3_behn_io_init(void);
 
       /* u2_behn_io_exit(): terminate timer.
       */
         void
-        u2_behn_io_exit(void);
+        u3_behn_io_exit(void);
 
       /* u3_behn_ef_bake(): notify %behn that we're live
       */


### PR DESCRIPTION
There used to be both u2 and u3 behn declarations in vere.h. I de-duplicated them, but accidentally left some of the u2 declarations in place of u3.