### PR TITLE
updates c3_assert() to print assertion/file/line before bail

### DIFF
--- a/include/c/defs.h
+++ b/include/c/defs.h
@@ -17,8 +17,17 @@
   **/
     /* Assert.  Good to capture.
     */
-// #     define c3_assert(x)   assert(x)
-#     define c3_assert(x)  ( (x) ? 0 : c3_cooked(), assert(x) )
+#     define c3_assert(x)                       \
+        do {                                    \
+          if (!(x)) {                           \
+            fprintf(stderr,                     \
+                    "\rAssertion '%s' failed "  \
+                    "in %s:%d\n",               \
+                    #x, __FILE__, __LINE__);    \
+            c3_cooked();                        \
+            assert(x);                          \
+          }                                     \
+        } while(0)
 
     /* Stub.
     */


### PR DESCRIPTION
Currently, `c3_assert()` calls `c3_cooked` calls `u3m_bail(c3__oops)` calls `assert(0)`. This has the unfortunate side effect of throwing away the context of the original assertion; all assertion failures look like #990 (which is why it became a catch-all). The bail protocol in vere needs polish and enforcement. 

In the meantime, this PR adds a typical assertion printf to `c3_assert()` prior to the call to `c3_cooked()`, so that context is not lost. It still includes `assert()` in the macro to avoid compiler warnings.