### PR TITLE
fix (my own) use-after-free in unix dir/file watch

### DIFF
--- a/vere/unix.c
+++ b/vere/unix.c
@@ -590,7 +590,8 @@ _unix_watch_file(u3_ufil* fil_u, u3_udir* par_u, c3_c* pax_c)
 
   fil_u->dir = c3n;
   fil_u->dry = c3n;
-  fil_u->pax_c = pax_c;
+  fil_u->pax_c = c3_malloc(1 + strlen(pax_c));
+  strcpy(fil_u->pax_c, pax_c);
   fil_u->par_u = par_u;
   fil_u->nex_u = NULL;
   fil_u->mug_w = 0;
@@ -627,7 +628,8 @@ _unix_watch_dir(u3_udir* dir_u, u3_udir* par_u, c3_c* pax_c)
 
   dir_u->dir = c3y;
   dir_u->dry = c3n;
-  dir_u->pax_c = pax_c;
+  dir_u->pax_c = c3_malloc(1 + strlen(pax_c));
+  strcpy(dir_u->pax_c, pax_c);
   dir_u->par_u = par_u;
   dir_u->nex_u = NULL;
   dir_u->kid_u = NULL;

--- a/vere/unix.c
+++ b/vere/unix.c
@@ -371,6 +371,8 @@ _unix_scan_mount_point(u3_umon* mon_u)
           _unix_watch_file(fil_u, &mon_u->dir_u, pax_c);
         }
       }
+
+      free(pax_c);
     }
   }
 }


### PR DESCRIPTION
In #1092, I was a little too aggressive in fixing a memory-leak in unix.c and introduced a use-after-free.  I thought I had specifically tested that this was not the case. Mea maxima culpa.

(My fix is to copy paths that are hung onto, hopefully making the allocations easier to track.)

closes #1096

/cc @rmariani 

