### PR TITLE
re-enable event-log encryption

### DIFF
--- a/vere/raft.c
+++ b/vere/raft.c
@@ -2026,8 +2026,7 @@ _raft_pump(u3_noun ovo)
 
   ron = u3ke_jam(u3nc(u3k(u3A->now), ovo));
   c3_assert(u3A->key);
-  // don't encrypt for the moment, bootstrapping
-  // ron = u3dc("en:crua", u3k(u3A->key), ron);
+  ron = u3dc("en:crub:crypto", u3k(u3A->key), ron);
 
   len_w = u3r_met(5, ron);
   bob_w = c3_malloc(len_w * 4L);

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -971,13 +971,10 @@ _sist_rest()
         continue;
       }
 
-#if 0
-      // disable encryption for now
-      //
       if ( u3A->key ) {
         u3_noun dep;
 
-        dep = u3dc("de:crua", u3k(u3A->key), ron);
+        dep = u3dc("de:crub:crypto", u3k(u3A->key), ron);
         if ( c3n == u3du(dep) ) {
           uL(fprintf(uH, "record (%s) is corrupt (k)\n", ful_c));
           u3_lo_bail();
@@ -987,7 +984,7 @@ _sist_rest()
           u3z(dep);
         }
       }
-#endif
+
       roe = u3nc(u3ke_cue(ron), roe);
     }
     u3A->ent_d = c3_max(las_d + 1ULL, old_d);


### PR DESCRIPTION
This is a trivial change -- I'm opening this PR so we can discuss whether we want to do so. On the one hand, this subsystem will change dramatically in the near future. On the other hand, it might be worth it for the profiling and opportunity to polish the parts that will persist (particularly the encryption gates in %zuse).

If we decide not to enable this, I think we should remove the passcode and related printfs.