### PR TITLE
renames event-timing, adds build option to enable

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -12,5 +12,6 @@
 
 #mesondefine U3_MEMORY_DEBUG
 #mesondefine U3_CPU_DEBUG
+#mesondefine U3_EVENT_TIME_DEBUG
 
 #endif /*CONFIG_H*/

--- a/meson.build
+++ b/meson.build
@@ -240,6 +240,7 @@ conf_data = configuration_data()
 conf_data.set('URBIT_VERSION', '"0.6.0"')
 conf_data.set('U3_MEMORY_DEBUG', get_option('gc'))
 conf_data.set('U3_CPU_DEBUG', get_option('prof'))
+conf_data.set('U3_EVENT_TIME_DEBUG', get_option('event-time'))
 
 osdet = build_machine.system()
 os_c_flags = ['-funsigned-char','-ffast-math']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,7 @@ option('gc', type : 'boolean', value : false,
   description : 'Add debugging information to heap. Run with -g. Breaks image.')
 option('prof', type : 'boolean', value : false,
   description : 'Activate profiling. Run with -P.')
+option('event-time', type : 'boolean', value : false,
+  description : 'Print timing information per event.')
 option('nix', type: 'boolean', value: false,
   description: 'Build using nix.')

--- a/noun/trace.c
+++ b/noun/trace.c
@@ -45,7 +45,7 @@ u3_lo_tank(c3_l tab_l, u3_noun tac);
 void
 u3t_slog(u3_noun hod)
 {
-#ifdef GHETTO
+#ifdef U3_EVENT_TIME_DEBUG
   static int old;
   static struct timeval b4, f2, d0;
   c3_w ms_w;

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -1559,7 +1559,7 @@ _raft_lame(u3_noun ovo, u3_noun why, u3_noun tan)
 static u3_noun
 _raft_punk(u3_noun ovo)
 {
-#ifdef GHETTO
+#ifdef U3_EVENT_TIME_DEBUG
   c3_c* txt_c = u3r_string(u3h(u3t(ovo)));
 #endif
   c3_w sec_w;
@@ -1574,7 +1574,7 @@ _raft_punk(u3_noun ovo)
     sec_w = 0;
   } else sec_w = 600;
 
-#ifdef GHETTO
+#ifdef U3_EVENT_TIME_DEBUG
   struct timeval b4, f2, d0;
   gettimeofday(&b4, 0);
   if( c3__belt != u3h(u3t(ovo)) ){
@@ -1587,7 +1587,7 @@ _raft_punk(u3_noun ovo)
   gon = u3m_soft(sec_w, u3v_poke, u3k(ovo));
   u3t_event_trace("Running", 'e');
 
-#ifdef GHETTO
+#ifdef U3_EVENT_TIME_DEBUG
   c3_w ms_w;
   c3_w clr_w;
 


### PR DESCRIPTION
Run meson with `-Devent-time=true`, and this will print timing information for each event, color-coded by duration thresholds. It also prints the time since the last slog hint.