### PR TITLE
don't abort on bail:fail, but continue with crash handling

### DIFF
--- a/noun/manage.c
+++ b/noun/manage.c
@@ -625,14 +625,15 @@ u3m_bail(u3_noun how)
     } 
     else {
       c3_assert(_(u3ud(u3h(how))));
-
       fprintf(stderr, "\r\nbail: %d\r\n", u3h(how));
-      u3m_p("bail", u3t(how));
     }
   }
 
   switch ( how ) {
-    case c3__fail:
+    case c3__fail: {
+      break;
+    }
+
     case c3__meme: {
       fprintf(stderr, "bailing out\r\n");
       abort();


### PR DESCRIPTION
This PR changes u3m_bail to a) not try to print the bail payload (which might be a massive stack trace) with `u3m_p` and b) allows `%fail` bails to continue through the crash handling protocol. I've tested with `(bex (bex 128))` and the compiler crash in urbit/arvo#69; both now turn into `%crud` replacement events.

`%fail` was made to abort instead of follow in 68c6adf3e1cf16317207abc664b836b648f2b4a6, and `%meme` was similarly changed. Both previously fell through to the `%exit` case. @cgyarvin, do you remember why this was changed?