### PR TITLE
Fixes the build on OpenBSD

### DIFF
--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -188,12 +188,7 @@
 
 /* Entropy
  */
-#      if defined(U3_OS_bsd) && defined(__OpenBSD__)
-#        define c3_rand(rd) (getentropy((void*)rd, 64) == 0 ? \
-                             (void)0 : c3_assert(!"ent"))
-#      else
-#        define c3_rand u3_sist_rand
-#      endif
+#define c3_rand u3_sist_rand
 
 /* Static assertion
  */

--- a/meson.build
+++ b/meson.build
@@ -282,7 +282,7 @@ elif osdet == 'bsd' or osdet == 'freebsd'
 
 elif osdet == 'openbsd'
   conf_data.set('U3_OS_bsd', true)
-  os_link_flags = ['-L /usr/local/lib', '-lgmp', '-lsigsegv', '-lcurses']
+  os_link_flags = ['-L/usr/local/lib', '-lgmp', '-lsigsegv', '-lcurses']
   gmp_dep = []
   sigsegv_dep = []
 

--- a/vere/main.c
+++ b/vere/main.c
@@ -187,7 +187,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   }
 
 #if defined(U3_OS_bsd)
-  {
+  if (u3_Host.ops_u.pro == c3y) {
     fprintf(stderr, "profiling isn't yet supported on BSD\r\n");
     return c3n;
   }

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -415,12 +415,18 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 void
 u3_sist_rand(c3_w* rad_w)
 {
+#if defined(U3_OS_bsd) && defined(__OpenBSD__)
+  if (-1 == getentropy(rad_w, 64)) {
+    c3_assert(!"lo_rand");
+  }
+#else
   c3_i fid_i = open(DEVRANDOM, O_RDONLY);
 
   if ( 64 != read(fid_i, (c3_y*) rad_w, 64) ) {
     c3_assert(!"lo_rand");
   }
   close(fid_i);
+#endif
 }
 
 /* _sist_fast(): offer to save passcode by mug in home directory.


### PR DESCRIPTION
Tested with stock clang on an OpenBSD 6.4 amd64 VM. Unfortunately
clang (and also gcc from ports) was not pleased about c3_rand,
whereas this was fine before. I have no idea what changed, but it
works now.

cc @joemfb 