### PR TITLE
Fix multiple behn effects in an event.

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -432,8 +432,9 @@
     /* u3_behn: just a timer for ever
     */
       typedef struct _u3_behn {
-        uv_timer_t tim_u;                   //  behn timer
-        c3_o       alm;                     //  alarm
+        uv_timer_t     tim_u;               //  behn timer
+        c3_o           alm;                 //  alarm
+        struct timeval next_tv;             //  next wakeup, unix timeval
       } u3_behn;
 
     /* u2_utfo: unix terminfo strings.


### PR DESCRIPTION
If an event generates multiple %doze effects, we may have a short
timer and a long term sent from the same event. The previous doze
handler would indiscriminantely unset the previous timer. This adds
logic to behn.c so that we compare the current timeout to the new
timeout and use the sooner one.