### PR TITLE
Use getentropy where possible, clean up some defs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,7 @@
 [submodule "subprojects/libsni"]
 	path = subprojects/libsni
 	url = https://github.com/urbit/sniproxy
+# TODO: fork and change this to urbit/libent
+[submodule "subprojects/libent"]
+	path = subprojects/libent
+	url = https://github.com/mrdomino/libent

--- a/include/c/defs.h
+++ b/include/c/defs.h
@@ -55,6 +55,11 @@
       int
       c3_cooked();
 
+    /* Fill 16 words (64 bytes) with high-quality entropy.
+    */
+      void
+      c3_rand(c3_w* rad_w);
+
     /* Short integers.
     */
 #     define c3_s1(a)          ( (a) )

--- a/include/c/defs.h
+++ b/include/c/defs.h
@@ -93,25 +93,25 @@
 
 /* c3_malloc(): asserting malloc
  */
-#define c3_malloc(s) ({                         \
-      void* rut = malloc(s);                    \
-      if ( 0 == rut ) {                         \
-        c3_assert(!"memory lost");              \
-      }                                         \
-      rut;})
+#     define c3_malloc(s) ({          \
+        void* rut = malloc(s);        \
+        if ( 0 == rut ) {             \
+          c3_assert(!"memory lost");  \
+        }                             \
+        rut;})
 
 /* c3_calloc(): asserting calloc
  */
-#define c3_calloc(s) ({                         \
-      void* rut = c3_malloc(s);                 \
-      memset(rut, 0, s);                        \
-      rut;})
+#     define c3_calloc(s) ({          \
+        void* rut = c3_malloc(s);     \
+        memset(rut, 0, s);            \
+        rut;})
 
 /* c3_realloc(): asserting realloc
  */
-#define c3_realloc(a, b) ({                     \
-      void* rut = realloc(a, b);                \
-      if ( 0 == rut ) {                         \
-        c3_assert(!"memory lost");              \
-      }                                         \
-      rut;})
+#     define c3_realloc(a, b) ({      \
+        void* rut = realloc(a, b);    \
+        if ( 0 == rut ) {             \
+          c3_assert(!"memory lost");  \
+        }                             \
+        rut;})

--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -186,10 +186,6 @@
 #        error "port: timeconvert"
 #      endif
 
-/* Entropy
- */
-#define c3_rand u3_sist_rand
-
 /* Static assertion
  */
 #define ASSERT_CONCAT_(a, b) a##b

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1180,11 +1180,6 @@
         void
         u3_sist_get(const c3_c* key_c, c3_y* val_y);
 
-      /* u3_sist_rand(): fill 8 words (32 bytes) with high-quality entropy.
-      */
-        void
-        u3_sist_rand(c3_w* rad_w);
-
     /**  HTTP client.
     **/
       /* u3_cttp_ef_thus(): send %thus effect to cttp.

--- a/meson.build
+++ b/meson.build
@@ -325,6 +325,7 @@ endif
 urbitscrypt_dep = dependency('libscrypt', version: '>=0.1.21', fallback: ['libscrypt', 'libscrypt_dep'])
 
 ed25519_dep = dependency('ed25519', version: '>=0.1.0', fallback: ['ed25519', 'ed25519_dep'])
+libent_dep = dependency('libent', version: '>=0.0.0', fallback: ['libent', 'libent_dep'])
 murmur3_dep = dependency('murmur3', version: '>=0.1.0', fallback: ['murmur3', 'murmur3_dep'])
 softfloat3_dep = dependency('softfloat3', version: '>=3.0.0', fallback: ['softfloat3', 'softfloat3_dep'])
 libuv_dep = dependency('libuv', version: '>=1.8.0', fallback:['libuv', 'libuv_dep'])
@@ -336,6 +337,7 @@ libsni_dep = dependency('libsni', version: '>=0.5.0', fallback: ['libsni', 'libs
 
 deps = [openssl_dep,
         curl_dep,
+        libent_dep,
         libuv_dep,
         libh2o_dep,
         secp256k1_dep,

--- a/vere/main.c
+++ b/vere/main.c
@@ -641,21 +641,6 @@ main(c3_i   argc,
   SSL_library_init();
   SSL_load_error_strings();
 
-  {
-    c3_i rad;
-    c3_y buf[4096];
-
-    // RAND_status, at least on OS X, never returns true.
-    // 4096 bytes should be enough entropy for anyone, right?
-    rad = open("/dev/urandom", O_RDONLY);
-    if ( 4096 != read(rad, &buf, 4096) ) {
-      perror("rand-seed");
-      exit(1);
-    }
-    RAND_seed(buf, 4096);
-    close(rad);
-  }
-
   // u3e_grab("main", u3_none);
   //
   u3_lo_loop();

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -1,6 +1,7 @@
 /* v/sist.c
 **
 */
+#include <ent/ent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -11,12 +12,6 @@
 
 #include "all.h"
 #include "vere/vere.h"
-
-#if defined(U3_OS_linux)
-#define DEVRANDOM "/dev/urandom"
-#else
-#define DEVRANDOM "/dev/random"
-#endif
 
 /* u3_sist_pack(): write a blob to disk, transferring.
 */
@@ -400,23 +395,15 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 }
 #endif
 
-/* u3_sist_rand(): fill a 512-bit (16-word) buffer.
+/* c3_rand(): fill a 512-bit (16-word) buffer.
 */
 void
-u3_sist_rand(c3_w* rad_w)
+c3_rand(c3_w* rad_w)
 {
-#if defined(U3_OS_bsd) && defined(__OpenBSD__)
-  if (-1 == getentropy(rad_w, 64)) {
-    c3_assert(!"lo_rand");
+  if (0 != ent_getentropy(rad_w, 64)) {
+    uL(fprintf(uH, "c3_rand: %s\n", strerror(errno)));
+    u3_lo_bail();
   }
-#else
-  c3_i fid_i = open(DEVRANDOM, O_RDONLY);
-
-  if ( 64 != read(fid_i, (c3_y*) rad_w, 64) ) {
-    c3_assert(!"lo_rand");
-  }
-  close(fid_i);
-#endif
 }
 
 /* _sist_fast(): offer to save passcode by mug in home directory.


### PR DESCRIPTION
PLEASE DON'T LOOK AT THIS UNLESSS YOU'RE BORED / NOT BUSY.

Note that this just brazenly rips out the call to RAND_seed for OpenSSL, since OpenSSL claims it does that on its own, and why not just take its word for it. That's in a separate commit in case we'd rather keep the prophylactic seed in there.