### PR TITLE
Clean up allocator defs

### DIFF
--- a/include/c/defs.h
+++ b/include/c/defs.h
@@ -91,27 +91,23 @@
           cnt_w = (cnt_w + 1) % (n);  \
         } while (0)
 
-/* c3_malloc(): asserting malloc
- */
-#define c3_malloc(s) ({                         \
-      void* rut = malloc(s);                    \
-      if ( 0 == rut ) {                         \
-        c3_assert(!"memory lost");              \
-      }                                         \
-      rut;})
-
-/* c3_calloc(): asserting calloc
- */
-#define c3_calloc(s) ({                         \
-      void* rut = c3_malloc(s);                 \
-      memset(rut, 0, s);                        \
-      rut;})
-
-/* c3_realloc(): asserting realloc
- */
-#define c3_realloc(a, b) ({                     \
-      void* rut = realloc(a, b);                \
-      if ( 0 == rut ) {                         \
-        c3_assert(!"memory lost");              \
-      }                                         \
-      rut;})
+    /* Asserting allocators.
+    */
+#     define c3_malloc(s) ({          \
+        void* rut = malloc(s);        \
+        if ( 0 == rut ) {             \
+          c3_assert(!"memory lost");  \
+        }                             \
+        rut;})
+#     define c3_calloc(s) ({          \
+        void* rut = calloc(1,s);      \
+        if ( 0 == rut ) {             \
+          c3_assert(!"memory lost");  \
+        }                             \
+        rut;})
+#     define c3_realloc(a, b) ({      \
+        void* rut = realloc(a, b);    \
+        if ( 0 == rut ) {             \
+          c3_assert(!"memory lost");  \
+        }                             \
+        rut;})

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -75,7 +75,7 @@ _raft_rnam_free(u3_rnam* nam_u)
 static u3_rnam*
 _raft_readname(const c3_c* str_c, c3_w siz_w)
 {
-  u3_rnam* nam_u = calloc(1, sizeof(*nam_u));
+  u3_rnam* nam_u = c3_calloc(sizeof(*nam_u));
   c3_c*    col_c;
   c3_w     nam_w;
 
@@ -520,8 +520,8 @@ _raft_rmsg_read(const u3_rbuf* buf_u, u3_rmsg* msg_u)
     memcpy(&msg_u->rest.apen.ent_d, buf_u->buf_y + red_i, sizeof(c3_d));
     red_i += sizeof(c3_d);
 
-    msg_u->rest.apen.ent_u = calloc(
-        1, msg_u->rest.apen.ent_d * sizeof(u3_rent));
+    msg_u->rest.apen.ent_u = c3_calloc(
+        msg_u->rest.apen.ent_d * sizeof(u3_rent));
     {
       c3_d     i_d;
       u3_rent* ent_u = msg_u->rest.apen.ent_u;
@@ -1152,7 +1152,7 @@ _raft_write_rest(u3_rcon* ron_u, c3_d lai_d, c3_w lat_w, u3_rmsg* msg_u)
   msg_u->rest.lai_d = lai_d;
   msg_u->rest.lat_w = lat_w;
   msg_u->rest.nam_w = 1 + strlen(raf_u->str_c) / 4;
-  msg_u->rest.nam_c = calloc(1, 4 * msg_u->rest.nam_w);
+  msg_u->rest.nam_c = c3_calloc(4 * msg_u->rest.nam_w);
   strncpy(msg_u->rest.nam_c, raf_u->str_c, 4 * msg_u->rest.nam_w + 1);
   msg_u->len_d += 4 + msg_u->rest.nam_w;
 }

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -272,7 +272,7 @@ _sist_cask(c3_c* dir_c, u3_noun nun)
 {
   c3_c   paw_c[60];
   u3_noun key;
-  u3_utty* uty_u = calloc(1, sizeof(u3_utty));
+  u3_utty* uty_u = c3_calloc(sizeof(u3_utty));
   uty_u->fid_i = 0;
 
   uH;

--- a/vere/term.c
+++ b/vere/term.c
@@ -95,7 +95,7 @@ _term_close_cb(uv_handle_t* han_t)
 void
 u3_term_io_init()
 {
-  u3_utty* uty_u = calloc(1, sizeof(u3_utty));
+  u3_utty* uty_u = c3_calloc(sizeof(u3_utty));
 
   if ( c3y == u3_Host.ops_u.dem ) {
     uty_u->fid_i = 1;


### PR DESCRIPTION
- Condense the allocator section in defs.h and make it match the
  surrounding style.

- Use real calloc in c3_calloc. Some guy on the internet says
  calloc can be faster than malloc since the OS may not actually
  need to call memset.

- Replace calloc calls in vere code with c3_calloc.

Note that I left the c3_calloc definition as-is (i.e., not taking
a count argument). I was going to change it, but it seems like
count is 1 at all call sites. If it's ever used with count != 1,
I'd be in support of changing it, fwiw.