### PR TITLE
c3_rand cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: node_js
 node_js:
 - 4
@@ -32,6 +33,8 @@ addons:
     packages:
     - python3
     - python3-pip
+    - python3-setuptools
+    - python3-wheel
     - libgmp3-dev
     - libsigsegv-dev
     - openssl

--- a/include/c/defs.h
+++ b/include/c/defs.h
@@ -55,6 +55,11 @@
       int
       c3_cooked();
 
+    /* Fill 16 words (64 bytes) with high-quality entropy.
+    */
+      void
+      c3_rand(c3_w* rad_w);
+
     /* Short integers.
     */
 #     define c3_s1(a)          ( (a) )

--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -2,17 +2,15 @@
 **
 ** This file is in the public domain.
 */
-  /** Must be compiled on gcc with C99 support.
-  **/
 
 #include "config.h"
 
-#    ifndef __GNUC__
-#      error "port me"
-#    endif
-#    ifndef _GNU_SOURCE
-#    define _GNU_SOURCE
-#    endif
+#   ifndef __GNUC__
+#     error "port me"
+#   endif
+#   ifndef _GNU_SOURCE
+#   define _GNU_SOURCE
+#   endif
 
 
   /** System include files.
@@ -79,26 +77,26 @@
 
   /** Address space layout.
   **/
-# if defined(U3_OS_linux)
-#   define U3_OS_LoomBase 0x36000000
-#   define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
-# elif defined(U3_OS_osx)
-#   ifdef __LP64__
-#     define U3_OS_LoomBase 0x200000000
+#   if defined(U3_OS_linux)
+#     define U3_OS_LoomBase 0x36000000
+#     define U3_OS_LoomBits 29              //  ie, 2^29 words == 2GB
+#   elif defined(U3_OS_osx)
+#     ifdef __LP64__
+#       define U3_OS_LoomBase 0x200000000
+#     else
+#       define U3_OS_LoomBase 0x4000000
+#     endif
+#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
+#   elif defined(U3_OS_bsd)
+#     ifdef __LP64__
+#       define U3_OS_LoomBase 0x200000000
+#     else
+#       define U3_OS_LoomBase 0x4000000
+#     endif
+#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
 #   else
-#     define U3_OS_LoomBase 0x4000000
+#     error "port: LoomBase"
 #   endif
-#     define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
-# elif defined(U3_OS_bsd)
-#   ifdef __LP64__
-#     define U3_OS_LoomBase 0x200000000
-#   else
-#     define U3_OS_LoomBase 0x4000000
-#   endif
-#     define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
-# else
-#   error "port: LoomBase"
-# endif
 
   /** Global variable control.
   ***
@@ -114,7 +112,7 @@
     /* The GMP (GNU arbitrary-precision arithmetic) library.
     ** (Tested with version 4.0.1.)
     */
-#      include <gmp.h>
+#     include <gmp.h>
 
 
   /** Private C "extensions."
@@ -138,70 +136,69 @@
 
     /* Byte swapping.
     */
-#      if defined(U3_OS_linux) || defined(U3_OS_bsd)
-#        define c3_bswap_16(x)  bswap_16(x)
-#        define c3_bswap_32(x)  bswap_32(x)
-#        define c3_bswap_64(x)  bswap_64(x)
+#     if defined(U3_OS_linux) || defined(U3_OS_bsd)
+#       define c3_bswap_16(x)  bswap_16(x)
+#       define c3_bswap_32(x)  bswap_32(x)
+#       define c3_bswap_64(x)  bswap_64(x)
+#     elif defined(U3_OS_osx)
+#       define c3_bswap_16(x)  NXSwapShort(x)
+#       define c3_bswap_32(x)  NXSwapInt(x)
+#       define c3_bswap_64(x)  NXSwapLongLong(x)
+#     else
+#       error "port: byte swap"
+#     endif
 
-#      elif defined(U3_OS_osx)
-#        define c3_bswap_16(x)  NXSwapShort(x)
-#        define c3_bswap_32(x)  NXSwapInt(x)
-#        define c3_bswap_64(x)  NXSwapLongLong(x)
-#      else
-#        error "port: byte swap"
-#      endif
+    /* Sync.
+    */
+#     if defined(U3_OS_linux)
+#       define c3_sync(fd) (fdatasync(fd))
+#     elif defined(U3_OS_osx)
+#       define c3_sync(fd) (fcntl(fd, F_FULLFSYNC, 0))
+#     elif defined(U3_OS_bsd)
+#       define c3_sync(fd) (fsync(fd))
+#     else
+#       error "port: sync"
+#     endif
 
-/* Sync
- */
-#      if defined(U3_OS_linux)
-#        define c3_sync(fd) (fdatasync(fd))
-#      elif defined(U3_OS_osx)
-#        define c3_sync(fd) (fcntl(fd, F_FULLFSYNC, 0))
-#      elif defined(U3_OS_bsd)
-#        define c3_sync(fd) (fsync(fd))
-#      else
-#        error "port: sync"
-#      endif
+    /* Purge.
+    */
+#     if defined(U3_OS_linux)
+#       include <stdio_ext.h>
+#       define c3_fpurge __fpurge
+#     elif defined(U3_OS_bsd) || defined(U3_OS_osx)
+#       define c3_fpurge fpurge
+#     else
+#       error "port: fpurge"
+#     endif
 
-/* Purge
- */
-#      if defined(U3_OS_linux)
-#        include <stdio_ext.h>
-#        define c3_fpurge __fpurge
-#      elif defined(U3_OS_bsd) || defined(U3_OS_osx)
-#        define c3_fpurge fpurge
-#      else
-#        error "port: fpurge"
-#      endif
+    /* Stat.
+    */
+#     if defined(U3_OS_linux)
+#       define c3_stat_mtime(dp) (u3_time_t_in_ts((dp)->st_mtime))
+#     elif defined(U3_OS_osx)
+#       define c3_stat_mtime(dp) (u3_time_in_ts(&((dp)->st_mtimespec)))
+#       define lseek64 lseek
+#     elif defined(U3_OS_bsd)
+#       define c3_stat_mtime(dp) (u3_time_in_ts(&((dp)->st_mtim)))
+#       define lseek64 lseek
+#     else
+#       error "port: timeconvert"
+#     endif
 
-/* Stat struct
- */
-#      if defined(U3_OS_linux)
-#        define c3_stat_mtime(dp) (u3_time_t_in_ts((dp)->st_mtime))
-#      elif defined(U3_OS_osx)
-#        define c3_stat_mtime(dp) (u3_time_in_ts(&((dp)->st_mtimespec)))
-#        define lseek64 lseek
-#      elif defined(U3_OS_bsd)
-#        define c3_stat_mtime(dp) (u3_time_in_ts(&((dp)->st_mtim)))
-#        define lseek64 lseek
-#      else
-#        error "port: timeconvert"
-#      endif
+    /* Entropy.
+    */
+#     if defined(U3_OS_linux)
+#       define c3_getentropy(B, L) \
+          ((L) == syscall(SYS_getrandom, B, L, 0) ? 0 : -1)
+#     elif defined(U3_OS_bsd) || defined(U3_OS_osx)
+#       define c3_getentropy getentropy
+#     else
+#       error "port: getentropy"
+#     endif
 
-/* Entropy
- */
-#      if defined(U3_OS_linux)
-#        define c3_getentropy(B, L) \
-           ((L) == syscall(SYS_getrandom, B, L, 0) ? 0 : -1)
-#      elif defined(U3_OS_bsd) || defined(U3_OS_osx)
-#        define c3_getentropy getentropy
-#      else
-#        error "port: getentropy"
-#      endif
-
-/* Static assertion
- */
-#define ASSERT_CONCAT_(a, b) a##b
-#define ASSERT_CONCAT(a, b) ASSERT_CONCAT_(a, b)
-#define STATIC_ASSERT(e,m) \
+    /* Static assertion.
+    */
+#     define ASSERT_CONCAT_(a, b) a##b
+#     define ASSERT_CONCAT(a, b) ASSERT_CONCAT_(a, b)
+#     define STATIC_ASSERT(e,m) \
         ;enum { ASSERT_CONCAT(assert_line_, __LINE__) = 1/(int)(!!(e)) }

--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -33,6 +33,7 @@
 #     include <setjmp.h>
 #     include <stdio.h>
 #     include <signal.h>
+#     include <sys/syscall.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
@@ -50,6 +51,7 @@
 #     include <machine/endian.h>
 #     include <machine/byte_order.h>
 #     include <stdio.h>
+#     include <sys/random.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
@@ -188,7 +190,14 @@
 
 /* Entropy
  */
-#define c3_rand u3_sist_rand
+#      if defined(U3_OS_linux)
+#        define c3_getentropy(B, L) \
+           ((L) == syscall(SYS_getrandom, B, L, 0) ? 0 : -1)
+#      elif defined(U3_OS_bsd) || defined(U3_OS_osx)
+#        define c3_getentropy getentropy
+#      else
+#        error "port: getentropy"
+#      endif
 
 /* Static assertion
  */

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1180,11 +1180,6 @@
         void
         u3_sist_get(const c3_c* key_c, c3_y* val_y);
 
-      /* u3_sist_rand(): fill 8 words (32 bytes) with high-quality entropy.
-      */
-        void
-        u3_sist_rand(c3_w* rad_w);
-
     /**  HTTP client.
     **/
       /* u3_cttp_ef_thus(): send %thus effect to cttp.

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -12,12 +12,6 @@
 #include "all.h"
 #include "vere/vere.h"
 
-#if defined(U3_OS_linux)
-#define DEVRANDOM "/dev/urandom"
-#else
-#define DEVRANDOM "/dev/random"
-#endif
-
 /* u3_sist_pack(): write a blob to disk, transferring.
 */
 c3_d
@@ -411,23 +405,15 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 }
 #endif
 
-/* u3_sist_rand(): fill a 512-bit (16-word) buffer.
+/* c3_rand(): fill a 512-bit (16-word) buffer.
 */
 void
-u3_sist_rand(c3_w* rad_w)
+c3_rand(c3_w* rad_w)
 {
-#if defined(U3_OS_bsd) && defined(__OpenBSD__)
-  if (-1 == getentropy(rad_w, 64)) {
-    c3_assert(!"lo_rand");
+  if ( 0 != c3_getentropy(rad_w, 64) ) {
+    uL(fprintf(uH, "c3_rand getentropy: %s\n", strerror(errno)));
+    u3_lo_bail();
   }
-#else
-  c3_i fid_i = open(DEVRANDOM, O_RDONLY);
-
-  if ( 64 != read(fid_i, (c3_y*) rad_w, 64) ) {
-    c3_assert(!"lo_rand");
-  }
-  close(fid_i);
-#endif
 }
 
 /* _sist_fast(): offer to save passcode by mug in home directory.


### PR DESCRIPTION
N.B. this broke the travis build since it uses a super old kernel. I bumped it to xenial, i.e. 16.04.

This should work on Linux since kernel 3.17, OS X since 10.12, OpenBSD
since 5.6, and FreeBSD since 12.0. It also introduces no external
dependencies. Note that getentropy should only be called with at most
256 bytes or it will return EIO. The getrandom variant on Linux doesn't
check for this. If called with len > 256, it's allowed to produce a
short read if it gets interrupted. This should show up as an error, so
everything's fine.