### PR TITLE
term.c hack

### DIFF
--- a/vere/term.c
+++ b/vere/term.c
@@ -50,10 +50,11 @@ _term_alloc(uv_handle_t* had_u,
             )
 {
   //  this read can range from a single byte to a paste buffer
-  //  32 bytes has been chosen heuristically
+  //  123 bytes has been chosen because its not a power of 2
+  //  this is probably still broken
   //
-  void* ptr_v = c3_malloc(32);
-  *buf = uv_buf_init(ptr_v, 32);
+  void* ptr_v = c3_malloc(123);
+  *buf = uv_buf_init(ptr_v, 123);
 }
 
 


### PR DESCRIPTION
We encountered a problem where pasting a string of exactly 64 characters (but no more or less) crashes a ship.

This just changes the number of bytes that gets allocated so that our 64 char keys can be pasted into the dojo. This is a terrible hack and should probably be flagged for an actual fix.