### PR TITLE
corrects u3r_mug_chub and u3r_mug_words

### DIFF
--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1506,14 +1506,12 @@ u3r_mug_string(const c3_c *a_c)
 c3_w
 u3r_mug_words(const c3_w* key_w, c3_w len_w)
 {
-  c3_w siz_w = 0;
   c3_w byt_w = 0;
   c3_w wor_w;
 
-  while ( siz_w < len_w ) {
-    wor_w  = key_w[siz_w];
+  while ( 0 < len_w ) {
+    wor_w  = key_w[--len_w];
     byt_w += _(u3a_is_cat(wor_w)) ? u3r_met(3, wor_w) : 4;
-    siz_w++;
   }
 
   return u3r_mug_bytes((c3_y*)key_w, byt_w);

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1485,7 +1485,12 @@ u3r_mug_bytes(const c3_y *buf_y,
 c3_w
 u3r_mug_chub(c3_d num_d)
 {
-  return u3r_mug_bytes((c3_y*)&num_d, 8);
+  c3_w buf_w[2];
+
+  buf_w[0] = (c3_w)(num_d & 0xffffffffULL);
+  buf_w[1] = (c3_w)(num_d >> 32ULL);
+
+  return u3r_mug_words(buf_w, 2);
 }
 
 /* u3r_mug_string(): Compute the mug of `a`, LSB first.
@@ -1501,7 +1506,17 @@ u3r_mug_string(const c3_c *a_c)
 c3_w
 u3r_mug_words(const c3_w* key_w, c3_w len_w)
 {
-  return u3r_mug_bytes((c3_y*)key_w, 4 * len_w);
+  c3_w siz_w = 0;
+  c3_w byt_w = 0;
+  c3_w wor_w;
+
+  while ( siz_w < len_w ) {
+    wor_w  = key_w[siz_w];
+    byt_w += _(u3a_is_cat(wor_w)) ? u3r_met(3, wor_w) : 4;
+    siz_w++;
+  }
+
+  return u3r_mug_bytes((c3_y*)key_w, byt_w);
 }
 
 /* u3r_mug_both(): Join two mugs.

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -53,6 +53,46 @@ _test_mug(void)
     fprintf(stderr, "fail (h)\r\n");
     exit(1);
   }
+
+  {
+    // stick some zero bytes in a string
+    u3_noun str = u3kc_lsh(3, 1,
+                           u3kc_mix(u3qc_bex(212),
+                           u3i_string("abcdefjhijklmnopqrstuvwxyz")));
+
+    c3_w  byt_w = u3r_met(3, str);
+    c3_w  wor_w = u3r_met(5, str);
+    c3_y* str_y = c3_malloc(byt_w);
+    c3_w* str_w = c3_malloc(wor_w);
+    c3_d  str_d = 0;
+
+    u3r_bytes(0, byt_w, str_y, str);
+    u3r_words(0, wor_w, str_w, str);
+
+    str_d |= str_w[0];
+    str_d |= ((c3_d)str_w[1] << 32ULL);
+
+    if ( 0x34d08717 != u3r_mug(str) ) {
+      fprintf(stderr, "fail (i) (1) \r\n");
+      exit(1);
+    }
+    if ( 0x34d08717 != u3r_mug_bytes(str_y, byt_w) ) {
+      fprintf(stderr, "fail (i) (2)\r\n");
+      exit(1);
+    }
+    if ( 0x34d08717 != u3r_mug_words(str_w, wor_w) ) {
+      fprintf(stderr, "fail (i) (3)\r\n");
+      exit(1);
+    }
+    if ( u3r_mug_words(str_w, 2) != u3r_mug_chub(str_d) ) {
+      fprintf(stderr, "fail (i) (4)\r\n");
+      exit(1);
+    }
+
+    free(str_w);
+    free(str_y);
+    u3z(str);
+  }
 }
 
 /* main(): run all test cases.

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -15,42 +15,42 @@ static void
 _test_mug(void)
 {
   if ( 0x4d441035 != u3r_mug_string("Hello, world!") ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (a)\r\n");
     exit(1);
   }
 
   if ( 0x4d441035 != u3r_mug(u3i_string("Hello, world!")) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (b)\r\n");
     exit(1);
   }
 
   if ( 0x79ff04e8 != u3r_mug_bytes(0, 0) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (c)\r\n");
     exit(1);
   }
 
   if ( 0x64dfda5c != u3r_mug(u3i_string("xxxxxxxxxxxxxxxxxxxxxxxxxxxx")) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (d)\r\n");
     exit(1);
   }
 
   if ( 0x389ca03a != u3r_mug_cell(0, 0) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (e)\r\n");
     exit(1);
   }
 
   if ( 0x389ca03a != u3r_mug_cell(1, 1) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (f)\r\n");
     exit(1);
   }
 
   if ( 0x5258a6c0 != u3r_mug_cell(0, u3qc_bex(32)) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (g)\r\n");
     exit(1);
   }
 
   if ( 0x2ad39968 != u3r_mug_cell(u3qa_dec(u3qc_bex(128)), 1) ) {
-    fprintf(stderr, "fail\r\n");
+    fprintf(stderr, "fail (h)\r\n");
     exit(1);
   }
 }

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -88,10 +88,6 @@ _test_mug(void)
       fprintf(stderr, "fail (i) (4)\r\n");
       exit(1);
     }
-
-    free(str_w);
-    free(str_y);
-    u3z(str);
   }
 }
 


### PR DESCRIPTION
They were changed in #1123 to calculate block aligned hashes, but we require them all to be exactly equivalent.

This partially fixes #1128, but ctrl-z is still fragile and inconsistent. Still looking for more ...