### PR TITLE
tcp proxy cleanup

### DIFF
--- a/include/noun/retrieve.h
+++ b/include/noun/retrieve.h
@@ -402,6 +402,16 @@
                   c3_w*   c_w,
                   u3_atom d);
 
+      /* u3r_chubs():
+      **
+      **  Copy double-words (a_w) through (a_w + b_w - 1) from (d) to (c).
+      */
+        void
+        u3r_chubs(c3_w    a_w,
+                  c3_w    b_w,
+                  c3_d*   c_d,
+                  u3_atom d);
+
       /* u3r_string(): `a`, a text atom, as malloced C string.
       */
         c3_c*

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -133,7 +133,7 @@
         c3_w             ipf_w;             //  ward ip
         c3_s             por_s;             //  ward port
         c3_o             sec;               //  secure connection
-        u3_atom          sip;               //  ward ship
+        c3_d             who_d[2];          //  ward ship
         c3_c*            hot_c;             //  ward hostname
         uv_buf_t         non_u;             //  nonce
         struct _u3_http* htp_u;             //  local server backlink
@@ -154,7 +154,7 @@
       typedef struct _u3_ward {
         uv_tcp_t         tcp_u;             //  listener handle
         uv_timer_t       tim_u;             //  expiration timer
-        u3_atom          sip;               //  reverse proxy for ship
+        c3_d             who_d[2];          //  reverse proxy for ship
         c3_s             por_s;             //  listening on port
         uv_buf_t         non_u;             //  nonce
         struct _u3_wcon* won_u;             //  candidate upstream connections

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1352,6 +1352,21 @@ u3r_words(c3_w    a_w,
   }
 }
 
+/* u3r_chubs():
+**
+**  Copy double-words (a_w) through (a_w + b_w - 1) from (d) to (c).
+*/
+void
+u3r_chubs(c3_w    a_w,
+          c3_w    b_w,
+          c3_d*   c_d,
+          u3_atom d)
+{
+  /* XX: assumes little-endian
+  */
+  u3r_words(a_w * 2, b_w * 2, (c3_w *)c_d, d);
+}
+
 /* u3r_chop():
 **
 **   Into the bloq space of `met`, from position `fum` for a

--- a/vere/http.c
+++ b/vere/http.c
@@ -2299,6 +2299,23 @@ _proxy_ward_timer_cb(uv_timer_t* tim_u)
 static void
 _proxy_ward_plan(u3_ward* rev_u)
 {
+  u3_noun non;
+
+  {
+    c3_w* non_w = c3_malloc(64);
+    c3_w  len_w;
+
+    c3_rand(non_w);
+
+    non = u3i_words(16, non_w);
+    len_w = u3r_met(3, non);
+
+    //  the nonce is saved to authenticate u3_wcon
+    //  and will be freed with u3_ward
+    //
+    rev_u->non_u = uv_buf_init((c3_c*)non_w, len_w);
+  }
+
   // XX confirm duct
   u3_noun pax = u3nq(u3_blip, c3__http, c3__prox,
                      u3nc(u3k(u3A->sen), u3_nul));
@@ -2306,7 +2323,7 @@ _proxy_ward_plan(u3_ward* rev_u)
   u3_noun wis = u3nc(c3__wise, u3nq(u3i_chubs(2, rev_u->who_d),
                                     rev_u->por_s,
                                     u3k(rev_u->con_u->sec),
-                                    u3i_words(16, (c3_w*)rev_u->non_u.base)));
+                                    non));
   u3v_plan(pax, wis);
 }
 
@@ -2353,24 +2370,11 @@ _proxy_ward_start(u3_pcon* con_u, u3_noun sip)
     }
 #endif
 
-    {
-      c3_w* non_w = c3_malloc(64);
-
-      c3_rand(non_w);
-
-      u3_noun non = u3i_words(16, non_w);
-      c3_w len_w = u3r_met(3, non);
-
-      rev_u->non_u = uv_buf_init((c3_c*)non_w, len_w);
-
-      u3z(non);
-    }
-
     _proxy_ward_plan(rev_u);
 
+    //  XX how long?
+    //
     uv_timer_init(u3L, &rev_u->tim_u);
-
-    // XX how long?
     uv_timer_start(&rev_u->tim_u, _proxy_ward_timer_cb, 300 * 1000, 0);
 
     // XX u3_lo_shut(c3y);

--- a/vere/http.c
+++ b/vere/http.c
@@ -2215,11 +2215,10 @@ _proxy_wcon_peek_read_cb(uv_stream_t* upt_u,
 
     c3_w len_w = rev_u->non_u.len;
 
-    // XX await further reads if siz_w < len_w ?
     if ( ((len_w + 1) != siz_w) ||
          (len_w != buf_u->base[0]) ||
          (0 != memcmp(rev_u->non_u.base, buf_u->base + 1, len_w)) ) {
-      uL(fprintf(uH, "proxy: ward auth fail\n"));
+      // uL(fprintf(uH, "proxy: ward auth fail\n"));
       _proxy_wcon_unlink(won_u);
       _proxy_wcon_close(won_u);
     }
@@ -2343,6 +2342,16 @@ _proxy_ward_start(u3_pcon* con_u, u3_noun sip)
     // XX u3_lo_open();
 
     rev_u->por_s = ntohs(add_u.sin_port);
+
+#if 0
+    {
+      u3_noun who = u3dc("scot", 'p', u3k(sip));
+      c3_c* who_c = u3r_string(who);
+      fprintf(stderr, "\r\nward for %s started on %u\r\n", who_c, rev_u->por_s);
+      free(who_c);
+      u3z(who);
+    }
+#endif
 
     {
       c3_w* non_w = c3_malloc(64);

--- a/vere/http.c
+++ b/vere/http.c
@@ -41,6 +41,10 @@ static void _http_form_free(void);
 
 static const c3_i TCP_BACKLOG = 16;
 
+//  XX temporary, add to u3_http_ef_form
+//
+#define PROXY_DOMAIN "arvo.network"
+
 /* _http_vec_to_meth(): convert h2o_iovec_t to meth
 */
 static u3_weak
@@ -2460,16 +2464,15 @@ _proxy_ward_resolve(u3_warc* cli_u)
   hin_u.ai_socktype = SOCK_STREAM;
   hin_u.ai_protocol = IPPROTO_TCP;
 
+  //  XX why the conditional?
+  //
   if ( 0 == cli_u->hot_c ) {
-    // XX revisit
-    c3_assert( 0 != u3_Host.sam_u.dns_c );
-
     u3_noun sip = u3dc("scot", 'p', u3i_chubs(2, cli_u->who_d));
     c3_c* sip_c = u3r_string(sip);
-    c3_w len_w = 1 + strlen(sip_c) + strlen(u3_Host.sam_u.dns_c);
+    c3_w len_w = 1 + strlen(sip_c) + strlen(PROXY_DOMAIN);
     cli_u->hot_c = c3_malloc(len_w);
     // incremented to skip '~'
-    snprintf(cli_u->hot_c, len_w, "%s.%s", sip_c + 1, u3_Host.sam_u.dns_c);
+    snprintf(cli_u->hot_c, len_w, "%s.%s", sip_c + 1, PROXY_DOMAIN);
 
     free(sip_c);
     u3z(sip);

--- a/vere/http.c
+++ b/vere/http.c
@@ -2689,7 +2689,7 @@ _proxy_peek(u3_pcon* con_u)
     }
   }
 
-  if ( 0 !=  hot_c ) {
+  if ( 0 != hot_c ) {
     free(hot_c);
   }
 }
@@ -2909,7 +2909,7 @@ u3_http_ef_that(u3_noun tat)
       cli_u = _proxy_warc_new(htp_u, (u3_atom)u3k(sip), (u3_atom)u3k(non),
                                                     (c3_s)por, (c3_o)sec);
 
-      //  resolve to loopback if networking is disabling
+      //  resolve to loopback if networking is disabled
       //
       if ( c3n == u3_Host.ops_u.net ) {
         cli_u->ipf_w = INADDR_LOOPBACK;

--- a/vere/http.c
+++ b/vere/http.c
@@ -2863,37 +2863,39 @@ u3_http_ef_that(u3_noun tat)
        !( c3y == sec || c3n == sec ) ||
        ( c3n == u3ud(non) ) ) {
     uL(fprintf(uH, "http: that: invalid card\n"));
-    u3z(tat);
-    return;
   }
+  else {
+    u3_http* htp_u;
+    u3_warc* cli_u;
 
-  u3_http* htp_u;
-  u3_warc* cli_u;
+    for ( htp_u = u3_Host.htp_u; (0 != htp_u); htp_u = htp_u->nex_u ) {
+      if ( c3n == htp_u->lop && sec == htp_u->sec ) {
+        break;
+      }
+    }
 
-  for ( htp_u = u3_Host.htp_u; (0 != htp_u); htp_u = htp_u->nex_u ) {
-    if ( c3n == htp_u->lop && sec == htp_u->sec ) {
-      break;
+    //  XX we should inform our sponsor if we aren't running a server
+    //  so this situation can be avoided
+    //
+    if ( 0 == htp_u ) {
+      uL(fprintf(uH, "http: that: no %s server\n", (c3y == sec) ?
+                                                   "secure" : "insecure"));
+    }
+    else {
+      cli_u = _proxy_warc_new(htp_u, (u3_atom)u3k(sip), (u3_atom)u3k(non),
+                                                    (c3_s)por, (c3_o)sec);
+
+      //  resolve to loopback if networking is disabling
+      //
+      if ( c3n == u3_Host.ops_u.net ) {
+        cli_u->ipf_w = INADDR_LOOPBACK;
+        _proxy_ward_connect(cli_u);
+      }
+      else {
+        _proxy_ward_resolve(cli_u);
+      }
     }
   }
-
-  if ( 0 == htp_u ) {
-    uL(fprintf(uH, "http: that: no %s server\n", (c3y == sec) ?
-                                                 "secure" : "insecure"));
-    u3z(tat);
-    return;
-  }
-
-  cli_u = _proxy_warc_new(htp_u, (u3_atom)u3k(sip), (u3_atom)u3k(non),
-                                                (c3_s)por, (c3_o)sec);
-
-  if ( c3n == u3_Host.ops_u.net ) {
-    cli_u->ipf_w = INADDR_LOOPBACK;
-    _proxy_ward_connect(cli_u);
-    u3z(tat);
-    return;
-  }
-
-  _proxy_ward_resolve(cli_u);
 
   u3z(tat);
 }


### PR DESCRIPTION
This PR includes a new hardcoded domain for the TCP proxy, fixes a couple small, known issues, and some minor refactoring.

The hardcoding is unfortunate -- it would be better for the domain to be given in an %eyre effect (along with the http configuration, perhaps). At the same time, it would just be hardcoded in %eyre then. I haven't added a CLI argument for the domain either (there's been a massive proliferation of arguments lately), but I can do that if there are strong feelings.