### PR TITLE
fix heap allocation in hash_tests

### DIFF
--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -63,7 +63,7 @@ _test_mug(void)
     c3_w  byt_w = u3r_met(3, str);
     c3_w  wor_w = u3r_met(5, str);
     c3_y* str_y = c3_malloc(byt_w);
-    c3_w* str_w = c3_malloc(wor_w);
+    c3_w* str_w = c3_malloc(4 * wor_w);
     c3_d  str_d = 0;
 
     u3r_bytes(0, byt_w, str_y, str);


### PR DESCRIPTION
No excuses for this.