### PR TITLE
exit cleanly if $galaxy is already running (fake or real)

### DIFF
--- a/vere/ames.c
+++ b/vere/ames.c
@@ -414,7 +414,7 @@ _ames_io_start()
         uL(fprintf(uH, 
                     "    ...perhaps you've got two copies of vere running?\n"));
       }
-      exit(1);
+      u3_lo_bail();
     }
 
     uv_udp_getsockname(&sam_u->wax_u, (struct sockaddr *)&add_u, &add_i);


### PR DESCRIPTION
Calling `exit()` here trashes the terminal.