### PR TITLE
Mug stack

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -381,4 +381,4 @@ link_args: os_link_flags,
 dependencies: deps + os_deps,
 install: false)
 
-test('test_hash', test_hash)
+test('test-hash', test_hash)

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1615,6 +1615,13 @@ _mug_pop(c3_ys mov, c3_ys off, c3_w mug_w)
 {
   u3R->cap_p -= mov;
   mugframe* fam = u3to(mugframe, u3R->cap_p + off);
+
+  //  the bottom of the stack
+  //
+  if ( u3_none == fam->veb ) {
+    return fam;
+  }
+
   //  place return value in head of previous frame if not already calculated
   //
   if ( 0 == fam->a ) {
@@ -1626,10 +1633,8 @@ _mug_pop(c3_ys mov, c3_ys off, c3_w mug_w)
     fam->b = mug_w;
   }
   //  shouldn't reach
+  //
   else {
-    fprintf(stderr, "oh no\r\n");
-    u3m_p("dying", fam->veb);
-    fflush(stderr);
     c3_assert(0); 
   }
   return fam;
@@ -1686,8 +1691,12 @@ u3r_mug(u3_noun veb)
   c3_ys mov    = ( c3y == nor_o ? -wis_y : wis_y );
   c3_ys off    = ( c3y == nor_o ? 0 : -wis_y );
 
+  //  stash the current stack pointer
+  //
   u3p(mugframe) empty = u3R->cap_p;
-  mugframe* don = u3to(mugframe, empty + off);
+  //  set the bottom of our stack
+  //
+  mugframe* don = _mug_push(mov, off, u3_none);
   mugframe* fam = _mug_push(mov, off, veb);
 
   c3_w mug_w;
@@ -1701,13 +1710,11 @@ u3r_mug(u3_noun veb)
     b     = fam->b;
     veb   = fam->veb;
     veb_u = u3a_to_ptr(veb);
-    //u3m_p("veb", veb);
     c3_assert(_(u3a_is_cell(veb)));
 
     //  already mugged; pop stack
     //
     if ( veb_u->mug_w ) {
-      //fprintf(stderr, "already mugged\r\n");
       mug_w = veb_u->mug_w;
       fam = _mug_pop(mov, off, mug_w);
     }
@@ -1736,12 +1743,12 @@ u3r_mug(u3_noun veb)
     //  both head and tail are mugged; combine them and pop stack
     //
     else {
-      //fprintf(stderr, "combining head and tail mugs\r\n");
       mug_w = u3r_mug_both(a, b);
       veb_u->mug_w = mug_w;
       fam = _mug_pop(mov, off, mug_w);
     }
   }
+
   u3R->cap_p = empty;
   return mug_w;
 }

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1701,14 +1701,10 @@ u3r_mug(u3_noun veb)
     veb   = fam->veb;
     veb_u = u3a_to_ptr(veb);
 
-    if ( _(u3a_is_atom(veb)) ) {
-      mug_w = _mug_atom(veb);
-      fam = _mug_pop(mov, off, mug_w);
-    }
     //  both head and tail are mugged; combine them and pop stack
     //
-    else if ( (0 != a) && (0 != b) ) {
-      //fprintf(stderr, "combining head and tail mugs\r\n");
+    if ( (0 != a) && (0 != b) ) {
+      fprintf(stderr, "combining head and tail mugs\r\n");
       mug_w = u3r_mug_both(a, b);
       veb_u->mug_w = mug_w;
       fam = _mug_pop(mov, off, mug_w);
@@ -1716,24 +1712,38 @@ u3r_mug(u3_noun veb)
     //  head is mugged, but not tail; push tail onto stack
     //
     else if ( (0 != a) && (0 == b) ) {
-      //fprintf(stderr, "pushing tail\r\n");
-      fam = _mug_push(mov, off, u3t(veb));
+      if ( _(u3a_is_atom(u3t(veb))) ) {
+        fprintf(stderr, "tail is atom\r\n");
+        mug_w = _mug_atom(u3t(veb));
+        fam->b = mug_w;
+      }
+      else {
+        fprintf(stderr, "pushing tail\r\n");
+        fam = _mug_push(mov, off, u3t(veb));
+      }
     }
     //  cell, and neither head nor tail is mugged; push head onto stack
     //
     else {
-      //fprintf(stderr, "asserting cell\r\n");
+      fprintf(stderr, "asserting cell\r\n");
       c3_assert(_(u3a_is_cell(veb)));
       //  already mugged; pop stack
       //
       if ( veb_u->mug_w ) {
-        //fprintf(stderr, "already mugged\r\n");
+        fprintf(stderr, "already mugged\r\n");
         mug_w = veb_u->mug_w;
         fam = _mug_pop(mov, off, mug_w);
       }
       else {
-        //fprintf(stderr, "pushing head\r\n");
-        fam = _mug_push(mov, off, u3h(veb));
+        if ( _(u3a_is_atom(u3h(veb))) ) {
+          fprintf(stderr, "head is atom\r\n");
+          mug_w = _mug_atom(u3h(veb));
+          fam->a = mug_w;
+        }
+        else {
+          fprintf(stderr, "pushing head\r\n");
+          fam = _mug_push(mov, off, u3h(veb));
+        }
       }
     }
   }

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1554,42 +1554,6 @@ u3r_mug_cell(u3_noun hed,
   return u3r_mug_both(lus_w, biq_w);
 }
 
-/* u3r_mug(): MurmurHash3 on a noun.
-*/
-c3_w
-u3r_mug_old(u3_noun veb)
-{
-  c3_assert(u3_none != veb);
-
-  if ( _(u3a_is_cat(veb)) ) {
-    c3_w len_w = u3r_met(3, veb);
-    return u3r_mug_bytes((c3_y*)&veb, len_w);
-  }
-  else {
-    c3_w mug_w;
-
-    u3a_noun* veb_u = u3a_to_ptr(veb);
-
-    if ( veb_u->mug_w ) {
-      return veb_u->mug_w;
-    }
-
-    if ( _(u3a_is_cell(veb)) ) {
-      mug_w = u3r_mug_cell(u3h(veb), u3t(veb));
-    }
-    else {
-      u3a_atom* vat_u = (u3a_atom*)veb_u;
-      c3_w len_w      = u3r_met(3, veb);
-
-      mug_w = u3r_mug_bytes((c3_y*)vat_u->buf_w, len_w);
-    }
-
-    veb_u->mug_w = mug_w;
-
-    return mug_w;
-  }
-}
-
 //  mugframe: head and tail mugs of veb, 0 if uncalculated
 //
 typedef struct mugframe
@@ -1686,7 +1650,7 @@ _mug_atom(u3_atom veb)
   }
 }
 
-//  u3r_mug(): statefully mug a noun
+//  u3r_mug(): statefully mug a noun using a 31-bit MurmurHash3
 //
 c3_w
 u3r_mug(u3_noun veb)

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1694,57 +1694,52 @@ u3r_mug(u3_noun veb)
   c3_w a;
   c3_w b;
   u3a_noun* veb_u;
+  u3_noun hed, tal;
 
   while ( don != fam ) {
     a     = fam->a;
     b     = fam->b;
     veb   = fam->veb;
     veb_u = u3a_to_ptr(veb);
+    //u3m_p("veb", veb);
+    c3_assert(_(u3a_is_cell(veb)));
 
+    //  already mugged; pop stack
+    //
+    if ( veb_u->mug_w ) {
+      //fprintf(stderr, "already mugged\r\n");
+      mug_w = veb_u->mug_w;
+      fam = _mug_pop(mov, off, mug_w);
+    }
+    //  neither head nor tail are mugged; start with head
+    //
+    else if ( 0 == a ) {
+      hed = u3h(veb);
+      if ( _(u3a_is_atom(hed)) ) {
+        fam->a = _mug_atom(hed);
+      }
+      else {
+        fam = _mug_push(mov, off, hed);
+      }
+    }
+    //  head is mugged, but not tail; mug tail or push tail onto stack
+    //
+    else if ( 0 == b ) {
+      tal = u3t(veb);
+      if ( _(u3a_is_atom(tal)) ) {
+        fam->b = _mug_atom(tal);
+      }
+      else {
+        fam = _mug_push(mov, off, tal);
+      }
+    }
     //  both head and tail are mugged; combine them and pop stack
     //
-    if ( (0 != a) && (0 != b) ) {
-      fprintf(stderr, "combining head and tail mugs\r\n");
+    else {
+      //fprintf(stderr, "combining head and tail mugs\r\n");
       mug_w = u3r_mug_both(a, b);
       veb_u->mug_w = mug_w;
       fam = _mug_pop(mov, off, mug_w);
-    }
-    //  head is mugged, but not tail; push tail onto stack
-    //
-    else if ( (0 != a) && (0 == b) ) {
-      if ( _(u3a_is_atom(u3t(veb))) ) {
-        fprintf(stderr, "tail is atom\r\n");
-        mug_w = _mug_atom(u3t(veb));
-        fam->b = mug_w;
-      }
-      else {
-        fprintf(stderr, "pushing tail\r\n");
-        fam = _mug_push(mov, off, u3t(veb));
-      }
-    }
-    //  cell, and neither head nor tail is mugged; push head onto stack
-    //
-    else {
-      fprintf(stderr, "asserting cell\r\n");
-      c3_assert(_(u3a_is_cell(veb)));
-      //  already mugged; pop stack
-      //
-      if ( veb_u->mug_w ) {
-        fprintf(stderr, "already mugged\r\n");
-        mug_w = veb_u->mug_w;
-        fam = _mug_pop(mov, off, mug_w);
-      }
-      else {
-        if ( _(u3a_is_atom(u3h(veb))) ) {
-          fprintf(stderr, "head is atom\r\n");
-          mug_w = _mug_atom(u3h(veb));
-          fam->a = mug_w;
-        }
-        else {
-          fprintf(stderr, "pushing head\r\n");
-          fam = _mug_push(mov, off, u3h(veb));
-        }
-      }
     }
   }
   u3R->cap_p = empty;

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1627,7 +1627,9 @@ _mug_pop(c3_ys mov, c3_ys off, c3_w mug_w)
   }
   //  shouldn't reach
   else {
-    c3_assert(0);
+    fprintf(stderr, "oh no\r\n");
+    fflush(stderr);
+    c3_assert(0); 
   }
   return fam;
 }
@@ -1691,8 +1693,8 @@ u3r_mug(u3_noun veb)
   c3_ys off    = ( c3y == nor_o ? 0 : -wis_y );
 
   u3p(mugframe) empty = u3R->cap_p;
-  mugframe* fam = _mug_push(mov, off, veb);
   mugframe* don = u3to(mugframe, empty + off);
+  mugframe* fam = _mug_push(mov, off, veb);
 
   c3_w mug_w;
   c3_w a;
@@ -1703,16 +1705,19 @@ u3r_mug(u3_noun veb)
     b     = fam->b;
     veb   = fam->veb;
     veb_u = u3a_to_ptr(veb);
+    fprintf(stderr, "ran ptr\r\n");
     
     //  already mugged; pop stack
     //
     if ( veb_u->mug_w ) {
+      fprintf(stderr, "already mugged\r\n");
       mug_w = veb_u->mug_w;
       fam = _mug_pop(mov, off, mug_w);
     }
     //  both head and tail are mugged; combine them and pop stack
     //
     else if ( (0 != a) && (0 != b) ) {
+      fprintf(stderr, "combining head and tail mugs\r\n");
       mug_w = u3r_mug_both(a, b);
       veb_u->mug_w = mug_w;
       fam = _mug_pop(mov, off, mug_w);
@@ -1720,25 +1725,31 @@ u3r_mug(u3_noun veb)
     //  head is mugged, but not tail; push tail onto stack
     //
     else if ( (0 != a) && (0 == b) ) {
+      fprintf(stderr, "pushing tail\r\n");
       fam = _mug_push(mov, off, u3t(veb));
     }
     //  direct atom; calculate and pop stack
     //
     else if ( _(u3a_is_cat(veb)) ) {
+      fprintf(stderr, "mugging cat\r\n");
       mug_w = _mug_cat(veb);
       fam = _mug_pop(mov, off, mug_w);
     }
     //  indirect atom; calculate and pop stack
     //
     else if ( _(u3a_is_pug(veb)) ) {
+      fprintf(stderr, "mugging pug\r\n");
       mug_w = _mug_pug(veb);
       fam = _mug_pop(mov, off, mug_w);
     }
     //  cell, and neither head nor tail is mugged; push head onto stack
     //
     else {
+      fprintf(stderr, "asserting cell\r\n");
       c3_assert(_(u3a_is_cell(veb)));
+      fprintf(stderr, "pushing head\r\n");
       fam = _mug_push(mov, off, u3h(veb));
+      fprintf(stderr, "pushed head\r\n");
     }
   }
   u3R->cap_p = empty;

--- a/noun/retrieve.c
+++ b/noun/retrieve.c
@@ -1603,6 +1603,17 @@ static inline mugframe*
 _mug_push(c3_ys mov, c3_ys off, u3_noun veb)
 {
   u3R->cap_p += mov;
+
+  //  ensure we haven't overflowed the stack
+  //  (off==0 means we're on a north road)
+  //
+  if ( 0 == off ) {
+    c3_assert(u3R->cap_p > u3R->hat_p);
+  }
+  else {
+    c3_assert(u3R->cap_p < u3R->hat_p);
+  }
+
   mugframe* cur = u3to(mugframe, u3R->cap_p + off);
   cur->veb   = veb;
   cur->a     = 0;

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -54,32 +54,9 @@ _test_mug(void)
     exit(1);
   }
 
-  c3_w mug_w;
-//  u3_noun a = u3qb_reap(0x7FFFFF, 0);
-//  mug_w = u3r_mug(a);
-//  u3z(a);
-//  fprintf(stderr, "mug_w1 %08x\r\n", mug_w);
-
-  u3_noun b = u3nc(u3nc(c3__doze, c3__doze), c3__doze);
-  mug_w = u3r_mug(b);
-  u3z(b);
-  fprintf(stderr, "mug_w2 %08x\r\n", mug_w);
-
-  u3_noun c = u3nc(u3_nul, u3nc(u3nt(u3nc(107, 141), u3nc(1, u3_nul), u3_nul), u3_nul));
-  mug_w = u3r_mug(c);
-  u3z(c);
-  fprintf(stderr, "mug_w3 %08x\r\n", mug_w);
-  
-  u3_noun set = u3_nul;
-  c3_w  len_w = 0;
-  while ( 0x1 > len_w ) {
-    set = u3qdi_put(set, len_w++);
-  }
-  u3r_mug(set);
-  u3z(set);
-
   { 
-    // stick some zero bytes in a string
+    //  stick some zero bytes in a string
+    //
     u3_noun str = u3kc_lsh(3, 1,
                            u3kc_mix(u3qc_bex(212),
                            u3i_string("abcdefjhijklmnopqrstuvwxyz")));

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -65,6 +65,19 @@ _test_mug(void)
   u3z(b);
   fprintf(stderr, "mug_w2 %08x\r\n", mug_w);
 
+  u3_noun c = u3nc(u3_nul, u3nc(u3nt(u3nc(107, 141), u3nc(1, u3_nul), u3_nul), u3_nul));
+  mug_w = u3r_mug(c);
+  u3z(c);
+  fprintf(stderr, "mug_w3 %08x\r\n", mug_w);
+  
+  u3_noun set = u3_nul;
+  c3_w  len_w = 0;
+  while ( 0xf > len_w ) {
+    set = u3qdi_put(set, len_w++);
+  }
+  u3r_mug(set);
+  u3z(set);
+
   { 
     // stick some zero bytes in a string
     u3_noun str = u3kc_lsh(3, 1,

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -72,7 +72,7 @@ _test_mug(void)
   
   u3_noun set = u3_nul;
   c3_w  len_w = 0;
-  while ( 0xf > len_w ) {
+  while ( 0x1 > len_w ) {
     set = u3qdi_put(set, len_w++);
   }
   u3r_mug(set);

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -54,7 +54,18 @@ _test_mug(void)
     exit(1);
   }
 
-  {
+  c3_w mug_w;
+//  u3_noun a = u3qb_reap(0x7FFFFF, 0);
+//  mug_w = u3r_mug(a);
+//  u3z(a);
+//  fprintf(stderr, "mug_w1 %08x\r\n", mug_w);
+
+  u3_noun b = u3nc(u3nc(c3__doze, c3__doze), c3__doze);
+  mug_w = u3r_mug(b);
+  u3z(b);
+  fprintf(stderr, "mug_w2 %08x\r\n", mug_w);
+
+  { 
     // stick some zero bytes in a string
     u3_noun str = u3kc_lsh(3, 1,
                            u3kc_mix(u3qc_bex(212),

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -683,7 +683,10 @@ _sist_rest_nuu(u3_ulog* lug_u, u3_uled led_u, c3_c* old_c)
       lar_u.ent_d = ent_d;
       lar_u.tem_w = 0;
       lar_u.typ_w = c3__ov;
-      lar_u.mug_w = u3r_mug_trel(ovo, u3_nul, c3__ov);
+
+      u3_noun moo = u3nt(u3k(ovo), u3_nul, c3__ov);
+      lar_u.mug_w = u3r_mug(moo);
+      u3z(moo);
 
       img_w = c3_malloc(lar_u.len_w << 2);
       u3r_words(0, lar_u.len_w, img_w, ovo);


### PR DESCRIPTION
Use an explicit stack when calculating mugs on nouns, to prevent stack overflows.