### PR TITLE
use /dev/urandom on OS X

### DIFF
--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -31,7 +31,6 @@
 #     include <setjmp.h>
 #     include <stdio.h>
 #     include <signal.h>
-#     include <sys/syscall.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
@@ -49,7 +48,6 @@
 #     include <machine/endian.h>
 #     include <machine/byte_order.h>
 #     include <stdio.h>
-#     include <sys/random.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
@@ -183,17 +181,6 @@
 #       define lseek64 lseek
 #     else
 #       error "port: timeconvert"
-#     endif
-
-    /* Entropy.
-    */
-#     if defined(U3_OS_linux)
-#       define c3_getentropy(B, L) \
-          ((L) == syscall(SYS_getrandom, B, L, 0) ? 0 : -1)
-#     elif defined(U3_OS_bsd) || defined(U3_OS_osx)
-#       define c3_getentropy getentropy
-#     else
-#       error "port: getentropy"
 #     endif
 
     /* Static assertion.

--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -31,6 +31,7 @@
 #     include <setjmp.h>
 #     include <stdio.h>
 #     include <signal.h>
+#     include <sys/syscall.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
@@ -181,6 +182,19 @@
 #       define lseek64 lseek
 #     else
 #       error "port: timeconvert"
+#     endif
+
+    /* Entropy.
+    */
+#     if defined(U3_OS_linux)
+#       define c3_getentropy(B, L) \
+          ((L) == syscall(SYS_getrandom, B, L, 0) ? 0 : -1)
+#     elif defined(U3_OS_osx)
+#       define c3_getentropy c3_getentropy_urandom
+#     elif defined(U3_OS_bsd)
+#       define c3_getentropy getentropy
+#     else
+#       error "port: getentropy"
 #     endif
 
     /* Static assertion.

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1182,6 +1182,11 @@
         void
         u3_sist_get(const c3_c* key_c, c3_y* val_y);
 
+      /* u3_sist_rand(): fill 8 words (32 bytes) with high-quality entropy.
+      */
+        void
+        u3_sist_rand(c3_w* rad_w);
+
     /**  HTTP client.
     **/
       /* u3_cttp_ef_thus(): send %thus effect to cttp.

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1182,11 +1182,13 @@
         void
         u3_sist_get(const c3_c* key_c, c3_y* val_y);
 
-    /* u3_getentropy_urandom(): Implementation of BSD's `getentropy`.
-    **/
+      /* c3_getentropy_urandom(): Implementation of BSD's `getentropy`.
+      **/
         int
         c3_getentropy_urandom(void* buffer, unsigned int numBytes);
 
+      /* c3_rand():
+      **/
         void
         c3_rand(c3_w* rad_w);
 

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1182,10 +1182,13 @@
         void
         u3_sist_get(const c3_c* key_c, c3_y* val_y);
 
-      /* u3_sist_rand(): fill 8 words (32 bytes) with high-quality entropy.
-      */
+    /* u3_getentropy_urandom(): Implementation of BSD's `getentropy`.
+    **/
+        int
+        c3_getentropy_urandom(void* buffer, unsigned int numBytes);
+
         void
-        u3_sist_rand(c3_w* rad_w);
+        c3_rand(c3_w* rad_w);
 
     /**  HTTP client.
     **/

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -8,12 +8,6 @@
 #include "all.h"
 #include "vere/vere.h"
 
-#if defined(U3_OS_linux)
-#define DEVRANDOM "/dev/urandom"
-#else
-#define DEVRANDOM "/dev/random"
-#endif
-
 /* u3_sist_pack(): write a blob to disk, transferring.
 */
 c3_d
@@ -407,23 +401,31 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 }
 #endif
 
+/* u3_getentropy_urandom(): Implementation of BSD's `getentropy`.
+*/
+int
+c3_getentropy_urandom(void* buf, unsigned int nbytes)
+{
+  c3_i fid_i = open("/dev/urandom", O_RDONLY);
+
+  if ( nbytes != read(fid_i, (c3_y*) buf, nbytes) ) {
+    return 0;
+  }
+
+  close(fid_i);
+
+  return nbytes;
+}
+
 /* c3_rand(): fill a 512-bit (16-word) buffer.
 */
 void
 c3_rand(c3_w* rad_w)
 {
-#if defined(U3_OS_bsd) && defined(__OpenBSD__)
-  if (-1 == getentropy(rad_w, 64)) {
-    c3_assert(!"lo_rand");
+  if ( 0 != c3_getentropy(rad_w, 64) ) {
+    uL(fprintf(uH, "c3_rand getentropy: %s\n", strerror(errno)));
+    u3_lo_bail();
   }
-#else
-  c3_i fid_i = open(DEVRANDOM, O_RDONLY);
-
-  if ( 64 != read(fid_i, (c3_y*) rad_w, 64) ) {
-    c3_assert(!"lo_rand");
-  }
-  close(fid_i);
-#endif
 }
 
 /* _sist_fast(): offer to save passcode by mug in home directory.

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -8,6 +8,12 @@
 #include "all.h"
 #include "vere/vere.h"
 
+#if defined(U3_OS_linux)
+#define DEVRANDOM "/dev/urandom"
+#else
+#define DEVRANDOM "/dev/random"
+#endif
+
 /* u3_sist_pack(): write a blob to disk, transferring.
 */
 c3_d
@@ -406,10 +412,18 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 void
 c3_rand(c3_w* rad_w)
 {
-  if ( 0 != c3_getentropy(rad_w, 64) ) {
-    uL(fprintf(uH, "c3_rand getentropy: %s\n", strerror(errno)));
-    u3_lo_bail();
+#if defined(U3_OS_bsd) && defined(__OpenBSD__)
+  if (-1 == getentropy(rad_w, 64)) {
+    c3_assert(!"lo_rand");
   }
+#else
+  c3_i fid_i = open(DEVRANDOM, O_RDONLY);
+
+  if ( 64 != read(fid_i, (c3_y*) rad_w, 64) ) {
+    c3_assert(!"lo_rand");
+  }
+  close(fid_i);
+#endif
 }
 
 /* _sist_fast(): offer to save passcode by mug in home directory.

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -401,7 +401,7 @@ _sist_bask(c3_c* pop_c, u3_noun may)
 }
 #endif
 
-/* u3_getentropy_urandom(): Implementation of BSD's `getentropy`.
+/* c3_getentropy_urandom(): Implementation of BSD's `getentropy`.
 */
 int
 c3_getentropy_urandom(void* buf, unsigned int nbytes)


### PR DESCRIPTION
This change relied on `getentropy` from `sys/random.h`, which is only in newer
versions of OSX.

This breaks `nix`, since it uses an older version of Apple's `libc` so that it can still work on older versions of OSX.