### PR TITLE
vere/unix.c: set _XOPEN_SOURCE

### DIFF
--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -20,6 +20,9 @@
   *** C file.
   **/
 #   if defined(U3_OS_linux)
+#     ifndef _XOPEN_SOURCE
+#     define _XOPEN_SOURCE 700
+#     endif
 #     include <inttypes.h>
 #     include <stdlib.h>
 #     include <string.h>

--- a/vere/unix.c
+++ b/vere/unix.c
@@ -1,6 +1,7 @@
 /* vere/unix.c
 **
 */
+#define _XOPEN_SOURCE 700
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>

--- a/vere/unix.c
+++ b/vere/unix.c
@@ -1,7 +1,7 @@
 /* vere/unix.c
 **
 */
-#define _XOPEN_SOURCE 700
+#include "all.h"
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -13,7 +13,6 @@
 #include <libgen.h>
 #include <ftw.h>
 
-#include "all.h"
 #include "vere/vere.h"
 
 /* _unix_down(): descend path.


### PR DESCRIPTION
Above feature macro is needed on glibc 2.17 era, in order to activate ftw* related functions/macros.