### PR TITLE
fixes dead link to swap instructions

### DIFF
--- a/noun/manage.c
+++ b/noun/manage.c
@@ -1483,7 +1483,7 @@ u3m_init(c3_o chk_o)
                          -1, 0);
 
       fprintf(stderr, "boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-      fprintf(stderr, "see urbit.org/docs/using/install for adding swap space\r\n");
+      fprintf(stderr, "see urbit.org/docs/getting-started#swap for adding swap space\r\n");
       if ( -1 != (c3_ps)map_v ) {
         fprintf(stderr, 
                 "if porting to a new platform, try U3_OS_LoomBase %p\r\n", 


### PR DESCRIPTION
A comment in manage.c links to now-nonexistent docs. I will soon be making a PR to the docs that will add the referenced section in getting-started.udon.

Related issue: https://github.com/urbit/urbit/issues/1164