### PR TITLE
replay one event at a time

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -326,15 +326,6 @@
         c3_l tno_l;                         //  terminal count in host
       } u3_uled;
 
-    /* u3_olar: event log trailer, old version.
-    */
-      typedef struct {
-        c3_w syn_w;                         //  must equal mug of address
-        c3_w ent_w;                         //  event sequence number
-        c3_w len_w;                         //  word length of this event
-        c3_w mug_w;                         //  mug of entry
-      } u3_olar;
-
     /* u3_ular: event log trailer.
     */
       typedef struct {

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -631,8 +631,7 @@ _sist_rest_nuu(u3_ulog* lug_u, u3_uled led_u, c3_c* old_c)
   }
 
   c3_o fir_o = c3y;
-  c3_d pos_d;
-  c3_d new_d = c3_wiseof(u3_uled);
+  c3_d pos_d, new_d;
 
   while ( end_d != c3_wiseof(u3_uled) ) {
     c3_d    tar_d;
@@ -661,7 +660,7 @@ _sist_rest_nuu(u3_ulog* lug_u, u3_uled led_u, c3_c* old_c)
     //
     if (c3y == fir_o) {
       pos_d = (end_d + lar_u.ent_d + 1);
-      new_d = (end_d + lar_u.ent_d + 1);
+      new_d = pos_d;
       fir_o = c3n;
     }
 
@@ -711,7 +710,7 @@ _sist_rest_nuu(u3_ulog* lug_u, u3_uled led_u, c3_c* old_c)
 
     // write event header
     //
-    pos_d -= (4ULL * c3_wiseof(c3_w));
+    pos_d -= c3_wiseof(c3_w);
     if ( -1 == lseek64(fud_i, (4ULL * pos_d), SEEK_SET) ) {
       uL(fprintf(uH, "rest_nuu failed (k), lseek64: %s\n", strerror(errno)));
       u3_lo_bail();

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -658,7 +658,7 @@ _sist_rest_nuu(u3_ulog* lug_u, u3_uled led_u, c3_c* old_c)
 
     //  calculate new log size
     //
-    if (c3y == fir_o) {
+    if ( c3y == fir_o ) {
       pos_d = (end_d + lar_u.ent_d + 1);
       new_d = pos_d;
       fir_o = c3n;
@@ -805,7 +805,8 @@ _sist_rest()
     if ( u3r_mug('g') == led_u.mag_l ) {
       _sist_rest_nuu(&u3Z->lug_u, led_u, ful_c);
       fid_i = u3Z->lug_u.fid_i;
-    } else if (u3r_mug('h') != led_u.mag_l ) {
+    }
+    else if (u3r_mug('h') != led_u.mag_l ) {
       uL(fprintf(uH, "record (%s) is obsolete (or corrupt)\n", ful_c));
       u3_lo_bail();
     }
@@ -964,7 +965,8 @@ _sist_rest()
                      "and do not delete your pier!\n"));
       u3_lo_bail();
     }
-  } else {
+  }
+  else {
     //  Read and execute the fscking things. This is pretty much certain to crash.
     //
     uL(fprintf(uH, "rest: replaying through event %" PRIu64 "\n", las_d));


### PR DESCRIPTION
To replay an event log, instead of loading the entire event log into memory, don't.

In order to do this, we changed the event log format to store a header before each event containing the size of that event, so that we can traverse backward and forward.