### PR TITLE
QOL improvements for -j trace and |mass outputs

### DIFF
--- a/include/noun/trace.h
+++ b/include/noun/trace.h
@@ -86,7 +86,7 @@
     /* u3t_trace_open(): opens the path for writing tracing information.
     */
       void
-      u3t_trace_open(c3_c*);
+      u3t_trace_open();
 
     /* u3t_trace_close(): closes the trace file. optional.
     */

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -583,7 +583,7 @@
         c3_c*   gen_c;                      //  -G, czar generator
         c3_o    gab;                        //  -g, test garbage collection
         c3_c*   dns_c;                      //  -H, ames bootstrap domain
-        c3_c*   json_file_c;                //  -j, json trace
+        c3_o    tra;                        //  -j, json trace
         c3_w    kno_w;                      //  -K, kernel version
         c3_c*   key_c;                      //  -k, private key file
         c3_o    net;                        //  -L, local-only networking

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -565,6 +565,14 @@
         c3_o             vog;               //  did they vote for us?
       } u3_rnam;
 
+    /* u3_trac: tracing information.
+    */
+      typedef struct _u3_trac {
+        c3_w   nid_w;                       //  nock pid
+        FILE*  fil_u;                       //  trace file (json)
+        c3_w   con_w;                       //  trace counter
+      } u3_trac;
+
     /* u3_opts: command line configuration.
     */
       typedef struct _u3_opts {
@@ -625,7 +633,7 @@
         c3_o       liv;                     //  if u3_no, shut down
         c3_i       xit_i;                   //  exit code for shutdown
         void*      tls_u;                   //  server SSL_CTX*
-        FILE*      trace_file_u;            //  trace file to write to
+        u3_trac    tra_u;                   //  tracing information
       } u3_host;                            //  host == computer == process
 
 #     define u3L  u3_Host.lup_u             //  global event loop

--- a/noun/trace.c
+++ b/noun/trace.c
@@ -319,7 +319,10 @@ u3t_trace_open()
     mkdir(fil_c, 0700);
   }
 
-  snprintf(fil_c, 2048, "%s/%ld.json", fil_c, time(NULL));
+  c3_c * wen_c = u3r_string(u3A->wen);
+
+  snprintf(fil_c, 2048, "%s/%s.json", fil_c, wen_c);
+  free(wen_c);
 
   trace_file_u = fopen(fil_c, "w");
   nock_pid_i = (int)getpid();
@@ -496,6 +499,11 @@ u3t_event_trace(const c3_c* name, c3_c type)
 {
   if (!trace_file_u)
     return;
+
+  if ( trace_counter >= 100000 ) {
+    u3t_trace_close();
+    u3t_trace_open();
+  }
 
   fprintf(trace_file_u,
           "{\"cat\": \"event\", \"name\": \"%s\", \"ph\":\"%c\", \"pid\": %d, "

--- a/noun/vortex.c
+++ b/noun/vortex.c
@@ -102,6 +102,9 @@ u3v_start(u3_noun now)
     printf("arvo: time: %s\n", wen_c);
     free(wen_c);
   }
+
+  if ( u3C.wag_w & u3o_trace )
+    u3t_trace_open();
 }
 
 /* u3v_wish(): text expression with cache.

--- a/vere/main.c
+++ b/vere/main.c
@@ -656,6 +656,9 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.tra) ) {
         u3C.wag_w |= u3o_trace;
+        u3_Host.tra_u.nid_w = 0;
+        u3_Host.tra_u.fil_u = NULL;
+        u3_Host.tra_u.con_w = 0;
       }
     }
     u3m_boot(u3_Host.ops_u.nuu,

--- a/vere/main.c
+++ b/vere/main.c
@@ -656,7 +656,6 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.tra) ) {
         u3C.wag_w |= u3o_trace;
-        u3t_trace_open();
       }
     }
     u3m_boot(u3_Host.ops_u.nuu,

--- a/vere/main.c
+++ b/vere/main.c
@@ -83,6 +83,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.qui = c3n;
   u3_Host.ops_u.rep = c3n;
   u3_Host.ops_u.tex = c3n;
+  u3_Host.ops_u.tra = c3n;
   u3_Host.ops_u.veb = c3n;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
@@ -91,7 +92,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.nam_c = 0;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:B:K:A:H:w:u:j:e:E:f:F:k:m:p:LabcCdgqstvxPDRS")) ) {
+                 "G:B:K:A:H:w:u:e:E:f:F:k:m:p:LjabcCdgqstvxPDRS")) ) {
 
     switch ( ch_i ) {
       case 'B': {
@@ -131,10 +132,6 @@ _main_getopt(c3_i argc, c3_c** argv)
         u3_Host.ops_u.url_c = strdup(optarg);
         break;
       }
-      case 'j': {
-        u3_Host.ops_u.json_file_c = strdup(optarg);
-        break;
-      }
       case 'x': {
         u3_Host.ops_u.tex = c3y;
         break;
@@ -170,6 +167,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         return c3y;
       }
       case 'L': { u3_Host.ops_u.net = c3n; break; }
+      case 'j': { u3_Host.ops_u.tra = c3y; break; }
       case 'a': { u3_Host.ops_u.abo = c3y; break; }
       case 'b': { u3_Host.ops_u.bat = c3y; break; }
       case 'c': { u3_Host.ops_u.nuu = c3y; break; }
@@ -656,9 +654,9 @@ main(c3_i   argc,
 
       /*  Set tracing flag
       */
-      if ( u3_Host.ops_u.json_file_c ) {
+      if ( _(u3_Host.ops_u.tra) ) {
         u3C.wag_w |= u3o_trace;
-        u3t_trace_open(u3_Host.ops_u.json_file_c);
+        u3t_trace_open();
       }
     }
     u3m_boot(u3_Host.ops_u.nuu,

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -2052,6 +2052,11 @@ _raft_pump(u3_noun ovo)
 void
 u3_raft_chip(void)
 {
+  if ( (u3C.wag_w & u3o_trace) && (u3_Host.tra_u.con_w >= 100000) ) {
+    u3t_trace_close();
+    u3t_trace_open();
+  }
+
   u3_weak rus = _raft_poke();
 
   _raft_crop();

--- a/vere/raft.c
+++ b/vere/raft.c
@@ -2,6 +2,7 @@
 **
 */
 #include <uv.h>
+#include <sys/stat.h>
 
 #include "all.h"
 #include "vere/vere.h"
@@ -1868,7 +1869,14 @@ _raft_grab(u3_noun rus)
       c3_c* wen_c = u3r_string(u3A->wen);
 
       c3_c nam_c[2048];
-      snprintf(nam_c, 2048, "%s/.urb/put/%s-mass.txt", u3_Host.dir_c, wen_c);
+      snprintf(nam_c, 2048, "%s/.urb/put/mass", u3_Host.dir_c);
+
+      struct stat st;
+      if ( -1 == stat(nam_c, &st) ) {
+        mkdir(nam_c, 0700);
+      }
+
+      snprintf(nam_c, 2048, "%s/%s.txt", nam_c, wen_c);
 
       fil_u = fopen(nam_c, "w");
       fprintf(fil_u, "%s\r\n", wen_c);


### PR DESCRIPTION
The output of -j tracer is now split every 100,000 lines so that chrome doesn't choke on large traces (is this a reasonable number?) Also stuck the output of these in the put directory under a subdirectory called trace, and named them by unix date.

Stuck |mass outputs in their own subdirectory of put, called mass, for better organization.