### PR TITLE
add capability for hashtable to cache bytecode, with tests

### DIFF
--- a/include/noun/hashtable.h
+++ b/include/noun/hashtable.h
@@ -49,6 +49,7 @@
             c3_o  buc_o;      // yes if in middle of hash bucket
           } arm_u;            // clock arm
           u3h_slot sot_w[64]; // slots
+          void (*freer)(c3_w);// optional function pointer to free values
         } u3h_root;
 
       /* u3h_buck: bottom bucket.

--- a/include/noun/nock.h
+++ b/include/noun/nock.h
@@ -112,6 +112,17 @@
       c3_w
       u3n_mark(FILE* fil_u);
 
+    /* u3n_prog_new(): allocate and set up pointers for u3n_prog
+     */
+    u3n_prog*
+    u3n_prog_new(c3_w byc_w, c3_w cal_w,
+                c3_w reg_w, c3_w lit_w, c3_w mem_w);
+
+    /* u3n_prog_free(): free memory retained by program
+    */
+    void
+    u3n_prog_free(u3n_prog* pog_u);
+
     /* u3n_free(): free bytecode cache.
      */
       void

--- a/noun/nock.c
+++ b/noun/nock.c
@@ -707,10 +707,10 @@ _n_prog_dat(u3n_prog* pog_u)
   return ((void*) pog_u) + sizeof(u3n_prog);
 }
 
-/* _n_prog_new(): allocate and set up pointers for u3n_prog
+/* u3n_prog_new(): allocate and set up pointers for u3n_prog
  */
-static u3n_prog*
-_n_prog_new(c3_w byc_w, c3_w cal_w,
+u3n_prog*
+u3n_prog_new(c3_w byc_w, c3_w cal_w,
             c3_w reg_w, c3_w lit_w, c3_w mem_w)
 {
   c3_w cab_w = (sizeof(u3j_site) * cal_w),
@@ -739,7 +739,7 @@ _n_prog_new(c3_w byc_w, c3_w cal_w,
   return pog_u;
 }
 
-/* _n_prog_old(): as _n_prog_new(),
+/* _n_prog_old(): as u3n_prog_new(),
  *                but leech off senior program's data segment
  */
 static u3n_prog*
@@ -953,7 +953,7 @@ _n_prog_from_ops(u3_noun ops)
        mem_w = 0;
 
   sip   = _n_melt(ops, &byc_w, &cal_w, &reg_w, &lit_w, &mem_w);
-  pog_u = _n_prog_new(byc_w, cal_w, reg_w, lit_w, mem_w);
+  pog_u = u3n_prog_new(byc_w, cal_w, reg_w, lit_w, mem_w);
   _n_prog_asm(ops, pog_u, sip);
   return pog_u;
 }
@@ -2412,7 +2412,7 @@ _n_prog_take(u3n_prog* pog_u)
   u3n_prog* gop_u;
 
   if ( c3y == pog_u->byc_u.own_o ) {
-    gop_u = _n_prog_new(pog_u->byc_u.len_w,
+    gop_u = u3n_prog_new(pog_u->byc_u.len_w,
         pog_u->cal_u.len_w, pog_u->reg_u.len_w,
         pog_u->lit_u.len_w, pog_u->mem_u.len_w);
     memcpy(gop_u->byc_u.ops_y, pog_u->byc_u.ops_y, pog_u->byc_u.len_w);
@@ -2426,10 +2426,10 @@ _n_prog_take(u3n_prog* pog_u)
 }
 
 
-/* _n_prog_free(): free memory retained by program
+/* u3n_prog_free(): free memory retained by program
 */
-static void
-_n_prog_free(u3n_prog* pog_u)
+void
+u3n_prog_free(u3n_prog* pog_u)
 {
   c3_w i_w;
 
@@ -2572,7 +2572,7 @@ u3n_mark(FILE* fil_u)
 static void
 _n_feb(u3_noun kev)
 {
-  _n_prog_free(u3to(u3n_prog, u3t(kev)));
+  u3n_prog_free(u3to(u3n_prog, u3t(kev)));
 }
 
 /* u3n_free(): free bytecode cache

--- a/tests/hashtable_tests.c
+++ b/tests/hashtable_tests.c
@@ -5,6 +5,7 @@ static void _test_cache_replace_value(void);
 static void _test_cache_trimming(void);
 static void _test_no_cache(void);
 static void _test_skip_slot(void);
+static void _test_cache_freer_trimming(void);
 
 /* main(): run all test cases.
 */
@@ -17,6 +18,7 @@ main(int argc, char* argv[])
   _test_skip_slot();
   _test_cache_trimming();
   _test_cache_replace_value();
+  _test_cache_freer_trimming();
 
   return 0;
 }
@@ -106,6 +108,38 @@ _test_cache_trimming(void)
   }
   if ( ( max_w / 10 ) != har_u->use_w ) {
     fprintf(stderr, "fail\r\n");
+    exit(1);
+  }
+  fprintf(stderr, "test_cache_trimming: ok\n");
+}
+
+static void
+_helper_test_freer(c3_w pog_p)
+{
+  u3n_prog* pog_u = u3to(u3n_prog, pog_p);
+  u3n_prog_free(pog_u);
+}
+
+/* _test_cache_freer_trimming(): ensure a caching hashtable removes stale items.
+*/
+static void
+_test_cache_freer_trimming(void)
+{
+  c3_w max_w = 620;
+  c3_w i_w;
+
+  u3p(u3h_root) har_p = u3h_new_cache_with_freer(max_w / 10, _helper_test_freer);
+  u3h_root*     har_u = u3to(u3h_root, har_p);
+
+  for ( i_w = 0; i_w < max_w; i_w++ ) {
+    u3n_prog* pog_u = u3n_prog_new(0, 0, 0, 0, 0);
+    u3h_put(har_p, i_w, u3of(u3n_prog, pog_u));
+  }
+
+  u3h_get(har_p, max_w - 1);
+
+  if ( ( max_w / 10 ) != har_u->use_w ) {
+    fprintf(stderr, "freer fail 2\r\n");
     exit(1);
   }
   fprintf(stderr, "test_cache_trimming: ok\n");


### PR DESCRIPTION
@frodwith might also want to take a look at this. I didn't change the way we handle the bytecode cache, but I added an optional per-hashtable function pointer that can be used to free values during cache reclamation. A basic test of this functionality passes.

This would be a breaching change, since the hashtable now has a new field in its struct.