### PR TITLE
simplifies loom init/restore, checkpoints during replay

### DIFF
--- a/include/noun/manage.h
+++ b/include/noun/manage.h
@@ -26,10 +26,10 @@
         c3_i
         u3m_bail(c3_m how_m) __attribute__((noreturn));
 
-      /* u3m_init(): start the environment, with/without checkpointing.
+      /* u3m_init(): start the environment.
       */
         void
-        u3m_init(c3_o chk_o);
+        u3m_init();
 
       /* u3m_pave(): instantiate or activate image.
       */

--- a/noun/events.c
+++ b/noun/events.c
@@ -165,9 +165,9 @@ u3e_fault(void* adr_v, c3_i ser_i)
 /* _ce_image_open(): open or create image.
 */
 static c3_o
-_ce_image_open(u3e_image* img_u, c3_o nuu_o)
+_ce_image_open(u3e_image* img_u)
 {
-  c3_i mod_i = _(nuu_o) ? (O_RDWR | O_CREAT) : O_RDWR;
+  c3_i mod_i = O_RDWR | O_CREAT;
   c3_c ful_c[8193];
 
   snprintf(ful_c, 8192, "%s", u3P.dir_c);
@@ -197,11 +197,7 @@ _ce_image_open(u3e_image* img_u, c3_o nuu_o)
       c3_d pgs_d = (siz_d + (c3_d)((1 << (u3a_page + 2)) - 1)) >> 
                    (c3_d)(u3a_page + 2);
 
-      if ( c3y == nuu_o ) {
-        if ( siz_d ) { 
-          c3_assert(0);
-          return c3n;
-        }
+      if ( !siz_d ) {
         return c3y;
       }
       else { 
@@ -817,7 +813,7 @@ u3e_save(void)
   _ce_patch_free(pat_u);
 }
 
-/* u3e_live(): start the persistence system.
+/* u3e_live(): start the checkpointing system.
 */
 c3_o
 u3e_live(c3_o nuu_o, c3_c* dir_c)
@@ -832,29 +828,17 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
   } else
 #endif
   {
-    /* Open and apply any patches.
-    */
-    if ( _(nuu_o) ) {
-      if ( (c3n == _ce_image_open(&u3P.nor_u, c3y)) ||
-           (c3n == _ce_image_open(&u3P.sou_u, c3y)) )
-      {
-        printf("boot: image failed\r\n");
-        exit(1);
-      }
+    //  Open image files.
+    //
+    if ( (c3n == _ce_image_open(&u3P.nor_u)) ||
+         (c3n == _ce_image_open(&u3P.sou_u)) )
+    {
+      printf("boot: image failed\r\n");
+      exit(1);
     }
     else {
       u3_ce_patch* pat_u;
 
-      /* Open image files.
-      */
-      {
-        if ( (c3n == _ce_image_open(&u3P.nor_u, c3n)) ||
-             (c3n == _ce_image_open(&u3P.sou_u, c3n)) ) 
-        {
-          fprintf(stderr, "boot: no image\r\n");
-          return u3e_live(c3y, dir_c);
-        }
-      }
       /* Load any patch files; apply them to images.
       */
       if ( 0 != (pat_u = _ce_patch_open()) ) {

--- a/noun/manage.c
+++ b/noun/manage.c
@@ -1495,10 +1495,10 @@ _cm_signals(void)
   }
 }
 
-/* u3m_init(): start the environment, with/without checkpointing.
+/* u3m_init(): start the environment.
 */
 void
-u3m_init(c3_o chk_o)
+u3m_init(void)
 {
   _cm_limits();
   _cm_signals();
@@ -1515,7 +1515,7 @@ u3m_init(c3_o chk_o)
 
     map_v = mmap((void *)u3_Loom,
                  len_w,
-                 _(chk_o) ? PROT_READ : (PROT_READ | PROT_WRITE),
+                 (PROT_READ | PROT_WRITE),
                  (MAP_ANON | MAP_FIXED | MAP_PRIVATE),
                  -1, 0);
 
@@ -1694,7 +1694,7 @@ u3m_boot(c3_o nuu_o, c3_o bug_o, c3_c* dir_c,
 {
   /* Activate the loom.
   */
-  u3m_init(nuu_o);
+  u3m_init();
 
   /* Activate the storage system.
   */

--- a/tests/hash_tests.c
+++ b/tests/hash_tests.c
@@ -5,7 +5,7 @@
 static void
 _setup(void)
 {
-  u3m_init(c3y);
+  u3m_init();
   u3m_pave(c3y, c3n);
 }
 

--- a/tests/hashtable_tests.c
+++ b/tests/hashtable_tests.c
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
 static void
 _setup(void)
 {
-  u3m_init(c3y);
+  u3m_init();
   u3m_pave(c3y, c3n);
 }
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -254,7 +254,7 @@ main(int argc, char *argv[])
   printf("hello, world: len %dMB\n", (1 << U3_OS_LoomBits) >> 18);
   // _test_words();
 
-  u3m_init(c3n);
+  u3m_init();
   u3m_pave(c3y, c3n);
   // u3j_boot();
 

--- a/vere/sist.c
+++ b/vere/sist.c
@@ -208,31 +208,57 @@ u3_sist_nil(const c3_c* key_c)
 /* _sist_suck(): past failure.
 */
 static void
-_sist_suck(u3_noun ovo, u3_noun gon)
+_sist_suck(c3_d evt_d, u3_noun ovo, u3_noun gon)
 {
-  uL(fprintf(uH, "sing: ovum failed!\n"));
+  fprintf(stderr, "sing: ovum failed!\r\n");
+
   {
     c3_c* hed_c = u3r_string(u3h(u3t(ovo)));
 
-    uL(fprintf(uH, "fail %s\n", hed_c));
+    fprintf(stderr, "sing: fail: %s event %lld mug %u\r\n",
+                    hed_c, evt_d, u3r_mug(ovo));
     free(hed_c);
   }
 
-  u3_lo_punt(2, u3kb_flop(u3k(u3t(gon))));
-  // u3_loom_exit();
-#if 1
-  u3_lo_exit();
+  {
+    u3_noun why;
+    u3x_cell(gon, &why, 0);
+    u3m_p("sist: why", why);
+  }
 
-  exit(1);
-#else
-  u3z(ovo); u3z(gon);
+  u3_lo_punt(2, u3kb_flop(u3k(u3t(gon))));
+
+#if 1
+  {
+    c3_c fil_c[2048];
+    snprintf(fil_c, 2048, "%s/.urb/put/failed-%lld.jam", u3_Host.dir_c, evt_d);
+
+    u3_noun pat = u3qe_jam(ovo);
+
+    fprintf(stderr, "sing: saving failed event\r\n");
+    u3_walk_save(fil_c, u3_nul, pat, 0, u3_nul);
+  }
+#endif
+
+#if 1
+  {
+    fprintf(stderr, "sing: saving checkpoint\r\n");
+    c3_d old_d = u3A->ent_d;
+    u3A->ent_d = evt_d - 1ULL;
+    u3e_save();
+    u3A->ent_d = old_d;
+  }
+#endif
+
+#if 1
+  u3_lo_bail();
 #endif
 }
 
 /* _sist_sing(): replay ovum from the past, time already set.
 */
 static void
-_sist_sing(u3_noun ovo)
+_sist_sing(c3_d evt_d, u3_noun ovo)
 {
   u3_noun gon = u3m_soft(0, u3v_poke, u3k(ovo));
 
@@ -241,7 +267,7 @@ _sist_sing(u3_noun ovo)
     u3x_cell(gon, &hed, &tal);
 
     if ( u3_blip != hed ) {
-      _sist_suck(ovo, gon);
+      _sist_suck(evt_d, ovo, gon);
     }
     else {
       u3_noun vir, cor;
@@ -1075,13 +1101,24 @@ _sist_rest()
         fprintf(stderr, "replay: skipped veer\n");
       }
       else {
-        _sist_sing(u3k(ovo));
+        _sist_sing(lar_u.ent_d, u3k(ovo));
         fputc('.', stderr);
       }
 
       // fprintf(stderr, "playback: sing: %d\n", xno_w));
 
       xno_w++;
+
+#if 1
+      //  save a checkpoint every 100K events
+      //
+      if ( 0 == (xno_w % 100000) ) {
+        c3_d old_d = u3A->ent_d;
+        u3A->ent_d = lar_u.ent_d;
+        u3e_save();
+        u3A->ent_d = old_d;
+      }
+#endif
 
       if ( 0 == (xno_w % 1000) ) {
         uL(fprintf(uH, "{%d}\n", xno_w));


### PR DESCRIPTION
These changes to loom initialization and checkpoint restoration are just a backport from cc-release.

The changes to replay are to just to make it simpler to investigate replay failures. On failure, we print some more event metadata, jam and write the failing event to disk, take a checkpoint at the previous event, and then exit. Every 100K successful events, we also take a checkpoint.