### PR TITLE
cc-release: reclaim memory regularly, automate checkpoints

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1249,6 +1249,11 @@
         void
         u3_pier_work(u3_pier* pir_u, u3_noun pax, u3_noun fav);
 
+      /* u3_pier_work_save(): tell worker to save checkpoint.
+      */
+        void
+        u3_pier_work_save(u3_pier* pir_u);
+
       /* u3_pier_stub(): get the One Pier for unreconstructed code.
       */
         u3_pier*

--- a/vere/pier.c
+++ b/vere/pier.c
@@ -408,14 +408,21 @@ _pier_work_send(u3_writ* wit_u)
   u3_newt_write(&god_u->inn_u, u3k(wit_u->mat), wit_u);
 }
 
-/* _pier_work_save(): tell worker to save checkpoint.
+/* u3_pier_work_save(): tell worker to save checkpoint.
 */
-static void
-_pier_work_save(u3_pier* pir_u)
+void
+u3_pier_work_save(u3_pier* pir_u)
 {
   u3_lord* god_u = pir_u->god_u;
+  u3_save* sav_u = pir_u->sav_u;
 
-  u3_newt_write(&god_u->inn_u, u3ke_jam(u3nc(c3__save, 0)), 0);
+  if ( god_u->dun_d > sav_u->ent_d ) {
+    u3_newt_write(&god_u->inn_u, u3ke_jam(u3nc(c3__save, 0)), 0);
+
+    //  XX report success first?
+    //
+    sav_u->ent_d = god_u->dun_d;
+  }
 }
 
 /* _pier_work_complete(): worker reported completion.
@@ -1206,7 +1213,7 @@ _pier_play(u3_pier* pir_u,
 {
   fprintf(stderr, "pier: (%lld): boot at mug %x\r\n", lav_d, mug_l);
 
-  _pier_work_save(pir_u);
+  u3_pier_work_save(pir_u);
 
   /* load all committed events
   */
@@ -1583,7 +1590,7 @@ u3_pier_exit(void)
     u3_pier* pir_u = u3K.tab_u[0];
 
     fprintf(stderr, "pier: exit\r\n");
-    _pier_work_save(pir_u);
+    u3_pier_work_save(pir_u);
     _pier_work_shutdown(pir_u);
     uv_stop(u3L);
   }
@@ -1874,7 +1881,7 @@ _pier_boot_complete(u3_pier* pir_u,
                    pir_u->god_u->dun_d,
                    (c3y == nuu_o ? "new" : "old"));
 
-  _pier_work_save(pir_u);
+  u3_pier_work_save(pir_u);
 
   /* the main course
   */

--- a/vere/save.c
+++ b/vere/save.c
@@ -17,20 +17,7 @@ static void
 _save_time_cb(uv_timer_t* tim_u)
 {
   u3_pier *pir_u = tim_u->data;
-  u3_save* sav_u = pir_u->sav_u;
-
-  if ( sav_u->pid_w ) {
-    return;
-  }
-
-  if ( u3A->ent_d > sav_u->ent_d ) {
-    // uL(fprintf(uH, "autosaving... ent_d %" PRIu64 "\n", u3A->ent_d));
-
-    // u3e_grab("save", u3_none);
-
-    u3e_save();
-    sav_u->ent_d = u3A->ent_d;
-  }
+  u3_pier_work_save(pir_u);
 }
 
 /* u3_save_ef_chld(): report save termination.

--- a/vere/serf.c
+++ b/vere/serf.c
@@ -33,40 +33,68 @@
     } u3_serf;
     static u3_serf u3V;
 
-    /*  serf-lord protocol:
-    **
-    **  ++  plea                            ::  from serf to lord
-    **    $%  $:  $play                     ::  send events
-    **            $=  p                     ::
-    **            %-  unit                  ::  ~ if no snapshot
-    **            $:  p=@                   ::  first number expected
-    **                q=@                   ::  mug of state
-    **                r=[our=@p fak=?]      ::  [identity fake?]
-    **        ==  ==                        ::
-    **        $:  $done                     ::  event executed unchanged
-    **            p/@                       ::  number of this event
-    **            q/@                       ::  mug of state (or 0)
-    **            r/(list ovum)             ::  actions
-    **        ==                            ::
-    **        $:  $work                     ::  replace and retry
-    **            p/@                       ::  event number
-    **            q/@                       ::  mug of state (or 0)
-    **            r/(pair date ovum)        ::  event
-    **    ==  ==                            ::
-    **
-    **  ++  writ                            ::  from lord to serf
-    **    $%  $:  $exit                     ::  snapshot, then exit
-    **            p/@                       ::  exit code
-    **        ==                            ::
-    **        $:  $save                     ::  save snapshot to disk
-    **            p/@                       ::  number of old snaps to save
-    **        ==                            ::
-    **        $:  $work                     ::  execute event
-    **            p/@                       ::  event number
-    **            q/@                       ::  mug of state (or 0)
-    **            r/(pair date ovum)        ::  event
-    **    ==  ==                            ::
-    */
+/*
+::  serf-lord protocol:
+::
+|%
+::  +plea: from serf to lord
+::
++$  plea
+  $%  ::  status on startup
+      ::
+      $:  %play
+          $=  p
+          ::  ~ if no snapshot
+          ::
+          %-  unit
+          ::  p: event number expected
+          ::  q: mug of kernel
+          ::  r: identity, fake flag
+          ::
+          [p=@ q=@ r=[our=@p fak=?]]
+      ==
+      ::  event executed unchanged (in response to %work)
+      ::
+      $:  %done
+          ::  p: event number
+          ::  q: mug of state (or 0)
+          ::  r: effects
+          ::
+          [p=@ q=@ r=(list ovum)]
+      ==
+      ::  replace event and retry (in response to %work)
+      ::
+      $:  %work
+          ::  p: event number
+          ::  q: mug of state (or 0)
+          ::  r: replacement event (at date)
+          ::
+          [p=@ q=@ r=(pair date ovum)]
+  ==  ==
+::  +writ: from lord to serf
+::
++$  writ
+  $%  ::  exit immediately
+      ::
+      ::  p: exit code
+      ::
+      [%exit p=@]
+      ::  save snapshot to disk
+      ::
+      ::  p: number of old snaps to save (XX not respected)
+      ::
+      [%save p=@]
+      ::  execute event
+      ::
+      $:  %work
+          ::  p: event number
+          ::  q: mug of state (or 0)
+          ::  r: event (at date)
+          ::
+          [p=@ q=@ r=(pair date ovum)]
+  ==  ==
+--
+*/
 
 /* _serf_space(): print n spaces.
 */

--- a/vere/serf.c
+++ b/vere/serf.c
@@ -362,7 +362,7 @@ _serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 
   u3_noun sac = u3_nul;
 
-  //  intercept |mass
+  //  intercept |mass, observe |reset
   //
   {
     u3_noun riv = vir;
@@ -387,6 +387,12 @@ _serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
         u3z(vir);
         vir = riv;
         break;
+      }
+
+      //  reclaim memory from persistent caches on |reset
+      //
+      if ( c3__vega == u3h(fec) ) {
+        u3m_reclaim();
       }
 
       riv = u3t(riv);
@@ -484,6 +490,12 @@ _serf_poke_live(c3_d    evt_d,              //  event number
     u3z(gon); u3z(job);
 
     _serf_sure(ovo, vir, cor);
+
+    //  reclaim memory from persistent caches on |reset
+    //
+    if ( 0 == (u3A->ent_d % 1000ULL) ) {
+      u3m_reclaim();
+    }
   }
 }
 


### PR DESCRIPTION
This PR forward-ports our solution to space leaks in the bytecode cache (by clearing caches on kernel resets and every 1k events), and wires up the checkpoint timer.