### PR TITLE
Re-add dawn snapshot printf

### DIFF
--- a/vere/dawn.c
+++ b/vere/dawn.c
@@ -310,7 +310,7 @@ u3_dawn_vent(u3_noun seed)
   //  load snapshot from file
   //
   if ( 0 != u3_Host.ops_u.ets_c ) {
-    fprintf(stderr, "boot: loading ethereum snapshot\r\n");
+    fprintf(stderr, "boot: loading azimuth snapshot\r\n");
     u3_noun raw_snap = u3ke_cue(u3m_file(u3_Host.ops_u.ets_c));
     sap = u3nc(u3_nul, raw_snap);
   }
@@ -325,7 +325,7 @@ u3_dawn_vent(u3_noun seed)
   //  no snapshot
   //
   else {
-    printf("dawn: no ethereum snapshot specified\n");
+    printf("dawn: no azimuth snapshot specified\n");
     sap = u3_nul;
   }
 

--- a/vere/dawn.c
+++ b/vere/dawn.c
@@ -317,6 +317,8 @@ u3_dawn_vent(u3_noun seed)
   //  load snapshot from HTTP URL
   //
   else if ( 0 != u3_Host.ops_u.sap_c ) {
+    printf("boot: downloading azimuth snapshot from %s\r\n",
+           u3_Host.ops_u.sap_c);
     u3_noun raw_snap = _dawn_get_jam(u3_Host.ops_u.sap_c);
     sap = u3nc(u3_nul, raw_snap);
   }

--- a/vere/dawn.c
+++ b/vere/dawn.c
@@ -197,7 +197,7 @@ _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
     }
   }
 
-  fprintf(stderr, "dawn: invalid keys for %s '%s'\r\n", rac_c, how_c);
+  fprintf(stderr, "boot: invalid keys for %s '%s'\r\n", rac_c, how_c);
 
   // XX deconstruct sas, print helpful error messages
   u3m_p("pre-boot error", u3t(sas));
@@ -325,7 +325,7 @@ u3_dawn_vent(u3_noun seed)
   //  no snapshot
   //
   else {
-    printf("dawn: no azimuth snapshot specified\n");
+    printf("boot: no azimuth snapshot specified\r\n");
     sap = u3_nul;
   }
 


### PR DESCRIPTION
As brought up in #1130. Turns out the printf had completely disappeared from `dawn.c`. Seems this happened during refactoring in b13f444.

I'm using "boot:" as the printf prefix here, since the majority of the printfs in `dawn.c` seem to use that. There's two existing printfs that say "dawn:" instead. That latter seems to be a bit clearer about where the printf and related logic lives, should I go ahead and change those while I'm at it?