### PR TITLE
cc-release: enables gc and implements |mass in the i/o process

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -1289,7 +1289,7 @@
         void
         u3_pier_sway(c3_l tab_l, u3_noun tax);
 
-      /* u3_pier_mark(): gc the piers
+      /* u3_pier_mark(): mark all Loom allocations in all u3_pier structs.
       */
         c3_w
         u3_pier_mark(FILE* fil_u);

--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -697,6 +697,7 @@
           u3_pier** tab_u;                      //  lord table
           uv_pipe_t cmd_u;                      //  command socket
           u3_moor*  cli_u;                      //  connected clients
+          uv_timer_t tim_u;                     //  gc timer
         } u3_king;
 
 #     define u3L  u3_Host.lup_u             //  global event loop
@@ -1288,6 +1289,11 @@
         void
         u3_pier_sway(c3_l tab_l, u3_noun tax);
 
+      /* u3_pier_mark(): gc the piers
+      */
+        c3_w
+        u3_pier_mark(FILE* fil_u);
+
       /* u3_dawn_come(): mine a comet
       */
         u3_noun
@@ -1302,3 +1308,8 @@
       */
         void
         u3_king_commence();
+
+      /* u3_king_grab(): gc the kingdom
+      */
+        void
+        u3_king_grab(void* vod_p);

--- a/noun/vortex.c
+++ b/noun/vortex.c
@@ -109,6 +109,7 @@ u3v_lite(u3_noun pil)
   pro = u3k(u3r_at(7, cor));
 
   u3z(cor);
+  u3z(arv);
   return pro;
 }
 

--- a/vere/king.c
+++ b/vere/king.c
@@ -588,6 +588,8 @@ u3_king_commence()
     u3K.soc_c = strdup(buf_c);
   }
 
+  uv_timer_init(u3L, &u3K.tim_u);
+
   uv_pipe_init(u3L, &u3K.cmd_u, 0);
   uv_pipe_bind(&u3K.cmd_u, u3K.soc_c);
   uv_listen((uv_stream_t *)&u3K.cmd_u, 128, _king_socket_connect);
@@ -599,4 +601,27 @@ u3_king_commence()
 
   _king_loop_exit();
   exit(0);
+}
+
+/* u3_king_grab(): gc the kingdom
+*/
+void
+u3_king_grab(void* vod_p)
+{
+  //  XX fix leaks and enable
+  //
+#if 0
+  c3_w man_w = 0, pir_w = 0;
+  FILE* fil_u = stderr;
+
+  c3_assert( u3R == &(u3H->rod_u) );
+
+  fprintf(fil_u, "measuring king:\r\n");
+
+  man_w = u3m_mark(fil_u);
+  pir_w = u3_pier_mark(fil_u);
+
+  u3a_print_memory(fil_u, "total marked", man_w + pir_w);
+  u3a_print_memory(fil_u, "sweep", u3a_sweep());
+#endif
 }

--- a/vere/king.c
+++ b/vere/king.c
@@ -561,8 +561,6 @@ u3_king_commence()
   //
   sag_w = u3C.wag_w;
   u3C.wag_w |= u3o_hashless;
-  u3C.wag_w &= ~u3o_debug_ram;
-  u3C.wag_w &= ~u3o_check_corrupt;
 
   u3m_boot_pier();
   {

--- a/vere/king.c
+++ b/vere/king.c
@@ -290,14 +290,16 @@ _king_bail(u3_moor *vod_p, const c3_c *err_c)
 {
   u3_moor *free_p;
   fprintf(stderr, "_king_bail: %s\r\n", err_c);
+
   if ( vod_p == 0 ) {
     free_p = u3K.cli_u;
     u3K.cli_u = u3K.cli_u->nex_u;
-    u3a_free(free_p);
-  } else {
+    c3_free(free_p);
+  }
+  else {
     free_p = vod_p->nex_u;
     vod_p->nex_u = vod_p->nex_u->nex_u;
-    u3a_free(free_p);
+    c3_free(free_p);
   }
 }
 
@@ -307,14 +309,17 @@ void
 _king_socket_connect(uv_stream_t *sock, int status)
 {
   u3_moor *mor_u;
+
   if ( u3K.cli_u == 0 ) {
-    u3K.cli_u = u3a_malloc(sizeof(u3_moor));
+    u3K.cli_u = c3_malloc(sizeof(u3_moor));
     mor_u = u3K.cli_u;
     mor_u->vod_p = 0;
     mor_u->nex_u = 0;
-  } else {
+  }
+  else {
     for (mor_u = u3K.cli_u; mor_u->nex_u; mor_u = mor_u->nex_u);
-    mor_u->nex_u = u3a_malloc(sizeof(u3_moor));
+
+    mor_u->nex_u = c3_malloc(sizeof(u3_moor));
     mor_u->nex_u->vod_p = mor_u;
     mor_u = mor_u->nex_u;
     mor_u->nex_u = 0;

--- a/vere/pier.c
+++ b/vere/pier.c
@@ -2125,7 +2125,7 @@ u3_pier_stay(c3_w wag_w, u3_noun pax)
   */
 }
 
-/* u3_pier_mark(): gc the piers
+/* u3_pier_mark(): mark all Loom allocations in all u3_pier structs.
 */
 c3_w
 u3_pier_mark(FILE* fil_u)

--- a/vere/pier.c
+++ b/vere/pier.c
@@ -2124,3 +2124,37 @@ u3_pier_stay(c3_w wag_w, u3_noun pax)
   /* XX: _pier_loop_exit() should be called somewhere, but is not.
   */
 }
+
+/* u3_pier_mark(): gc the piers
+*/
+c3_w
+u3_pier_mark(FILE* fil_u)
+{
+  c3_w len_w = u3K.len_w;
+  c3_w tot_w = 0;
+  u3_pier* pir_u;
+
+  while ( 0 < len_w ) {
+    pir_u = u3K.tab_u[--len_w];
+    fprintf(stderr, "pier: %u\r\n", len_w);
+
+    tot_w += u3a_maid(fil_u, "  boot event", u3a_mark_noun(pir_u->bot));
+
+    {
+      u3_writ* wit_u = pir_u->ent_u;
+      c3_w wit_w = 0;
+
+      while ( 0 != wit_u ) {
+        wit_w += u3a_mark_noun(wit_u->job);
+        wit_w += u3a_mark_noun(wit_u->now);
+        wit_w += u3a_mark_noun(wit_u->mat);
+        wit_w += u3a_mark_noun(wit_u->act);
+        wit_u = wit_u->nex_u;
+      }
+
+      tot_w += u3a_maid(fil_u, "  writs", wit_w);
+    }
+  }
+
+  return tot_w;
+}

--- a/vere/reck.c
+++ b/vere/reck.c
@@ -131,9 +131,12 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
 
     case c3__mass: p_fav = u3t(fav);
     {
-      //  XX GC the full king state
+      u3z(pox); u3z(fav);
+
+      //  gc the kingdom
       //
-      u3z(pox); u3z(fav); return c3y;
+      uv_timer_start(&u3K.tim_u, (uv_timer_cb)u3_king_grab, 0, 0);
+      return c3y;
     } break;
   }
   c3_assert(!"not reached"); return 0;

--- a/vere/serf.c
+++ b/vere/serf.c
@@ -394,6 +394,8 @@ _serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
     }
   }
 
+  //  XX this runs on replay too
+  //
   _serf_grab(sac, ovo, vir);
   _serf_send_complete(vir);
 


### PR DESCRIPTION
This PR fixes a leak in `u3v_lite()`, so the GC that runs when booting an ivory pill now passes.

This PR implements also `|mass` in the I/O process, but leaves it def'd out -- there are either leaks in `pier.c` and the I/O drivers, this GC pass is missing roots, or both. In any case, I'd like to get the implementation in early, rather than waiting to find and fix all leaks.