### PR TITLE
Rewrite cttp.c to use libcurl and support http/2

### DIFF
--- a/include/vere/vere.h
+++ b/include/vere/vere.h
@@ -4,6 +4,7 @@
 */
 
 #include "h2o.h"
+#include <curl/curl.h>
 
   /** Quasi-tunable parameters.
   **/
@@ -174,20 +175,11 @@
         struct _u3_ward* rev_u;             //  active reverse listeners
       } u3_prox;
 
-    /* u3_csat: client connection state.
-    */
-      typedef enum {
-        u3_csat_init = 0,                   //  initialized
-        u3_csat_addr = 1,                   //  address resolution begun
-        u3_csat_quit = 2,                   //  cancellation requested
-        u3_csat_ripe = 3                    //  passed to libh2o
-      } u3_csat;
-
     /* u3_cres: response to http client.
     */
       typedef struct _u3_cres {
         c3_w             sas_w;             //  status code
-        u3_noun          hed;               //  headers
+        u3_hhed*         hed_u;             //  headers
         u3_hbod*         bod_u;             //  exit of body queue
         u3_hbod*         dob_u;             //  entry of body queue
       } u3_cres;
@@ -195,25 +187,24 @@
     /* u3_creq: outgoing http request.
     */
       typedef struct _u3_creq {             //  client request
-        c3_l             num_l;             //  request number
-        h2o_http1client_t* cli_u;           //  h2o client
-        u3_csat          sat_e;             //  connection state
-        c3_o             sec;               //  yes == https
-        c3_w             ipf_w;             //  IP
-        c3_c*            ipf_c;             //  IP (string)
-        c3_c*            hot_c;             //  host
-        c3_s             por_s;             //  port
-        c3_c*            por_c;             //  port (string)
-        c3_m             met_m;             //  method
-        c3_c*            url_c;             //  url
-        u3_hhed*         hed_u;             //  headers
-        u3_hbod*         bod_u;             //  body
-        u3_hbod*         rub_u;             //  exit of send queue
-        u3_hbod*         bur_u;             //  entry of send queue
-        h2o_iovec_t*     vec_u;             //  send-buffer array
-        u3_cres*         res_u;             //  nascent response
-        struct _u3_creq* nex_u;             //  next in list
-        struct _u3_creq* pre_u;             //  previous in list
+        c3_l               num_l;           //  request number
+        CURL*              cur_u;           //  curl handle
+        struct curl_slist* lis_u;           //  curl headers list pointer
+        c3_o               sec;             //  yes == https
+        c3_w               ipf_w;           //  IP
+        c3_c*              ipf_c;           //  IP (string)
+        c3_c*              hot_c;           //  host
+        c3_s               por_s;           //  port
+        c3_c*              por_c;           //  port (string)
+        c3_m               met_m;           //  method
+        c3_c*              url_c;           //  url
+        u3_hhed*           hed_u;           //  headers
+        u3_hbod*           bod_u;           //  body
+        c3_w               rem_w;           //  size of body remaining
+        c3_c*              err_c;           //  CURLOPT_ERRORBUFFER
+        u3_cres*           res_u;           //  nascent response
+        struct _u3_creq*   nex_u;           //  next in list
+        struct _u3_creq*   pre_u;           //  previous in list
       } u3_creq;
 
     /* u3_chot: foreign host (not yet used).
@@ -229,9 +220,9 @@
     */
       typedef struct _u3_cttp {
         u3_creq*         ceq_u;             //  request list
-        h2o_http1client_ctx_t*              //
-                         ctx_u;             //  h2o client ctx
-        void*            tls_u;             //  client SSL_CTX*
+        CURLM*           mul_u;             //  multiplex curl
+        int*             run_u;             //  number of running transfers
+        uv_timer_t       tim_u;             //  uv timer for curl
       } u3_cttp;
 
     /* u3_pact: ames packet, coming or going.

--- a/meson.build
+++ b/meson.build
@@ -291,7 +291,7 @@ configure_file(input : 'include/config.h.in',
                configuration : conf_data)
 
 # We expect these libs to supplied with the distribution
-curl_dep = dependency('libcurl', version: '>=7.19.0')
+curl_dep = dependency('libcurl', version: '>=7.47.0')
 
 if (osdet == 'darwin' and not get_option('nix') and
     run_command('test', '-d', '/usr/local/opt/openssl/lib').returncode() == 0)


### PR DESCRIPTION
Now requires libcurl 7.47.0 minimum.

Supports sending get, post, put, and delete requests.
Supports HTTP/1.1, ALPN upgrade, and HTTP/2.
Supports setting custom HTTP headers.
Returns libcurl "human-readable error messages" alongside error code instead of the default 504 upon failing.

Uses the libcurl [multi_socket_action](https://curl.haxx.se/libcurl/c/curl_multi_socket_action.html) interface to handle multiple requests asynchronously.

Thanks!


The next pull request will contain the ability to set custom SSL certificates and accept %cert events from Eyre.