### PR TITLE
cc-release tracing

### DIFF
--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -122,6 +122,11 @@
         c3_c*
         u3m_pretty(u3_noun som);
 
+      /* u3m_pretty_path(): prettyprint a path to string.  RETAIN.
+      */
+        c3_c*
+        u3m_pretty_path(u3_noun som);
+
       /* u3m_p(): dumb print with caption.  RETAIN.
       */
         void

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -541,6 +541,7 @@
         c3_w   nid_w;                       //  nock pid
         FILE*  fil_u;                       //  trace file (json)
         c3_w   con_w;                       //  trace counter
+        c3_w   fun_w;                       //  file counter
       } u3_trac;
 
     /* u3_opts: command line configuration.

--- a/pkg/urbit/king/main.c
+++ b/pkg/urbit/king/main.c
@@ -762,6 +762,7 @@ main(c3_i   argc,
         u3_Host.tra_u.nid_w = 0;
         u3_Host.tra_u.fil_u = NULL;
         u3_Host.tra_u.con_w = 0;
+        u3_Host.tra_u.fun_w = 0;
       }
     }
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1369,6 +1369,56 @@ u3m_pretty(u3_noun som)
   return pre_c;
 }
 
+/*  _cm_in_pretty_path: measure/cut prettyprint.
+ *
+ *  Modeled after _cm_in_pretty(), the backend to u3m_p(), but with the
+ *  assumption that we're always displaying a path.
+ */
+static c3_w
+_cm_in_pretty_path(u3_noun som, c3_c* str_c)
+{
+  if ( _(u3du(som)) ) {
+    c3_w sel_w, one_w, two_w;
+    if ( str_c ) {
+      *(str_c++) = '/';
+    }
+    sel_w = 1;
+
+    one_w = _cm_in_pretty_path(u3h(som), str_c);
+    if ( str_c ) {
+      str_c += one_w;
+    }
+
+    two_w = _cm_in_pretty_path(u3t(som), str_c);
+    if ( str_c ) {
+      str_c += two_w;
+    }
+
+    return sel_w + one_w + two_w;
+  }
+  else {
+    c3_w len_w = u3r_met(3, som);
+    if ( str_c && len_w ) {
+      u3r_bytes(0, len_w, (c3_y *)str_c, som);
+      str_c += len_w;
+    }
+    return len_w;
+  }
+}
+
+/* u3m_pretty_path(): prettyprint a path to string.
+*/
+c3_c*
+u3m_pretty_path(u3_noun som)
+{
+  c3_w len_w = _cm_in_pretty_path(som, NULL);
+  c3_c* pre_c = malloc(len_w + 1);
+
+  _cm_in_pretty_path(som, pre_c);
+  pre_c[len_w] = 0;
+  return pre_c;
+}
+
 /* u3m_p(): dumb print with caption.
 */
 void

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -433,54 +433,6 @@ u3t_nock_trace_push(u3_noun lab)
   }
 }
 
-/*  _in_trace_pretty: measure/cut prettyprint.
- *
- *  Modeled after _cm_in_pretty(), the backend to u3m_p(), but with the
- *  assumption that we're always displaying a path.
- */
-static c3_w
-_in_trace_pretty(u3_noun som, c3_c* str_c)
-{
-  if ( _(u3du(som)) ) {
-    c3_w sel_w, one_w, two_w;
-    if ( str_c ) {
-      *(str_c++) = '/';
-    }
-    sel_w = 1;
-
-    one_w = _in_trace_pretty(u3h(som), str_c);
-    if ( str_c ) {
-      str_c += one_w;
-    }
-
-    two_w = _in_trace_pretty(u3t(som), str_c);
-    if ( str_c ) {
-      str_c += two_w;
-    }
-
-    return sel_w + one_w + two_w;
-  }
-  else {
-    c3_w len_w = u3r_met(3, som);
-    if ( str_c && len_w ) {
-      u3r_bytes(0, len_w, (c3_y *)str_c, som);
-      str_c += len_w;
-    }
-    return len_w;
-  }
-}
-
-static c3_c*
-trace_pretty(u3_noun som)
-{
-  c3_w len_w = _in_trace_pretty(som, NULL);
-  c3_c* pre_c = malloc(len_w + 1);
-
-  _in_trace_pretty(som, pre_c);
-  pre_c[len_w] = 0;
-  return pre_c;
-}
-
 /* u3t_nock_trace_pop(): pops a trace from the trace stack.
  *
  * When we remove the trace from the stack, we check to see if the sample is
@@ -503,7 +455,7 @@ u3t_nock_trace_pop()
   // 33microseconds (a 30th of a millisecond).
   c3_d duration = u3t_trace_time() - start_time;
   if (duration > 33) {
-    c3_c* name = trace_pretty(lab);
+    c3_c* name = u3m_pretty_path(lab);
 
     fprintf(u3_Host.tra_u.fil_u,
             "{\"cat\": \"nock\", \"name\": \"%s\", \"ph\":\"%c\", \"pid\": %d, "

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -486,7 +486,7 @@ u3t_event_trace(const c3_c* name, c3_c type)
           "\"tid\": 1, \"ts\": %" PRIu64 ", \"id\": \"0x100\"}, \n",
           name,
           type,
-          u3_Host.tra_u.nid_w,
+          getpid(),
           u3t_trace_time());
   u3_Host.tra_u.con_w++;
 }

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -346,19 +346,16 @@ u3t_flee(void)
 void
 u3t_trace_open()
 {
-
   c3_c fil_c[2048];
-  snprintf(fil_c, 2048, "%s/.urb/put/trace", u3_Host.dir_c);
+  snprintf(fil_c, 2048, "%s/.urb/put/trace", u3C.dir_c);
 
   struct stat st;
   if ( -1 == stat(fil_c, &st) ) {
     mkdir(fil_c, 0700);
   }
 
-  c3_c * wen_c = u3r_string(u3A->wen);
   c3_c lif_c[2048];
-  snprintf(lif_c, 2048, "%s/%s.json", fil_c, wen_c);
-  free(wen_c);
+  snprintf(lif_c, 2048, "%s/%d.json", fil_c, u3_Host.tra_u.fun_w);
 
   u3_Host.tra_u.fil_u = fopen(lif_c, "w");
   u3_Host.tra_u.nid_w = (int)getpid();
@@ -402,6 +399,7 @@ u3t_trace_close()
   // We don't terminate the JSON because of the file format.
   fclose(u3_Host.tra_u.fil_u);
   u3_Host.tra_u.con_w = 0;
+  u3_Host.tra_u.fun_w++;
 }
 
 /*  u3t_trace_time(): microsecond clock

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -344,10 +344,10 @@ u3t_flee(void)
 /*  u3t_trace_open(): opens a trace file and writes the preamble.
 */
 void
-u3t_trace_open()
+u3t_trace_open(c3_c* dir_c)
 {
   c3_c fil_c[2048];
-  snprintf(fil_c, 2048, "%s/.urb/put/trace", u3C.dir_c);
+  snprintf(fil_c, 2048, "%s/.urb/put/trace", dir_c);
 
   struct stat st;
   if ( -1 == stat(fil_c, &st) ) {
@@ -486,7 +486,7 @@ u3t_event_trace(const c3_c* name, c3_c type)
           "\"tid\": 1, \"ts\": %" PRIu64 ", \"id\": \"0x100\"}, \n",
           name,
           type,
-          getpid(),
+          u3_Host.tra_u.nid_w,
           u3t_trace_time());
   u3_Host.tra_u.con_w++;
 }

--- a/pkg/urbit/serf/main.c
+++ b/pkg/urbit/serf/main.c
@@ -31,6 +31,7 @@
       c3_d    key_d[4];                     //  disk key
       u3_moat inn_u;                        //  message input
       u3_mojo out_u;                        //  message output
+      c3_c*   dir_c;                        //  execution directory (pier)
     } u3_serf;
     static u3_serf u3V;
 
@@ -578,17 +579,17 @@ _serf_poke_work(c3_d    evt_d,              //  event number
 {
   if ( u3C.wag_w & u3o_trace ) {
     if ( u3_Host.tra_u.con_w == 0  && u3_Host.tra_u.fun_w == 0 ) {
-      u3t_trace_open();
+      u3t_trace_open(u3V.dir_c);
     }
     else if ( u3_Host.tra_u.con_w >= 100000 ) {
       u3t_trace_close();
-      u3t_trace_open();
+      u3t_trace_open(u3V.dir_c);
     }
   }
 
-  if ( evt_d < 6 ) {
+  if ( evt_d <= u3V.len_w ) {
     c3_c lab_c[8];
-    snprintf(lab_c, 8, "boot: %llu", evt_d);
+    snprintf(lab_c, 8, "boot: %" PRIu64 "", evt_d);
 
     u3t_event_trace(lab_c, 'B');
     _serf_work_boot(evt_d, mug_l, job);
@@ -599,7 +600,7 @@ _serf_poke_work(c3_d    evt_d,              //  event number
     u3_noun cad = u3h(u3t(u3t(job)));
 
     c3_c lab_c[2048];
-    snprintf(lab_c, 2048, "event %llu: [%s %s]", evt_d,
+    snprintf(lab_c, 2048, "event %" PRIu64 ": [%s %s]", evt_d,
              u3m_pretty_path(wir), u3m_pretty(cad));
 
     u3t_event_trace(lab_c, 'B');
@@ -789,23 +790,7 @@ main(c3_i argc, c3_c* argv[])
   /* load pier directory
   */
   {
-    c3_i  abs_i = 1000;
-    c3_c* abs_c = c3_malloc(abs_i);
-
-    while ( abs_c != getcwd(abs_c, abs_i) ) {
-      free(abs_c);
-      abs_i *= 2;
-      abs_c = c3_malloc(abs_i);
-    }
-
-    c3_i ful_i = abs_i + strlen(dir_c);
-    c3_c* ful_c = c3_malloc(ful_i);
-    snprintf(ful_c, ful_i, "%s/%s", abs_c, dir_c);
-
-    u3C.dir_c = strdup(ful_c);
-
-    free(ful_c);
-    free(abs_c);
+    u3V.dir_c = strdup(dir_c);
   }
 
   /*  clear tracing struct

--- a/pkg/urbit/serf/main.c
+++ b/pkg/urbit/serf/main.c
@@ -762,6 +762,37 @@ main(c3_i argc, c3_c* argv[])
     sscanf(wag_c, "%" SCNu32, &u3C.wag_w);
   }
 
+  /* load pier directory
+  */
+  {
+    c3_i  abs_i = 1000;
+    c3_c* abs_c = c3_malloc(abs_i);
+
+    while ( abs_c != getcwd(abs_c, abs_i) ) {
+      free(abs_c);
+      abs_i *= 2;
+      abs_c = c3_malloc(abs_i);
+    }
+
+    c3_i ful_i = abs_i + strlen(dir_c);
+    c3_c* ful_c = c3_malloc(ful_i);
+    snprintf(ful_c, ful_i, "%s/%s", abs_c, dir_c);
+
+    u3C.dir_c = strdup(ful_c);
+
+    free(ful_c);
+    free(abs_c);
+  }
+
+  /*  clear tracing struct
+  */
+  {
+    u3_Host.tra_u.nid_w = 0;
+    u3_Host.tra_u.fil_u = NULL;
+    u3_Host.tra_u.con_w = 0;
+    u3_Host.tra_u.fun_w = 0;
+  }
+
   /* boot image
   */
   {

--- a/pkg/urbit/serf/main.c
+++ b/pkg/urbit/serf/main.c
@@ -576,11 +576,35 @@ _serf_poke_work(c3_d    evt_d,              //  event number
                 c3_l    mug_l,              //  mug of state
                 u3_noun job)                //  full event
 {
-  if ( evt_d <= u3V.len_w ) {
+  if ( u3C.wag_w & u3o_trace ) {
+    if ( u3_Host.tra_u.con_w == 0  && u3_Host.tra_u.fun_w == 0 ) {
+      u3t_trace_open();
+    }
+    else if ( u3_Host.tra_u.con_w >= 100000 ) {
+      u3t_trace_close();
+      u3t_trace_open();
+    }
+  }
+
+  if ( evt_d < 6 ) {
+    c3_c lab_c[8];
+    snprintf(lab_c, 8, "boot: %llu", evt_d);
+
+    u3t_event_trace(lab_c, 'B');
     _serf_work_boot(evt_d, mug_l, job);
+    u3t_event_trace(lab_c, 'E');
   }
   else {
+    u3_noun wir = u3h(u3t(job));
+    u3_noun cad = u3h(u3t(u3t(job)));
+
+    c3_c lab_c[2048];
+    snprintf(lab_c, 2048, "event %llu: [%s %s]", evt_d,
+             u3m_pretty_path(wir), u3m_pretty(cad));
+
+    u3t_event_trace(lab_c, 'B');
     _serf_work_live(evt_d, mug_l, job);
+    u3t_event_trace(lab_c, 'E');
   }
 }
 

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -10,7 +10,7 @@
 
 //  stash config flags for serf
 //
-static c3_c sag_w;
+static c3_w sag_w;
 
 /*
 ::  king/client protocol:

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -444,7 +444,6 @@ _reck_kick_norm(u3_pier* pir_u, u3_noun pox, u3_noun fav)
 void
 u3_reck_kick(u3_pier* pir_u, u3_noun ovo)
 {
-  u3t_event_trace("Effect", 'b');
   if ( (c3n == _reck_kick_spec(pir_u, u3k(u3h(ovo)), u3k(u3t(ovo)))) &&
        (c3n == _reck_kick_norm(pir_u, u3k(u3h(ovo)), u3k(u3t(ovo)))) )
   {
@@ -480,5 +479,4 @@ u3_reck_kick(u3_pier* pir_u, u3_noun ovo)
 #endif
   }
   u3z(ovo);
-  u3t_event_trace("Effect", 'e');
 }


### PR DESCRIPTION
This PR adds tracing functionality to cc-release.

The serf process is responsible for tracing nock computation and writing the output to a file. In the future we'll want to trace i/o as well, which needs to happen on the king.