### PR TITLE
if sweep gives 0 and reference count != 0, leak

### DIFF
--- a/noun/allocate.c
+++ b/noun/allocate.c
@@ -1851,7 +1851,7 @@ u3a_sweep(void)
           weq_w += box_u->siz_w;
         }
         else {
-          _ca_print_leak("weak", box_u, box_u->eus_w, box_u->use_w);
+          _ca_print_leak("leak", box_u, box_u->eus_w, box_u->use_w);
 
           leq_w += box_u->siz_w;
         }


### PR DESCRIPTION
  - "leak" means actual uses are 0, but reference count is > 0
  - "dank" means actual uses are > 0, but reference count is 0 (ie "reverse-leak":  we're still using freed memory; corruption is likely to occur).
  - "weak" means actual uses are > 0, but actual uses are != reference count (i.e. this will be a leak or a dank at some point).

This was recorded correctly in `leq_w`, just printed wrong.