### PR TITLE
cc-release event state machine corrections

### DIFF
--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -612,7 +612,6 @@
           u3_noun          now;                 //  event time
           c3_l             msc_l;               //  ms to timeout
           c3_l             mug_l;               //  hash before executing
-          u3_foil*         fol_u;               //  precommit file
           u3_atom          mat;                 //  jammed $work, or 0
           u3_noun          act;                 //  action list
           struct _u3_writ* nex_u;               //  next in queue, or 0
@@ -644,11 +643,8 @@
           u3_dire*         dir_u;               //  main pier directory
           u3_dire*         urb_u;               //  urbit system data
           u3_dire*         com_u;               //  log directory
-          u3_dire*         pre_u;               //  precommit directory
           u3_foil*         fol_u;               //  logfile
           c3_d             end_d;               //  byte end of file
-          c3_d             rep_d;               //  precommit requested
-          c3_d             pre_d;               //  precommitted
           c3_d             moc_d;               //  commit requested
           c3_d             com_d;               //  committed
           struct _u3_pier* pir_u;               //  pier backpointer

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -673,6 +673,7 @@
           c3_c*            who_c;               //  identity as C string
           c3_s             por_s;               //  UDP port
           c3_o             fak_o;               //  yes iff fake security
+          c3_o             liv_o;               //  live
           u3_noun          bot;                 //  boot event XX review
           u3_noun          pil;                 //  pill XX review
           u3_disk*         log_u;               //  event log

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -658,6 +658,15 @@
 
         } u3_boot;
 
+      /* u3_psat: pier state.
+      */
+        typedef enum {
+          u3_psat_init = 0,                   //  initialized
+          u3_psat_boot = 1,                   //  booting
+          u3_psat_pace = 2,                   //  replaying
+          u3_psat_play = 3                    //  full operation
+        } u3_psat;
+
       /* u3_pier: ship controller.
       */
         typedef struct _u3_pier {
@@ -674,6 +683,7 @@
           c3_s             por_s;               //  UDP port
           c3_o             fak_o;               //  yes iff fake security
           c3_o             liv_o;               //  live
+          u3_psat          sat_e;               //  pier state
           u3_noun          bot;                 //  boot event XX review
           u3_noun          pil;                 //  pill XX review
           u3_disk*         log_u;               //  event log

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -351,7 +351,8 @@
       typedef struct _u3_save {
         uv_timer_t  tim_u;                  //  checkpoint timer
         uv_signal_t sil_u;                  //  child signal
-        c3_d        ent_d;                  //  event number
+        c3_d        req_d;                  //  requested at evt_d
+        c3_d        dun_d;                  //  completed at evt_d
         c3_w        pid_w;                  //  pid of checkpoint process
       } u3_save;
 
@@ -664,7 +665,8 @@
           u3_psat_init = 0,                   //  initialized
           u3_psat_boot = 1,                   //  booting
           u3_psat_pace = 2,                   //  replaying
-          u3_psat_play = 3                    //  full operation
+          u3_psat_play = 3,                   //  full operation
+          u3_psat_done = 4                    //  shutting down
         } u3_psat;
 
       /* u3_pier: ship controller.
@@ -1264,10 +1266,10 @@
         void
         u3_pier_work(u3_pier* pir_u, u3_noun pax, u3_noun fav);
 
-      /* u3_pier_work_save(): tell worker to save checkpoint.
+      /* u3_pier_snap(): request checkpoint.
       */
         void
-        u3_pier_work_save(u3_pier* pir_u);
+        u3_pier_snap(u3_pier* pir_u);
 
       /* u3_pier_stub(): get the One Pier for unreconstructed code.
       */

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -626,6 +626,7 @@
           time_t               wen_t;           //  process creation time
           u3_mojo              inn_u;           //  client's stdin
           u3_moat              out_u;           //  client's stdout
+          c3_o                 liv_o;           //  live
           c3_d                 sen_d;           //  last event dispatched
           c3_d                 dun_d;           //  last event completed
           c3_d                 rel_d;           //  last event released

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -645,6 +645,7 @@
           u3_dire*         urb_u;               //  urbit system data
           u3_dire*         com_u;               //  log directory
           u3_foil*         fol_u;               //  logfile
+          c3_o             liv_o;               //  live
           c3_d             end_d;               //  byte end of file
           c3_d             moc_d;               //  commit requested
           c3_d             com_d;               //  committed

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1239,7 +1239,12 @@
       /* u3_pier_exit(): trigger a gentle shutdown.
       */
         void
-        u3_pier_exit(void);
+        u3_pier_exit(u3_pier* pir_u);
+
+      /* u3_pier_bail(): clean up all event state.
+      */
+        void
+        u3_pier_bail(void);
 
       /* u3_pier_work(): send event; real pier pointer.
       */

--- a/pkg/urbit/king/main.c
+++ b/pkg/urbit/king/main.c
@@ -529,7 +529,7 @@ _stop_exit(c3_i int_i)
   fprintf(stderr, "\r\n[received keyboard stop signal, exiting]\r\n");
   //  XX crashes if we haven't started a pier yet
   //
-  u3_pier_exit();
+  u3_pier_exit(u3_pier_stub());
 }
 
 /*

--- a/pkg/urbit/serf/main.c
+++ b/pkg/urbit/serf/main.c
@@ -89,7 +89,7 @@
       [%exit p=@]
       ::  save snapshot to disk
       ::
-      ::  p: number of old snaps to save (XX not respected)
+      ::  p: event number
       ::
       [%save p=@]
       ::  execute event
@@ -684,15 +684,19 @@ _serf_poke(void* vod_p, u3_noun mat)
       }
 
       case c3__save: {
-        u3_noun sap;
+        u3_noun evt;
+        c3_d evt_d;
 
-        if ( (c3n == u3r_cell(jar, 0, &sap)) ||
-             (c3n == u3ud(sap)) )
+        if ( (c3n == u3r_cell(jar, 0, &evt)) ||
+             (c3n == u3ud(evt)) )
         {
           goto error;
         }
 
-        u3z(jar);
+        evt_d = u3r_chub(0, evt);
+        u3z(evt);
+
+        c3_assert( evt_d == u3V.evt_d );
 
         return u3e_save();
       }

--- a/pkg/urbit/serf/main.c
+++ b/pkg/urbit/serf/main.c
@@ -598,6 +598,7 @@ static void
 _serf_poke_boot(u3_noun who, u3_noun fak, c3_w len_w)
 {
   c3_assert( u3_none == u3A->our );
+  c3_assert( 0 != len_w );
 
   u3A->our = who;
   u3A->fak = fak;

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -434,7 +434,7 @@ _ames_io_start(u3_pier* pir_u)
         uL(fprintf(uH,
                     "    ...perhaps you've got two copies of vere running?\n"));
       }
-      u3_pier_exit();
+      u3_pier_exit(pir_u);
     }
 
     uv_udp_getsockname(&sam_u->wax_u, (struct sockaddr *)&add_u, &add_i);

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -740,37 +740,6 @@ _king_loop_init()
 void
 _king_loop_exit()
 {
-  /*  all needs to move extept unlink */
-  c3_l cod_l;
-
-  cod_l = u3a_lush(c3__unix);
-  u3_unix_io_exit(u3_pier_stub());
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__ames);
-  u3_ames_io_exit(u3_pier_stub());
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__term);
-  u3_term_io_exit();
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__http);
-  u3_http_io_exit();
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__cttp);
-  u3_cttp_io_exit();
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__save);
-  u3_save_io_exit(u3_pier_stub());
-  u3a_lop(cod_l);
-
-  cod_l = u3a_lush(c3__behn);
-  u3_behn_io_exit(u3_pier_stub());
-  u3a_lop(cod_l);
-
   unlink(u3K.soc_c);
 }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -124,6 +124,8 @@ _pier_work_boot(u3_pier* pir_u, c3_o sav_o)
 {
   u3_lord* god_u = pir_u->god_u;
 
+  c3_assert( 0 != pir_u->lif_d );
+
   u3_noun who = u3i_chubs(2, pir_u->who_d);
   u3_noun len = u3i_chubs(1, &pir_u->lif_d);
   u3_noun msg = u3nq(c3__boot, who, pir_u->fak_o, len);
@@ -661,6 +663,8 @@ _pier_disk_read_header(u3_pier* pir_u, u3_noun ovo)
   c3_assert( 1 >= u3r_met(3, len) );
 
   _pier_set_ship(pir_u, u3k(who), u3k(fak));
+
+  pir_u->lif_d = u3r_chub(0, len);
 
   u3z(ovo);
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -276,7 +276,7 @@ _pier_work_release(u3_writ* wit_u)
 {
   u3_pier* pir_u = wit_u->pir_u;
   u3_lord* god_u = pir_u->god_u;
-  u3_noun  vir;
+  u3_noun    vir = wit_u->act;
 
 #ifdef VERBOSE_EVENTS
   fprintf(stderr, "pier: (%" PRIu64 "): compute: release\r\n", wit_u->evt_d);
@@ -291,13 +291,12 @@ _pier_work_release(u3_writ* wit_u)
 
   /* apply actions
   */
-  vir = wit_u->act;
   while ( u3_nul != vir ) {
-    u3_noun ovo = u3k(u3h(vir));
-    u3_noun nex = u3k(u3t(vir));
-    u3z(vir); vir = nex;
+    u3_noun ovo, nex;
+    u3x_cell(vir, &ovo, &nex);
 
-    u3_reck_kick(pir_u, ovo);
+    u3_reck_kick(pir_u, u3k(ovo));
+    vir = nex;
   }
 }
 
@@ -1279,7 +1278,7 @@ _pier_work_poke(void*   vod_p,
                 u3_noun mat)
 {
   u3_pier* pir_u = vod_p;
-  u3_noun jar    = u3ke_cue(u3k(mat));
+  u3_noun  jar   = u3ke_cue(u3k(mat));
   u3_noun  p_jar, q_jar, r_jar;
 
   if ( c3y != u3du(jar) ) {
@@ -1325,8 +1324,6 @@ _pier_work_poke(void*   vod_p,
       }
 
       _pier_work_play(pir_u, lav_d, mug_l);
-
-      u3z(jar); u3z(mat);
       break;
     }
 
@@ -1360,7 +1357,7 @@ _pier_work_poke(void*   vod_p,
         }
         fprintf(stderr, "pier: replace: %" PRIu64 "\r\n", evt_d);
 
-        _pier_work_replace(wit_u, u3k(r_jar), mat);
+        _pier_work_replace(wit_u, u3k(r_jar), u3k(mat));
       }
       break;
     }
@@ -1389,13 +1386,13 @@ _pier_work_poke(void*   vod_p,
     }
   }
 
+  u3z(jar); u3z(mat);
   _pier_apply(pir_u);
   return;
 
   error: {
+    u3z(jar); u3z(mat);
     _pier_work_bail(0, "bad jar");
-    u3z(jar);
-    u3z(mat);
   }
 }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -255,16 +255,18 @@ _pier_disk_commit_request(u3_writ* wit_u)
   }
 }
 
-/* _pier_dispose(): dispose of writ.
+/* _pier_writ_dispose(): dispose of writ.
 */
 static void
-_pier_dispose(u3_writ* wit_u)
+_pier_writ_dispose(u3_writ* wit_u)
 {
   /* free contents
   */
   u3z(wit_u->job);
   u3z(wit_u->mat);
   u3z(wit_u->act);
+
+  c3_free(wit_u);
 }
 
 /* _pier_work_release(): apply side effects.
@@ -507,7 +509,7 @@ start:
         _pier_work_release(wit_u);
       }
 
-      _pier_dispose(wit_u);
+      _pier_writ_dispose(wit_u);
 
       wit_u = pir_u->ext_u;
       act_o = c3y;

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -536,73 +536,6 @@ start:
   }
 }
 
-/* _pier_disk_init_complete():
-** XX async
-*/
-static void
-_pier_disk_init_complete(u3_disk* log_u, c3_d evt_d)
-{
-  c3_assert( c3n == log_u->liv_o );
-
-  log_u->com_d = log_u->moc_d = evt_d;
-
-  log_u->liv_o = c3y;
-}
-
-/* _pier_disk_init():
-** XX async
-*/
-static c3_o
-_pier_disk_init(u3_disk* log_u)
-{
-  c3_d evt_d = 0;
-  c3_d pos_d = 0;
-
-  c3_assert( c3n == log_u->liv_o );
-
-  log_u->fol_u = u3_foil_absorb(log_u->com_u, "commit.urbit-log");
-
-  if ( !log_u->fol_u ) {
-    return c3n;
-  }
-
-  //  use the last event in the log to set the commit point.
-  //
-  if ( 0 != (pos_d = log_u->fol_u->end_d) ) {
-    c3_d len_d = 0;
-
-    c3_d* buf_d = u3_foil_reveal(log_u->fol_u, &pos_d, &len_d);
-
-    if ( !buf_d ) {
-      fprintf(stderr, "pier: load: commit: corrupt\r\n");
-      return c3n;
-    }
-
-    {
-      u3_noun mat = u3i_chubs(len_d, buf_d);
-      u3_noun ovo = u3ke_cue(u3k(mat));
-
-      c3_assert(c3__work == u3h(ovo));
-
-      u3_noun evt = u3h(u3t(ovo));
-
-      evt_d = u3r_chub(0, evt);
-
-      u3z(mat); u3z(ovo); u3z(evt);
-    }
-
-#ifdef VERBOSE_EVENTS
-    fprintf(stderr, "pier: load: last %" PRIu64 "\r\n", evt_d);
-#endif
-
-    c3_free(buf_d);
-  }
-
-  _pier_disk_init_complete(log_u, evt_d);
-
-  return c3y;
-}
-
 /* _pier_set_ship():
 */
 static void
@@ -1046,6 +979,73 @@ _pier_disk_consolidate(u3_pier*  pir_u,
     */
     _pier_boot_complete(pir_u, c3n);
   }
+
+  return c3y;
+}
+
+/* _pier_disk_init_complete():
+** XX async
+*/
+static void
+_pier_disk_init_complete(u3_disk* log_u, c3_d evt_d)
+{
+  c3_assert( c3n == log_u->liv_o );
+
+  log_u->com_d = log_u->moc_d = evt_d;
+
+  log_u->liv_o = c3y;
+}
+
+/* _pier_disk_init():
+** XX async
+*/
+static c3_o
+_pier_disk_init(u3_disk* log_u)
+{
+  c3_d evt_d = 0;
+  c3_d pos_d = 0;
+
+  c3_assert( c3n == log_u->liv_o );
+
+  log_u->fol_u = u3_foil_absorb(log_u->com_u, "commit.urbit-log");
+
+  if ( !log_u->fol_u ) {
+    return c3n;
+  }
+
+  //  use the last event in the log to set the commit point.
+  //
+  if ( 0 != (pos_d = log_u->fol_u->end_d) ) {
+    c3_d len_d = 0;
+
+    c3_d* buf_d = u3_foil_reveal(log_u->fol_u, &pos_d, &len_d);
+
+    if ( !buf_d ) {
+      fprintf(stderr, "pier: load: commit: corrupt\r\n");
+      return c3n;
+    }
+
+    {
+      u3_noun mat = u3i_chubs(len_d, buf_d);
+      u3_noun ovo = u3ke_cue(u3k(mat));
+
+      c3_assert(c3__work == u3h(ovo));
+
+      u3_noun evt = u3h(u3t(ovo));
+
+      evt_d = u3r_chub(0, evt);
+
+      u3z(mat); u3z(ovo); u3z(evt);
+    }
+
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: load: last %" PRIu64 "\r\n", evt_d);
+#endif
+
+    c3_free(buf_d);
+  }
+
+  _pier_disk_init_complete(log_u, evt_d);
 
   return c3y;
 }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1427,19 +1427,6 @@ c3_rand(c3_w* rad_w)
   }
 }
 
-#if 0
-/* _pier_zen(): get OS entropy.
-*/
-static u3_noun
-_pier_zen()
-{
-  c3_w rad_w[16];
-
-  c3_rand(rad_w);
-  return u3i_words(16, rad_w);
-}
-#endif
-
 /* _pier_loop_time(): set time.
 */
 static void
@@ -1572,91 +1559,6 @@ _pier_loop_exit(u3_pier* pir_u)
     u3a_lop(cod_l);
   }
 }
-
-#if 0
-/* _pier_boot_seed(): build the cryptographic seed noun.
-*/
-static u3_noun
-_pier_boot_seed(u3_pier* pir_u)
-{
-  if ( 0 == u3_Host.ops_u.imp_c ) {
-    u3_noun ten = _pier_zen();
-    return u3nq(c3__make, u3_nul, 11, u3nc(ten, u3_Host.ops_u.fak));
-  }
-  else {
-    u3_noun imp = u3i_string(u3_Host.ops_u.imp_c);
-    u3_noun whu = u3dc("slaw", 'p', u3k(imp));
-
-    if ( (u3_nul == whu) ) {
-      fprintf(stderr, "czar: incorrect format\r\n");
-      c3_assert(0);
-    }
-    else {
-      u3_noun gun = u3_nul;
-      if (c3n == u3_Host.ops_u.fak) {
-        c3_assert(!"must run as fake for now");
-      }
-      else {
-        gun = u3nc(u3_nul, u3_nul);
-      }
-      return u3nq(c3__sith,
-                 u3k(u3t(whu)),
-                 u3k(u3t(gun)),
-                 u3_Host.ops_u.fak);
-
-      u3z(whu); u3z(gun);
-    }
-    u3z(imp);
-  }
-}
-#endif
-
-#if 0
-/* _pier_boot_legacy(): poorly organized legacy boot calls.
-*/
-static void
-_pier_boot_legacy(u3_pier* pir_u,
-                  c3_o     nuu_o)
-{
-  /* XX XX horrible backward compatibility hack - still used
-  ** in sist.c, raft.c, unix.c
-  */
-  u3_Host.ops_u.nuu = nuu_o;
-
-  if ( c3y == nuu_o ) {
-    u3_noun pig = _pier_boot_seed(pir_u);
-
-    {
-      u3_noun pax = u3nq(u3_blip, c3__term, '1', u3_nul);
-      u3_pier_plan(pax, u3nc(c3__boot, pig));
-    }
-
-    u3_ames_ef_bake();
-    u3_term_ef_bunk();
-
-    if ( u3_Host.ops_u.imp_c ) {
-      u3_unix_ef_initial_into();
-    }
-    /* from unix.c
-    */
-    if ( c3n == nuu_o ) {
-      u3_pier_plan(u3nt(u3_blip, c3__boat, u3_nul),
-                   u3nc(c3__boat, u3_nul));
-    }
-  }
-
-  u3_http_ef_bake();
-
-  _pier_loop_talk();
-
-  _pier_loop_poll();
-  u3_term_ef_boil(1);
-
-  if ( c3y == u3_Host.ops_u.veb ) {
-    u3_term_ef_verb();
-  }
-}
-#endif
 
 /* _pier_boot_complete(): start organic event flow on boot/reboot.
 */

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -255,6 +255,25 @@ _pier_disk_commit_request(u3_writ* wit_u)
   }
 }
 
+/* _pier_writ_unlink(): unlink writ from queue.
+*/
+static void
+_pier_writ_unlink(u3_writ* wit_u)
+{
+  u3_pier* pir_u = wit_u->pir_u;
+
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
+#endif
+
+  pir_u->ext_u = wit_u->nex_u;
+
+  if ( wit_u == pir_u->ent_u ) {
+    c3_assert(pir_u->ext_u == 0);
+    pir_u->ent_u = 0;
+  }
+}
+
 /* _pier_writ_dispose(): dispose of writ.
 */
 static void
@@ -492,18 +511,7 @@ start:
       //    XX must be done before releasing effects
       //    which is currently reentrant
       //
-      {
-#ifdef VERBOSE_EVENTS
-        fprintf(stderr, "pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
-#endif
-
-        pir_u->ext_u = wit_u->nex_u;
-
-        if ( wit_u == pir_u->ent_u ) {
-          c3_assert(pir_u->ext_u == 0);
-          pir_u->ent_u = 0;
-        }
-      }
+      _pier_writ_unlink(wit_u);
 
       //  will be false during replay
       //

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -440,8 +440,13 @@ _pier_apply(u3_pier* pir_u)
   u3_disk* log_u = pir_u->log_u;
   u3_lord* god_u = pir_u->god_u;
 
-  if ( !log_u || !god_u ) {
+  if ( (0 == log_u) ||
+       (0 == god_u) ||
+       (c3n == god_u->liv_o) )
+  {
+    return;
   }
+
   u3_writ* wit_u;
   c3_o     act_o = c3n;
 
@@ -1028,18 +1033,25 @@ _pier_disk_create(u3_pier* pir_u,
   return c3y;
 }
 
-/* _pier_play(): with active worker, create or load log.
+/* _pier_work_play(): with active worker, create or load log.
 */
 static void
-_pier_play(u3_pier* pir_u,
-           c3_d     lav_d,
-           c3_l     mug_l)
+_pier_work_play(u3_pier* pir_u,
+                c3_d     lav_d,
+                c3_l     mug_l)
 {
+  u3_lord* god_u = pir_u->god_u;
+
 #ifdef VERBOSE_EVENTS
   fprintf(stderr, "pier: (%" PRIu64 "): boot at mug %x\r\n", lav_d, mug_l);
 #endif
 
-  u3_pier_work_save(pir_u);
+  c3_assert( c3n == god_u->liv_o );
+  god_u->liv_o = c3y;
+
+  //  all events in the serf are complete
+  //
+  god_u->rel_d = god_u->dun_d = god_u->sen_d = (lav_d - 1ULL);
 
   /* load all committed events
   */
@@ -1153,7 +1165,7 @@ _pier_work_poke(void*   vod_p,
             }
           }
 
-          _pier_play(pir_u, lav_d, mug_l);
+          _pier_work_play(pir_u, lav_d, mug_l);
 
           u3z(jar); u3z(mat);
           break;
@@ -1242,6 +1254,7 @@ _pier_work_create(u3_pier* pir_u)
 
   pir_u->god_u = god_u;
   god_u->pir_u = pir_u;
+  god_u->liv_o = c3n;
 
   /* spawn new process and connect to it
   */

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -23,6 +23,8 @@
 #include "all.h"
 #include "vere/vere.h"
 
+#undef VERBOSE_EVENTS
+
   /*    event handling proceeds on two parallel paths.  on the first
   **    path, the event is processed in the child worker process (serf).
   **    state transitions are as follows:
@@ -222,7 +224,9 @@ _pier_disk_precommit_complete(void*    vod_p,
 
     /* delete the file; the reactor will re-request.
     */
-    //  fprintf(stderr, "pier: (%" PRIu64 "): precommit: replaced\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: (%" PRIu64 "): precommit: replaced\r\n", wit_u->evt_d);
+#endif
 
     u3_foil_delete(0, 0, fol_u);
     wit_u->fol_u = 0;
@@ -230,7 +234,9 @@ _pier_disk_precommit_complete(void*    vod_p,
   else {
     /* advance the precommit complete pointer.
     */
-    //  fprintf(stderr, "pier: (%" PRIu64 "): precommit: complete\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: (%" PRIu64 "): precommit: complete\r\n", wit_u->evt_d);
+#endif
 
     c3_assert(wit_u->evt_d == (1ULL + log_u->pre_d));
     log_u->pre_d = wit_u->evt_d;
@@ -248,7 +254,9 @@ _pier_disk_precommit_request(u3_writ* wit_u)
 
   c3_c* nam_c;
 
-  //  fprintf(stderr, "pier: (%" PRIu64 "): precommit: request\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: (%" PRIu64 "): precommit: request\r\n", wit_u->evt_d);
+#endif
 
   /* writ must be fully computed
   */
@@ -304,7 +312,9 @@ _pier_disk_precommit_replace(u3_writ* wit_u)
     c3_assert(wit_u->evt_d == log_u->rep_d);
     c3_assert(wit_u->evt_d == log_u->pre_d);
 
-    // fprintf(stderr, "pier: (%" PRIu64 "): precommit: replacing\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: (%" PRIu64 "): precommit: replacing\r\n", wit_u->evt_d);
+#endif
 
     log_u->rep_d -= 1ULL;
     log_u->pre_d -= 1ULL;
@@ -315,7 +325,9 @@ _pier_disk_precommit_replace(u3_writ* wit_u)
     /* otherwise, decrement the precommit request counter.
     ** the returning request will notice this and rerequest.
     */
-    // fprintf(stderr, "pier: (%" PRIu64 "): precommit: replace\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: (%" PRIu64 "): precommit: replace\r\n", wit_u->evt_d);
+#endif
 
     c3_assert(wit_u->evt_d == log_u->rep_d);
     log_u->rep_d -= 1ULL;
@@ -331,7 +343,9 @@ _pier_disk_commit_complete(void* vod_p)
   u3_pier* pir_u = wit_u->pir_u;
   u3_disk* log_u = pir_u->log_u;
 
-  //  fprintf(stderr, "pier: (%" PRIu64 "): commit: complete\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): commit: complete\r\n", wit_u->evt_d);
+#endif
 
   /* advance commit counter
   */
@@ -352,7 +366,9 @@ _pier_disk_commit_request(u3_writ* wit_u)
   u3_pier* pir_u = wit_u->pir_u;
   u3_disk* log_u = pir_u->log_u;
 
-  //  fprintf(stderr, "pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
+#endif
 
   /* append to logfile
   */
@@ -403,7 +419,9 @@ _pier_work_release(u3_writ* wit_u)
   u3_lord* god_u = pir_u->god_u;
   u3_noun  vir;
 
-  // fprintf(stderr, "pier: (%" PRIu64 "): compute: release\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): compute: release\r\n", wit_u->evt_d);
+#endif
 
   /* advance release counter
   */
@@ -485,7 +503,9 @@ _pier_work_complete(u3_writ* wit_u,
   u3_pier* pir_u = wit_u->pir_u;
   u3_lord* god_u = pir_u->god_u;
 
-  // fprintf(stderr, "pier: (%" PRIu64 "): compute: complete\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): compute: complete\r\n", wit_u->evt_d);
+#endif
 
   god_u->dun_d += 1;
   c3_assert(god_u->dun_d == wit_u->evt_d);
@@ -512,7 +532,10 @@ _pier_work_replace(u3_writ* wit_u,
   u3_pier* pir_u = wit_u->pir_u;
   u3_lord* god_u = pir_u->god_u;
 
+#ifdef VERBOSE_EVENTS
   fprintf(stderr, "pier: (%" PRIu64 "): compute: replace\r\n", wit_u->evt_d);
+#endif
+
   c3_assert(god_u->sen_d == wit_u->evt_d);
 
   /* move backward in work processing
@@ -540,7 +563,10 @@ _pier_work_compute(u3_writ* wit_u)
   u3_pier* pir_u = wit_u->pir_u;
   u3_lord* god_u = pir_u->god_u;
 
-  //  fprintf(stderr, "pier: (%" PRIu64 "): compute: request\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): compute: request\r\n", wit_u->evt_d);
+#endif
+
   c3_assert(wit_u->evt_d == (1 + god_u->sen_d));
 
   wit_u->mug_l = god_u->mug_l;
@@ -619,7 +645,9 @@ start:
     if ( (wit_u->evt_d <= log_u->com_d) &&
          (wit_u->evt_d <= god_u->dun_d) )
     {
-      //  fprintf(stderr, "pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
+#ifdef VERBOSE_EVENTS
+      fprintf(stderr, "pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
+#endif
 
       /* remove from queue; must be at end, since commit/compute are serial
       */
@@ -673,7 +701,9 @@ _pier_disk_load_precommit_file(u3_pier* pir_u,
 
   wit_u = c3_calloc(sizeof(*wit_u));
 
-  //  fprintf(stderr, "pier: (%" PRIu64 "): %p restore\r\n", evt_d, wit_u);
+#ifdef VERBOSE_EVENTS
+  fprintf(stderr, "pier: (%" PRIu64 "): %p restore\r\n", evt_d, wit_u);
+#endif
 
   wit_u->pir_u = pir_u;
   wit_u->evt_d = evt_d;
@@ -812,7 +842,9 @@ _pier_disk_load_commit(u3_pier* pir_u,
   else {
     c3_d pos_d = log_u->fol_u->end_d;
 
-    //  fprintf(stderr, "pier: load: commit: at %" PRIx64 "\r\n", pos_d);
+#ifdef VERBOSE_EVENTS
+    fprintf(stderr, "pier: load: commit: at %" PRIx64 "\r\n", pos_d);
+#endif
 
     while ( pos_d ) {
       c3_d  len_d, evt_d;
@@ -821,7 +853,7 @@ _pier_disk_load_commit(u3_pier* pir_u,
 
       buf_d = u3_foil_reveal(log_u->fol_u, &pos_d, &len_d);
       if ( !buf_d ) {
-        //  fprintf(stderr, "pier: load: commit: corrupt\r\n");
+        fprintf(stderr, "pier: load: commit: corrupt\r\n");
         return c3n;
       }
 
@@ -872,7 +904,9 @@ _pier_disk_load_commit(u3_pier* pir_u,
       */
       {
         if ( !old_d ) {
-          //  fprintf(stderr, "pier: load: last %" PRIu64 "\r\n", evt_d);
+#ifdef VERBOSE_EVENTS
+          fprintf(stderr, "pier: load: last %" PRIu64 "\r\n", evt_d);
+#endif
 
           log_u->com_d = log_u->moc_d = old_d = evt_d;
         }
@@ -894,7 +928,9 @@ _pier_disk_load_commit(u3_pier* pir_u,
       else {
         u3_writ* wit_u = c3_calloc(sizeof(u3_writ));
 
-        //  fprintf(stderr, "pier: load: commit: %" PRIu64 "\r\n", evt_d);
+#ifdef VERBOSE_EVENTS
+        fprintf(stderr, "pier: load: commit: %" PRIu64 "\r\n", evt_d);
+#endif
 
         wit_u->pir_u = pir_u;
         wit_u->evt_d = evt_d;
@@ -1352,7 +1388,9 @@ _pier_play(u3_pier* pir_u,
            c3_d     lav_d,
            c3_l     mug_l)
 {
+#ifdef VERBOSE_EVENTS
   fprintf(stderr, "pier: (%" PRIu64 "): boot at mug %x\r\n", lav_d, mug_l);
+#endif
 
   u3_pier_work_save(pir_u);
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1016,7 +1016,9 @@ _pier_disk_init_complete(u3_disk* log_u, c3_d evt_d)
     u3_pier* pir_u = log_u->pir_u;
     u3_lord* god_u = pir_u->god_u;
 
-    if ( (c3y == god_u->liv_o) && (c3n == pir_u->liv_o) ) {
+    if ( (0 != god_u) &&
+         (c3y == god_u->liv_o) &&
+         (c3n == pir_u->liv_o) ) {
       _pier_boot_ready(pir_u);
     }
   }
@@ -1174,14 +1176,12 @@ _pier_work_play(u3_pier* pir_u,
   //
   god_u->rel_d = god_u->dun_d = god_u->sen_d = (lav_d - 1ULL);
 
-  //  load all committed events
-  //
-  _pier_disk_create(pir_u);
-
   {
     u3_disk* log_u = pir_u->log_u;
 
-    if ( (c3y == log_u->liv_o) && (c3n == pir_u->liv_o) ) {
+    if ( (0 != log_u) &&
+         (c3y == log_u->liv_o) &&
+         (c3n == pir_u->liv_o) ) {
       _pier_boot_ready(pir_u);
     }
   }
@@ -1235,116 +1235,110 @@ _pier_work_poke(void*   vod_p,
   if ( c3y != u3du(jar) ) {
     goto error;
   }
-  else {
-    /* the worker process starts with a %play task,
-    ** which tells us where to start playback
-    ** (and who we are, if it knows)
-    */
-    if ( 0 == pir_u->log_u ) {
-      switch ( u3h(jar) ) {
-        default: goto error;
 
-        case c3__play: {
-          c3_d lav_d;
-          c3_l mug_l;
+  switch ( u3h(jar) ) {
+    default: goto error;
 
-          if ( (c3n == u3r_qual(u3t(jar), 0, &p_jar, &q_jar, &r_jar)) ||
-               (c3n == u3ud(p_jar)) ||
-               (u3r_met(6, p_jar) != 1) ||
-               (c3n == u3ud(q_jar)) ||
-               (u3r_met(5, p_jar) != 1) ||
-               (c3n == u3du(r_jar)) ||
-               (c3n == u3ud(u3h(r_jar))) ||
-               ((c3y != u3t(r_jar)) && (c3n != u3t(r_jar))) )
-          {
-            if ( u3_nul == u3t(jar) ) {
-              lav_d = 1ULL;
-              mug_l = 0;
-            }
-            else {
-              goto error;
-            }
-          }
+    //  the worker process starts with a %play task,
+    //  which tells us where to start playback
+    //  (and who we are, if it knows) XX remove in favor of event-log header
+    //
+    case c3__play: {
+      c3_d lav_d;
+      c3_l mug_l;
 
-          if ( u3_nul != u3t(jar) ) {
-            lav_d = u3r_chub(0, p_jar);
-            mug_l = u3r_word(0, q_jar);
-
-            //  single-home
-            //
-            _pier_set_ship(pir_u, u3k(u3h(r_jar)), u3k(u3t(r_jar)));
-          }
-
-          _pier_work_play(pir_u, lav_d, mug_l);
-
-          u3z(jar); u3z(mat);
-          break;
+      if ( (c3n == u3r_qual(u3t(jar), 0, &p_jar, &q_jar, &r_jar)) ||
+           (c3n == u3ud(p_jar)) ||
+           (u3r_met(6, p_jar) != 1) ||
+           (c3n == u3ud(q_jar)) ||
+           (u3r_met(5, p_jar) != 1) ||
+           (c3n == u3du(r_jar)) ||
+           (c3n == u3ud(u3h(r_jar))) ||
+           ((c3y != u3t(r_jar)) && (c3n != u3t(r_jar))) )
+      {
+        if ( u3_nul == u3t(jar) ) {
+          lav_d = 1ULL;
+          mug_l = 0;
+        }
+        else {
+          goto error;
         }
       }
+
+      if ( u3_nul != u3t(jar) ) {
+        lav_d = u3r_chub(0, p_jar);
+        mug_l = u3r_word(0, q_jar);
+
+        //  single-home
+        //
+        _pier_set_ship(pir_u, u3k(u3h(r_jar)), u3k(u3t(r_jar)));
+      }
+
+      _pier_work_play(pir_u, lav_d, mug_l);
+
+      u3z(jar); u3z(mat);
+      break;
     }
-    else {
-      switch ( u3h(jar) ) {
-        default: goto error;
 
-        case c3__work: {
-          if ( (c3n == u3r_qual(jar, 0, &p_jar, &q_jar, &r_jar)) ||
-               (c3n == u3ud(p_jar)) ||
-               (u3r_met(6, p_jar) != 1) ||
-               (c3n == u3ud(q_jar)) ||
-               (u3r_met(5, q_jar) > 1) )
-          {
-            goto error;
-          }
-          else {
-            c3_d     evt_d = u3r_chub(0, p_jar);
-            c3_l     mug_l = u3r_word(0, q_jar);
-            u3_writ* wit_u = _pier_work_writ(pir_u, evt_d);
-
-            if ( !wit_u || (mug_l && (mug_l != wit_u->mug_l)) ) {
-              goto error;
-            }
-            {
-              // XX not the right place to print an error!
-              //
-              u3m_p("wire", u3h(u3t(r_jar)));
-              u3m_p("oust", u3h(u3t(u3t(wit_u->job))));
-              u3m_p("with", u3h(u3t(u3t(r_jar))));
-              if ( c3__crud == u3h(u3t(u3t(r_jar))) ) {
-                u3_pier_punt(0, u3k(u3t(u3t(u3t(u3t(r_jar))))));
-              }
-
-            }
-            fprintf(stderr, "pier: replace: %" PRIu64 "\r\n", evt_d);
-
-            _pier_work_replace(wit_u, u3k(r_jar), mat);
-          }
-          break;
-        }
-        case c3__done: {
-          if ( (c3n == u3r_qual(jar, 0, &p_jar, &q_jar, &r_jar)) ||
-               (c3n == u3ud(p_jar)) ||
-               (u3r_met(6, p_jar) != 1) ||
-               (c3n == u3ud(q_jar)) ||
-               (u3r_met(5, q_jar) > 1) )
-          {
-            goto error;
-          }
-          else {
-            c3_d     evt_d = u3r_chub(0, p_jar);
-            c3_l     mug_l = u3r_word(0, q_jar);
-            u3_writ* wit_u = _pier_work_writ(pir_u, evt_d);
-
-            if ( !wit_u ) {
-              fprintf(stderr, "poke: no writ: %" PRIu64 "\r\n", evt_d);
-              goto error;
-            }
-            _pier_work_complete(wit_u, mug_l, u3k(r_jar));
-          }
-          break;
-        }
+    case c3__work: {
+      if ( (c3n == u3r_qual(jar, 0, &p_jar, &q_jar, &r_jar)) ||
+           (c3n == u3ud(p_jar)) ||
+           (u3r_met(6, p_jar) != 1) ||
+           (c3n == u3ud(q_jar)) ||
+           (u3r_met(5, q_jar) > 1) )
+      {
+        goto error;
       }
+      else {
+        c3_d     evt_d = u3r_chub(0, p_jar);
+        c3_l     mug_l = u3r_word(0, q_jar);
+        u3_writ* wit_u = _pier_work_writ(pir_u, evt_d);
+
+        if ( !wit_u || (mug_l && (mug_l != wit_u->mug_l)) ) {
+          goto error;
+        }
+        {
+          // XX not the right place to print an error!
+          //
+          u3m_p("wire", u3h(u3t(r_jar)));
+          u3m_p("oust", u3h(u3t(u3t(wit_u->job))));
+          u3m_p("with", u3h(u3t(u3t(r_jar))));
+          if ( c3__crud == u3h(u3t(u3t(r_jar))) ) {
+            u3_pier_punt(0, u3k(u3t(u3t(u3t(u3t(r_jar))))));
+          }
+
+        }
+        fprintf(stderr, "pier: replace: %" PRIu64 "\r\n", evt_d);
+
+        _pier_work_replace(wit_u, u3k(r_jar), mat);
+      }
+      break;
+    }
+
+    case c3__done: {
+      if ( (c3n == u3r_qual(jar, 0, &p_jar, &q_jar, &r_jar)) ||
+           (c3n == u3ud(p_jar)) ||
+           (u3r_met(6, p_jar) != 1) ||
+           (c3n == u3ud(q_jar)) ||
+           (u3r_met(5, q_jar) > 1) )
+      {
+        goto error;
+      }
+      else {
+        c3_d     evt_d = u3r_chub(0, p_jar);
+        c3_l     mug_l = u3r_word(0, q_jar);
+        u3_writ* wit_u = _pier_work_writ(pir_u, evt_d);
+
+        if ( !wit_u ) {
+          fprintf(stderr, "poke: no writ: %" PRIu64 "\r\n", evt_d);
+          goto error;
+        }
+        _pier_work_complete(wit_u, mug_l, u3k(r_jar));
+      }
+      break;
     }
   }
+
   _pier_apply(pir_u);
   return;
 
@@ -1451,6 +1445,12 @@ u3_pier_create(c3_w wag_w, c3_c* pax_c)
   pir_u->teh_u = c3_calloc(sizeof(u3_behn));
   pir_u->unx_u = c3_calloc(sizeof(u3_unix));
   pir_u->sav_u = c3_calloc(sizeof(u3_save));
+
+  //  initialize persistence
+  //
+  if ( c3n == _pier_disk_create(pir_u) ) {
+    return 0;
+  }
 
   //  start the serf process
   //

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -601,6 +601,39 @@ _pier_disk_init(u3_disk* log_u)
   return c3y;
 }
 
+/* _pier_disk_read_header():
+** XX async
+*/
+static c3_o
+_pier_disk_read_header(u3_pier* pir_u, u3_noun ovo)
+{
+  u3_noun who, fak, len;
+
+  c3_assert( c3__boot == u3h(ovo) );
+  u3x_qual(ovo, 0, &who, &fak, &len);
+
+  c3_assert( c3y == u3ud(who) );
+  c3_assert( 1 >= u3r_met(7, who) );
+  c3_assert( c3y == u3ud(fak) );
+  c3_assert( 1 >= u3r_met(0, fak) );
+  c3_assert( c3y == u3ud(len) );
+  c3_assert( 1 >= u3r_met(3, len) );
+
+  pir_u->fak_o = (c3_o)fak;
+  pir_u->lif_d = u3r_word(0, len);
+  u3r_chubs(0, 2, pir_u->who_d, who);
+
+  //  Disable networking for fake ships
+  //
+  if ( c3y == pir_u->fak_o ) {
+    u3_Host.ops_u.net = c3n;
+  }
+
+  u3z(ovo);
+
+  return c3y;
+}
+
 /* _pier_disk_load_commit(): load all commits >= evt_d; set ent_u, ext_u.
 ** XX async
 */
@@ -643,30 +676,12 @@ _pier_disk_load_commit(u3_pier* pir_u,
       if ( (0ULL == pos_d) &&
            (1ULL == lav_d) )
       {
-        u3_noun who, fak, len;
+        u3z(mat);
 
-        c3_assert( c3__boot == u3h(ovo) );
-        u3x_qual(ovo, 0, &who, &fak, &len);
-
-        c3_assert( c3y == u3ud(who) );
-        c3_assert( 1 >= u3r_met(7, who) );
-        c3_assert( c3y == u3ud(fak) );
-        c3_assert( 1 >= u3r_met(0, fak) );
-        c3_assert( c3y == u3ud(len) );
-        c3_assert( 1 >= u3r_met(3, len) );
-
-        pir_u->fak_o = (c3_o)fak;
-        pir_u->lif_d = u3r_word(0, len);
-        u3r_chubs(0, 2, pir_u->who_d, who);
-
-        //  Disable networking for fake ships
-        //
-        if ( c3y == pir_u->fak_o ) {
-          u3_Host.ops_u.net = c3n;
+        if ( c3n == _pier_disk_read_header(pir_u, ovo) ) {
+          return c3n;
         }
 
-        u3z(mat);
-        u3z(ovo);
         break;
       }
 

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -115,7 +115,7 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
 
     case c3__logo:
     {
-      u3_pier_exit();
+      u3_pier_exit(pir_u);
       u3_Host.xit_i = u3t(fav);
 
       u3z(pox); u3z(fav); return c3y;
@@ -430,7 +430,7 @@ _reck_kick_norm(u3_pier* pir_u, u3_noun pox, u3_noun fav)
     case c3__exit:
     {
       uL(fprintf(uH, "<<<goodbye>>>\n"));
-      u3_pier_exit();
+      u3_pier_exit(pir_u);
 
       u3z(pox); u3z(fav); return c3y;
     } break;

--- a/pkg/urbit/vere/save.c
+++ b/pkg/urbit/vere/save.c
@@ -17,7 +17,7 @@ static void
 _save_time_cb(uv_timer_t* tim_u)
 {
   u3_pier *pir_u = tim_u->data;
-  u3_pier_work_save(pir_u);
+  u3_pier_snap(pir_u);
 }
 
 /* u3_save_ef_chld(): report save termination.
@@ -49,7 +49,8 @@ u3_save_io_init(u3_pier *pir_u)
 {
   u3_save* sav_u = pir_u->sav_u;
 
-  sav_u->ent_d = 0;
+  sav_u->req_d = 0;
+  sav_u->dun_d = 0;
   sav_u->pid_w = 0;
 
   sav_u->tim_u.data = pir_u;

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -729,7 +729,7 @@ _term_suck(u3_utty* uty_u, const c3_y* buf, ssize_t siz_i)
       //  then corrupts the event log), so we force shutdown.
       //
       fprintf(stderr, "term: hangup (EOF)\r\n");
-      u3_pier_exit();
+      u3_pier_exit(u3_pier_stub());
     }
     else if ( siz_i < 0 ) {
       uL(fprintf(uH, "term %d: read: %s\n", uty_u->tid_l, uv_strerror(siz_i)));

--- a/pkg/urbit/vere/unix.c
+++ b/pkg/urbit/vere/unix.c
@@ -1010,7 +1010,7 @@ _unix_sign_cb(uv_signal_t* sil_u, c3_i num_i)
     switch ( num_i ) {
       default: fprintf(stderr, "\r\nmysterious signal %d\r\n", num_i); break;
       case SIGTERM:
-        u3_pier_exit();
+        u3_pier_exit(u3_pier_stub());
         break;
       case SIGINT:
         fprintf(stderr, "\r\ninterrupt\r\n");


### PR DESCRIPTION
- removes precommits
- sequences compute, commit, and effect application
- ensures that snapshots are correlated with the most recently committed event (ie, never run ahead of the event log)
- adds explicit initialization and operation states to the pier, assertions to ensure valid state transitions

and fixes various other minor issues