### PR TITLE
cc-release pier boot state-machine corrections

### DIFF
--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -685,7 +685,6 @@
           c3_c*            who_c;               //  identity as C string
           c3_s             por_s;               //  UDP port
           c3_o             fak_o;               //  yes iff fake security
-          c3_o             liv_o;               //  live
           u3_psat          sat_e;               //  pier state
           u3_noun          bot;                 //  boot event XX review
           u3_noun          pil;                 //  pill XX review

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -657,7 +657,9 @@
       /* u3_boot: startup controller.
       */
         typedef struct _u3_boot {
-
+          u3_noun          pil;                 //  pill
+          u3_noun          ven;                 //  boot event
+          struct _u3_pier* pir_u;               //  pier backpointer
         } u3_boot;
 
       /* u3_psat: pier state.
@@ -676,8 +678,9 @@
           c3_c*            pax_c;               //  pier directory
           c3_w             wag_w;               //  config flags
           c3_d             gen_d;               //  last event discovered
-          c3_d             but_d;               //  boot barrier
-          c3_d             lif_d;               //  lifecycle boot barrier
+          c3_d             lif_d;               //  lifecycle barrier
+          u3_boot*         bot_u;               //  boot state
+          c3_d             but_d;               //  boot/restart barrier
           c3_d             tic_d[1];            //  ticket (unstretched)
           c3_d             sec_d[1];            //  generator (unstretched)
           c3_d             key_d[4];            //  secret (stretched)
@@ -686,8 +689,6 @@
           c3_s             por_s;               //  UDP port
           c3_o             fak_o;               //  yes iff fake security
           u3_psat          sat_e;               //  pier state
-          u3_noun          bot;                 //  boot event XX review
-          u3_noun          pil;                 //  pill XX review
           u3_disk*         log_u;               //  event log
           u3_lord*         god_u;               //  computer
           u3_ames*         sam_u;               //  packet interface

--- a/pkg/urbit/king/main.c
+++ b/pkg/urbit/king/main.c
@@ -232,12 +232,18 @@ _main_getopt(c3_i argc, c3_c** argv)
     u3_Host.ops_u.nuu = c3y;
   }
 
-  //  make -c optional
+  //  make -c optional, catch invalid boot of existing pier
   //
-  if ( c3n == u3_Host.ops_u.nuu ) {
+  {
     struct stat s;
     if ( 0 != stat(u3_Host.dir_c, &s) ) {
-      u3_Host.ops_u.nuu = c3y;
+      if ( c3n == u3_Host.ops_u.nuu ) {
+        u3_Host.ops_u.nuu = c3y;
+      }
+    }
+    else if ( c3y == u3_Host.ops_u.nuu ) {
+      fprintf(stderr, "unable to boot; %s already exists\r\n", u3_Host.dir_c);
+      return c3n;
     }
   }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -106,6 +106,10 @@ _pier_save_boot(u3_pier* pir_u, u3_atom mat)
 {
   //  XX deduplicate with _pier_disk_commit_request
   //
+  u3_disk* log_u = pir_u->log_u;
+
+  c3_assert( 0ULL == log_u->fol_u->end_d );
+
   c3_d  len_d = u3r_met(6, mat);
   c3_d* buf_d = c3_malloc(8 * len_d);
 
@@ -113,7 +117,7 @@ _pier_save_boot(u3_pier* pir_u, u3_atom mat)
 
   u3_foil_append(_pier_save_boot_complete,
                  (void*)0,
-                 pir_u->log_u->fol_u,
+                 log_u->fol_u,
                  buf_d,
                  len_d);
 }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1035,11 +1035,15 @@ _pier_boot_ready(u3_pier* pir_u)
   u3_lord* god_u = pir_u->god_u;
   u3_disk* log_u = pir_u->log_u;
 
-  c3_assert( c3y == god_u->liv_o );
-  c3_assert( c3y == log_u->liv_o );
   c3_assert( u3_psat_init == pir_u->sat_e );
-  c3_assert( c3n == pir_u->liv_o );
-  pir_u->liv_o = c3y;
+
+  if ( ( 0 == god_u) ||
+       ( 0 == log_u) ||
+       (c3y != god_u->liv_o) ||
+       (c3y != log_u->liv_o) )
+  {
+    return;
+  }
 
   //  mark all commits as released
   //
@@ -1132,16 +1136,7 @@ _pier_disk_init_complete(u3_disk* log_u, c3_d evt_d)
 
   log_u->com_d = log_u->moc_d = evt_d;
 
-  {
-    u3_pier* pir_u = log_u->pir_u;
-    u3_lord* god_u = pir_u->god_u;
-
-    if ( (0 != god_u) &&
-         (c3y == god_u->liv_o) &&
-         (c3n == pir_u->liv_o) ) {
-      _pier_boot_ready(pir_u);
-    }
-  }
+  _pier_boot_ready(log_u->pir_u);
 }
 
 /* _pier_disk_init():
@@ -1296,15 +1291,7 @@ _pier_work_play(u3_pier* pir_u,
   //
   god_u->rel_d = god_u->dun_d = god_u->sen_d = (lav_d - 1ULL);
 
-  {
-    u3_disk* log_u = pir_u->log_u;
-
-    if ( (0 != log_u) &&
-         (c3y == log_u->liv_o) &&
-         (c3n == pir_u->liv_o) ) {
-      _pier_boot_ready(pir_u);
-    }
-  }
+  _pier_boot_ready(pir_u);
 }
 
 /* _pier_work_exit(): handle subprocess exit.
@@ -1558,7 +1545,6 @@ u3_pier_create(c3_w wag_w, c3_c* pax_c)
   pir_u->pax_c = pax_c;
   pir_u->wag_w = wag_w;
   pir_u->sat_e = u3_psat_init;
-  pir_u->liv_o = c3n;
 
   pir_u->sam_u = c3_calloc(sizeof(u3_ames));
   pir_u->teh_u = c3_calloc(sizeof(u3_behn));


### PR DESCRIPTION
Some further enhancements to and cleanup of the work done in #1232:

- batch event reads during replay
- remove a superfluous state flag in the pier
- use more specific conditions and assertions for some pier state transitions
- reorder pier initialization, disabling absurdly inefficient explicit log header read
