### PR TITLE
Remove the -L from the cp statements, since it is erroring on OSX.

### DIFF
--- a/sh/mk-bootbus
+++ b/sh/mk-bootbus
@@ -17,5 +17,5 @@ fi
 pkg=$(nix-build nix/ops -A bootbus --no-out-link)
 
 mkdir -p "$(dirname "$target")"
-cp -L -r $pkg/ $target
+cp -r $pkg/ $target
 chmod -R u+rw $target

--- a/sh/mk-bootzod
+++ b/sh/mk-bootzod
@@ -17,5 +17,5 @@ fi
 pkg=$(nix-build nix/ops -A bootzod --no-out-link)
 
 mkdir -p "$(dirname "$target")"
-cp -L -r $pkg/ $target
+cp -r $pkg/ $target
 chmod -R u+rw $target

--- a/sh/mk-fakezod
+++ b/sh/mk-fakezod
@@ -17,5 +17,5 @@ fi
 pkg=$(nix-build nix/ops -A fakezod --no-out-link)
 
 mkdir -p "$(dirname "$target")"
-cp -L -r $pkg/ $target
+cp -r $pkg/ $target
 chmod -R u+rw $target


### PR DESCRIPTION
The scripts don't work on OSX because of the `-L` option. I talked to Ben and he said to just remove it.