### PR TITLE
Adds u3l_log() and moves most things to it.

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -3,18 +3,18 @@ include config.mk
 jets = jets/tree.c $(wildcard jets/*/*.c)
 noun = $(wildcard noun/*.c)
 vere = $(wildcard vere/*.c)
-king = $(wildcard king/*.c)
-serf = $(wildcard serf/*.c)
+daemon = $(wildcard daemon/*.c)
+worker = $(wildcard worker/*.c)
 
 common  = $(jets) $(noun) $(vere)
 headers = $(shell find include -type f)
 
 common_objs = $(shell echo $(common) | sed 's/\.c/.o/g')
-king_objs   = $(shell echo $(king) | sed 's/\.c/.o/g')
-serf_objs   = $(shell echo $(serf) | sed 's/\.c/.o/g')
+daemon_objs = $(shell echo $(daemon) | sed 's/\.c/.o/g')
+worker_objs = $(shell echo $(worker) | sed 's/\.c/.o/g')
 
-all_objs = $(common_objs) $(king_objs) $(serf_objs)
-all_srcs = $(common) $(king) $(serf)
+all_objs = $(common_objs) $(daemon_objs) $(worker_objs)
+all_srcs = $(common) $(daemon) $(worker)
 
 ################################################################################
 
@@ -32,11 +32,11 @@ mrproper: clean
 
 ################################################################################
 
-urbit: $(common_objs) $(king_objs)
+urbit: $(common_objs) $(daemon_objs)
 	@echo CC -o $@
 	@$(CC) $^ $(LDFLAGS) -o $@
 
-urbit-worker: $(common_objs) $(serf_objs)
+urbit-worker: $(common_objs) $(worker_objs)
 	@echo CC -o $@
 	@$(CC) $^ $(LDFLAGS) -o $@
 

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -792,7 +792,7 @@ main(c3_i   argc,
       close(rad);
     }
 
-    u3_king_commence();
+    u3_daemon_commence();
   }
   return 0;
 }

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -532,7 +532,7 @@ report(void)
 void
 _stop_exit(c3_i int_i)
 {
-  fprintf(stderr, "\r\n[received keyboard stop signal, exiting]\r\n");
+  u3l_log("\r\n[received keyboard stop signal, exiting]\r\n");
   //  XX crashes if we haven't started a pier yet
   //
   u3_pier_exit(u3_pier_stub());
@@ -724,6 +724,10 @@ main(c3_i   argc,
       /*  Set pier directory.
       */
       u3C.dir_c = u3_Host.dir_c;
+
+      /*  Sets the logging function to one that doesn't interfere with the
+      */
+      u3C.err_log_f = u3_term_io_log;
 
       /*  Set GC flag.
       */

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -726,9 +726,9 @@ main(c3_i   argc,
       */
       u3C.dir_c = u3_Host.dir_c;
 
-      /*  Sets the logging function to one that doesn't interfere with the
+      /*  Logging that doesn't interfere with console output.
       */
-      u3C.err_log_f = u3_term_io_log;
+      u3C.stderr_log_f = u3_term_io_log;
 
       /*  Set GC flag.
       */

--- a/pkg/urbit/include/all.h
+++ b/pkg/urbit/include/all.h
@@ -19,6 +19,7 @@
 #   include "noun/hashtable.h" //  u3h: hashtables
 #   include "noun/imprison.h"  //  u3i: noun construction
 #   include "noun/jets.h"      //  u3j: jet control
+#   include "noun/log.h"       //  u3l: logging
 #   include "noun/manage.h"    //  u3m: master state
 #   include "noun/nock.h"      //  u3n: nock execution
 #   include "noun/options.h"   //  u3o: config options
@@ -31,24 +32,3 @@
 #   include "jets/k.h"         //  u3k: jets (transfer, args)
 #   include "jets/q.h"         //  u3q: jets (retain, args)
 #   include "jets/w.h"         //  u3w: jets (retain, core)
-
-  /** u3_term: log output dependencies.
-  **/
-    extern FILE*
-    u3_term_io_hija(void);
-
-    extern void
-    u3_term_io_loja(int x);
-
-    extern void
-    u3_term_tape(u3_noun tep);
-
-    extern void
-    u3_term_wall(u3_noun wol);
-
-  /* uL, uH: wrap hijack/lojack around fprintf.
-  **
-  **  uL(fprintf(uH, ...));
-  */
-#   define uH    u3_term_io_hija()
-#   define uL(x) u3_term_io_loja(x)

--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -20,8 +20,7 @@
 #     define c3_assert(x)                       \
         do {                                    \
           if (!(x)) {                           \
-            fprintf(stderr,                     \
-                    "\rAssertion '%s' failed "  \
+            u3l_log("\rAssertion '%s' failed "  \
                     "in %s:%d\n",               \
                     #x, __FILE__, __LINE__);    \
             c3_cooked();                        \
@@ -83,18 +82,6 @@
         | (((w) >> 16) & 0xff) << 8 \
         | (((w) >>  8) & 0xff) << 16 \
         | ( (w)        & 0xff) << 24 )
-
-    /* Logging shorthand.
-    */
-#     define c3_log_every(n, args...) \
-        do {                          \
-          static c3_w cnt_w = 0;      \
-                                      \
-          if ( 0 == cnt_w % (n) ) {   \
-            uL(fprintf(uH, args));    \
-          }                           \
-          cnt_w = (cnt_w + 1) % (n);  \
-        } while (0)
 
     /* Asserting allocators.
     */

--- a/pkg/urbit/include/c/motes.h
+++ b/pkg/urbit/include/c/motes.h
@@ -1042,6 +1042,7 @@
 #   define c3__spot   c3_s4('s','p','o','t')
 #   define c3__stam   c3_s4('s','t','a','m')
 #   define c3__star   c3_s4('s','t','a','r')
+#   define c3__stdr   c3_s4('s','t','d','r')
 #   define c3__stem   c3_s4('s','t','e','m')
 #   define c3__step   c3_s4('s','t','e','p')
 #   define c3__stid   c3_s4('s','t','i','d')

--- a/pkg/urbit/include/noun/log.h
+++ b/pkg/urbit/include/noun/log.h
@@ -1,0 +1,9 @@
+/* noun/log.h
+**
+*/
+
+/* u3_log(): logs to stderr or redirects to configured function.
+*/
+  void
+  u3l_log(const char* format, ...)
+    __attribute__ ((format (printf, 1, 2)));

--- a/pkg/urbit/include/noun/options.h
+++ b/pkg/urbit/include/noun/options.h
@@ -10,8 +10,8 @@
         u3_noun who;                          //  single identity
         c3_c*   dir_c;                        //  execution directory (pier)
         c3_w    wag_w;                        //  flags (both ways)
-        void (*err_log_f)(c3_c*);             //  optional error logging redirect
-        void (*log_f)(u3_noun);               //  function pointer for slog
+        void (*stderr_log_f)(c3_c*);          //  errors from c code
+        void (*slog_f)(u3_noun);              //  function pointer for slog
       } u3o_config;
 
     /* u3o_flag: process/system flags.

--- a/pkg/urbit/include/noun/options.h
+++ b/pkg/urbit/include/noun/options.h
@@ -10,6 +10,7 @@
         u3_noun who;                          //  single identity
         c3_c*   dir_c;                        //  execution directory (pier)
         c3_w    wag_w;                        //  flags (both ways)
+        void (*err_log_f)(c3_c*);             //  optional error logging redirect
       } u3o_config;
 
     /* u3o_flag: process/system flags.

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -619,9 +619,9 @@
           struct _u3_writ* nex_u;               //  next in queue, or 0
         } u3_writ;
 
-      /* u3_lord: working process controller.
+      /* u3_controller: working process controller.
       */
-        typedef struct _u3_lord {
+        typedef struct _u3_controller {
           uv_process_t         cub_u;           //  process handle
           uv_process_options_t ops_u;           //  process configuration
           uv_stdio_container_t cod_u[3];        //  process options
@@ -634,7 +634,7 @@
           c3_d                 rel_d;           //  last event released
           c3_l                 mug_l;           //  mug after last completion
           struct _u3_pier*     pir_u;           //  pier backpointer
-        } u3_lord;
+        } u3_controller;
 
       /* u3_disk: manage events on disk.
       **
@@ -690,7 +690,7 @@
           c3_o             fak_o;               //  yes iff fake security
           u3_psat          sat_e;               //  pier state
           u3_disk*         log_u;               //  event log
-          u3_lord*         god_u;               //  computer
+          u3_controller*   god_u;               //  computer
           u3_ames*         sam_u;               //  packet interface
           u3_behn*         teh_u;               //  behn timer
           u3_unix*         unx_u;               //  sync and clay
@@ -702,25 +702,25 @@
 
       /* u3_king: all executing piers.
       */
-        typedef struct _u3_king {
+        typedef struct _u3_daemon {
           c3_c*     soc_c;                      //  socket name
-          c3_w      len_w;                      //  number of lords used
-          c3_w      all_w;                      //  number of lords allocated
-          u3_pier** tab_u;                      //  lord table
+          c3_w      len_w;                      //  number used
+          c3_w      all_w;                      //  number allocated
+          u3_pier** tab_u;                      //  pier table
           uv_pipe_t cmd_u;                      //  command socket
           u3_moor*  cli_u;                      //  connected clients
           uv_timer_t tim_u;                     //  gc timer
-        } u3_king;
+        } u3_daemon;
 
 #     define u3L  u3_Host.lup_u             //  global event loop
 #     define u3Z  (&(u3_Raft))
-#     define u3K  u3_King
+#     define u3K  u3_Daemon
 
   /** Global variables.
   **/
-    c3_global  u3_host  u3_Host;
-    c3_global  c3_c*    u3_Local;
-    c3_global  u3_king  u3_King;
+    c3_global  u3_host   u3_Host;
+    c3_global  c3_c*     u3_Local;
+    c3_global  u3_daemon u3_Daemon;
 
   /** Functions.
   **/
@@ -1326,12 +1326,12 @@
         u3_noun
         u3_dawn_vent(u3_noun seed);
 
-      /* u3_king_commence(): start the daemon
+      /* u3_daemon_commence(): start the daemon
       */
         void
-        u3_king_commence();
+        u3_daemon_commence();
 
-      /* u3_king_grab(): gc the kingdom
+      /* u3_king_grab(): gc the daemon area
       */
         void
-        u3_king_grab(void* vod_p);
+        u3_daemon_grab(void* vod_p);

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -990,6 +990,11 @@
         FILE*
         u3_term_io_hija(void);
 
+      /* u3_term_it_log(): writes a log message
+      */
+        void
+        u3_term_io_log(c3_c* line);
+
       /* u3_term_io_loja(): release console from cooked print.
       */
         void

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1010,13 +1010,6 @@
         void
         u3_term_io_loja(int x);
 
-      /* uL, uH: wrap hijack/lojack around fprintf.
-      **
-      **  uL(fprintf(uH, ...));
-      */
-#       define uH    u3_term_io_hija()
-#       define uL(x) u3_term_io_loja(x)
-
 
     /**  Ames, packet networking.
     **/

--- a/pkg/urbit/jets/e/argon2.c
+++ b/pkg/urbit/jets/e/argon2.c
@@ -72,7 +72,7 @@
     int argon_res;
     switch ( type ) {
       default:
-        fprintf(stderr, "\nunjetted argon2 variant %i\n", type);
+        u3l_log("\nunjetted argon2 variant %i\n", type);
         u3m_bail(c3__exit);
         break;
       //
@@ -94,7 +94,7 @@
     }
 
     if ( ARGON2_OK != argon_res ) {
-      fprintf(stderr, "\nargon2 error: %s\n", argon2_error_message(argon_res));
+      u3l_log("\nargon2 error: %s\n", argon2_error_message(argon_res));
       u3m_bail(c3__exit);
     }
 

--- a/pkg/urbit/jets/e/blake.c
+++ b/pkg/urbit/jets/e/blake.c
@@ -43,7 +43,7 @@
 
     if ( 0 != ret )
     {
-      fprintf(stderr, "\rblake jet: cryto lib error\n");
+      u3l_log("\rblake jet: cryto lib error\n");
       return u3m_bail(c3__exit);
     }
 
@@ -64,7 +64,7 @@
                 u3r_cell(key, &wik, &dak) || u3ud(wik) || u3ud(dak) ||
                 u3ud(out) )
     {
-      fprintf(stderr, "\rblake jet: arguments error\n");
+      u3l_log("\rblake jet: arguments error\n");
       return u3m_bail(c3__exit);
     } else {
       return u3qe_blake(wid, dat, wik, dak, out);

--- a/pkg/urbit/jets/e/ripe.c
+++ b/pkg/urbit/jets/e/ripe.c
@@ -37,20 +37,20 @@
     ret_w = EVP_DigestInit_ex(con_u, rip_u, NULL);
     if ( 1 != ret_w ) {
       u3a_free(dat_y);
-      fprintf(stderr, "\rripe jet: crypto library fail 1\n");
+      u3l_log("\rripe jet: crypto library fail 1\n");
       return u3m_bail(c3__exit);
     }
 
     ret_w = EVP_DigestUpdate(con_u, (void*)dat_y, wid);
     u3a_free(dat_y);
     if (1 != ret_w) {
-      fprintf(stderr, "\rripe jet: crypto library fail 2\n");
+      u3l_log("\rripe jet: crypto library fail 2\n");
       return u3m_bail(c3__exit);
     }
 
     ret_w = EVP_DigestFinal_ex(con_u, sib_y, &sil_w);
     if ( 1 != ret_w ) {
-      fprintf(stderr, "\rripe jet: crypto library fail 3\n");
+      u3l_log("\rripe jet: crypto library fail 3\n");
       return u3m_bail(c3__exit);
     }
 
@@ -71,7 +71,7 @@
                  u3ud(wid) || u3ud(dat))
        )
     {
-      fprintf(stderr, "\rripe jet: argument error\n");
+      u3l_log("\rripe jet: argument error\n");
       return u3m_bail(c3__exit);
     }
     else {

--- a/pkg/urbit/jets/e/rub.c
+++ b/pkg/urbit/jets/e/rub.c
@@ -25,7 +25,7 @@
 
         //  Sanity check: crash if decoding more bits than available
         if ( c3y == u3qa_gth(x, m)) {
-          //  fprintf(stderr, "[%%rub-hard %d %d %d]\r\n", a, x, m);
+          //  u3l_log("[%%rub-hard %d %d %d]\r\n", a, x, m);
           return u3m_bail(c3__exit);
         }
 

--- a/pkg/urbit/jets/e/secp.c
+++ b/pkg/urbit/jets/e/secp.c
@@ -64,7 +64,7 @@ u3we_sign(u3_noun cor)
                         0)) ||
        (c3n == u3ud(has)) ||
        (c3n == u3ud(prv))) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   } else {
     return (u3qe_sign(has, prv));
@@ -100,7 +100,7 @@ u3qe_sign(u3_atom has,
                                          (secp256k1_nonce_function) NULL,  /* IN: nonce-function ptr ; NULL = default */
                                          (const void *) NULL);             /* IN: data for nonce function; not used  */
   if (1 != ret) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 
@@ -113,7 +113,7 @@ u3qe_sign(u3_atom has,
                                                                 & v,      /* OUT: v */
                                                                 & sig_u); /* IN:  65 byte sig */
   if (1 != ret) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 
@@ -149,7 +149,7 @@ u3we_reco(u3_noun cor)
        (c3n == u3ud(sir)) ||
        (c3n == u3ud(sis)) )
     {
-      fprintf(stderr, "\rsecp jet: crypto package error\n");
+      u3l_log("\rsecp jet: crypto package error\n");
       return u3m_bail(c3__exit);
     } else {
     return u3qe_reco(has, siv, sir, sis);
@@ -197,7 +197,7 @@ u3qe_reco(u3_atom has,
                                                                   ras_y,     /* IN:  r/s */
                                                                   siv_ws);   /* IN:  v */
   if (1 != ret) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 
@@ -210,7 +210,7 @@ u3qe_reco(u3_atom has,
                                 (const c3_y *) & has);        /* IN: message has */
 
   if (1 != ret) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 
@@ -226,7 +226,7 @@ u3qe_reco(u3_atom has,
                                       SECP256K1_EC_UNCOMPRESSED); /* IN: flags */
 
   if (1 != ret) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 
@@ -269,7 +269,7 @@ u3we_make(u3_noun cor)
        (c3n == u3ud(has)) ||
        (c3n == u3ud(prv)) )
     {
-      fprintf(stderr, "\rsecp jet: crypto package error\n");
+      u3l_log("\rsecp jet: crypto package error\n");
       return u3m_bail(c3__exit);
     } else {
     return u3qe_make(has, prv);
@@ -303,7 +303,7 @@ u3qe_make(u3_atom has,
                                             (void *) NULL,        /* IN: arbitrary data pointer (unused) */
                                             0);                   /* IN: attempt number (0 == normal) */
   if (1 != ret_ws) {
-    fprintf(stderr, "\rsecp jet: crypto package error\n");
+    u3l_log("\rsecp jet: crypto package error\n");
     return u3m_bail(c3__exit);
   }
 

--- a/pkg/urbit/jets/f/core.c
+++ b/pkg/urbit/jets/f/core.c
@@ -22,7 +22,7 @@
              (u3_nul == u3h(hr_con)) &&
              (u3_nul == u3t(hr_con)) )
         {
-          fprintf(stderr, "old core\r\n");
+          u3l_log("old core\r\n");
           abort();
         }
       }

--- a/pkg/urbit/jets/f/look.c
+++ b/pkg/urbit/jets/f/look.c
@@ -20,7 +20,7 @@
       u3r_trel(dab, &n_dab, &l_dab, &r_dab);
       if ( c3n == u3du(n_dab) ) {
         // return u3m_bail(c3__fail);
-        fprintf(stderr, "bad look\r\n");
+        u3l_log("bad look\r\n");
         return u3m_bail(c3__exit) ;
       }
       else {

--- a/pkg/urbit/jets/f/ut_find.c
+++ b/pkg/urbit/jets/f/ut_find.c
@@ -630,11 +630,11 @@
       default: return u3m_bail(c3__fail);
 
       case c3__noun: {
-        // fprintf(stderr, "noun\r\n");
+        // u3l_log("noun\r\n");
         return _find_buck_stop(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__void: {
-        // fprintf(stderr, "void\r\n");
+        // u3l_log("void\r\n");
         // return _find_buck_stop(van, sut, way, p_heg, q_heg, axe, lon, gil);
         return u3_nul;
       }
@@ -644,17 +644,17 @@
 
       case c3__atom:
       {
-        // fprintf(stderr, "atom\r\n");
+        // u3l_log("atom\r\n");
         return _find_buck_stop(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__cell:
       {
-        // fprintf(stderr, "cell\r\n");
+        // u3l_log("cell\r\n");
         return _find_buck_cell(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__core:
       {
-        // fprintf(stderr, "core\r\n");
+        // u3l_log("core\r\n");
         return _find_buck_core(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__hint:
@@ -666,17 +666,17 @@
       }
       case c3__face:
       {
-        // fprintf(stderr, "face\r\n");
+        // u3l_log("face\r\n");
         return _find_buck_face(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__fork:
       {
-        // fprintf(stderr, "fork\r\n");
+        // u3l_log("fork\r\n");
         return _find_buck_fork(van, sut, way, p_heg, q_heg, axe, lon, gil);
       }
       case c3__hold:
       {
-        // fprintf(stderr, "hold\r\n");
+        // u3l_log("hold\r\n");
         if ( (c3y == u3qdi_has(gil, sut)) ) {
           return u3_nul;
         }

--- a/pkg/urbit/jets/f/ut_mull.c
+++ b/pkg/urbit/jets/f/ut_mull.c
@@ -88,7 +88,7 @@
     u3_noun von = u3i_molt(u3k(van), u3x_sam, u3k(sut), 0);
     u3_noun gat = u3j_hook(von, "mile");
 
-    // fprintf(stderr, "mile\r\n");
+    // u3l_log("mile\r\n");
     return u3n_kick_on(u3i_molt(gat,
                                 u3x_sam_2,
                                 u3k(dox),

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -373,13 +373,13 @@ u3a_reclaim(void)
   if ( (0 == u3R->cax.har_p) ||
        (0 == u3to(u3h_root, u3R->cax.har_p)->use_w) )
   {
-    fprintf(stderr, "allocate: reclaim: memo cache: empty\r\n");
+    u3l_log("allocate: reclaim: memo cache: empty\r\n");
     u3m_bail(c3__meme);
   }
 
 #if 1
-  fprintf(stderr, "allocate: reclaim: half of %d entries\r\n",
-                   u3to(u3h_root, u3R->cax.har_p)->use_w);
+  u3l_log("allocate: reclaim: half of %d entries\r\n",
+          u3to(u3h_root, u3R->cax.har_p)->use_w);
 
   u3h_trim_to(u3R->cax.har_p, u3to(u3h_root, u3R->cax.har_p)->use_w / 2);
 #else
@@ -406,7 +406,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
     sel_w += 1;
   }
 
-  // fprintf(stderr, "walloc %d: *pfr_p %x\n", len_w, u3R->all.fre_p[sel_w]);
+  // u3l_log("walloc %d: *pfr_p %x\n", len_w, u3R->all.fre_p[sel_w]);
   while ( 1 ) {
     u3p(u3a_fbox) *pfr_p = &u3R->all.fre_p[sel_w];
 
@@ -664,7 +664,7 @@ u3a_malloc(size_t len_i)
   if ( u3a_botox(out_w) == (u3a_box*)(void *)0x3bdd1c80) {
     static int xuc_i = 0;
 
-    fprintf(stderr,"xuc_i %d\r\n", xuc_i);
+    u3l_log("xuc_i %d\r\n", xuc_i);
     // if ( 1 == xuc_i ) { abort(); }
     xuc_i++;
   }
@@ -1185,7 +1185,7 @@ _me_copy_south(u3_noun dog)
         // printf("south: cell %p to %p\r\n", old_u, new_u);
 #if 0
         if ( old_u->mug_w == 0x730e66cc ) {
-          fprintf(stderr, "BAD: take %p\r\n", new_u);
+          u3l_log("BAD: take %p\r\n", new_u);
         }
 #endif
         new_u->mug_w = old_u->mug_w;
@@ -1497,7 +1497,7 @@ void
 u3a_luse(u3_noun som)
 {
   if ( 0 == u3a_use(som) ) {
-    fprintf(stderr, "luse: insane %d 0x%x\r\n", som, som);
+    u3l_log("luse: insane %d 0x%x\r\n", som, som);
     abort();
   }
   if ( _(u3du(som)) ) {
@@ -1545,7 +1545,7 @@ u3a_mark_ptr(void* ptr_v)
     c3_ws use_ws = (c3_ws)box_u->use_w;
 
     if ( use_ws == 0 ) {
-      fprintf(stderr, "%p is bogus\r\n", ptr_v);
+      u3l_log("%p is bogus\r\n", ptr_v);
       siz_w = 0;
     }
     else {
@@ -1733,12 +1733,12 @@ _ca_print_box(u3a_box* box_u)
 static void
 _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
 {
-  fprintf(stderr, "%s: %p mug=%x (marked=%u swept=%u)\r\n",
-                  cap_c,
-                  box_u,
-                  ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
-                  eus_w,
-                  use_w);
+  u3l_log("%s: %p mug=%x (marked=%u swept=%u)\r\n",
+          cap_c,
+          box_u,
+          ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
+          eus_w,
+          use_w);
 
   if ( box_u->cod_w ) {
     u3m_p("    code", box_u->cod_w);
@@ -1748,7 +1748,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
-    fprintf(stderr, "    data: %s\r\n", dat_c);
+    u3l_log("    data: %s\r\n", dat_c);
     free(dat_c);
   }
 }
@@ -1758,17 +1758,17 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
 static void
 _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_ws use_ws)
 {
-  fprintf(stderr, "%s: %p mug=%x swept=%d\r\n",
-                  cap_c,
-                  box_u,
-                  ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
-                  use_ws);
+  u3l_log("%s: %p mug=%x swept=%d\r\n",
+          cap_c,
+          box_u,
+          ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
+          use_ws);
 
   u3a_print_memory(stderr, "    size", box_u->siz_w);
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
-    fprintf(stderr, "    data: %s\r\n", dat_c);
+    u3l_log("    data: %s\r\n", dat_c);
     free(dat_c);
   }
 }
@@ -1808,8 +1808,8 @@ u3a_sweep(void)
     }
 #ifdef U3_CPU_DEBUG
     if ( fre_w != u3R->all.fre_w ) {
-      fprintf(stderr, "fre discrepancy (%x): %x, %x, %x\r\n", u3R->par_p,
-          fre_w, u3R->all.fre_w, (u3R->all.fre_w - fre_w));
+      u3l_log("fre discrepancy (%x): %x, %x, %x\r\n", u3R->par_p,
+              fre_w, u3R->all.fre_w, (u3R->all.fre_w - fre_w));
     }
 #endif
     neg_w = (end_w - fre_w);

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -121,8 +121,8 @@ u3e_fault(void* adr_v, c3_i ser_i)
   c3_w* adr_w = (c3_w*) adr_v;
 
   if ( (adr_w < u3_Loom) || (adr_w >= (u3_Loom + u3a_words)) ) {
-    fprintf(stderr, "address %p out of loom!\r\n", adr_v);
-    fprintf(stderr, "loom: [%p : %p)\r\n", u3_Loom, u3_Loom + u3a_words);
+    u3l_log("address %p out of loom!\r\n", adr_v);
+    u3l_log("loom: [%p : %p)\r\n", u3_Loom, u3_Loom + u3a_words);
     c3_assert(0);
     return 0;
   }
@@ -143,8 +143,8 @@ u3e_fault(void* adr_v, c3_i ser_i)
 #endif
 
     if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      fprintf(stderr, "strange page: %d, at %p, off %x\r\n",
-                      pag_w, adr_w, off_w);
+      u3l_log("strange page: %d, at %p, off %x\r\n",
+              pag_w, adr_w, off_w);
       abort();
     }
 
@@ -203,7 +203,7 @@ _ce_image_open(u3e_image* img_u)
       }
       else {
         if ( siz_d != (pgs_d << (c3_d)(u3a_page + 2)) ) {
-          fprintf(stderr, "%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
+          u3l_log("%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
           return c3n;
         }
         img_u->pgs_w = (c3_w) pgs_d;
@@ -738,11 +738,11 @@ _ce_image_fine(u3e_image* img_u,
     if ( mem_w != fil_w ) {
       c3_w pag_w = (ptr_w - u3_Loom) >> u3a_page;
 
-      fprintf(stderr, "mismatch: page %d, mem_w %x, fil_w %x, K %x\r\n",
-                       pag_w,
-                       mem_w,
-                       fil_w,
-                       u3K.mug_w[pag_w]);
+      u3l_log("mismatch: page %d, mem_w %x, fil_w %x, K %x\r\n",
+              pag_w,
+              mem_w,
+              fil_w,
+              u3K.mug_w[pag_w]);
       abort();
     }
     ptr_w += stp_ws;

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -352,7 +352,7 @@ _ch_trim_slot(u3h_root* har_u, u3h_slot *sot_w, c3_w lef_w, c3_w rem_w)
   else {
     u3_noun kev = u3h_slot_to_noun(*sot_w);
     *sot_w = 0;
-    // uL(fprintf(uH, "trim: freeing %x, use count %d\r\n", kev, u3a_use(kev)));
+    // u3l_log("trim: freeing %x, use count %d\r\n", kev, u3a_use(kev)));
     u3z(kev);
 
     har_u->arm_u.mug_w = _ch_skip_slot(har_u->arm_u.mug_w, lef_w);

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -220,7 +220,7 @@ u3i_cell(u3_noun a, u3_noun b)
     if ( (0x730e66cc == u3r_mug(pro)) &&
          (c3__tssg == u3h(u3t(u3t(pro)))) ) {
       static c3_w xuc_w;
-      fprintf(stderr, "BAD %x %p\r\n", pro, u3a_to_ptr(a));
+      u3l_log("BAD %x %p\r\n", pro, u3a_to_ptr(a));
       BAD = pro;
       if ( xuc_w == 1 ) u3m_bail(c3__exit);
       xuc_w++;

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -80,7 +80,7 @@ _cj_hash(c3_c* has_c)
 {
   c3_w i_w, len_w = strlen(has_c);
   if ( 64 != len_w ) {
-    fprintf(stderr, "bash not 64 characters: %s\r\n", has_c);
+    u3l_log("bash not 64 characters: %s\r\n", has_c);
     c3_assert(0);
   }
   c3_assert( 64 == len_w );
@@ -257,18 +257,18 @@ _cj_axis(u3_noun fol)
          (0 != p_fol) ||
          (!_(u3a_is_cat(q_fol))) )
     {
-      fprintf(stderr, "axis: bad a\r\n");
+      u3l_log("axis: bad a\r\n");
       return 0;
     }
     return q_fol;
   }
   else {
     if ( 9 != p_fol )
-      { fprintf(stderr, "axis: bad b\r\n"); return 0; }
+      { u3l_log("axis: bad b\r\n"); return 0; }
     if ( !_(u3a_is_cat(q_fol)) )
-      { fprintf(stderr, "axis: bad c\r\n"); return 0; }
+      { u3l_log("axis: bad c\r\n"); return 0; }
     if ( !_(u3du(r_fol)) || (0 != u3h(r_fol)) || (1 != u3t(r_fol)) )
-      { fprintf(stderr, "axis: bad d\r\n"); return 0; }
+      { u3l_log("axis: bad d\r\n"); return 0; }
 
     return q_fol;
   }
@@ -299,7 +299,7 @@ _cj_warm_hump(c3_l jax_l, u3_noun huc)
              ((1 << 31) & (axe_l = (c3_w)axe_d)) ||
              (axe_l < 2) )
         {
-          fprintf(stderr, "jets: activate: bad fcs %s\r\n", jet_u->fcs_c);
+          u3l_log("jets: activate: bad fcs %s\r\n", jet_u->fcs_c);
         }
       }
       else {
@@ -307,7 +307,7 @@ _cj_warm_hump(c3_l jax_l, u3_noun huc)
         u3_noun fol = u3kdb_get(u3k(huc), nam);
 
         if ( u3_none == fol ) {
-          fprintf(stderr, "jets: activate: bad fcs %s\r\n", jet_u->fcs_c);
+          u3l_log("jets: activate: bad fcs %s\r\n", jet_u->fcs_c);
         }
         else {
           axe_l = _cj_axis(fol);
@@ -802,7 +802,7 @@ _cj_hot_mean(c3_l par_l, u3_noun nam)
     while ( (cop_u = &dev_u[i_l])->cos_c ) {
       if ( _(u3r_sing_c(cop_u->cos_c, nam)) ) {
 #if 0
-        fprintf(stderr, "hot: bound jet %d/%s/%s/\r\n",
+        u3l_log("hot: bound jet %d/%s/%s/\r\n",
                         cop_u->jax_l,
                         cop_u->cos_c,
                         par_u ? par_u->cos_c : "~");
@@ -834,7 +834,7 @@ u3j_boot(c3_o nuu_o)
   }
   u3R->jed.hot_p = u3h_new();
   jax_l = _cj_install(u3D.ray_u, 1, (c3_l) (long long) u3D.dev_u[0].par_u, u3_nul, u3D.dev_u);
-  fprintf(stderr, "boot: installed %d jets\r\n", jax_l);
+  u3l_log("boot: installed %d jets\r\n", jax_l);
 }
 
 /* _cj_soft(): kick softly by arm axis.
@@ -912,7 +912,7 @@ _cj_kick_z(u3_noun cor, u3j_core* cop_u, u3j_harm* ham_u, u3_atom axe)
       ham_u->liv = c3y;
 
       if ( c3n == u3r_sing(ame, pro) ) {
-        fprintf(stderr, "test: %s %s: mismatch: good %x, bad %x\r\n",
+        u3l_log("test: %s %s: mismatch: good %x, bad %x\r\n",
                cop_u->cos_c,
                (!strcmp(".2", ham_u->fcs_c)) ? "$" : ham_u->fcs_c,
                u3r_mug(ame),
@@ -925,7 +925,7 @@ _cj_kick_z(u3_noun cor, u3j_core* cop_u, u3j_harm* ham_u, u3_atom axe)
       else {
 
 #if 1
-        fprintf(stderr, "test: %s %s\r\n",
+        u3l_log("test: %s %s\r\n",
                cop_u->cos_c,
                (!strcmp(".2", ham_u->fcs_c)) ? "$" : ham_u->fcs_c);
 #endif
@@ -1674,7 +1674,7 @@ u3j_gate_prep(u3j_site* sit_u, u3_noun cor)
             pay = u3qc_cap(pax),
             pam = u3qc_mas(pax);
     if ( 3 != pay || 2 == pam || (3 != pam && 3 != u3qc_cap(pam)) ) {
-      fprintf(stderr, "u3j_gate_prep(): parent axis includes sample\r\n");
+      u3l_log("u3j_gate_prep(): parent axis includes sample\r\n");
       u3m_p("axis", pax);
       u3_weak act = _cj_find_warm(loc);
       c3_assert( u3_none != act );
@@ -1745,12 +1745,12 @@ _cj_minx(u3_noun cey, u3_noun cor)
 
     par = u3r_at(axe, cor);
     if ( u3_none == par || c3n == u3du(par) ) {
-      fprintf(stderr, "fund: %s is bogus\r\n", u3r_string(nam));
+      u3l_log("fund: %s is bogus\r\n", u3r_string(nam));
       return u3_none;
     }
     pel = _cj_spot(par, NULL);
     if ( u3_none == pel ) {
-      fprintf(stderr, "fund: in %s, parent %x not found at %d\r\n",
+      u3l_log("fund: in %s, parent %x not found at %d\r\n",
                       u3r_string(nam),
                       u3r_mug(u3h(par)),
                       axe);
@@ -1809,7 +1809,7 @@ _cj_mine(u3_noun cey, u3_noun cor, u3_noun bas)
     jax_l = _cj_hot_mean(par_l, nam);
 #if 0
     u3m_p("new jet", bal);
-    fprintf(stderr, "  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
+    u3l_log("  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
 #endif
 
     if ( !(u3C.wag_w & u3o_hashless) ) {
@@ -1817,17 +1817,17 @@ _cj_mine(u3_noun cey, u3_noun cor, u3_noun bas)
         c3_y dig_y[32];
         c3_w i_w;
         u3_noun i = bal;
-        fprintf(stderr, "hot jet: ");
+        u3l_log("hot jet: ");
         while ( i != u3_nul ) {
           _cj_print_tas(stderr, u3h(i));
           i = u3t(i);
         }
-        fprintf(stderr, "\r\n  axe %d, jax %d,\r\n  bash ", axe, jax_l);
+        u3l_log("\r\n  axe %d, jax %d,\r\n  bash ", axe, jax_l);
         u3r_bytes(0, 32, dig_y, bas);
         for ( i_w = 32; i_w > 0; ) {
-          fprintf(stderr, "%02x", dig_y[--i_w]);
+          u3l_log("%02x", dig_y[--i_w]);
         }
-        fprintf(stderr, "\r\n");
+        u3l_log("\r\n");
       }
     }
 
@@ -1857,7 +1857,7 @@ _cj_mine(u3_noun cey, u3_noun cor, u3_noun bas)
 
     if ( c3n == hav_o ) {
       u3m_p("unregistered battery", bal);
-      fprintf(stderr, "hash: %x\r\n", bas);
+      u3l_log("hash: %x\r\n", bas);
     }
     u3z(bas);
   }
@@ -2069,7 +2069,7 @@ _cj_ream(u3_noun all)
       act   = u3nq(jax_l, hap, bal, _cj_jit(jax_l, bat));
 #if 0
       u3m_p("old jet", bal);
-      fprintf(stderr, "  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
+      u3l_log("  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
 #endif
       u3h_put(u3R->jed.war_p, loc, act);
     }
@@ -2108,7 +2108,7 @@ _cj_ream(u3_noun all)
         act   = u3nq(jax_l, hap, bal, _cj_jit(jax_l, bat));
 #if 0
         u3m_p("old jet", bal);
-        fprintf(stderr, "  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
+        u3l_log("  bat %x, jax %d\r\n", u3r_mug(bat), jax_l);
 #endif
         u3h_put(u3R->jed.war_p, loc, act);
       }

--- a/pkg/urbit/noun/log.c
+++ b/pkg/urbit/noun/log.c
@@ -12,7 +12,8 @@ u3l_log(const char* format, ...)
   va_start(myargs, format);
 
   if (u3C.stderr_log_f) {
-    //  the user set their own logging function. render the line and redirect to them
+    //  the user set their own logging function. render the line and redirect
+    //  to them.
     //
     char msg[4096];
     vsnprintf(msg, 4096, format, myargs);

--- a/pkg/urbit/noun/log.c
+++ b/pkg/urbit/noun/log.c
@@ -1,0 +1,27 @@
+/* noun/log.c
+**
+*/
+#include "all.h"
+
+#include <stdarg.h>
+
+void
+u3l_log(const char* format, ...)
+{
+  va_list myargs;
+  va_start(myargs, format);
+
+  if (u3C.err_log_f) {
+    //  the user set their own logging function. render the line and redirect to them
+    //
+    char msg[4096];
+    vsnprintf(msg, 4096, format, myargs);
+    u3C.err_log_f(msg);
+  } else  {
+    //  this process did not set a logging function, fallback to stderr
+    //
+    vfprintf(stderr, format, myargs);
+  }
+
+  va_end(myargs);
+}

--- a/pkg/urbit/noun/log.c
+++ b/pkg/urbit/noun/log.c
@@ -11,12 +11,12 @@ u3l_log(const char* format, ...)
   va_list myargs;
   va_start(myargs, format);
 
-  if (u3C.err_log_f) {
+  if (u3C.stderr_log_f) {
     //  the user set their own logging function. render the line and redirect to them
     //
     char msg[4096];
     vsnprintf(msg, 4096, format, myargs);
-    u3C.err_log_f(msg);
+    u3C.stderr_log_f(msg);
   } else  {
     //  this process did not set a logging function, fallback to stderr
     //

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1874,7 +1874,7 @@ u3m_boot_new(c3_c* dir_c)
 
   /* Activate tracing.
   */
-  u3C.log_f = 0;
+  u3C.slog_f = 0;
   u3t_init();
 
   /* Construct or activate the allocator.
@@ -1918,7 +1918,7 @@ u3m_boot_pier(void)
 
   /* Activate tracing.
   */
-  u3C.log_f = 0;
+  u3C.slog_f = 0;
   u3t_init();
 
   /* Construct or activate the allocator.

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -296,7 +296,7 @@ _cm_signal_recover(c3_l sig_l, u3_noun arg)
 
       while ( rod_u->kid_p ) {
 #if 0
-        fprintf(stderr, "collecting %d frames\r\n",
+        u3l_log("collecting %d frames\r\n",
               u3kb_lent((u3to(u3_road, rod_u->kid_p)->bug.tax));
 #endif
         tax = u3kb_weld(_cm_stack_recover(u3to(u3_road, rod_u->kid_p)), tax);
@@ -389,7 +389,7 @@ u3m_file(c3_c* pas_c)
   c3_y*       pad_y;
 
   if ( (fid_i < 0) || (fstat(fid_i, &buf_b) < 0) ) {
-    fprintf(stderr, "%s: %s\r\n", pas_c, strerror(errno));
+    u3l_log("%s: %s\r\n", pas_c, strerror(errno));
     return u3m_bail(c3__fail);
   }
   fln_w = buf_b.st_size;
@@ -548,7 +548,7 @@ u3m_dump(void)
       fre_u = fre_u->nex_u;
     }
   }
-  fprintf(stderr, "dump: hat_w %x, fre_w %x, allocated %x\n",
+  u3l_log("dump: hat_w %x, fre_w %x, allocated %x\n",
           hat_w, fre_w, (hat_w - fre_w));
 
   if ( 0 != (hat_w - fre_w) ) {
@@ -567,7 +567,7 @@ u3m_dump(void)
       box_w += box_u->siz_w;
     }
 
-    fprintf(stderr, "second count: %x\n", mem_w);
+    u3l_log("second count: %x\n", mem_w);
   }
 }
 #endif
@@ -613,11 +613,11 @@ u3m_bail(u3_noun how)
       str_c[2] = ((how >> 16) & 0xff);
       str_c[3] = ((how >> 24) & 0xff);
       str_c[4] = 0;
-      fprintf(stderr, "\r\nbail: %s\r\n", str_c);
+      u3l_log("\r\nbail: %s\r\n", str_c);
     }
     else {
       c3_assert(_(u3ud(u3h(how))));
-      fprintf(stderr, "\r\nbail: %d\r\n", u3h(how));
+      u3l_log("\r\nbail: %d\r\n", u3h(how));
     }
   }
 
@@ -627,7 +627,7 @@ u3m_bail(u3_noun how)
     }
 
     case c3__meme: {
-      fprintf(stderr, "bailing out\r\n");
+      u3l_log("bailing out\r\n");
       abort();
     }
     case c3__exit: {
@@ -635,7 +635,7 @@ u3m_bail(u3_noun how)
       static c3_w xuc_w = 0;
 
       {
-        // fprintf(stderr, "exit %d\r\n", xuc_w);
+        // u3l_log("exit %d\r\n", xuc_w);
         // if ( 49 == xuc_w ) { abort(); }
         xuc_w++;
         break;
@@ -643,7 +643,7 @@ u3m_bail(u3_noun how)
     }
     case c3__foul:
     case c3__oops:
-      fprintf(stderr, "bailing out\r\n");
+      u3l_log("bailing out\r\n");
       assert(0);
   }
 
@@ -728,7 +728,7 @@ u3m_leap(c3_w pad_w)
 
       rod_u = _pave_south(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
 #if 0
-      fprintf(stderr, "leap: from north %p (cap %x), to south %p\r\n",
+      u3l_log("leap: from north %p (cap %x), to south %p\r\n",
               u3R,
               u3R->cap_p + len_p,
               rod_u);
@@ -740,7 +740,7 @@ u3m_leap(c3_w pad_w)
 
       rod_u = _pave_north(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
 #if 0
-      fprintf(stderr, "leap: from north %p (cap %p), to south %p\r\n",
+      u3l_log("leap: from north %p (cap %p), to south %p\r\n",
               u3R,
               u3R->cap_p - len_p,
               rod_u);
@@ -775,7 +775,7 @@ u3m_fall()
   c3_assert(0 != u3R->par_p);
 
 #if 0
-  fprintf(stderr, "fall: from %s %p, to %s %p (cap %p, was %p)\r\n",
+  u3l_log("fall: from %s %p, to %s %p (cap %p, was %p)\r\n",
           _(u3a_is_north(u3R)) ? "north" : "south",
           u3R,
           _(u3a_is_north(u3R)) ? "north" : "south",
@@ -1426,7 +1426,7 @@ u3m_p(const c3_c* cap_c, u3_noun som)
 {
   c3_c* pre_c = u3m_pretty(som);
 
-  fprintf(stderr, "%s: %s\r\n", cap_c, pre_c);
+  u3l_log("%s: %s\r\n", cap_c, pre_c);
   free(pre_c);
 }
 
@@ -1520,7 +1520,7 @@ static void
 _cm_signals(void)
 {
   if ( 0 != sigsegv_install_handler(u3e_fault) ) {
-    fprintf(stderr, "sigsegv install failed\n");
+    u3l_log("sigsegv install failed\n");
     exit(1);
   }
   // signal(SIGINT, _loom_stop);
@@ -1573,11 +1573,10 @@ u3m_init(void)
                          MAP_ANON | MAP_PRIVATE,
                          -1, 0);
 
-      fprintf(stderr, "boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-      fprintf(stderr, "see urbit.org/docs/getting-started#swap for adding swap space\r\n");
+      u3l_log("boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
+      u3l_log("see urbit.org/docs/getting-started#swap for adding swap space\r\n");
       if ( -1 != (c3_ps)map_v ) {
-        fprintf(stderr,
-                "if porting to a new platform, try U3_OS_LoomBase %p\r\n",
+        u3l_log("if porting to a new platform, try U3_OS_LoomBase %p\r\n",
                 dyn_v);
       }
       exit(1);
@@ -1617,11 +1616,10 @@ _cm_init_new(void)
                          MAP_ANON | MAP_PRIVATE,
                          -1, 0);
 
-      fprintf(stderr, "boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-      fprintf(stderr, "see urbit.org/docs/using/install to add swap space\r\n");
+      u3l_log("boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
+      u3l_log("see urbit.org/docs/using/install to add swap space\r\n");
       if ( -1 != (c3_ps)map_v ) {
-        fprintf(stderr,
-                "if porting to a new platform, try U3_OS_LoomBase %p\r\n",
+        u3l_log("if porting to a new platform, try U3_OS_LoomBase %p\r\n",
                 dyn_v);
       }
       exit(1);
@@ -1642,12 +1640,12 @@ _get_cmd_output(c3_c *cmd_c, c3_c *out_c, c3_w len_c)
 {
   FILE *fp = popen(cmd_c, "r");
   if ( NULL == fp ) {
-    fprintf(stderr, "'%s' failed\n", cmd_c);
+    u3l_log("'%s' failed\n", cmd_c);
     exit(1);
   }
 
   if ( NULL == fgets(out_c, len_c, fp) ) {
-    fprintf(stderr, "'%s' produced no output\n", cmd_c);
+    u3l_log("'%s' produced no output\n", cmd_c);
     exit(1);
   }
 
@@ -1680,7 +1678,7 @@ _git_pill_url(c3_c *out_c, c3_c *arv_c)
   assert(NULL != arv_c);
 
   if ( 0 != system("which git >> /dev/null") ) {
-    fprintf(stderr, "Could not find git executable\n");
+    u3l_log("Could not find git executable\n");
     exit(1);
   }
 
@@ -1733,7 +1731,7 @@ _boot_home(c3_c *dir_c, c3_c *pil_c, c3_c *url_c, c3_c *arv_c)
                       pil_c, dir_c, nam_c);
       printf("%s\r\n", ful_c);
       if ( 0 != system(ful_c) ) {
-        fprintf(stderr, "could not %s\n", ful_c);
+        u3l_log("could not %s\n", ful_c);
         exit(1);
       }
     }
@@ -1754,11 +1752,11 @@ _boot_home(c3_c *dir_c, c3_c *pil_c, c3_c *url_c, c3_c *arv_c)
       snprintf(ful_c, 2048, "%s/.urb/urbit.pill", dir_c);
       printf("fetching %s to %s\r\n", url_c, ful_c);
       if ( !(curl = curl_easy_init()) ) {
-        fprintf(stderr, "failed to initialize libcurl\n");
+        u3l_log("failed to initialize libcurl\n");
         exit(1);
       }
       if ( !(file = fopen(ful_c, "w")) ) {
-        fprintf(stderr, "failed to open %s\n", ful_c);
+        u3l_log("failed to open %s\n", ful_c);
         exit(1);
       }
       curl_easy_setopt(curl, CURLOPT_URL, url_c);
@@ -1767,16 +1765,14 @@ _boot_home(c3_c *dir_c, c3_c *pil_c, c3_c *url_c, c3_c *arv_c)
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &cod_l);
       fclose(file);
       if ( CURLE_OK != result ) {
-        fprintf(stderr, "failed to fetch %s: %s\n",
-                        url_c, curl_easy_strerror(result));
-        fprintf(stderr,
-                "please fetch it manually and specify the location with -B\n");
+        u3l_log("failed to fetch %s: %s\n",
+                url_c, curl_easy_strerror(result));
+        u3l_log("please fetch it manually and specify the location with -B\n");
         exit(1);
       }
       if ( 300 <= cod_l ) {
-        fprintf(stderr, "error fetching %s: HTTP %ld\n", url_c, cod_l);
-        fprintf(stderr,
-                "please fetch it manually and specify the location with -B\n");
+        u3l_log("error fetching %s: HTTP %ld\n", url_c, cod_l);
+        u3l_log("please fetch it manually and specify the location with -B\n");
         exit(1);
       }
       curl_easy_cleanup(curl);
@@ -1831,7 +1827,7 @@ u3m_boot(c3_o nuu_o, c3_o bug_o, c3_c* dir_c,
         u3_noun pro = u3m_soft(0, u3ke_cue, u3k(pil));
 
         if ( 0 != u3h(pro) ) {
-          fprintf(stderr, "boot: failed: unable to parse pill\r\n");
+          u3l_log("boot: failed: unable to parse pill\r\n");
           exit(1);
         }
 
@@ -1842,7 +1838,7 @@ u3m_boot(c3_o nuu_o, c3_o bug_o, c3_c* dir_c,
       //  XX confirm trel of lists?
       //
       if ( c3n == u3r_trel(sys, &bot, 0, 0) ) {
-        fprintf(stderr, "boot: failed: obsolete pill structure\r\n");
+        u3l_log("boot: failed: obsolete pill structure\r\n");
         exit(1);
       }
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1885,7 +1885,7 @@ u3m_boot_new(c3_c* dir_c)
   */
   {
     c3_w len_w = u3j_boot(nuu_o);
-    fprintf(stderr, "boot: installed %d jets\r\n", len_w);
+    u3l_log("boot: installed %d jets\r\n", len_w);
   }
 
   /* Reactivate jets on old kernel.

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -3,23 +3,6 @@
 */
 #include "all.h"
 
-      /* u3_term_io_hija(): hijack console for cooked print.
-      */
-        FILE*
-        u3_term_io_hija(void);
-
-      /* u3_term_io_loja(): release console from cooked print.
-      */
-        void
-        u3_term_io_loja(int x);
-
-      /* uL, uH: wrap hijack/lojack around fprintf.
-      **
-      **  uL(fprintf(uH, ...));
-      */
-#       define uH    u3_term_io_hija()
-#       define uL(x) u3_term_io_loja(x)
-
 // define to have each opcode printed as it executes,
 // along with some other debugging info
 #        undef VERBOSE_BYTECODE
@@ -96,11 +79,11 @@ _n_hint(u3_noun zep,
           low_i = 1;
           if ( 0 == (u3R->pro.nox_d % 65536ULL) ) {
             if ( c3__spot == zep ) {
-              uL(fprintf(uH, "spot %d/%d : %d/%d\r\n",
-                             u3h(u3h(u3t(hod))),
-                             u3t(u3h(u3t(hod))),
-                             u3h(u3t(u3t(hod))),
-                             u3t(u3t(u3t(hod)))));
+              u3l_log("spot %d/%d : %d/%d\r\n",
+                      u3h(u3h(u3t(hod))),
+                      u3t(u3h(u3t(hod))),
+                      u3h(u3t(u3t(hod))),
+                      u3t(u3t(u3t(hod))));
             }
           }
           low_i = 0;

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -45,8 +45,8 @@ u3t_drop(void)
 void
 u3t_slog(u3_noun hod)
 {
-  if ( 0 != u3C.log_f ) {
-    u3C.log_f(hod);
+  if ( 0 != u3C.slog_f ) {
+    u3C.slog_f(hod);
   }
   else {
     u3z(hod);

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -47,7 +47,7 @@ u3v_boot(u3_noun eve)
     u3_noun pro = u3m_soft_run(gul, u3n_nock_on, eve, lyf);
 
     if ( 0 != u3h(pro) ) {
-      fprintf(stderr, "boot: failed: invalid boot sequence (from pill)\r\n");
+      u3l_log("boot: failed: invalid boot sequence (from pill)\r\n");
       u3z(pro);
       return;
     }
@@ -79,7 +79,7 @@ u3v_load(u3_noun pil)
 {
   u3_noun sys = u3ke_cue(pil);
 
-  fprintf(stderr, "load: mug: %x\r\n", u3r_mug(sys));
+  u3l_log("load: mug: %x\r\n", u3r_mug(sys));
   {
     u3_noun cor = u3v_fire(sys);
     u3_noun pro;
@@ -102,9 +102,9 @@ u3v_lite(u3_noun pil)
 
   u3x_trel(arv, &bot, 0, 0);
 
-  fprintf(stderr, "lite: arvo formula %x\r\n", u3r_mug(arv));
+  u3l_log("lite: arvo formula %x\r\n", u3r_mug(arv));
   cor = u3n_nock_on(bot, lyf);
-  fprintf(stderr, "lite: core %x\r\n", u3r_mug(cor));
+  u3l_log("lite: core %x\r\n", u3r_mug(cor));
 
   pro = u3k(u3r_at(7, cor));
 
@@ -129,11 +129,11 @@ u3v_boot(c3_c* pas_c)
   pru = u3m_soft(0, u3v_load, u3k(u3A->sys));
 
   if ( u3h(pru) != 0 ) {
-    fprintf(stderr, "boot failed\r\n");
+    u3l_log("boot failed\r\n");
     exit(1);
   }
 
-  fprintf(stderr, "boot: final state %x\r\n", u3r_mug(u3t(pru)));
+  u3l_log("boot: final state %x\r\n", u3r_mug(u3t(pru)));
 
   u3A->ken = 0;
   u3A->roc = u3k(u3t(pru));
@@ -150,11 +150,11 @@ u3v_boot_lite(u3_atom lit)
   u3_noun pru = u3m_soft(0, u3v_lite, lit);
 
   if ( u3h(pru) != 0 ) {
-    fprintf(stderr, "boot failed\r\n");
+    u3l_log("boot failed\r\n");
     exit(1);
   }
 
-  fprintf(stderr, "lite: final state %x\r\n", u3r_mug(u3t(pru)));
+  u3l_log("lite: final state %x\r\n", u3r_mug(u3t(pru)));
 
   u3A->roc = u3k(u3t(pru));
 
@@ -281,7 +281,7 @@ _cv_nock_poke(u3_noun ovo)
     u3_noun tox = u3do("spat", u3k(u3h(ovo)));
     c3_c*   tox_c = u3r_string(tox);
 
-    fprintf(stderr, "poke: %%%s (%x) on %s\r\n", ovi_c, u3r_mug(ovo), tox_c);
+    u3l_log("poke: %%%s (%x) on %s\r\n", ovi_c, u3r_mug(ovo), tox_c);
     free(tox_c); free(ovi_c); u3z(tox);
   }
 #endif
@@ -295,9 +295,9 @@ _cv_nock_poke(u3_noun ovo)
     c3_c*   ovi_c = u3r_string(u3h(u3t(ovo)));
 
     if ( u3_nul == u3h(pro) ) {
-      fprintf(stderr, "  blank: %s\r\n", ovi_c);
+      u3l_log("  blank: %s\r\n", ovi_c);
     } else {
-      fprintf(stderr, "  happy: %s: %d\r\n", ovi_c, u3kb_lent(u3k(u3h(pro))));
+      u3l_log("  happy: %s: %d\r\n", ovi_c, u3kb_lent(u3k(u3h(pro))));
     }
     free(ovi_c);
   }
@@ -405,7 +405,7 @@ _cv_mole(u3_noun  fot,
        (0 != q_uco) ||
        (c3n == u3_sing(fot, r_uco)) )
   {
-    uL(fprintf(uH, "strange mole %s\n", u3r_string(san)));
+    u3l_log("strange mole %s\n", u3r_string(san)));
 
     u3z(fot); u3z(uco); return c3n;
   }

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -36,7 +36,7 @@ _ames_alloc(uv_handle_t* had_u,
 static void
 _ames_free(void* ptr_v)
 {
-//  uL(fprintf(uH, "free %p\n", ptr_v));
+//  u3l_log("free %p\n", ptr_v);
   free(ptr_v);
 }
 
@@ -59,7 +59,7 @@ _ames_send_cb(uv_udp_send_t* req_u, c3_i sas_i)
 
 #if 0
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "ames: send_cb: %s\n", uv_strerror(sas_i)));
+    u3l_log("ames: send_cb: %s\n", uv_strerror(sas_i));
   }
 #endif
 
@@ -96,7 +96,7 @@ _ames_send(u3_pact* pac_u)
                                  &buf_u, 1,
                                  (const struct sockaddr*)&add_u,
                                  _ames_send_cb)) ) {
-    uL(fprintf(uH, "ames: send: %s\n", uv_strerror(sas_i)));
+    u3l_log("ames: send: %s\n", uv_strerror(sas_i));
   }
 }
 
@@ -122,7 +122,7 @@ _ames_czar_gone(u3_pact* pac_u, time_t now)
   u3_pier* pir_u = u3_pier_stub();
   u3_ames* sam_u = pir_u->sam_u;
 
-  uL(fprintf(uH, "ames: czar at %s: not found (b)\n", pac_u->dns_c));
+  u3l_log("ames: czar at %s: not found (b)\n", pac_u->dns_c);
   if ( (0 == sam_u->imp_w[pac_u->imp_y]) ||
        (0xffffffff == sam_u->imp_w[pac_u->imp_y]) ) {
     sam_u->imp_w[pac_u->imp_y] = 0xffffffff;
@@ -168,7 +168,7 @@ _ames_czar_cb(uv_getaddrinfo_t* adr_u,
         u3_noun nam = u3dc("scot", c3__if, wad);
         c3_c*   nam_c = u3r_string(nam);
 
-        uL(fprintf(uH, "ames: czar %s: ip %s\n", pac_u->dns_c, nam_c));
+        u3l_log("ames: czar %s: ip %s\n", pac_u->dns_c, nam_c);
 
         free(nam_c); u3z(nam);
       }
@@ -208,7 +208,7 @@ _ames_czar(u3_pact* pac_u, c3_c* bos_c)
   if ( 0 == bos_c ) {
     u3_noun nam = u3dc("scot", 'p', pac_u->imp_y);
     c3_c*  nam_c = u3r_string(nam);
-    fprintf(stderr, "ames: no galaxy domain for %s, no-op\r\n", nam_c);
+    u3l_log("ames: no galaxy domain for %s, no-op\r\n", nam_c);
 
     free(nam_c);
     u3z(nam);
@@ -232,7 +232,7 @@ _ames_czar(u3_pact* pac_u, c3_c* bos_c)
     pac_u->dns_c = c3_malloc(1 + strlen(bos_c) + 1 + strlen(nam_c));
 
     snprintf(pac_u->dns_c, 256, "%s.%s", nam_c + 1, bos_c);
-    // uL(fprintf(uH, "czar %s, dns %s\n", nam_c, pac_u->dns_c));
+    // u3l_log("czar %s, dns %s\n", nam_c, pac_u->dns_c);
 
     free(nam_c);
     u3z(nam);
@@ -246,7 +246,7 @@ _ames_czar(u3_pact* pac_u, c3_c* bos_c)
       if ( 0 != (sas_i = uv_getaddrinfo(u3L, adr_u,
                                         _ames_czar_cb,
                                         pac_u->dns_c, 0, 0)) ) {
-        uL(fprintf(uH, "ames: %s\n", uv_strerror(sas_i)));
+        u3l_log("ames: %s\n", uv_strerror(sas_i));
         _ames_czar_gone(pac_u, now);
         return;
       }
@@ -351,7 +351,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
               const struct sockaddr* adr_u,
               unsigned         flg_i)
 {
-  // uL(fprintf(uH, "ames: rx %p\r\n", buf_u.base));
+  // u3l_log("ames: rx %p\r\n", buf_u.base);
 
   if ( 0 == nrd_i ) {
     _ames_free(buf_u->base);
@@ -360,7 +360,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
     {
       u3_noun             msg   = u3i_bytes((c3_w)nrd_i, (c3_y*)buf_u->base);
 
-      // fprintf(stderr, "ames: plan\r\n");
+      // u3l_log("ames: plan\r\n");
 #if 0
       u3z(msg);
 #else
@@ -397,10 +397,10 @@ _ames_io_start(u3_pier* pir_u)
     por_s = _ames_czar_port(num_y);
 
     if ( c3y == u3_Host.ops_u.net ) {
-      uL(fprintf(uH, "ames: czar: %s on %d\n", imp_c, por_s));
+      u3l_log("ames: czar: %s on %d\n", imp_c, por_s);
     }
     else {
-      uL(fprintf(uH, "ames: czar: %s on %d (localhost only)\n", imp_c, por_s));
+      u3l_log("ames: czar: %s on %d (localhost only)\n", imp_c, por_s);
     }
 
     u3z(imp);
@@ -409,7 +409,7 @@ _ames_io_start(u3_pier* pir_u)
 
   int ret;
   if ( 0 != (ret = uv_udp_init(u3L, &sam_u->wax_u)) ) {
-    uL(fprintf(uH, "ames: init: %s\n", uv_strerror(ret)));
+    u3l_log("ames: init: %s\n", uv_strerror(ret));
     c3_assert(0);
   }
 
@@ -428,11 +428,10 @@ _ames_io_start(u3_pier* pir_u)
     int ret;
     if ( (ret = uv_udp_bind(&sam_u->wax_u,
                             (const struct sockaddr*) & add_u, 0)) != 0 ) {
-      uL(fprintf(uH, "ames: bind: %s\n",
-                     uv_strerror(ret)));
+      u3l_log("ames: bind: %s\n",
+              uv_strerror(ret));
       if (UV_EADDRINUSE == ret){
-        uL(fprintf(uH,
-                    "    ...perhaps you've got two copies of vere running?\n"));
+        u3l_log("    ...perhaps you've got two copies of vere running?\n");
       }
       u3_pier_exit(pir_u);
     }
@@ -443,7 +442,7 @@ _ames_io_start(u3_pier* pir_u)
     sam_u->por_s = ntohs(add_u.sin_port);
   }
 
-  // uL(fprintf(uH, "ames: on localhost, UDP %d.\n", sam_u->por_s));
+  // u3l_log("ames: on localhost, UDP %d.\n", sam_u->por_s);
   uv_udp_recv_start(&sam_u->wax_u, _ames_alloc, _ames_recv_cb);
 
   sam_u->liv = c3y;
@@ -526,7 +525,7 @@ u3_ames_ef_turf(u3_pier* pir_u, u3_noun tuf)
     u3z(tuf);
   }
   else if ( (c3n == pir_u->fak_o) && (0 == sam_u->dns_c) ) {
-    uL(fprintf(uH, "ames: turf: no domains\n"));
+    u3l_log("ames: turf: no domains\n");
   }
 
   if ( c3n == sam_u->liv ) {

--- a/pkg/urbit/vere/cttp.c
+++ b/pkg/urbit/vere/cttp.c
@@ -706,7 +706,7 @@ _cttp_creq_fail(u3_creq* ceq_u, const c3_c* err_c)
   // XX anything other than a 504?
   c3_w cod_w = 504;
 
-  uL(fprintf(uH, "http: fail (%d, %d): %s\r\n", ceq_u->num_l, cod_w, err_c));
+  u3l_log("http: fail (%d, %d): %s\r\n", ceq_u->num_l, cod_w, err_c);
 
   // XX include err_c as response body?
   _cttp_httr(ceq_u->num_l, cod_w, u3_nul, u3_nul);

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -374,7 +374,7 @@ void
 _daemon_bail(u3_moor *vod_p, const c3_c *err_c)
 {
   u3_moor *free_p;
-  fprintf(stderr, "_daemon_bail: %s\r\n", err_c);
+  u3l_log("_daemon_bail: %s\r\n", err_c);
 
   if ( vod_p == 0 ) {
     free_p = u3K.cli_u;
@@ -447,7 +447,7 @@ _daemon_get_atom(c3_c* url_c)
   uv_buf_t buf_u = uv_buf_init(c3_malloc(1), 0);
 
   if ( !(curl = curl_easy_init()) ) {
-    fprintf(stderr, "failed to initialize libcurl\n");
+    u3l_log("failed to initialize libcurl\n");
     exit(1);
   }
 
@@ -461,12 +461,12 @@ _daemon_get_atom(c3_c* url_c)
   //  XX retry?
   //
   if ( CURLE_OK != result ) {
-    fprintf(stderr, "failed to fetch %s: %s\n",
-                    url_c, curl_easy_strerror(result));
+    u3l_log("failed to fetch %s: %s\n",
+            url_c, curl_easy_strerror(result));
     exit(1);
   }
   if ( 300 <= cod_l ) {
-    fprintf(stderr, "error fetching %s: HTTP %ld\n", url_c, cod_l);
+    u3l_log("error fetching %s: HTTP %ld\n", url_c, cod_l);
     exit(1);
   }
 
@@ -485,12 +485,12 @@ _get_cmd_output(c3_c *cmd_c, c3_c *out_c, c3_w len_c)
 {
   FILE *fp = popen(cmd_c, "r");
   if ( NULL == fp ) {
-    fprintf(stderr, "'%s' failed\n", cmd_c);
+    u3l_log("'%s' failed\n", cmd_c);
     exit(1);
   }
 
   if ( NULL == fgets(out_c, len_c, fp) ) {
-    fprintf(stderr, "'%s' produced no output\n", cmd_c);
+    u3l_log("'%s' produced no output\n", cmd_c);
     exit(1);
   }
 
@@ -523,7 +523,7 @@ _git_pill_url(c3_c *out_c, c3_c *arv_c)
   assert(NULL != arv_c);
 
   if ( 0 != system("which git >> /dev/null") ) {
-    fprintf(stderr, "boot: could not find git executable\r\n");
+    u3l_log("boot: could not find git executable\r\n");
     exit(1);
   }
 
@@ -540,7 +540,7 @@ _boothack_pill(void)
   u3_noun pil;
 
   if ( 0 != u3_Host.ops_u.pil_c ) {
-    fprintf(stderr, "boot: loading pill %s\r\n", u3_Host.ops_u.pil_c);
+    u3l_log("boot: loading pill %s\r\n", u3_Host.ops_u.pil_c);
     pil = u3m_file(u3_Host.ops_u.pil_c);
   }
   else {
@@ -556,13 +556,13 @@ _boothack_pill(void)
       strcpy(url_c, u3_Host.ops_u.url_c);
     }
 
-    fprintf(stderr, "boot: downloading pill %s\r\n", url_c);
+    u3l_log("boot: downloading pill %s\r\n", url_c);
     pil = _daemon_get_atom(url_c);
   }
 
   if ( 0 != u3_Host.ops_u.arv_c ) {
-    fprintf(stderr, "boot: preparing filesystem from %s\r\n",
-                    u3_Host.ops_u.arv_c);
+    u3l_log("boot: preparing filesystem from %s\r\n",
+            u3_Host.ops_u.arv_c);
     arv = u3nc(u3_nul, u3_unix_initial_into_card(u3_Host.ops_u.arv_c));
   }
 
@@ -581,7 +581,7 @@ _boothack_key(u3_noun kef)
 
     if ( u3_nul == des ) {
       c3_c* kef_c = u3r_string(kef);
-      fprintf(stderr, "dawn: invalid private keys: %s\r\n", kef_c);
+      u3l_log("dawn: invalid private keys: %s\r\n", kef_c);
       free(kef_c);
       exit(1);
     }
@@ -601,16 +601,16 @@ _boothack_key(u3_noun kef)
     u3_noun whu = u3dc("slaw", 'p', u3k(woh));
 
     if ( u3_nul == whu ) {
-      fprintf(stderr, "dawn: invalid ship specificed with -w %s\r\n",
-                                                 u3_Host.ops_u.who_c);
+      u3l_log("dawn: invalid ship specificed with -w %s\r\n",
+              u3_Host.ops_u.who_c);
       exit(1);
     }
 
     if ( c3n == u3r_sing(ship, u3t(whu)) ) {
       u3_noun how = u3dc("scot", 'p', u3k(ship));
       c3_c* how_c = u3r_string(u3k(how));
-      fprintf(stderr, "dawn: mismatch between -w %s and -K %s\r\n",
-                                                 u3_Host.ops_u.who_c, how_c);
+      u3l_log("dawn: mismatch between -w %s and -K %s\r\n",
+              u3_Host.ops_u.who_c, how_c);
 
       u3z(how);
       free(how_c);
@@ -640,7 +640,7 @@ _boothack_doom(void)
     u3_noun whu = u3dc("slaw", 'p', u3k(fak));
 
     if ( u3_nul == whu ) {
-      fprintf(stderr, "boot: malformed -F ship %s\r\n", u3_Host.ops_u.fak_c);
+      u3l_log("boot: malformed -F ship %s\r\n", u3_Host.ops_u.fak_c);
       exit(1);
     }
 
@@ -659,7 +659,7 @@ _boothack_doom(void)
       kef = u3i_string(u3_Host.ops_u.gen_c);
     }
     else {
-      fprintf(stderr, "boot: must specify a key with -k or -G\r\n");
+      u3l_log("boot: must specify a key with -k or -G\r\n");
       exit(1);
     }
 
@@ -787,7 +787,7 @@ u3_daemon_commence()
   uv_pipe_init(u3L, &u3K.cmd_u, 0);
   uv_pipe_bind(&u3K.cmd_u, u3K.soc_c);
   uv_listen((uv_stream_t *)&u3K.cmd_u, 128, _daemon_socket_connect);
-  fprintf(stderr, "cmd socket up\r\n");
+  u3l_log("cmd socket up\r\n");
 
   _daemon_loop_init();
 

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -1,4 +1,4 @@
-/* vere/king.c
+/* vere/daemon.c
 **
 ** the main loop of the daemon process
 */
@@ -8,15 +8,15 @@
 #include "all.h"
 #include "vere/vere.h"
 
-//  stash config flags for serf
+//  stash config flags for worker
 //
 static c3_w sag_w;
 
 /*
-::  king/client protocol:
+::  daemon to worker protocol
 ::
 |%
-::  +fate: client to lord
+::  +fate: worker to daemon
 ::
 +$  fate
   $%  ::  authenticate client
@@ -112,7 +112,7 @@ static c3_w sag_w;
   ::  r: userspace ova
   ::
   [p=@ q=(list ovum) r=(list ovum)]
-::  +cede: lord to client
+::  +cede: daemon to client
 ::
 ::  XX not implemented
 ::
@@ -132,34 +132,34 @@ static c3_w sag_w;
 --
 */
 
-void _king_auth(u3_noun auth);
+void _daemon_auth(u3_noun auth);
 
-void _king_wyrd(u3_noun ship_wyrd);
-  void _king_susp(u3_atom ship, u3_noun susp);
-  void _king_vent(u3_atom ship, u3_noun vent);
+void _daemon_wyrd(u3_noun ship_wyrd);
+  void _daemon_susp(u3_atom ship, u3_noun susp);
+  void _daemon_vent(u3_atom ship, u3_noun vent);
 
-void _king_doom(u3_noun doom);
-  void _king_boot(u3_noun boot);
-    void _king_come(u3_noun star, u3_noun pill, u3_noun path);
-    void _king_dawn(u3_noun seed, u3_noun pill, u3_noun path);
-    void _king_fake(u3_noun ship, u3_noun pill, u3_noun path);
-  void _king_exit(u3_noun exit);
-  void _king_pier(u3_noun pier);
-  void _king_root(u3_noun root);
+void _daemon_doom(u3_noun doom);
+  void _daemon_boot(u3_noun boot);
+    void _daemon_come(u3_noun star, u3_noun pill, u3_noun path);
+    void _daemon_dawn(u3_noun seed, u3_noun pill, u3_noun path);
+    void _daemon_fake(u3_noun ship, u3_noun pill, u3_noun path);
+  void _daemon_exit(u3_noun exit);
+  void _daemon_pier(u3_noun pier);
+  void _daemon_root(u3_noun root);
 
 
-/* _king_defy_fate(): invalid fate
+/* _daemon_defy_fate(): invalid fate
 */
 void
-_king_defy_fate()
+_daemon_defy_fate()
 {
   exit(1);
 }
 
-/* _king_fate(): top-level fate parser
+/* _daemon_fate(): top-level fate parser
 */
 void
-_king_fate(void *vod_p, u3_noun mat)
+_daemon_fate(void *vod_p, u3_noun mat)
 {
   u3_noun fate = u3ke_cue(u3k(mat));
   u3_noun load;
@@ -170,16 +170,16 @@ _king_fate(void *vod_p, u3_noun mat)
 
   switch ( u3h(fate) ) {
     case c3__auth:
-      next = _king_auth;
+      next = _daemon_auth;
       break;
     case c3__wyrd:
-      next = _king_wyrd;
+      next = _daemon_wyrd;
       break;
     case c3__doom:
-      next = _king_doom;
+      next = _daemon_doom;
       break;
     default:
-      _king_defy_fate();
+      _daemon_defy_fate();
   }
 
   load = u3k(u3t(fate));
@@ -187,17 +187,17 @@ _king_fate(void *vod_p, u3_noun mat)
   next(load);
 }
 
-/* _king_auth(): auth parser
+/* _daemon_auth(): auth parser
 */
 void
-_king_auth(u3_noun auth)
+_daemon_auth(u3_noun auth)
 {
 }
 
-/* _king_wyrd(): wyrd parser
+/* _daemon_wyrd(): wyrd parser
 */
 void
-_king_wyrd(u3_noun ship_wyrd)
+_daemon_wyrd(u3_noun ship_wyrd)
 {
   u3_atom ship;
   u3_noun wyrd;
@@ -215,13 +215,13 @@ _king_wyrd(u3_noun ship_wyrd)
 
   switch ( u3h(wyrd) ) {
     case c3__susp:
-      next = _king_susp;
+      next = _daemon_susp;
       break;
     case c3__vent:
-      next = _king_vent;
+      next = _daemon_vent;
       break;
     default:
-      _king_defy_fate();
+      _daemon_defy_fate();
   }
 
   load = u3k(u3t(wyrd));
@@ -229,17 +229,17 @@ _king_wyrd(u3_noun ship_wyrd)
   next(ship, load);
 }
 
-/* _king_susp(): susp parser
+/* _daemon_susp(): susp parser
 */
 void
-_king_susp(u3_atom ship, u3_noun susp)
+_daemon_susp(u3_atom ship, u3_noun susp)
 {
 }
 
-/* _king_vent(): vent parser
+/* _daemon_vent(): vent parser
 */
 void
-_king_vent(u3_atom ship, u3_noun vent)
+_daemon_vent(u3_atom ship, u3_noun vent)
 {
   /* stub; have to find pier from ship */
   u3z(ship);
@@ -247,10 +247,10 @@ _king_vent(u3_atom ship, u3_noun vent)
   u3z(vent);
 }
 
-/* _king_doom(): doom parser
+/* _daemon_doom(): doom parser
 */
 void
-_king_doom(u3_noun doom)
+_daemon_doom(u3_noun doom)
 {
   u3_noun load;
   void (*next)(u3_noun);
@@ -260,19 +260,19 @@ _king_doom(u3_noun doom)
 
   switch ( u3h(doom) ) {
     case c3__boot:
-      next = _king_boot;
+      next = _daemon_boot;
       break;
     case c3__exit:
-      next = _king_exit;
+      next = _daemon_exit;
       break;
     case c3__pier:
-      next = _king_pier;
+      next = _daemon_pier;
       break;
     case c3__root:
-      next = _king_root;
+      next = _daemon_root;
       break;
     default:
-      _king_defy_fate();
+      _daemon_defy_fate();
   }
 
   load = u3k(u3t(doom));
@@ -280,10 +280,10 @@ _king_doom(u3_noun doom)
   next(load);
 }
 
-/* _king_boot(): boot parser
+/* _daemon_boot(): boot parser
 */
 void
-_king_boot(u3_noun bul)
+_daemon_boot(u3_noun bul)
 {
   u3_noun boot, pill, path;
   void (*next)(u3_noun, u3_noun, u3_noun);
@@ -294,66 +294,66 @@ _king_boot(u3_noun bul)
 
   switch ( u3h(boot) ) {
     case c3__fake: {
-      next = _king_fake;
+      next = _daemon_fake;
       break;
     }
     case c3__come: {
-      next = _king_come;
+      next = _daemon_come;
       break;
     }
     case c3__dawn: {
-      next = _king_dawn;
+      next = _daemon_dawn;
       break;
     }
     default:
-      return _king_defy_fate();
+      return _daemon_defy_fate();
   }
 
   next(u3k(u3t(boot)), u3k(pill), u3k(path));
   u3z(bul);
 }
 
-/* _king_fake(): boot with fake keys
+/* _daemon_fake(): boot with fake keys
 */
 void
-_king_fake(u3_noun ship, u3_noun pill, u3_noun path)
+_daemon_fake(u3_noun ship, u3_noun pill, u3_noun path)
 {
   u3_pier_boot(sag_w, ship, u3nc(c3__fake, u3k(ship)), pill, path);
 }
 
-/* _king_come(): mine a comet under star (unit)
+/* _daemon_come(): mine a comet under star (unit)
 **
 **   XX revise to exclude star argument
 */
 void
-_king_come(u3_noun star, u3_noun pill, u3_noun path)
+_daemon_come(u3_noun star, u3_noun pill, u3_noun path)
 {
-  _king_dawn(u3_dawn_come(), pill, path);
+  _daemon_dawn(u3_dawn_come(), pill, path);
 }
 
-/* _king_dawn(): boot from keys, validating
+/* _daemon_dawn(): boot from keys, validating
 */
 void
-_king_dawn(u3_noun seed, u3_noun pill, u3_noun path)
+_daemon_dawn(u3_noun seed, u3_noun pill, u3_noun path)
 {
   u3_pier_boot(sag_w, u3k(u3h(seed)), u3_dawn_vent(seed), pill, path);
 }
 
-/* _king_exit(): exit parser
+/* _daemon_exit(): exit parser
 */
 void
-_king_exit(u3_noun exit)
+_daemon_exit(u3_noun exit)
 {
 }
 
-/* _king_pier(): pier parser
+/* _daemon_pier(): pier parser
 */
 void
-_king_pier(u3_noun pier)
+_daemon_pier(u3_noun pier)
 {
   if ( (c3n == u3du(pier)) ||
        (c3n == u3ud(u3t(pier))) ) {
-    u3m_p("king: invalid pier", pier);
+    u3m_p("daemon: invalid pier", pier);
     exit(1);
   }
 
@@ -361,20 +361,20 @@ _king_pier(u3_noun pier)
   u3z(pier);
 }
 
-/* _king_root(): root parser
+/* _daemon_root(): root parser
 */
 void
-_king_root(u3_noun root)
+_daemon_root(u3_noun root)
 {
 }
 
-/* _king_bail(): bail for command socket newt
+/* _daemon_bail(): bail for command socket newt
 */
 void
-_king_bail(u3_moor *vod_p, const c3_c *err_c)
+_daemon_bail(u3_moor *vod_p, const c3_c *err_c)
 {
   u3_moor *free_p;
-  fprintf(stderr, "_king_bail: %s\r\n", err_c);
+  fprintf(stderr, "_daemon_bail: %s\r\n", err_c);
 
   if ( vod_p == 0 ) {
     free_p = u3K.cli_u;
@@ -388,10 +388,10 @@ _king_bail(u3_moor *vod_p, const c3_c *err_c)
   }
 }
 
-/* _king_socket_connect(): callback for new connections
+/* _daemon_socket_connect(): callback for new connections
 */
 void
-_king_socket_connect(uv_stream_t *sock, int status)
+_daemon_socket_connect(uv_stream_t *sock, int status)
 {
   u3_moor *mor_u;
 
@@ -411,18 +411,18 @@ _king_socket_connect(uv_stream_t *sock, int status)
   }
 
   uv_pipe_init(u3L, &mor_u->pyp_u, 0);
-  mor_u->pok_f = _king_fate;
-  mor_u->bal_f = (u3_bail)_king_bail;
+  mor_u->pok_f = _daemon_fate;
+  mor_u->bal_f = (u3_bail)_daemon_bail;
 
   uv_accept(sock, (uv_stream_t *)&mor_u->pyp_u);
   u3_newt_read((u3_moat *)mor_u);
 }
 
-/* _king_curl_alloc(): allocate a response buffer for curl
+/* _daemon_curl_alloc(): allocate a response buffer for curl
 **  XX deduplicate with dawn.c
 */
 static size_t
-_king_curl_alloc(void* dat_v, size_t uni_t, size_t mem_t, uv_buf_t* buf_u)
+_daemon_curl_alloc(void* dat_v, size_t uni_t, size_t mem_t, uv_buf_t* buf_u)
 {
   size_t siz_t = uni_t * mem_t;
   buf_u->base = c3_realloc(buf_u->base, 1 + siz_t + buf_u->len);
@@ -434,11 +434,11 @@ _king_curl_alloc(void* dat_v, size_t uni_t, size_t mem_t, uv_buf_t* buf_u)
   return siz_t;
 }
 
-/* _king_get_atom(): HTTP GET url_c, produce the response body as an atom.
+/* _daemon_get_atom(): HTTP GET url_c, produce the response body as an atom.
 **  XX deduplicate with dawn.c
 */
 static u3_noun
-_king_get_atom(c3_c* url_c)
+_daemon_get_atom(c3_c* url_c)
 {
   CURL *curl;
   CURLcode result;
@@ -452,7 +452,7 @@ _king_get_atom(c3_c* url_c)
   }
 
   curl_easy_setopt(curl, CURLOPT_URL, url_c);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _king_curl_alloc);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _daemon_curl_alloc);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)&buf_u);
 
   result = curl_easy_perform(curl);
@@ -557,7 +557,7 @@ _boothack_pill(void)
     }
 
     fprintf(stderr, "boot: downloading pill %s\r\n", url_c);
-    pil = _king_get_atom(url_c);
+    pil = _daemon_get_atom(url_c);
   }
 
   if ( 0 != u3_Host.ops_u.arv_c ) {
@@ -688,10 +688,10 @@ _boothack_cb(uv_connect_t *conn, int status)
   u3_newt_write(moj_u, mat, 0);
 }
 
-/* _king_loop_init(): stuff that comes before the event loop
+/* _daemon_loop_init(): stuff that comes before the event loop
 */
 void
-_king_loop_init()
+_daemon_loop_init()
 {
   /* move signals out of unix.c */
   {
@@ -735,18 +735,18 @@ _king_loop_init()
   }
 }
 
-/* _king_loop_exit(): cleanup after event loop
+/* _daemon_loop_exit(): cleanup after event loop
 */
 void
-_king_loop_exit()
+_daemon_loop_exit()
 {
   unlink(u3K.soc_c);
 }
 
-/* u3_king_commence(): start the daemon
+/* u3_daemon_commence(): start the daemon
 */
 void
-u3_king_commence()
+u3_daemon_commence()
 {
   u3_Host.lup_u = uv_default_loop();
 
@@ -786,21 +786,21 @@ u3_king_commence()
 
   uv_pipe_init(u3L, &u3K.cmd_u, 0);
   uv_pipe_bind(&u3K.cmd_u, u3K.soc_c);
-  uv_listen((uv_stream_t *)&u3K.cmd_u, 128, _king_socket_connect);
+  uv_listen((uv_stream_t *)&u3K.cmd_u, 128, _daemon_socket_connect);
   fprintf(stderr, "cmd socket up\r\n");
 
-  _king_loop_init();
+  _daemon_loop_init();
 
   uv_run(u3L, UV_RUN_DEFAULT);
 
-  _king_loop_exit();
+  _daemon_loop_exit();
   exit(0);
 }
 
-/* u3_king_grab(): gc the kingdom
+/* u3_daemon_grab(): gc the daemon area
 */
 void
-u3_king_grab(void* vod_p)
+u3_daemon_grab(void* vod_p)
 {
   //  XX fix leaks and enable
   //
@@ -810,7 +810,7 @@ u3_king_grab(void* vod_p)
 
   c3_assert( u3R == &(u3H->rod_u) );
 
-  fprintf(fil_u, "measuring king:\r\n");
+  fprintf(fil_u, "measuring daemon:\r\n");
 
   man_w = u3m_mark(fil_u);
   pir_w = u3_pier_mark(fil_u);

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -70,7 +70,7 @@ _dawn_post_json(c3_c* url_c, uv_buf_t lod_u)
   uv_buf_t buf_u = uv_buf_init(c3_malloc(1), 0);
 
   if ( !(curl = curl_easy_init()) ) {
-    fprintf(stderr, "failed to initialize libcurl\n");
+    u3l_log("failed to initialize libcurl\n");
     exit(1);
   }
 
@@ -93,12 +93,12 @@ _dawn_post_json(c3_c* url_c, uv_buf_t lod_u)
 
   // XX retry?
   if ( CURLE_OK != result ) {
-    fprintf(stderr, "failed to fetch %s: %s\n",
-                    url_c, curl_easy_strerror(result));
+    u3l_log("failed to fetch %s: %s\n",
+            url_c, curl_easy_strerror(result));
     exit(1);
   }
   if ( 300 <= cod_l ) {
-    fprintf(stderr, "error fetching %s: HTTP %ld\n", url_c, cod_l);
+    u3l_log("error fetching %s: HTTP %ld\n", url_c, cod_l);
     exit(1);
   }
 
@@ -120,7 +120,7 @@ _dawn_get_jam(c3_c* url_c)
   uv_buf_t buf_u = uv_buf_init(c3_malloc(1), 0);
 
   if ( !(curl = curl_easy_init()) ) {
-    fprintf(stderr, "failed to initialize libcurl\n");
+    u3l_log("failed to initialize libcurl\n");
     exit(1);
   }
 
@@ -135,12 +135,12 @@ _dawn_get_jam(c3_c* url_c)
 
   // XX retry?
   if ( CURLE_OK != result ) {
-    fprintf(stderr, "failed to fetch %s: %s\n",
-                    url_c, curl_easy_strerror(result));
+    u3l_log("failed to fetch %s: %s\n",
+            url_c, curl_easy_strerror(result));
     exit(1);
   }
   if ( 300 <= cod_l ) {
-    fprintf(stderr, "error fetching %s: HTTP %ld\n", url_c, cod_l);
+    u3l_log("error fetching %s: HTTP %ld\n", url_c, cod_l);
     exit(1);
   }
 
@@ -197,7 +197,7 @@ _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
     }
   }
 
-  fprintf(stderr, "dawn: invalid keys for %s '%s'\r\n", rac_c, how_c);
+  u3l_log("dawn: invalid keys for %s '%s'\r\n", rac_c, how_c);
 
   // XX deconstruct sas, print helpful error messages
   u3m_p("pre-boot error", u3t(sas));
@@ -213,7 +213,7 @@ static u3_noun
 _dawn_need_unit(u3_noun nit, c3_c* msg_c)
 {
   if ( u3_nul == nit ) {
-    fprintf(stderr, "%s\r\n", msg_c);
+    u3l_log("%s\r\n", msg_c);
     exit(1);
   }
   else {
@@ -232,7 +232,7 @@ _dawn_purl(u3_noun rac)
 
   if ( 0 == u3_Host.ops_u.eth_c ) {
     if ( c3__czar == rac ) {
-      fprintf(stderr, "boot: galaxy requires ethereum gateway via -e\r\n");
+      u3l_log("boot: galaxy requires ethereum gateway via -e\r\n");
       exit(1);
     }
 
@@ -247,7 +247,7 @@ _dawn_purl(u3_noun rac)
 
     if ( u3_nul == rul ) {
       if ( c3__czar == rac ) {
-        fprintf(stderr, "boot: galaxy requires ethereum gateway via -e\r\n");
+        u3l_log("boot: galaxy requires ethereum gateway via -e\r\n");
         exit(1);
       }
 
@@ -279,11 +279,11 @@ _dawn_turf(c3_c* dns_c)
   u3_noun rul = u3dc("rush", u3k(dns), u3k(par));
 
   if ( (u3_nul == rul) || (c3n == u3h(u3t(rul))) ) {
-    fprintf(stderr, "boot: invalid domain specified with -H %s\r\n", dns_c);
+    u3l_log("boot: invalid domain specified with -H %s\r\n", dns_c);
     exit(1);
   }
   else {
-    fprintf(stderr, "boot: overriding network domains with %s\r\n", dns_c);
+    u3l_log("boot: overriding network domains with %s\r\n", dns_c);
     u3_noun dom = u3t(u3t(rul));
     tuf = u3nc(u3k(dom), u3_nul);
   }
@@ -306,7 +306,7 @@ u3_dawn_vent(u3_noun seed)
   //  load snapshot from file
   //
   if ( 0 != u3_Host.ops_u.ets_c ) {
-    fprintf(stderr, "boot: loading ethereum snapshot\r\n");
+    u3l_log("boot: loading ethereum snapshot\r\n");
     u3_noun raw_snap = u3ke_cue(u3m_file(u3_Host.ops_u.ets_c));
     sap = u3nc(u3_nul, raw_snap);
   }
@@ -334,14 +334,14 @@ u3_dawn_vent(u3_noun seed)
   //  pin block number
   //
   if ( c3y == u3_Host.ops_u.etn ) {
-    fprintf(stderr, "boot: extracting block from snapshot\r\n");
+    u3l_log("boot: extracting block from snapshot\r\n");
 
     bok = _dawn_need_unit(u3do("bloq:snap:dawn", u3k(u3t(sap))),
                           "boot: failed to extract "
                           "block from snapshot");
   }
   else {
-    fprintf(stderr, "boot: retrieving latest block\r\n");
+    u3l_log("boot: retrieving latest block\r\n");
 
     u3_noun oct = u3v_wish("bloq:give:dawn");
     u3_noun kob = _dawn_eth_rpc(url_c, u3k(oct));
@@ -357,7 +357,7 @@ u3_dawn_vent(u3_noun seed)
     u3_noun pot;
 
     if ( c3y == u3_Host.ops_u.etn ) {
-      fprintf(stderr, "boot: extracting public keys from snapshot\r\n");
+      u3l_log("boot: extracting public keys from snapshot\r\n");
 
       pot = _dawn_need_unit(u3dc("point:snap:dawn", u3k(ship), u3k(u3t(sap))),
                             "boot: failed to extract "
@@ -378,16 +378,16 @@ u3_dawn_vent(u3_noun seed)
           u3_noun seg = u3dc("scot", 'p', u3k(who));
           c3_c* seg_c = u3r_string(seg);
 
-          fprintf(stderr, "boot: retrieving %s's public keys (for %s)\r\n",
-                                              seg_c, u3_Host.ops_u.who_c);
+          u3l_log("boot: retrieving %s's public keys (for %s)\r\n",
+                  seg_c, u3_Host.ops_u.who_c);
           free(seg_c);
           u3z(seg);
         }
       }
       else {
         who = u3k(ship);
-        fprintf(stderr, "boot: retrieving %s's public keys\r\n",
-                                           u3_Host.ops_u.who_c);
+        u3l_log("boot: retrieving %s's public keys\r\n",
+                u3_Host.ops_u.who_c);
       }
 
       {
@@ -408,7 +408,7 @@ u3_dawn_vent(u3_noun seed)
     u3_noun liv = u3_nul;
     // u3_noun liv = _dawn_get_json(parent, /some/url)
 
-    fprintf(stderr, "boot: verifying keys\r\n");
+    u3l_log("boot: verifying keys\r\n");
 
     //  (each sponsor=ship error=@tas)
     //
@@ -432,14 +432,14 @@ u3_dawn_vent(u3_noun seed)
   //  (map ship [=life =pass]): galaxy table
   //
   if ( c3y == u3_Host.ops_u.etn ) {
-    fprintf(stderr, "boot: extracting galaxy table from snapshot\r\n");
+    u3l_log("boot: extracting galaxy table from snapshot\r\n");
 
     zar = _dawn_need_unit(u3do("czar:snap:dawn", u3k(u3t(sap))),
                           "boot: failed to extract "
                           "galaxy table from snapshot");
   }
   else {
-    fprintf(stderr, "boot: retrieving galaxy table\r\n");
+    u3l_log("boot: retrieving galaxy table\r\n");
 
     u3_noun oct = u3do("czar:give:dawn", u3k(bok));
     u3_noun raz = _dawn_eth_rpc(url_c, u3k(oct));
@@ -455,14 +455,14 @@ u3_dawn_vent(u3_noun seed)
     tuf = _dawn_turf(u3_Host.ops_u.dns_c);
   }
   else if ( c3y == u3_Host.ops_u.etn ) {
-    fprintf(stderr, "boot: extracting network domains from snapshot\r\n");
+    u3l_log("boot: extracting network domains from snapshot\r\n");
 
     tuf = _dawn_need_unit(u3do("turf:snap:dawn", u3k(u3t(sap))),
                           "boot: failed to extract "
                           "network domains from snapshot");
   }
   else {
-    fprintf(stderr, "boot: retrieving network domains\r\n");
+    u3l_log("boot: retrieving network domains\r\n");
 
     u3_noun oct = u3do("turf:give:dawn", u3k(bok));
     u3_noun fut = _dawn_eth_rpc(url_c, u3k(oct));
@@ -492,8 +492,8 @@ _dawn_come(u3_noun stars)
     c3_rand(eny_w);
     eny = u3i_words(16, eny_w);
 
-    fprintf(stderr, "boot: mining a comet. May take up to an hour.\r\n");
-    fprintf(stderr, "If you want to boot faster, get an Azimuth point.\r\n");
+    u3l_log("boot: mining a comet. May take up to an hour.\r\n");
+    u3l_log("If you want to boot faster, get an Azimuth point.\r\n");
 
     seed = u3dc("come:dawn", u3k(stars), u3k(eny));
     u3z(eny);
@@ -503,7 +503,7 @@ _dawn_come(u3_noun stars)
     u3_noun who = u3dc("scot", 'p', u3k(u3h(seed)));
     c3_c* who_c = u3r_string(who);
 
-    fprintf(stderr, "boot: found comet %s\r\n", who_c);
+    u3l_log("boot: found comet %s\r\n", who_c);
     free(who_c);
     u3z(who);
   }

--- a/pkg/urbit/vere/foil.c
+++ b/pkg/urbit/vere/foil.c
@@ -54,10 +54,10 @@ static void
 _foil_fail(const c3_c* why_c, c3_i err_i)
 {
   if ( err_i ) {
-    fprintf(stderr, "%s: error: %s\r\n", why_c, uv_strerror(err_i));
+    u3l_log("%s: error: %s\r\n", why_c, uv_strerror(err_i));
     c3_assert(0);
   } else {
-    fprintf(stderr, "%s: file error\r\n", why_c);
+    u3l_log("%s: file error\r\n", why_c);
   }
   exit(1);
 }
@@ -561,7 +561,7 @@ u3_foil_reveal(u3_foil* fol_u,              //  file from
       timersub(&aft_u, &req_u->bef_u, &gap_u);
       mls_w = (gap_u.tv_sec * 1000) + (gap_u.tv_usec / 1000);
 
-      fprintf(stderr, "invent ms: %d\r\n", mls_w);
+      u3l_log("invent ms: %d\r\n", mls_w);
     }
 #endif
       req_u->fun_f(req_u->vod_p, req_u->fol_u);

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -355,7 +355,7 @@ _http_req_respond(u3_hreq* req_u, u3_noun sas, u3_noun hed, u3_noun bod)
   //c3_assert(u3_rsat_plan == req_u->sat_e);
 
   if ( u3_rsat_plan != req_u->sat_e ) {
-    //uL(fprintf(uH, "duplicate response\n"));
+    //u3l_log("duplicate response\n");
     return;
   }
 
@@ -442,8 +442,8 @@ _http_rec_accept(h2o_handler_t* han_u, h2o_req_t* rec_u)
 
   if ( u3_none == req ) {
     if ( (u3C.wag_w & u3o_verbose) ) {
-      uL(fprintf(uH, "strange %.*s request\n", (int)rec_u->method.len,
-                                               rec_u->method.base));
+      u3l_log("strange %.*s request\n", (int)rec_u->method.len,
+              rec_u->method.base);
     }
     c3_c* msg_c = "bad request";
     h2o_send_error_generic(rec_u, 400, msg_c, msg_c, 0);
@@ -545,7 +545,7 @@ _http_conn_free(uv_handle_t* han_t)
       noh_u = noh_u->nex_u;
     }
 
-    uL(fprintf(uH, "http conn free %d of %u server %d\n", hon_u->coq_l, len_w, htp_u->sev_l));
+    u3l_log("http conn free %d of %u server %d\n", hon_u->coq_l, len_w, htp_u->sev_l);
   }
 #endif
 
@@ -562,13 +562,13 @@ _http_conn_free(uv_handle_t* han_t)
       noh_u = noh_u->nex_u;
     }
 
-    uL(fprintf(uH, "http conn free %u remaining\n", len_w));
+    u3l_log("http conn free %u remaining\n", len_w);
   }
 #endif
 
   if ( (0 == htp_u->hon_u) && (0 != h2o_u->ctx_u.shutdown_requested) ) {
 #if 0
-    uL(fprintf(uH, "http conn free %d free server %d\n", hon_u->coq_l, htp_u->sev_l));
+    u3l_log("http conn free %d free server %d\n", hon_u->coq_l, htp_u->sev_l);
 #endif
     _http_serv_free(htp_u);
   }
@@ -592,7 +592,7 @@ _http_conn_new(u3_http* htp_u)
   _http_conn_link(htp_u, hon_u);
 
 #if 0
-  uL(fprintf(uH, "http conn neww %d server %d\n", hon_u->coq_l, htp_u->sev_l));
+  u3l_log("http conn neww %d server %d\n", hon_u->coq_l, htp_u->sev_l);
 #endif
 
   return hon_u;
@@ -758,7 +758,7 @@ static void
 _http_serv_free(u3_http* htp_u)
 {
 #if 0
-  uL(fprintf(uH, "http serv free %d\n", htp_u->sev_l));
+  u3l_log("http serv free %d\n", htp_u->sev_l);
 #endif
 
   c3_assert( 0 == htp_u->hon_u );
@@ -827,7 +827,7 @@ _http_serv_close(u3_http* htp_u)
   h2o_context_request_shutdown(&h2o_u->ctx_u);
 
 #if 0
-  uL(fprintf(uH, "http serv close %d %p\n", htp_u->sev_l, &htp_u->wax_u));
+  u3l_log("http serv close %d %p\n", htp_u->sev_l, &htp_u->wax_u);
 #endif
 
   uv_close((uv_handle_t*)&htp_u->wax_u, _http_serv_close_cb);
@@ -875,7 +875,7 @@ _http_serv_accept(u3_http* htp_u)
   if ( 0 != (sas_i = uv_accept((uv_stream_t*)&htp_u->wax_u,
                                (uv_stream_t*)&hon_u->wax_u)) ) {
     if ( (u3C.wag_w & u3o_verbose) ) {
-      uL(fprintf(uH, "http: accept: %s\n", uv_strerror(sas_i)));
+      u3l_log("http: accept: %s\n", uv_strerror(sas_i));
     }
 
     uv_close((uv_handle_t*)&hon_u->wax_u, _http_conn_free);
@@ -904,7 +904,7 @@ _http_serv_listen_cb(uv_stream_t* str_u, c3_i sas_i)
   u3_http* htp_u = (u3_http*)str_u;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "http: listen_cb: %s\n", uv_strerror(sas_i)));
+    u3l_log("http: listen_cb: %s\n", uv_strerror(sas_i));
   }
   else {
     _http_serv_accept(htp_u);
@@ -1012,7 +1012,7 @@ _http_serv_start(u3_http* htp_u)
         continue;
       }
 
-      uL(fprintf(uH, "http: listen: %s\n", uv_strerror(sas_i)));
+      u3l_log("http: listen: %s\n", uv_strerror(sas_i));
 
       if ( 0 != htp_u->rox_u ) {
         _proxy_serv_free(htp_u->rox_u);
@@ -1027,17 +1027,17 @@ _http_serv_start(u3_http* htp_u)
     }
 
     if ( 0 != htp_u->rox_u ) {
-      uL(fprintf(uH, "http: live (%s, %s) on %d (proxied on %d)\n",
-                   (c3y == htp_u->sec) ? "secure" : "insecure",
-                   (c3y == htp_u->lop) ? "loopback" : "public",
-                   htp_u->por_s,
-                   htp_u->rox_u->por_s));
+      u3l_log("http: live (%s, %s) on %d (proxied on %d)\n",
+              (c3y == htp_u->sec) ? "secure" : "insecure",
+              (c3y == htp_u->lop) ? "loopback" : "public",
+              htp_u->por_s,
+              htp_u->rox_u->por_s);
     }
     else {
-      uL(fprintf(uH, "http: live (%s, %s) on %d\n",
-                   (c3y == htp_u->sec) ? "secure" : "insecure",
-                   (c3y == htp_u->lop) ? "loopback" : "public",
-                   htp_u->por_s));
+      u3l_log("http: live (%s, %s) on %d\n",
+              (c3y == htp_u->sec) ? "secure" : "insecure",
+              (c3y == htp_u->lop) ? "loopback" : "public",
+              htp_u->por_s);
     }
 
     break;
@@ -1141,7 +1141,7 @@ _http_init_tls(uv_buf_t key_u, uv_buf_t cer_u)
     BIO_free(bio_u);
 
     if( 0 == sas_i ) {
-      uL(fprintf(uH, "http: load private key failed:\n"));
+      u3l_log("http: load private key failed:\n");
       ERR_print_errors_fp(uH);
       uL(1);
 
@@ -1159,7 +1159,7 @@ _http_init_tls(uv_buf_t key_u, uv_buf_t cer_u)
     X509_free(xer_u);
 
     if( 0 == sas_i ) {
-      uL(fprintf(uH, "http: load certificate failed:\n"));
+      u3l_log("http: load certificate failed:\n");
       ERR_print_errors_fp(uH);
       uL(1);
 
@@ -1341,25 +1341,25 @@ u3_http_ef_thou(c3_l     sev_l,
 
   if ( !(htp_u = _http_serv_find(sev_l)) ) {
     if ( bug_w ) {
-      uL(fprintf(uH, "http: server not found: %x\r\n", sev_l));
+      u3l_log("http: server not found: %x\r\n", sev_l);
     }
   }
   else if ( !(hon_u = _http_conn_find(htp_u, coq_l)) ) {
     if ( bug_w ) {
-      uL(fprintf(uH, "http: connection not found: %x/%d\r\n", sev_l, coq_l));
+      u3l_log("http: connection not found: %x/%d\r\n", sev_l, coq_l);
     }
   }
   else if ( !(req_u = _http_req_find(hon_u, seq_l)) ) {
     if ( bug_w ) {
-      uL(fprintf(uH, "http: request not found: %x/%d/%d\r\n",
-                     sev_l, coq_l, seq_l));
+      u3l_log("http: request not found: %x/%d/%d\r\n",
+              sev_l, coq_l, seq_l);
     }
   }
   else {
     u3_noun p_rep, q_rep, r_rep;
 
     if ( c3n == u3r_trel(rep, &p_rep, &q_rep, &r_rep) ) {
-      uL(fprintf(uH, "http: strange response\n"));
+      u3l_log("http: strange response\n");
     }
     else {
       _http_req_respond(req_u, u3k(p_rep), u3k(q_rep), u3k(r_rep));
@@ -1455,7 +1455,7 @@ _http_serv_restart(void)
     _http_serv_start_all();
   }
   else {
-    uL(fprintf(uH, "http: restarting servers to apply configuration\n"));
+    u3l_log("http: restarting servers to apply configuration\n");
 
     while ( 0 != htp_u ) {
       if ( c3y == htp_u->liv ) {
@@ -1507,7 +1507,7 @@ u3_http_ef_form(u3_noun fig)
        !( c3y == pro || c3n == pro ) ||
        !( c3y == log || c3n == log ) ||
        !( c3y == red || c3n == red ) ) {
-    uL(fprintf(uH, "http: form: invalid card\n"));
+    u3l_log("http: form: invalid card\n");
     u3z(fig);
     return;
   }
@@ -1832,17 +1832,17 @@ _proxy_write_cb(uv_write_t* wri_u, c3_i sas_i)
       proxy_write_ctx* ctx_u = wri_u->data;
 
       if ( ctx_u->str_u == (uv_stream_t*)ctx_u->con_u->upt_u ) {
-        uL(fprintf(uH, "proxy: write upstream: %s\n", uv_strerror(sas_i)));
+        u3l_log("proxy: write upstream: %s\n", uv_strerror(sas_i));
       }
       else if ( ctx_u->str_u == (uv_stream_t*)&(ctx_u->con_u->don_u) ) {
-        uL(fprintf(uH, "proxy: write downstream: %s\n", uv_strerror(sas_i)));
+        u3l_log("proxy: write downstream: %s\n", uv_strerror(sas_i));
       }
       else {
-        uL(fprintf(uH, "proxy: write: %s\n", uv_strerror(sas_i)));
+        u3l_log("proxy: write: %s\n", uv_strerror(sas_i));
       }
     }
     else {
-      uL(fprintf(uH, "proxy: write: %s\n", uv_strerror(sas_i)));
+      u3l_log("proxy: write: %s\n", uv_strerror(sas_i));
     }
   }
 
@@ -1888,7 +1888,7 @@ _proxy_read_downstream_cb(uv_stream_t* don_u,
 
   if ( 0 > siz_w ) {
     if ( UV_EOF != siz_w ) {
-      uL(fprintf(uH, "proxy: read downstream: %s\n", uv_strerror(siz_w)));
+      u3l_log("proxy: read downstream: %s\n", uv_strerror(siz_w));
     }
     _proxy_conn_close(con_u);
   }
@@ -1909,7 +1909,7 @@ _proxy_read_upstream_cb(uv_stream_t* upt_u,
 
   if ( 0 > siz_w ) {
     if ( UV_EOF != siz_w ) {
-      uL(fprintf(uH, "proxy: read upstream: %s\n", uv_strerror(siz_w)));
+      u3l_log("proxy: read upstream: %s\n", uv_strerror(siz_w));
     }
     _proxy_conn_close(con_u);
   }
@@ -1950,7 +1950,7 @@ _proxy_loop_connect_cb(uv_connect_t * upc_u, c3_i sas_i)
   u3_pcon* con_u = upc_u->data;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "proxy: connect: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: connect: %s\n", uv_strerror(sas_i));
     _proxy_conn_close(con_u);
   }
   else {
@@ -2010,7 +2010,7 @@ _proxy_loop_connect(u3_pcon* con_u)
   if ( 0 != (sas_i = uv_tcp_connect(upc_u, upt_u,
                                     (const struct sockaddr*)&lop_u,
                                     _proxy_loop_connect_cb)) ) {
-    uL(fprintf(uH, "proxy: connect: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: connect: %s\n", uv_strerror(sas_i));
     free(upc_u);
     _proxy_conn_close(con_u);
   }
@@ -2192,7 +2192,7 @@ _proxy_wcon_peek_read_cb(uv_stream_t* upt_u,
 
   if ( 0 > siz_w ) {
     if ( UV_EOF != siz_w ) {
-      uL(fprintf(uH, "proxy: ward peek: %s\n", uv_strerror(siz_w)));
+      u3l_log("proxy: ward peek: %s\n", uv_strerror(siz_w));
     }
     _proxy_wcon_close(won_u);
   }
@@ -2204,7 +2204,7 @@ _proxy_wcon_peek_read_cb(uv_stream_t* upt_u,
     if ( ((len_w + 1) != siz_w) ||
          (len_w != buf_u->base[0]) ||
          (0 != memcmp(rev_u->non_u.base, buf_u->base + 1, len_w)) ) {
-      // uL(fprintf(uH, "proxy: ward auth fail\n"));
+      // u3l_log("proxy: ward auth fail\n");
       _proxy_wcon_unlink(won_u);
       _proxy_wcon_close(won_u);
     }
@@ -2243,7 +2243,7 @@ _proxy_ward_accept(u3_ward* rev_u)
 
   if ( 0 != (sas_i = uv_accept((uv_stream_t*)&rev_u->tcp_u,
                                (uv_stream_t*)&won_u->upt_u)) ) {
-    uL(fprintf(uH, "proxy: accept: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: accept: %s\n", uv_strerror(sas_i));
     _proxy_wcon_close(won_u);
   }
   else {
@@ -2259,7 +2259,7 @@ _proxy_ward_listen_cb(uv_stream_t* tcp_u, c3_i sas_i)
   u3_ward* rev_u = (u3_ward*)tcp_u;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "proxy: ward: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: ward: %s\n", uv_strerror(sas_i));
   }
   else {
     _proxy_ward_accept(rev_u);
@@ -2274,7 +2274,7 @@ _proxy_ward_timer_cb(uv_timer_t* tim_u)
   u3_ward* rev_u = tim_u->data;
 
   if ( 0 != rev_u ) {
-    uL(fprintf(uH, "proxy: ward expired: %d\n", rev_u->por_s));
+    u3l_log("proxy: ward expired: %d\n", rev_u->por_s);
     _proxy_ward_close(rev_u);
     _proxy_conn_close(rev_u->con_u);
   }
@@ -2337,7 +2337,7 @@ _proxy_ward_start(u3_pcon* con_u, u3_noun sip)
                                TCP_BACKLOG, _proxy_ward_listen_cb)) ||
        0 != (sas_i = uv_tcp_getsockname(&rev_u->tcp_u,
                                         (struct sockaddr*)&add_u, &add_i))) {
-    uL(fprintf(uH, "proxy: ward: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: ward: %s\n", uv_strerror(sas_i));
     _proxy_ward_close(rev_u);
     _proxy_conn_close(con_u);
   }
@@ -2348,7 +2348,7 @@ _proxy_ward_start(u3_pcon* con_u, u3_noun sip)
     {
       u3_noun who = u3dc("scot", 'p', u3k(sip));
       c3_c* who_c = u3r_string(who);
-      fprintf(stderr, "\r\nward for %s started on %u\r\n", who_c, rev_u->por_s);
+      u3l_log("\r\nward for %s started on %u\r\n", who_c, rev_u->por_s);
       free(who_c);
       u3z(who);
     }
@@ -2373,7 +2373,7 @@ _proxy_ward_connect_cb(uv_connect_t * upc_u, c3_i sas_i)
   u3_pcon* con_u = upc_u->data;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "proxy: ward connect: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: ward connect: %s\n", uv_strerror(sas_i));
     _proxy_conn_close(con_u);
   }
   else {
@@ -2415,7 +2415,7 @@ _proxy_ward_connect(u3_warc* cli_u)
   if ( 0 != (sas_i = uv_tcp_connect(upc_u, &con_u->don_u,
                                     (const struct sockaddr*)&add_u,
                                     _proxy_ward_connect_cb)) ) {
-      uL(fprintf(uH, "proxy: ward connect: %s\n", uv_strerror(sas_i)));
+      u3l_log("proxy: ward connect: %s\n", uv_strerror(sas_i));
       free(upc_u);
       _proxy_conn_close(con_u);
   }
@@ -2431,7 +2431,7 @@ _proxy_ward_resolve_cb(uv_getaddrinfo_t* adr_u,
   u3_warc* cli_u = adr_u->data;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "proxy: ward: resolve: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: ward: resolve: %s\n", uv_strerror(sas_i));
     _proxy_warc_free(cli_u);
   }
   else {
@@ -2477,7 +2477,7 @@ _proxy_ward_resolve(u3_warc* cli_u)
 
   if ( 0 != (sas_i = uv_getaddrinfo(u3L, adr_u, _proxy_ward_resolve_cb,
                                          cli_u->hot_c, 0, &hin_u)) ) {
-    uL(fprintf(uH, "proxy: ward: resolve: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: ward: resolve: %s\n", uv_strerror(sas_i));
     _proxy_warc_free(cli_u);
   }
 }
@@ -2657,13 +2657,13 @@ _proxy_peek(u3_pcon* con_u)
     default: c3_assert(0);
 
     case u3_pars_fail: {
-      uL(fprintf(uH, "proxy: peek fail\n"));
+      u3l_log("proxy: peek fail\n");
       _proxy_conn_close(con_u);
       break;
     }
 
     case u3_pars_moar: {
-      uL(fprintf(uH, "proxy: peek moar\n"));
+      u3l_log("proxy: peek moar\n");
       // XX count retries, fail after some n
       _proxy_peek_read(con_u);
       break;
@@ -2692,7 +2692,7 @@ _proxy_peek_read_cb(uv_stream_t* don_u,
 
   if ( 0 > siz_w ) {
     if ( UV_EOF != siz_w ) {
-      uL(fprintf(uH, "proxy: peek: %s\n", uv_strerror(siz_w)));
+      u3l_log("proxy: peek: %s\n", uv_strerror(siz_w));
     }
     _proxy_conn_close(con_u);
   }
@@ -2787,7 +2787,7 @@ _proxy_serv_accept(u3_prox* lis_u)
   c3_i sas_i;
   if ( 0 != (sas_i = uv_accept((uv_stream_t*)&lis_u->sev_u,
                                (uv_stream_t*)&con_u->don_u)) ) {
-    uL(fprintf(uH, "proxy: accept: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: accept: %s\n", uv_strerror(sas_i));
     _proxy_conn_close(con_u);
   }
   else {
@@ -2803,7 +2803,7 @@ _proxy_serv_listen_cb(uv_stream_t* sev_u, c3_i sas_i)
   u3_prox* lis_u = (u3_prox*)sev_u;
 
   if ( 0 != sas_i ) {
-    uL(fprintf(uH, "proxy: listen_cb: %s\n", uv_strerror(sas_i)));
+    u3l_log("proxy: listen_cb: %s\n", uv_strerror(sas_i));
   }
   else {
     _proxy_serv_accept(lis_u);
@@ -2848,7 +2848,7 @@ _proxy_serv_start(u3_prox* lis_u)
         continue;
       }
 
-      uL(fprintf(uH, "proxy: listen: %s\n", uv_strerror(sas_i)));
+      u3l_log("proxy: listen: %s\n", uv_strerror(sas_i));
       _proxy_serv_free(lis_u);
       return 0;
     }
@@ -2869,7 +2869,7 @@ u3_http_ef_that(u3_noun tat)
        ( c3n == u3a_is_cat(por) ) ||
        !( c3y == sec || c3n == sec ) ||
        ( c3n == u3ud(non) ) ) {
-    uL(fprintf(uH, "http: that: invalid card\n"));
+    u3l_log("http: that: invalid card\n");
   }
   else {
     u3_http* htp_u;
@@ -2885,8 +2885,8 @@ u3_http_ef_that(u3_noun tat)
     //  so this situation can be avoided
     //
     if ( 0 == htp_u ) {
-      uL(fprintf(uH, "http: that: no %s server\n", (c3y == sec) ?
-                                                   "secure" : "insecure"));
+      u3l_log("http: that: no %s server\n",
+              (c3y == sec) ? "secure" : "insecure");
     }
     else {
       cli_u = _proxy_warc_new(htp_u, (u3_atom)u3k(sip), (u3_atom)u3k(non),

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -1142,8 +1142,8 @@ _http_init_tls(uv_buf_t key_u, uv_buf_t cer_u)
 
     if( 0 == sas_i ) {
       u3l_log("http: load private key failed:\n");
-      ERR_print_errors_fp(uH);
-      uL(1);
+      ERR_print_errors_fp(u3_term_io_hija());
+      u3_term_io_loja(1);
 
       SSL_CTX_free(tls_u);
 
@@ -1160,8 +1160,8 @@ _http_init_tls(uv_buf_t key_u, uv_buf_t cer_u)
 
     if( 0 == sas_i ) {
       u3l_log("http: load certificate failed:\n");
-      ERR_print_errors_fp(uH);
-      uL(1);
+      ERR_print_errors_fp(u3_term_io_hija());
+      u3_term_io_loja(1);
 
       BIO_free(bio_u);
       SSL_CTX_free(tls_u);

--- a/pkg/urbit/vere/newt.c
+++ b/pkg/urbit/vere/newt.c
@@ -54,15 +54,14 @@ _newt_consume(u3_moat* mot_u)
         memcpy(met_u->hun_y, mot_u->rag_y, mot_u->len_d);
 
 #if 0
-          fprintf(stderr,
-              "newt: %d: create: msg %p, new block %p, len %"
-              PRIu64 ", has %" PRIu64 ", needs %" PRIu64 "\r\n",
-              getpid(),
-              mot_u->mes_u,
-              met_u,
-              met_u->len_d,
-              mot_u->mes_u->has_d,
-              mot_u->mes_u->len_d);
+        u3l_log("newt: %d: create: msg %p, new block %p, len %"
+                PRIu64 ", has %" PRIu64 ", needs %" PRIu64 "\r\n",
+                getpid(),
+                mot_u->mes_u,
+                met_u,
+                met_u->len_d,
+                mot_u->mes_u->has_d,
+                mot_u->mes_u->len_d);
 #endif
         /* enqueue block
         */
@@ -97,9 +96,9 @@ _newt_consume(u3_moat* mot_u)
           nel_d |= ((c3_d) mot_u->rag_y[6]) << 48ULL;
           nel_d |= ((c3_d) mot_u->rag_y[7]) << 56ULL;
 #if 0
-          fprintf(stderr, "newt: %d: parsed length %" PRIu64 "\r\n",
-                          getpid(),
-                          nel_d);
+          u3l_log("newt: %d: parsed length %" PRIu64 "\r\n",
+                  getpid(),
+                  nel_d);
 #endif
           mot_u->len_d -= 8ULL;
 
@@ -225,13 +224,13 @@ _newt_read_cb(uv_stream_t*    str_u,
   u3_moat* mot_u = (void *)str_u;
 
   if ( UV_EOF == len_i ) {
-    // fprintf(stderr, "newt: %d: stream closed\r\n", getpid());
+    // u3l_log("newt: %d: stream closed\r\n", getpid());
     uv_read_stop(str_u);
     mot_u->bal_f(mot_u->vod_p, "stream closed");
   }
   else {
 #if 0
-    fprintf(stderr, "newt: %d: read %ld\r\n", getpid(), len_i);
+    u3l_log("newt: %d: read %ld\r\n", getpid(), len_i);
 #endif
 
     if ( mot_u->rag_y ) {
@@ -289,7 +288,7 @@ _newt_write_cb(uv_write_t* wri_u, c3_i sas_i)
   free(req_u);
 
   if ( 0 != sas_i ) {
-    fprintf(stderr, "newt: bad write %d\r\n", sas_i);
+    u3l_log("newt: bad write %d\r\n", sas_i);
     moj_u->bal_f(vod_p, uv_strerror(sas_i));
   }
 }
@@ -323,7 +322,7 @@ u3_newt_write(u3_mojo* moj_u,
   buf_u.len = len_w + 8;
 
 #if 0
-  fprintf(stderr, "newt: %d: write %d\n", getpid(), len_w + 8);
+  u3l_log("newt: %d: write %d\n", getpid(), len_w + 8);
 #endif
   if ( 0 != (err_i = uv_write((uv_write_t*)req_u,
                               (uv_stream_t*)&moj_u->pyp_u,

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -903,6 +903,16 @@ _pier_work_play(u3_pier* pir_u,
   _pier_boot_ready(pir_u);
 }
 
+/* _pier_work_stdr(): prints an error message to stderr
+ */
+static void
+_pier_work_stdr(u3_writ* wit_u, u3_noun cord)
+{
+  c3_c* str = u3r_string(cord);
+  u3C.stderr_log_f(str);
+  free(str);
+}
+
 /* _pier_work_slog(): print directly.
 */
 static void
@@ -1082,6 +1092,23 @@ _pier_work_poke(void*   vod_p,
           goto error;
         }
         _pier_work_complete(wit_u, mug_l, u3k(r_jar));
+      }
+      break;
+    }
+
+    case c3__stdr: {
+      if ( (c3n == u3r_trel(jar, 0, &p_jar, &q_jar)) ||
+           (c3n == u3ud(p_jar)) ||
+           (u3r_met(6, p_jar) != 1) ||
+           (c3n == u3ud(q_jar)) )
+      {
+        goto error;
+      }
+      else {
+        c3_d     evt_d = u3r_chub(0, p_jar);
+        u3_writ* wit_u = _pier_writ_find(pir_u, evt_d);
+
+        _pier_work_stdr(wit_u, q_jar);
       }
       break;
     }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -78,7 +78,7 @@ _pier_disk_bail(void* vod_p, const c3_c* err_c)
 {
   // u3_writ* wit_u = vod_p;
 
-  fprintf(stderr, "disk error: %s\r\n", err_c);
+  u3l_log("disk error: %s\r\n", err_c);
 }
 
 /* _pier_work_bail(): handle subprocess error.
@@ -87,7 +87,7 @@ static void
 _pier_work_bail(void*       vod_p,
                 const c3_c* err_c)
 {
-  fprintf(stderr, "pier: work error: %s\r\n", err_c);
+  u3l_log("pier: work error: %s\r\n", err_c);
 }
 
 /* _pier_save_boot_complete(): commit complete.
@@ -214,7 +214,7 @@ _pier_disk_commit_complete(void* vod_p)
   u3_disk* log_u = pir_u->log_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): commit: complete\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): commit: complete\r\n", wit_u->evt_d);
 #endif
 
   /* advance commit counter
@@ -237,7 +237,7 @@ _pier_disk_commit_request(u3_writ* wit_u)
   u3_disk* log_u = pir_u->log_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
 #endif
 
   /* append to logfile
@@ -270,7 +270,7 @@ _pier_writ_unlink(u3_writ* wit_u)
   u3_pier* pir_u = wit_u->pir_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): delete\r\n", wit_u->evt_d);
 #endif
 
   pir_u->ext_u = wit_u->nex_u;
@@ -323,7 +323,7 @@ _pier_work_release(u3_writ* wit_u)
   }
   else {
 #ifdef VERBOSE_EVENTS
-    fprintf(stderr, "pier: (%" PRIu64 "): compute: release\r\n", wit_u->evt_d);
+    u3l_log("pier: (%" PRIu64 "): compute: release\r\n", wit_u->evt_d);
 #endif
 
     //  advance release counter
@@ -461,7 +461,7 @@ _pier_work_complete(u3_writ* wit_u,
   u3_controller* god_u = pir_u->god_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): compute: complete\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): compute: complete\r\n", wit_u->evt_d);
 #endif
 
   god_u->dun_d += 1;
@@ -484,7 +484,7 @@ _pier_work_replace(u3_writ* wit_u,
   u3_controller* god_u = pir_u->god_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): compute: replace\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): compute: replace\r\n", wit_u->evt_d);
 #endif
 
   c3_assert(god_u->sen_d == wit_u->evt_d);
@@ -511,7 +511,7 @@ _pier_work_compute(u3_writ* wit_u)
   u3_controller* god_u = pir_u->god_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): compute: request\r\n", wit_u->evt_d);
+  u3l_log("pier: (%" PRIu64 "): compute: request\r\n", wit_u->evt_d);
 #endif
 
   c3_assert(wit_u->evt_d == (1 + god_u->sen_d));
@@ -752,7 +752,7 @@ _pier_disk_load_commit(u3_pier* pir_u,
   c3_assert ( 0 != log_u->fol_u );
 
 #ifdef VERBOSE_EVENTS
-    fprintf(stderr, "pier: load: commit: at %" PRIx64 "\r\n", pos_d);
+    u3l_log("pier: load: commit: at %" PRIx64 "\r\n", pos_d);
 #endif
 
   while ( pos_d ) {
@@ -821,7 +821,7 @@ _pier_disk_load_commit(u3_pier* pir_u,
       u3_writ* wit_u = c3_calloc(sizeof(u3_writ));
 
 #ifdef VERBOSE_EVENTS
-      fprintf(stderr, "pier: load: commit: %" PRIu64 "\r\n", evt_d);
+      u3l_log("pier: load: commit: %" PRIu64 "\r\n", evt_d);
 #endif
 
       wit_u->pir_u = pir_u;
@@ -836,10 +836,10 @@ _pier_disk_load_commit(u3_pier* pir_u,
       }
       else {
         if ( (1ULL + wit_u->evt_d) != pir_u->ext_u->evt_d ) {
-          fprintf(stderr, "pier: load: commit: event gap: %" PRIx64 ", %"
-                           PRIx64 "\r\n",
-                           wit_u->evt_d,
-                           pir_u->ext_u->evt_d);
+          u3l_log("pier: load: commit: event gap: %" PRIx64 ", %"
+                  PRIx64 "\r\n",
+                  wit_u->evt_d,
+                  pir_u->ext_u->evt_d);
           u3z(mat);
           u3z(job);
           _pier_disk_bail(0, "pier: load: comit: event gap");
@@ -913,7 +913,7 @@ _pier_boot_vent(u3_boot* bot_u)
     pro = u3m_soft(0, u3ke_cue, u3k(pil_p));
 
     if ( 0 != u3h(pro) ) {
-      fprintf(stderr, "boot: failed: unable to parse pill\r\n");
+      u3l_log("boot: failed: unable to parse pill\r\n");
       exit(1);
     }
 
@@ -1120,9 +1120,9 @@ _pier_boot_ready(u3_pier* pir_u)
     //
     _pier_work_boot(pir_u, c3y);
 
-    fprintf(stderr, "boot: ship: %s%s\r\n",
-                     pir_u->who_c,
-                     (c3y == pir_u->fak_o) ? " (fake)" : "");
+    u3l_log("boot: ship: %s%s\r\n",
+            pir_u->who_c,
+            (c3y == pir_u->fak_o) ? " (fake)" : "");
 
     pir_u->sat_e = u3_psat_boot;
   }
@@ -1131,7 +1131,7 @@ _pier_boot_ready(u3_pier* pir_u)
   else if ( god_u->dun_d < log_u->com_d ) {
     c3_assert( 0 != log_u->com_d );
 
-    fprintf(stderr, "---------------- playback starting----------------\r\n");
+    u3l_log("---------------- playback starting----------------\r\n");
 
     //  set the boot barrier to the last committed event
     //
@@ -1142,18 +1142,18 @@ _pier_boot_ready(u3_pier* pir_u)
     _pier_disk_load_commit(pir_u, (1ULL + god_u->dun_d), 1000ULL);
 
     if ( 0 == god_u->dun_d ) {
-      fprintf(stderr, "pier: replaying events 1 through %" PRIu64 "\r\n",
-                      log_u->com_d);
+      u3l_log("pier: replaying events 1 through %" PRIu64 "\r\n",
+              log_u->com_d);
 
       //  prepare worker for replay of boot sequence, don't write log header
       //
       _pier_work_boot(pir_u, c3n);
     }
     else {
-      fprintf(stderr, "pier: replaying events %" PRIu64
-                      " through %" PRIu64 "\r\n",
-                      god_u->dun_d,
-                      log_u->com_d);
+      u3l_log("pier: replaying events %" PRIu64
+              " through %" PRIu64 "\r\n",
+              god_u->dun_d,
+              log_u->com_d);
     }
 
     pir_u->sat_e = u3_psat_pace;
@@ -1215,7 +1215,7 @@ _pier_disk_init(u3_disk* log_u)
     c3_d* buf_d = u3_foil_reveal(log_u->fol_u, &pos_d, &len_d);
 
     if ( !buf_d ) {
-      fprintf(stderr, "pier: load: commit: corrupt\r\n");
+      u3l_log("pier: load: commit: corrupt\r\n");
       return c3n;
     }
 
@@ -1233,7 +1233,7 @@ _pier_disk_init(u3_disk* log_u)
     }
 
 #ifdef VERBOSE_EVENTS
-    fprintf(stderr, "pier: load: last %" PRIu64 "\r\n", evt_d);
+    u3l_log("pier: load: last %" PRIu64 "\r\n", evt_d);
 #endif
 
     c3_free(buf_d);
@@ -1332,7 +1332,7 @@ _pier_work_play(u3_pier* pir_u,
   u3_controller* god_u = pir_u->god_u;
 
 #ifdef VERBOSE_EVENTS
-  fprintf(stderr, "pier: (%" PRIu64 "): boot at mug %x\r\n", lav_d, mug_l);
+  u3l_log("pier: (%" PRIu64 "): boot at mug %x\r\n", lav_d, mug_l);
 #endif
 
   c3_assert( c3n == god_u->liv_o );
@@ -1355,7 +1355,7 @@ _pier_work_exit(uv_process_t* req_u,
   u3_controller* god_u = (void *) req_u;
   u3_pier* pir_u = god_u->pir_u;
 
-  fprintf(stderr, "pier: exit: status %" PRIu64 ", signal %d\r\n", sas_i, sig_i);
+  u3l_log("pier: exit: status %" PRIu64 ", signal %d\r\n", sas_i, sig_i);
   uv_close((uv_handle_t*) req_u, 0);
 
   _pier_disk_shutdown(pir_u);
@@ -1464,7 +1464,7 @@ _pier_work_poke(void*   vod_p,
           }
 
         }
-        fprintf(stderr, "pier: replace: %" PRIu64 "\r\n", evt_d);
+        u3l_log("pier: replace: %" PRIu64 "\r\n", evt_d);
 
         _pier_work_replace(wit_u, u3k(r_jar), u3k(mat));
       }
@@ -1486,7 +1486,7 @@ _pier_work_poke(void*   vod_p,
         u3_writ* wit_u = _pier_work_writ(pir_u, evt_d);
 
         if ( !wit_u ) {
-          fprintf(stderr, "poke: no writ: %" PRIu64 "\r\n", evt_d);
+          u3l_log("poke: no writ: %" PRIu64 "\r\n", evt_d);
           goto error;
         }
         _pier_work_complete(wit_u, mug_l, u3k(r_jar));
@@ -1562,9 +1562,9 @@ _pier_work_create(u3_pier* pir_u)
     god_u->ops_u.file = arg_c[0];
     god_u->ops_u.args = arg_c;
 
-    fprintf(stderr, "pier: spawn\r\n");
+    u3l_log("pier: spawn\r\n");
     if ( (err_i = uv_spawn(u3L, &god_u->cub_u, &god_u->ops_u)) ) {
-      fprintf(stderr, "spawn: %s: %s\r\n", arg_c[0], uv_strerror(err_i));
+      u3l_log("spawn: %s: %s\r\n", arg_c[0], uv_strerror(err_i));
 
       return 0;
     }
@@ -1653,7 +1653,7 @@ u3_pier_discover(u3_pier* pir_u,
 static void
 _pier_exit_done(u3_pier* pir_u)
 {
-  fprintf(stderr, "pier: exit\r\n");
+  u3l_log("pier: exit\r\n");
 
   _pier_work_shutdown(pir_u);
   _pier_loop_exit(pir_u);
@@ -1716,7 +1716,7 @@ void
 c3_rand(c3_w* rad_w)
 {
   if ( 0 != ent_getentropy(rad_w, 64) ) {
-    uL(fprintf(uH, "c3_rand getentropy: %s\n", strerror(errno)));
+    u3l_log("c3_rand getentropy: %s\n", strerror(errno));
     //  XX review
     //
     u3_pier_bail();
@@ -1866,10 +1866,10 @@ _pier_boot_complete(u3_pier* pir_u)
   }
 
   if ( u3_psat_boot == pir_u->sat_e ) {
-    fprintf(stderr, "pier: boot complete\r\n");
+    u3l_log("pier: boot complete\r\n");
   }
   else if ( u3_psat_pace == pir_u->sat_e ) {
-    fprintf(stderr, "\n\r---------------- playback complete----------------\r\n");
+    u3l_log("\n\r---------------- playback complete----------------\r\n");
   }
 
   pir_u->sat_e = u3_psat_play;
@@ -2081,7 +2081,7 @@ u3_pier_mark(FILE* fil_u)
 
   while ( 0 < len_w ) {
     pir_u = u3K.tab_u[--len_w];
-    fprintf(stderr, "pier: %u\r\n", len_w);
+    u3l_log("pier: %u\r\n", len_w);
 
     if ( 0 != pir_u->bot_u ) {
       tot_w += u3a_maid(fil_u, "  boot event", u3a_mark_noun(pir_u->bot_u->ven));

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1099,7 +1099,7 @@ _pier_work_poke(void*   vod_p,
     case c3__stdr: {
       if ( (c3n == u3r_trel(jar, 0, &p_jar, &q_jar)) ||
            (c3n == u3ud(p_jar)) ||
-           (u3r_met(6, p_jar) != 1) ||
+           (u3r_met(6, p_jar) > 1) ||
            (c3n == u3ud(q_jar)) )
       {
         goto error;

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -26,7 +26,7 @@ _reck_mole(u3_noun  fot,
   if ( (c3n == u3r_cell(uco, &p_uco, &q_uco)) ||
        (u3_nul != p_uco) )
   {
-    uL(fprintf(uH, "strange mole %s\n", u3r_string(san)));
+    u3l_log("strange mole %s\n", u3r_string(san));
 
     u3z(fot); u3z(uco); return c3n;
   }
@@ -108,7 +108,7 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
       u3_noun lan = u3k(u3h(u3t(fav)));
       u3_noun pac = u3k(u3t(u3t(fav)));
 
-      fprintf(stderr, "kick: strange send\r\n");
+      u3l_log("kick: strange send\r\n");
       u3_ames_ef_send(pir_u, lan, pac);
       u3z(pox); u3z(fav); return c3y;
     } break;
@@ -125,7 +125,7 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
     {
       // daemon ignores %init
       // u3A->own = u3nc(u3k(p_fav), u3A->own);
-      // uL(fprintf(uH, "kick: init: %d\n", p_fav));
+      // u3l_log("kick: init: %d\n", p_fav);
       u3z(pox); u3z(fav); return c3y;
     } break;
 
@@ -288,7 +288,7 @@ _reck_kick_ames(u3_pier* pir_u, u3_noun pox, u3_noun fav)
     {
       // daemon ignores %init
       // u3A->own = u3nc(u3k(p_fav), u3A->own);
-      // uL(fprintf(uH, "kick: init: %d\n", p_fav));
+      // u3l_log("kick: init: %d\n", p_fav);
       u3z(pox); u3z(fav); return c3y;
     } break;
   }
@@ -380,7 +380,7 @@ _reck_kick_spec(u3_pier* pir_u, u3_noun pox, u3_noun fav)
         // daemon ignores %init
         // p_fav = u3t(fav);
         // u3A->own = u3nc(u3k(p_fav), u3A->own);
-        // uL(fprintf(uH, "kick: init: %d\n", p_fav));
+        // u3l_log("kick: init: %d\n", p_fav);
         u3z(pox); u3z(fav); return c3y;
       } break;
 
@@ -393,7 +393,7 @@ _reck_kick_spec(u3_pier* pir_u, u3_noun pox, u3_noun fav)
              (u3_nul != q_pud) ||
              (c3n == _reck_orchid(c3__ud, u3k(p_pud), &tid_l)) )
         {
-          uL(fprintf(uH, "term: bad tire\n"));
+          u3l_log("term: bad tire\n");
           u3z(pox); u3z(fav); return c3n;
         } else {
           return _reck_kick_term(pir_u, pox, tid_l, fav);
@@ -418,7 +418,7 @@ _reck_kick_norm(u3_pier* pir_u, u3_noun pox, u3_noun fav)
 
     case c3__vega:
     {
-      uL(fprintf(uH, "<<<reset>>>\n"));
+      u3l_log("<<<reset>>>\n");
       u3z(pox); u3z(fav);
 
       //  reclaim memory from persistent caches
@@ -429,7 +429,7 @@ _reck_kick_norm(u3_pier* pir_u, u3_noun pox, u3_noun fav)
     }
     case c3__exit:
     {
-      uL(fprintf(uH, "<<<goodbye>>>\n"));
+      u3l_log("<<<goodbye>>>\n");
       u3_pier_exit(pir_u);
 
       u3z(pox); u3z(fav); return c3y;
@@ -466,9 +466,9 @@ u3_reck_kick(u3_pier* pir_u, u3_noun ovo)
     }
     else {
       u3_noun tox = u3do("spat", u3k(u3h(ovo)));
-      uL(fprintf(uH, "kick: lost %%%s on %s\n",
-                     u3r_string(u3h(u3t(ovo))),
-                     u3r_string(tox)));
+      u3l_log("kick: lost %%%s on %s\n",
+              u3r_string(u3h(u3t(ovo))),
+              u3r_string(tox));
       u3z(tox);
 #if 0
       if ( c3__hear == u3h(u3t(ovo)) ) {

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -123,7 +123,7 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
 
     case c3__init: p_fav = u3t(fav);
     {
-      // king ignores %init
+      // daemon ignores %init
       // u3A->own = u3nc(u3k(p_fav), u3A->own);
       // uL(fprintf(uH, "kick: init: %d\n", p_fav));
       u3z(pox); u3z(fav); return c3y;
@@ -133,9 +133,9 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
     {
       u3z(pox); u3z(fav);
 
-      //  gc the kingdom
+      //  gc the daemon area
       //
-      uv_timer_start(&u3K.tim_u, (uv_timer_cb)u3_king_grab, 0, 0);
+      uv_timer_start(&u3K.tim_u, (uv_timer_cb)u3_daemon_grab, 0, 0);
       return c3y;
     } break;
   }
@@ -286,7 +286,7 @@ _reck_kick_ames(u3_pier* pir_u, u3_noun pox, u3_noun fav)
     default: break;
     case c3__init: p_fav = u3t(fav);
     {
-      // king ignores %init
+      // daemon ignores %init
       // u3A->own = u3nc(u3k(p_fav), u3A->own);
       // uL(fprintf(uH, "kick: init: %d\n", p_fav));
       u3z(pox); u3z(fav); return c3y;
@@ -377,7 +377,7 @@ _reck_kick_spec(u3_pier* pir_u, u3_noun pox, u3_noun fav)
       } break;
 
       case c3__init: {
-        // king ignores %init
+        // daemon ignores %init
         // p_fav = u3t(fav);
         // u3A->own = u3nc(u3k(p_fav), u3A->own);
         // uL(fprintf(uH, "kick: init: %d\n", p_fav));

--- a/pkg/urbit/vere/save.c
+++ b/pkg/urbit/vere/save.c
@@ -31,7 +31,7 @@ u3_save_ef_chld(u3_pier *pir_u)
 
   /* modified for cases with no pid_w
   */
-  uL(fprintf(uH, "checkpoint: complete %d\n", sav_u->pid_w));
+  u3l_log("checkpoint: complete %d\n", sav_u->pid_w);
   pid_w = wait(&loc_i);
   if (0 != sav_u->pid_w) {
     c3_assert(pid_w == sav_u->pid_w);

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -255,7 +255,7 @@ u3_term_io_init()
                                       _term_spinner_cb,
                                       uty_u);
         if ( 0 != ret_w ) {
-          uL(fprintf(uH, "term: spinner start: %s\n", uv_strerror(ret_w)));
+          u3l_log("term: spinner start: %s\n", uv_strerror(ret_w));
           free(uty_u->tat_u.sun.sit_u);
           uty_u->tat_u.sun.sit_u = NULL;
           uv_mutex_unlock(&uty_u->tat_u.mex_u);
@@ -302,7 +302,7 @@ u3_term_io_exit(void)
         //  XX can block exit waiting for wakeup (max _SPIN_COOL_US)
         c3_w ret_w;
         if ( 0 != (ret_w = uv_thread_join(sit_u)) ) {
-          uL(fprintf(uH, "term: spinner exit: %s\n", uv_strerror(ret_w)));
+          u3l_log("term: spinner exit: %s\n", uv_strerror(ret_w));
         }
         else {
           uv_mutex_destroy(&uty_u->tat_u.mex_u);
@@ -344,7 +344,7 @@ _term_write_cb(uv_write_t* wri_u, c3_i sas_i)
   _u3_write_t* ruq_u = (void *)wri_u;
 
   if ( 0 != sas_i ) {
-    // uL(fprintf(uH, "term: write: ERROR\n"));
+    // u3l_log("term: write: ERROR\n");
   }
   free(ruq_u->buf_y);
   free(ruq_u);
@@ -365,7 +365,7 @@ _term_it_write_buf(u3_utty* uty_u, uv_buf_t buf_u)
                      &buf_u, 1,
                               _term_write_cb)) )
   {
-    uL(fprintf(uH, "terminal: %s\n", uv_strerror(ret_w)));
+    u3l_log("terminal: %s\n", uv_strerror(ret_w));
   }
 }
 
@@ -657,10 +657,10 @@ _term_io_suck_char(u3_utty* uty_u, c3_y cay_y)
       u3_noun huv = u3i_bytes(tat_u->fut.wid_w, tat_u->fut.syb_y);
       u3_noun wug;
 
-      // uL(fprintf(uH, "muck-utf8 len %d\n", tat_u->fut.len_w));
-      // uL(fprintf(uH, "muck-utf8 %x\n", huv));
+      // u3l_log("muck-utf8 len %d\n", tat_u->fut.len_w);
+      // u3l_log("muck-utf8 %x\n", huv);
       wug = u3do("taft", huv);
-      // uL(fprintf(uH, "muck-utf32 %x\n", tat_u->fut.len_w));
+      // u3l_log("muck-utf32 %x\n", tat_u->fut.len_w);
 
       tat_u->fut.len_w = tat_u->fut.wid_w = 0;
       _term_io_belt(uty_u, u3nt(c3__txt, wug, u3_nul));
@@ -728,11 +728,11 @@ _term_suck(u3_utty* uty_u, const c3_y* buf, ssize_t siz_i)
       //  The process hangs if we do nothing (and ctrl-z
       //  then corrupts the event log), so we force shutdown.
       //
-      fprintf(stderr, "term: hangup (EOF)\r\n");
+      u3l_log("term: hangup (EOF)\r\n");
       u3_pier_exit(u3_pier_stub());
     }
     else if ( siz_i < 0 ) {
-      uL(fprintf(uH, "term %d: read: %s\n", uty_u->tid_l, uv_strerror(siz_i)));
+      u3l_log("term %d: read: %s\n", uty_u->tid_l, uv_strerror(siz_i));
     }
     else {
       c3_i i;
@@ -1147,8 +1147,8 @@ u3_term_ef_blit(c3_l     tid_l,
   u3_utty* uty_u = _term_ef_get(tid_l);
 
   if ( 0 == uty_u ) {
-    // uL(fprintf(uH, "no terminal %d\n", tid_l));
-    // uL(fprintf(uH, "uty_u %p\n", u3_Host.uty_u));
+    // u3l_log("no terminal %d\n", tid_l);
+    // u3l_log("uty_u %p\n", u3_Host.uty_u);
 
     u3z(bls); return;
   }
@@ -1245,6 +1245,15 @@ u3_term_io_loja(int x)
       }
     }
   }
+}
+
+/* u3_term_it_log(): writes a log message
+*/
+void
+u3_term_io_log(c3_c* line)
+{
+  FILE* stream = u3_term_io_hija();
+  u3_term_io_loja(fprintf(stream, "%s", line));
 }
 
 /* u3_term_tape_to(): dump a tape to a file.

--- a/pkg/urbit/vere/unix.c
+++ b/pkg/urbit/vere/unix.c
@@ -84,35 +84,35 @@ _unix_rm_r_cb(const c3_c* pax_c,
 {
   switch ( typeflag ) {
     default:
-      uL(fprintf(uH, "bad file type in rm_r: %s\r\n", pax_c));
+      u3l_log("bad file type in rm_r: %s\r\n", pax_c);
       break;
     case FTW_F:
       if ( 0 != unlink(pax_c) && ENOENT != errno ) {
-        uL(fprintf(uH, "error unlinking (in rm_r) %s: %s\n",
-                   pax_c, strerror(errno)));
+        u3l_log("error unlinking (in rm_r) %s: %s\n",
+                pax_c, strerror(errno));
         c3_assert(0);
       }
       break;
     case FTW_D:
-      uL(fprintf(uH, "shouldn't have gotten pure directory: %s\r\n", pax_c));
+      u3l_log("shouldn't have gotten pure directory: %s\r\n", pax_c);
       break;
     case FTW_DNR:
-      uL(fprintf(uH, "couldn't read directory: %s\r\n", pax_c));
+      u3l_log("couldn't read directory: %s\r\n", pax_c);
       break;
     case FTW_NS:
-      uL(fprintf(uH, "couldn't stat path: %s\r\n", pax_c));
+      u3l_log("couldn't stat path: %s\r\n", pax_c);
       break;
     case FTW_DP:
       if ( 0 != rmdir(pax_c) && ENOENT != errno ) {
-        uL(fprintf(uH, "error rmdiring %s: %s\n", pax_c, strerror(errno)));
+        u3l_log("error rmdiring %s: %s\n", pax_c, strerror(errno));
         c3_assert(0);
       }
       break;
     case FTW_SL:
-      uL(fprintf(uH, "got symbolic link: %s\r\n", pax_c));
+      u3l_log("got symbolic link: %s\r\n", pax_c);
       break;
     case FTW_SLN:
-      uL(fprintf(uH, "got nonexistent symbolic link: %s\r\n", pax_c));
+      u3l_log("got nonexistent symbolic link: %s\r\n", pax_c);
       break;
   }
 
@@ -126,7 +126,7 @@ _unix_rm_r(c3_c* pax_c)
 {
   if ( 0 > nftw(pax_c, _unix_rm_r_cb, 100, FTW_DEPTH | FTW_PHYS )
        && ENOENT != errno) {
-    uL(fprintf(uH, "rm_r error on %s: %s\r\n", pax_c, strerror(errno)));
+    u3l_log("rm_r error on %s: %s\r\n", pax_c, strerror(errno));
   }
 }
 
@@ -136,7 +136,7 @@ static void
 _unix_mkdir(c3_c* pax_c)
 {
   if ( 0 != mkdir(pax_c, 0755) && EEXIST != errno) {
-    uL(fprintf(uH, "error mkdiring %s: %s\n", pax_c, strerror(errno)));
+    u3l_log("error mkdiring %s: %s\n", pax_c, strerror(errno));
     c3_assert(0);
   }
 }
@@ -153,8 +153,8 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
   u3_noun dat = u3t(u3t(mim));
 
   if ( fid_i < 0 ) {
-    uL(fprintf(uH, "error opening %s for writing: %s\r\n",
-               pax_c, strerror(errno)));
+    u3l_log("error opening %s for writing: %s\r\n",
+            pax_c, strerror(errno));
     u3z(mim);
     return 0;
   }
@@ -169,8 +169,8 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
   rit_w = write(fid_i, dat_y, siz_w);
 
   if ( rit_w != siz_w ) {
-    uL(fprintf(uH, "error writing %s: %s\r\n",
-               pax_c, strerror(errno)));
+    u3l_log("error writing %s: %s\r\n",
+            pax_c, strerror(errno));
     mug_w = 0;
   }
   else {
@@ -199,8 +199,8 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
       goto _unix_write_file_soft_go;
     }
     else {
-      uL(fprintf(uH, "error opening file (soft) %s: %s\r\n",
-                 fil_u->pax_c, strerror(errno)));
+      u3l_log("error opening file (soft) %s: %s\r\n",
+              fil_u->pax_c, strerror(errno));
       u3z(mim);
       return;
     }
@@ -212,18 +212,18 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
   red_ws = read(fid_i, old_y, len_ws);
 
   if ( close(fid_i) < 0 ) {
-    uL(fprintf(uH, "error closing file (soft) %s: %s\r\n",
-               fil_u->pax_c, strerror(errno)));
+    u3l_log("error closing file (soft) %s: %s\r\n",
+            fil_u->pax_c, strerror(errno));
   }
 
   if ( len_ws != red_ws ) {
     if ( red_ws < 0 ) {
-      uL(fprintf(uH, "error reading file (soft) %s: %s\r\n",
-                 fil_u->pax_c, strerror(errno)));
+      u3l_log("error reading file (soft) %s: %s\r\n",
+              fil_u->pax_c, strerror(errno));
     }
     else {
-      uL(fprintf(uH, "wrong # of bytes read in file %s: %d %d\r\n",
-                 fil_u->pax_c, len_ws, red_ws));
+      u3l_log("wrong # of bytes read in file %s: %d %d\r\n",
+              fil_u->pax_c, len_ws, red_ws);
     }
     free(old_y);
     u3z(mim);
@@ -299,8 +299,8 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
 {
   DIR* rid_u = opendir(mon_u->dir_u.pax_c);
   if ( !rid_u ) {
-    uL(fprintf(uH, "error opening pier directory: %s: %s\r\n",
-               mon_u->dir_u.pax_c, strerror(errno)));
+    u3l_log("error opening pier directory: %s: %s\r\n",
+            mon_u->dir_u.pax_c, strerror(errno));
     return;
   }
 
@@ -312,8 +312,8 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
     c3_w err_w;
 
     if ( 0 != (err_w = readdir_r(rid_u, &ent_u, &out_u)) ) {
-      uL(fprintf(uH, "erroring loading pier directory %s: %s\r\n",
-                 mon_u->dir_u.pax_c, strerror(errno)));
+      u3l_log("erroring loading pier directory %s: %s\r\n",
+              mon_u->dir_u.pax_c, strerror(errno));
       c3_assert(0);
     }
     else if ( !out_u ) {
@@ -331,8 +331,8 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
       struct stat buf_u;
 
       if ( 0 != stat(pax_c, &buf_u) ) {
-        uL(fprintf(uH, "can't stat pier directory %s: %s\r\n",
-                   mon_u->dir_u.pax_c, strerror(errno)));
+        u3l_log("can't stat pier directory %s: %s\r\n",
+                mon_u->dir_u.pax_c, strerror(errno));
         free(pax_c);
         continue;
       }
@@ -375,7 +375,7 @@ static void
 _unix_free_file(u3_ufil *fil_u)
 {
   if ( 0 != unlink(fil_u->pax_c) && ENOENT != errno ) {
-    uL(fprintf(uH, "error unlinking %s: %s\n", fil_u->pax_c, strerror(errno)));
+    u3l_log("error unlinking %s: %s\n", fil_u->pax_c, strerror(errno));
     c3_assert(0);
   }
 
@@ -487,7 +487,7 @@ _unix_delete_mount_point(u3_pier *pir_u, u3_noun mon)
 
   mon_u = pir_u->unx_u->mon_u;
   if ( !mon_u ) {
-    uL(fprintf(uH, "mount point already gone: %s\r\n", nam_c));
+    u3l_log("mount point already gone: %s\r\n", nam_c);
     goto _delete_mount_point_out;
   }
   if ( 0 == strcmp(nam_c, mon_u->nam_c) ) {
@@ -503,7 +503,7 @@ _unix_delete_mount_point(u3_pier *pir_u, u3_noun mon)
   }
 
   if ( !mon_u->nex_u ) {
-    uL(fprintf(uH, "mount point already gone: %s\r\n", nam_c));
+    u3l_log("mount point already gone: %s\r\n", nam_c);
     goto _delete_mount_point_out;
   }
 
@@ -623,8 +623,8 @@ _unix_update_file(u3_pier *pir_u, u3_ufil* fil_u)
       return u3nc(u3nc(_unix_string_to_path(pir_u, fil_u->pax_c), u3_nul), u3_nul);
     }
     else {
-      uL(fprintf(uH, "error opening file %s: %s\r\n",
-                 fil_u->pax_c, strerror(errno)));
+      u3l_log("error opening file %s: %s\r\n",
+              fil_u->pax_c, strerror(errno));
       return u3_nul;
     }
   }
@@ -635,18 +635,18 @@ _unix_update_file(u3_pier *pir_u, u3_ufil* fil_u)
   red_ws = read(fid_i, dat_y, len_ws);
 
   if ( close(fid_i) < 0 ) {
-    uL(fprintf(uH, "error closing file %s: %s\r\n",
-               fil_u->pax_c, strerror(errno)));
+    u3l_log("error closing file %s: %s\r\n",
+            fil_u->pax_c, strerror(errno));
   }
 
   if ( len_ws != red_ws ) {
     if ( red_ws < 0 ) {
-      uL(fprintf(uH, "error reading file %s: %s\r\n",
-                 fil_u->pax_c, strerror(errno)));
+      u3l_log("error reading file %s: %s\r\n",
+              fil_u->pax_c, strerror(errno));
     }
     else {
-      uL(fprintf(uH, "wrong # of bytes read in file %s: %d %d\r\n",
-                 fil_u->pax_c, len_ws, red_ws));
+      u3l_log("wrong # of bytes read in file %s: %d %d\r\n",
+              fil_u->pax_c, len_ws, red_ws);
     }
     free(dat_y);
     return u3_nul;
@@ -721,8 +721,8 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
 
           if ( (fid_i < 0) || (fstat(fid_i, &buf_u) < 0) ) {
             if ( ENOENT != errno ) {
-              uL(fprintf(uH, "_unix_update_dir: error opening file %s: %s\r\n",
-                         nod_u->pax_c, strerror(errno)));
+              u3l_log("_unix_update_dir: error opening file %s: %s\r\n",
+                      nod_u->pax_c, strerror(errno));
             }
 
             u3_unod* nex_u = nod_u->nex_u;
@@ -731,8 +731,8 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
           }
           else {
             if ( close(fid_i) < 0 ) {
-              uL(fprintf(uH, "_unix_update_dir: error closing file %s: %s\r\n",
-                         nod_u->pax_c, strerror(errno)));
+              u3l_log("_unix_update_dir: error closing file %s: %s\r\n",
+                      nod_u->pax_c, strerror(errno));
             }
 
             nod_u = nod_u->nex_u;
@@ -746,8 +746,8 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
 
   DIR* rid_u = opendir(dir_u->pax_c);
   if ( !rid_u ) {
-    uL(fprintf(uH, "error opening directory %s: %s\r\n",
-               dir_u->pax_c, strerror(errno)));
+    u3l_log("error opening directory %s: %s\r\n",
+            dir_u->pax_c, strerror(errno));
     c3_assert(0);
   }
 
@@ -757,8 +757,8 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
     c3_w err_w;
 
     if ( (err_w = readdir_r(rid_u, &ent_u, &out_u)) != 0 ) {
-      uL(fprintf(uH, "error loading directory %s: %s\r\n",
-                 dir_u->pax_c, strerror(err_w)));
+      u3l_log("error loading directory %s: %s\r\n",
+              dir_u->pax_c, strerror(err_w));
       c3_assert(0);
     }
     else if ( !out_u ) {
@@ -773,7 +773,7 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
       struct stat buf_u;
 
       if ( 0 != stat(pax_c, &buf_u) ) {
-        uL(fprintf(uH, "can't stat %s: %s\r\n", pax_c, strerror(errno)));
+        u3l_log("can't stat %s: %s\r\n", pax_c, strerror(errno));
         free(pax_c);
         continue;
       }
@@ -783,13 +783,13 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
           if ( 0 == strcmp(pax_c, nod_u->pax_c) ) {
             if ( S_ISDIR(buf_u.st_mode) ) {
               if ( c3n == nod_u->dir ) {
-                uL(fprintf(uH, "not a directory: %s\r\n", nod_u->pax_c));
+                u3l_log("not a directory: %s\r\n", nod_u->pax_c);
                 c3_assert(0);
               }
             }
             else {
               if ( c3y == nod_u->dir ) {
-                uL(fprintf(uH, "not a file: %s\r\n", nod_u->pax_c));
+                u3l_log("not a file: %s\r\n", nod_u->pax_c);
                 c3_assert(0);
               }
             }
@@ -824,8 +824,8 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
   }
 
   if ( closedir(rid_u) < 0 ) {
-    uL(fprintf(uH, "error closing directory %s: %s\r\n",
-               dir_u->pax_c, strerror(errno)));
+    u3l_log("error closing directory %s: %s\r\n",
+            dir_u->pax_c, strerror(errno));
   }
 
   if ( !dir_u->kid_u ) {
@@ -888,8 +888,8 @@ _unix_initial_update_file(c3_c* pax_c, c3_c* bas_c)
       return u3_nul;
     }
     else {
-      uL(fprintf(uH, "error opening initial file %s: %s\r\n",
-                 pax_c, strerror(errno)));
+      u3l_log("error opening initial file %s: %s\r\n",
+              pax_c, strerror(errno));
       return u3_nul;
     }
   }
@@ -900,18 +900,18 @@ _unix_initial_update_file(c3_c* pax_c, c3_c* bas_c)
   red_ws = read(fid_i, dat_y, len_ws);
 
   if ( close(fid_i) < 0 ) {
-    uL(fprintf(uH, "error closing initial file %s: %s\r\n",
-               pax_c, strerror(errno)));
+    u3l_log("error closing initial file %s: %s\r\n",
+            pax_c, strerror(errno));
   }
 
   if ( len_ws != red_ws ) {
     if ( red_ws < 0 ) {
-      uL(fprintf(uH, "error reading initial file %s: %s\r\n",
-                 pax_c, strerror(errno)));
+      u3l_log("error reading initial file %s: %s\r\n",
+              pax_c, strerror(errno));
     }
     else {
-      uL(fprintf(uH, "wrong # of bytes read in initial file %s: %d %d\r\n",
-                 pax_c, len_ws, red_ws));
+      u3l_log("wrong # of bytes read in initial file %s: %d %d\r\n",
+              pax_c, len_ws, red_ws);
     }
     free(dat_y);
     return u3_nul;
@@ -938,8 +938,8 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
 
   DIR* rid_u = opendir(pax_c);
   if ( !rid_u ) {
-    uL(fprintf(uH, "error opening initial directory: %s: %s\r\n",
-               pax_c, strerror(errno)));
+    u3l_log("error opening initial directory: %s: %s\r\n",
+            pax_c, strerror(errno));
     return u3_nul;
   }
 
@@ -949,8 +949,8 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
     c3_w err_w;
 
     if ( 0 != (err_w = readdir_r(rid_u, &ent_u, &out_u)) ) {
-      uL(fprintf(uH, "error loading initial directory %s: %s\r\n",
-                 pax_c, strerror(errno)));
+      u3l_log("error loading initial directory %s: %s\r\n",
+              pax_c, strerror(errno));
       c3_assert(0);
     }
     else if ( !out_u ) {
@@ -965,8 +965,8 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
       struct stat buf_u;
 
       if ( 0 != stat(pox_c, &buf_u) ) {
-        uL(fprintf(uH, "initial can't stat %s: %s\r\n",
-                   pox_c, strerror(errno)));
+        u3l_log("initial can't stat %s: %s\r\n",
+                pox_c, strerror(errno));
         free(pox_c);
         continue;
       }
@@ -983,8 +983,8 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
   }
 
   if ( closedir(rid_u) < 0 ) {
-    uL(fprintf(uH, "error closing initial directory %s: %s\r\n",
-               pax_c, strerror(errno)));
+    u3l_log("error closing initial directory %s: %s\r\n",
+            pax_c, strerror(errno));
   }
 
   return can;
@@ -1008,12 +1008,12 @@ _unix_sign_cb(uv_signal_t* sil_u, c3_i num_i)
 {
   {
     switch ( num_i ) {
-      default: fprintf(stderr, "\r\nmysterious signal %d\r\n", num_i); break;
+      default: u3l_log("\r\nmysterious signal %d\r\n", num_i); break;
       case SIGTERM:
         u3_pier_exit(u3_pier_stub());
         break;
       case SIGINT:
-        fprintf(stderr, "\r\ninterrupt\r\n");
+        u3l_log("\r\ninterrupt\r\n");
         u3_term_ef_ctlc();
         break;
       case SIGWINCH: u3_term_ef_winc(); break;
@@ -1094,16 +1094,16 @@ _unix_sync_change(u3_pier *pir_u, u3_udir* dir_u, u3_noun pax, u3_noun mim)
 
   if ( c3n == u3du(pax) ) {
     if ( u3_nul == pax ) {
-      uL(fprintf(uH,"can't sync out file as top-level, strange\r\n"));
+      u3l_log("can't sync out file as top-level, strange\r\n");
     }
     else {
-      uL(fprintf(uH,"sync out: bad path\r\n"));
+      u3l_log("sync out: bad path\r\n");
     }
     u3z(pax); u3z(mim);
     return;
   }
   else if ( c3n == u3du(u3t(pax)) ) {
-    uL(fprintf(uH,"can't sync out file as top-level, strangely\r\n"));
+    u3l_log("can't sync out file as top-level, strangely\r\n");
     u3z(pax); u3z(mim);
   }
   else {
@@ -1133,8 +1133,7 @@ _unix_sync_change(u3_pier *pir_u, u3_udir* dir_u, u3_noun pax, u3_noun mim)
       }
 
       if ( c3n == nod_u->dir ) {
-        uL(fprintf(uH,
-           "weird, we got a file when we weren't expecting to\r\n"));
+        u3l_log("weird, we got a file when we weren't expecting to\r\n");
         c3_assert(0);
       }
 
@@ -1228,7 +1227,7 @@ u3_unix_acquire(c3_c* pax_c)
 
   if ( NULL != (loq_u = fopen(paf_c, "r")) ) {
     if ( 1 != fscanf(loq_u, "%" SCNu32, &pid_w) ) {
-      uL(fprintf(uH, "lockfile %s is corrupt!\n", paf_c));
+      u3l_log("lockfile %s is corrupt!\n", paf_c);
       kill(getpid(), SIGTERM);
       sleep(1); c3_assert(0);
     }
@@ -1236,8 +1235,8 @@ u3_unix_acquire(c3_c* pax_c)
       c3_w i_w;
 
       if ( -1 != kill(pid_w, SIGTERM) ) {
-        uL(fprintf(uH, "unix: stopping process %d, live in %s...\n",
-                        pid_w, pax_c));
+        u3l_log("unix: stopping process %d, live in %s...\n",
+                pid_w, pax_c);
 
         for ( i_w = 0; i_w < 16; i_w++ ) {
           sleep(1);
@@ -1254,10 +1253,10 @@ u3_unix_acquire(c3_c* pax_c)
           }
         }
         if ( 16 == i_w ) {
-          uL(fprintf(uH, "process %d seems unkillable!\n", pid_w));
+          u3l_log("process %d seems unkillable!\n", pid_w);
           c3_assert(0);
         }
-        uL(fprintf(uH, "unix: stopped old process %u\n", pid_w));
+        u3l_log("unix: stopped old process %u\n", pid_w);
       }
     }
     fclose(loq_u);

--- a/pkg/urbit/vere/walk.c
+++ b/pkg/urbit/vere/walk.c
@@ -47,7 +47,7 @@ u3_walk_safe(c3_c* pas_c)
   c3_y*       pad_y;
 
   if ( (fid_i < 0) || (fstat(fid_i, &buf_b) < 0) ) {
-    // uL(fprintf(uH, "%s: %s\n", pas_c, strerror(errno)));
+    // u3l_log("%s: %s\n", pas_c, strerror(errno));
     return 0;
   }
   fln_w = buf_b.st_size;
@@ -79,7 +79,7 @@ u3_walk_load(c3_c* pas_c)
   c3_y*       pad_y;
 
   if ( (fid_i < 0) || (fstat(fid_i, &buf_b) < 0) ) {
-    uL(fprintf(uH, "%s: %s\n", pas_c, strerror(errno)));
+    u3l_log("%s: %s\n", pas_c, strerror(errno));
     return u3m_bail(c3__fail);
   }
   fln_w = buf_b.st_size;
@@ -125,7 +125,7 @@ _walk_mkdirp(c3_c* bas_c, u3_noun pax)
   pax_c[len_w] = '\0';
 
   if ( 0 != mkdir(pax_c, 0755) && EEXIST != errno ) {
-    uL(fprintf(uH, "error mkdiring %s: %s\n", pax_c, strerror(errno)));
+    u3l_log("error mkdiring %s: %s\n", pax_c, strerror(errno));
     u3m_bail(c3__fail);
   }
 
@@ -148,7 +148,7 @@ u3_walk_save(c3_c* pas_c, u3_noun tim, u3_atom pad, c3_c* bas_c, u3_noun pax)
       return u3_walk_save(pas_c, tim, pad, 0, u3_nul);
     }
 
-    uL(fprintf(uH, "%s: %s\n", pas_c, strerror(errno)));
+    u3l_log("%s: %s\n", pas_c, strerror(errno));
     u3m_bail(c3__fail);
   }
 
@@ -163,7 +163,7 @@ u3_walk_save(c3_c* pas_c, u3_noun tim, u3_atom pad, c3_c* bas_c, u3_noun pax)
   free(pad_y);
 
   if ( rit_w != fln_w ) {
-    uL(fprintf(uH, "%s: %s\n", pas_c, strerror(errno)));
+    u3l_log("%s: %s\n", pas_c, strerror(errno));
     u3m_bail(c3__fail);
   }
 
@@ -193,7 +193,7 @@ _walk_in(const c3_c* dir_c, c3_w len_w)
     struct dirent* out_n;
 
     if ( readdir_r(dir_d, &ent_n, &out_n) != 0 ) {
-      uL(fprintf(uH, "%s: %s\n", dir_c, strerror(errno)));
+      u3l_log("%s: %s\n", dir_c, strerror(errno));
       break;
     }
     else if ( !out_n ) {
@@ -275,7 +275,7 @@ u3_walk(const c3_c* dir_c, u3_noun old)
     struct stat buf_b;
 
     if ( 0 != stat(dir_c, &buf_b) ) {
-      uL(fprintf(uH, "can't stat %s\n", dir_c));
+      u3l_log("can't stat %s\n", dir_c);
       // return u3m_bail(c3__fail);
       c3_assert(0);
     }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -370,9 +370,9 @@ _worker_send_complete(u3_noun vir)
 /* _worker_send_stdr(): send stderr output
 */
 static void
-_worker_send_stdr(c3_c* cstr)
+_worker_send_stdr(c3_c* str_c)
 {
-  _worker_send(u3nt(c3__stdr, u3i_chubs(1, &u3V.evt_d), u3i_string(cstr)));
+  _worker_send(u3nt(c3__stdr, u3i_chubs(1, &u3V.evt_d), u3i_string(str_c)));
 }
 
 /* _worker_send_slog(): send hint output (hod is [priority tank]).

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -312,7 +312,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
 static void
 _worker_fail(void* vod_p, const c3_c* wut_c)
 {
-  fprintf(stderr, "worker: fail: %s\r\n", wut_c);
+  u3l_log("worker: fail: %s\r\n", wut_c);
   exit(1);
 }
 
@@ -329,9 +329,9 @@ _worker_send(u3_noun job)
 static void
 _worker_send_replace(c3_d evt_d, u3_noun ovo)
 {
-  fprintf(stderr, "worker_send_replace %" PRIu64 " %s\r\n",
-                  evt_d,
-                  u3r_string(u3h(u3t(ovo))));
+  u3l_log("worker_send_replace %" PRIu64 " %s\r\n",
+          evt_d,
+          u3r_string(u3h(u3t(ovo))));
 
   _worker_send(u3nq(c3__work,
                     u3i_chubs(1, &evt_d),
@@ -448,7 +448,7 @@ _worker_work_live(c3_d    evt_d,              //  event number
     if ( c3__belt != u3h(u3t(ovo)) ) {
       c3_c* txt_c = u3r_string(u3h(u3t(ovo)));
 
-      fprintf(stderr, "worker: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
+      u3l_log("worker: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
     }
   }
 #endif
@@ -466,9 +466,9 @@ _worker_work_live(c3_d    evt_d,              //  event number
     ms_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
     clr_w = ms_w > 1000 ? 1 : ms_w < 100 ? 2 : 3; //  red, green, yellow
     if (c3__belt != u3h(u3t(ovo)) || clr_w != 2) {
-      uL(fprintf(uH, "\x1b[3%dm%%%s (%" PRIu64 ") %4d.%02dms\x1b[0m\n",
-                        clr_w, txt_c, evt_d, ms_w,
-                        (int) (d0.tv_usec % 1000) / 10));
+      u3l_log("\x1b[3%dm%%%s (%" PRIu64 ") %4d.%02dms\x1b[0m\n",
+              clr_w, txt_c, evt_d, ms_w,
+              (int) (d0.tv_usec % 1000) / 10);
     }
     free(txt_c);
   }
@@ -538,7 +538,7 @@ _worker_work_boot(c3_d    evt_d,
 
   u3A->roe = u3nc(job, u3A->roe);
 
-  fprintf(stderr, "worker: (%" PRIu64 ")| boot\r\n", evt_d);
+  u3l_log("worker: (%" PRIu64 ")| boot\r\n", evt_d);
 
   if ( u3V.len_w == evt_d ) {
     u3_noun eve, pru;
@@ -546,18 +546,18 @@ _worker_work_boot(c3_d    evt_d,
     eve = u3kb_flop(u3A->roe);
     u3A->roe = 0;
 
-    fprintf(stderr, "worker: (%" PRIu64 ")| pill: %x\r\n", evt_d, u3r_mug(eve));
+    u3l_log("worker: (%" PRIu64 ")| pill: %x\r\n", evt_d, u3r_mug(eve));
 
     pru = u3m_soft(0, _worker_boot_fire, eve);
 
     if ( u3_blip != u3h(pru) ) {
-      fprintf(stderr, "boot failed\r\n");
+      u3l_log("boot failed\r\n");
       exit(1);
     }
 
     u3A->roc = u3k(u3t(pru));
 
-    fprintf(stderr, "worker: (%" PRIu64 ")| core: %x\r\n", evt_d, u3r_mug(u3A->roc));
+    u3l_log("worker: (%" PRIu64 ")| core: %x\r\n", evt_d, u3r_mug(u3A->roc));
 
     //  XX set u3A->evt_d ?
     //
@@ -759,7 +759,7 @@ u3_worker_boot(void)
     u3V.len_w = 0;
   }
 
-  fprintf(stderr, "worker: play %" PRIu64 "\r\n", nex_d);
+  u3l_log("worker: play %" PRIu64 "\r\n", nex_d);
 
   _worker_send(u3nc(c3__play, dat));
 }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -73,6 +73,14 @@
           ::
           [p=@ q=@ r=(pair date ovum)]
       ==
+      ::  sends a line to stderr while computing event
+      ::
+      $:  %stdr
+          ::  p: event number
+          ::  q: output cord
+          ::
+          [p=@ q=cord]
+      ==
       ::  send slog hint while computing event
       ::
       $:  %slog
@@ -357,6 +365,14 @@ _worker_send_complete(u3_noun vir)
                     u3i_chubs(1, &u3V.evt_d),
                     u3r_mug(u3A->roc),
                     vir));
+}
+
+/* _worker_send_stdr(): send stderr output
+*/
+static void
+_worker_send_stdr(c3_c* cstr)
+{
+  _worker_send(u3nt(c3__stdr, u3i_chubs(1, &u3V.evt_d), u3i_string(cstr)));
 }
 
 /* _worker_send_slog(): send hint output (hod is [priority tank]).
@@ -828,7 +844,8 @@ main(c3_i argc, c3_c* argv[])
   */
   {
     u3V.evt_d = u3m_boot_new(dir_c);
-    u3C.log_f = _worker_send_slog;
+    u3C.stderr_log_f = _worker_send_stdr;
+    u3C.slog_f = _worker_send_slog;
   }
 
   /* configure pipe to daemon process

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -1,4 +1,4 @@
-/* vere/serf.c
+/* worker/main.c
 **
 **  the main loop of a worker process.
 */
@@ -24,7 +24,7 @@
 #include "all.h"
 #include <vere/vere.h>
 
-    typedef struct _u3_serf {
+    typedef struct _u3_worker {
       c3_w    len_w;                        //  boot sequence length
       c3_d    evt_d;                        //  last event processed
       c3_l    mug_l;                        //  hash of state
@@ -32,14 +32,14 @@
       u3_moat inn_u;                        //  message input
       u3_mojo out_u;                        //  message output
       c3_c*   dir_c;                        //  execution directory (pier)
-    } u3_serf;
-    static u3_serf u3V;
+    } u3_worker;
+    static u3_worker u3V;
 
 /*
-::  serf-lord protocol:
+::  worker to daemon protocol
 ::
 |%
-::  +plea: from serf to lord
+::  +plea: from worker to daemon
 ::
 +$  plea
   $%  ::  status on startup
@@ -73,7 +73,7 @@
           ::
           [p=@ q=@ r=(pair date ovum)]
   ==  ==
-::  +writ: from lord to serf
+::  +writ: from daemon to worker
 ::
 +$  writ
   $%  ::  prepare to boot
@@ -105,20 +105,20 @@
 --
 */
 
-/* _serf_space(): print n spaces.
+/* _worker_space(): print n spaces.
 */
-void _serf_space(FILE* fil_u,  c3_w n)
+void _worker_space(FILE* fil_u,  c3_w n)
 {
   for (; n > 0; n--)
     (fprintf(fil_u," "));
 }
 
-/* _serf_print_memory(): print memory amount.
+/* _worker_print_memory(): print memory amount.
 **
-**  Helper for _serf_prof(), just an un-captioned u3a_print_memory().
+**  Helper for _worker_prof(), just an un-captioned u3a_print_memory().
 */
 void
-_serf_print_memory(FILE* fil_u, c3_w wor_w)
+_worker_print_memory(FILE* fil_u, c3_w wor_w)
 {
   c3_w byt_w = (wor_w * 4);
   c3_w gib_w = (byt_w / 1000000000);
@@ -141,21 +141,21 @@ _serf_print_memory(FILE* fil_u, c3_w wor_w)
   }
 }
 
-/* _serf_prof(): print memory profile. RETAIN.
+/* _worker_prof(): print memory profile. RETAIN.
 */
 c3_w
-_serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
+_worker_prof(FILE* fil_u, c3_w den, u3_noun mas)
 {
   c3_w tot_w = 0;
   u3_noun h_mas, t_mas;
 
   if ( c3n == u3r_cell(mas, &h_mas, &t_mas) ) {
-    _serf_space(fil_u, den);
+    _worker_space(fil_u, den);
     fprintf(fil_u, "mistyped mass\r\n");
     return tot_w;
   }
   else if ( _(u3du(h_mas)) ) {
-    _serf_space(fil_u, den);
+    _worker_space(fil_u, den);
     fprintf(fil_u, "mistyped mass head\r\n");
     {
       c3_c* lab_c = u3m_pretty(h_mas);
@@ -165,7 +165,7 @@ _serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
     return tot_w;
   }
   else {
-    _serf_space(fil_u, den);
+    _worker_space(fil_u, den);
 
     {
       c3_c* lab_c = u3m_pretty(h_mas);
@@ -181,7 +181,7 @@ _serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
     }
     else if ( c3y == it_mas ) {
       tot_w += u3a_mark_noun(tt_mas);
-      _serf_print_memory(fil_u, tot_w);
+      _worker_print_memory(fil_u, tot_w);
 
 #if 1
       /* The basic issue here is that tt_mas is included in
@@ -216,29 +216,29 @@ _serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
       fprintf(fil_u, "\r\n");
 
       while ( _(u3du(tt_mas)) ) {
-        tot_w += _serf_prof(fil_u, den+2, u3h(tt_mas));
+        tot_w += _worker_prof(fil_u, den+2, u3h(tt_mas));
         tt_mas = u3t(tt_mas);
       }
 
-      _serf_space(fil_u, den);
+      _worker_space(fil_u, den);
       fprintf(fil_u, "--");
-      _serf_print_memory(fil_u, tot_w);
+      _worker_print_memory(fil_u, tot_w);
 
       return tot_w;
 
     }
     else {
-      _serf_space(fil_u, den);
+      _worker_space(fil_u, den);
       fprintf(fil_u, "mistyped (strange) mass tail\r\n");
       return tot_w;
     }
   }
 }
 
-/* _serf_grab(): garbage collect, checking for profiling. RETAIN.
+/* _worker_grab(): garbage collect, checking for profiling. RETAIN.
 */
 static void
-_serf_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
+_worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
 {
   if ( u3_nul == sac) {
     if ( u3C.wag_w & (u3o_debug_ram | u3o_check_corrupt) ) {
@@ -281,7 +281,7 @@ _serf_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
     c3_assert( u3R == &(u3H->rod_u) );
 
     fprintf(fil_u, "\r\n");
-    usr_w = _serf_prof(fil_u, 0, sac);
+    usr_w = _worker_prof(fil_u, 0, sac);
     u3a_print_memory(fil_u, "total userspace", usr_w);
 
     man_w = u3m_mark(fil_u);
@@ -307,64 +307,64 @@ _serf_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
   }
 }
 
-/* _serf_fail(): failure stub.
+/* _worker_fail(): failure stub.
 */
 static void
-_serf_fail(void* vod_p, const c3_c* wut_c)
+_worker_fail(void* vod_p, const c3_c* wut_c)
 {
-  fprintf(stderr, "serf: fail: %s\r\n", wut_c);
+  fprintf(stderr, "worker: fail: %s\r\n", wut_c);
   exit(1);
 }
 
-/* _serf_send(): send result back to lord.
+/* _worker_send(): send result back to daemon.
 */
 static void
-_serf_send(u3_noun job)
+_worker_send(u3_noun job)
 {
   u3_newt_write(&u3V.out_u, u3ke_jam(job), 0);
 }
 
-/* _serf_send_replace(): send replacement job back to lord.
+/* _worker_send_replace(): send replacement job back to daemon.
 */
 static void
-_serf_send_replace(c3_d evt_d, u3_noun ovo)
+_worker_send_replace(c3_d evt_d, u3_noun ovo)
 {
-  fprintf(stderr, "serf_send_replace %" PRIu64 " %s\r\n",
+  fprintf(stderr, "worker_send_replace %" PRIu64 " %s\r\n",
                   evt_d,
                   u3r_string(u3h(u3t(ovo))));
 
-  _serf_send(u3nq(c3__work,
-                  u3i_chubs(1, &evt_d),
-                  u3V.mug_l,
-                  u3nc(u3k(u3A->now), ovo)));
+  _worker_send(u3nq(c3__work,
+                    u3i_chubs(1, &evt_d),
+                    u3V.mug_l,
+                    u3nc(u3k(u3A->now), ovo)));
 }
 
-/* _serf_send_complete(): report completion.
+/* _worker_send_complete(): report completion.
 */
 static void
-_serf_send_complete(u3_noun vir)
+_worker_send_complete(u3_noun vir)
 {
-  _serf_send(u3nq(c3__done,
-                  u3i_chubs(1, &u3V.evt_d),
-                  u3r_mug(u3A->roc),
-                  vir));
+  _worker_send(u3nq(c3__done,
+                    u3i_chubs(1, &u3V.evt_d),
+                    u3r_mug(u3A->roc),
+                    vir));
 }
 
-/* _serf_lame(): event failed, replace with error event.
+/* _worker_lame(): event failed, replace with error event.
 */
 static void
-_serf_lame(c3_d evt_d, u3_noun ovo, u3_noun why, u3_noun tan)
+_worker_lame(c3_d evt_d, u3_noun ovo, u3_noun why, u3_noun tan)
 {
   // %crud will be sent on the original wire.
   //
-  _serf_send_replace(evt_d, u3nc(u3k(u3h(ovo)), u3nt(c3__crud, why, tan)));
+  _worker_send_replace(evt_d, u3nc(u3k(u3h(ovo)), u3nt(c3__crud, why, tan)));
   u3z(ovo);
 }
 
-/* _serf_sure(): event succeeded, report completion.
+/* _worker_sure(): event succeeded, report completion.
 */
 static void
-_serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
+_worker_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 {
   u3z(u3A->roc);
   u3A->roc = cor;
@@ -388,7 +388,7 @@ _serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
         sac = u3k(u3t(fec));
         //  replace the %mass data with ~
         //
-        //    For efficient transmission to king.
+        //    For efficient transmission to daemon.
         //
         riv = u3kb_weld(u3qb_scag(i_w, vir),
                         u3nc(u3nt(u3k(u3h(u3h(riv))), c3__mass, u3_nul),
@@ -411,18 +411,18 @@ _serf_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 
   //  XX this runs on replay too
   //
-  _serf_grab(sac, ovo, vir);
-  _serf_send_complete(vir);
+  _worker_grab(sac, ovo, vir);
+  _worker_send_complete(vir);
 
   u3z(sac); u3z(ovo);
 }
 
-/* _serf_work_live(): apply event.
+/* _worker_work_live(): apply event.
 */
 static void
-_serf_work_live(c3_d    evt_d,              //  event number
-                c3_l    mug_l,              //  mug of state
-                u3_noun job)                //  event date
+_worker_work_live(c3_d    evt_d,              //  event number
+                  c3_l    mug_l,              //  mug of state
+                  u3_noun job)                //  event date
 {
   u3_noun now, ovo, gon;
 
@@ -448,7 +448,7 @@ _serf_work_live(c3_d    evt_d,              //  event number
     if ( c3__belt != u3h(u3t(ovo)) ) {
       c3_c* txt_c = u3r_string(u3h(u3t(ovo)));
 
-      fprintf(stderr, "serf: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
+      fprintf(stderr, "worker: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
     }
   }
 #endif
@@ -483,7 +483,7 @@ _serf_work_live(c3_d    evt_d,              //  event number
     u3k(ovo); u3k(why); u3k(tan);
     u3z(gon); u3z(job);
 
-    _serf_lame(evt_d, ovo, why, tan);
+    _worker_lame(evt_d, ovo, why, tan);
   }
   else {
     //  event accepted
@@ -500,7 +500,7 @@ _serf_work_live(c3_d    evt_d,              //  event number
     u3k(ovo); u3k(vir); u3k(cor);
     u3z(gon); u3z(job);
 
-    _serf_sure(ovo, vir, cor);
+    _worker_sure(ovo, vir, cor);
 
     //  reclaim memory from persistent caches on |reset
     //
@@ -510,10 +510,10 @@ _serf_work_live(c3_d    evt_d,              //  event number
   }
 }
 
-/* _serf_boot_fire(): execute boot sequence.
+/* _worker_boot_fire(): execute boot sequence.
 */
 static u3_noun
-_serf_boot_fire(u3_noun eve)
+_worker_boot_fire(u3_noun eve)
 {
   //  XX virtualize? use u3v_boot?
   //
@@ -526,10 +526,10 @@ _serf_boot_fire(u3_noun eve)
   return pro;
 }
 
-/* _serf_work_boot(): apply initial-stage event.
+/* _worker_work_boot(): apply initial-stage event.
 */
 static void
-_serf_work_boot(c3_d    evt_d,
+_worker_work_boot(c3_d    evt_d,
                 c3_l    mug_l,
                 u3_noun job)
 {
@@ -538,7 +538,7 @@ _serf_work_boot(c3_d    evt_d,
 
   u3A->roe = u3nc(job, u3A->roe);
 
-  fprintf(stderr, "serf: (%" PRIu64 ")| boot\r\n", evt_d);
+  fprintf(stderr, "worker: (%" PRIu64 ")| boot\r\n", evt_d);
 
   if ( u3V.len_w == evt_d ) {
     u3_noun eve, pru;
@@ -546,9 +546,9 @@ _serf_work_boot(c3_d    evt_d,
     eve = u3kb_flop(u3A->roe);
     u3A->roe = 0;
 
-    fprintf(stderr, "serf: (%" PRIu64 ")| pill: %x\r\n", evt_d, u3r_mug(eve));
+    fprintf(stderr, "worker: (%" PRIu64 ")| pill: %x\r\n", evt_d, u3r_mug(eve));
 
-    pru = u3m_soft(0, _serf_boot_fire, eve);
+    pru = u3m_soft(0, _worker_boot_fire, eve);
 
     if ( u3_blip != u3h(pru) ) {
       fprintf(stderr, "boot failed\r\n");
@@ -557,23 +557,23 @@ _serf_work_boot(c3_d    evt_d,
 
     u3A->roc = u3k(u3t(pru));
 
-    fprintf(stderr, "serf: (%" PRIu64 ")| core: %x\r\n", evt_d, u3r_mug(u3A->roc));
+    fprintf(stderr, "worker: (%" PRIu64 ")| core: %x\r\n", evt_d, u3r_mug(u3A->roc));
 
     //  XX set u3A->evt_d ?
     //
     u3z(pru);
   }
 
-  _serf_send(u3nq(c3__done,
-                  u3i_chubs(1, &evt_d),
-                  0,
-                  u3_nul));
+  _worker_send(u3nq(c3__done,
+                    u3i_chubs(1, &evt_d),
+                    0,
+                    u3_nul));
 }
 
-/* _serf_poke_work(): apply event.
+/* _worker_poke_work(): apply event.
 */
 static void
-_serf_poke_work(c3_d    evt_d,              //  event number
+_worker_poke_work(c3_d    evt_d,              //  event number
                 c3_l    mug_l,              //  mug of state
                 u3_noun job)                //  full event
 {
@@ -592,7 +592,7 @@ _serf_poke_work(c3_d    evt_d,              //  event number
     snprintf(lab_c, 8, "boot: %" PRIu64 "", evt_d);
 
     u3t_event_trace(lab_c, 'B');
-    _serf_work_boot(evt_d, mug_l, job);
+    _worker_work_boot(evt_d, mug_l, job);
     u3t_event_trace(lab_c, 'E');
   }
   else {
@@ -604,23 +604,23 @@ _serf_poke_work(c3_d    evt_d,              //  event number
              u3m_pretty_path(wir), u3m_pretty(cad));
 
     u3t_event_trace(lab_c, 'B');
-    _serf_work_live(evt_d, mug_l, job);
+    _worker_work_live(evt_d, mug_l, job);
     u3t_event_trace(lab_c, 'E');
   }
 }
 
-/* _serf_poke_exit(): exit on command.
+/* _worker_poke_exit(): exit on command.
 */
 static void
-_serf_poke_exit(c3_w cod_w)                 //  exit code
+_worker_poke_exit(c3_w cod_w)                 //  exit code
 {
   exit(cod_w);
 }
 
-/* _serf_poke_boot(): prepare to boot.
+/* _worker_poke_boot(): prepare to boot.
 */
 static void
-_serf_poke_boot(u3_noun who, u3_noun fak, c3_w len_w)
+_worker_poke_boot(u3_noun who, u3_noun fak, c3_w len_w)
 {
   c3_assert( u3_none == u3A->our );
   c3_assert( 0 != len_w );
@@ -630,10 +630,10 @@ _serf_poke_boot(u3_noun who, u3_noun fak, c3_w len_w)
   u3V.len_w = len_w;
 }
 
-/* _serf_poke():
+/* _worker_poke():
 */
 void
-_serf_poke(void* vod_p, u3_noun mat)
+_worker_poke(void* vod_p, u3_noun mat)
 {
   u3_noun jar = u3ke_cue(mat);
 
@@ -666,7 +666,7 @@ _serf_poke(void* vod_p, u3_noun mat)
         u3k(fak);
         u3z(jar);
 
-        return _serf_poke_boot(who, fak, len_w);
+        return _worker_poke_boot(who, fak, len_w);
       }
 
       case c3__work: {
@@ -688,7 +688,7 @@ _serf_poke(void* vod_p, u3_noun mat)
         u3k(job);
         u3z(jar);
 
-        return _serf_poke_work(evt_d, mug_l, job);
+        return _worker_poke_work(evt_d, mug_l, job);
       }
 
       case c3__exit: {
@@ -705,7 +705,7 @@ _serf_poke(void* vod_p, u3_noun mat)
         cod_w = u3r_word(0, cod);
         u3z(jar);
 
-        return _serf_poke_exit(cod_w);
+        return _worker_poke_exit(cod_w);
       }
 
       case c3__save: {
@@ -730,14 +730,14 @@ _serf_poke(void* vod_p, u3_noun mat)
 
   error: {
     u3z(jar);
-    _serf_fail(0, "bad jar");
+    _worker_fail(0, "bad jar");
   }
 }
 
-/* u3_serf_boot(): send startup message to manager.
+/* u3_worker_boot(): send startup message to manager.
 */
 void
-u3_serf_boot(void)
+u3_worker_boot(void)
 {
   c3_d nex_d  = 1ULL;
   u3_noun dat = u3_nul;
@@ -759,9 +759,9 @@ u3_serf_boot(void)
     u3V.len_w = 0;
   }
 
-  fprintf(stderr, "serf: play %" PRIu64 "\r\n", nex_d);
+  fprintf(stderr, "worker: play %" PRIu64 "\r\n", nex_d);
 
-  _serf_send(u3nc(c3__play, dat));
+  _worker_send(u3nc(c3__play, dat));
 }
 
 /* main(): main() when run as urbit-worker
@@ -813,7 +813,7 @@ main(c3_i argc, c3_c* argv[])
     u3V.evt_d = u3m_boot_new(dir_c);
   }
 
-  /* configure pipe to lord process
+  /* configure pipe to daemon process
   */
   {
     c3_i err_i;
@@ -829,19 +829,19 @@ main(c3_i argc, c3_c* argv[])
 
   /* set up writing
   */
-  u3V.out_u.bal_f = _serf_fail;
+  u3V.out_u.bal_f = _worker_fail;
 
   /* start reading
   */
   u3V.inn_u.vod_p = &u3V;
-  u3V.inn_u.pok_f = _serf_poke;
-  u3V.inn_u.bal_f = _serf_fail;
+  u3V.inn_u.pok_f = _worker_poke;
+  u3V.inn_u.bal_f = _worker_fail;
 
   u3_newt_read(&u3V.inn_u);
 
   /* send start request
   */
-  u3_serf_boot();
+  u3_worker_boot();
 
   /* enter loop
   */


### PR DESCRIPTION
This moves all printing to stderr through `uL(fprintf(uH, ...))` to an explicit u3l_log() which has a redirect function pointer in the nock options. This means that there is no longer a direct dependency on the vere terminal code from libnock (there are still other dependencies on vere internals). All the stderr lines are then ferried over the IPC between the daemon and the worker and are passed to the daemon's current stderr handler, which interacts with the terminal's output correctly.