### PR TITLE
cc-release: restores -P sample-based profiling

### DIFF
--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -422,46 +422,33 @@ u3t_event_trace(const c3_c* name, c3_c type)
   u3_Host.tra_u.con_w++;
 }
 
-extern FILE*
-u3_term_io_hija(void);
-
-extern void
-u3_term_io_loja(int x);
-
-extern void
-u3_term_tape(u3_noun tep);
-
-extern void
-u3_term_wall(u3_noun wol);
-
 /* u3t_print_steps: print step counter.
 */
 void
 u3t_print_steps(c3_c* cap_c, c3_d sep_d)
 {
-  FILE* fil_f = u3_term_io_hija();
-
   c3_w gib_w = (sep_d / 1000000000ULL);
   c3_w mib_w = (sep_d % 1000000000ULL) / 1000000ULL;
   c3_w kib_w = (sep_d % 1000000ULL) / 1000ULL;
   c3_w bib_w = (sep_d % 1000ULL);
 
+  //  XX prints to stderr since it's called on shutdown, daemon may be gone
+  //
   if ( sep_d ) {
     if ( gib_w ) {
-      fprintf(fil_f, "%s: G/%d.%03d.%03d.%03d\r\n",
+      fprintf(stderr, "%s: G/%d.%03d.%03d.%03d\r\n",
           cap_c, gib_w, mib_w, kib_w, bib_w);
     }
     else if ( mib_w ) {
-      fprintf(fil_f, "%s: M/%d.%03d.%03d\r\n", cap_c, mib_w, kib_w, bib_w);
+      fprintf(stderr, "%s: M/%d.%03d.%03d\r\n", cap_c, mib_w, kib_w, bib_w);
     }
     else if ( kib_w ) {
-      fprintf(fil_f, "%s: K/%d.%03d\r\n", cap_c, kib_w, bib_w);
+      fprintf(stderr, "%s: K/%d.%03d\r\n", cap_c, kib_w, bib_w);
     }
     else if ( bib_w ) {
-      fprintf(fil_f, "%s: %d\r\n", cap_c, bib_w);
+      fprintf(stderr, "%s: %d\r\n", cap_c, bib_w);
     }
   }
-  u3_term_io_loja(0);
 }
 
 /* u3t_damp(): print and clear profile data.
@@ -472,8 +459,22 @@ u3t_damp(void)
   if ( 0 != u3R->pro.day ) {
     u3_noun wol = u3do("pi-tell", u3R->pro.day);
 
-    fprintf(stderr, "\r\n");
-    u3_term_wall(wol);
+    //  XX prints to stderr since it's called on shutdown, daemon may be gone
+    //
+    {
+      u3_noun low = wol;
+
+      while ( u3_nul != low ) {
+        c3_c* str_c = (c3_c*)u3r_tape(u3h(low));
+
+        fprintf(stderr, "%s\r\n", str_c);
+        c3_free(str_c);
+
+        low = u3t(low);
+      }
+
+      u3z(wol);
+    }
 
     /* bunt a +doss
     */
@@ -491,7 +492,6 @@ u3t_damp(void)
 */
 void _ct_sigaction(c3_i x_i)
 {
-  // fprintf(stderr, "itimer!\r\n"); abort();
   u3t_samp();
 }
 

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -647,6 +647,10 @@ _worker_poke_work(c3_d    evt_d,              //  event number
 static void
 _worker_poke_exit(c3_w cod_w)                 //  exit code
 {
+  if ( u3C.wag_w & u3o_debug_cpu ) {
+    u3t_damp();
+  }
+
   exit(cod_w);
 }
 


### PR DESCRIPTION
This PR takes the shortest path to re-enabling -P sample profiling. Since we print the output upon shutdown, we print directly to stderr -- we can't reliably send the output over the pipe back to the daemon.

In the longer term, we may want to explicitly request the profiling output be sent over the pipe, write it to a file, etc. But we may also just want to remove it in favor of the trace profiling. I think it should remain enabled in some form until such a time as a final decision can be made (and the relevant work scheduled).

/cc @benjamin-tlon 