### PR TITLE
cc-release general cleanup

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -729,21 +729,6 @@ main(c3_i   argc,
     SSL_library_init();
     SSL_load_error_strings();
 
-    {
-      c3_i rad;
-      c3_y buf[4096];
-
-      // RAND_status, at least on OS X, never returns true.
-      // 4096 bytes should be enough entropy for anyone, right?
-      rad = open("/dev/urandom", O_RDONLY);
-      if ( 4096 != read(rad, &buf, 4096) ) {
-        perror("rand-seed");
-        exit(1);
-      }
-      RAND_seed(buf, 4096);
-      close(rad);
-    }
-
     u3_daemon_commence();
   }
   return 0;

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -456,6 +456,10 @@ report(void)
          H2O_LIBRARY_VERSION_MAJOR,
          H2O_LIBRARY_VERSION_MINOR,
          H2O_LIBRARY_VERSION_PATCH);
+  printf("lmdb: %d.%d.%d\n",
+         MDB_VERSION_MAJOR,
+         MDB_VERSION_MINOR,
+         MDB_VERSION_PATCH);
   printf("curl: %d.%d.%d\n",
          LIBCURL_VERSION_MAJOR,
          LIBCURL_VERSION_MINOR,

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -615,7 +615,7 @@ main(c3_i   argc,
     sigemptyset(&set);
     sigaddset(&set, SIGPROF);
     if ( 0 != pthread_sigmask(SIG_BLOCK, &set, NULL) ) {
-      perror("pthread_sigmask");
+      u3l_log("boot: thread mask SIGPROF: %s\r\n", strerror(errno));
       exit(1);
     }
   }

--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -4,18 +4,6 @@
 */
   /**  Data structures.
   **/
-    /* u3_cart: ovum carton.
-    */
-      struct _u3v_arvo;
-
-      typedef struct _u3v_cart {
-        u3_noun               vir;      //  effects of ovum
-        c3_o                  did;      //  cart considered for commit?
-        c3_o                  cit;      //  cart committed?
-        c3_d                  ent_d;    //  event number
-        u3p(struct _u3v_cart) nex_p;
-      } u3v_cart;
-
     /* u3v_arvo: modern arvo structure.
     */
       typedef struct _u3v_arvo {
@@ -28,18 +16,9 @@
         u3_noun our;                      //  identity
         u3_noun fak;                      //  c3y is fake
 
-        u3_noun sac;                      //  space profiling
-
-        u3_noun roe;                      //  temporary unsaved events
-        u3_noun key;                      //  log key, or 0
         u3_noun sys;                      //  system pill
 
         u3_noun roc;                      //  kernel core
-
-        struct {                          //  ova waiting to process
-          u3p(u3v_cart) egg_p;            //  exit of ovum queue
-          u3p(u3v_cart) geg_p;            //  entry of ovum queue
-        } ova;
       } u3v_arvo;
 
     /* u3v_home: all internal (within image) state.
@@ -144,11 +123,6 @@
     */
       void
       u3v_plow(u3_noun ova);
-
-    /* u3v_hose(): clear initial ovum queue.
-    */
-      void
-      u3v_hose(void);
 
     /* u3v_mark(): mark arvo kernel.
     */

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -155,7 +155,7 @@ u3e_fault(void* adr_v, c3_i ser_i)
                         (1 << (u3a_page + 2)),
                         (PROT_READ | PROT_WRITE)) )
     {
-      perror("mprotect");
+      u3l_log("loom: fault mprotect: %s\r\n", strerror(errno));
       c3_assert(0);
       return 0;
     }
@@ -182,14 +182,14 @@ _ce_image_open(u3e_image* img_u)
 
   snprintf(ful_c, 8192, "%s/.urb/chk/%s.bin", u3P.dir_c, img_u->nam_c);
   if ( -1 == (img_u->fid_i = open(ful_c, mod_i, 0666)) ) {
-    perror(ful_c);
+    u3l_log("loom: open %s: %s\r\n", ful_c, strerror(errno));
     return c3n;
   }
   else {
     struct stat buf_u;
 
     if ( -1 == fstat(img_u->fid_i, &buf_u) ) {
-      perror(ful_c);
+      u3l_log("loom: stat %s: %s\r\n", ful_c, strerror(errno));
       c3_assert(0);
       return c3n;
     }
@@ -273,13 +273,13 @@ _ce_patch_create(u3_ce_patch* pat_u)
 
   snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
   if ( -1 == (pat_u->ctl_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    perror(ful_c);
+    u3l_log("loom: patch open control.bin: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 
   snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
   if ( -1 == (pat_u->mem_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    perror(ful_c);
+    u3l_log("loom: patch open memory.bin: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 }
@@ -311,12 +311,12 @@ _ce_patch_verify(u3_ce_patch* pat_u)
     c3_w mem_w[1 << u3a_page];
 
     if ( -1 == lseek(pat_u->mem_i, (i_w << (u3a_page + 2)), SEEK_SET) ) {
-      perror("seek");
+      u3l_log("loom: patch seek: %s\r\n", strerror(errno));
       c3_assert(0);
       return c3n;
     }
     if ( -1 == read(pat_u->mem_i, mem_w, (1 << (u3a_page + 2))) ) {
-      perror("read");
+      u3l_log("loom: patch read: %s\r\n", strerror(errno));
       c3_assert(0);
       return c3n;
     }
@@ -636,7 +636,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     c3_w ret_w;
     ret_w = ftruncate(u3P.nor_u.fid_i, u3P.nor_u.pgs_w << (u3a_page + 2));
     if (ret_w){
-      perror("_ce_patch_apply");
+      u3l_log("loom: patch apply truncate north: %s\r\n", strerror(errno));
       c3_assert(0);
     }
   }
@@ -646,7 +646,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     c3_w ret_w;
     ret_w = ftruncate(u3P.sou_u.fid_i, u3P.sou_u.pgs_w << (u3a_page + 2));
     if (ret_w){
-      perror("_ce_patch_apply");
+      u3l_log("loom: patch apply truncate south: %s\r\n", strerror(errno));
       c3_assert(0);
     }
   }
@@ -656,7 +656,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
        (-1 == lseek(u3P.nor_u.fid_i, 0, SEEK_SET)) ||
        (-1 == lseek(u3P.sou_u.fid_i, 0, SEEK_SET)) )
   {
-    perror("apply: seek");
+    u3l_log("loom: patch apply seek 0: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 
@@ -676,16 +676,16 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     }
 
     if ( -1 == read(pat_u->mem_i, mem_w, (1 << (u3a_page + 2))) ) {
-      perror("apply: read");
+      u3l_log("loom: patch apply read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
     else {
       if ( -1 == lseek(fid_i, (off_w << (u3a_page + 2)), SEEK_SET) ) {
-        perror("apply: lseek");
+        u3l_log("loom: patch apply seek: %s\r\n", strerror(errno));
         c3_assert(0);
       }
       if ( -1 == write(fid_i, mem_w, (1 << (u3a_page + 2))) ) {
-        perror("apply: write");
+        u3l_log("loom: patch apply write: %s\r\n", strerror(errno));
         c3_assert(0);
       }
     }
@@ -707,7 +707,7 @@ _ce_image_blit(u3e_image* img_u,
   lseek(img_u->fid_i, 0, SEEK_SET);
   for ( i_w=0; i_w < img_u->pgs_w; i_w++ ) {
     if ( -1 == read(img_u->fid_i, ptr_w, (1 << (u3a_page + 2))) ) {
-      perror("read");
+      u3l_log("loom: image blit read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
 #if 0
@@ -739,7 +739,7 @@ _ce_image_fine(u3e_image* img_u,
     c3_w mem_w, fil_w;
 
     if ( -1 == read(img_u->fid_i, buf_w, (1 << (u3a_page + 2))) ) {
-      perror("read");
+      u3l_log("loom: image fine read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
     mem_w = u3r_mug_words(ptr_w, (1 << u3a_page));
@@ -882,7 +882,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
                        -(1 << u3a_page));
 
         if ( 0 != mprotect((void *)u3_Loom, u3a_bytes, PROT_READ) ) {
-          perror("protect");
+          u3l_log("loom: live mprotect: %s\r\n", strerror(errno));
           c3_assert(0);
         }
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1911,7 +1911,6 @@ u3m_boot_new(c3_c* dir_c)
   /* Reactivate jets on old kernel.
   */
   if ( !_(nuu_o) ) {
-    u3v_hose();
     u3j_ream();
     u3n_ream();
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1501,7 +1501,7 @@ _cm_limits(void)
                           ? (65536 << 10)
                           : rlm.rlim_max;
     if ( 0 != setrlimit(RLIMIT_STACK, &rlm) ) {
-      perror("stack");
+      u3l_log("boot: stack size: %s\r\n", strerror(errno));
       exit(1);
     }
   }
@@ -1513,7 +1513,7 @@ _cm_limits(void)
     c3_assert(0 == ret_i);
     rlm.rlim_cur = 10240; // default OSX max, not in rlim_max irritatingly
     if ( 0 != setrlimit(RLIMIT_NOFILE, &rlm) ) {
-      // perror("file limit");
+      u3l_log("boot: open file limit: %s\r\n", strerror(errno));
       //  no exit, not a critical limit
     }
   }
@@ -1524,7 +1524,7 @@ _cm_limits(void)
     getrlimit(RLIMIT_CORE, &rlm);
     rlm.rlim_cur = RLIM_INFINITY;
     if ( 0 != setrlimit(RLIMIT_CORE, &rlm) ) {
-      perror("core limit");
+      u3l_log("boot: core limit: %s\r\n", strerror(errno));
       //  no exit, not a critical limit
     }
   }
@@ -1536,7 +1536,7 @@ static void
 _cm_signals(void)
 {
   if ( 0 != sigsegv_install_handler(u3e_fault) ) {
-    u3l_log("sigsegv install failed\n");
+    u3l_log("boot: sigsegv install failed\n");
     exit(1);
   }
   // signal(SIGINT, _loom_stop);
@@ -1552,7 +1552,7 @@ _cm_signals(void)
     sigaddset(&set, SIGPROF);
 
     if ( 0 != pthread_sigmask(SIG_BLOCK, &set, NULL) ) {
-      perror("pthread_sigmask");
+      u3l_log("boot: thread mask SIGPROF: %s\r\n", strerror(errno));
       exit(1);
     }
   }

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -167,7 +167,7 @@ _t_samp_process(u3_road* rod_u)
       pef = t_pef;
     }
 
-    // fprintf(stderr, "sample: stack length %d\r\n", u3kb_lent(u3k(pal)));
+    // u3l_log("sample: stack length %d\r\n", u3kb_lent(u3k(pal)));
     return pal;
   }
 }
@@ -536,7 +536,7 @@ u3t_boot(void)
       sigemptyset(&set);
       sigaddset(&set, SIGPROF);
       if ( 0 != pthread_sigmask(SIG_UNBLOCK, &set, NULL) ) {
-        perror("pthread_sigmask");
+        u3l_log("trace: thread mask SIGPROF: %s\r\n", strerror(errno));
       }
     }
 
@@ -569,7 +569,7 @@ u3t_boff(void)
       sigemptyset(&set);
       sigaddset(&set, SIGPROF);
       if ( 0 != pthread_sigmask(SIG_BLOCK, &set, NULL) ) {
-        perror("pthread_sigmask");
+        u3l_log("trace: thread mask SIGPROF: %s\r\n", strerror(errno));
       }
     }
 

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -159,50 +159,6 @@ u3v_boot_lite(u3_atom lit)
   u3z(pru);
 }
 
-/* u3v_hose(): clear initial ovum queue.
-*/
-void
-u3v_hose(void)
-{
-  u3p(u3v_cart) egg_p = u3A->ova.egg_p;
-
-  while ( egg_p ) {
-    u3v_cart*     egg_u = u3to(u3v_cart, egg_p);
-    u3p(u3v_cart) nex_p = egg_u->nex_p;
-
-    u3a_lose(egg_u->vir);
-    u3a_free(egg_u);
-
-    egg_p = nex_p;
-  }
-  u3A->ova.egg_p = u3A->ova.geg_p = 0;
-  u3z(u3A->roe);
-  u3A->roe = u3_nul;
-}
-
-//  XX deprecated, remove
-#if 0
-/* u3v_start(): start time.
-*/
-void
-u3v_start(u3_noun now)
-{
-  u3v_time(now);
-  u3v_numb();
-  u3A->sac = u3_nul;
-
-  {
-    c3_c* wen_c = u3r_string(u3A->wen);
-
-    u3l_log("arvo: time: %s\n", wen_c);
-    free(wen_c);
-  }
-
-  if ( u3C.wag_w & u3o_trace )
-    u3t_trace_open();
-}
-#endif
-
 /* u3v_wish(): text expression with cache.
 */
 u3_noun
@@ -485,56 +441,6 @@ u3v_sway(u3_noun blu, c3_l tab_l, u3_noun tax)
   u3z(mok);
 }
 
-//  XX deprecated, remove
-#if 0
-/* u3v_plan(): queue ovum (external).
-*/
-void
-u3v_plan(u3_noun pax, u3_noun fav)
-{
-  u3_noun egg = u3nc(pax, fav);
-  u3A->roe = u3nc(u3nc(u3_nul, egg), u3A->roe);
-}
-#endif
-
-//  XX deprecated, remove
-#if 0
-/* u3v_plow(): queue multiple ova (external).
-*/
-void
-u3v_plow(u3_noun ova)
-{
-  u3_noun ovi = ova;
-
-  while ( u3_nul != ovi ) {
-    u3_noun ovo=u3h(ovi);
-
-    u3v_plan(u3k(u3h(ovo)), u3k(u3t(ovo)));
-    ovi = u3t(ovi);
-  }
-  u3z(ova);
-}
-#endif
-
-/* _cv_mark_ova(): mark ova queue.
-*/
-c3_w
-_cv_mark_ova(u3p(u3v_cart) egg_p)
-{
-  c3_w tot_w = 0;
-
-  while ( egg_p ) {
-    u3v_cart* egg_u = u3to(u3v_cart, egg_p);
-
-    tot_w += u3a_mark_mptr(egg_u);
-    tot_w += u3a_mark_noun(egg_u->vir);
-
-    egg_p = egg_u->nex_p;
-  }
-
-  return tot_w;
-}
-
 /* u3v_mark(): mark arvo kernel.
 */
 c3_w
@@ -549,9 +455,6 @@ u3v_mark(FILE* fil_u)
   tot_w += u3a_maid(fil_u, "  instance string", u3a_mark_noun(arv_u->sen));
   tot_w += u3a_maid(fil_u, "  identity", u3a_mark_noun(arv_u->our));
   tot_w += u3a_maid(fil_u, "  fake", u3a_mark_noun(arv_u->fak));
-  tot_w += u3a_maid(fil_u, "  pending events", u3a_mark_noun(arv_u->roe));
-  tot_w += u3a_maid(fil_u, "  event-log key", u3a_mark_noun(arv_u->key));
   tot_w += u3a_maid(fil_u, "  kernel", u3a_mark_noun(arv_u->roc));
-  tot_w += u3a_maid(fil_u, "  egg basket", _cv_mark_ova(arv_u->ova.egg_p));
   return   u3a_maid(fil_u, "total arvo stuff", tot_w);
 }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -765,6 +765,7 @@ _pier_work_play(u3_pier* pir_u,
   //  all events in the worker are complete
   //
   god_u->rel_d = god_u->dun_d = god_u->sen_d = (lav_d - 1ULL);
+  god_u->mug_l = mug_l;
 
   _pier_boot_ready(pir_u);
 }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -987,16 +987,14 @@ _pier_work_poke(void*   vod_p,
         goto error;
       }
       else {
-        // XXX: The wit_u pointer will almost always be 0 because of how the
-        // worker process manages the difference between u3V.evt_d vs
-        // u3A->ent_d. Either stop communicating the evt_d in the wire protocol
-        // or fix the worker to keep track of and communicate the correct event
-        // number.
         c3_d     evt_d = u3r_chub(0, p_jar);
         c3_w     pri_w = u3r_word(0, q_jar);
         u3_writ* wit_u = _pier_writ_find(pir_u, evt_d);
 
-        // Only print this slog if the event is uncommitted.
+        //  skip slog during replay
+        //
+        //    XX also update the worker to skip *sending* the slog during replay
+        //
         if ( u3_psat_pace != pir_u->sat_e ) {
           _pier_work_slog(wit_u, pri_w, u3k(r_jar));
         }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -652,20 +652,6 @@ _pier_work_complete(u3_writ* wit_u,
   fprintf(stderr, "pier: (%" PRIu64 "): compute: complete\r\n", wit_u->evt_d);
 #endif
 
-  if ( u3_psat_pace == pir_u->sat_e &&
-       wit_u->nex_u &&
-       mug_l != wit_u->nex_u->mug_l ) {
-    // While we are replaying the event log, we also perform checks that the
-    // resulting mug_l for this urbit's state is equivalent to the expected
-    // input state of the next event. If it isn't, we have either corruption or
-    // non-determinism during replay and either should cause a bail.
-    u3l_log("Invalid recomputed state. For event %" PRIu64 ", the computed mug "
-            "was %x but event %" PRIu64 " expected %x.\r\n",
-            wit_u->evt_d, mug_l, wit_u->nex_u->evt_d, wit_u->nex_u->mug_l);
-
-    u3_pier_bail();
-  }
-
   god_u->dun_d += 1;
   c3_assert(god_u->dun_d == wit_u->evt_d);
 

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -1213,19 +1213,19 @@ u3_term_io_hija(void)
     else {
       if ( c3n == u3_Host.ops_u.dem ) {
         if ( 0 != tcsetattr(1, TCSADRAIN, &uty_u->bak_u) ) {
-          u3l_log("term: hija tcsetattr-1: %s\r\n", strerror(errno));
+          perror("hija-tcsetattr-1");
           c3_assert(!"hija-tcsetattr");
         }
         if ( -1 == fcntl(1, F_SETFL, uty_u->cug_i) ) {
-          u3l_log("term: hija fcntl-1: %s\r\n", strerror(errno));
+          perror("hija-fcntl-1");
           c3_assert(!"hija-fcntl");
         }
         if ( 0 != tcsetattr(0, TCSADRAIN, &uty_u->bak_u) ) {
-          u3l_log("term: hija tcsetattr-0: %s\r\n", strerror(errno));
+          perror("hija-tcsetattr-0");
           c3_assert(!"hija-tcsetattr");
         }
         if ( -1 == fcntl(0, F_SETFL, uty_u->cug_i) ) {
-          u3l_log("term: hija fcntl-0: %s\r\n", strerror(errno));
+          perror("hija-fcntl-0");
           c3_assert(!"hija-fcntl");
         }
         _write(uty_u->fid_i, "\r", 1);
@@ -1258,19 +1258,19 @@ u3_term_io_loja(int x)
       }
       else {
         if ( 0 != tcsetattr(1, TCSADRAIN, &uty_u->raw_u) ) {
-          u3l_log("term: loja tcsetattr-1: %s\r\n", strerror(errno));
+          perror("loja-tcsetattr-1");
           c3_assert(!"loja-tcsetattr");
         }
         if ( -1 == fcntl(1, F_SETFL, uty_u->nob_i) ) {
-          u3l_log("term: loja fcntl-1: %s\r\n", strerror(errno));
+          perror("hija-fcntl-1");
           c3_assert(!"loja-fcntl");
         }
         if ( 0 != tcsetattr(0, TCSADRAIN, &uty_u->raw_u) ) {
-          u3l_log("term: loja tcsetattr-0: %s\r\n", strerror(errno));
+          perror("loja-tcsetattr-0");
           c3_assert(!"loja-tcsetattr");
         }
         if ( -1 == fcntl(0, F_SETFL, uty_u->nob_i) ) {
-          u3l_log("term: loja fcntl-0: %s\r\n", strerror(errno));
+          perror("hija-fcntl-0");
           c3_assert(!"loja-fcntl");
         }
         _term_it_refresh_line(uty_u);

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -1213,19 +1213,19 @@ u3_term_io_hija(void)
     else {
       if ( c3n == u3_Host.ops_u.dem ) {
         if ( 0 != tcsetattr(1, TCSADRAIN, &uty_u->bak_u) ) {
-          perror("hija-tcsetattr-1");
+          u3l_log("term: hija tcsetattr-1: %s\r\n", strerror(errno));
           c3_assert(!"hija-tcsetattr");
         }
         if ( -1 == fcntl(1, F_SETFL, uty_u->cug_i) ) {
-          perror("hija-fcntl-1");
+          u3l_log("term: hija fcntl-1: %s\r\n", strerror(errno));
           c3_assert(!"hija-fcntl");
         }
         if ( 0 != tcsetattr(0, TCSADRAIN, &uty_u->bak_u) ) {
-          perror("hija-tcsetattr-0");
+          u3l_log("term: hija tcsetattr-0: %s\r\n", strerror(errno));
           c3_assert(!"hija-tcsetattr");
         }
         if ( -1 == fcntl(0, F_SETFL, uty_u->cug_i) ) {
-          perror("hija-fcntl-0");
+          u3l_log("term: hija fcntl-0: %s\r\n", strerror(errno));
           c3_assert(!"hija-fcntl");
         }
         _write(uty_u->fid_i, "\r", 1);
@@ -1258,19 +1258,19 @@ u3_term_io_loja(int x)
       }
       else {
         if ( 0 != tcsetattr(1, TCSADRAIN, &uty_u->raw_u) ) {
-          perror("loja-tcsetattr-1");
+          u3l_log("term: loja tcsetattr-1: %s\r\n", strerror(errno));
           c3_assert(!"loja-tcsetattr");
         }
         if ( -1 == fcntl(1, F_SETFL, uty_u->nob_i) ) {
-          perror("hija-fcntl-1");
+          u3l_log("term: loja fcntl-1: %s\r\n", strerror(errno));
           c3_assert(!"loja-fcntl");
         }
         if ( 0 != tcsetattr(0, TCSADRAIN, &uty_u->raw_u) ) {
-          perror("loja-tcsetattr-0");
+          u3l_log("term: loja tcsetattr-0: %s\r\n", strerror(errno));
           c3_assert(!"loja-tcsetattr");
         }
         if ( -1 == fcntl(0, F_SETFL, uty_u->nob_i) ) {
-          perror("hija-fcntl-0");
+          u3l_log("term: loja fcntl-0: %s\r\n", strerror(errno));
           c3_assert(!"loja-fcntl");
         }
         _term_it_refresh_line(uty_u);

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -773,7 +773,7 @@ _worker_poke(void* vod_p, u3_noun mat)
           goto error;
         }
 
-        u3_noun entry = u3ke_cue(u3k(jammed_entry));
+        u3_noun entry = u3qe_cue(jammed_entry);
         if ( (c3y != u3du(entry)) ||
              (c3n == u3r_cell(entry, &mug, &job)) ||
              (c3n == u3ud(mug)) ||
@@ -818,7 +818,6 @@ _worker_poke(void* vod_p, u3_noun mat)
         }
 
         evt_d = u3r_chub(0, evt);
-        u3z(evt);
         u3z(jar);
 
         c3_assert( evt_d == u3V.evt_d );

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -26,6 +26,7 @@
 
     typedef struct _u3_worker {
       c3_w    len_w;                        //  boot sequence length
+      u3_noun roe;                          //  lifecycle formulas
       c3_d    sen_d;                        //  last event requested
       c3_d    dun_d;                        //  last event processed
       c3_l    mug_l;                        //  hash of state
@@ -201,9 +202,9 @@ _worker_prof(FILE* fil_u, c3_w den, u3_noun mas)
       _worker_print_memory(fil_u, tot_w);
 
 #if 1
-      /* The basic issue here is that tt_mas is included in
-       * u3A->sac, so they can't both be roots in the normal
-       * sense. When we mark u3A->sac later on, we want tt_mas
+      /* The basic issue here is that tt_mas is included in .sac
+       * (the whole profile), so they can't both be roots in the
+       * normal sense. When we mark .sac later on, we want tt_mas
        * to appear unmarked, but its children should be already
        * marked.
       */
@@ -263,7 +264,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
     }
   }
   else {
-    c3_w usr_w = 0, man_w = 0, sac_w = 0, ova_w = 0, vir_w = 0;
+    c3_w usr_w = 0, man_w = 0, sac_w = 0, ova_w = 0, roe_w = 0, vir_w = 0;
 
     FILE* fil_u;
 
@@ -308,6 +309,9 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
 
     ova_w = u3a_mark_noun(ovo);
     u3a_print_memory(fil_u, "event", ova_w);
+
+    roe_w = u3a_mark_noun(u3V.roe);
+    u3a_print_memory(fil_u, "lifecycle events", roe_w);
 
     vir_w = u3a_mark_noun(vir);
     u3a_print_memory(fil_u, "effects", vir_w);
@@ -616,15 +620,15 @@ _worker_work_boot(c3_d evt_d, u3_noun job)
   c3_assert(evt_d == u3V.sen_d + 1ULL);
   u3V.sen_d = evt_d;
 
-  u3A->roe = u3nc(job, u3A->roe);
+  u3V.roe = u3nc(job, u3V.roe);
 
   u3l_log("work: (%" PRIu64 ")| boot\r\n", evt_d);
 
   if ( u3V.len_w == evt_d ) {
     u3_noun eve, pru;
 
-    eve = u3kb_flop(u3A->roe);
-    u3A->roe = 0;
+    eve = u3kb_flop(u3V.roe);
+    u3V.roe = u3_nul;
 
     u3l_log("work: (%" PRIu64 ")| pill: %x\r\n", evt_d, u3r_mug(eve));
 

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -585,7 +585,11 @@ _worker_work_live(c3_d evt_d, u3_noun job)
 
     _worker_sure(ovo, vir, cor);
 
-    //  reclaim memory from persistent caches on |reset
+    //  reclaim memory from persistent caches periodically
+    //
+    //    XX this is a hack to work around the fact that
+    //    the bytecode caches grow rapidly and are not
+    //    able to be simply capped (due to internal posts).
     //
     if ( 0 == (evt_d % 1000ULL) ) {
       u3m_reclaim();

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -344,17 +344,15 @@ _worker_send(u3_noun job)
 /* _worker_send_replace(): send replacement job back to daemon.
 */
 static void
-_worker_send_replace(c3_d evt_d, u3_noun ovo)
+_worker_send_replace(c3_d evt_d, u3_noun job)
 {
   u3l_log("worker_send_replace %" PRIu64 " %s\r\n",
           evt_d,
-          u3r_string(u3h(u3t(ovo))));
+          u3r_string(u3h(u3t(u3t(job)))));
 
   _worker_send(u3nt(c3__work,
                     u3i_chubs(1, &evt_d),
-                    u3ke_jam(u3nt(u3V.mug_l,
-                                  u3k(u3A->now),
-                                  ovo))));
+                    u3ke_jam(u3nc(u3V.mug_l, job))));
 }
 
 /* _worker_send_complete(): report completion.
@@ -387,7 +385,7 @@ _worker_send_slog(u3_noun hod)
 /* _worker_lame(): event failed, replace with error event.
 */
 static void
-_worker_lame(c3_d evt_d, u3_noun ovo, u3_noun why, u3_noun tan)
+_worker_lame(c3_d evt_d, u3_noun now, u3_noun ovo, u3_noun why, u3_noun tan)
 {
   u3_noun rep;
   u3_noun wir, tag, cad;
@@ -436,7 +434,7 @@ _worker_lame(c3_d evt_d, u3_noun ovo, u3_noun why, u3_noun tan)
     rep = u3nc(u3k(wir), u3nt(c3__crud, u3k(tag), nat));
   }
 
-  _worker_send_replace(evt_d, rep);
+  _worker_send_replace(evt_d, u3nc(now, rep));
 
   u3z(ovo); u3z(why); u3z(tan);
 }
@@ -505,14 +503,15 @@ static void
 _worker_work_live(c3_d evt_d, u3_noun job)
 {
   u3_noun now, ovo, gon;
+  u3_noun last_date;
 
   c3_assert(evt_d == u3V.dun_d + 1ULL);
   u3V.sen_d = evt_d;
 
   u3x_cell(job, &now, &ovo);
 
-  u3z(u3A->now);
-  u3A->now = u3k(now);
+  last_date = u3A->now;
+  u3A->now  = u3k(now);
 
 #ifdef U3_EVENT_TIME_DEBUG
   {
@@ -552,6 +551,10 @@ _worker_work_live(c3_d evt_d, u3_noun job)
     //  event rejected
     //
     u3V.sen_d = u3V.dun_d;
+    //  restore previous time
+    //
+    u3_noun nex = u3A->now;
+    u3A->now    = last_date;
 
     u3_noun why, tan;
     u3x_cell(gon, &why, &tan);
@@ -559,12 +562,13 @@ _worker_work_live(c3_d evt_d, u3_noun job)
     u3k(ovo); u3k(why); u3k(tan);
     u3z(gon); u3z(job);
 
-    _worker_lame(evt_d, ovo, why, tan);
+    _worker_lame(evt_d, nex, ovo, why, tan);
   }
   else {
     //  event accepted
     //
     u3V.dun_d = u3V.sen_d;
+    u3z(last_date);
 
     //  vir/(list ovum)  list of effects
     //  cor/arvo         arvo core


### PR DESCRIPTION
This PR merges master into cc-release, further replaces `perror()` and similar functions with `u3l_log()`, cleans up some recent additions to the worker, and removes obsolete code/members for `vortex.c` and `u3A`. The latter two deserve further notes:

- we move the mug-chain checking/enforcement/error printing exclusively into the worker (previously split across worker and daemon), and require it at all times, not only during replay
- we fix a bug where the kernel mug was not being appropriately captured on process restart
- we separately track event-numbers in the worker for latest request and latest completed, so log/slog messages during event evaluation have the correct event number
- we make sure that `u3A->now` is always set to the time of the last successful event evaluation when the worker is between events