### PR TITLE
Batch event log commits

### DIFF
--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1303,8 +1303,9 @@
       /* u3_lmdb_write_event(): Persists an event to the database
       */
       void u3_lmdb_write_event(MDB_env* environment,
-                               u3_writ* event_u,
-                               void (*on_complete)(c3_o success, u3_writ*));
+                               u3_pier* pir_u,
+                               struct u3_lmdb_write_request* request_u,
+                               void (*on_complete)(c3_o success, u3_pier*, c3_d, c3_d));
 
       /* u3_lmdb_read_events(): Reads events back from the database
       **

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1294,11 +1294,20 @@
       c3_o u3_lmdb_get_latest_event_number(MDB_env* environment,
                                            c3_d* event_number);
 
+      /* u3_lmdb_write_request: opaque write request structures
+      */
       struct u3_lmdb_write_request;
 
+      /* u3_lmdb_build_write_reuqest(): allocates and builds a write request
+      **
+      ** Reads count sequential writs starting with event_u and creates a
+      ** single write request for all those writs.
+      */
       struct u3_lmdb_write_request*
       u3_lmdb_build_write_request(u3_writ* event_u, c3_d count);
 
+      /* u3_lmdb_free_write_request(): frees a write requst
+      */
       void u3_lmdb_free_write_request(struct u3_lmdb_write_request* request);
 
       /* u3_lmdb_write_event(): Persists an event to the database
@@ -1306,7 +1315,8 @@
       void u3_lmdb_write_event(MDB_env* environment,
                                u3_pier* pir_u,
                                struct u3_lmdb_write_request* request_u,
-                               void (*on_complete)(c3_o success, u3_pier*, c3_d, c3_d));
+                               void (*on_complete)(c3_o success, u3_pier*,
+                                                   c3_d, c3_d));
 
       /* u3_lmdb_read_events(): Reads events back from the database
       **

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1293,6 +1293,13 @@
       c3_o u3_lmdb_get_latest_event_number(MDB_env* environment,
                                            c3_d* event_number);
 
+      struct u3_lmdb_write_request;
+
+      struct u3_lmdb_write_request*
+      u3_lmdb_build_write_request(u3_writ* event_u, c3_d count);
+
+      void u3_lmdb_free_write_request(struct u3_lmdb_write_request* request);
+
       /* u3_lmdb_write_event(): Persists an event to the database
       */
       void u3_lmdb_write_event(MDB_env* environment,

--- a/pkg/urbit/vere/lmdb.c
+++ b/pkg/urbit/vere/lmdb.c
@@ -317,10 +317,11 @@ static void _u3_lmdb_write_event_cb(uv_work_t* req) {
               request->first_event,
               mdb_strerror(ret_w));
     } else {
+      c3_d through = request->first_event + request->event_count - 1ULL;
       u3l_log("lmdb: failed to commit events %" PRIu64  " through %" PRIu64
               ": %s\n",
               request->first_event,
-              request->first_event + request->event_count - 1ULL,
+              through,
               mdb_strerror(ret_w));
     }
     data->success = c3n;

--- a/pkg/urbit/vere/lmdb.c
+++ b/pkg/urbit/vere/lmdb.c
@@ -174,8 +174,7 @@ c3_o _perform_get_on_database_noun(MDB_txn* transaction_u,
   return c3y;
 }
 
-/* u3_lmdb_write_request: contains multiple events to be written together
-**
+/* u3_lmdb_write_request: Events to be written together
 */
 struct u3_lmdb_write_request {
   // The event number of the first event.
@@ -194,9 +193,7 @@ struct u3_lmdb_write_request {
   size_t* malloced_event_data_size;
 };
 
-/* u3_lmdb_build_write_request(): Reads t
-**
-** Returns null when the event ids in u3_writ are not contiguous.
+/* u3_lmdb_build_write_request(): Allocates and builds a write request
 */
 struct u3_lmdb_write_request*
 u3_lmdb_build_write_request(u3_writ* event_u, c3_d count)

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -104,10 +104,10 @@ _pier_db_commit_complete(c3_o success,
 
 #ifdef VERBOSE_EVENTS
   if (event_count_d != 1) {
-    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): db commit completed\r\n",
-            first_event_d, first_event_d + count_d - 1ULL);
+    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): db commit: complete\r\n",
+            first_event_d, first_event_d + event_count_d - 1ULL);
   } else {
-    u3l_log("pier: (%" PRIu64 "): db commit completed\r\n", first_event_d);
+    u3l_log("pier: (%" PRIu64 "): db commit: complete\r\n", first_event_d);
   }
 #endif
 
@@ -116,7 +116,7 @@ _pier_db_commit_complete(c3_o success,
   {
     c3_assert((first_event_d + event_count_d - 1ULL) == log_u->moc_d);
     c3_assert(first_event_d == (1ULL + log_u->com_d));
-    log_u->com_d += 1ULL;
+    log_u->com_d += event_count_d;
   }
 
   _pier_loop_resume(pir_u);
@@ -134,10 +134,10 @@ _pier_db_commit_request(u3_pier* pir_u,
 
 #ifdef VERBOSE_EVENTS
   if (count_d != 1) {
-    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): commit: request\r\n",
+    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): db commit: request\r\n",
             first_event_d, first_event_d + count_d - 1ULL);
   } else {
-    u3l_log("pier: (%" PRIu64 "): commit: request\r\n", first_event_d);
+    u3l_log("pier: (%" PRIu64 "): db commit: request\r\n", first_event_d);
   }
 #endif
 
@@ -1647,6 +1647,11 @@ _pier_apply(u3_pier* pir_u)
 
   u3_writ* wit_u;
   c3_o     act_o = c3n;
+
+  // Warning: This entire event queuing system is way too clever; it tries to
+  // maintain a single linked list with multiple index based integer iterators
+  // over it instead of just using separate lists for the different stages of
+  // event handling.
 
 start:
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -89,9 +89,11 @@ _pier_db_shutdown(u3_pier* pir_u)
 /* _pier_db_commit_complete(): commit complete.
  */
 static void
-_pier_db_commit_complete(c3_o success, u3_writ* wit_u)
+_pier_db_commit_complete(c3_o success,
+                         u3_pier* pir_u,
+                         c3_d first_event_d,
+                         c3_d event_count_d)
 {
-  u3_pier* pir_u = wit_u->pir_u;
   u3_disk* log_u = pir_u->log_u;
 
   if (success == c3n) {
@@ -100,14 +102,19 @@ _pier_db_commit_complete(c3_o success, u3_writ* wit_u)
   }
 
 #ifdef VERBOSE_EVENTS
-  u3l_log("pier: (%" PRIu64 "): db commit completed\r\n", wit_u->evt_d);
+  if (event_count_d != 1) {
+    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): db commit completed\r\n",
+            first_event_d, first_event_d + count_d - 1ULL);
+  } else {
+    u3l_log("pier: (%" PRIu64 "): db commit completed\r\n", first_event_d);
+  }
 #endif
 
   /* advance commit counter
   */
   {
-    c3_assert(wit_u->evt_d == log_u->moc_d);
-    c3_assert(wit_u->evt_d == (1ULL + log_u->com_d));
+    c3_assert((first_event_d + event_count_d - 1ULL) == log_u->moc_d);
+    c3_assert(first_event_d == (1ULL + log_u->com_d));
     log_u->com_d += 1ULL;
   }
 
@@ -117,34 +124,36 @@ _pier_db_commit_complete(c3_o success, u3_writ* wit_u)
 /* _pier_db_commit_request(): start commit.
 */
 static void
-_pier_db_commit_request(u3_writ* wit_u)
+_pier_db_commit_request(u3_pier* pir_u,
+                        struct u3_lmdb_write_request* request_u,
+                        c3_d first_event_d,
+                        c3_d count_d)
 {
-  u3_pier* pir_u = wit_u->pir_u;
   u3_disk* log_u = pir_u->log_u;
 
 #ifdef VERBOSE_EVENTS
-  u3l_log("pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
+  if (count_d != 1) {
+    u3l_log("pier: (%" PRIu64 "-%" PRIu64 "): commit: request\r\n",
+            first_event_d, first_event_d + count_d - 1ULL);
+  } else {
+    u3l_log("pier: (%" PRIu64 "): commit: request\r\n", first_event_d);
+  }
 #endif
-
-  // |wit_u| is the first of possibly several uncommitted events. We instead
-  // want to commit all of them at once.
-  //
-  //
-
 
   /* put it in the database
   */
   {
     u3_lmdb_write_event(log_u->db_u,
-                        wit_u,
+                        pir_u,
+                        request_u,
                         _pier_db_commit_complete);
   }
 
   /* advance commit-request counter
   */
   {
-    c3_assert(wit_u->evt_d == (1ULL + log_u->moc_d));
-    log_u->moc_d += 1ULL;
+    c3_assert(first_event_d == (1ULL + log_u->moc_d));
+    log_u->moc_d += count_d;
   }
 }
 
@@ -1661,10 +1670,11 @@ start:
       struct u3_lmdb_write_request* request =
           u3_lmdb_build_write_request(wit_u, count);
       c3_assert(request != 0);
-      u3_lmdb_free_write_request(request);
 
-      // TODO(erg): This is the place where we build up things into a queue.
-      _pier_db_commit_request(wit_u);
+      _pier_db_commit_request(pir_u,
+                              request,
+                              wit_u->evt_d,
+                              count);
       act_o = c3y;
     }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -126,6 +126,12 @@ _pier_db_commit_request(u3_writ* wit_u)
   u3l_log("pier: (%" PRIu64 "): commit: request\r\n", wit_u->evt_d);
 #endif
 
+  // |wit_u| is the first of possibly several uncommitted events. We instead
+  // want to commit all of them at once.
+  //
+  //
+
+
   /* put it in the database
   */
   {
@@ -1651,6 +1657,12 @@ start:
          (wit_u->evt_d == (1 + log_u->moc_d)) &&
          (wit_u->evt_d == (1 + log_u->com_d)) )
     {
+      c3_d count = 1 + (god_u->dun_d - wit_u->evt_d);
+      struct u3_lmdb_write_request* request =
+          u3_lmdb_build_write_request(wit_u, count);
+      c3_assert(request != 0);
+      u3_lmdb_free_write_request(request);
+
       // TODO(erg): This is the place where we build up things into a queue.
       _pier_db_commit_request(wit_u);
       act_o = c3y;

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1648,11 +1648,6 @@ _pier_apply(u3_pier* pir_u)
   u3_writ* wit_u;
   c3_o     act_o = c3n;
 
-  // Warning: This entire event queuing system is way too clever; it tries to
-  // maintain a single linked list with multiple index based integer iterators
-  // over it instead of just using separate lists for the different stages of
-  // event handling.
-
 start:
 
   /* iterate from queue exit, advancing any writs that can advance


### PR DESCRIPTION
When we have lots of small events, Urbit's throughput is hampered by `fsync()` costs on a per-event basis. This patch lets us batch up multiple events so they're committed to lmdb as a single transaction.