### PR TITLE
Add `git` to default.nix dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
     with darwin.apple_sdk.frameworks;
       [ Cocoa CoreServices ]);
 
-  deps = [ cmark curl gcc gmp libsigsegv meson ncurses ninja pkgconfig zlib
+  deps = [ cmark curl gcc git gmp libsigsegv meson ncurses ninja pkgconfig zlib
            re2c openssl ];
 
   isGitDir = (path: type: type != "directory" || baseNameOf path != ".git");


### PR DESCRIPTION
Running `./scripts/nixbuild` on a NixOS machine, i get the following error:

```
jgl@n3: ~/repos/urbit $ ./scripts/nixbuild
these paths will be fetched (0.16 MiB download, 1.00 MiB unpacked):
  /nix/store/4vgpb5yb350mvw7czvnn9hha3p8spgvn-cmark-0.28.3
copying path '/nix/store/4vgpb5yb350mvw7czvnn9hha3p8spgvn-cmark-0.28.3' from 'https://cache.nixos.org'...
The Meson build system
Version: 0.46.1
Source dir: /home/jgl/repos/urbit
Build dir: /home/jgl/repos/urbit/build
Build type: native build
Project name: urbit
Native C compiler: gcc (gcc 7.3.0 "gcc (GCC) 7.3.0")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Dependency threads found: YES
Found pkg-config: /nix/store/sbg7j9ghnhl3kiw5gck9khhr2wwd5y8f-pkg-config-0.29.2/bin/pkg-config (0.29.2)
Native dependency ncurses found: YES 6.1.20180127
Configuring config.h using configuration
Native dependency libcurl found: YES 7.61.1
Native dependency openssl found: YES 1.0.2p
Library gmp found: YES
Library sigsegv found: YES
Also couldn't find a fallback subproject in subprojects/argon2 for the dependency argon2
Reason: [Errno 2] No such file or directory: 'git': 'git'

meson.build:322:0: ERROR:  Native dependency 'argon2' not found

A full log can be found at /home/jgl/repos/urbit/build/meson-logs/meson-log.txt
ninja: Entering directory `build'
ninja: error: loading 'build.ninja': No such file or directory
jgl@n3: ~/repos/urbit $
```

Adding `git` to deps in default.nix fixed the issue for me.