### PR TITLE
Use a 40 gigabyte log size

### DIFF
--- a/pkg/urbit/vere/lmdb.c
+++ b/pkg/urbit/vere/lmdb.c
@@ -41,9 +41,10 @@ MDB_env* u3_lmdb_init(const char* log_path)
     return 0;
   }
 
-  // TODO: Start with a gigabyte for the event log.
+  // TODO: Start with forty gigabytes for the maximum event log size. We'll
+  // need to do something more sophisticated for real in the long term, though.
   //
-  ret_w = mdb_env_set_mapsize(env, 1024 * 1024 * 1024);
+  ret_w = mdb_env_set_mapsize(env, 40 * 1024 * 1024 * 1024);
   if (ret_w != 0) {
     u3l_log("lmdb: failed to set database size: %s\n", mdb_strerror(ret_w));
     return 0;

--- a/pkg/urbit/vere/lmdb.c
+++ b/pkg/urbit/vere/lmdb.c
@@ -44,7 +44,8 @@ MDB_env* u3_lmdb_init(const char* log_path)
   // TODO: Start with forty gigabytes for the maximum event log size. We'll
   // need to do something more sophisticated for real in the long term, though.
   //
-  ret_w = mdb_env_set_mapsize(env, 40 * 1024 * 1024 * 1024);
+  const size_t forty_gigabytes = 42949672960;
+  ret_w = mdb_env_set_mapsize(env, forty_gigabytes);
   if (ret_w != 0) {
     u3l_log("lmdb: failed to set database size: %s\n", mdb_strerror(ret_w));
     return 0;


### PR DESCRIPTION
With lmdb, you have to have a maximum file size. I set this to a gigabyte during development, but I suspect ~zod would blow past this limit.

I've gone with 40gb here as a (hopefully) safe guess for now.