### PR TITLE
cc-release: fix memory bug, tweak limits and core dumps

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -467,6 +467,8 @@ report(void)
   printf("argon2: 0x%x\n", ARGON2_VERSION_NUMBER);
 }
 
+/* _stop_exit(): exit immediately.
+*/
 static void
 _stop_exit(c3_i int_i)
 {
@@ -474,6 +476,18 @@ _stop_exit(c3_i int_i)
   //
   fprintf(stderr, "\r\n[received keyboard stop signal, exiting]\r\n");
   u3_daemon_bail();
+}
+
+/* _stop_trace(): print trace on SIGABRT.
+*/
+static void
+_stop_trace(c3_i int_i)
+{
+  //  if we have a pier, unmap the event log before dumping core
+  //
+  if ( 0 != u3K.len_w ) {
+    u3_pier_db_shutdown(u3_pier_stub());
+  }
 }
 
 /*
@@ -625,6 +639,10 @@ main(c3_i   argc,
   //    Configured here using signal() so as to be immediately available.
   //
   signal(SIGTSTP, _stop_exit);
+
+  //  Cleanup on SIGABRT.
+  //
+  signal(SIGABRT, _stop_trace);
 
   printf("~\n");
   //  printf("welcome.\n");

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1174,6 +1174,11 @@
 
     /** Pier control.
     **/
+      /* u3_pier_db_shutdown(): close the log.
+      */
+        void
+        u3_pier_db_shutdown(u3_pier* pir_u);
+
       /* u3_pier_interrupt(): interrupt running process.
       */
         void

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -601,7 +601,7 @@ _boothack_key(u3_noun kef)
     u3_noun whu = u3dc("slaw", 'p', u3k(woh));
 
     if ( u3_nul == whu ) {
-      u3l_log("dawn: invalid ship specificed with -w %s\r\n",
+      u3l_log("dawn: invalid ship specified with -w %s\r\n",
               u3_Host.ops_u.who_c);
       exit(1);
     }

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -506,6 +506,30 @@ _dawn_come(u3_noun stars)
     c3_c* who_c = u3r_string(who);
 
     u3l_log("boot: found comet %s\r\n", who_c);
+
+  //  enable to print and save comet private key for future reuse
+  //
+#if 0
+    {
+      u3_noun key = u3dc("scot", c3__uw, u3qe_jam(seed));
+      c3_c* key_c = u3r_string(key);
+
+      u3l_log("boot: comet private key\n  %s\n", key_c);
+
+      {
+        c3_c  pat_c[64];
+        snprintf(pat_c, 64, "%s.key", who_c + 1);
+
+        FILE* fil_u = fopen(pat_c, "w");
+        fprintf(fil_u, "%s\n", key_c);
+        fclose(fil_u);
+      }
+
+      free(key_c);
+      u3z(key);
+    }
+#endif
+
     free(who_c);
     u3z(who);
   }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -79,10 +79,10 @@ _pier_db_bail(void* vod_p, const c3_c* err_c)
   u3l_log("disk error: %s\r\n", err_c);
 }
 
-/* _pier_db_shutdown(): close the log.
+/* u3_pier_db_shutdown(): close the log.
 */
-static void
-_pier_db_shutdown(u3_pier* pir_u)
+void
+u3_pier_db_shutdown(u3_pier* pir_u)
 {
   u3_lmdb_shutdown(pir_u->log_u->db_u);
 }
@@ -844,7 +844,7 @@ _pier_work_exit(uv_process_t* req_u,
   u3l_log("pier: exit: status %" PRIu64 ", signal %d\r\n", sas_i, sig_i);
   uv_close((uv_handle_t*) req_u, 0);
 
-  _pier_db_shutdown(pir_u);
+  u3_pier_db_shutdown(pir_u);
   _pier_work_shutdown(pir_u);
 }
 
@@ -1787,7 +1787,7 @@ _pier_exit_done(u3_pier* pir_u)
 {
   u3l_log("pier: exit\r\n");
 
-  _pier_db_shutdown(pir_u);
+  u3_pier_db_shutdown(pir_u);
   _pier_work_shutdown(pir_u);
   _pier_loop_exit(pir_u);
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -508,7 +508,7 @@ _pier_work_boot(u3_pier* pir_u, c3_o sav_o)
   u3_noun len = u3i_chubs(1, &pir_u->lif_d);
 
   if ( c3y == sav_o ) {
-    _pier_db_write_header(pir_u, who, u3k(pir_u->fak_o), len);
+    _pier_db_write_header(pir_u, u3k(who), pir_u->fak_o, u3k(len));
   }
 
   u3_noun msg = u3nq(c3__boot, who, pir_u->fak_o, len);


### PR DESCRIPTION
This PR includes a variety of small fixes and tweaks:

- fixes a use-after-free in pier.c
- adds (disabled) helper code to print the keypair for a comet
- separates process limit handling in the daemon and the worker
- disables core dumps in the daemon
- updates the daemon (only) to print a backtrace on SIGABRT.

Core dumps are still enabled in the worker, but disabled in the daemon due to their now unwieldy size (as the entire event-log is mmap'd). Example output from a SIGABRT on the daemon:

```
Assertion '0' failed in vere/pier.c:1510

bail: oops
bailing out
Assertion failed: (0), function u3m_bail, file noun/manage.c, line 663.

backtrace:
1   libsystem_platform.dylib            0x00007fff6b0e2b3d _sigtramp + 29
2   urbit                               0x000000010babecc8 h2o_mime_attributes_as_is + 13352
3   libsystem_c.dylib                   0x00007fff6afa11c9 abort + 127
4   libsystem_c.dylib                   0x00007fff6af69868 basename_r + 0
5   urbit                               0x000000010b805d5e u3m_bail + 478
6   urbit                               0x000000010b805f4e c3_cooked + 14
7   urbit                               0x000000010b80b295 _pier_boot_complete + 53
8   urbit                               0x000000010b80be99 _pier_boot_ready + 809
9   urbit                               0x000000010b80cb0a _pier_work_poke + 1210
10  urbit                               0x000000010b808d36 _newt_consume + 166
11  urbit                               0x000000010b86f5a0 uv__stream_io + 1232
12  urbit                               0x000000010b877974 uv__io_poll + 1764
13  urbit                               0x000000010b8Abort trap: 6
```