### PR TITLE
lte: restore lens control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all install cross release test clean
+.PHONY: build build-all install cross release test pills clean
 
 build:
 	nix-build -A urbit -A herb --no-out-link
@@ -17,6 +17,10 @@ release:
 
 test:
 	sh/test
+
+pills:
+	sh/update-solid-pill
+	sh/update-brass-pill
 
 clean:
 	rm -rf ./out ./work

--- a/bin/brass.pill
+++ b/bin/brass.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6186c1ae6122325e6b924092ae160c7a1d6069c08826900bc77b659244fcea82
-size 5456611
+oid sha256:1d2948cfe7dbf431ad12bffd8ea3cd99ac89ac5f60beb6167d431cf718addb24
+size 4461167

--- a/bin/brass.pill
+++ b/bin/brass.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d2948cfe7dbf431ad12bffd8ea3cd99ac89ac5f60beb6167d431cf718addb24
-size 4461167
+oid sha256:2b7ee602f18661a07c88f2fbb2297f2d8e6fd329db0afc760ad334a845e73c9c
+size 4601348

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8e037056b3abb0407cf2b4a1d9051a833ad385fca663f0da89113ee07d5c727
-size 8075122
+oid sha256:3f7e072702921ebe858cfc8056bf9a9930ee6ef32184254930cf4ee1908f0461
+size 7018824

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f7e072702921ebe858cfc8056bf9a9930ee6ef32184254930cf4ee1908f0461
-size 7018824
+oid sha256:cdf8ed31292285c9dda789a8ac313babb4d9ce98f19ace4a813d821a9861d685
+size 7168503

--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -15,7 +15,7 @@ worker_objs = $(shell echo $(worker) | sed 's/\.c/.o/g')
 
 all_objs = $(common_objs) $(daemon_objs) $(worker_objs)
 all_srcs = $(common) $(daemon) $(worker)
-all_exes = ./hash_tests ./hashtable_tests ./urbit ./urbit-worker
+all_exes = ./mug_tests jam_tests ./hashtable_tests ./urbit ./urbit-worker
 
 
 # -Werror promotes all warnings that are enabled into errors (this is on)
@@ -29,11 +29,12 @@ CFLAGS := $(CFLAGS)
 
 ################################################################################
 
-all: urbit urbit-worker hashtable_tests hash_tests
+all: urbit urbit-worker hashtable_tests jam_tests mug_tests
 
-test: hashtable_tests hash_tests
+test: hashtable_tests jam_tests mug_tests
 	./hashtable_tests
-	./hash_tests
+	./jam_tests
+	./mug_tests
 
 clean:
 	rm -f ./tags $(all_objs) $(all_exes)
@@ -47,7 +48,11 @@ hashtable_tests: $(common_objs) tests/hashtable_tests.o
 	@echo CC -o $@
 	@$(CC) $^ $(LDFLAGS) -o $@
 
-hash_tests: $(common_objs) tests/hash_tests.o
+jam_tests: $(common_objs) tests/jam_tests.o
+	@echo CC -o $@
+	@$(CC) $^ $(LDFLAGS) -o $@
+
+mug_tests: $(common_objs) tests/mug_tests.o
 	@echo CC -o $@
 	@$(CC) $^ $(LDFLAGS) -o $@
 

--- a/pkg/urbit/jets/e/cue.c
+++ b/pkg/urbit/jets/e/cue.c
@@ -3,94 +3,239 @@
 */
 #include "all.h"
 
+#define CUE_ROOT 0
+#define CUE_HEAD 1
+#define CUE_TAIL 2
 
-  static u3_noun
-  _cue_in(u3p(u3h_root) har_p,
-          u3_atom       a,
-          u3_atom       b)
+//  stack frame for record head vs tail iteration
+//
+//    In Hoon, this structure would be as follows:
+//
+//    $%  [%root ~]
+//        [%head cell-cursor=@]
+//        [%tail cell-cursor=@ hed-width=@ hed-value=@]
+//    ==
+//
+typedef struct cueframe
+{
+  c3_y    tag_y;
+  u3_atom cur;
+  u3_atom wid;
+  u3_noun hed;
+} cueframe;
+
+static inline void
+_cue_push(c3_ys   mov,
+          c3_ys   off,
+          c3_y    tag_y,
+          u3_atom cur,
+          u3_atom wid,
+          u3_noun hed)
+{
+  u3R->cap_p += mov;
+
+  //  ensure we haven't overflowed the stack
+  //  (off==0 means we're on a north road)
+  //
+  if ( 0 == off ) {
+    c3_assert(u3R->cap_p > u3R->hat_p);
+  }
+  else {
+    c3_assert(u3R->cap_p < u3R->hat_p);
+  }
+
+  cueframe* fam_u = u3to(cueframe, u3R->cap_p + off);
+  fam_u->tag_y = tag_y;
+  fam_u->cur   = cur;
+  fam_u->wid   = wid;
+  fam_u->hed   = hed;
+}
+
+static inline cueframe
+_cue_pop(c3_ys mov, c3_ys off)
+{
+  cueframe* fam_u = u3to(cueframe, u3R->cap_p + off);
+  u3R->cap_p -= mov;
+
+  return *fam_u;
+}
+
+u3_noun
+u3qe_cue(u3_atom a)
+{
+  //  initialize signed stack offsets (relative to north/south road)
+  //
+  c3_ys mov, off;
   {
-    u3_noun p, q;
+    c3_y wis_y = c3_wiseof(cueframe);
+    c3_o nor_o = u3a_is_north(u3R);
+    mov = ( c3y == nor_o ? -wis_y : wis_y );
+    off = ( c3y == nor_o ? 0 : -wis_y );
+  }
 
-    if ( 0 == u3qc_cut(0, b, 1, a) ) {
-      u3_noun x = u3qa_inc(b);
-      u3_noun c = u3qe_rub(x, a);
+  //  initialize a hash table for dereference backrefs
+  //
+  u3p(u3h_root) har_p = u3h_new();
 
-      p = u3qa_inc(u3k(u3h(c)));
-      q = u3k(u3t(c));
+  //  stash the current stack post
+  //
+  u3p(cueframe) cap_p = u3R->cap_p;
 
-      u3h_put(har_p, u3k(b), u3k(q));
+  //  push the (only) ROOT stack frame (our termination condition)
+  //
+  _cue_push(mov, off, CUE_ROOT, 0, 0, 0);
 
-      u3z(c);
+  // initialize cursor to bit-position 0
+  //
+  u3_atom cur = 0;
+
+  //  the bitwidth and product from reading at cursor
+  //
+  u3_atom wid, pro;
+
+  //  read from atom at cursor
+  //
+  //    TRANSFER .cur
+  //
+  pass: {
+    //  read tag bit at cur
+    //
+    c3_y tag_y = u3qc_cut(0, cur, 1, a);
+
+    //  low bit unset, (1 + cur) points to an atom
+    //
+    //    produce atom and the width we read
+    //
+    if ( 0 == tag_y ) {
+      u3_noun bur;
+      {
+        u3_noun x = u3qa_inc(cur);
+        bur = u3qe_rub(x, a);
+        u3z(x);
+      }
+
+      pro = u3k(u3t(bur));
+      u3h_put(har_p, cur, u3k(pro));
+      wid = u3qa_inc(u3h(bur));
+
+      u3z(bur);
+      goto give;
+    }
+
+    //  read tag bit at (1 + cur)
+    //
+    {
+      u3_noun x = u3qa_inc(cur);
+      tag_y = u3qc_cut(0, x, 1, a);
       u3z(x);
     }
-    else {
-      u3_noun c = u3qa_add(2, b);
-      u3_noun l = u3qa_inc(b);
 
-      if ( 0 == u3qc_cut(0, l, 1, a) ) {
-        u3_noun u, v, w;
-        u3_noun x, y;
-
-        u = _cue_in(har_p, a, c);
-        x = u3qa_add(u3h(u), c);
-        v = _cue_in(har_p, a, x);
-        w = u3nc(u3k(u3h(u3t(u))), u3k(u3h(u3t(v))));
-
-        y = u3qa_add(u3h(u), u3h(v));
-        p = u3qa_add(2, y);
-
-        q = w;
-        u3h_put(har_p, u3k(b), u3k(q));
-
-        u3z(u); u3z(v); u3z(x); u3z(y);
+    //  next bit set, (2 + cur) points to a backref
+    //
+    //    produce referenced value and the width we read
+    //
+    if ( 1 == tag_y ) {
+      u3_noun bur;
+      {
+        u3_noun x = u3ka_add(2, cur);
+        bur = u3qe_rub(x, a);
+        u3z(x);
       }
-      else {
-        u3_noun d = u3qe_rub(c, a);
-        u3_noun x = u3h_get(har_p, u3k(u3t(d)));
 
-        p = u3qa_add(2, u3h(d));
-        if ( u3_none == x ) {
-          return u3m_bail(c3__exit);
-        }
-        q = x;
-        u3z(d);
+      pro = u3h_get(har_p, u3k(u3t(bur)));
+
+      if ( u3_none == pro ) {
+        return u3m_bail(c3__exit);
       }
-      u3z(l);
-      u3z(c);
+
+      wid = u3qa_add(2, u3h(bur));
+
+      u3z(bur);
+      goto give;
     }
-    return u3nt(p, q, 0);
-  }
 
-  u3_noun
-  u3qe_cue(u3_atom a)
-  {
-    u3p(u3h_root) har_p = u3h_new();
+    //  next bit unset, (2 + cur) points to the head of a cell
+    //
+    //    push a frame to mark HEAD recursion and read the head
+    //
+    {
+      _cue_push(mov, off, CUE_HEAD, cur, 0, 0);
 
-    u3_noun x = _cue_in(har_p, a, 0);
-    u3_noun y = u3k(u3h(u3t(x)));
-
-    u3h_free(har_p);
-
-    u3z(x);
-    return y;
-  }
-  u3_noun
-  u3we_cue(u3_noun cor)
-  {
-    u3_noun a;
-
-    if ( (u3_none == (a = u3r_at(u3x_sam, cor))) ) {
-      return u3m_bail(c3__fail);
-    } else {
-      return u3qe_cue(a);
+      cur = u3qa_add(2, cur);
+      goto pass;
     }
   }
-  u3_noun
-  u3ke_cue(u3_atom a)
-  {
-    u3_noun b = u3qe_cue(a);
 
-    u3z(a);
-    return b;
+  //  consume: popped stack frame, .wid and .pro from above.
+  //
+  //    TRANSFER .wid, .pro, and contents of .fam_u
+  //    (.cur is in scope, but we have already lost our reference to it)
+  //
+  give: {
+    cueframe fam_u = _cue_pop(mov, off);
+
+    switch ( fam_u.tag_y ) {
+      default: {
+        c3_assert(0);
+      }
+
+      //  fam_u is our stack root, we're done.
+      //
+      case CUE_ROOT: {
+        break;
+      }
+
+      //  .wid and .pro are the head of the cell at fam_u.cur.
+      //  save them (and the cell cursor) in a TAIL frame,
+      //  set the cursor to the tail and read there.
+      //
+      case CUE_HEAD: {
+        _cue_push(mov, off, CUE_TAIL, fam_u.cur, wid, pro);
+
+        cur = u3ka_add(2, u3qa_add(wid, fam_u.cur));
+        goto pass;
+      }
+
+      //  .wid and .pro are the tail of the cell at fam_u.cur,
+      //  construct the cell, memoize it, and produce it along with
+      //  its total width (as if it were a read from above).
+      //
+      case CUE_TAIL: {
+        pro = u3nc(fam_u.hed, pro);
+        u3h_put(har_p, fam_u.cur, u3k(pro));
+        wid = u3ka_add(2, u3ka_add(wid, fam_u.wid));
+        goto give;
+      }
+    }
   }
 
+  u3z(wid);
+  u3h_free(har_p);
+
+  //  sanity check
+  //
+  c3_assert( u3R->cap_p == cap_p );
+
+  return pro;
+}
+
+u3_noun
+u3we_cue(u3_noun cor)
+{
+  u3_noun a;
+
+  if ( (u3_none == (a = u3r_at(u3x_sam, cor))) ) {
+    return u3m_bail(c3__fail);
+  } else {
+    return u3qe_cue(a);
+  }
+}
+
+u3_noun
+u3ke_cue(u3_atom a)
+{
+  u3_noun b = u3qe_cue(a);
+
+  u3z(a);
+  return b;
+}

--- a/pkg/urbit/tests/jam_tests.c
+++ b/pkg/urbit/tests/jam_tests.c
@@ -1,0 +1,113 @@
+#include "all.h"
+
+/* _setup(): prepare for tests.
+*/
+static void
+_setup(void)
+{
+  u3m_init();
+  u3m_pave(c3y, c3n);
+}
+
+/* _test_jam(): spot check jam/cue
+*/
+static void
+_test_jam(void)
+{
+  if ( 0xc != u3qe_jam(1) ) {
+    fprintf(stderr, "jam: fail (a)\r\n");
+    exit(1);
+  }
+
+  if ( 1 != u3ke_cue(u3qe_jam(1)) ) {
+    fprintf(stderr, "jam: fail (b)\r\n");
+    exit(1);
+  }
+
+  {
+    u3_noun a = u3nc(1, 2);
+
+    if ( 0x1231 != u3qe_jam(a) ) {
+      fprintf(stderr, "jam: fail (c)\r\n");
+      exit(1);
+    }
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (d)\r\n");
+      exit(1);
+    }
+  }
+
+  {
+    u3_noun a = u3nt(1, 2, 3);
+
+    if ( 0x344871 != u3qe_jam(a) ) {
+      fprintf(stderr, "jam: fail (e)\r\n");
+      exit(1);
+    }
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (f)\r\n");
+      exit(1);
+    }
+  }
+
+  {
+    u3_noun a = u3nc(u3nc(1, 2), 3);
+
+    // fprintf(stderr, "%x\n", u3qe_jam(a));
+
+    if ( 0x3448c5 != u3qe_jam(a) ) {
+      fprintf(stderr, "jam: fail (g)\r\n");
+      exit(1);
+    }
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (h)\r\n");
+      exit(1);
+    }
+  }
+
+  {
+    u3_noun b = u3nc(1, 2);
+    u3_noun a = u3nt(b, b, b);
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (j)\r\n");
+      exit(1);
+    }
+  }
+
+  {
+    u3_noun b = u3i_string("abcdefjhijklmnopqrstuvwxyz");
+    u3_noun a = u3nq(b, 2, 3, b);
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (k)\r\n");
+      exit(1);
+    }
+  }
+
+  {
+    u3_noun a = u3nc(u3nc(u3nc(1, u3nc(u3nc(2, u3nc(u3nc(3, u3nc(u3nc(4, u3nc(u3nt(5, 6, u3nc(7, u3nc(u3nc(8, 0), 0))), 0)), 0)), 0)), 0)), 0), 0);
+
+    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
+      fprintf(stderr, "jam: fail (l)\r\n");
+      exit(1);
+    }
+  }
+
+  fprintf(stderr, "test_jam: ok\n");
+}
+
+/* main(): run all test cases.
+*/
+int
+main(int argc, char* argv[])
+{
+  _setup();
+
+  _test_jam();
+
+  return 0;
+}

--- a/pkg/urbit/tests/mug_tests.c
+++ b/pkg/urbit/tests/mug_tests.c
@@ -90,6 +90,8 @@ _test_mug(void)
       exit(1);
     }
   }
+
+  fprintf(stderr, "test_mug: ok\n");
 }
 
 /* main(): run all test cases.

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -1790,6 +1790,18 @@ u3_http_ef_form(u3_noun fig)
   u3_Host.fig_u.for_u = for_u;
 
   _http_serv_restart();
+
+  //  The control server has now started.
+  //
+  //    If we're in daemon mode, we need to inform the parent process
+  //    that we've finished booting.
+  //
+  //    XX using this effect is a terrible heuristic;
+  //    "fully booted" should be formalized.
+  //
+  if (u3_Host.bot_f) {
+    u3_Host.bot_f();
+  }
 }
 
 /* u3_http_io_init(): initialize http I/O.

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -1317,7 +1317,7 @@ _http_init_tls(uv_buf_t key_u, uv_buf_t cer_u)
                           "RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS");
 
   // enable ALPN for HTTP 2 support
-#if H2O_USE_ALPN
+#if 0 //H2O_USE_ALPN
   {
     SSL_CTX_set_ecdh_auto(tls_u, 1);
     h2o_ssl_register_alpn_protocols(tls_u, h2o_http2_alpn_protocols);

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -383,11 +383,23 @@ _http_req_dispatch(u3_hreq* req_u, u3_noun req)
 
   u3_noun pox = _http_req_to_duct(req_u);
 
-  u3_pier_plan(pox, u3nq(u3i_string("request"),
-                         req_u->hon_u->htp_u->sec,
-                         u3nc(c3__ipv4,
-                              u3i_words(1, &req_u->hon_u->ipf_w)),
-                         req));
+  if ( c3y == req_u->hon_u->htp_u->lop ) {
+    u3_pier_plan(pox, u3nq(u3i_string("request-local"),
+                           //  XX automatically secure too?
+                           //
+                           req_u->hon_u->htp_u->sec,
+                           u3nc(c3__ipv4,
+                                u3i_words(1, &req_u->hon_u->ipf_w)),
+                           req));
+
+  }
+  else {
+    u3_pier_plan(pox, u3nq(u3i_string("request"),
+                           req_u->hon_u->htp_u->sec,
+                           u3nc(c3__ipv4,
+                                u3i_words(1, &req_u->hon_u->ipf_w)),
+                           req));
+  }
 }
 
 /* _http_hgen_dispose(): dispose response generator and buffers

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -658,7 +658,7 @@ _http_rec_accept(h2o_handler_t* han_u, h2o_req_t* rec_u)
     req_u->tim_u = c3_malloc(sizeof(*req_u->tim_u));
     req_u->tim_u->data = req_u;
     uv_timer_init(u3L, req_u->tim_u);
-    uv_timer_start(req_u->tim_u, _http_req_timer_cb, 300 * 1000, 0);
+    uv_timer_start(req_u->tim_u, _http_req_timer_cb, 600 * 1000, 0);
 
     _http_req_dispatch(req_u, req);
   }
@@ -2630,7 +2630,7 @@ _proxy_ward_start(u3_pcon* con_u, u3_noun sip)
     //  XX how long?
     //
     uv_timer_init(u3L, &rev_u->tim_u);
-    uv_timer_start(&rev_u->tim_u, _proxy_ward_timer_cb, 300 * 1000, 0);
+    uv_timer_start(&rev_u->tim_u, _proxy_ward_timer_cb, 600 * 1000, 0);
   }
 
   u3z(sip);


### PR DESCRIPTION
The PR gets `lighter-than-eyre` back to a working state on top of `cc-release`.

There's a new, pre-authorized `%request-local` task for `%rver` sent by the "lens" server, which is bound to localhost (thanks @ixv!). The cc-release daemon-mode "boot-complete" callback is restored to the `%form` effect handler (a inelegant but effective heuristic). And HTTP2 is disabled (for now). This also includes a merge of the latest cc-release to pick up the improvements to the +cue jet. 