### PR TITLE
cc-release: revise explicit-stack conventions in mug

### DIFF
--- a/pkg/urbit/jets/e/cue.c
+++ b/pkg/urbit/jets/e/cue.c
@@ -97,7 +97,7 @@ u3qe_cue(u3_atom a)
   //
   //    TRANSFER .cur
   //
-  read: {
+  advance: {
     //  read tag bit at cur
     //
     c3_y tag_y = u3qc_cut(0, cur, 1, a);
@@ -119,50 +119,50 @@ u3qe_cue(u3_atom a)
       wid = u3qa_inc(u3h(bur));
 
       u3z(bur);
-      goto take;
+      goto retreat;
     }
-
-    //  read tag bit at (1 + cur)
-    //
-    {
-      u3_noun x = u3qa_inc(cur);
-      tag_y = u3qc_cut(0, x, 1, a);
-      u3z(x);
-    }
-
-    //  next bit set, (2 + cur) points to a backref
-    //
-    //    produce referenced value and the width we read
-    //
-    if ( 1 == tag_y ) {
-      u3_noun bur;
+    else {
+      //  read tag bit at (1 + cur)
+      //
       {
-        u3_noun x = u3ka_add(2, cur);
-        bur = u3qe_rub(x, a);
+        u3_noun x = u3qa_inc(cur);
+        tag_y = u3qc_cut(0, x, 1, a);
         u3z(x);
       }
 
-      pro = u3h_get(har_p, u3k(u3t(bur)));
+      //  next bit set, (2 + cur) points to a backref
+      //
+      //    produce referenced value and the width we read
+      //
+      if ( 1 == tag_y ) {
+        u3_noun bur;
+        {
+          u3_noun x = u3ka_add(2, cur);
+          bur = u3qe_rub(x, a);
+          u3z(x);
+        }
 
-      if ( u3_none == pro ) {
-        return u3m_bail(c3__exit);
+        pro = u3h_get(har_p, u3k(u3t(bur)));
+
+        if ( u3_none == pro ) {
+          return u3m_bail(c3__exit);
+        }
+
+        wid = u3qa_add(2, u3h(bur));
+
+        u3z(bur);
+        goto retreat;
       }
+      //  next bit unset, (2 + cur) points to the head of a cell
+      //
+      //    push a frame to mark HEAD recursion and read the head
+      //
+      else {
+        _cue_push(mov, off, CUE_HEAD, cur, 0, 0);
 
-      wid = u3qa_add(2, u3h(bur));
-
-      u3z(bur);
-      goto take;
-    }
-
-    //  next bit unset, (2 + cur) points to the head of a cell
-    //
-    //    push a frame to mark HEAD recursion and read the head
-    //
-    {
-      _cue_push(mov, off, CUE_HEAD, cur, 0, 0);
-
-      cur = u3qa_add(2, cur);
-      goto read;
+        cur = u3qa_add(2, cur);
+        goto advance;
+      }
     }
   }
 
@@ -171,7 +171,7 @@ u3qe_cue(u3_atom a)
   //    TRANSFER .wid, .pro, and contents of .fam_u
   //    (.cur is in scope, but we have already lost our reference to it)
   //
-  take: {
+  retreat: {
     cueframe fam_u = _cue_pop(mov, off);
 
     switch ( fam_u.tag_y ) {
@@ -193,7 +193,7 @@ u3qe_cue(u3_atom a)
         _cue_push(mov, off, CUE_TAIL, fam_u.cur, wid, pro);
 
         cur = u3ka_add(2, u3qa_add(wid, fam_u.cur));
-        goto read;
+        goto advance;
       }
 
       //  .wid and .pro are the tail of the cell at fam_u.cur,
@@ -204,7 +204,7 @@ u3qe_cue(u3_atom a)
         pro = u3nc(fam_u.hed, pro);
         u3h_put(har_p, fam_u.cur, u3k(pro));
         wid = u3ka_add(2, u3ka_add(wid, fam_u.wid));
-        goto take;
+        goto retreat;
       }
     }
   }

--- a/pkg/urbit/jets/e/cue.c
+++ b/pkg/urbit/jets/e/cue.c
@@ -7,7 +7,7 @@
 #define CUE_HEAD 1
 #define CUE_TAIL 2
 
-//  stack frame for record head vs tail iteration
+//  stack frame for recording head vs tail iteration
 //
 //    In Hoon, this structure would be as follows:
 //
@@ -97,7 +97,7 @@ u3qe_cue(u3_atom a)
   //
   //    TRANSFER .cur
   //
-  pass: {
+  read: {
     //  read tag bit at cur
     //
     c3_y tag_y = u3qc_cut(0, cur, 1, a);
@@ -119,7 +119,7 @@ u3qe_cue(u3_atom a)
       wid = u3qa_inc(u3h(bur));
 
       u3z(bur);
-      goto give;
+      goto take;
     }
 
     //  read tag bit at (1 + cur)
@@ -151,7 +151,7 @@ u3qe_cue(u3_atom a)
       wid = u3qa_add(2, u3h(bur));
 
       u3z(bur);
-      goto give;
+      goto take;
     }
 
     //  next bit unset, (2 + cur) points to the head of a cell
@@ -162,7 +162,7 @@ u3qe_cue(u3_atom a)
       _cue_push(mov, off, CUE_HEAD, cur, 0, 0);
 
       cur = u3qa_add(2, cur);
-      goto pass;
+      goto read;
     }
   }
 
@@ -171,7 +171,7 @@ u3qe_cue(u3_atom a)
   //    TRANSFER .wid, .pro, and contents of .fam_u
   //    (.cur is in scope, but we have already lost our reference to it)
   //
-  give: {
+  take: {
     cueframe fam_u = _cue_pop(mov, off);
 
     switch ( fam_u.tag_y ) {
@@ -193,7 +193,7 @@ u3qe_cue(u3_atom a)
         _cue_push(mov, off, CUE_TAIL, fam_u.cur, wid, pro);
 
         cur = u3ka_add(2, u3qa_add(wid, fam_u.cur));
-        goto pass;
+        goto read;
       }
 
       //  .wid and .pro are the tail of the cell at fam_u.cur,
@@ -204,7 +204,7 @@ u3qe_cue(u3_atom a)
         pro = u3nc(fam_u.hed, pro);
         u3h_put(har_p, fam_u.cur, u3k(pro));
         wid = u3ka_add(2, u3ka_add(wid, fam_u.wid));
-        goto give;
+        goto take;
       }
     }
   }

--- a/pkg/urbit/jets/e/cue.c
+++ b/pkg/urbit/jets/e/cue.c
@@ -13,7 +13,7 @@
 //
 //    $%  [%root ~]
 //        [%head cell-cursor=@]
-//        [%tail cell-cursor=@ hed-width=@ hed-value=@]
+//        [%tail cell-cursor=@ hed-width=@ hed-value=*]
 //    ==
 //
 typedef struct cueframe

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1639,11 +1639,12 @@ u3r_mug(u3_noun veb)
 
   //  read from the current noun .veb
   //
-  read: {
+  advance: {
     //  veb is a direct atom, mug is not memoized
     //
     if ( _(u3a_is_cat(veb)) ) {
       mug_w = u3r_mug_bytes((c3_y*)&veb, u3r_met(3, veb));
+      goto retreat;
     }
     //  veb is indirect, a pointer into the loom
     //
@@ -1654,6 +1655,7 @@ u3r_mug(u3_noun veb)
       //
       if ( 0 != veb_u->mug_w ) {
         mug_w = veb_u->mug_w;
+        goto retreat;
       }
       //  veb is an indirect atom, mug its bytes and memoize
       //
@@ -1661,6 +1663,7 @@ u3r_mug(u3_noun veb)
         u3a_atom* vat_u = (u3a_atom*)veb_u;
         mug_w = u3r_mug_bytes((c3_y*)vat_u->buf_w, u3r_met(3, veb));
         vat_u->mug_w = mug_w;
+        goto retreat;
       }
       //  veb is a cell, push a stack frame to mark head-recursion
       //  and read the head
@@ -1669,14 +1672,14 @@ u3r_mug(u3_noun veb)
         u3a_cell* cel_u = (u3a_cell*)veb_u;
         _mug_push(mov, off, MUG_HEAD, cel_u, 0);
         veb = cel_u->hed;
-        goto read;
+        goto advance;
       }
     }
   }
 
   //  consume the popped stack frame and mug from above
   //
-  take: {
+  retreat: {
     mugframe fam_u = _mug_pop(mov, off);
 
     switch ( fam_u.tag_y ) {
@@ -1698,7 +1701,7 @@ u3r_mug(u3_noun veb)
         _mug_push(mov, off, MUG_TAIL, fam_u.cel_u, mug_w);
 
         veb = fam_u.cel_u->tel;
-        goto read;
+        goto advance;
       }
 
       //  mug_w is the mug of the tail of cel_u
@@ -1708,7 +1711,7 @@ u3r_mug(u3_noun veb)
         u3a_cell* cel_u = fam_u.cel_u;
         mug_w = u3r_mug_both(fam_u.mug_w, mug_w);
         cel_u->mug_w = mug_w;
-        goto take;
+        goto retreat;
       }
     }
   }

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1554,17 +1554,32 @@ u3r_mug_cell(u3_noun hed,
   return u3r_mug_both(lus_w, biq_w);
 }
 
-//  mugframe: head and tail mugs of veb, 0 if uncalculated
+#define MUG_ROOT 0
+#define MUG_HEAD 1
+#define MUG_TAIL 2
+
+//  stack frame for recording head vs tail iteration
+//
+//    In Hoon, this structure would be as follows:
+//
+//    $%  [%root ~]
+//        [%head cell=^]
+//        [%tail cell=^ hed-mug=@]
+//    ==
 //
 typedef struct mugframe
 {
-  u3_noun veb;
-  c3_w a;
-  c3_w b;
+  c3_y      tag_y;
+  u3a_cell* cel_u;
+  c3_w      mug_w;
 } mugframe;
 
-static inline mugframe*
-_mug_push(c3_ys mov, c3_ys off, u3_noun veb)
+static inline void
+_mug_push(c3_ys mov,
+          c3_ys off,
+          c3_y tag_y,
+          u3a_cell* cel_u,
+          c3_w mug_w)
 {
   u3R->cap_p += mov;
 
@@ -1578,76 +1593,19 @@ _mug_push(c3_ys mov, c3_ys off, u3_noun veb)
     c3_assert(u3R->cap_p < u3R->hat_p);
   }
 
-  mugframe* cur = u3to(mugframe, u3R->cap_p + off);
-  cur->veb   = veb;
-  cur->a     = 0;
-  cur->b     = 0;
-  return cur;
+  mugframe* fam_u = u3to(mugframe, u3R->cap_p + off);
+  fam_u->tag_y = tag_y;
+  fam_u->cel_u = cel_u;
+  fam_u->mug_w = mug_w;
 }
 
-static inline mugframe*
-_mug_pop(c3_ys mov, c3_ys off, c3_w mug_w)
+static inline mugframe
+_mug_pop(c3_ys mov, c3_ys off)
 {
+  mugframe* fam_u = u3to(mugframe, u3R->cap_p + off);
   u3R->cap_p -= mov;
-  mugframe* fam = u3to(mugframe, u3R->cap_p + off);
 
-  //  the bottom of the stack
-  //
-  if ( u3_none == fam->veb ) {
-    return fam;
-  }
-
-  //  place return value in head of previous frame if not already calculated
-  //
-  if ( 0 == fam->a ) {
-    fam->a = mug_w;
-  }
-  //  otherwise, place the return value in the tail
-  //
-  else if ( 0 == fam->b ) {
-    fam->b = mug_w;
-  }
-  //  shouldn't reach
-  //
-  else {
-    c3_assert(0);
-  }
-  return fam;
-}
-
-//  _mug_cat(): return the mug of a direct atom
-//
-static c3_w
-_mug_cat(u3_atom veb)
-{
-  c3_w len_w = u3r_met(3, veb);
-  return u3r_mug_bytes((c3_y*)&veb, len_w);
-}
-
-/* _mug_pug(): statefully mug an indirect atom
-*/
-static c3_w
-_mug_pug(u3_atom veb)
-{
-  u3a_atom* vat_u = (u3a_atom*)(u3a_to_ptr(veb));
-  c3_w len_w      = u3r_met(3, veb);
-
-  c3_w mug_w = u3r_mug_bytes((c3_y*)vat_u->buf_w, len_w);
-  vat_u->mug_w = mug_w;
-  return mug_w;
-}
-
-/* _mug_atom(): mug an atom, either direct or indirect
-*/
-static c3_w
-_mug_atom(u3_atom veb)
-{
-  if ( _(u3a_is_cat(veb)) ) {
-    return _mug_cat(veb);
-  }
-  else {
-    return _mug_pug(veb);
-  }
+  return *fam_u;
 }
 
 //  u3r_mug(): statefully mug a noun using a 31-bit MurmurHash3
@@ -1655,75 +1613,109 @@ _mug_atom(u3_atom veb)
 c3_w
 u3r_mug(u3_noun veb)
 {
+  //  sanity check (makes a clear error message)
+  //
   c3_assert( u3_none != veb );
 
-  if ( _(u3a_is_atom(veb)) ) {
-    return _mug_atom(veb);
+  //  initialize signed stack offsets (relative to north/south road)
+  //
+  c3_ys mov, off;
+  {
+    c3_y wis_y = c3_wiseof(mugframe);
+    c3_o nor_o = u3a_is_north(u3R);
+    mov = ( c3y == nor_o ? -wis_y : wis_y );
+    off = ( c3y == nor_o ? 0 : -wis_y );
   }
 
-  c3_y  wis_y  = c3_wiseof(mugframe);
-  c3_o  nor_o  = u3a_is_north(u3R);
-  c3_ys mov    = ( c3y == nor_o ? -wis_y : wis_y );
-  c3_ys off    = ( c3y == nor_o ? 0 : -wis_y );
+  //  stash the current stack post
+  //
+  u3p(mugframe) cap_p = u3R->cap_p;
 
-  //  stash the current stack pointer
+  //  push the (only) ROOT stack frame (our termination condition)
   //
-  u3p(mugframe) empty = u3R->cap_p;
-  //  set the bottom of our stack
-  //
-  mugframe* don = _mug_push(mov, off, u3_none);
-  mugframe* fam = _mug_push(mov, off, veb);
+  _mug_push(mov, off, MUG_ROOT, 0, 0);
 
   c3_w mug_w;
-  c3_w a;
-  c3_w b;
-  u3a_noun* veb_u;
-  u3_noun hed, tal;
 
-  while ( don != fam ) {
-    a     = fam->a;
-    b     = fam->b;
-    veb   = fam->veb;
-    veb_u = u3a_to_ptr(veb);
-    c3_assert(_(u3a_is_cell(veb)));
-
-    //  already mugged; pop stack
+  //  read from the current noun .veb
+  //
+  read: {
+    //  veb is a direct atom, mug is not memoized
     //
-    if ( veb_u->mug_w ) {
-      mug_w = veb_u->mug_w;
-      fam = _mug_pop(mov, off, mug_w);
+    if ( _(u3a_is_cat(veb)) ) {
+      mug_w = u3r_mug_bytes((c3_y*)&veb, u3r_met(3, veb));
     }
-    //  neither head nor tail are mugged; start with head
-    //
-    else if ( 0 == a ) {
-      hed = u3h(veb);
-      if ( _(u3a_is_atom(hed)) ) {
-        fam->a = _mug_atom(hed);
-      }
-      else {
-        fam = _mug_push(mov, off, hed);
-      }
-    }
-    //  head is mugged, but not tail; mug tail or push tail onto stack
-    //
-    else if ( 0 == b ) {
-      tal = u3t(veb);
-      if ( _(u3a_is_atom(tal)) ) {
-        fam->b = _mug_atom(tal);
-      }
-      else {
-        fam = _mug_push(mov, off, tal);
-      }
-    }
-    //  both head and tail are mugged; combine them and pop stack
+    //  veb is indirect, a pointer into the loom
     //
     else {
-      mug_w = u3r_mug_both(a, b);
-      veb_u->mug_w = mug_w;
-      fam = _mug_pop(mov, off, mug_w);
+      u3a_noun* veb_u = u3a_to_ptr(veb);
+
+      //  veb has already been mugged, return memoized value
+      //
+      if ( 0 != veb_u->mug_w ) {
+        mug_w = veb_u->mug_w;
+      }
+      //  veb is an indirect atom, mug its bytes and memoize
+      //
+      else if ( _(u3a_is_atom(veb)) ) {
+        u3a_atom* vat_u = (u3a_atom*)veb_u;
+        mug_w = u3r_mug_bytes((c3_y*)vat_u->buf_w, u3r_met(3, veb));
+        vat_u->mug_w = mug_w;
+      }
+      //  veb is a cell, push a stack frame to mark head-recursion
+      //  and read the head
+      //
+      else {
+        u3a_cell* cel_u = (u3a_cell*)veb_u;
+        _mug_push(mov, off, MUG_HEAD, cel_u, 0);
+        veb = cel_u->hed;
+        goto read;
+      }
     }
   }
 
-  u3R->cap_p = empty;
+  //  consume the popped stack frame and mug from above
+  //
+  take: {
+    mugframe fam_u = _mug_pop(mov, off);
+
+    switch ( fam_u.tag_y ) {
+      default: {
+        c3_assert(0);
+      }
+
+      //  we done
+      //
+      case MUG_ROOT: {
+        break;
+      }
+
+      //  mug_w is the mug of the head of cel_u
+      //  push a stack frame to mark tail recursion,
+      //  record the mug of the head, and read the tail
+      //
+      case MUG_HEAD: {
+        _mug_push(mov, off, MUG_TAIL, fam_u.cel_u, mug_w);
+
+        veb = fam_u.cel_u->tel;
+        goto read;
+      }
+
+      //  mug_w is the mug of the tail of cel_u
+      //  combine the mugs, memoize the value, and recur
+      //
+      case MUG_TAIL: {
+        u3a_cell* cel_u = fam_u.cel_u;
+        mug_w = u3r_mug_both(fam_u.mug_w, mug_w);
+        cel_u->mug_w = mug_w;
+        goto take;
+      }
+    }
+  }
+
+  //  sanity check
+  //
+  c3_assert( u3R->cap_p == cap_p );
+
   return mug_w;
 }


### PR DESCRIPTION
NB, this PR is not urgent.

I've rewritten the mug implementation to maintain the stack discipline developed in #1275, and tweaked the conventions for both. We have a few of these potentially-massive recursive noun traversals, and I think it would be very helpful for them to follow the same conventions to the degree that's possible. I also think this refactoring makes for a clearer and simpler implementation on its own merits.

This is the right place to bikeshed this style, naming conventions, stack usage, etc. If approved, I'm inclined to implement the same style in the +jam jet, as will as u3r_sing/u3r_sung (noun equality, unifying). This kind of code is intrinsically complicated, but it would be much easier to work with if it were consistent.