### PR TITLE
cc-release: uses a separate desk and manual commit for +solid staging (avoids -A)

### DIFF
--- a/nix/ops/default.nix
+++ b/nix/ops/default.nix
@@ -10,6 +10,13 @@ let
   bootbrass = ../../bin/brass.pill;
   bootsolid = ../../bin/solid.pill;
 
+  rawzod = import ./fakeship {
+    inherit pkgs tlon deps debug;
+    pill = bootsolid;
+    ship = "zod";
+    arvo = null;
+  };
+
   zod = import ./fakeship {
     inherit pkgs tlon deps arvo debug;
     pill = bootsolid;
@@ -33,7 +40,7 @@ rec {
 
   solid = import ./solid {
     inherit arvo pkgs tlon deps debug;
-    pier = zod;
+    pier = rawzod;
   };
 
   brass = import ./brass {

--- a/nix/ops/fakeship/builder.sh
+++ b/nix/ops/fakeship/builder.sh
@@ -2,7 +2,12 @@ source $stdenv/setup
 
 set -ex
 
-$URBIT -d -F $SHIP -A "$ARVO" -B "$PILL" $out
+if [ -z "$ARVO" ]
+then
+    $URBIT -d -F $SHIP -B "$PILL" $out
+else
+    $URBIT -d -F $SHIP -A "$ARVO" -B "$PILL" $out
+fi
 
 check () {
   [ 3 -eq "$(herb $out -d 3)" ]

--- a/nix/ops/solid/builder.sh
+++ b/nix/ops/solid/builder.sh
@@ -15,7 +15,15 @@ cleanup () {
 
 trap cleanup EXIT
 
-herb ./pier -P solid.pill -d '+solid, =dub &'
+herb ./pier -p hood -d '+hood/merge %stage our %home'
+herb ./pier -p hood -d "+hood/mount /=stage="
+
+rm -r ./pier/stage
+cp -r $ARVO ./pier/stage
+
+herb ./pier -p hood -d "+hood/commit %stage"
+
+herb ./pier -P solid.pill -d '+solid /=stage=/sys, =dub &'
 
 mv solid.pill $out
 


### PR DESCRIPTION
This fixes the incorrect pill-staging behavior discussed in urbit/arvo#1171.

I've only made this change to the use of `+solid` and not that of `+brass`. This implies that changes should be staged in the solid.pill, and that the brass.pill should be updated afterwards. This strikes me as the desired developer experience, and the correct approach more generally, but I'm open to dissent. (Long story short, if you're going to do both, run `./sh/update-solid-pill` *before* `./sh/update-brass-pill`.