### PR TITLE
cleans up some printf edge-cases on cc-release

### DIFF
--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -20,8 +20,8 @@
 #     define c3_assert(x)                       \
         do {                                    \
           if (!(x)) {                           \
-            u3l_log("\rAssertion '%s' failed "  \
-                    "in %s:%d\n",               \
+            fprintf(stderr, "\rAssertion '%s' " \
+                    "failed in %s:%d\n",        \
                     #x, __FILE__, __LINE__);    \
             c3_cooked();                        \
             assert(x);                          \

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -370,15 +370,18 @@ u3a_reflux(void)
 void
 u3a_reclaim(void)
 {
+  //  XX u3l_log avoid here, as it can
+  //  cause problems when handling errors
+
   if ( (0 == u3R->cax.har_p) ||
        (0 == u3to(u3h_root, u3R->cax.har_p)->use_w) )
   {
-    u3l_log("allocate: reclaim: memo cache: empty\r\n");
+    fprintf(stderr, "allocate: reclaim: memo cache: empty\r\n");
     u3m_bail(c3__meme);
   }
 
 #if 1
-  u3l_log("allocate: reclaim: half of %d entries\r\n",
+  fprintf(stderr, "allocate: reclaim: half of %d entries\r\n",
           u3to(u3h_root, u3R->cax.har_p)->use_w);
 
   u3h_trim_to(u3R->cax.har_p, u3to(u3h_root, u3R->cax.har_p)->use_w / 2);

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -118,11 +118,14 @@ u3e_fault(void* adr_v, c3_i ser_i)
     return 0;
   }
 
+  //  XX u3l_log avoid here, as it can
+  //  cause problems when handling errors
+
   c3_w* adr_w = (c3_w*) adr_v;
 
   if ( (adr_w < u3_Loom) || (adr_w >= (u3_Loom + u3a_words)) ) {
-    u3l_log("address %p out of loom!\r\n", adr_v);
-    u3l_log("loom: [%p : %p)\r\n", u3_Loom, u3_Loom + u3a_words);
+    fprintf(stderr, "address %p out of loom!\r\n", adr_v);
+    fprintf(stderr, "loom: [%p : %p)\r\n", u3_Loom, u3_Loom + u3a_words);
     c3_assert(0);
     return 0;
   }
@@ -143,7 +146,7 @@ u3e_fault(void* adr_v, c3_i ser_i)
 #endif
 
     if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      u3l_log("strange page: %d, at %p, off %x\r\n",
+      fprintf(stderr, "strange page: %d, at %p, off %x\r\n",
               pag_w, adr_w, off_w);
       abort();
     }
@@ -155,7 +158,7 @@ u3e_fault(void* adr_v, c3_i ser_i)
                         (1 << (u3a_page + 2)),
                         (PROT_READ | PROT_WRITE)) )
     {
-      u3l_log("loom: fault mprotect: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: fault mprotect: %s\r\n", strerror(errno));
       c3_assert(0);
       return 0;
     }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -629,11 +629,11 @@ u3m_bail(u3_noun how)
       str_c[2] = ((how >> 16) & 0xff);
       str_c[3] = ((how >> 24) & 0xff);
       str_c[4] = 0;
-      u3l_log("\r\nbail: %s\r\n", str_c);
+      fprintf(stderr, "\r\nbail: %s\r\n", str_c);
     }
     else {
       c3_assert(_(u3ud(u3h(how))));
-      u3l_log("\r\nbail: %d\r\n", u3h(how));
+      fprintf(stderr, "\r\nbail: %d\r\n", u3h(how));
     }
   }
 
@@ -643,7 +643,7 @@ u3m_bail(u3_noun how)
     }
 
     case c3__meme: {
-      u3l_log("bailing out\r\n");
+      fprintf(stderr, "bailing out\r\n");
       abort();
     }
     case c3__exit: {
@@ -659,7 +659,7 @@ u3m_bail(u3_noun how)
     }
     case c3__foul:
     case c3__oops:
-      u3l_log("bailing out\r\n");
+      fprintf(stderr, "bailing out\r\n");
       assert(0);
   }
 

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -331,12 +331,27 @@ _daemon_come(u3_noun star, u3_noun pill, u3_noun path)
   _daemon_dawn(u3_dawn_come(), pill, path);
 }
 
+static void
+_daemon_slog(u3_noun hod)
+{
+  u3_pier_tank(0, u3k(u3t(hod)));
+  u3z(hod);
+}
+
 /* _daemon_dawn(): boot from keys, validating
 */
 void
 _daemon_dawn(u3_noun seed, u3_noun pill, u3_noun path)
 {
+  // enable ivory slog printfs
+  //
+  u3C.slog_f = _daemon_slog;
+
   u3_pier_boot(sag_w, u3k(u3h(seed)), u3_dawn_vent(seed), pill, path);
+
+  // disable ivory slog printfs
+  //
+  u3C.slog_f = 0;
 }
 
 /* _daemon_exit(): exit parser


### PR DESCRIPTION
Namely, enabling slog hint printfs during ethereum pre-boot validation (in the daemon) and disabling cross-process (worker to daemon) printfs when handling errors (segmentation faults and OOM).