### PR TITLE
Update README, CONTRIBUTING for 0.8.0 release.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,172 @@
+# Contributing to Urbit
+
+Thank you for your interest in contributing to urbit.
+
+See [urbit.org/docs/getting-started][start] for basic orientation and usage
+instructions.
+
+[start]: https://urbit.org/docs/getting-started/#arvo
+
+## Fake ships
+
+You may have an identity on the live network, but doing all your development on
+the live network would be cumbersome and unnecessary.  Standard practice in
+urbit development is to work on a fake `~zod`.  Fake ships use deterministic
+keys (derived from the ship address) and don't talk to the live network. They
+can talk to each other over the local loopback.
+
+To start a fake ship, simply specify the name with `-F`:
+
+```
+$ urbit -F zod
+```
+
+You can also pass a name for the *pier* (or ship directory):
+
+```
+$ urbit -F zod -c my-fake-zod
+```
+
+To resume a fake ship, just pass the name of the pier:
+
+```
+$ urbit my-fake-zod
+```
+
+## Git practice
+
+Since we use the GitHub issue tracker, it is helpful (though not required) to
+contribute via a GitHub pull request. If you already know what you are doing,
+skip down to the Style section.
+
+Start by cloning the repository on your work machine:
+
+```
+$ git clone https://github.com/urbit/urbit
+```
+
+And, additionally, fork the repository on GitHub by clicking the "Fork"
+button. Add your fork as a remote:
+
+```
+$ git remote add [username] https://github.com/[username]/urbit
+```
+
+and set it as the default remote to push to:
+
+```
+$ git config --local remote.pushDefault [username]
+```
+
+This is good practice for any project that uses git. You will pull
+upstream branches from urbit/urbit and push to your personal urbit fork
+by default.
+
+Next, start a new branch to do your work on.  Normally you'll want to use the
+`master` branch as your starting point:
+
+```
+$ git checkout -b [branch name] master
+```
+
+Now you are free to do your work on this branch. When finished, you may
+want to clean up your commits:
+
+```
+$ git rebase -i master
+```
+
+Then you can push to your public fork with `git push` and make a pull request
+via the GitHub UI.
+
+After your changes are merged upstream, you can delete your branch (via github
+UI or `git push :[branch]` remotely, and with `git branch -d` locally).
+
+## Style
+
+The urbit project uses two-space indentation and avoids tab characters.
+In C code, it should not be too difficult to mimic the style of the code
+around you, which is just fairly standard K&R with braces on every
+compound statement. One thing to watch out for is top-level sections in
+source files that are denoted by comments and are actually indented one
+level.
+
+Hoon will be a less familiar language to many contributors. More details are
+forthcoming; for now, the `%ford` vane (in [`sys/vane/ford.hoon`][ford]) is
+some of the highest quality code in the kernel.
+
+[ford]: https://github.com/urbit/arvo/blob/master/sys/vane/ford.hoon
+
+## Kernel development
+
+Working on either C or non-kernel Hoon should not bring any surprises, but the
+Hoon kernel (anything under `sys/` in [urbit/arvo][arvo]) is bootstrapped from
+a so-called *pill*, and must be recompiled if any changes are made. This should
+happen automatically when you make changes, but if it doesn't, the command to
+manually recompile and install the new kernel is `|reset` in `dojo`.  This
+rebuilds from the `sys` directory in the `home` desk in `%clay`.
+
+Currently, `|reset` does not reload apps like `dojo` itself, which will still
+reference the old kernel. To force them to reload, make a trivial edit to their
+main source file (under the `app` directory) in `%clay`.
+
+[arvo]: https://github.com/urbit/arvo
+
+## The kernel and pills
+
+Urbit bootstraps itself using a binary blob called a pill (you can see it being
+fetched from `bootstrap.urbit.org` on boot).  This is the compiled version of
+the kernel (which you can find in the `sys` directory of [urbit/arvo][arvo]),
+along with a complete copy of the `urbit/arvo` repository as source.
+
+The procedure for creating a pill is often called "soliding." It is somewhat
+similar to `|reset`, but instead of replacing your running kernel, it writes
+the compiled kernel to a file. The command to solid is:
+
+```
+> .urbit/pill +solid
+```
+
+When the compilation finishes, your pill will be found in the
+`[pier]/.urb/put/` directory as `urbit.pill`.
+
+You can boot a new ship from your local pill with `-B`:
+
+```
+$ urbit -F zod -B path/to/urbit.pill my-fake-zod
+```
+
+Ordinarily, `https://bootstrap.urbit.org/latest.pill` will be updated
+to match whatever's on the HEAD of `master` in the `urbit/arvo` repository.
+Older pills are indexed by the first 10 characters of the `git` SHA1 of the
+relevant commit, i.e. as `git-[sha1].pill`.  The continuous integration build
+of the `urbit/arvo` repository uploads these pills for any successful build of
+a commit or pull request that affects the `sys/` directory.
+
+You can boot from one of these pills by passing the path to an Arvo working
+copy with `-A` (and `-s` for *search*):
+
+```
+$ git clone https://github.com/urbit/arvo
+$ urbit -F zod -A path/to/arvo -s my-fake-zod
+```
+
+## What to work on
+
+If you are not thinking of contributing with a specific goal in mind, the
+GitHub issue tracker is the first place you should look for ideas.  Issues are
+occasionally tagged with a priority and a difficulty; a good place to start is
+on a low-difficulty or low-priority issue.  Higher-priority issues are likely
+to be assigned to someone -- if this is the case, then contacting that person
+to coordinate before starting to work is probably a good idea.
+
+There is also a "help wanted" tag for things that we are especially eager to
+have outside contributions on. Check here first!
+
+## Staying in touch
+
+Questions or other communications about contributing to Urbit can go to
+[support@urbit.org][mail].
+
+[mail]: mailto:support@urbit.org
+

--- a/README.md
+++ b/README.md
@@ -1,79 +1,65 @@
-> The Urbit address space is now live on the Ethereum blockchain. We’re calling it ‘Azimuth’ and you can find it at [`0x223c067f8cf28ae173ee5cafea60ca44c335fecb`](https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb) or [`azimuth.eth`](https://etherscan.io/address/azimuth.eth). Owners of Azimuth ‘points’ (galaxies, stars or planets) can use [Bridge](https://github.com/urbit/bridge/releases) to manage them and view their balance now. Sometime in the next few days, owners of Azimuth points will be able to boot Arvo, the Urbit OS, from their Azimuth point and request access to one of our ‘cities’: private communities for chat and discussion. These new cities use Landscape, a brand new UI for using Urbit in the browser.
+# Urbit
 
-# Install instructions
+> The Urbit address space, Azimuth, is now live on the Ethereum blockchain. You
+> can find it at [`0x223c067f8cf28ae173ee5cafea60ca44c335fecb`][azim] or
+> [`azimuth.eth`][aens]. Owners of Azimuth points (galaxies, stars, or planets)
+> can view or manage them using [Bridge][brid], and can also use them to boot
+> [Arvo][arvo], the Urbit OS.
+
+[azim]: https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb
+[aens]: https://etherscan.io/address/azimuth.eth
+[brid]: https://github.com/urbit/bridge/releases
+[arvo]: https://github.com/urbit/arvo/
+
+## Install instructions
 
 To install and run Urbit please follow the instructions at
-[urbit.org/docs/getting-started/](https://urbit.org/docs/getting-started/).
-Packages and source tarballs are available there. You'll be on the live network
-in a few minutes.
+[urbit.org/docs/getting-started/][start].  Packages and source tarballs are
+available there. You'll be on the live network in a few minutes.
 
-If you're doing development on Urbit, keep reading.
+[start]: https://urbit.org/docs/getting-started/
 
-# Build instructions
+## Build instructions
 
-[![Build Status](https://travis-ci.org/urbit/urbit.svg?branch=master)](https://travis-ci.org/urbit/urbit)
+[![Build Status](https://travis-ci.org/urbit/urbit.svg?branch=master)][trav]
 
-## External dependencies
+Urbit uses [Nix][nix] to manage builds.  On Linux and OS X you can install Nix
+via:
 
-`vere`, the Urbit virtual machine, depends on the following:
+```
+curl https://nixos.org/nix/install | sh
+```
 
-- C compiler ([gcc](https://gcc.gnu.org) or [clang](http://clang.llvm.org))
-- [Meson](http://mesonbuild.com/)
-- [GMP](https://gmplib.org)
-- [OpenSSL](https://www.openssl.org)
-- [libsigsegv](https://www.gnu.org/software/libsigsegv/)
-- [libcurl](https://curl.haxx.se/libcurl/)
-- [libuv](http://libuv.org)
-- curses implementation (ncurses on Linux distributions, OS curses otherwise)
+Given a Nix installation, you can build Urbit with a simple:
 
-Most of these dependencies are unfortunate; we aim to drastically shrink the
-list in upcoming versions. `vere` proper makes use of GMP, OpenSSL, libcurl, and
-libsigsegv.
+```
+nix-build -A urbit --no-out-link
+```
 
-## Building
+The Makefile in the project's root directory contains several useful phony
+targets for building, installing, testing, and so on.
 
-Urbit uses Meson build system.
+[trav]: https://github.com/urbit/urbit.git
+[nix]: https://nixos.org/nix/
 
-Some libraries which are not found in major distributions:
+## Contributing
 
-- ed25519
-- libh2o
-- murmur3
-- softfloat3
-- scrypt
+Contributions of any form are more than welcome! If something doesn't seem
+right, and there is no issue about it yet, feel free to open one.
 
-are included as git submodules. To build urbit from source, perform the following steps:
+If you're looking to get involved, there are a few things you can do:
 
-## Configuration & compilation
-(For instructions for legacy meson, also see below)
+- Join the [urbit-dev][list] mailing list.
+- [Ask us about Hoon School][mail], a course we run to teach the Hoon
+  programming language and Urbit application development.
+- Check out [good contributor issues][good].
+- Reach out to [support@urbit.org][mail] to say hi and ask any questions you
+  might have.
 
-1. Install all required dependencies.
-2. Run `./scripts/bootstrap`
-3. Run `./scripts/build`
-4. The executable should appear in `./build` directory.
+Once you've got your bearings, have a look at [CONTRIBUTING.md][cont] for some
+pointers on setting up your development environment.
 
-### Using meson & ninja
-
-To configure the project, enter the build directory and enter
-`meson configure -Dbuildtype=release`.  To compile a debug build of urbit, use
-`meson configure -Dbuildtype=debug`.
-To set a prefix for installation use
-`meson configure -Dprefix=/usr`.
-
-## Configuration & compilation for legacy meson
-
-The syntax for legacy meson (Version `0.29`) is a bit different.
-
-1. Manually create `build` directory and invoke meson as `meson . ./build`
-2. If you want to set options, this is done in one step.
-   Use `meson -D [options] . ./build` to prepare customized build.
-
-Once the project is configured, use `ninja` to build it.
-To install it into the default prefix, use `ninja install`.
-If you want to specify custom `DESTDIR`, use `DESTDIR=... ninja install`.
-
-## Contact
-
-We are using our new UI, Landscape to run a few experimental cities.
-If you have an Azimuth point, please send us your planet name at
-[support@urbit.org](mailto:support@urbit.org) to request access.
+[list]: https://groups.google.com/a/urbit.org/forum/#!forum/dev
+[mail]: mailto:support@urbit.org
+[good]: https://github.com/urbit/urbit/labels/good%20contributor%20issue
+[cont]: https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're interested in Urbit development, keep reading.
 
 [![Build Status](https://travis-ci.org/urbit/urbit.svg?branch=master)][trav]
 
-Urbit uses [Nix][nix] to manage builds.  On Linux and OS X you can install Nix
+Urbit uses [Nix][nix] to manage builds.  On Linux and macOS you can install Nix
 via:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Urbit
 
+A personal server operating function.
+
 > The Urbit address space, Azimuth, is now live on the Ethereum blockchain. You
 > can find it at [`0x223c067f8cf28ae173ee5cafea60ca44c335fecb`][azim] or
 > [`azimuth.eth`][aens]. Owners of Azimuth points (galaxies, stars, or planets)
@@ -11,15 +13,17 @@
 [brid]: https://github.com/urbit/bridge/releases
 [arvo]: https://github.com/urbit/arvo/
 
-## Install instructions
+## Install
 
-To install and run Urbit please follow the instructions at
-[urbit.org/docs/getting-started/][start].  Packages and source tarballs are
-available there. You'll be on the live network in a few minutes.
+To install and run Urbit, please follow the instructions at
+[urbit.org/docs/getting-started/][start].  You'll be on the live network in a
+few minutes.
+
+If you're interested in Urbit development, keep reading.
 
 [start]: https://urbit.org/docs/getting-started/
 
-## Build instructions
+## Development
 
 [![Build Status](https://travis-ci.org/urbit/urbit.svg?branch=master)][trav]
 
@@ -30,14 +34,21 @@ via:
 curl https://nixos.org/nix/install | sh
 ```
 
-Given a Nix installation, you can build Urbit with a simple:
+The Makefile in the project's root directory contains useful phony targets for
+building, installing, testing, and so on.  You can use it to avoid dealing with
+Nix explicitly.
+
+To build Urbit, for example, use:
 
 ```
-nix-build -A urbit --no-out-link
+make build
 ```
 
-The Makefile in the project's root directory contains several useful phony
-targets for building, installing, testing, and so on.
+The test suite can similarly be run via a simple:
+
+```
+make test
+```
 
 [trav]: https://github.com/urbit/urbit.git
 [nix]: https://nixos.org/nix/


### PR DESCRIPTION
(Resolves #1235.)

The main changes to `README` have simply been to remove the detailed build information, which is now subsumed by Nix.  I've added the simple `curl` one-liner instruction for downloading Nix, as well as pointed at the Makefile for performing most desirable dev tasks.

Note that the `README` also points at the "Getting Started" section of the docs proper.  I'm updating that in turn and will PR my changes when we release 0.8.0.  You can see the changes I've made [here](https://github.com/urbit/docs/commit/9b2b34e6ca2ac15e4e12e800fdb4d00b22679637) -- again, I've simplified the installation instructions and have primarily pointed at the static binaries we produce for macOS and Linux.

`CONTRIBUTING` hasn't changed much, but was missing from the cc-release branch.