### PR TITLE
fix monorepo merge builds in CI

### DIFF
--- a/sh/ci-tests
+++ b/sh/ci-tests
@@ -9,13 +9,6 @@ then
 
 else
 
-    nix-build nix/ops       \
-              -A test       \
-              -A brass      \
-              --max-jobs 2  \
-              --no-out-link
-
     sh/test --arg debug true
-    sh/update-brass-pill
 
 fi


### PR DESCRIPTION
This PR fixes the monorepo merge builds in CI by removing the pill staging (which was causing request timeouts to be hit due to resource contention due to being run in parallel with testing under GC). If we decide it's useful and want to bring it back, we should use the TravisCI build-matrix functionality to run it in a separate job.