### PR TITLE
moves :dns scry for ames domains in :dns|auto generator

### DIFF
--- a/pkg/arvo/app/dns.hoon
+++ b/pkg/arvo/app/dns.hoon
@@ -12,7 +12,7 @@
       ==
     +$  peek-data  _!!
     +$  in-poke-data
-      $%  [%dns-auto ~]
+      $%  [%dns-auto ames-domains=(list turf)]
           [%dns-address =address:dns]
       ==
     +$  out-poke-data
@@ -125,12 +125,13 @@
     ::  +galaxy-domains
     ::
     ++  galaxy-domains
+      |=  ames-domains=(list turf)
       =/  m  (async:stdio ,~)
       ^-  form:m
       ;<  our=@p   bind:m  get-identity:stdio
-      ;<  now=@da  bind:m  get-time:stdio
-      =/  ames-domains=(list turf)
-        .^((list turf) %j /(scot %p our)/turf/(scot %da now))
+      :: ;<  now=@da  bind:m  get-time:stdio
+      :: =/  ames-domains=(list turf)
+      ::   .^((list turf) %j /(scot %p our)/turf/(scot %da now))
       |-  ^-  form:m
       =*  loop  $
       ?~  ames-domains
@@ -194,7 +195,7 @@
       ::
       ~&  %galaxy-only
       (pure:m state)
-    ;<  ~  bind:m  galaxy-domains
+    ;<  ~  bind:m  (galaxy-domains ames-domains.in-poke-data)
     (pure:m state)
   ::
   ::  manual dns binding -- by explicit ipv4

--- a/pkg/arvo/gen/dns/auto.hoon
+++ b/pkg/arvo/gen/dns/auto.hoon
@@ -6,7 +6,7 @@
 /+  *generators
 :-  %ask
 |=  [[now=@da eny=@uvJ bec=beak] ~ ~]
-^-  (sole-result [%dns-auto ~])
+^-  (sole-result [%dns-auto (list turf)])
 =*  our  p.bec
 =/  rac  (clan:title our)
 ::
@@ -23,4 +23,7 @@
   %+  print  leaf+msg3
   %+  print  leaf+msg2
   (print leaf+msg1 no-product)
-(produce [%dns-auto ~])
+::
+=/  ames-domains=(list turf)
+  .^((list turf) %j /(scot %p our)/turf/(scot %da now))
+(produce [%dns-auto ames-domains])


### PR DESCRIPTION
... working around the current inability to scry within a tapp (see `+mule`). This fixes a bug introduced by an oversight in urbit/arvo#1197