### PR TITLE
disables (kind of) spurious condition in %ames ping flow

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1127,7 +1127,9 @@
                   ?|  bust:puz
                       ?=(~ rue.puz)
                       (gth now (add ~s32 u.rue.puz))
-                      (lth u.rue.puz hop.fox)
+                      ::  XX hop.fox is never set, nothing sends %kick
+                      ::
+                      :: (lth u.rue.puz hop.fox)
                   ==
               ==
             +>.$

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -12,18 +12,126 @@
 ::
 ++  test-init
   =^  results1  ames-gate
-    =/  hen=duct
-      [/ /term/1 / ~]
-    =/  wir=wire
-      /our/~nul
-    %-  ames-call
-    :*  ames-gate
-        now=~1234.5.6
-        call-args=[hen type=*type %soft %init ~nul]
-        [[hen %pass wir %j %vein ~] [hen %pass / %j %turf ~] ~]
+    =/  =duct  [/ /term/1 / ~]
+    =/  =wire  /our/~nul
+    %:  ames-call
+      ames-gate
+      now=~1234.5.6
+      call-args=[duct type=*type %soft %init ~nul]
+      expected-moves=[[duct %pass wire %j %vein ~] [duct %pass / %j %turf ~] ~]
     ==
   ::
   results1
+::
+::  tests that %ames sends a message to itself
+::
+++  test-send
+  =/  now  ~1234.5.6
+  =/  =duct  [/ /term/1 / ~]
+  =/  =wire  /our/~nul
+  =/  pact1
+    0wHfb.1hdCh.0oxed.Ta7-f.4IIDV.4ku6J.PoJe7.AiyMS.w~mfu.V04ja.iXj8d.E3nq7.
+    gcW-a.0II6T.vb5zH.FHEkp.J7wgT.XTnuu.KaUiu.xZ6dg.qgWSH.3ovaO.dETNQ.5YAOR.
+    Lw8Mj.iQCrM.-TcjY.gFysP.XCfdx.52ack.MN~yA.0CNFU.0eL1M.Un-ey.CZyf9.Omk2p.
+    -Wbar.-w2bs.02sNg.340cg.okHUP
+  =/  pact2
+        0w78EWp.7898D.odZ3b.7iLvr.vyjzn.XBNaN.vxTZj.b4BFp.EHHvW.IjvpB.j0~87.
+    t06D0.SbrGK.QlIeE.1Xj1v.CX~YY.c9cAE.eUPSb.gj8-M.e15TJ.EPPXN.efms-.8y9og.
+    IdyLr.lkZJ5.KMB-F.S7mwd.t5rmo.CEYCp.3zC4n.HYh2T.RgVI8.0eT1z.Jxj9c.m1Sm5.
+    SaYrP.0LKO3.-w2cA.02sNg.340cg.oi9Nj
+  =/  vein-data
+    [life=1 (my [1 sec:ex:(pit:nu:crub:crypto 512 ~nul)] ~)]
+  ::
+  =^  results1  ames-gate
+    %:  ames-call
+      ames-gate
+      now
+      call-args=[duct type=*type %soft [%barn ~]]
+      expected-moves=[[duct %give %turf ~] ~]
+    ==
+  ::
+  =.  now  (add ~m1 now)
+  :: ~&  [%fox1 now fox.ames-gate]
+  =^  results2  ames-gate
+    %:  ames-take
+      ames-gate
+      now
+      take-args=[wire duct -:!>([%j %vein vein-data]) [%j %vein vein-data]]
+      expected-moves=~
+    ==
+  ::
+  =.  now  (add ~m1 now)
+  :: ~&  [%fox2 now fox.ames-gate]
+  =^  results3  ames-gate
+    %:  ames-call
+      ames-gate
+      now
+      call-args=[duct type=*type %soft [%want ~nul /foo 1]]
+      :~  [duct %pass /pubs/~nul %j %pubs ~nul]
+          [duct %give %send *lane:ames pact1]
+          ::  XX why ~s4 ??
+          ::
+          [duct %pass /ames %b %wait (add ~s4 now)]
+      ==
+    ==
+  ::
+  =.  now  (add ~m1 now)
+  :: ~&  [%fox3 now fox.ames-gate]
+  =^  results4  ames-gate
+    %:  ames-call
+      ames-gate
+      now
+      call-args=[duct type=*type %soft [%want ~nul /foo 2]]
+      expected-moves=[[duct %give %send *lane:ames pact2] ~]
+    ==
+  ::
+  =.  now  (add ~m1 now)
+  :: ~&  [%fox4 now fox.ames-gate]
+  =^  results5  ames-gate
+    %:  ames-take
+      ames-gate
+      now
+      take-args=[wire duct -:!>([%b %wake ~]) [%b %wake ~]]
+      :~  [duct %give %send *lane:ames pact1]
+          [duct %give %send *lane:ames pact2]
+          [duct %pass /ames %b %wait (add ~s8 now)]
+      ==
+    ==
+  ::
+  :: ~&  [%fox5 now fox.ames-gate]
+  :(weld results1 results2 results3 results4 results5)
+::
+++  ames-scry
+  ^-  sley
+  |=  [* (unit (set monk)) =term =beam]
+  ^-  (unit (unit cage))
+  ?:  =(%turf q.beam)
+    (some (some %noun !>(~)))
+  ::
+  ?:  ?&  =(%life q.beam)
+          =(/~nul s.beam)
+      ==
+    (some (some %atom !>(1)))
+  ::
+  ?:  ?&  =(%saxo q.beam)
+          =(/~nul s.beam)
+      ==
+    (some (some %noun !>([~nul ~])))
+  ::
+  ?:  ?&  =(%sein q.beam)
+          =(/~nul s.beam)
+      ==
+    (some (some %atom !>(~nul)))
+  ::
+  ?:  ?&  =(%deed q.beam)
+          =(/1/~nul s.beam)
+      ==
+    =/  =deed:ames
+      [life=1 pub:ex:(pit:nu:crub:crypto 512 ~nul) ~]
+    (some (some %noun !>(deed)))
+  ::
+  ~&  [%ames-scry-fail +<]
+  ~
 ::
 ++  ames-call
   |=  $:  ames-gate=_ames-gate
@@ -33,10 +141,30 @@
       ==
   ^-  [tang _ames-gate]
   ::
-  =/  ames  (ames-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
+  =/  ames  (ames-gate our=~nul now=now eny=`@`0xdead.beef ames-scry)
   ::
   =^  moves  ames-gate
-    %-  call:ames  call-args
+    (call:ames call-args)
+  ::
+  =/  output=tang
+    %+  expect-eq
+      !>  expected-moves
+      !>  moves
+  ::
+  [output ames-gate]
+::
+++  ames-take
+  |=  $:  ames-gate=_ames-gate
+          now=@da
+          take-args=[=wire =duct wrapped-sign=(hypo sign:ames-gate)]
+          expected-moves=(list move:ames-gate)
+      ==
+  ^-  [tang _ames-gate]
+  ::
+  =/  ames  (ames-gate our=~nul now=now eny=`@`0xdead.beef ames-scry)
+  ::
+  =^  moves  ames-gate
+    (take:ames take-args)
   ::
   =/  output=tang
     %+  expect-eq


### PR DESCRIPTION
I've been trying to track down the %ames retry failures (leading to states where ships need to be `|bonk`'ed), using the included packet-sending test to inspect the state transitions. Along the way, I discovered that pings to a ship's sponsorship chain are sent very rarely, as their gated by the "network era" timestamp set on restart by the `%kick` event. What's more, they'll never be sent with the current runtime, as it doesn't send the `%kick` event (which is unquestionably my fault).

This could be handled one of two ways: adding `%kick` to the runtime, or disabling the condition. I chose the latter, as that will have the side effect of sending a lot more pings. I expect that in turn to keep routes from being timed out, to result in less packet forwarding, and generally keep the network more synchronized. (It might even help with the retry issues I was looking for in the first place.)

The full ping condition is now:

```
?&  =(~ puq.puz)
    ?|  bust:puz
        ?=(~ rue.puz)
        (gth now (add ~s32 u.rue.puz))
    ==
==
```

Ie, "ping if the packet pump for this peer is empty and they're either a) not responding, b) have never responded, or c) haven't communicated with us in longer than ~s32". This is not an intuitive condition, and ~s32 seems like a particularly short period. On the other hand, it's been fairly common to experience ames becoming unblocked by restarting your ship, ie, by sending pings. I consider this a minor hack on what is basically dead code, to be tried on a testnet in anticipation fo the coming release. New ames can't get here soon enough.

/cc @belisarius222 @philipcmonk 