### PR TITLE
enables |mass in the daemon

### DIFF
--- a/nix/ops/test/builder.sh
+++ b/nix/ops/test/builder.sh
@@ -20,6 +20,8 @@ shutdown () {
 
 trap shutdown EXIT
 
+herb ./ship -p hood -d '+hood/mass'
+
 # Start the test app
 herb ./ship -p hood -d '+hood/start %test'
 
@@ -27,6 +29,8 @@ herb ./ship -p hood -d '+hood/start %test'
 herb ./ship -d '~&  ~  ~&  %start-test-cores  ~'
 herb ./ship -p test -d ':-  %cores  /'
 herb ./ship -d '~&  %finish-test-cores  ~'
+
+herb ./ship -p hood -d '+hood/mass'
 
 # Run the %renders tests
 herb ./ship -d '~&  ~  ~&  %start-test-renders  ~'
@@ -36,6 +40,8 @@ herb ./ship -d '~&  %finish-test-renders  ~'
 # Run the test generator
 herb ./ship -d '+test, =seed `@uvI`(shaz %reproducible)' |
   tee test-generator-output
+
+herb ./ship -p hood -d '+hood/mass'
 
 shutdown
 

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -18,6 +18,7 @@ defmacro () {
 defmacro URBIT_VERSION "\"$URBIT_VERSION\""
 
 [ -n "$MEMORY_DEBUG" ]     && defmacro U3_MEMORY_DEBUG 1
+[ -n "$MEMORY_LOG" ]       && defmacro U3_MEMORY_LOG 1
 [ -n "$CPU_DEBUG" ]        && defmacro U3_CPU_DEBUG 1
 [ -n "$EVENT_TIME_DEBUG" ] && defmacro U3_EVENT_TIME_DEBUG 1
 

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1276,7 +1276,7 @@
         void
         u3_daemon_bail(void);
 
-      /* u3_king_grab(): gc the daemon area
+      /* u3_daemon_grab(): gc the daemon
       */
         void
         u3_daemon_grab(void* vod_p);

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1712,9 +1712,9 @@ _ca_print_box(u3a_box* box_u)
       {
         int i;
         for ( i = 0; i < box_u->siz_w; i++ ) {
-          u3l_log("%08x ", (unsigned int)(((c3_w*)box_u)[i]));
+          fprintf(stderr, "%08x ", (unsigned int)(((c3_w*)box_u)[i]));
         }
-        u3l_log("\r\n");
+        fprintf(stderr, "\r\n");
       }
 #endif
       return 0;
@@ -1736,22 +1736,24 @@ _ca_print_box(u3a_box* box_u)
 static void
 _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
 {
-  u3l_log("%s: %p mug=%x (marked=%u swept=%u)\r\n",
-          cap_c,
-          box_u,
-          ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
-          eus_w,
-          use_w);
+  fprintf(stderr, "%s: %p mug=%x (marked=%u swept=%u)\r\n",
+                  cap_c,
+                  box_u,
+                  ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
+                  eus_w,
+                  use_w);
 
   if ( box_u->cod_w ) {
-    u3m_p("    code", box_u->cod_w);
+    c3_c* cod_c = u3m_pretty(box_u->cod_w);
+    fprintf(stderr, "code: %s\r\n", cod_c);
+    free(cod_c);
   }
 
   u3a_print_memory(stderr, "    size", box_u->siz_w);
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
-    u3l_log("    data: %s\r\n", dat_c);
+    fprintf(stderr, "    data: %s\r\n", dat_c);
     free(dat_c);
   }
 }
@@ -1761,17 +1763,17 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
 static void
 _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_ws use_ws)
 {
-  u3l_log("%s: %p mug=%x swept=%d\r\n",
-          cap_c,
-          box_u,
-          ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
-          use_ws);
+  fprintf(stderr, "%s: %p mug=%x swept=%d\r\n",
+                  cap_c,
+                  box_u,
+                  ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
+                  use_ws);
 
   u3a_print_memory(stderr, "    size", box_u->siz_w);
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
-    u3l_log("    data: %s\r\n", dat_c);
+    fprintf(stderr, "    data: %s\r\n", dat_c);
     free(dat_c);
   }
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -916,14 +916,11 @@ u3_daemon_bail(void)
   exit(1);
 }
 
-/* u3_daemon_grab(): gc the daemon area
+/* u3_daemon_grab(): gc the daemon
 */
 void
 u3_daemon_grab(void* vod_p)
 {
-  //  XX fix leaks and enable
-  //
-#if 0
   c3_w man_w = 0, pir_w = 0;
   FILE* fil_u = u3_term_io_hija();
 
@@ -938,5 +935,4 @@ u3_daemon_grab(void* vod_p)
   u3a_print_memory(fil_u, "sweep", u3a_sweep());
 
   u3_term_io_loja(0);
-#endif
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -925,7 +925,7 @@ u3_daemon_grab(void* vod_p)
   //
 #if 0
   c3_w man_w = 0, pir_w = 0;
-  FILE* fil_u = stderr;
+  FILE* fil_u = u3_term_io_hija();
 
   c3_assert( u3R == &(u3H->rod_u) );
 
@@ -936,5 +936,7 @@ u3_daemon_grab(void* vod_p)
 
   u3a_print_memory(fil_u, "total marked", man_w + pir_w);
   u3a_print_memory(fil_u, "sweep", u3a_sweep());
+
+  u3_term_io_loja(0);
 #endif
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -921,18 +921,55 @@ u3_daemon_bail(void)
 void
 u3_daemon_grab(void* vod_p)
 {
-  c3_w man_w = 0, pir_w = 0;
-  FILE* fil_u = u3_term_io_hija();
+  c3_w tot_w = 0;
+  FILE* fil_u;
 
   c3_assert( u3R == &(u3H->rod_u) );
 
-  fprintf(fil_u, "measuring daemon:\r\n");
+#ifdef U3_MEMORY_LOG
+  {
+    //  XX date will not match up with that of the worker
+    //
+    u3_noun wen = u3dc("scot", c3__da, u3k(u3A->now));
+    c3_c* wen_c = u3r_string(wen);
 
-  man_w = u3m_mark(fil_u);
-  pir_w = u3_pier_mark(fil_u);
+    c3_c nam_c[2048];
+    snprintf(nam_c, 2048, "%s/.urb/put/mass", u3_pier_stub()->pax_c);
 
-  u3a_print_memory(fil_u, "total marked", man_w + pir_w);
+    struct stat st;
+    if ( -1 == stat(nam_c, &st) ) {
+      mkdir(nam_c, 0700);
+    }
+
+    c3_c man_c[2048];
+    snprintf(man_c, 2048, "%s/%s-daemon.txt", nam_c, wen_c);
+
+    fil_u = fopen(man_c, "w");
+    fprintf(fil_u, "%s\r\n", wen_c);
+
+    free(wen_c);
+    u3z(wen);
+  }
+#else
+  {
+    fil_u = u3_term_io_hija();
+    fprintf(fil_u, "measuring daemon:\r\n");
+  }
+#endif
+
+  tot_w += u3m_mark(fil_u);
+  tot_w += u3_pier_mark(fil_u);
+
+  u3a_print_memory(fil_u, "total marked", tot_w);
   u3a_print_memory(fil_u, "sweep", u3a_sweep());
 
-  u3_term_io_loja(0);
+#ifdef U3_MEMORY_LOG
+  {
+    fclose(fil_u);
+  }
+#else
+  {
+    u3_term_io_loja(0);
+  }
+#endif
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -161,7 +161,7 @@ _daemon_defy_fate()
 void
 _daemon_fate(void *vod_p, u3_noun mat)
 {
-  u3_noun fate = u3ke_cue(u3k(mat));
+  u3_noun fate = u3ke_cue(mat);
   u3_noun load;
   void (*next)(u3_noun);
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -2080,7 +2080,7 @@ u3_pier_boot(c3_w  wag_w,                   //  config flags
   //  set boot params
   //
   {
-    pir_u->bot_u = _pier_boot_create(pir_u, u3k(pil), u3k(ven));
+    pir_u->bot_u = _pier_boot_create(pir_u, pil, ven);
 
     _pier_boot_set_ship(pir_u, u3k(who), ( c3__fake == u3h(ven) ) ? c3y : c3n);
   }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -2116,31 +2116,45 @@ c3_w
 u3_pier_mark(FILE* fil_u)
 {
   c3_w len_w = u3K.len_w;
-  c3_w tot_w = 0;
+  c3_w tot_w = 0, pir_w = 0;
   u3_pier* pir_u;
 
   while ( 0 < len_w ) {
     pir_u = u3K.tab_u[--len_w];
-    fprintf(fil_u, "pier: %u\r\n", len_w);
+    pir_w = 0;
+
+    if ( 1 < u3K.len_w ) {
+      fprintf(fil_u, "pier: %u\r\n", len_w);
+    }
 
     if ( 0 != pir_u->bot_u ) {
-      tot_w += u3a_maid(fil_u, "  boot event", u3a_mark_noun(pir_u->bot_u->ven));
-      tot_w += u3a_maid(fil_u, "  pill", u3a_mark_noun(pir_u->bot_u->pil));
+      pir_w += u3a_maid(fil_u, "  boot event", u3a_mark_noun(pir_u->bot_u->ven));
+      pir_w += u3a_maid(fil_u, "  pill", u3a_mark_noun(pir_u->bot_u->pil));
     }
 
     {
-      u3_writ* wit_u = pir_u->ent_u;
-      c3_w wit_w = 0;
+      u3_writ* wit_u = pir_u->ext_u;
+      c3_w len_w = 0, tim_w = 0, job_w = 0, mat_w = 0, act_w =0;
 
       while ( 0 != wit_u ) {
-        wit_w += u3a_mark_noun(wit_u->job);
-        wit_w += u3a_mark_noun(wit_u->now);
-        wit_w += u3a_mark_noun(wit_u->mat);
-        wit_w += u3a_mark_noun(wit_u->act);
+        tim_w += u3a_mark_noun(wit_u->now);
+        job_w += u3a_mark_noun(wit_u->job);
+        mat_w += u3a_mark_noun(wit_u->mat);
+        act_w += u3a_mark_noun(wit_u->act);
+        len_w++;
         wit_u = wit_u->nex_u;
       }
 
-      tot_w += u3a_maid(fil_u, "  writs", wit_w);
+      if ( 0 < len_w ) {
+        fprintf(fil_u, "  marked %u writs\r\n", len_w);
+      }
+
+      pir_w += u3a_maid(fil_u, "  timestamps", tim_w);
+      pir_w += u3a_maid(fil_u, "  events", job_w);
+      pir_w += u3a_maid(fil_u, "  encoded events", mat_w);
+      pir_w += u3a_maid(fil_u, "  pending effects", act_w);
+
+      tot_w += u3a_maid(fil_u, "total pier stuff", pir_w);
     }
   }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1393,7 +1393,7 @@ _pier_boot_vent(u3_boot* bot_u)
           if ( c3__into == u3h(u3t(ovo)) ) {
             c3_assert( 0 == len_w );
             len_w++;
-            ovo = u3k(u3t(pil_q));
+            ovo = u3t(pil_q);
           }
 
           new = u3nc(u3k(ovo), new);

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -193,6 +193,9 @@ _pier_db_read_header(u3_pier* pir_u)
   u3z(life);
 }
 
+/* _pier_db_on_commit_loaded(): lmdb read callback
+**  RETAIN mat
+*/
 static c3_o
 _pier_db_on_commit_loaded(u3_pier* pir_u,
                           c3_d id,
@@ -702,18 +705,17 @@ _pier_work_replace(u3_writ* wit_u,
     u3_pier_bail();
   }
 
-  /* move backward in work processing
-  */
+  //  move backward in work processing
+  //
   {
     u3z(wit_u->job);
+    u3z(wit_u->mat);
+    wit_u->mat = 0;
     wit_u->job = job;
 
-    u3z(wit_u->mat);
-    wit_u->mat = u3ke_jam(u3nc(wit_u->mug_l,
-                               u3k(wit_u->job)));
+    _pier_work_build(wit_u);
 
     wit_u->rep_d += 1ULL;
-
     god_u->sen_d -= 1ULL;
   }
 
@@ -1870,6 +1872,8 @@ u3_pier_work(u3_pier* pir_u, u3_noun pax, u3_noun fav)
   struct timeval tim_tv;
 
   gettimeofday(&tim_tv, 0);
+  //  XX use wit_u->now (currently unused)
+  //
   now = u3_time_in_tv(&tim_tv);
 
   u3_pier_discover(pir_u, 0, u3nt(now, pax, fav));

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -2121,7 +2121,7 @@ u3_pier_mark(FILE* fil_u)
 
   while ( 0 < len_w ) {
     pir_u = u3K.tab_u[--len_w];
-    u3l_log("pier: %u\r\n", len_w);
+    fprintf(fil_u, "pier: %u\r\n", len_w);
 
     if ( 0 != pir_u->bot_u ) {
       tot_w += u3a_maid(fil_u, "  boot event", u3a_mark_noun(pir_u->bot_u->ven));

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -264,8 +264,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
     }
   }
   else {
-    c3_w usr_w = 0, man_w = 0, sac_w = 0, ova_w = 0, roe_w = 0, vir_w = 0;
-
+    c3_w tot_w = 0;
     FILE* fil_u;
 
 #ifdef U3_MEMORY_LOG
@@ -282,7 +281,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
       }
 
       c3_c man_c[2048];
-      snprintf(man_c, 2048, "%s/%s.txt", nam_c, wen_c);
+      snprintf(man_c, 2048, "%s/%s-worker.txt", nam_c, wen_c);
 
       fil_u = fopen(man_c, "w");
       fprintf(fil_u, "%s\r\n", wen_c);
@@ -297,27 +296,16 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
 #endif
 
     c3_assert( u3R == &(u3H->rod_u) );
-
     fprintf(fil_u, "\r\n");
-    usr_w = _worker_prof(fil_u, 0, sac);
-    u3a_print_memory(fil_u, "total userspace", usr_w);
 
-    man_w = u3m_mark(fil_u);
+    tot_w += u3a_maid(fil_u, "total userspace", _worker_prof(fil_u, 0, sac));
+    tot_w += u3m_mark(fil_u);
+    tot_w += u3a_maid(fil_u, "space profile", u3a_mark_noun(sac));
+    tot_w += u3a_maid(fil_u, "event", u3a_mark_noun(ovo));
+    tot_w += u3a_maid(fil_u, "lifecycle events", u3a_mark_noun(u3V.roe));
+    tot_w += u3a_maid(fil_u, "effects", u3a_mark_noun(vir));
 
-    sac_w = u3a_mark_noun(sac);
-    u3a_print_memory(fil_u, "space profile", sac_w);
-
-    ova_w = u3a_mark_noun(ovo);
-    u3a_print_memory(fil_u, "event", ova_w);
-
-    roe_w = u3a_mark_noun(u3V.roe);
-    u3a_print_memory(fil_u, "lifecycle events", roe_w);
-
-    vir_w = u3a_mark_noun(vir);
-    u3a_print_memory(fil_u, "effects", vir_w);
-
-    u3a_print_memory(fil_u, "total marked", usr_w + man_w + sac_w + ova_w + vir_w);
-
+    u3a_print_memory(fil_u, "total marked", tot_w);
     u3a_print_memory(fil_u, "sweep", u3a_sweep());
 
 #ifdef U3_MEMORY_LOG


### PR DESCRIPTION
plugging memory leaks and refactoring the implementation along the way.

This work is on response to #1322, but nothing I've found explains or fixes the issue(s) reported therein. This PR enables us to measure usage in the daemon, which should help track down that meme.

