### PR TITLE
fixes jet-registration hint in %ames +turf-scry (for profiling)

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f9fded01729cc0693ab3d060427fc4d6d22ef100b3c29c3e6d6cfe4d7f7704f
-size 8632183
+oid sha256:df460df0c422a71df0fca6780ac8766c007fed629e87b1b2cc4b990b9bdcbe02
+size 8706989

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -608,8 +608,9 @@
     ::  +turf-scry: for network domains
     ::
     ++  turf-scry
-      ~/  %turf
-      ;;  (list turf)
+      =<  $
+      ~%  %turf  +  ~
+      |.  ;;  (list turf)
       %-  need  %-  need
       %-  (sloy-light ski)
       [[151 %noun] %j our %turf da+now ~]


### PR DESCRIPTION
The turf was, in fact, bogus. As noted in #1262 and many other places.