### PR TITLE
Remove cheesy Libraries header in main.c:report()

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -472,7 +472,6 @@ static void
 report(void)
 {
   printf("urbit %s\n", URBIT_VERSION);
-  printf("---------\nLibraries\n---------\n");
   printf("gmp: %s\n", gmp_version);
   printf("sigsegv: %d.%d\n",
          (libsigsegv_version >> 8) & 0xff,


### PR DESCRIPTION
I wrote report() with the Libraries header a while ago but removed it as un-urbit-like on the master branch at some point.  This PR does that in this branch.