### PR TITLE
Fix jet mismatch in play

### DIFF
--- a/bin/ivory.pill
+++ b/bin/ivory.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96b1f1ad730789b1d557aac66b847047c98341bcf436e1927f40f082a728d641
-size 3816083
+oid sha256:e0fc64a80074ed3c62fa3f9f5c85ee606bf87e063b2f1dee8a110d7750cf8c76
+size 4232444

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4a4f8f86b18de5e410caeb491eecf8cf4fe24fbaba03ad8183b55a13eee154a
-size 9108350
+oid sha256:054d477c7747198b4bbfa1027715ea445696af7eedffb63abe03b8ed80e51546
+size 9211844

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -10727,11 +10727,11 @@
       {$rock *}  |-  ^-  type
                  ?@  q.gen  [%atom p.gen `q.gen]
                  [%cell $(q.gen -.q.gen) $(q.gen +.q.gen)]
-      {$sand *}  |-  ^-  type
-                 ?@  q.gen
-                   ?:  =(%n p.gen)  ?>(=(0 q.gen) [%atom p.gen ~ q.gen])
-                   ?:(=(%f p.gen) ?>((lte q.gen 1) bool) [%atom p.gen ~])
-                 [%cell $(q.gen -.q.gen) $(q.gen +.q.gen)]
+      {$sand *}  ?@  q.gen
+                   ?:  =(%n p.gen)  ?>(=(0 q.gen) [%atom p.gen `q.gen])
+                   ?:  =(%f p.gen)  ?>((lte q.gen 1) bool)
+                   [%atom p.gen ~]
+                 $(-.gen %rock)
       {$tune *}  (face p.gen sut)
       {$dttr *}  %noun
       {$dtts *}  bool
@@ -10746,6 +10746,7 @@
       {$sgzp *}  ~_(duck(sut ^$(gen p.gen)) $(gen q.gen))
       {$sgbn *}  $(gen q.gen)
       {$tsbn *}  $(gen q.gen, sut $(gen p.gen))
+      {$tscm *}  $(gen q.gen, sut (busk p.gen))
       {$wtcl *}  =+  [fex=(gain p.gen) wux=(lose p.gen)]
                  %-  fork  :~
                    ?:(=(%void fex) %void $(sut fex, gen q.gen))
@@ -10754,7 +10755,7 @@
       {$fits *}  bool
       {$wthx *}  bool
       {$dbug *}  ~_((show %o p.gen) $(gen q.gen))
-      {$zpcm *}  (play p.gen)
+      {$zpcm *}  $(gen p.gen)
       {$lost *}  %void
       {$zpmc *}  (cell $(gen p.gen) $(gen q.gen))
       {$zpts *}  %noun


### PR DESCRIPTION
(moved from https://github.com/urbit/arvo/pull/1215)

There are several differences between the hoon for play and the jet:

- The jet handles a bunch of additional cases which no longer exist (%fail, "%zpmc"); I have disregarded these.
- The hoon simply fails to implement %tscm (fixed here).
- The jet and the hoon disagree about how %sand should be interpreted. I've changed the hoon to match the jet, but am unsure this is the right thing to do.

More on the last: There's a distinction between rock constants and sand constants. A rock constant is one whose value (e.g. 1) the type system tracks. A sand constant only has its aura and cellular shape tracked (with a special case for flag and null auras). Or rather, that's what the old hoon said. The new hoon, modified to match the jet, maintains this distinction for atomic constants. However, a sandy cell constant has the type system track the values in the leaves. This corresponds to the jet code:

```
  static u3_noun
  _play_rock(u3_noun odo, u3_noun bob)
  { 
    if ( c3y == u3ud(bob) ) {
      return u3nq(c3__atom, u3k(odo), u3_nul, u3k(bob));
    }
    else return u3nt(c3__cell, _play_rock(odo, u3h(bob)), 
                               _play_rock(odo, u3t(bob)));
  }

  static u3_noun
  _play_sand(u3_noun odo, u3_noun bob)
  { 
    if ( c3y == u3ud(bob) ) {
      if ( 'n' == odo ) {
        if ( (bob != 0) ) {
          return u3m_bail(c3__exit);
        } else {
          return u3nq(c3__atom, odo, u3_nul, bob);
        }
      }
      if ( 'f' == odo ) {
        if ( (bob > 1) ) {
          return u3m_bail(c3__exit);
        } else {
          return _play_bean();
        }
      }
      return u3nt(c3__atom, u3k(odo), u3_nul);
    }
    else return u3nt(c3__cell, _play_rock(odo, u3h(bob)), 
                               _play_rock(odo, u3t(bob)));
  }
```

On the one hand, it is hard to imagine the jet author not being deliberate about calling rock from sand; it would have been just as easy to recur back into sand as the hoon code did. On the other hand, the old hoon behavior seems prima facie more sensible (though obviously I would need more info on the rock/sand distinction to feel confident about this). Note that the old hoon version, if actually run, doesn't cause any breakage, as far as I can tell! So either version seems to work. Out of an abundance of caution, and following what I think is a sensible default policy, I have gone with the jet version, but I'm happy to revisit this.

Test plan: boot up a new ship from scratch with this modification in a pill and a play-decapitated binary. Run +test and +solid.