### PR TITLE
adds sample type to +get:by, fixes call-sites

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:054d477c7747198b4bbfa1027715ea445696af7eedffb63abe03b8ed80e51546
-size 9211844
+oid sha256:7fb2efecc5b3fb277e0d634b12afdda6cf9ffab75ac351fefbd7dfa393f7c5cd
+size 9299426

--- a/pkg/arvo/app/dns-collector.hoon
+++ b/pkg/arvo/app/dns-collector.hoon
@@ -149,10 +149,10 @@
     =.  ..this  (give-result path %dns-request i.requests)
     loop(requests t.requests)
   ::
-  =/  who  (slaw %p i.path)
+  =/  who=(unit @p)  (slaw %p i.path)
   ?~  who
     ~|  %invalid-path  !!
-  ?~  dun=(~(get by completed.state) who)
+  ?~  dun=(~(get by completed.state) u.who)
     this
   (give-result path %dns-binding u.dun)
 --

--- a/pkg/arvo/app/hall.hoon
+++ b/pkg/arvo/app/hall.hoon
@@ -3293,7 +3293,7 @@
       |=  {t/telegram c/@ud k/(map serial @ud) s/(map circle (list @ud))}
       :+  +(c)  (~(put by k) uid.t c)
       =/  src/circle
-        ?:  (~(has by aud.t) [our.bol nom])  [our.bol nom]
+        ?:  (~(has in aud.t) [our.bol nom])  [our.bol nom]
         ?~  aud.t  ~&(%strange-aud [our.bol %inbox])
         n.aud.t
       %+  ~(put by s)  src

--- a/pkg/arvo/app/talk.hoon
+++ b/pkg/arvo/app/talk.hoon
@@ -1391,13 +1391,15 @@
         ::
         ::  prints binding details. goes both ways.
         ::
+        ::    XX this type is a misjunction, audience can be ~
+        ::
         |=  qur/(unit $@(char audience))
         ^+  ..sh-work
         ?^  qur
           ?^  u.qur
             =+  cha=(~(get by bound) u.qur)
             (sh-fact %txt ?~(cha "none" [u.cha]~))
-          =+  pan=~(tap in (~(get ju binds) u.qur))
+          =+  pan=~(tap in (~(get ju binds) `@t`u.qur))
           ?:  =(~ pan)  (sh-fact %txt "~")
           =<  (sh-fact %mor (turn pan .))
           |=(a/audience [%txt ~(ar-phat ar a)])

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1479,13 +1479,13 @@
   ::
   ++  get                                               ::  grab value by key
     ~/  %get
-    |=  b/*
-    ^-  {$@(~ {~ u/_?>(?=(^ a) q.n.a)})}
-    =+  42
+    |*  b=*
+    =>  .(b `_?>(?=(^ a) p.n.a)`b)
+    |-  ^-  (unit _?>(?=(^ a) q.n.a))
     ?~  a
       ~
     ?:  =(b p.n.a)
-      [~ u=q.n.a]
+      (some q.n.a)
     ?:  (gor b p.n.a)
       $(a l.a)
     $(a r.a)

--- a/pkg/arvo/sys/vane/alef.hoon
+++ b/pkg/arvo/sys/vane/alef.hoon
@@ -2271,7 +2271,7 @@
       ::
       u.existing
     ::
-    =/  already-heard=?  (~(has by fragments.partial-rcv-message) seq)
+    =/  already-heard=?  (~(has by fragments.partial-rcv-message) `^fragment-num``@`seq)
     ::  ack dupes except for the last fragment, in which case drop
     ::
     ?:  already-heard

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2264,7 +2264,7 @@
     ::  These convert between aeon (version number), tako (commit hash), yaki
     ::  (commit data structure), lobe (content hash), and blob (content).
     ++  aeon-to-tako  ~(got by hit.dom)
-    ++  aeon-to-yaki  (cork aeon-to-tako tako-to-yaki)
+    ++  aeon-to-yaki  |=(=aeon (tako-to-yaki (aeon-to-tako aeon)))
     ++  lobe-to-blob  ~(got by lat.ran)
     ++  tako-to-yaki  ~(got by hut.ran)
     ++  lobe-to-mark
@@ -3670,8 +3670,11 @@
     |%
     ::  These convert between aeon (version number), tako (commit hash), yaki
     ::  (commit data structure), lobe (content hash), and blob (content).
+    ::
+    ::    XX the following are duplicated from the +state core
+    ::
     ++  aeon-to-tako  ~(got by hit.dom)
-    ++  aeon-to-yaki  (cork aeon-to-tako tako-to-yaki)
+    ++  aeon-to-yaki  |=(=aeon (tako-to-yaki (aeon-to-tako aeon)))
     ++  lobe-to-blob  ~(got by lat.ran)
     ++  tako-to-yaki  ~(got by hut.ran)
     ++  page-to-lobe  page-to-lobe:util

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1042,7 +1042,7 @@
         %.n
       ::  is this a session that we know about?
       ::
-      ?~  session=(~(get by sessions.authentication-state.state) u.session-id)
+      ?~  session=(~(get by sessions.authentication-state.state) `@uv`u.session-id)
         %.n
       ::  is this session still valid?
       ::


### PR DESCRIPTION
This PR fixes a longstanding issue; `+get:by` was untyped. This also fixes a couple of minor bugs (that would have been prevented had `+get:by` already been typed), and adds some now-necessary casts.

This is logged in #323, with further explanation in urbit/arvo#688. As @ohAitch notes in the latter, adding types here compromises on the notion of a gate -- in particular, the type system is now not able to synthesize a valid sample bunt for `+get:by`. Notably, this breaks gate composition (see the changes in `clay.hoon`. I acknowledge this is a problem, but I think it's less of a problem than having such a fundamental map operation be untyped. I'm curious to hear if anyone feels otherwise.