### PR TITLE
Fix % not working as talk glyph

### DIFF
--- a/pkg/arvo/app/talk.hoon
+++ b/pkg/arvo/app/talk.hoon
@@ -716,7 +716,6 @@
       ++  circ                                          ::  circle
         ;~  pose
           (cold incir col)
-          ;~(pfix cen (stag self urs:ab))
           ;~(pfix net (stag (^sein:title self) urs:ab))
         ::
           %+  cook


### PR DESCRIPTION
Now I don't really understand what's going on here but this seems to fix urbit/arvo#743.