### PR TITLE
Don't sh-note updates to a circle's read counter

### DIFF
--- a/pkg/arvo/app/talk.hoon
+++ b/pkg/arvo/app/talk.hoon
@@ -1922,7 +1922,7 @@
         $(dif [%filter fit.cof.dif])
       ?:  ?=($remove -.dif)
         (sh-note (weld "rip " (~(cr-show cr cir) ~)))
-      ?:  ?=($usage -.dif)  +>
+      ?:  ?=(?($usage $read) -.dif)  +>
       %-  sh-note
       %+  weld
         (weld ~(cr-phat cr cir) ": ")
@@ -1933,9 +1933,6 @@
       ::
           $caption
         "cap: {(trip cap.dif)}"
-      ::
-          $read
-        ""
       ::
           $filter
         ;:  weld


### PR DESCRIPTION
Fixes #1381.

Not sure why we ever rendered `$read` updates in the first place, but it _certainly_ shouldn't be an empty string. This just remove sit altogether.