### PR TITLE
Fix ~zod crash by fixing how %eyre handles app cancels.

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -802,7 +802,7 @@
     ::
     :_  state
     :_  ~
-    :^  duct  %pass  /run-app/[app.act]
+    :^  duct  %pass  /run-app-request/[app.act]
     ^-  note
     :^  %g  %deal  [our our]
     ::
@@ -847,7 +847,7 @@
         %app
       :_  state
       :_  ~
-      :^  duct  %pass  /run-app/[app.action]
+      :^  duct  %pass  /run-app-request/[app.action]
       ^-  note
       :^  %g  %deal  [our our]
       ::  todo: i don't entirely understand gall; there's a way to make a gall
@@ -892,12 +892,9 @@
         %app
       :_  state
       :_  ~
-      :^  duct  %pass  /run-app/[app.action.u.connection]
+      :^  duct  %pass  /run-app-cancel/[app.action.u.connection]
       ^-  note
       :^  %g  %deal  [our our]
-      ::  todo: i don't entirely understand gall; there's a way to make a gall
-      ::  use a %handle arm instead of a sub-%poke with the
-      ::  %handle-http-request type.
       ::
       ^-  cush:gall
       :*  app.action.u.connection
@@ -2029,13 +2026,14 @@
       ?+     i.wire
            ~|([%bad-take-wire wire] !!)
       ::
-         %run-app    run-app
-         %run-build  run-build
-         %channel    channel
-         %acme       acme-ack
+         %run-app-request  run-app-request
+         %run-app-cancel   run-app-cancel
+         %run-build        run-build
+         %channel          channel
+         %acme             acme-ack
       ==
   ::
-  ++  run-app
+  ++  run-app-request
     ::
     ?>  ?=([%g %unto *] sign)
     ::
@@ -2059,6 +2057,18 @@
     =/  handle-response  handle-response:(per-server-event event-args)
     =^  moves  server-state.ax  (handle-response http-event.p.sign)
     [moves http-server-gate]
+  ::
+  ++  run-app-cancel
+    ::
+    ?>  ?=([%g %unto *] sign)
+    ::
+    ::  we explicitly don't care about the return value of a
+    ::  %handle-http-cancel. It is purely a notification and we don't care if
+    ::  it succeeds or not. The user might not have implemented
+    ::  +poke-handle-http-cancel or it might have crashed, but since it's a
+    ::  notification, we don't don't care about its return value.
+    ::
+    [~ http-server-gate]
   ::
   ++  run-build
     ::

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -272,7 +272,7 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/' ~ ~]])
@@ -287,7 +287,7 @@
       now=~1111.1.4
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/run-app/app1  duct=~[/http-blah]
+        :*  wire=/run-app-request/app1  duct=~[/http-blah]
             ^-  (hypo sign:http-server-gate)
             :-  *type
             :*  %g  %unto  %http-response
@@ -359,7 +359,7 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/' ~ ~]])
@@ -374,7 +374,7 @@
       now=~1111.1.4
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/run-app/app1  duct=~[/http-blah]
+        :*  wire=/run-app-request/app1  duct=~[/http-blah]
             ^-  (hypo sign:http-server-gate)
             :-  *type
             :*  %g  %unto  %coup  ~
@@ -449,7 +449,7 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/' ~ ~]])
@@ -464,7 +464,7 @@
       now=~1111.1.4
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/run-app/app1  duct=~[/http-blah]
+        :*  wire=/run-app-request/app1  duct=~[/http-blah]
             ^-  (hypo sign:http-server-gate)  :-  *type
             :*  %g  %unto  %http-response
                 %start
@@ -485,7 +485,7 @@
       now=~1111.1.4
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/run-app/app1  duct=~[/http-blah]
+        :*  wire=/run-app-request/app1  duct=~[/http-blah]
             ^-  (hypo sign:http-server-gate)  :-  *type
             :*  %g  %unto  %http-response
                 [%continue [~ (as-octs:mimes:html 'ya!')] %.y]
@@ -556,7 +556,7 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/~landscape/inner-path' ~ ~]])
@@ -571,7 +571,7 @@
       now=~1111.1.4
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/run-app/app1  duct=~[/http-blah]
+        :*  wire=/run-app-request/app1  duct=~[/http-blah]
             ^-  (hypo sign:http-server-gate)  :-  *type
             :*  %g  %unto  %http-response
                 [%start [307 ['location' '/~/login?redirect=/~landscape/inner-path']~] ~ %.y]
@@ -624,7 +624,7 @@
         ::  expect authenticated=%.y in the handle below
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>  :*
@@ -1814,7 +1814,7 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-request/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-request
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/' ~ ~]])
@@ -1848,12 +1848,30 @@
           (expect-eq !>(~[/http-blah]) !>(duct))
         ::
         %+  expect-gall-deal
-          :+  /run-app/app1  [~nul ~nul]
+          :+  /run-app-cancel/app1  [~nul ~nul]
               ^-  cush:gall
               :*  %app1  %poke  %handle-http-cancel
                   !>([%.n %.n [%ipv4 .192.168.1.1] [%'GET' '/' ~ ~]])
               ==
           card
+    ==
+  ::  app1 doesn't have a %handle-http-cancel arm, but that's fine and doesn't
+  ::  crash eyre when it sends its error coup back because we take no action on
+  ::  the response to handle-http-cancel.
+  ::
+  =^  results5  http-server-gate
+    %-  http-server-take  :*
+      http-server-gate
+      now=~1111.1.4
+      scry=scry-provides-code
+      ^=  take-args
+        :*  wire=/run-app-cancel/app1  duct=~[/http-blah]
+            ^-  (hypo sign:http-server-gate)  :-  *type
+            :*  %g  %unto  %coup
+                `[[%leaf "error! error! error!"] ~]
+            ==
+         ==
+      expected-move=~
     ==
   ::
   ;:  weld
@@ -1861,6 +1879,7 @@
     results2
     results3
     results4
+    results5
   ==
 ::
 ++  http-server-call


### PR DESCRIPTION
When we ask an app to run a %handle-http-cancel event, we don't
actually care about the return value or even if it errors. The
cancel event is purely informative. Likewise, because we cause
cancels on restart of urbit, they cannot expose crashes to the
system. Otherwise, an app with an open connection but a broken
or non-existent cancel handler can prevent your ship from
coming back up.