### PR TITLE
add -I to inject event

### DIFF
--- a/pkg/arvo/gen/reload-event.hoon
+++ b/pkg/arvo/gen/reload-event.hoon
@@ -1,0 +1,26 @@
+::  Produce a raw event to reload a vane
+::
+::  Try: .event/ovo +reload-event %c, then restart urbit with
+::  -I pier/.urb/put/event.ovo
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bek=beak]
+        [[tam=term ~] ~]
+    ==
+:-  %ovo
+=/  top  `path`/(scot %p p.bek)/[q.bek]/(scot r.bek)
+=/  nam
+  =/  van=(list [term ~])
+    :-  zus=[%zuse ~]
+    ~(tap by dir:.^(arch %cy (welp top /sys/vane)))
+  ?.  =(1 (met 3 tam))
+    tam
+  =+  ^-  zaz=(list [p=knot ~])
+      (skim van |=([a=term ~] =(tam (end 3 1 a))))
+  ?>  ?=([[@ ~] ~] zaz)
+  `term`p.i.zaz
+=/  tip  (end 3 1 nam)
+=/  bip  ?:(=('z' tip) %$ tip)
+=/  way  ?:(=('z' tip) (welp top /sys/[nam]) (welp top /sys/vane/[nam]))
+=/  fil  .^(@ %cx (welp way /hoon))
+[//arvo %veer bip way fil]

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -95,7 +95,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:J:B:K:A:H:w:u:e:E:f:F:k:m:p:LjabcCdgqstvxPDRS")) )
+                 "G:J:B:K:A:H:I:w:u:e:E:f:F:k:m:p:LjabcCdgqstvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'J': {
@@ -116,6 +116,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 'H': {
         u3_Host.ops_u.dns_c = strdup(optarg);
+        break;
+      }
+      case 'I': {
+        u3_Host.ops_u.jin_c = strdup(optarg);
         break;
       }
       case 'e': {

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -556,6 +556,7 @@
         c3_c*   gen_c;                      //  -G, czar generator
         c3_o    gab;                        //  -g, test garbage collection
         c3_c*   dns_c;                      //  -H, ames bootstrap domain
+        c3_c*   jin_c;                      //  -I, inject raw event
         c3_c*   lit_c;                      //  -J, ivory (fastboot) kernel
         c3_o    tra;                        //  -j, json trace
         c3_w    kno_w;                      //  -K, kernel version

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -69,6 +69,7 @@ static void _pier_boot_complete(u3_pier* pir_u);
 static void _pier_boot_ready(u3_pier* pir_u);
 static void _pier_boot_set_ship(u3_pier* pir_u, u3_noun who, u3_noun fak);
 static void _pier_exit_done(u3_pier* pir_u);
+static void _pier_inject(u3_pier* pir_u, c3_c* pax_c);
 static void _pier_loop_resume(u3_pier* pir_u);
 
 /* _pier_db_bail(): bail from disk i/o.
@@ -1531,6 +1532,12 @@ _pier_boot_complete(u3_pier* pir_u)
       u3_term_ef_verb();
     }
   }
+
+  {
+    if ( 0 != u3_Host.ops_u.jin_c ) {
+      _pier_inject(pir_u, u3_Host.ops_u.jin_c);
+    }
+  }
 }
 
 /* _pier_boot_ready():
@@ -1770,6 +1777,17 @@ _pier_create(c3_w wag_w, c3_c* pax_c)
   u3K.tab_u[u3K.len_w++] = pir_u;
 
   return pir_u;
+}
+
+/* _pier_inject(): inject raw event at filename
+*/
+static void
+_pier_inject(u3_pier* pir_u, c3_c* pax_c)
+{
+  u3_noun ovo = u3ke_cue(u3m_file(pax_c));
+  u3m_p("injecting event", u3h(ovo));
+  u3_pier_work(pir_u, u3k(u3h(ovo)), u3k(u3t(ovo)));
+  u3z(ovo);
 }
 
 /* u3_pier_interrupt(): interrupt running process.


### PR DESCRIPTION
Try:

```
> .event/ovo +reload-event %c
$ urbit -I pier/.urb/put/event.ovo pier
```

This will inject any arbitrary event into a pier.  The intended use-case is to rescue ships that are in gridlock due to eg clay issues.