### PR TITLE
updates ivory codegen to fail if ivory.pill is an lfs pointer

### DIFF
--- a/nix/crossdeps.nix
+++ b/nix/crossdeps.nix
@@ -11,4 +11,5 @@ rec {
   secp256k1    = import ./deps/secp256k1/cross.nix    { inherit crossenv; };
   h2o          = import ./deps/h2o/cross.nix          { inherit crossenv uv; };
   ivory-header = import ./deps/ivory-header/cross.nix { inherit crossenv; };
+  ca-header    = import ./deps/ca-header/cross.nix    { inherit crossenv; };
 }

--- a/nix/crossdeps.nix
+++ b/nix/crossdeps.nix
@@ -1,13 +1,14 @@
 crossenv:
 
 rec {
-  argon2     = import ./deps/argon2/cross.nix     { inherit crossenv; };
-  murmur3    = import ./deps/murmur3/cross.nix    { inherit crossenv; };
-  uv         = import ./deps/uv/cross.nix         { inherit crossenv; };
-  ed25519    = import ./deps/ed25519/cross.nix    { inherit crossenv; };
-  sni        = import ./deps/sni/cross.nix        { inherit crossenv; };
-  scrypt     = import ./deps/scrypt/cross.nix     { inherit crossenv; };
-  softfloat3 = import ./deps/softfloat3/cross.nix { inherit crossenv; };
-  secp256k1  = import ./deps/secp256k1/cross.nix  { inherit crossenv; };
-  h2o        = import ./deps/h2o/cross.nix        { inherit crossenv uv; };
+  argon2       = import ./deps/argon2/cross.nix       { inherit crossenv; };
+  murmur3      = import ./deps/murmur3/cross.nix      { inherit crossenv; };
+  uv           = import ./deps/uv/cross.nix           { inherit crossenv; };
+  ed25519      = import ./deps/ed25519/cross.nix      { inherit crossenv; };
+  sni          = import ./deps/sni/cross.nix          { inherit crossenv; };
+  scrypt       = import ./deps/scrypt/cross.nix       { inherit crossenv; };
+  softfloat3   = import ./deps/softfloat3/cross.nix   { inherit crossenv; };
+  secp256k1    = import ./deps/secp256k1/cross.nix    { inherit crossenv; };
+  h2o          = import ./deps/h2o/cross.nix          { inherit crossenv uv; };
+  ivory-header = import ./deps/ivory-header/cross.nix { inherit crossenv; };
 }

--- a/nix/deps-env.nix
+++ b/nix/deps-env.nix
@@ -20,7 +20,7 @@ let
 
   vendor =
     with deps;
-    [ argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ent ge-additions ];
+    [ argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ent ge-additions ivory-header ];
 
 in
 

--- a/nix/deps-env.nix
+++ b/nix/deps-env.nix
@@ -20,7 +20,7 @@ let
 
   vendor =
     with deps;
-    [ argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ent ge-additions ivory-header ];
+    [ argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ent ge-additions ivory-header ca-header ];
 
 in
 

--- a/nix/deps/ca-header/builder.sh
+++ b/nix/deps/ca-header/builder.sh
@@ -1,0 +1,27 @@
+source $stdenv/setup
+
+set -ex
+
+cleanup () {
+  echo "done"
+}
+
+trap cleanup EXIT
+
+
+if ! [ -f "$SSL_CERT_FILE" ]; then
+  echo "$SSL_CERT_FILE doesn't exist"
+  exit 1
+fi
+
+mkdir -p ./include
+
+cat $SSL_CERT_FILE > include/ca-bundle.crt
+xxd -i include/ca-bundle.crt > ca-bundle.h
+
+mkdir -p $out/include
+
+mv ca-bundle.h $out/include
+rm -rf ./include
+
+set +x

--- a/nix/deps/ca-header/cross.nix
+++ b/nix/deps/ca-header/cross.nix
@@ -1,0 +1,8 @@
+{ crossenv }:
+
+crossenv.make_derivation rec {
+  name              = "ca-bundle.h";
+  builder           = ./builder.sh;
+  native_inputs     = with crossenv.nixpkgs; [ cacert xxd ];
+  SSL_CERT_FILE     = "${crossenv.nixpkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+}

--- a/nix/deps/ca-header/default.nix
+++ b/nix/deps/ca-header/default.nix
@@ -1,0 +1,7 @@
+{ pkgs }:
+
+pkgs.stdenv.mkDerivation {
+  name              = "ca-bundle.h";
+  builder           = ./builder.sh;
+  nativeBuildInputs = with pkgs; [ cacert xxd ];
+}

--- a/nix/deps/default.nix
+++ b/nix/deps/default.nix
@@ -1,13 +1,14 @@
 { pkgs ? import ../nixpkgs.nix }:
 
 rec {
-  argon2     = import ./argon2       { inherit pkgs; };
-  murmur3    = import ./murmur3      { inherit pkgs; };
-  uv         = import ./uv           { inherit pkgs; };
-  ed25519    = import ./ed25519      { inherit pkgs; };
-  sni        = import ./sni          { inherit pkgs; };
-  scrypt     = import ./scrypt       { inherit pkgs; };
-  softfloat3 = import ./softfloat3   { inherit pkgs; };
-  secp256k1  = import ./secp256k1    { inherit pkgs; };
-  h2o        = import ./h2o          { inherit pkgs uv; };
+  argon2       = import ./argon2       { inherit pkgs; };
+  murmur3      = import ./murmur3      { inherit pkgs; };
+  uv           = import ./uv           { inherit pkgs; };
+  ed25519      = import ./ed25519      { inherit pkgs; };
+  sni          = import ./sni          { inherit pkgs; };
+  scrypt       = import ./scrypt       { inherit pkgs; };
+  softfloat3   = import ./softfloat3   { inherit pkgs; };
+  secp256k1    = import ./secp256k1    { inherit pkgs; };
+  h2o          = import ./h2o          { inherit pkgs uv; };
+  ivory-header = import ./ivory-header { inherit pkgs; };
 }

--- a/nix/deps/default.nix
+++ b/nix/deps/default.nix
@@ -11,4 +11,5 @@ rec {
   secp256k1    = import ./secp256k1    { inherit pkgs; };
   h2o          = import ./h2o          { inherit pkgs uv; };
   ivory-header = import ./ivory-header { inherit pkgs; };
+  ca-header    = import ./ca-header    { inherit pkgs; };
 }

--- a/nix/deps/ivory-header/builder.sh
+++ b/nix/deps/ivory-header/builder.sh
@@ -1,0 +1,41 @@
+source $stdenv/setup
+
+set -ex
+
+cleanup () {
+  echo "done"
+}
+
+trap cleanup EXIT
+
+
+if ! [ -f "$IVORY" ]; then
+  echo "$IVORY doesn't exist"
+  exit 1
+fi
+
+#
+#  heuristics to confirm the ivory pill is valid
+#
+
+#  greater than 10KB
+#
+if [ $(du -k $IVORY | cut -f1) -gt 10 ]; then
+  echo "$IVORY is less than 10KB"
+fi
+
+#  first 7 bytes != "version" (start of an lfs pointer)
+#
+if [ "$(cat $(IVORY) | head -c 7)" = "version" ]; then
+  echo "$IVORY starts with 'version'; it's an LFS pointer"
+fi
+
+cat $IVORY > u3_Ivory.pill
+xxd -i u3_Ivory.pill > ivory.h
+
+mkdir -p $out/include
+
+mv ivory.h $out/include
+rm u3_Ivory.pill
+
+set +x

--- a/nix/deps/ivory-header/cross.nix
+++ b/nix/deps/ivory-header/cross.nix
@@ -1,0 +1,11 @@
+{
+  crossenv,
+  ivory ? ../../../bin/ivory.pill
+}:
+
+crossenv.make_derivation rec {
+  name              = "ivory.h";
+  builder           = ./builder.sh;
+  native_inputs     = with crossenv.nixpkgs; [ xxd ];
+  IVORY             = ivory;
+}

--- a/nix/deps/ivory-header/default.nix
+++ b/nix/deps/ivory-header/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  ivory ? ../../../bin/ivory.pill
+}:
+
+pkgs.stdenv.mkDerivation {
+  name              = "ivory.h";
+  builder           = ./builder.sh;
+  nativeBuildInputs = with pkgs; [ xxd ];
+  IVORY             = ivory;
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -17,7 +17,7 @@ let
     import ./urbit {
       inherit pkgs ent debug ge-additions;
       inherit (deps) argon2 murmur3 uv ed25519 sni scrypt softfloat3;
-      inherit (deps) secp256k1 h2o ivory-header;
+      inherit (deps) secp256k1 h2o ivory-header ca-header;
     };
 
   urbit       = mkUrbit { debug=false; };

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -17,7 +17,7 @@ let
     import ./urbit {
       inherit pkgs ent debug ge-additions;
       inherit (deps) argon2 murmur3 uv ed25519 sni scrypt softfloat3;
-      inherit (deps) secp256k1 h2o;
+      inherit (deps) secp256k1 h2o ivory-header;
     };
 
   urbit       = mkUrbit { debug=false; };

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -1,7 +1,7 @@
 {
   pkgs,
   debug,
-  argon2, ed25519, ent, ge-additions, h2o, murmur3, scrypt, secp256k1, sni, softfloat3, uv, ivory-header
+  argon2, ed25519, ent, ge-additions, h2o, murmur3, scrypt, secp256k1, sni, softfloat3, uv, ivory-header, ca-header
 }:
 
 let
@@ -11,10 +11,10 @@ let
 
   deps =
     with pkgs;
-    [ curl gmp libsigsegv ncurses openssl zlib lmdb cacert xxd ];
+    [ curl gmp libsigsegv ncurses openssl zlib lmdb ];
 
   vendor =
-    [ argon2 softfloat3 ed25519 ent ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ];
+    [ argon2 softfloat3 ed25519 ent ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ca-header ];
 
 in
 

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -1,8 +1,7 @@
 {
   pkgs,
   debug,
-  ivory ? ../../../bin/ivory.pill,
-  argon2, ed25519, ent, ge-additions, h2o, murmur3, scrypt, secp256k1, sni, softfloat3, uv
+  argon2, ed25519, ent, ge-additions, h2o, murmur3, scrypt, secp256k1, sni, softfloat3, uv, ivory-header
 }:
 
 let
@@ -15,7 +14,7 @@ let
     [ curl gmp libsigsegv ncurses openssl zlib lmdb cacert xxd ];
 
   vendor =
-    [ argon2 softfloat3 ed25519 ent ge-additions h2o scrypt uv murmur3 secp256k1 sni ];
+    [ argon2 softfloat3 ed25519 ent ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ];
 
 in
 
@@ -31,7 +30,6 @@ pkgs.stdenv.mkDerivation {
   hardeningDisable = if debug then [ "all" ] else [];
 
   CFLAGS           = if debug then "-O3 -g -Werror" else "-O3 -Werror";
-  IVORY            = ivory;
   MEMORY_DEBUG     = debug;
   CPU_DEBUG        = debug;
   EVENT_TIME_DEBUG = false;

--- a/nix/pkgs/urbit/release.nix
+++ b/nix/pkgs/urbit/release.nix
@@ -4,7 +4,6 @@
   ent,
   name ? "urbit",
   debug ? false,
-  ivory ? ../../../bin/ivory.pill,
   ge-additions, cacert, xxd
 }:
 
@@ -16,7 +15,7 @@ let
 
   vendor =
     with deps;
-    [ argon2 softfloat3 ed25519 ge-additions h2o scrypt uv murmur3 secp256k1 sni ];
+    [ argon2 softfloat3 ed25519 ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ];
 
 in
 
@@ -28,7 +27,6 @@ env.make_derivation {
   EVENT_TIME_DEBUG = false;
   NCURSES          = env.ncurses;
   SSL_CERT_FILE    = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-  IVORY            = ivory;
 
   name              = "${name}-${env_name}";
   exename           = name;

--- a/nix/pkgs/urbit/release.nix
+++ b/nix/pkgs/urbit/release.nix
@@ -4,7 +4,7 @@
   ent,
   name ? "urbit",
   debug ? false,
-  ge-additions, cacert, xxd
+  ge-additions
 }:
 
 let
@@ -15,7 +15,7 @@ let
 
   vendor =
     with deps;
-    [ argon2 softfloat3 ed25519 ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ];
+    [ argon2 softfloat3 ed25519 ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ca-header ];
 
 in
 
@@ -26,12 +26,10 @@ env.make_derivation {
   CPU_DEBUG        = debug;
   EVENT_TIME_DEBUG = false;
   NCURSES          = env.ncurses;
-  SSL_CERT_FILE    = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   name              = "${name}-${env_name}";
   exename           = name;
   src               = ../../../pkg/urbit;
-  native_inputs     = [ xxd ];
   cross_inputs      = crossdeps ++ vendor ++ [ ent ];
   builder           = ./release.sh;
 }

--- a/nix/pkgs/urbit/shell.nix
+++ b/nix/pkgs/urbit/shell.nix
@@ -12,5 +12,5 @@ import ./default.nix {
   inherit (tlon)
     ent ge-additions;
   inherit (deps)
-    argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ivory-header;
+    argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ivory-header ca-header;
 }

--- a/nix/pkgs/urbit/shell.nix
+++ b/nix/pkgs/urbit/shell.nix
@@ -12,5 +12,5 @@ import ./default.nix {
   inherit (tlon)
     ent ge-additions;
   inherit (deps)
-    argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv;
+    argon2 ed25519 h2o murmur3 scrypt secp256k1 sni softfloat3 uv ivory-header;
 }

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -21,8 +21,7 @@ let
 
   urbit = env:
     import ./pkgs/urbit/release.nix env
-      { ent = ent env; ge-additions = ge-additions env; cacert = nixpkgs.cacert;
-        xxd = nixpkgs.xxd; debug = false; name = "urbit"; };
+      { ent = ent env; ge-additions = ge-additions env; debug = false; name = "urbit"; };
 
   builds-for-platform = plat:
     plat.deps // {

--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -7,7 +7,7 @@ daemon = $(wildcard daemon/*.c)
 worker = $(wildcard worker/*.c)
 
 common  = $(jets) $(noun) $(vere)
-headers = $(shell find include -type f) include/ca-bundle.h
+headers = $(shell find include -type f)
 
 common_objs = $(shell echo $(common) | sed 's/\.c/.o/g')
 daemon_objs = $(shell echo $(daemon) | sed 's/\.c/.o/g')
@@ -22,10 +22,6 @@ all_exes = ./build/mug_tests ./build/jam_tests ./build/hashtable_tests \
 # -Werror promotes all warnings that are enabled into errors (this is on)
 # -Wall issues all types of errors.  This is off (for now)
 CFLAGS := $(CFLAGS)
-
-ifeq ($(SSL_CERT_FILE),)
-  $(error SSL_CERT_FILE is undefined)
-endif
 
 ################################################################################
 
@@ -44,15 +40,9 @@ clean:
 	rm -f ./tags $(all_objs) $(all_exes)
 
 mrproper: clean
-	rm -f config.mk include/config.h include/ca-bundle.h
+	rm -f config.mk include/config.h
 
 ################################################################################
-
-include/ca-bundle.h:
-	@echo XXD -i $(SSL_CERT_FILE)
-	@cat $(SSL_CERT_FILE) > include/ca-bundle.crt
-	@xxd -i include/ca-bundle.crt > include/ca-bundle.h
-	@rm include/ca-bundle.crt
 
 build/hashtable_tests: $(common_objs) tests/hashtable_tests.o
 	@echo CC -o $@

--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -60,6 +60,14 @@ include/ca-bundle.h:
 
 include/ivory.h:
 	@echo XXD -i $(IVORY)
+	@#  heuristics to confirm the ivory pill is valid
+	@#
+	@#    greater than 10KB
+	@#    first 7 bytes != "version" (start of an lfs pointer)
+	@#    XX move these to a nix build that produces the ivory pill
+	@#
+	@test "`du -k $(IVORY) | cut -f1`" -gt 10
+	@test "`cat $(IVORY) | head -c 7`" != "version"
 	@cat $(IVORY) > u3_Ivory.pill
 	@xxd -i u3_Ivory.pill > include/ivory.h
 	@rm u3_Ivory.pill

--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -7,7 +7,7 @@ daemon = $(wildcard daemon/*.c)
 worker = $(wildcard worker/*.c)
 
 common  = $(jets) $(noun) $(vere)
-headers = $(shell find include -type f) include/ca-bundle.h include/ivory.h
+headers = $(shell find include -type f) include/ca-bundle.h
 
 common_objs = $(shell echo $(common) | sed 's/\.c/.o/g')
 daemon_objs = $(shell echo $(daemon) | sed 's/\.c/.o/g')
@@ -27,10 +27,6 @@ ifeq ($(SSL_CERT_FILE),)
   $(error SSL_CERT_FILE is undefined)
 endif
 
-ifeq ($(IVORY),)
-  $(error IVORY is undefined)
-endif
-
 ################################################################################
 
 .PHONY: all test clean mkproper
@@ -48,7 +44,7 @@ clean:
 	rm -f ./tags $(all_objs) $(all_exes)
 
 mrproper: clean
-	rm -f config.mk include/config.h include/ca-bundle.h include/ivory.h
+	rm -f config.mk include/config.h include/ca-bundle.h
 
 ################################################################################
 
@@ -57,20 +53,6 @@ include/ca-bundle.h:
 	@cat $(SSL_CERT_FILE) > include/ca-bundle.crt
 	@xxd -i include/ca-bundle.crt > include/ca-bundle.h
 	@rm include/ca-bundle.crt
-
-include/ivory.h:
-	@echo XXD -i $(IVORY)
-	@#  heuristics to confirm the ivory pill is valid
-	@#
-	@#    greater than 10KB
-	@#    first 7 bytes != "version" (start of an lfs pointer)
-	@#    XX move these to a nix build that produces the ivory pill
-	@#
-	@test "`du -k $(IVORY) | cut -f1`" -gt 10
-	@test "`cat $(IVORY) | head -c 7`" != "version"
-	@cat $(IVORY) > u3_Ivory.pill
-	@xxd -i u3_Ivory.pill > include/ivory.h
-	@rm u3_Ivory.pill
 
 build/hashtable_tests: $(common_objs) tests/hashtable_tests.o
 	@echo CC -o $@

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -9,6 +9,10 @@ deps="                                                                    \
   softfloat3 ncurses ssl crypto z lmdb ge-additions                       \
 "
 
+headers="  \
+  ivory.h  \
+"
+
 echo '#pragma once' >include/config.h
 
 defmacro () {
@@ -75,6 +79,10 @@ esac
 for dep in ${osdeps-} $deps
 do LDFLAGS="${LDFLAGS-} -l$dep"
    ${PKG_CONFIG-pkg-config} --cflags --libs $dep 2>/dev/null || true
+done
+
+for header in $headers
+do LDFLAGS="${LDFLAGS-} -I$header"
 done
 
 cat >config.mk <<EOF

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -9,8 +9,8 @@ deps="                                                                    \
   softfloat3 ncurses ssl crypto z lmdb ge-additions                       \
 "
 
-headers="  \
-  ivory.h  \
+headers="             \
+  ivory.h ca-bundle.h \
 "
 
 echo '#pragma once' >include/config.h


### PR DESCRIPTION
We embed the ivory pill into the daemon process, so we can eval hoon without IPC. As of #1374, that embedding is automated. Currently, the ivory pill is checked in via git-lfs, and if git-lfs has not been properly initialized, the contents of the ivory pill are just an LFS pointer (some descriptive text and hashes). If that's the case, the codegen and build complete successfully, but the resulting binary just prints `lite: boot failed` if you try to boot or restart a ship with it. That's obviously unacceptable. 

This PR adds some conditions to fail the build if the ivory pill appears to be an LFS pointer. But, in it's current state, it's still pretty unsatisfactory. It does not print a useful error message when it fails the build, and I don't know how to fix that. The current state of things still feels worse, but I'm open to alternative approaches to this problem.