### PR TITLE
Behn fixes

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4a8e1daf0bfe86d5fc4ef7060b0c6a6c2678a344787926f14bb4b8cfabe8752
-size 9549390
+oid sha256:5473058c09227359a1f41c1ac16b081dc1806c677b08b51ff653ec874c0521ff
+size 9619972

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -260,11 +260,10 @@
 ::  +load: migrate an old state to a new behn version
 ::
 ++  load
-  |=  old=*
+  |=  old=behn-state
   ^+  behn-gate
   ::
-  ~|  %behn-load-fail
-  behn-gate(state ;;(behn-state old))
+  behn-gate(state old)
 ::  +scry: view timer state
 ::
 ::    TODO: not referentially transparent w.r.t. elapsed timers,

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -101,8 +101,11 @@
   ++  wake
     |=  error=(unit tang)
     ^+  [moves state]
+    ::  no-op on spurious but innocuous unix wakeups
     ::
-    ?~  timers.state  ~|  %behn-wake-no-timer^error  !!
+    ?~  timers.state
+      ~?  ?=(^ error)  %behn-wake-no-timer^u.error
+      [moves state]
     ::  if we errored, pop the timer and notify the client vane of the error
     ::
     ?^  error
@@ -111,7 +114,6 @@
     ::  if unix woke us too early, retry by resetting the unix wakeup timer
     ::
     ?:  (gth date.i.timers.state now)
-      ~?  debug=%.n  [%behn-wake-too-soon `@dr`(sub date.i.timers.state now)]
       set-unix-wake(next-wake.state ~)
     ::  pop first timer, tell vane it has elapsed, and adjust next unix wakeup
     ::
@@ -197,7 +199,6 @@
     ::  ignore duplicates
     ::
     ?:  =(t i.timers)
-      ~?  debug=%.n  [%behn-set-duplicate t]
       timers
     ::  timers at the same date form a fifo queue
     ::
@@ -214,7 +215,6 @@
     ::  if we don't have this timer, no-op
     ::
     ?~  timers
-      ~?  debug=%.n  [%behn-unset-missing t]
       ~
     ?:  =(i.timers t)
       t.timers
@@ -264,7 +264,7 @@
   ^+  behn-gate
   ::
   ~|  %behn-load-fail
-  behn-gate(state (behn-state old))
+  behn-gate(state ;;(behn-state old))
 ::  +scry: view timer state
 ::
 ::    TODO: not referentially transparent w.r.t. elapsed timers,


### PR DESCRIPTION
- Fix |reload %b by no longer clamming in +load, which can hang or eat up all the memory because the Behn state has vases in it.
- Fix loud, annoying crashes by no-op'ing when Behn receives an unsolicited %wake event from Unix.