### PR TITLE
exit cleanly where appropriate; don't, where not

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -509,10 +509,10 @@ _stop_exit(c3_i int_i)
   u3_daemon_bail();
 }
 
-/* _stop_trace(): print trace on SIGABRT.
+/* _stop_signal(): handle termination signal.
 */
 static void
-_stop_trace(c3_i int_i)
+_stop_signal(c3_i int_i)
 {
   //  if we have a pier, unmap the event log before dumping core
   //
@@ -673,7 +673,7 @@ main(c3_i   argc,
 
   //  Cleanup on SIGABRT.
   //
-  signal(SIGABRT, _stop_trace);
+  signal(SIGABRT, _stop_signal);
 
   printf("~\n");
   //  printf("welcome.\n");

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -750,6 +750,19 @@ _daemon_sign_init(void)
     sig_u->nex_u = u3_Host.sig_u;
     u3_Host.sig_u = sig_u;
   }
+
+  //  handle SIGQUIT (turn it into SIGABRT)
+  //
+  {
+    u3_usig* sig_u;
+
+    sig_u = c3_malloc(sizeof(u3_usig));
+    uv_signal_init(u3L, &sig_u->sil_u);
+
+    sig_u->num_i = SIGQUIT;
+    sig_u->nex_u = u3_Host.sig_u;
+    u3_Host.sig_u = sig_u;
+  }
 }
 
 /* _daemon_sign_cb: signal callback.
@@ -777,6 +790,10 @@ _daemon_sign_cb(uv_signal_t* sil_u, c3_i num_i)
     case SIGWINCH: {
       u3_term_ef_winc();
       break;
+    }
+
+    case SIGQUIT: {
+      abort();
     }
   }
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -866,6 +866,14 @@ u3_daemon_commence()
   u3C.sign_hold_f = _daemon_sign_hold;
   u3C.sign_move_f = _daemon_sign_move;
 
+  //  Ignore SIGPIPE signals.
+  {
+    struct sigaction sig_s = {{0}};
+    sigemptyset(&(sig_s.sa_mask));
+    sig_s.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &sig_s, 0);
+  }
+
   //  boot the ivory pill
   //
   {

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -496,7 +496,7 @@ static void
 _pier_work_bail(void*       vod_p,
                 const c3_c* err_c)
 {
-  fprintf(stderr, "pier: work error: %s\r\n", err_c);
+  fprintf(stderr, "\rpier: work error: %s\r\n", err_c);
 }
 
 /* _pier_work_boot(): prepare for boot.
@@ -838,11 +838,15 @@ _pier_work_exit(uv_process_t* req_u,
   u3_controller* god_u = (void *) req_u;
   u3_pier* pir_u = god_u->pir_u;
 
-  u3l_log("pier: exit: status %" PRIu64 ", signal %d\r\n", sas_i, sig_i);
+  fprintf(stderr, "\rpier: work exit: status %" PRId64 ", signal %d\r\n",
+                  sas_i, sig_i);
   uv_close((uv_handle_t*) req_u, 0);
 
-  u3_pier_db_shutdown(pir_u);
-  _pier_work_shutdown(pir_u);
+  //  XX dispose
+  //
+  pir_u->god_u = 0;
+
+  u3_pier_bail();
 }
 
 /* _pier_work_poke(): handle subprocess result.  transfer nouns.
@@ -1803,10 +1807,12 @@ u3_pier_interrupt(u3_pier* pir_u)
 static void
 _pier_exit_done(u3_pier* pir_u)
 {
-  u3l_log("pier: exit\r\n");
-
   u3_pier_db_shutdown(pir_u);
-  _pier_work_shutdown(pir_u);
+
+  if ( 0 != pir_u->god_u ) {
+    _pier_work_shutdown(pir_u);
+  }
+
   _pier_loop_exit(pir_u);
 
   //  XX uninstall pier from u3K.tab_u, dispose

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -898,6 +898,15 @@ main(c3_i argc, c3_c* argv[])
     u3C.slog_f = _worker_send_slog;
   }
 
+  //  Ignore SIGPIPE signals.
+  //
+  {
+    struct sigaction sig_s = {{0}};
+    sigemptyset(&(sig_s.sa_mask));
+    sig_s.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &sig_s, 0);
+  }
+
   /* configure pipe to daemon process
   */
   {


### PR DESCRIPTION
This PR ignores SIGPIPE in both daemon and worker processes (which is correct, since we handle socket errors directly). It also handles turns SIGQUIT into SIGABRT in the daemon (to avoid dumping ~45 GB of core. Finally, it cleans up the handling of worker process exits.