### PR TITLE
make udon inline code match block code and enable inline code gaps in…

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -15904,7 +15904,6 @@
         |*  tem=rule
         %-  star
         ;~  pose
-          whit
           ;~(pfix bas tem)
           ;~(less tem prn)
         ==

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -23,6 +23,12 @@ pre {
   background-color: #f9f9f9;
 }
 
+code {
+  padding: 8px;
+  background-color: #f9f9f9;
+  white-space: pre-wrap;
+}
+
 a {
   color: inherit;
   text-decoration: inherit;


### PR DESCRIPTION
… Publish app

before:
<img width="723" alt="before" src="https://user-images.githubusercontent.com/15039850/62446863-7bcbb280-b729-11e9-8342-ab7765833d73.png">

after:
<img width="719" alt="css-after" src="https://user-images.githubusercontent.com/15039850/62450733-7e7ed580-b732-11e9-828e-7cc03ca2bb92.png">

Note that gaps still aren't rendered properly as that requires a change to the udon parser.  I will do that in a separate PR.

I think the background color for code blocks is too light.  The urbit.org repo uses `#eee` and looks great.

---

(So much for the separate PR for the parser change..  I don't understand GitHub sometimes.)

Here's the final result with the css and parser changes:
<img width="719" alt="parser-after" src="https://user-images.githubusercontent.com/15039850/62452425-c7845900-b735-11e9-9027-9a206194841c.png">
