### PR TITLE
Fix % not working as talk glyph

### DIFF
--- a/pkg/arvo/app/talk.hoon
+++ b/pkg/arvo/app/talk.hoon
@@ -716,8 +716,12 @@
       ++  circ                                          ::  circle
         ;~  pose
           (cold incir col)
-          ;~(pfix cen (stag self urs:ab))
           ;~(pfix net (stag (^sein:title self) urs:ab))
+          ;~  pfix  cen
+            %+  stag  self
+            %+  sear  |=(circ=name ?:(=('' circ) ~ (some circ)))
+            urs:ab
+          ==
         ::
           %+  cook
             |=  {a/@p b/(unit term)}


### PR DESCRIPTION
Fixes urbit/arvo#743.

The problem is that `~(pfix cen (stag self urs:ab)` catches the bare `%` character before we get to parsing glyphs instead of circles.

This basically replaces urs:ab in circle parsing with an exact copy implemented in terms of `plus` instead of `star`. I find this re-implementing somewhat unaesthetic, let me know if there's a smarter way to do this.

Another option that I discussed with @Fang- is to just parse glyphs before circles instead. Glyph parsing is however implemented in terms of `mask` which would never allow `%foo` to fall through to circle parsing as it should.