### PR TITLE
uses bail:meme for all road stack-overflow error conditions

### DIFF
--- a/pkg/urbit/jets/e/cue.c
+++ b/pkg/urbit/jets/e/cue.c
@@ -38,10 +38,14 @@ _cue_push(c3_ys   mov,
   //  (off==0 means we're on a north road)
   //
   if ( 0 == off ) {
-    c3_assert(u3R->cap_p > u3R->hat_p);
+    if( !(u3R->cap_p > u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
   }
   else {
-    c3_assert(u3R->cap_p < u3R->hat_p);
+    if( !(u3R->cap_p < u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
   }
 
   cueframe* fam_u = u3to(cueframe, u3R->cap_p + off);

--- a/pkg/urbit/jets/e/jam.c
+++ b/pkg/urbit/jets/e/jam.c
@@ -138,8 +138,25 @@ _jam_buf_atom(_jam_buf* buf_u, u3_noun a)
         else {
           _jam_buf_chop(&buf_u, 2, 1);
           *top         = u3t(a);
-
           u3R->cap_p  += mov;
+
+          //  XX disabled for performance
+          //  may be unnecessary, u3h_put calls u3r_mug,
+          //  which uses and checks the stack
+          //
+#if 0
+          if ( 0 == off ) {
+            if( !(u3R->cap_p > u3R->hat_p) ) {
+              u3m_bail(c3__meme);
+            }
+          }
+          else {
+            if( !(u3R->cap_p < u3R->hat_p) ) {
+              u3m_bail(c3__meme);
+            }
+          }
+#endif
+
           top          = u3to(u3_noun, u3R->cap_p + off);
           *top         = u3h(a);
         }

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -586,8 +586,13 @@ u3a_push(c3_w len_w)
     top -= len_w;
     cur = top;
     u3p(void) cap_p = u3R->cap_p = u3of(void, top);
-    c3_assert(cap_p < u3R->mat_p);
-    c3_assert(cap_p > u3R->hat_p);
+
+    if( !( cap_p < u3R->mat_p &&
+           cap_p > u3R->hat_p ) )
+    {
+      u3m_bail(c3__meme);
+    }
+
     return cur;
   }
   else {
@@ -595,8 +600,13 @@ u3a_push(c3_w len_w)
     top += len_w;
     u3R->cap_p = u3of(void, top);
     u3p(void) cap_p = u3R->cap_p = u3of(void, top);
-    c3_assert(cap_p > u3R->mat_p);
-    c3_assert(cap_p < u3R->hat_p);
+
+    if( !( cap_p > u3R->mat_p &&
+           cap_p < u3R->hat_p ) )
+    {
+      u3m_bail(c3__meme);
+    }
+
     return cur;
   }
 }

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1345,6 +1345,22 @@ static inline void
 _n_push(c3_ys mov, c3_ys off, u3_noun a)
 {
   u3R->cap_p += mov;
+
+  //  XX stack sanity-check disabled for performance
+  //
+#if 0
+  if ( 0 == off ) {
+    if( !(u3R->cap_p > u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
+  }
+  else {
+    if( !(u3R->cap_p < u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
+  }
+#endif
+
   u3_noun* p = u3to(u3_noun, u3R->cap_p + off);
   *p = a;
 }

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1597,10 +1597,14 @@ _mug_push(c3_ys mov,
   //  (off==0 means we're on a north road)
   //
   if ( 0 == off ) {
-    c3_assert(u3R->cap_p > u3R->hat_p);
+    if( !(u3R->cap_p > u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
   }
   else {
-    c3_assert(u3R->cap_p < u3R->hat_p);
+    if( !(u3R->cap_p < u3R->hat_p) ) {
+      u3m_bail(c3__meme);
+    }
   }
 
   mugframe* fam_u = u3to(mugframe, u3R->cap_p + off);


### PR DESCRIPTION
This PR replaces road stack sanity assertions (`bail:oops` on error) with explicit `bail:meme` error conditions. It also adds such error conditions to the `+jam` jet and the nock bytecode interpreter, where previously there were none.

/cc @frodwith 