### PR TITLE
Change ship name CSS in eyre to monospace

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -374,6 +374,9 @@
              #topborder {
                border-top: 3px #fff solid;
              }
+             #ship-name {
+               font-family: 'Source Code Pro', monospace, sans-serif;
+             }
              h1 {
                line-height: 77px;
                font-size: 64px;
@@ -425,7 +428,7 @@
       ;div#main
         ;div#inner
           ;h1#topborder:"Welcome"
-          ;h1:"{(scow %p our)}"
+          ;h1#ship-name:"{(scow %p our)}"
           ;form(action "/~/login", method "post", enctype "application/x-www-form-urlencoded")
             ;input(type "password", name "password", placeholder "passcode", autofocus "true");
             ;input(type "hidden", name "redirect", value redirect-str);


### PR DESCRIPTION
See screenshot.

<img width="1440" alt="Screen Shot 2019-08-08 at 5 34 28 PM" src="https://user-images.githubusercontent.com/20846414/62739510-e5d2a900-ba02-11e9-88cb-1949a1a4ca43.png">

@g-a-v-i-n Do we have a specific font weight for ship names or is this adequate?