### PR TITLE
Kick write queue on |cancel

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4158,17 +4158,15 @@
     [[[hen %slip %d %flog req] ~] ..^$]
   ::
       %drop
-      ?:  =(~ act.ruf)
-        ~&  %clay-idle
-        [~ ..^$]
-      ~&  :-  %clay-cancelling
-          ?>  ?=(^ act.ruf)
-          [hen -.req -.eval-data]:u.act.ruf
-      =.  act.ruf  ~
-      ?~  cue.ruf
-        [~ ..^$]
-      =/  =duct  duct:(need ~(top to cue.ruf))
-      [[duct %pass /queued-request %b %wait now]~ ..^$]
+    ~?  =(~ act.ruf)
+      [%clay-idle cue-length=~(wyt in cue.ruf)]
+    ~?  ?=(^ act.ruf)
+      [%clay-cancelling hen -.req -.eval-data]:u.act.ruf
+    =.  act.ruf  ~
+    ?~  cue.ruf
+      [~ ..^$]
+    =/  =duct  duct:(need ~(top to cue.ruf))
+    [[duct %pass /queued-request %b %wait now]~ ..^$]
   ::
       %info
     ?:  =(%$ des.req)


### PR DESCRIPTION
Looks like somehow the write queue in Clay on ~zod got stuck in a state where the cue has contents, but no write is active.  This make `|cancel` start the next write in the queue.