### PR TITLE
Loading spinner moved to left alignment

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/header-bar.js
+++ b/pkg/interface/chat/src/js/components/lib/header-bar.js
@@ -7,7 +7,7 @@ export class HeaderBar extends Component {
   render() {
     let spin = (this.props.spinner)
       ?  <div className="absolute"
-           style={{width: 16, height: 16, top: 16, right: 16}}>
+           style={{width: 16, height: 16, top: 16, left: 55}}>
            <IconSpinner/>
          </div>
       :  null;

--- a/pkg/interface/publish/src/js/components/lib/header-bar.js
+++ b/pkg/interface/publish/src/js/components/lib/header-bar.js
@@ -7,7 +7,7 @@ export class HeaderBar extends Component {
   render() {
     let spin = (this.props.spinner)
       ?  <div className="absolute"
-           style={{width: 16, height: 16, top: 16, right: 16}}>
+           style={{width: 16, height: 16, top: 16, left: 55}}>
            <IconSpinner/>
          </div>
       :  null;


### PR DESCRIPTION
Upon @galenwp's request.

<img width="1440" alt="Screen Shot 2019-08-09 at 6 43 34 PM" src="https://user-images.githubusercontent.com/20846414/62813036-b0978b00-bad6-11e9-9c5b-5618e1427b64.png">

This PR distinctly does *not* include the compiled pkg/arvo code, in the hopes of establishing a brighter future. It can easily be added as a separate commit if need be.