### PR TITLE
add +scry to lib/stdio

### DIFF
--- a/pkg/arvo/lib/stdio.hoon
+++ b/pkg/arvo/lib/stdio.hoon
@@ -62,6 +62,25 @@
 ::
 ::    ----
 ::
+::  Scry from the namespace.
+::
+::    Direct scrys are impossible in a tapp, so this routes around that.
+::
+++  scry
+  |*  result-type=mold
+  |=  =path
+  =/  m  (async ,result-type)
+  ;<  ~  bind:m  (send-raw-card %scry path)
+  |=  =async-input
+  :^  ~  ~  ~
+  ?~  in.async-input
+    [%wait ~]
+  ?.  ?=(%scry-result -.sign.u.in.async-input)
+    [%fail %expected-scry-result >got=-.sign< ~]
+  [%done (result-type result.sign.u.in.async-input)]
+::
+::    ----
+::
 ::  Outgoing HTTP requests
 ::
 ++  send-request

--- a/pkg/arvo/lib/tapp.hoon
+++ b/pkg/arvo/lib/tapp.hoon
@@ -428,6 +428,9 @@
     |=  =async-input:async-lib
     ^-  (quip move _this-tapp)
     =/  m  tapp-async
+    =|  moves=(list move)
+    =|  scrys=(list path)
+    |-  ^-  (quip move _this-tapp)
     ?~  active
       ~|  %no-active-async
       ~|  ?~  in.async-input
@@ -442,14 +445,27 @@
         %&  p.out
         %|  [[~ [%fail contracts.u.active %crash p.out]] u.active]
       ==
+    =.  moves  (weld moves (skip moves.r |=(=move =(%scry -.q.move))))
+    =.  scrys
+      %+  weld  scrys
+      ^-  (list path)
+      %+  murn  moves.r
+      |=  =move
+      ^-  (unit path)
+      ?.  ?=(%scry -.q.move)
+        ~
+      `path.q.move
+    ?^  scrys
+      =/  scry-result  .^(* i.scrys)
+      $(scrys t.scrys, in.async-input `[i.scrys %scry-result scry-result])
     =>  .(active `(unit eval-form:eval:tapp-async)`active)  :: TMI
-    =^  moves=(list move)  this-tapp
+    =^  final-moves=(list move)  this-tapp
       ?-  -.eval-result.r
         %next  `this-tapp
         %fail  (fail-async [contracts err]:eval-result.r)
         %done  (done-async [contracts value]:eval-result.r)
       ==
-    [(weld moves.r moves) this-tapp]
+    [(weld moves final-moves) this-tapp]
   ::
   ::  Fails currently-running async
   ::

--- a/pkg/arvo/sur/tapp.hoon
+++ b/pkg/arvo/sur/tapp.hoon
@@ -4,7 +4,8 @@
 ::  Possible async calls
 ::
 +$  card
-  $%  [%wait wire @da]
+  $%  [%scry =path]
+      [%wait wire @da]
       [%rest wire @da]
       [%poke wire dock poke-data]
       [%peer wire dock path]
@@ -24,7 +25,8 @@
 ::  Possible async responses
 ::
 +$  sign
-  $%  [%wake error=(unit tang)]
+  $%  [%scry-result result=*]
+      [%wake error=(unit tang)]
       [%coup =dock error=(unit tang)]
       [%quit =dock =path]
       [%reap =dock =path error=(unit tang)]


### PR DESCRIPTION
Usage:

```
;<  =life  bind:m  ((scry ,life) %j /(scot %p our)/life/(scot %da now)/~zod)
~&  zod-life=life
...
```

Scry is currently disabled in async apps because we run them within `+mule`, and it's not immediately clear how to supply a scry function to `+mule` without introducing a type hole.  A `+scry` in lib/stdio is just about as good.  To implement this, we thought about sending a `%scry` schematic to ford, but ford currently only supports clay scrys.  We also thought about creating a special-purpose app to scry results, but this seemed like overkill, and it wasn't clear what ordering guarantees we would be relying on.

Since `lib/tapp` is the one that introduces the `+mule` calls, it seems that's the right place to complete the virtualization.  This adds special handling in `lib/tapp` for scry request "moves", which we guarantee to handle immediately.

Type-wise, we clam the result to the correct type, so this won't work for anything that's not clammable.