### PR TITLE
Store subscribers to all ships in Jael

### DIFF
--- a/bin/ivory.pill
+++ b/bin/ivory.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e828e89f4e6f2b39d4d8d62101f9c052253cdfa4e91abb8682678acd796f999
-size 4707549
+oid sha256:43fe5bd4c7437c027eba746f6d04e03ce39372f06429a66d1fe4839de331196f
+size 4955047

--- a/bin/ivory.pill
+++ b/bin/ivory.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43fe5bd4c7437c027eba746f6d04e03ce39372f06429a66d1fe4839de331196f
-size 4955047
+oid sha256:14108fb21079a53b82e5f6f11d5837c6dddf373e98591286ccffc5450ca27d8f
+size 5145547

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a7be485bbece9d4a4624a8267d2e969bed2a2923b4b67f0ed6423cd71d49373
-size 13474032
+oid sha256:c6ca3b56982d9ff6c1fb5b42b94c2d9e689436f364b90f08c3e96a52961ddb5e
+size 12486405

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e28039e2f563abd8eadd42e3e3fcff3a8d66aea8809caaa2cbf6427ed57176b
-size 12588345
+oid sha256:a2cde0b21e3a73fe26c98f0fb6bd5d5a2f8b2fbae28985e2aac98e474f82e80d
+size 12633194

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2cde0b21e3a73fe26c98f0fb6bd5d5a2f8b2fbae28985e2aac98e474f82e80d
-size 12633194
+oid sha256:4bdec2be8d0c0840dd939de4ff860bc8e9c5ef7b6298a0c3b184c05278b694f2
+size 15445158

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6ca3b56982d9ff6c1fb5b42b94c2d9e689436f364b90f08c3e96a52961ddb5e
-size 12486405
+oid sha256:8e28039e2f563abd8eadd42e3e3fcff3a8d66aea8809caaa2cbf6427ed57176b
+size 12588345

--- a/pkg/arvo/lib/ph/azimuth.hoon
+++ b/pkg/arvo/lib/ph/azimuth.hoon
@@ -288,7 +288,7 @@
       ~
     ?:  ?=(%czar (clan:title ship))
       [a-point]~
-    [a-point $(who who.sponsor:(need net.a-point))]
+    [a-point $(who ship)]
   =/  =seed:able:jael
     ?^  seed
       u.seed

--- a/pkg/arvo/lib/ph/azimuth.hoon
+++ b/pkg/arvo/lib/ph/azimuth.hoon
@@ -265,15 +265,12 @@
 ::
 ++  dawn
   |=  [who=ship seed=(unit seed:able:jael)]
-  ^-  dawn-event
+  ^-  dawn-event:able:jael
   =/  spon=(list [ship point:azimuth])
     |-  ^-  (list [ship point:azimuth])
     =/  =ship  (^sein:title who)
     =/  a-point=[^ship point:azimuth]
-      =/  spon-spon
-        ?:  ?=(%czar (clan:title ship))
-          [| ~zod]
-        [& (^sein:title ship)]
+      =/  spon-spon  [& (^sein:title ship)]
       =/  life-rift  ~|([ship lives] (~(got by lives) ship))
       =/  =life  lyfe.life-rift
       =/  =rift  rut.life-rift

--- a/pkg/arvo/lib/ph/azimuth.hoon
+++ b/pkg/arvo/lib/ph/azimuth.hoon
@@ -266,24 +266,29 @@
 ++  dawn
   |=  [who=ship seed=(unit seed:able:jael)]
   ^-  dawn-event
-  =/  spon
+  =/  spon=(list [ship point:azimuth])
+    |-  ^-  (list [ship point:azimuth])
     =/  =ship  (^sein:title who)
-    =/  spon-spon
-      ?:  ?=(%czar (clan:title ship))
-        [| ~zod]
-      [& (^sein:title ship)]
-    =/  life-rift  ~|([ship lives] (~(got by lives) ship))
-    =/  =life  lyfe.life-rift
-    =/  =rift  rut.life-rift
-    =/  =pass
-      %^    pass-from-eth:azimuth
-          (as-octs:mimes:html (get-public ship life %crypt))
-        (as-octs:mimes:html (get-public ship life %auth))
-      1
-    :^    ship=ship
-        *[address address address address]:azimuth
-      `[life=life pass rift spon-spon ~]
-    ~
+    =/  a-point=[^ship point:azimuth]
+      =/  spon-spon
+        ?:  ?=(%czar (clan:title ship))
+          [| ~zod]
+        [& (^sein:title ship)]
+      =/  life-rift  ~|([ship lives] (~(got by lives) ship))
+      =/  =life  lyfe.life-rift
+      =/  =rift  rut.life-rift
+      =/  =pass
+        %^    pass-from-eth:azimuth
+            (as-octs:mimes:html (get-public ship life %crypt))
+          (as-octs:mimes:html (get-public ship life %auth))
+        1
+      :^    ship
+          *[address address address address]:azimuth
+        `[life=life pass rift spon-spon ~]
+      ~
+    ?:  ?=(%czar (clan:title ship))
+      [a-point]~
+    [a-point $(who who.sponsor:(need net.a-point))]
   =/  =seed:able:jael
     ?^  seed
       u.seed

--- a/pkg/arvo/lib/ph/tests.hoon
+++ b/pkg/arvo/lib/ph/tests.hoon
@@ -49,7 +49,7 @@
 ::  Boot ship; don't check it succeeded.
 ::
 ++  boot-ship
-  |=  [her=ship keys=(unit dawn-event)]
+  |=  [her=ship keys=(unit dawn-event:able:jael)]
   ^+  *form:(ph ,~)
   |=  ph-input
   [& (init her keys) %done ~]
@@ -96,7 +96,7 @@
 ::  Boot a ship and verify it booted.  Parent must already be booted.
 ::
 ++  raw-ship
-  |=  [her=ship keys=(unit dawn-event)]
+  |=  [her=ship keys=(unit dawn-event:able:jael)]
   =/  m  (ph ,~)
   ^-  form:m
   ;<  ~  bind:m  (boot-ship her keys)

--- a/pkg/arvo/lib/ph/util.hoon
+++ b/pkg/arvo/lib/ph/util.hoon
@@ -16,7 +16,7 @@
 ::  Start a ship (low-level; prefer +raw-ship)
 ::
 ++  init
-  |=  [who=ship keys=(unit dawn-event)]
+  |=  [who=ship keys=(unit dawn-event:able:jael)]
   ^-  (list ph-event)
   [%init-ship who keys]~
 ::

--- a/pkg/arvo/lib/pill.hoon
+++ b/pkg/arvo/lib/pill.hoon
@@ -13,17 +13,8 @@
   %+  pair  wire
   $%  [%wack p=@]
       [%whom p=ship]
-      [%boot $%([%fake p=ship] [%dawn p=dawn-event])]
+      [%boot $%($>(%fake task:able:jael) $>(%dawn task:able:jael))]
       unix-task
-  ==
-::
-+$  dawn-event
-  $:  =seed:able:jael
-      spon=(list [=ship point:azimuth])
-      czar=(map ship [=rift =life =pass])
-      turf=(list turf)
-      bloq=@ud
-      node=(unit purl:eyre)
   ==
 ::
 ++  module-ova

--- a/pkg/arvo/lib/pill.hoon
+++ b/pkg/arvo/lib/pill.hoon
@@ -19,7 +19,7 @@
 ::
 +$  dawn-event
   $:  =seed:able:jael
-      spon=[=ship point:azimuth]
+      spon=(list [=ship point:azimuth])
       czar=(map ship [=rift =life =pass])
       turf=(list turf)
       bloq=@ud

--- a/pkg/arvo/sur/aquarium.hoon
+++ b/pkg/arvo/sur/aquarium.hoon
@@ -19,11 +19,10 @@
   ==
 ::
 +$  unix-event  unix-event:pill-lib
-+$  dawn-event  dawn-event:pill-lib
 +$  pill        pill:pill-lib
 ::
 +$  aqua-event
-  $%  [%init-ship who=ship keys=(unit dawn-event)]
+  $%  [%init-ship who=ship keys=(unit dawn-event:able:jael)]
       [%pause-events who=ship]
       [%snap-ships lab=term hers=(list ship)]
       [%restore-snap lab=term]

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -678,7 +678,10 @@
     |=  =ship
     ^-  (set duct)
     =/  specific-subs  (~(get ju ney.zim) ship)
-    =/  general-subs   nel.zim
+    =/  general-subs=(set duct)
+      ?:  ?=(?(%czar %king %duke) (clan:title ship))
+        nel.zim
+      ~
     (~(uni in specific-subs) general-subs)
   ::
   ++  feed

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -255,7 +255,8 @@
         =/  cub  (nol:nu:crub:crypto key.seed.tac)
         %+  ~(put by pos.zim.pki)
           our
-        [1 lyf.seed.tac (my [lyf.seed.tac [1 pub:ex:cub]] ~) `ship.spon.tac]
+        =/  spon-ship  ?~(spon.tac ~ `ship.i.spon.tac)
+        [1 lyf.seed.tac (my [lyf.seed.tac [1 pub:ex:cub]] ~) spon-ship]
       ::  our initial private key
       ::
       =.  lyf.own.pki  lyf.seed.tac
@@ -267,15 +268,18 @@
       =.  tuf.own.pki  turf.tac
       ::  our initial galaxy table as a +map from +life to +public
       ::
-      =/  spon-point=point
-        ~|  [%sponsor-point point]
-        ?>  ?=(^ net.spon.tac)
-        :*  continuity-number.u.net.spon.tac
-            life.u.net.spon.tac
-            (malt [life.u.net.spon.tac 1 pass.u.net.spon.tac] ~)
-            ?.  has.sponsor.u.net.spon.tac
+      =/  spon-points=(list [ship point])
+        %+  turn  spon.tac
+        |=  [=ship az-point=point:azimuth]
+        ~|  [%sponsor-point az-point]
+        ?>  ?=(^ net.az-point)
+        :*  ship
+            continuity-number.u.net.az-point
+            life.u.net.az-point
+            (malt [life.u.net.az-point 1 pass.u.net.az-point] ~)
+            ?.  has.sponsor.u.net.az-point
               ~
-            `who.sponsor.u.net.spon.tac
+            `who.sponsor.u.net.az-point
         ==
       =/  points=(map =ship =point)
         %-  ~(run by czar.tac)
@@ -283,7 +287,7 @@
         ^-  point
         [a-rift a-life (malt [a-life 1 a-pass] ~) ~]
       =.  points
-        (~(put by points) ship.spon.tac spon-point)
+        (~(gas by points) spon-points)
       =.  +>.$
         %-  curd  =<  abet
         (public-keys:~(feel su hen our pki etn) %full points)
@@ -298,13 +302,16 @@
           (sources:~(feel su hen our pki etn) ~ [%| %azimuth-tracker])
         ::
             *
+          =/  spon-ship
+            ?>  ?=(^ spon.tac)
+            ship.i.spon.tac
           =.  +>.$
             %-  curd  =<  abet
             %+  sources:~(feel su hen our pki etn)
-              (silt ship.spon.tac ~)
+              (silt spon-ship ~)
             [%| %azimuth-tracker]
           %-  curd  =<  abet
-          (sources:~(feel su hen our pki etn) ~ [%& ship.spon.tac])
+          (sources:~(feel su hen our pki etn) ~ [%& spon-ship])
         ==
       ::
       =.  moz

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -54,6 +54,7 @@
       $=  zim                                           ::  public
         $:  yen=(jug duct ship)                         ::  trackers
             ney=(jug ship duct)                         ::  reverse trackers
+            nel=(set duct)                              ::  trackers of all
             dns=dnses                                   ::  on-chain dns state
             pos=(map ship point)                        ::  on-chain ship state
         ==                                              ::
@@ -392,6 +393,8 @@
         ?~  ships
           yen.zim.pki
         (~(del ju $(ships t.ships)) hen i.ships)
+      =?  nel.zim.pki  ?=(~ whos.tac)
+        (~(del in nel.zim.pki) hen)
       ?^  whos.tac
         +>.$
       %_  +>.$
@@ -671,6 +674,13 @@
       this-su
     (public-keys:feel %diff a-ship u.a-diff)
   ::
+  ++  subscribers-on-ship
+    |=  =ship
+    ^-  (set duct)
+    =/  specific-subs  (~(get ju ney.zim) ship)
+    =/  general-subs   nel.zim
+    (~(uni in specific-subs) general-subs)
+  ::
   ++  feed
     |_  ::  hen: subscription source
         ::
@@ -717,6 +727,8 @@
         %+  turn  ~(tap in whos)
         |=  who=ship
         [hen who]
+      =?  nel.zim  ?=(~ whos)
+        (~(put in nel.zim) hen)
       ::  Give initial result
       ::
       =/  =public-keys-result
@@ -782,7 +794,7 @@
         ?~  pointl
           ..feel
         %+  public-keys-give
-          (~(get ju ney.zim) who.i.pointl)
+          (subscribers-on-ship who.i.pointl)
         [%full (my i.pointl ~)]
       =*  who  who.public-keys-result
       =/  a-diff=diff:point  diff.public-keys-result
@@ -803,7 +815,7 @@
         ==
       =.  pos.zim  (~(put by pos.zim) who point)
       %+  public-keys-give
-        (~(get ju ney.zim) who)
+        (subscribers-on-ship who)
       ?~  maybe-point
         [%full (my [who point]~)]
       [%diff who a-diff]

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -2072,14 +2072,7 @@
     ::
     +=  task                                            ::  in request ->$
       $~  [%vega ~]                                     ::
-      $%  $:  %dawn                                     ::  boot from keys
-              =seed:able:jael                           ::    identity params
-              spon=(list [=ship point:azimuth-types])   ::
-              czar=(map ship [=rift =life =pass])       ::    galaxy table
-              turf=(list turf)                          ::    domains
-              bloq=@ud                                  ::    block number
-              node=(unit purl:eyre)                     ::    gateway url
-          ==                                            ::
+      $%  [%dawn dawn-event]                            ::  boot from keys
           [%fake =ship]                                 ::  fake boot
           [%listen whos=(set ship) =source]             ::  set ethereum source
           ::TODO  %next for generating/putting new private key
@@ -2094,6 +2087,15 @@
           $>(%wegh vane-task)                           ::  memory usage request
           $>(%west vane-task)                           ::  remote request
       ==                                                ::
+    ::
+    +$  dawn-event
+      $:  =seed
+          spon=(list [=ship point:azimuth-types])
+          czar=(map ship [=rift =life =pass])
+          turf=(list turf)
+          bloq=@ud
+          node=(unit purl:eyre)
+      ==
     ::
     ++  block
       =<  block

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -8978,7 +8978,7 @@
   ::
   ++  veri
     |=  [=seed:able:jael =point:azimuth =live]
-    ^-  (each sponsor=ship error=term)
+    ^-  (unit error=term)
     =/  rac  (clan:title who.seed)
     =/  cub  (nol:nu:crub:crypto key.seed)
     ?-  rac
@@ -8986,39 +8986,35 @@
       ::  a comet address is the fingerprint of the keypair
       ::
       ?.  =(who.seed `@`fig:ex:cub)
-        [%| %key-mismatch]
+        `%key-mismatch
       ::  a comet can never be breached
       ::
       ?^  live
-        [%| %already-booted]
+        `%already-booted
       ::  a comet can never be re-keyed
       ::
       ?.  ?=(%1 lyf.seed)
-        [%| %invalid-life]
-      [%& (^sein:title who.seed)]
+        `%invalid-life
+      ~
     ::
         %earl
-      ::  the parent must be launched
-      ::
-      ?~  net.point
-        [%| %parent-not-keyed]
-      [%& (^sein:title who.seed)]
+      ~
     ::
         *
       ::  on-chain ships must be launched
       ::
       ?~  net.point
-        [%| %not-keyed]
+        `%not-keyed
       =*  net  u.net.point
       ::  boot keys must match the contract
       ::
       ?.  =(pub:ex:cub pass.net)
         ~&  [%key-mismatch pub:ex:cub pass.net]
-        [%| %key-mismatch]
+        `%key-mismatch
       ::  life must match the contract
       ::
       ?.  =(lyf.seed life.net)
-        [%| %life-mismatch]
+        `%life-mismatch
       ::  the boot life must be greater than and discontinuous with
       ::  the last seen life (per the sponsor)
       ::
@@ -9026,12 +9022,28 @@
               ?|  ?=(%| breach.u.live)
                   (lte life.net life.u.live)
           ==  ==
-        [%| %already-booted]
+        `%already-booted
       ::  produce the sponsor for vere
       ::
       ~?  !has.sponsor.net
         [%no-sponsorship-guarantees-from who.sponsor.net]
-      [%& who.sponsor.net]
+      ~
+    ==
+  ::  +sponsor:dawn: retreive sponsor from point
+  ::
+  ++  sponsor
+    |=  [who=ship =point:azimuth]
+    ^-  (each ship error=term)
+    ?-    (clan:title who)
+        %pawn  [%& (^sein:title who)]
+        %earl  [%& (^sein:title who)]
+        %czar  [%& (^sein:title who)]
+        *
+      ?~  net.point
+        [%| %not-booted]
+      ?.  has.sponsor.u.net.point
+        [%| %no-sponsor]
+      [%& who.sponsor.u.net.point]
     ==
   --
 --  ::

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -2074,7 +2074,7 @@
       $~  [%vega ~]                                     ::
       $%  $:  %dawn                                     ::  boot from keys
               =seed:able:jael                           ::    identity params
-              spon=[=ship point:azimuth-types]          ::    sponsor
+              spon=(list [=ship point:azimuth-types])   ::
               czar=(map ship [=rift =life =pass])       ::    galaxy table
               turf=(list turf)                          ::    domains
               bloq=@ud                                  ::    block number

--- a/pkg/arvo/tests/sys/zuse/dawn.hoon
+++ b/pkg/arvo/tests/sys/zuse/dawn.hoon
@@ -188,36 +188,36 @@
 ++  test-veri-good
   =/  sed  [~zod 1 sec ~]
   %+  expect-eq
-    !>  [%& ~zod]
+    !>  ~
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-not-spawned
   =/  sed  [~zod 1 sec ~]
   %+  expect-eq
-    !>  [%| %not-keyed]
+    !>  `%not-keyed
     !>  (veri:dawn sed =>(pot .(net ~)) ~)
 ::
 ++  test-veri-wrong-key
   =/  sed  [~zod 1 sec:ex:(pit:nu:crub:crypto 24 %foo) ~]
   %+  expect-eq
-    !>  [%| %key-mismatch]
+    !>  `%key-mismatch
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-life-mismatch
   =/  sed  [~zod 2 sec ~]
   %+  expect-eq
-    !>  [%| %life-mismatch]
+    !>  `%life-mismatch
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-already-booted
   =/  sed  [~zod 1 sec ~]
   ;:  weld
     %+  expect-eq
-      !>  [%| %already-booted]
+      !>  `%already-booted
       !>  (veri:dawn sed pot `[1 |])
   ::
     %+  expect-eq
-      !>  [%| %already-booted]
+      !>  `%already-booted
       !>  (veri:dawn sed pot `[2 &])
   ==
 ::
@@ -230,7 +230,7 @@
       (shaf %earl (sham who 1 pub:ex:cub))
     [who 1 sec:ex:cub `sig]
   %+  expect-eq
-    !>  [%& (^sein:title who)]
+    !>  ~
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-earl-parent-not-keyed
@@ -242,7 +242,7 @@
       (shaf %earl (sham who 1 pub:ex:cub))
     [who 1 sec:ex:cub `sig]
   %+  expect-eq
-    !>  [%| %parent-not-keyed]
+    !>  ~
     !>  (veri:dawn sed =>(pot .(net ~)) ~)
 ::
 ++  test-veri-pawn-good
@@ -250,7 +250,7 @@
   =/  who=ship  `@`fig:ex:cub
   =/  sed  [who 1 sec:ex:cub ~]
   %+  expect-eq
-    !>  [%& ~mittun]
+    !>  ~
     !>  (veri:dawn sed *point:azimuth-types ~)
 ::
 ++  test-veri-pawn-key-mismatch
@@ -258,7 +258,7 @@
   =/  who=ship  `@`fig:ex:cub
   =/  sed  [who 1 sec:ex:(pit:nu:crub:crypto 24 %bar) ~]
   %+  expect-eq
-    !>  [%| %key-mismatch]
+    !>  `%key-mismatch
     !>  (veri:dawn sed *point:azimuth-types ~)
 ::
 ++  test-veri-pawn-invalid-life
@@ -266,7 +266,7 @@
   =/  who=ship  `@`fig:ex:cub
   =/  sed  [who 2 sec:ex:cub ~]
   %+  expect-eq
-    !>  [%| %invalid-life]
+    !>  `%invalid-life
     !>  (veri:dawn sed *point:azimuth-types ~)
 ::
 ++  test-veri-pawn-already-booted
@@ -274,6 +274,6 @@
   =/  who=ship  `@`fig:ex:cub
   =/  sed  [who 1 sec:ex:cub ~]
   %+  expect-eq
-    !>  [%| %already-booted]
+    !>  `%already-booted
     !>  (veri:dawn sed *point:azimuth-types `[1 |])
 --


### PR DESCRIPTION
Fixes a bug in Jael that @belisarius222 uncovered while testing new Ames.  We supported the idea of "subscribe to updates about all ships" on the client side but not the server side.