### PR TITLE
Sort clauses of $fork type pretty-printing

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11505,7 +11505,7 @@
       ?^(p.sut yad [p.yad [%face p.sut q.yad]])
     ::
         {$fork *}
-      =+  yed=~(tap in p.sut)
+      =+  yed=(sort ~(tap in p.sut) aor)
       =-  [p [%bswt q]]
       |-  ^-  {p/{p/(map type @) q/(map @ wine)} q/(list wine)}
       ?~  yed


### PR DESCRIPTION
Fixes #1405.

On master, if you run 

`=y |=  x=(list *)  |-  ?~  x  "derp"  i.x`

`(y ~[1 2])`

repeatedly in the dojo you'll get `[%dojo-lame %made]` approximately 50 % of the time. Unlike the issue I haven't encountered any difference with respect to printing out the function or not. The problem is that sometimes we try to print out a `cape` containing `[%bswt p=~[%yarn %noun]]` instead of the expected `[%bswt p=~[%noun %yarn]]`.

This is basically just commit 676aa77afdba87001c689717e3ffdce97e1017df, which was dropped from master at some point, git bisect doesn't return anything useful though.