### PR TITLE
vere: version bump (0.8.2)

### DIFF
--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -2,7 +2,7 @@
 
 set -e
 
-URBIT_VERSION=0.8.1
+URBIT_VERSION=0.8.2
 
 deps="                                                                    \
   curl gmp sigsegv argon2 ed25519 ent h2o scrypt sni uv murmur3 secp256k1 \


### PR DESCRIPTION
Simply bumps vere to v0.8.2.

This commit was made directly on the v0.8.2 release branch, but it *should* have been made on master and then been cherry-picked over.  Here we're just performing the reverse action to fix that up.