### PR TITLE
Add colors for priority printfs

### DIFF
--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1997,9 +1997,9 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
   }
 
   switch ( pri_w ) {
-    case 3: fprintf(fil_u, ">>> "); break;
-    case 2: fprintf(fil_u, ">> "); break;
-    case 1: fprintf(fil_u, "> "); break;
+    case 3: fprintf(fil_u, "\033[31m>>> "); break;
+    case 2: fprintf(fil_u, "\033[33m>>  "); break;
+    case 1: fprintf(fil_u, "\033[32m>   "); break;
   }
 
   //  if we have no arvo kernel and can't evaluate nock
@@ -2020,6 +2020,7 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
     _pier_wall(fil_u, wol);
   }
 
+  fprintf(fil_u, "\033[0m");
   u3_term_io_loja(0);
   u3z(blu);
   u3z(tac);


### PR DESCRIPTION
In debugging it's useful to use "priority" printfs, which just prepend `>` to the result to make them visually distinct.  This is especially useful when there is a large amount of output, as in complicated aqua tests.  This isn't used in production, I think the only place they're checked in is in tests.

This gives colors to priority printfs:

```
~&  >  'green'
~&  >>  'yellow'
~&  >>>  'red'
```