### PR TITLE
zuse: make of-wain:format use linear space (or "Make commits fast")

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c41d46da7d12258f46dee61f7350701600b73f08ac5076c6b070378b3fc9ece
-size 15526512
+oid sha256:6257ddbfaefc14fce97d214350bb28d370dbc2f0c3c38e79fe61bbc3b6bf5107
+size 15382912

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5415,15 +5415,7 @@
   ::                                                    ::  ++of-wain:format
   ++  of-wain                                           ::  line list to atom
     |=  tez/(list @t)
-    =|  {our/@ i/@ud}
-    |-  ^-  @
-    ?~  tez
-      our
-    ?:  =(%$ i.tez)
-      $(i +(i), tez t.tez, our (cat 3 our 10))
-    ?:  =(0 i)
-      $(i +(i), tez t.tez, our i.tez)
-    $(i +(i), tez t.tez, our (cat 3 (cat 3 our 10) i.tez))
+    (rap 3 (join '\0a' tez))
   ::                                                    ::  ++of-wall:format
   ++  of-wall                                           ::  line list to tape
     |=  a/wall  ^-  tape


### PR DESCRIPTION
You know how writing large files to Clay seems to take forever?  It's not your imagination, hoon.hoon takes 19 seconds on my machine. This PR reduces that by 93% to 1.3 seconds.

Turns out `+of-wain:format` used quadratic space.  It converts a list of lines into one big atom.  Its algorithm was more or less:

- set result = 0
- if no more lines, return result
- else, concatenate result and the next line, then recurse

Of course, each time it hits step 3 (once per line), it allocates a new big atom.  For hoon.hoon, that's 17000 allocations and writes, averaging 250KB each, for a total allocation/write of 3.4 GB.

Memory-wise, the solution is to do a single allocation and paste in all the lines at once.  Hoon doesn't let us access memory directly, but vere has a jet for `+can` which does this.  This is a good example of a virtuous jet:  while it doesn't reduce the time complexity, it does reduce the space complexity (write complexity?) from quadratic to linear.

`+of-wain:format` was used in several other places, including pretty much any mark that gets written as plain-text to unix.  These should speed up, but it'll probably be less noticeable because the files are smaller.