### PR TITLE
dill, helm: add fast boot option with -l

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c41d46da7d12258f46dee61f7350701600b73f08ac5076c6b070378b3fc9ece
-size 15526512
+oid sha256:4c5bb0742d068cd462fd25ebed4fdcd1a509cdd4cd9de0d3b61d7bac6919d8f6
+size 16118338

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -430,7 +430,7 @@
           [/ %whom who.ae]  ::  eny
           [//newt/0v1n.2m9vh %barn ~]
           [//behn/0v1n.2m9vh %born ~]
-          :+  //term/1  %boot
+          :^  //term/1  %boot  &
           ?~  keys.ae
             [%fake who.ae]
           [%dawn u.keys.ae]

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -151,6 +151,7 @@
 ++  poke-drum-unlink          (wrap poke-unlink):from-drum
 ++  poke-drum-exit            (wrap poke-exit):from-drum
 ++  poke-drum-start           (wrap poke-start):from-drum
+++  poke-drum-set-boot-apps   (wrap poke-set-boot-apps):from-drum
 ++  poke-helm-hi              (wrap poke-hi):from-helm
 ::++  poke-helm-invite          (wrap poke-invite):from-helm
 ++  poke-helm-mass            (wrap poke-mass):from-helm

--- a/pkg/arvo/app/ph.hoon
+++ b/pkg/arvo/app/ph.hoon
@@ -81,7 +81,9 @@
       :+  %hi
         ~[~bud ~dev]
       ;<  ~  bind:m  (raw-ship ~bud ~)
+      ~&  >  "BUD DONE"
       ;<  ~  bind:m  (raw-ship ~dev ~)
+      ~&  >  "DEV DONE"
       (send-hi ~bud ~dev)
     ::
       :+  %boot-planet

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -21,9 +21,9 @@
 ::                                                      ::
 ++  pith-2                                              ::
   $:  sys/(unit bone)                                   ::  local console
-      eel/(set gill:gall)                              ::  connect to
-      ray/(set well:gall)                              ::
-      fur/(map dude:gall (unit server))                ::  servers
+      eel/(set gill:gall)                               ::  connect to
+      ray/(set well:gall)                               ::
+      fur/(map dude:gall (unit server))                 ::  servers
       bin/(map bone source)                             ::  terminals
   ==                                                    ::
 ::                                                      ::  ::
@@ -73,9 +73,13 @@
   ::                                                    ::  ::
 |%
 ++  deft-apes                                           ::  default servers
-  |=  our/ship
+  |=  [our/ship lit/?]
   %-  ~(gas in *(set well:gall))
   ^-  (list well:gall)
+  ?:  lit
+    :~  [%home %dojo]
+        [%home %azimuth-tracker]
+    ==
   =+  myr=(clan:title our)
   ::
   ?:  ?=($pawn myr)
@@ -118,7 +122,7 @@
       %2
       sys=~
       eel=(deft-fish our)
-      ray=(deft-apes our)
+      ray=~
       fur=~
       bin=~
   ==
@@ -170,6 +174,16 @@
   ?>  (team:title our.hid src.hid)               ::  or our own moon
   =<  se-abet  =<  se-view
   (se-text "[{<src.hid>}, driving {<our.hid>}]")
+::
+++  poke-set-boot-apps                                ::
+  |=  lit/?
+  ^-  (quip move part)
+  ::  We do not run se-abet:se-view here because that starts the apps,
+  ::  and some apps are not ready to start (eg Talk crashes because the
+  ::  terminal has width 0).  It appears the first message to drum must
+  ::  be the peer.
+  ::
+  [~ +<+.^$(ray (deft-apes our.hid lit))]
 ::
 ++  poke-dill-belt                                    ::  terminal event
   |=  bet/dill-belt:dill

--- a/pkg/arvo/lib/pill.hoon
+++ b/pkg/arvo/lib/pill.hoon
@@ -13,7 +13,7 @@
   %+  pair  wire
   $%  [%wack p=@]
       [%whom p=ship]
-      [%boot $%($>(%fake task:able:jael) $>(%dawn task:able:jael))]
+      [%boot ? $%($>(%fake task:able:jael) $>(%dawn task:able:jael))]
       unix-task
   ==
 ::

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -12,6 +12,7 @@
   $:  $0                                                ::
       hey/(unit duct)                                   ::  default duct
       dug/(map duct axon)                               ::  conversations
+      lit/?                                             ::  boot in lite mode
       $=  hef                                           ::  other weights
       $:  a/(unit mass)                                 ::
           b/(unit mass)                                 ::
@@ -317,6 +318,7 @@
                 ::
                 (show %kids):(sync %kids our %base)
         =.  +>  autoload
+        =.  +>  hood-set-boot-apps
         =.  +>  peer
         |-  ^+  +>+
         ?~  myt  +>+
@@ -333,6 +335,7 @@
       ::
       ++  send                                          ::  send action
         |=  bet/dill-belt
+        ^+  +>
         ?^  tem
           +>(tem `[bet u.tem])
         %_    +>
@@ -340,6 +343,16 @@
           :_  moz
           [hen %pass ~ %g %deal [our our] ram %poke [%dill-belt -:!>(bet) bet]]
         ==
+      ::
+      ++  hood-set-boot-apps
+        %_    .
+            moz
+          :_  moz
+          :*  hen  %pass  ~  %g  %deal  [our our]
+              ram  %poke  %drum-set-boot-apps  !>(lit.all)
+          ==
+        ==
+      ::
       ++  peer
         %_    .
             moz
@@ -515,7 +528,8 @@
       ~&  %dill-no-boot
       ~&  p.task
       ~|  invalid-boot-event+hen  !!
-    :_(..^$ [hen %pass / %j u.boot]~)
+    =.  lit.all  lit.task
+    [[hen %pass / %j u.boot]~ ..^$]
   ::  we are subsequently initialized. single-home
   ::
   ?:  ?=(%init -.task)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -779,7 +779,7 @@
       $~  [%vega ~]                                     ::
       $%  {$belt p/belt}                                ::  terminal input
           {$blew p/blew}                                ::  terminal config
-          {$boot p/*}                                   ::  weird %dill boot
+          {$boot lit/? p/*}                             ::  weird %dill boot
           $>(%crud vane-task)                           ::  error with trace
           {$flog p/flog}                                ::  wrapped error
           {$flow p/@tas q/(list gill:gall)}             ::  terminal config

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -84,6 +84,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.has = c3y;
 
   u3_Host.ops_u.net = c3y;
+  u3_Host.ops_u.lit = c3n;
   u3_Host.ops_u.nuu = c3n;
   u3_Host.ops_u.pro = c3n;
   u3_Host.ops_u.qui = c3n;
@@ -94,7 +95,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:J:B:K:A:H:I:w:u:e:E:f:F:k:p:LjabcCdgqsvxPDRS")) )
+                 "G:J:B:K:A:H:I:w:u:e:E:f:F:k:p:LljabcCdgqsvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'J': {
@@ -174,6 +175,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         return c3y;
       }
       case 'L': { u3_Host.ops_u.net = c3n; break; }
+      case 'l': { u3_Host.ops_u.lit = c3y; break; }
       case 'j': { u3_Host.ops_u.tra = c3y; break; }
       case 'a': { u3_Host.ops_u.abo = c3y; break; }
       case 'b': { u3_Host.ops_u.bat = c3y; break; }

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -563,6 +563,7 @@
         c3_w    kno_w;                      //  -K, kernel version
         c3_c*   key_c;                      //  -k, private key file
         c3_o    net;                        //  -L, local-only networking
+        c3_o    lit;                        //  -l, lite mode
         c3_o    pro;                        //  -P, profile
         c3_s    por_s;                      //  -p, ames port
         c3_o    qui;                        //  -q, quiet

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1485,7 +1485,7 @@ _pier_boot_vent(u3_boot* bot_u)
     c3_assert( c3y == u3du(bot_u->ven) );
 
     u3_noun wir = u3nq(u3_blip, c3__term, '1', u3_nul);
-    u3_noun car = u3nc(c3__boot, u3k(bot_u->ven));
+    u3_noun car = u3nt(c3__boot, u3_Host.ops_u.lit, u3k(bot_u->ven));
     u3_noun ovo = u3nc(wir, car);
 
     _pier_writ_insert_ovum(pir_u, 0, ovo);


### PR DESCRIPTION
A large portion of the boot process is just compiling apps.  In development, this is usually wasted time unless you're working on those specific apps.  This adds a `-l` flag, which starts the ship with just two apps: dojo and azimuth-tracker (the two you need to have a real ship).

On bare metal, this reduces boot time from 79 to 49 seconds (about a third faster).  The effect is even more pronounced on aqua, because you don't need to set up the C stuff.

Another possible improvement would be to whitelist a small set of files to be loaded into clay on boot.  Quite a bit of time is spent in clay on boot.

I was hoping this would be a small change, but it's a bit messier than I would have liked.  It's not clear to me whether the benefit is worth the complexity.  What do you guys think?