### PR TITLE
zuse: added CDATA support to de-xml:html

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:447868a553c636c2b46c1d3cd2f48def1f66050976fb2ea03775443bdb591aae
-size 16468208
+oid sha256:f7038662e98bd66dafa6c0b2f516c11dfefe3b3ccbd97d75c268094407a276f1
+size 13914300

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6331,6 +6331,14 @@
           (easy ~)
         ==
       ==
+    ::                                                  ::  ++cdat:de-xml:html
+    ++  cdat                                            ::  CDATA section
+      %+  cook
+        |=(a/tape ^-(mars ;/(a)))
+      %+  ifix
+        [(jest '<![CDATA[') (jest ']]>')]
+      %-  star
+      ;~(less (jest ']]>') next)
     ::                                                  ::  ++chrd:de-xml:html
     ++  chrd                                            ::  character data
       %+  cook  |=(a/tape ^-(mars ;/(a)))
@@ -6367,7 +6375,7 @@
       (ifix [gal ban] ;~(plug name attr))
     ::                                                  ::  ++many:de-xml:html
     ++  many                                            ::  contents
-      (more (star comt) ;~(pose apex chrd))
+      (more (star comt) ;~(pose apex chrd cdat))
     ::                                                  ::  ++name:de-xml:html
     ++  name                                            ::  tag name
       =+  ^=  chx

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6375,7 +6375,7 @@
       (ifix [gal ban] ;~(plug name attr))
     ::                                                  ::  ++many:de-xml:html
     ++  many                                            ::  contents
-      (more (star comt) ;~(pose apex chrd cdat))
+      ;~(pfix (star comt) (star ;~(sfix ;~(pose apex chrd cdat) (star comt))))
     ::                                                  ::  ++name:de-xml:html
     ++  name                                            ::  tag name
       =+  ^=  chx

--- a/pkg/arvo/tests/sys/zuse/html.hoon
+++ b/pkg/arvo/tests/sys/zuse/html.hoon
@@ -1,0 +1,92 @@
+::  tests for html
+/+  *test
+=,  de-xml:html
+=,  en-xml:html
+|%
+:: de-xml takes a cord but en-xml returns a tape?
+::
+++  test-de-xml
+  ;:  weld
+    :: Basic use
+    ::
+    %+  expect-eq
+      !>  ^-  manx  +:(de-xml:html (crip "<html><head><title>My first webpage</title></head><body><h1>Welcome!</h1>Hello, world! We are on the web.\0a<div></div><script src=\"http://unsafely.tracking.you/cookiemonster.js\"></script></body></html>"))
+    !>  ^-  manx
+    ;html
+        ;head
+          ;title: My first webpage
+        ==
+        ;body
+          ;h1: Welcome!
+          ; Hello, world! We are on the web.
+          ;div;
+          ;script(src "http://unsafely.tracking.you/cookiemonster.js");
+        ==
+      ==
+    :: CDATA sections
+    ::
+    %+  expect-eq
+      !>  ^-  manx
+      +:(de-xml:html (crip "<elem><![CDATA[text]]></elem>"))
+    !>  ^-  manx
+    ;elem: text
+    :: comments
+    %+  expect-eq
+      !>  ^-  manx
+      ;elem: text
+    !>  +:(de-xml:html (crip "<elem>text<!-- comment --></elem>"))
+    %+  expect-eq
+      !>  ^-  manx
+      ;elem;
+    !>  +:(de-xml:html (crip "<elem><!-- comment --></elem>"))
+    :: entities
+    ::
+    %+  expect-eq
+      !>  ^-  manx
+      +:(de-xml:html (crip "<elem>&#62;</elem>"))
+      !>  ^-  manx
+      ;elem: >
+    :: self-closing tag
+    ::
+    %+  expect-eq
+      !>  ^-  manx
+      +:(de-xml:html (crip "<img />"))
+      !>  ^-  manx
+      ;img;
+
+  ==
+
+::
+++  test-en-xml
+  ;:  weld
+    :: Entities
+    ::
+    %+  expect-eq
+      !>  "<elem>&gt;</elem>"
+    !>  %-  en-xml:html
+    ;elem: >
+    :: Basic use
+    ::
+    %+  expect-eq
+      !>   %-  en-xml:html
+      ;html
+        ;head
+          ;title: My first webpage
+        ==
+        ;body
+          ;h1: Welcome!
+          ; Hello, world!
+          ; We are on the web.
+          ;div;
+          ;script@"http://unsafely.tracking.you/cookiemonster.js";
+        ==
+      ==
+    !>  "<html><head><title>My first webpage</title></head><body><h1>Welcome!</h1>Hello, world!\0aWe are on the web.\0a<div></div><script src=\"http://unsafely.tracking.you/cookiemonster.js\"></script></body></html>"
+    :: Attributes
+    ::
+    %+  expect-eq
+      !>  "<input type=\"submit\">Submit</input>"
+      !>  %-  en-xml:html
+      ;input(type "submit"): Submit
+  ==
+--


### PR DESCRIPTION
de-xml:html now parses CDATA sections correctly, instead of failing to parse