### PR TITLE
rewrites the terminal spinner on the main loop

### DIFF
--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -384,14 +384,12 @@
         } fut;
 
         struct {
-          uv_thread_t* sit_u;               //  spinner thread
-          c3_o         diz_o;               //  spinner activated
-          c3_d         eve_d;               //  spinner start tick (unix μs)
-          c3_d         end_d;               //  spinner end tick (unix μs)
-          c3_c*        why_c;               //  spinner event wire (root only)
-        } sun;
-
-        uv_mutex_t     mex_u;               //  mutex for non-daemon term state
+          uv_timer_t tim_u;                 //  spinner timeout
+          c3_o       diz_o;                 //  spinner activated
+          c3_d       eve_d;                 //  spin count
+          c3_d       end_d;                 //  spinner end tick (ms)
+          c3_c*      why_c;                 //  spinner label
+        } sun_u;
       } u3_utat;
 
       struct _u3_umon;
@@ -871,7 +869,7 @@
       /* u3_term_start_spinner(): prepare spinner state. RETAIN.
       */
         void
-        u3_term_start_spinner(u3_noun ovo);
+        u3_term_start_spinner(c3_c* why_c, c3_o now_o);
 
       /* u3_term_stop_spinner(): reset spinner state and restore input line.
       */

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -658,6 +658,54 @@ _pier_work_release(u3_writ* wit_u)
   }
 }
 
+/* _pier_work_spin_start(): activate spinner.
+*/
+static void
+_pier_work_spin_start(u3_writ* wit_u)
+{
+  u3_pier* pir_u = wit_u->pir_u;
+  c3_o now_o = c3n;
+  c3_c* why_c = 0;
+
+  if ( wit_u->evt_d <= pir_u->lif_d ) {
+    why_c = strdup("nock");
+  }
+  else {
+    u3_noun why;
+
+    //  second item of the event wire
+    //
+    //    i.t.p.q:*(pair @da ovum)
+    //
+    if ( u3_none != (why = u3r_at(26, wit_u->job)) ) {
+      u3_noun cad, tag, lag;
+
+
+      if ( c3__term != why ) {
+        why_c = u3r_string(why);
+      }
+      else if (  ( u3_none != (cad = u3r_at(7, wit_u->job)) ) &&
+                 ( u3_none != (tag = u3r_at(2, cad)) ) &&
+                 ( u3_none != (lag = u3r_at(6, cad)) ) &&
+                 ( c3__belt == tag ) &&
+                 ( c3__ret  == lag ) )
+      {
+        now_o = c3y;
+      }
+    }
+  }
+
+  u3_term_start_spinner(why_c, now_o);
+}
+
+/* _pier_work_spin_stop(): deactivate spinner.
+*/
+static void
+_pier_work_spin_stop(u3_writ* wit_u)
+{
+  u3_term_stop_spinner();
+}
+
 /* _pier_work_complete(): worker reported completion.
 */
 static void
@@ -680,9 +728,7 @@ _pier_work_complete(u3_writ* wit_u,
   c3_assert(wit_u->act == 0);
   wit_u->act = act;
 
-  if ( wit_u->evt_d > pir_u->lif_d ) {
-    u3_term_stop_spinner();
-  }
+  _pier_work_spin_stop(wit_u);
 }
 
 /* _pier_work_replace(): worker reported replacement.
@@ -720,9 +766,7 @@ _pier_work_replace(u3_writ* wit_u,
     god_u->sen_d -= 1ULL;
   }
 
-  if ( wit_u->evt_d > pir_u->lif_d ) {
-    u3_term_stop_spinner();
-  }
+  _pier_work_spin_stop(wit_u);
 }
 
 /* _pier_work_compute(): dispatch for processing.
@@ -746,9 +790,7 @@ _pier_work_compute(u3_writ* wit_u)
 
   god_u->sen_d += 1;
 
-  if ( wit_u->evt_d > pir_u->lif_d ) {
-    u3_term_start_spinner(wit_u->job);
-  }
+  _pier_work_spin_start(wit_u);
 }
 
 /* _pier_work_play(): with active worker, create or load log.


### PR DESCRIPTION
The terminal spinner, introduced in #651, was rendered on a separate thread and protected by a mutex. This was necessary before `v0.8.0`, as nock evaluation would block the main loop. With the new multiprocess architecture, that separate thread is unnecessary.

I suspect that my original re-integration of the spinner in the multi-process architecture was not quite right. There have been reports of process hangs, and deadlock on that mutex seems like a likely cause. To cancel the spinner, the main thread would need to acquire a lock on the mutex -- put another way, the spinner could block the main event loop. That's obviously not desirable. I think this implementation (a libuv timer reoccurring at some interval) is much simpler to reason about.