### PR TITLE
hoon: don't nest check in zpmc

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c7a2c5c36de2a929de2bddc34a1b315a348e0f4ae338da17d817c1d890b161a
-size 16396085
+oid sha256:447868a553c636c2b46c1d3cd2f48def1f66050976fb2ea03775443bdb591aae
+size 16468208

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -10300,7 +10300,6 @@
         {$zpmc *}
       =+  vos=$(gol %noun, gen q.gen)
       =+  ref=p:$(gol %noun, gen p.gen)
-      ?>  (~(nest ut p:!>(*type)) & ref)
       [(nice (cell ref p.vos)) (cons [%1 burp(sut p.vos)] q.vos)]
     ::
         {$zpts *}   [(nice %noun) [%1 q:$(vet |, gen p.gen)]]


### PR DESCRIPTION
This check required the new type of +type to nest within the old type of
+type, which is wrong.  Specifically, this disallowed adding new runes
wihtout a staging procedure (which we didn't successfully complete).

Usually, you can add a rune to +hoon without going through the staging procedure that's required for changing the type of +type.  +hoon is referenced with +type, so technically you are changeing the type of +type, but since the old type nests within the new type it doesn't cause a problem.  This doesn't work anymore -- anything with a `~&` crashes with a `nest-fail`.

- In #1422, we "decapitated" all compiler jets -- all that remains in those jets is some aching logic.

- `!;` is a natural rune in the expansion of several runes, including `~&` and `!>`.  Specifically, `!;(*type 5)` gives `[[%atom %tas ~] 5]` with type `(pair type @ud)`.  The entry in `++mint` is:

```
      =+  vos=$(gol %noun, gen q.gen)
      =+  ref=p:$(gol %noun, gen p.gen)
      ?>  (~(nest ut p:!>(*type)) & ref)
      [(nice (cell ref p.vos)) (cons [%1 burp(sut p.vos)] q.vos)]
```

- `!;` has a type hole.  Demonstration:

```
> =/  hole  !;([%atom %tas ~] [1 2])
  ((hypo vase) !>(hole))
```

gives

```
[#t/{{$atom $tas $~} @ud @ud} q=[#t/{@ud @ud} q=[1 2]]] 
```

or, if you disable the type-specific printer:

```
[   p
  [ %cell
      p
    [ %cell
      p=[%atom p=%tas q=[~ 1.836.020.833]]
      q=[%cell p=[%atom p=%tas q=[~ 7.561.588]] q=[%atom p=%n q=[~ 0]]]
    ]
    q=[%cell p=[%atom p=%ud q=~] q=[%atom p=%ud q=~]]
  ]
  q=[p=[%cell p=[%atom p=%ud q=~] q=[%atom p=%ud q=~]] q=[1 2]]
]
```

Thus, the type of `-.hole` is `,[%atom %tas ~]` while the value is `[%cell [%atom %ud ~] [%atom %ud ~]]`, which is clearly not a value of that type.

- The pre-decaptitated compiler jet for `!;` has two differences relative to the hoon.  First, the `=+  ref` line is a call to +play rather than a recursion to +mint.  I believe this would be a bit more efficient but would have no semantic effect.

- Second, the nest assertion isn't there.  Why does this nest assertion exist in the hoon?  My best guess is that it was an attempt to put a lid on the type hole.  However, it doesn't close it entirely, and it introduces a spurious requirement that the new type of +type must nest within the old type of +type.

- If you remove the nest check, everything compiles as expected.

Given the above, I propose we delete the nest check.  Later, we should close the type hole in `!;`.

@frodwith