### PR TITLE
weather: automatic units based of geo location

### DIFF
--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -87,10 +87,10 @@
 ++  request-darksky
   |=  location=@t
   ^-  request:http
-  =/  url/@t
-    %-  crip  %+  weld
-    (trip 'https://api.darksky.net/forecast/634639c10670c7376dc66b6692fe57ca/')
-    (trip location)
+  =/  base
+    "https://api.darksky.net/forecast/634639c10670c7376dc66b6692fe57ca/"
+  =/  url/@t  %-  crip
+    :(weld base (trip location) "?units=auto")
   =/  hed  [['Accept' 'application/json']]~
   [%'GET' url hed *(unit octs)]
 ::


### PR DESCRIPTION
We've had a very hot summer in Europe so when I saw 68º I thought it was completely normal. Then I looked at Darksky's API docs.

This adds automatic units based on location. At first I used string interpolation to create the URL but I think that concatenating the base url with the parameters using an n-ary weld looks more readable.