### PR TITLE
Publish: Add a check for publish-info when importing a notebook

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1251,6 +1251,7 @@
       [~ this]
     =/  files=(list path)
       .^((list path) %ct (weld our-beak /web/publish/[coll.act]))
+    ?>  ?=(^ (find [/web/publish/[coll.act]/publish-info]~ files))
     =/  all=[moves=(list move) builds=(set wire)]
     %+  roll  files
     |=  [pax=path out=[moves=(list move) builds=(set wire)]]


### PR DESCRIPTION
When migrating notebooks to a new ship, Publish's `%serve` command currently makes builds for notes even if the publish-info file is missing. It now crashes the build if the file is missing, with a one-line `?>` asserting that the file is found in the list of paths associated with the collection, before continuing to import.

## Steps to reproduce
1. Make a notebook.
2. Copy its files from `/web/publish/[notebook-name]` (and `notebook-name.publish-info`) into another folder.
3. Make a new ship. Copy those files into `/web/publish` but delete the `publish-info` file.
4. `:publish &publish-action [%serve %notebook-name]`