### PR TITLE
fixes U3_EVENT_TIME_DEBUG event-timing printfs

### DIFF
--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -506,15 +506,13 @@ _worker_work_live(c3_d evt_d, u3_noun job)
   u3A->now  = u3k(now);
 
 #ifdef U3_EVENT_TIME_DEBUG
-  {
-    struct timeval b4, f2, d0;
-    gettimeofday(&b4, 0);
+  struct timeval b4, f2, d0;
+  gettimeofday(&b4, 0);
 
-    if ( c3__belt != u3h(u3t(ovo)) ) {
-      c3_c* txt_c = u3r_string(u3h(u3t(ovo)));
+  if ( c3__belt != u3h(u3t(ovo)) ) {
+    c3_c* txt_c = u3r_string(u3h(u3t(ovo)));
 
-      u3l_log("work: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
-    }
+    u3l_log("work: %s (%" PRIu64 ") live\r\n", txt_c, evt_d);
   }
 #endif
 


### PR DESCRIPTION
I introduced a scoping issue at some point when refactoring these printfs. (Maybe we should turn them on CI ... Not an isolated problem, we have way too many `#ifdef`'s.)