### PR TITLE
Clay syncing.

### DIFF
--- a/pkg/king/lib/Arvo/Effect.hs
+++ b/pkg/king/lib/Arvo/Effect.hs
@@ -7,6 +7,7 @@ import Arvo.Common (KingId(..), ServId(..))
 import Arvo.Common (Header, HttpEvent, HttpServerConf, Method, Mime)
 import Arvo.Common (AmesDest, Turf)
 import Arvo.Common (ReOrg(..), reorgThroughNoun)
+import Arvo.Common (Desk)
 
 
 -- Newt Effects ----------------------------------------------------------------
@@ -69,10 +70,10 @@ deriveNoun ''HttpServerEf
     %ogre -- TODO
 -}
 data SyncEf
-    = SyncEfHill ()  [Term]
-    | SyncEfDirk Path Term
-    | SyncEfErgo Path Term [(Path, Maybe Mime)]
-    | SyncEfOgre Path Term
+    = SyncEfHill ()  [Desk]
+    | SyncEfDirk Path Desk
+    | SyncEfErgo Path Desk [(Path, Maybe Mime)]
+    | SyncEfOgre Path Desk
   deriving (Eq, Ord, Show)
 
 deriveNoun ''SyncEf

--- a/pkg/king/lib/Arvo/Event.hs
+++ b/pkg/king/lib/Arvo/Event.hs
@@ -197,8 +197,8 @@ deriveNoun ''NewtEv
 -- FileSystem Events -----------------------------------------------------------
 
 data SyncEv
-    = SyncEvInto (Nullable (Atom, ())) Desk Bool [(Path, Maybe Mime)]
-    | SyncEvCrud Path                  Cord Tang
+    = SyncEvInto (Nullable (KingId, ())) Desk Bool [(Path, Maybe Mime)]
+    | SyncEvCrud Path                    Cord Tang
   deriving (Eq, Ord, Show)
 
 deriveNoun ''SyncEv

--- a/pkg/king/lib/Noun/Conversions.hs
+++ b/pkg/king/lib/Noun/Conversions.hs
@@ -9,7 +9,7 @@ module Noun.Conversions
   , Wall
   , UD(..), UV(..)
   , Mug(..), Path(..), EvilPath(..), Ship(..)
-  , Lenient(..)
+  , Lenient(..), pathToFilePath
   ) where
 
 import ClassyPrelude hiding (hash)
@@ -35,6 +35,8 @@ import Prelude          ((!!))
 import RIO              (decodeUtf8Lenient)
 import System.IO.Unsafe (unsafePerformIO)
 import Text.Show.Pretty (ppShow)
+import RIO.FilePath  ((</>), (<.>), joinPath, splitDirectories,
+                         takeBaseName, takeDirectory, takeExtension)
 
 import qualified Data.Char                as C
 import qualified Data.Text.Encoding       as T
@@ -472,6 +474,15 @@ newtype EvilPath = EvilPath { unEvilPath :: [Atom] }
 instance Show EvilPath where
   show = show . unEvilPath
 
+pathToFilePath :: Path -> FilePath
+pathToFilePath p = joinPath (dirs ++ [filename])
+  where
+    elements :: [String] = map (unpack . unKnot) (unPath p)
+    (dirs, f) = splitAt ((length elements) - 2) elements
+    filename = case length f of
+      0 -> ""
+      1 -> (f !! 0)
+      _ -> (f !! 0) RIO.FilePath.<.> (f !! 1)
 
 -- Mug -------------------------------------------------------------------------
 

--- a/pkg/king/lib/Vere/Clay.hs
+++ b/pkg/king/lib/Vere/Clay.hs
@@ -1,0 +1,231 @@
+module Vere.Clay (clay) where
+
+import Arvo            hiding (Term)
+import UrbitPrelude
+import Vere.Pier.Types
+
+import Conduit
+import RIO.Directory
+import RIO.FilePath
+
+import qualified Data.Conduit.Combinators as CC
+import qualified Data.Map.Strict          as M
+import qualified Data.Set                 as S
+
+data ClayDrv = ClayDrv
+  { cdMountPoints :: TVar (M.Map Desk (M.Map FilePath Int))
+  }
+
+deskToPath :: Desk -> FilePath
+deskToPath (Desk (Cord t)) = unpack t
+
+-- Takes a filepath and converts it to a clay path, changing the '.' to a '/'
+-- and removing any prefixed '/'.
+filePathToPath :: FilePath -> Path
+filePathToPath fp = Path path
+  where
+    dir = case (splitDirectories $ (takeDirectory fp)) of
+      ("/":xs) -> xs
+      x        -> x
+    file = [takeBaseName fp, ext]
+    path = map (MkKnot . pack) (dir ++ file)
+    ext = case takeExtension fp of
+      ('.':xs) -> xs
+      x        -> x
+
+-- The hard coded mime type of every file.
+textPlain = Path [(MkKnot "text"), (MkKnot "plain")]
+
+-- Filter for dotfiles, tempfiles and backup files.
+validClaySyncPath :: FilePath -> Bool
+validClaySyncPath fp = hasPeriod && notTildeFile && notDotHash && notDoubleHash
+  where
+    fileName = takeFileName fp
+    hasPeriod = elem '.' fileName
+    notTildeFile = not $ "~" `isSuffixOf` fileName
+    notDotHash = not $ ".#" `isPrefixOf` fileName
+    notDoubleHash =
+      not $ ("#" `isPrefixOf` fileName) && ("#" `isSuffixOf` fileName)
+
+-- Returns a list of the result of running a function on each valid file in the
+-- directory fp. Runnable in IO.
+foreachFileIn :: (MonadUnliftIO m)
+              => FilePath -> (FilePath -> (ResourceT m) a) -> m [a]
+foreachFileIn fp fun =
+  runConduitRes $ (sourceDirectoryDeep False fp)
+               .| filterC validClaySyncPath
+               .| CC.mapM fun
+               .| sinkList
+
+-- Note: Vere just reuses +mug, but since the actual hash function is an
+-- implementation detail which doesn't leave the io driver, we just use the
+-- standard hash.
+getHashOfFile :: (MonadIO m) => FilePath -> m (FilePath, Int)
+getHashOfFile fp = do
+  bs <- readFile fp
+  let !h = hash bs
+  pure (fp, h)
+
+-- Takes an initial snapshot of the filesystem, recording what files exist and
+-- what their hashes are.
+takeFilesystemSnapshot :: FilePath -> RIO e (M.Map FilePath Int)
+takeFilesystemSnapshot fp = do
+  exists <- doesDirectoryExist fp
+  if not exists then
+    pure M.empty
+  else
+    M.fromList <$> foreachFileIn fp getHashOfFile
+
+-- Check an existing filepath against a snapshot of files that existed on disk
+-- the last time we checked. Returns Either (unchanged) (new file data).
+checkFileForUpdates :: (MonadIO m)
+                    => M.Map FilePath Int -> FilePath
+                    -> m (Either FilePath (FilePath, Mime, Int))
+checkFileForUpdates snapshot fp = do
+  bs <- readFile fp
+  let !newHash = hash bs
+  pure $ case M.lookup fp snapshot of
+    -- text/plain is the hardcoded mime type of every file sent to clay.
+    Nothing -> Right (fp, (Mime textPlain (File (Octs bs))), newHash)
+    Just i -> if i == newHash then Left fp
+              else Right (fp, (Mime textPlain (File (Octs bs))), newHash)
+
+-- Given a previous snapshot of the filesystem, produces a list of changes
+buildActionListFromDifferences :: FilePath -> M.Map FilePath Int
+                               -> RIO e [(FilePath, Maybe (Mime, Int))]
+buildActionListFromDifferences fp snapshot = do
+  checks <- foreachFileIn fp (checkFileForUpdates snapshot)
+
+  let changedItems = flip map (rights checks) $ \(fp, m, i) -> (fp, Just (m, i))
+
+  let existsSet = S.fromList $ flip map checks $ \case
+        Left fp          -> fp
+        Right (fp, _, _) -> fp
+  let deletedSet = S.difference (M.keysSet snapshot) existsSet
+  let deletedItems = flip map (S.toList deletedSet) $ \x -> (x, Nothing)
+
+  pure $ sort (deletedItems ++ changedItems)
+
+--------------------------------------------------------------------------------
+
+clay :: forall e. HasLogFunc e
+     => FilePath -> KingId -> QueueEv -> ([Ev], RAcquire e (EffCb e SyncEf))
+clay pierPath king enqueueEv =
+    (initialEvents, runSync)
+  where
+    initialEvents = [
+      EvBlip $ BlipEvBoat $ BoatEvBoat () ()
+      -- TODO: In the case of -A, we need to read all the data from the
+      -- specified directory and shove it into an %into event.
+      ]
+
+    runSync :: RAcquire e (EffCb e SyncEf)
+    runSync = do
+      tim <- mkRAcquire start stop
+      pure (handleEffect tim)
+
+    -- TODO: Traditionally, lock file acquisition was handled in the unix
+    -- driver. This should instead be bumped up to main or something.
+    start :: RIO e ClayDrv
+    start = do
+      var <- newTVarIO M.empty
+      pure $ ClayDrv var
+    stop c = pure ()
+
+    handleEffect :: ClayDrv -> SyncEf -> RIO e ()
+    handleEffect cd = \case
+      SyncEfHill _ mountPoints -> do
+        logDebug $ displayShow ("(clay) known mount points:", mountPoints)
+        mountPairs <- flip mapM mountPoints $ \desk -> do
+          ss <- takeFilesystemSnapshot (pierPath </> (deskToPath desk))
+          pure (desk, ss)
+        atomically $ writeTVar (cdMountPoints cd) (M.fromList mountPairs)
+
+      SyncEfDirk p desk -> do
+        logDebug $ displayShow ("(clay) dirk:", p, desk)
+        m <- atomically $ readTVar (cdMountPoints cd)
+        let snapshot = M.findWithDefault M.empty desk m
+        let dir = pierPath </> deskToPath desk
+        actions <- buildActionListFromDifferences dir snapshot
+
+        logDebug $ displayShow ("(clay) dirk actions: ", actions)
+
+        let !intoList = map (actionsToInto dir) actions
+        atomically $ enqueueEv $ EvBlip $ BlipEvSync $
+            SyncEvInto (Some (king, ())) desk False intoList
+
+        atomically $ modifyTVar
+            (cdMountPoints cd)
+            (applyActionsToMountPoints desk actions)
+
+      SyncEfErgo p desk actions -> do
+        logDebug $ displayShow ("(clay) ergo:", p, desk, actions)
+
+        m <- atomically $ readTVar (cdMountPoints cd)
+        let mountPoint = M.findWithDefault M.empty desk m
+
+        let dir = pierPath </> deskToPath desk
+        let hashedActions = map (calculateActionHash dir) actions
+        for_ hashedActions (performAction mountPoint)
+
+        atomically $ modifyTVar
+            (cdMountPoints cd)
+            (applyActionsToMountPoints desk hashedActions)
+
+      SyncEfOgre p desk -> do
+        logDebug $ displayShow ("(clay) ogre:", p, desk)
+        removeDirectoryRecursive $ pierPath </> deskToPath desk
+        atomically $ modifyTVar (cdMountPoints cd) (M.delete desk)
+
+
+    -- Change the structures off of the event into something we can work with in Unix.
+    calculateActionHash :: FilePath -> (Path, Maybe Mime) -> (FilePath, Maybe (Mime, Int))
+    calculateActionHash base (p, Nothing) = (base </> pathToFilePath p, Nothing)
+    calculateActionHash base (p, Just (Mime t f)) =
+      (base </> pathToFilePath p, Just ((Mime t f), (hash $ unOcts $ unFile f)))
+
+    -- Performs the actions on the actual filesystem
+    performAction :: (M.Map FilePath Int) -> (FilePath, Maybe (Mime, Int)) -> RIO e ()
+    performAction m (fp, Nothing) = do
+      logDebug $ displayShow ("(clay) deleting file ", fp)
+      removeFile fp
+    performAction m (fp, Just ((Mime _ (File (Octs bs)), hash)))
+        | skip =
+            logDebug $ displayShow ("(clay) skipping unchanged file update " , fp)
+        | otherwise = do
+            logDebug $ displayShow ("(clay) updating file " , fp)
+            createDirectoryIfMissing True $ takeDirectory fp
+            writeFile fp bs
+      where
+        skip = case M.lookup fp m of
+          Nothing -> False
+          Just i  -> i == hash
+
+    -- Apply the actions to our internal snapshots
+    applyActionsToMountPoints :: Desk
+                              -> [(FilePath, Maybe (Mime, Int))]
+                              -> (M.Map Desk (M.Map FilePath Int))
+                              -> (M.Map Desk (M.Map FilePath Int))
+    applyActionsToMountPoints desk actions m = M.alter change desk m
+      where
+        change (Just fileMap) = Just (foldl' applySyncAction fileMap actions)
+        change Nothing        = change (Just M.empty)
+
+        -- Applies the sync mutations specified.
+        applySyncAction :: (M.Map FilePath Int)
+                        -> (FilePath, Maybe (Mime, Int))
+                        -> (M.Map FilePath Int)
+        applySyncAction m (fp, Nothing)       = M.delete fp m
+        applySyncAction m (fp, (Just (_, h))) = M.insert fp h m
+
+    -- Changes an action list item into a form injectable into Urbit
+    actionsToInto :: FilePath -> (FilePath, Maybe (Mime, Int)) -> (Path, Maybe Mime)
+    actionsToInto prefix (fp, mybData) = (p, mybOutData)
+      where
+        p = filePathToPath strippedFp
+        strippedFp = case stripPrefix prefix fp of
+          Nothing -> error "Impossible missing prefix"
+          Just x  -> x
+        mybOutData = case mybData of
+          Nothing     -> Nothing
+          Just (m, i) -> Just m

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -18,6 +18,7 @@ import Vere.Http.Client   (client)
 import Vere.Http.Server   (serv)
 import Vere.Log           (EventLog)
 import Vere.Serf          (Serf, sStderr, SerfState(..), doJob)
+import Vere.Clay          (clay)
 import Vere.Term
 
 import qualified System.Entropy as Ent
@@ -210,16 +211,18 @@ drivers pierPath inst who mPort plan shutdownSTM termSys =
     (behnBorn, runBehn) = behn inst plan
     (amesBorn, runAmes) = ames inst who mPort plan
     (httpBorn, runHttp) = serv pierPath inst plan
+    (clayBorn, runClay) = clay pierPath inst plan
     (irisBorn, runIris) = client inst plan
     (termBorn, runTerm) = term termSys shutdownSTM pierPath inst plan
-    initialEvents       = mconcat [behnBorn, amesBorn, httpBorn, termBorn, irisBorn]
+    initialEvents       = mconcat [behnBorn, clayBorn, amesBorn, httpBorn,
+                                   termBorn, irisBorn]
     runDrivers          = do
         dNewt       <- liftAcquire $ runAmes
         dBehn       <- liftAcquire $ runBehn
         dAmes       <- pure $ const $ pure ()
         dHttpClient <- runIris
         dHttpServer <- runHttp
-        dSync       <- pure $ const $ pure ()
+        dSync       <- runClay
         dTerm       <- runTerm
         pure (Drivers{..})
 

--- a/pkg/king/lib/Vere/Pier/Types.hs
+++ b/pkg/king/lib/Vere/Pier/Types.hs
@@ -42,9 +42,6 @@ data LogIdentity = LogIdentity
 data BootSeq = BootSeq LogIdentity [Nock] [Ev]
   deriving (Eq, Show)
 
-newtype Desk = Desk Cord
-  deriving newtype (Eq, Ord, Show, ToNoun, FromNoun)
-
 deriveNoun ''LogIdentity
 deriveNoun ''Pill
 


### PR DESCRIPTION
This performs all normal filesystem operations. We can take
filesystem hash snapshots on startup, write the contents of an
%ergo to disk, send changes to Urbit with an %into, and finally
delete mount points when they are %ogre.

This doesn't deal with updating an initial filesystem on first
run with -A, or with acquiring a lockfile, which should happen
elsewhere.

Can take filesystem hash snapshots on startup, and can write the
contents of an %ergo to disk.