### PR TITLE
Further terminal fixes and cleanups

### DIFF
--- a/pkg/king/lib/Vere/Clay.hs
+++ b/pkg/king/lib/Vere/Clay.hs
@@ -106,12 +106,8 @@ clay pierPath king enqueueEv =
       ]
 
     runSync :: RAcquire e (EffCb e SyncEf)
-    runSync = do
-      tim <- mkRAcquire start stop
-      pure (handleEffect tim)
+    runSync = handleEffect <$> mkRAcquire start stop
 
-    -- TODO: Traditionally, lock file acquisition was handled in the unix
-    -- driver. This should instead be bumped up to main or something.
     start :: RIO e ClayDrv
     start = ClayDrv <$> newTVarIO mempty
     stop c = pure ()

--- a/pkg/king/lib/Vere/Clay.hs
+++ b/pkg/king/lib/Vere/Clay.hs
@@ -162,20 +162,23 @@ clay pierPath king enqueueEv =
         atomically $ modifyTVar (cdMountPoints cd) (M.delete desk)
 
 
-    -- Change the structures off of the event into something we can work with in Unix.
-    calculateActionHash :: FilePath -> (Path, Maybe Mime) -> (FilePath, Maybe (Mime, Int))
+    -- Change the structures off of the event into something we can work with
+    -- in Unix.
+    calculateActionHash :: FilePath -> (Path, Maybe Mime)
+                        -> (FilePath, Maybe (Mime, Int))
     calculateActionHash base (p, Nothing) = (base </> pathToFilePath p, Nothing)
     calculateActionHash base (p, Just (Mime t f)) =
       (base </> pathToFilePath p, Just ((Mime t f), (hash $ unOcts $ unFile f)))
 
     -- Performs the actions on the actual filesystem
-    performAction :: (Map FilePath Int) -> (FilePath, Maybe (Mime, Int)) -> RIO e ()
+    performAction :: (Map FilePath Int) -> (FilePath, Maybe (Mime, Int))
+                  -> RIO e ()
     performAction m (fp, Nothing) = do
       logDebug $ displayShow ("(clay) deleting file ", fp)
       removeFile fp
     performAction m (fp, Just ((Mime _ (File (Octs bs)), hash)))
-        | skip =
-            logDebug $ displayShow ("(clay) skipping unchanged file update " , fp)
+        | skip = logDebug $
+                 displayShow ("(clay) skipping unchanged file update " , fp)
         | otherwise = do
             logDebug $ displayShow ("(clay) updating file " , fp)
             createDirectoryIfMissing True $ takeDirectory fp
@@ -203,7 +206,8 @@ clay pierPath king enqueueEv =
         applySyncAction m (fp, (Just (_, h))) = M.insert fp h m
 
     -- Changes an action list item into a form injectable into Urbit
-    actionsToInto :: FilePath -> (FilePath, Maybe (Mime, Int)) -> (Path, Maybe Mime)
+    actionsToInto :: FilePath -> (FilePath, Maybe (Mime, Int))
+                  -> (Path, Maybe Mime)
     actionsToInto prefix (fp, mybData) = (p, mybOutData)
       where
         p = filePathToPath strippedFp

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -148,7 +148,7 @@ pier pierPath mPort (serf, log, ss) = do
     inst <- io (KingId . UV . fromIntegral <$> randomIO @Word16)
 
     terminalSystem <- initializeLocalTerminal
-    serf <- pure serf { sStderr = (tsStderr terminalSystem) }
+    swapMVar (sStderr serf) (tsStderr terminalSystem)
 
     let ship = who (Log.identity log)
 

--- a/pkg/king/lib/Vere/Term.hs
+++ b/pkg/king/lib/Vere/Term.hs
@@ -17,6 +17,9 @@ import System.Console.Terminfo.Base
 
 import Data.ByteString.Internal
 
+import qualified Data.ByteString      as B
+import qualified Data.ByteString.UTF8 as UTF8
+
 -- Types -----------------------------------------------------------------------
 
 -- Output to the attached terminal is either a series of vere blits, or it is an
@@ -29,9 +32,11 @@ data LineState = LineState String Int
 
 -- A record used in reading data from stdInput.
 data ReadData = ReadData
-  { rdBuf     :: Ptr Word8
-  , rdEscape  :: Bool
-  , rdBracket :: Bool
+  { rdBuf       :: Ptr Word8
+  , rdEscape    :: Bool
+  , rdBracket   :: Bool
+  , rdUTF8      :: ByteString
+  , rdUTF8width :: Int
   }
 
 -- Minimal terminal interface.
@@ -250,12 +255,13 @@ initializeLocalTerminal = do
     readTerminal :: forall e. HasLogFunc e
                  => TQueue Belt -> TQueue VereOutput -> (RIO e ()) -> RIO e ()
     readTerminal rq wq bell =
-      rioAllocaBytes 1 $ \ buf -> loop (ReadData buf False False)
+      rioAllocaBytes 1 $ \ buf -> loop (ReadData buf False False B.empty 0)
       where
         loop :: ReadData -> RIO e ()
         loop rd@ReadData{..} = do
-          -- The problem with using fdRead raw is that it will text encode things
-          -- like \ESC instead of 27. That makes it broken for our purposes.
+          -- The problem with using fdRead raw is that it will text encode
+          -- things like \ESC instead of 27. That makes it broken for our
+          -- purposes.
           --
           t <- io $ try (fdReadBuf stdInput rdBuf 1)
           case t of
@@ -290,10 +296,18 @@ initializeLocalTerminal = do
                 else do
                   bell
                   loop rd { rdEscape = False }
-              -- if not escape
-              else if False then
-                -- TODO: Put the unicode accumulation logic here.
-                loop rd
+              else if rdUTF8width /= 0 then do
+                -- continue reading into the utf8 accumulation buffer
+                rd@ReadData{..} <- pure rd { rdUTF8 = snoc rdUTF8 w }
+                if length rdUTF8 /= rdUTF8width then loop rd
+                else do
+                  case UTF8.decode rdUTF8 of
+                    Nothing ->
+                      error "empty utf8 accumulation buffer"
+                    Just (c, bytes) | bytes /= rdUTF8width ->
+                      error "utf8 character size mismatch?!"
+                    Just (c, bytes) -> sendBelt $ Txt $ Tour $ [c]
+                  loop rd { rdUTF8 = B.empty, rdUTF8width = 0 }
               else if w >= 32 && w < 127 then do
                 sendBelt $ Txt $ Tour $ [c]
                 loop rd
@@ -320,7 +334,10 @@ initializeLocalTerminal = do
                 loop rd { rdEscape = True }
               else do
                 -- start the utf8 accumulation buffer
-                loop rd
+                loop rd { rdUTF8 = singleton w,
+                          rdUTF8width = if w < 224 then 2
+                                        else if w < 240 then 3
+                                        else 4 }
 
         sendBelt :: HasLogFunc e => Belt -> RIO e ()
         sendBelt b = do
@@ -367,7 +384,7 @@ term TerminalSystem{..} shutdownSTM pierPath king enqueueEv =
 
     handleFsWrite :: Blit -> RIO e ()
     handleFsWrite (Sag path noun) = performPut path (jamBS noun)
-    handleFsWrite (Sav path atom) = pure () --performPut path atom
+    handleFsWrite (Sav path atom) = performPut path (atom ^. atomBytes)
     handleFsWrite _               = pure ()
 
     performPut :: Path -> ByteString -> RIO e ()

--- a/pkg/king/package.yaml
+++ b/pkg/king/package.yaml
@@ -89,6 +89,7 @@ dependencies:
   - unliftio
   - unliftio-core
   - unordered-containers
+  - utf8-string
   - vector
   - wai
   - wai-conduit


### PR DESCRIPTION
- This goes through everything I've previously done and makes sure it's all <80 cols and stylish. Sorry!

- Attaches serf stderr output to the terminal driver so that we get boot messages on startup.

- Actually implemented the UTF-8 handling in the terminal driver. You can now paste a ☃ or other emoji into the console.

- The atom putfile command should actually do something.

- Further haskell golfing.