### PR TITLE
Makes a progress bar on booting a new ship.

### DIFF
--- a/pkg/king/app/Main.hs
+++ b/pkg/king/app/Main.hs
@@ -91,7 +91,7 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Data.Acquire
 import Data.Conduit
 import Data.Conduit.List hiding (replicate, take)
-import Noun hiding (Parser)
+import Noun              hiding (Parser)
 import Vere.Pier
 import Vere.Pier.Types
 import Vere.Serf
@@ -99,12 +99,12 @@ import Vere.Serf
 import Control.Concurrent   (myThreadId, runInBoundThread)
 import Control.Lens         ((&))
 import Data.Default         (def)
-import System.Directory     (doesFileExist, removeFile)
-import System.Directory     (createDirectoryIfMissing, getHomeDirectory)
 import System.Environment   (getProgName)
 import System.Posix.Signals (Handler(Catch), installHandler, sigTERM)
 import Text.Show.Pretty     (pPrint)
 import Urbit.Time           (Wen)
+
+import RIO.Directory
 
 import qualified CLI
 import qualified Data.Set                    as Set
@@ -159,9 +159,9 @@ zod = 0
 
 removeFileIfExists :: HasLogFunc env => FilePath -> RIO env ()
 removeFileIfExists pax = do
-  exists <- io $ doesFileExist pax
+  exists <- doesFileExist pax
   when exists $ do
-      io $ removeFile pax
+      removeFile pax
 
 --------------------------------------------------------------------------------
 
@@ -208,6 +208,7 @@ lockFile pax = void $ mkRAcquire start stop
     params = def { Lock.retryToAcquireLock = Lock.No }
 
     start = do
+        createDirectoryIfMissing True pax
         logInfo $ display @Text $ ("Taking lock file: " <> pack fil)
         io (Lock.lock params fil)
 

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -7,19 +7,20 @@ module Vere.Pier
 import UrbitPrelude
 
 import Arvo
-import Vere.Pier.Types
 import System.Random
+import Vere.Pier.Types
 
-import System.Directory   (createDirectoryIfMissing)
 import System.Posix.Files (ownerModes, setFileMode)
 import Vere.Ames          (ames)
 import Vere.Behn          (behn)
+import Vere.Clay          (clay)
 import Vere.Http.Client   (client)
 import Vere.Http.Server   (serv)
 import Vere.Log           (EventLog)
-import Vere.Serf          (Serf, sStderr, SerfState(..), doJob)
-import Vere.Clay          (clay)
+import Vere.Serf          (Serf, SerfState(..), doJob, sStderr)
 import Vere.Term
+
+import RIO.Directory
 
 import qualified System.Entropy as Ent
 import qualified Urbit.Time     as Time
@@ -35,7 +36,7 @@ setupPierDirectory :: FilePath -> RIO e ()
 setupPierDirectory shipPath = do
    for_ ["put", "get", "log", "chk"] $ \seg -> do
        let pax = shipPath <> "/.urb/" <> seg
-       io $ createDirectoryIfMissing True pax
+       createDirectoryIfMissing True pax
        io $ setFileMode pax ownerModes
 
 

--- a/pkg/king/package.yaml
+++ b/pkg/king/package.yaml
@@ -90,6 +90,7 @@ dependencies:
   - unliftio
   - unliftio-core
   - unordered-containers
+  - urbit-hob
   - utf8-string
   - vector
   - wai

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,7 @@ extra-deps:
   - flat-0.3.4@sha256:002a0e0ae656ea8cc02a772d0bcb6ea7dbd7f2e79070959cc748ad1e7138eb38
   - base58-bytestring-0.1.0@sha256:a1da72ee89d5450bac1c792d9fcbe95ed7154ab7246f2172b57bd4fd9b5eab79
   - lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00
+  - urbit-hob-0.1.0@sha256:ad893bb71ffcf9500820213c12cfa2544e8757ab143ebb45f9c7cc48c7536e11
 
 nix:
   packages:


### PR DESCRIPTION
Also prints the name of the ship you're trying to boot, along with
whether its a fake or not. Also fixes a regression where we were
trying to acquire a lockfile before the pier directory was created.