### PR TITLE
Make king shutdown cleanly on a new line.

### DIFF
--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -7,18 +7,18 @@ module Vere.Pier
 import UrbitPrelude
 
 import Arvo
-import Vere.Pier.Types
 import System.Random
+import Vere.Pier.Types
 
 import System.Directory   (createDirectoryIfMissing)
 import System.Posix.Files (ownerModes, setFileMode)
 import Vere.Ames          (ames)
 import Vere.Behn          (behn)
+import Vere.Clay          (clay)
 import Vere.Http.Client   (client)
 import Vere.Http.Server   (serv)
 import Vere.Log           (EventLog)
-import Vere.Serf          (Serf, sStderr, SerfState(..), doJob)
-import Vere.Clay          (clay)
+import Vere.Serf          (Serf, SerfState(..), doJob, sStderr)
 import Vere.Term
 
 import qualified System.Entropy as Ent
@@ -329,16 +329,14 @@ instance Exception PersistExn where
             , "\tExpected " <> show expected <> " but got " <> show got
             ]
 
-runPersist :: EventLog
+runPersist :: ∀e. HasLogFunc e
+           => EventLog
            -> TQueue (Job, FX)
            -> (FX -> STM ())
            -> RAcquire e (Async ())
 runPersist log inpQ out =
-    mkRAcquire runThread cancelWait
+    mkRAcquire runThread cancel
   where
-    cancelWait :: Async () -> RIO e ()
-    cancelWait tid = cancel tid >> wait tid
-
     runThread :: RIO e (Async ())
     runThread = asyncBound $ forever $ do
         writs  <- atomically getBatchFromQueue

--- a/pkg/king/lib/Vere/Term.hs
+++ b/pkg/king/lib/Vere/Term.hs
@@ -57,7 +57,7 @@ data ReadData = ReadData
 data Private = Private
   { pReaderThread          :: Async ()
   , pWriterThread          :: Async ()
-  , pTerminal              :: Terminal
+  , pTerminal              :: T.Terminal
   , pPreviousConfiguration :: TerminalAttributes
   }
 
@@ -212,7 +212,7 @@ localClient = fst <$> mkRAcquire start stop
       cancel pWriterThread
 
       -- inject one final newline, as we're usually on the prompt.
-      io $ runTermOutput pTerminal $ termText "\r\n"
+      io $ T.runTermOutput pTerminal $ termText "\r\n"
 
       -- take the terminal out of raw mode
       io $ setTerminalAttributes stdInput pPreviousConfiguration Immediately


### PR DESCRIPTION
This makes canceling the persistance thread not rethrow an exception
which kills the process, and makes the terminal driver write one
final newline before giving control back to the terminal so the
bash prompt writes to its own line.