### PR TITLE
Hacky External Terminals

### DIFF
--- a/pkg/king/app/CLI.hs
+++ b/pkg/king/app/CLI.hs
@@ -68,6 +68,7 @@ data Cmd
     = CmdNew New Opts
     | CmdRun Run Opts
     | CmdBug Bug
+    | CmdCon Word16
   deriving (Show)
 
 --------------------------------------------------------------------------------
@@ -270,6 +271,13 @@ bugCmd = fmap CmdBug
             $ progDesc "Parse all data in event log"
             )
 
+conCmd :: Parser Cmd
+conCmd = do
+    port <- argument auto ( metavar "PORT"
+                         <> help "Port of terminal server"
+                          )
+    pure (CmdCon port)
+
 allFx :: Parser Bug
 allFx = do
     bPierPath <- strArgument (metavar "PIER" <> help "Path to pier")
@@ -285,4 +293,7 @@ cmd = subparser
                         )
        <> command "bug" ( info (bugCmd <**> helper)
                         $ progDesc "Run a debugging sub-command."
+                        )
+       <> command "con" ( info (conCmd <**> helper)
+                        $ progDesc "Connect a terminal to a running urbit."
                         )

--- a/pkg/king/app/Main.hs
+++ b/pkg/king/app/Main.hs
@@ -113,6 +113,7 @@ import qualified System.IO.LockFile.Internal as Lock
 import qualified Vere.Log                    as Log
 import qualified Vere.Pier                   as Pier
 import qualified Vere.Serf                   as Serf
+import qualified Vere.Term                   as Term
 
 --------------------------------------------------------------------------------
 
@@ -341,6 +342,15 @@ main = do
         CLI.CmdBug (CLI.ValidatePill pax pil seq) -> testPill pax pil seq
         CLI.CmdBug (CLI.ValidateEvents pax f l)   -> checkEvs pax f l
         CLI.CmdBug (CLI.ValidateFX pax f l)       -> checkFx  pax f l
+        CLI.CmdCon port                           -> connTerm port
+
+
+--------------------------------------------------------------------------------
+
+connTerm :: ∀e. HasLogFunc e => Word16 -> RIO e ()
+connTerm port =
+    Term.runTerminalClient (fromIntegral port)
+
 
 --------------------------------------------------------------------------------
 

--- a/pkg/king/app/Main.hs
+++ b/pkg/king/app/Main.hs
@@ -351,7 +351,6 @@ connTerm :: ∀e. HasLogFunc e => Word16 -> RIO e ()
 connTerm port =
     Term.runTerminalClient (fromIntegral port)
 
-
 --------------------------------------------------------------------------------
 
 checkFx :: HasLogFunc e

--- a/pkg/king/lib/Arvo/Event.hs
+++ b/pkg/king/lib/Arvo/Event.hs
@@ -302,23 +302,25 @@ instance FromNoun Ev where
 
 -- Short Event Names -----------------------------------------------------------
 
-getSpinnerNameForEvent :: Ev -> Maybe String
+{-
+    In the case of the user hitting enter, the cause is technically a
+    terminal event, but we don't display any name because the cause is
+    really the user.
+-}
+getSpinnerNameForEvent :: Ev -> Maybe Text
 getSpinnerNameForEvent = \case
-  EvVane _ -> Nothing
-  EvBlip b -> case b of
-    BlipEvAmes _ -> Just "ames"
-    BlipEvArvo _ -> Just "arvo"
-    BlipEvBehn _ -> Just "behn"
-    BlipEvBoat _ -> Just "boat"
-    BlipEvHttpClient _ -> Just "iris"
-    BlipEvHttpServer _ -> Just "eyre"
-    BlipEvNewt _       -> Just "newt"
-    BlipEvSync _       -> Just "clay"
-    BlipEvTerm t -> case t of
-      TermEvBelt _ belt -> case belt of
-        -- In the case of the user hitting enter, the cause is technically a
-        -- terminal event, but we don't display any name because the cause is
-        -- really the user.
-        Ret () -> Nothing
-        _      -> Just "term"
-      _ -> Just "term"
+    EvVane _ -> Nothing
+    EvBlip b -> case b of
+        BlipEvAmes _           -> Just "ames"
+        BlipEvArvo _           -> Just "arvo"
+        BlipEvBehn _           -> Just "behn"
+        BlipEvBoat _           -> Just "boat"
+        BlipEvHttpClient _     -> Just "iris"
+        BlipEvHttpServer _     -> Just "eyre"
+        BlipEvNewt _           -> Just "newt"
+        BlipEvSync _           -> Just "clay"
+        BlipEvTerm t | isRet t -> Nothing
+        BlipEvTerm t           -> Just "term"
+  where
+    isRet (TermEvBelt _ (Ret ())) = True
+    isRet _                       = False

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -149,7 +149,7 @@ pier pierPath mPort (serf, log, ss) = do
     inst <- io (KingId . UV . fromIntegral <$> randomIO @Word16)
 
     terminalSystem <- initializeLocalTerminal
-    swapMVar (sStderr serf) (tsStderr terminalSystem)
+    swapMVar (sStderr serf) (atomically . tsStderr terminalSystem)
 
     let ship = who (Log.identity log)
 
@@ -209,7 +209,7 @@ data Drivers e = Drivers
 
 drivers :: HasLogFunc e
         => FilePath -> KingId -> Ship -> Maybe Port -> (Ev -> STM ()) -> STM()
-        -> TerminalSystem e
+        -> TerminalSystem
         -> ([Ev], RAcquire e (Drivers e))
 drivers pierPath inst who mPort plan shutdownSTM termSys =
     (initialEvents, runDrivers)

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -163,18 +163,22 @@ pier pierPath mPort (serf, log, ss) = do
 
     (demux, muxed) <- atomically $ do
         res <- Term.mkDemux
-        Term.addDemux local res
+        -- Term.addDemux local res
         pure (res, Term.useDemux res)
 
     rio $ logInfo $ display $
-        "Terminal Server running on port: " <> tshow termServPort
+        "TERMSERV Terminal Server running on port: " <> tshow termServPort
 
     let listenLoop = do
+            logTrace "TERMSERV Waiting for external terminal."
             ok <- atomically $ do
                 waitExternalTerm >>= \case
                     Nothing  -> pure False
                     Just ext -> Term.addDemux ext demux >> pure True
-            when ok listenLoop
+            if ok
+               then do logTrace "TERMSERV External terminal connected"
+                       listenLoop
+               else logTrace "TERMSERV Termainal server is dead"
 
     acquireWorker listenLoop
 

--- a/pkg/king/lib/Vere/Pier.hs
+++ b/pkg/king/lib/Vere/Pier.hs
@@ -161,9 +161,13 @@ pier pierPath mPort (serf, log, ss) = do
 
     tExe  <- startDrivers >>= router (readTQueue executeQ)
     tDisk <- runPersist log persistQ (writeTQueue executeQ)
-    tCpu  <- runCompute serf ss (readTQueue computeQ) (takeTMVar saveM)
-      (takeTMVar shutdownM) (tsShowSpinner terminalSystem)
-      (tsHideSpinner terminalSystem) (writeTQueue persistQ)
+    tCpu  <- runCompute serf ss
+               (readTQueue computeQ)
+               (takeTMVar saveM)
+               (takeTMVar shutdownM)
+               (tsShowSpinner terminalSystem)
+               (tsHideSpinner terminalSystem)
+               (writeTQueue persistQ)
 
     tSaveSignal <- saveSignalThread saveM
 
@@ -286,7 +290,7 @@ runCompute :: ∀e. HasLogFunc e
            -> STM Ev
            -> STM ()
            -> STM ()
-           -> (Maybe String -> STM ())
+           -> (Maybe Text -> STM ())
            -> STM ()
            -> ((Job, FX) -> STM ())
            -> RAcquire e (Async ())

--- a/pkg/king/lib/Vere/Term/API.hs
+++ b/pkg/king/lib/Vere/Term/API.hs
@@ -16,23 +16,26 @@ import Arvo (Blit, Belt)
     %spinr -- Start or stop the spinner
 -}
 data Ev = Blits [Blit]
-        | Trace Text
+        | Trace Cord
         | Blank
-        | Spinr (Maybe (Maybe Text))
+        | Spinr (Maybe (Maybe Cord))
+  deriving (Show)
 
 data Client = Client
     { take :: STM Belt
     , give :: Ev -> STM ()
     }
 
+deriveNoun ''Ev
+
 
 -- Utilities -------------------------------------------------------------------
 
 trace :: Client -> Text -> STM ()
-trace ts = give ts . Trace
+trace ts = give ts . Trace . Cord
 
 spin :: Client -> Maybe Text -> STM ()
-spin ts = give ts . Spinr . Just
+spin ts = give ts . Spinr . Just . fmap Cord
 
 stopSpin :: Client -> STM ()
 stopSpin ts = give ts (Spinr Nothing)

--- a/pkg/king/lib/Vere/Term/API.hs
+++ b/pkg/king/lib/Vere/Term/API.hs
@@ -23,7 +23,7 @@ data Ev = Blits [Blit]
 
 data Client = Client
     { take :: STM Belt
-    , give :: Ev -> STM ()
+    , give :: [Ev] -> STM ()
     }
 
 deriveNoun ''Ev
@@ -32,10 +32,10 @@ deriveNoun ''Ev
 -- Utilities -------------------------------------------------------------------
 
 trace :: Client -> Text -> STM ()
-trace ts = give ts . Trace . Cord
+trace ts = give ts . singleton . Trace . Cord
 
 spin :: Client -> Maybe Text -> STM ()
-spin ts = give ts . Spinr . Just . fmap Cord
+spin ts = give ts . singleton . Spinr . Just . fmap Cord
 
 stopSpin :: Client -> STM ()
-stopSpin ts = give ts (Spinr Nothing)
+stopSpin ts = give ts [Spinr Nothing]

--- a/pkg/king/lib/Vere/Term/API.hs
+++ b/pkg/king/lib/Vere/Term/API.hs
@@ -1,0 +1,38 @@
+module Vere.Term.API (Ev(..), Client(..), trace, spin, stopSpin) where
+
+import UrbitPrelude hiding (trace)
+
+import Arvo (Blit, Belt)
+
+
+-- External Types --------------------------------------------------------------
+
+{-
+    Input Event for terminal driver:
+
+    %blits -- list of blits from arvo.
+    %trace -- stderr line from runtime.
+    %blank -- print a blank line
+    %spinr -- Start or stop the spinner
+-}
+data Ev = Blits [Blit]
+        | Trace Text
+        | Blank
+        | Spinr (Maybe (Maybe Text))
+
+data Client = Client
+    { take :: STM Belt
+    , give :: Ev -> STM ()
+    }
+
+
+-- Utilities -------------------------------------------------------------------
+
+trace :: Client -> Text -> STM ()
+trace ts = give ts . Trace
+
+spin :: Client -> Maybe Text -> STM ()
+spin ts = give ts . Spinr . Just
+
+stopSpin :: Client -> STM ()
+stopSpin ts = give ts (Spinr Nothing)

--- a/pkg/king/lib/Vere/Term/Demux.hs
+++ b/pkg/king/lib/Vere/Term/Demux.hs
@@ -1,0 +1,48 @@
+{-
+    This allows multiple (zero or more) terminal clients to connect to
+    the *same* logical arvo terminal. Terminals that connect will be
+    given full event history since the creation of the demuxer.
+-}
+
+module Vere.Term.Demux (Demux, mkDemux, addDemux, useDemux) where
+
+import UrbitPrelude
+
+import Arvo          (Belt)
+import Vere.Term.API (Client(Client))
+
+import qualified Vere.Term.API as Term
+
+
+--------------------------------------------------------------------------------
+
+data Demux = Demux
+    { dConns :: TVar [Client]
+    , dStash :: TVar [Term.Ev]
+    }
+
+mkDemux :: STM Demux
+mkDemux = Demux <$> newTVar [] <*> newTVar []
+
+addDemux :: Client -> Demux -> STM ()
+addDemux conn Demux{..} = do
+    stash <- readTVar dStash
+    modifyTVar' dConns (conn:)
+    for_ stash (Term.give conn)
+
+useDemux :: Demux -> Client
+useDemux d = Client { give = dGive d, take = dTake d }
+
+
+-- Internal --------------------------------------------------------------------
+
+dGive :: Demux -> Term.Ev -> STM ()
+dGive Demux{..} ev = do
+    modifyTVar' dStash (ev:)
+    conns <- readTVar dConns
+    for_ conns $ \c -> Term.give c ev
+
+dTake :: Demux -> STM Belt
+dTake Demux{..} = do
+    conns <- readTVar dConns
+    asum (Term.take <$> conns)

--- a/pkg/king/lib/Vere/Term/Demux.hs
+++ b/pkg/king/lib/Vere/Term/Demux.hs
@@ -26,7 +26,7 @@ mkDemux = Demux <$> newTVar [] <*> newTVar []
 
 addDemux :: Client -> Demux -> STM ()
 addDemux conn Demux{..} = do
-    stash <- readTVar dStash
+    stash <- reverse <$> readTVar dStash
     modifyTVar' dConns (conn:)
     for_ stash (Term.give conn)
 

--- a/pkg/king/package.yaml
+++ b/pkg/king/package.yaml
@@ -37,6 +37,7 @@ dependencies:
   - classy-prelude
   - conduit
   - containers
+  - data-default
   - data-fix
   - directory
   - entropy
@@ -81,6 +82,7 @@ dependencies:
   - tasty-th
   - template-haskell
   - terminal-progress-bar
+  - terminal-size
   - terminfo
   - text
   - these
@@ -98,7 +100,6 @@ dependencies:
   - warp
   - warp-tls
   - websockets
-  - data-default
 
 default-extensions:
   - ApplicativeDo


### PR DESCRIPTION
This branch implements external terminals in a very hacky way:

- Record all terminal events since start of KH process.
- When external terminals connect, dump all recorded events to external terminal.

In effect, this allows multiple client connections to *the same* terminal.

This is not ideal, obviously. I think this is a good idea as a short-term hack because:

- I need external terminal support in order to make the king a daemon.
- I need the king to be a daemon in order to support the client flow.
- Implementing external terminal support is hard.
- This approach bites off half the work needed to properly implement external terminals.