### PR TITLE
u3: hashtable improvements, road promotion refactor

### DIFF
--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -90,6 +90,16 @@
         u3p(struct _u3a_fbox) nex_p;
       } u3a_fbox;
 
+    /* u3a_jets: jet dashboard
+    */
+      typedef struct _u3a_jets {
+        u3p(u3h_root) hot_p;                  //  hot state (home road only)
+        u3p(u3h_root) war_p;                  //  warm state
+        u3p(u3h_root) cod_p;                  //  cold state
+        u3p(u3h_root) han_p;                  //  hank cache
+        u3p(u3h_root) bas_p;                  //  battery hashes
+      } u3a_jets;
+
     /* u3a_road: contiguous allocation and execution context.
     */
       typedef struct _u3a_road {
@@ -123,13 +133,7 @@
           c3_w max_w;                         //  maximum allocated
         } all;
 
-        struct {                              //  jet dashboard
-          u3p(u3h_root) hot_p;                //  hot state (home road only)
-          u3p(u3h_root) war_p;                //  warm state
-          u3p(u3h_root) cod_p;                //  cold state
-          u3p(u3h_root) han_p;                //  hank cache
-          u3p(u3h_root) bas_p;                //  battery hashes
-        } jed;
+        u3a_jets jed;                         //  jet dashboard
 
         struct {                              // bytecode state
           u3p(u3h_root) har_p;                // formula->post of bytecode

--- a/pkg/urbit/include/noun/hashtable.h
+++ b/pkg/urbit/include/noun/hashtable.h
@@ -105,6 +105,11 @@
         void
         u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val);
 
+      /* u3h_uni(): unify hashtables, copying [rah_p] into [har_p]
+      */
+        void
+        u3h_uni(u3p(u3h_root) har_p, u3p(u3h_root) rah_p);
+
       /* u3h_get(): read from hashtable.
       **
       ** `key` is RETAINED; result is PRODUCED.

--- a/pkg/urbit/include/noun/hashtable.h
+++ b/pkg/urbit/include/noun/hashtable.h
@@ -158,3 +158,14 @@
       */
         void
         u3h_walk(u3p(u3h_root) har_p, void (*fun_f)(u3_noun));
+
+      /* u3h_take_with(): gain hashtable, copying junior keys
+      ** and calling [fun_f] on values
+      */
+        u3p(u3h_root)
+        u3h_take_with(u3p(u3h_root) har_p, u3_funk fun_f);
+
+      /* u3h_take(): gain hashtable, copying junior nouns
+      */
+        u3p(u3h_root)
+        u3h_take(u3p(u3h_root) har_p);

--- a/pkg/urbit/include/noun/hashtable.h
+++ b/pkg/urbit/include/noun/hashtable.h
@@ -34,8 +34,8 @@
       /* u3h_node: map node.
       */
         typedef struct {
-          c3_w     map_w;
-          u3h_slot sot_w[0];
+          c3_w     map_w;     // bitmap for [sot_w]
+          u3h_slot sot_w[0];  // filled slots
         } u3h_node;
 
       /* u3h_root: hash root table
@@ -54,8 +54,8 @@
       /* u3h_buck: bottom bucket.
       */
         typedef struct {
-          c3_w    len_w;
-          u3h_slot sot_w[0];
+          c3_w     len_w;     // length of [sot_w]
+          u3h_slot sot_w[0];  // filled slots
         } u3h_buck;
 
     /**  HAMT macros.

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -190,21 +190,20 @@
         void
         u3j_ream(void);
 
-      /* u3j_reap(): promote jet state.  RETAINS.
+      /* u3j_reap(): promote jet state.
       */
         void
-        u3j_reap(u3p(u3h_root) cod_p, u3p(u3h_root) war_p, u3p(u3h_root) han_p, u3p(u3h_root) bas_p);
+        u3j_reap(u3a_jets jed_u);
+
+      /* u3j_take(): copy junior jet state.
+      */
+        u3a_jets
+        u3j_take(u3a_jets jed_u);
 
       /* u3j_rite_mine(): mine cor with clu, using u3j_rite for caching
       */
         void
         u3j_rite_mine(u3j_rite* rit_u, u3_noun clu, u3_noun cor);
-
-      /* u3j_rite_copy(): copy rite references from src_u to dst_u,
-      **                  losing old references if los_o is yes
-      */
-        void
-        u3j_rite_copy(u3j_rite* dst_u, u3j_rite* src_u, c3_o los_o);
 
       /* u3j_rite_take(): copy junior rite references from src_u to dst_u.
       */

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -206,11 +206,33 @@
         void
         u3j_rite_copy(u3j_rite* dst_u, u3j_rite* src_u, c3_o los_o);
 
+      /* u3j_rite_take(): copy junior rite references from src_u to dst_u.
+      */
+        void
+        u3j_rite_take(u3j_rite* dst_u, u3j_rite* src_u);
+
+      /* u3j_rite_merge(): copy rite references from src_u to dst_u,
+      **                   losing old references
+      */
+        void
+        u3j_rite_merge(u3j_rite* dst_u, u3j_rite* src_u);
+
       /* u3j_site_copy(): copy site references from src_u to dst_u,
       **                  losing old references if los_o is yes
       */
         void
         u3j_site_copy(u3j_site* dst_u, u3j_site* src_u, c3_o los_o);
+
+      /* u3j_site_take(): copy junior site references.
+      */
+        void
+        u3j_site_take(u3j_site* dst_u, u3j_site* src_u);
+
+      /* u3j_site_merge(): copy site references from src_u to dst_u,
+      **                   losing old references
+      */
+        void
+        u3j_site_merge(u3j_site* dst_u, u3j_site* src_u);
 
       /* u3j_site_ream(): refresh u3j_site after restoring from checkpoint
       */

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -216,12 +216,6 @@
         void
         u3j_rite_merge(u3j_rite* dst_u, u3j_rite* src_u);
 
-      /* u3j_site_copy(): copy site references from src_u to dst_u,
-      **                  losing old references if los_o is yes
-      */
-        void
-        u3j_site_copy(u3j_site* dst_u, u3j_site* src_u, c3_o los_o);
-
       /* u3j_site_take(): copy junior site references.
       */
         void

--- a/pkg/urbit/include/noun/nock.h
+++ b/pkg/urbit/include/noun/nock.h
@@ -107,6 +107,11 @@
       void
       u3n_reap(u3p(u3h_root) har_p);
 
+    /* u3n_take(): copy junior bytecode state.
+     */
+      u3p(u3h_root)
+      u3n_take(u3p(u3h_root) har_p);
+
     /* u3n_mark(): mark bytecode cache.
      */
       c3_w

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -3,6 +3,14 @@
 */
 #include "all.h"
 
+/* CUT_END(): extract [b_w] low bits from [a_w]
+*/
+#define CUT_END(a_w, b_w) (a_w & ((1 << b_w) - 1))
+
+/* BIT_SET(): [1] if bit [b_w] is set in [a_w]
+*/
+#define BIT_SET(a_w, b_w) (a_w & (1 << b_w))
+
 static void
 _ch_slot_put(u3h_slot* sot_w, u3_noun kev, c3_w lef_w, c3_w rem_w, c3_w* use_w);
 
@@ -93,11 +101,11 @@ _ch_node_add(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun kev, c3_w *use_w)
 
   lef_w -= 5;
   bit_w = (rem_w >> lef_w);
-  rem_w = (rem_w & ((1 << lef_w) - 1));
+  rem_w = CUT_END(rem_w, lef_w);
   map_w = han_u->map_w;
-  inx_w = _ch_popcount(map_w & ((1 << bit_w) - 1));
+  inx_w = _ch_popcount(CUT_END(map_w, bit_w));
 
-  if ( map_w & (1 << bit_w) ) {
+  if ( BIT_SET(map_w, bit_w) ) {
     _ch_slot_put(&(han_u->sot_w[inx_w]), kev, lef_w, rem_w, use_w);
     return han_u;
   }
@@ -191,7 +199,7 @@ _ch_slot_put(u3h_slot* sot_w, u3_noun kev, c3_w lef_w, c3_w rem_w, c3_w* use_w)
       u3z(kov);
     }
     else {
-      c3_w  rom_w = u3r_mug(u3h(kov)) & ((1 << lef_w) - 1);
+      c3_w  rom_w = CUT_END(u3r_mug(u3h(kov)), lef_w);
       void* hav_v = _ch_some_new(lef_w);
 
       *use_w -= 1; // take one out, add two
@@ -225,13 +233,13 @@ _ch_trim_node(u3h_root* har_u, u3h_slot* sot_w, c3_w lef_w, c3_w rem_w)
   bit_w = (rem_w >> lef_w);
   map_w = han_u->map_w;
 
-  if ( 0 == (map_w & (1 << bit_w)) ) {
+  if ( !BIT_SET(map_w, bit_w) ) {
     har_u->arm_u.mug_w = _ch_skip_slot(har_u->arm_u.mug_w, lef_w);
     return c3n;
   }
 
-  rem_w = (rem_w & ((1 << lef_w) - 1));
-  inx_w = _ch_popcount(map_w & ((1 << bit_w) - 1));
+  rem_w = CUT_END(rem_w, lef_w);
+  inx_w = _ch_popcount(CUT_END(map_w, bit_w));
   tos_w = &(han_u->sot_w[inx_w]);
 
   if ( c3n == _ch_trim_slot(har_u, tos_w, lef_w, rem_w) ) {
@@ -325,7 +333,7 @@ c3_w
 _ch_skip_slot(c3_w mug_w, c3_w lef_w)
 {
   c3_w hig_w = mug_w >> lef_w;
-  c3_w new_w = (hig_w + 1) & ((1 << (31 - lef_w)) - 1); // modulo 2^(31 - lef_w)
+  c3_w new_w = CUT_END(hig_w + 1, (31 - lef_w)); // modulo 2^(31 - lef_w)
   return new_w << lef_w;
 }
 
@@ -366,7 +374,7 @@ _ch_trim_root(u3h_root* har_u)
 {
   c3_w      mug_w = har_u->arm_u.mug_w;
   c3_w      inx_w = mug_w >> 25; // 6 bits
-  c3_w      rem_w = mug_w & ((1 << 25) - 1);
+  c3_w      rem_w = CUT_END(mug_w, 25);
   u3h_slot* sot_w = &(har_u->sot_w[inx_w]);
 
   return _ch_trim_slot(har_u, sot_w, 25, rem_w);
@@ -404,7 +412,7 @@ u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val)
   u3_noun   kev   = u3nc(u3k(key), val);
   c3_w      mug_w = u3r_mug(key);
   c3_w      inx_w = (mug_w >> 25);  //  6 bits
-  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      rem_w = CUT_END(mug_w, 25);
 
   _ch_slot_put(&(har_u->sot_w[inx_w]), kev, 25, rem_w, &(har_u->use_w));
   if ( har_u->max_w > 0 ) {
@@ -436,14 +444,14 @@ _ch_node_hum(u3h_node* han_u, c3_w lef_w, c3_w rem_w, c3_w mug_w)
 
   lef_w -= 5;
   bit_w = (rem_w >> lef_w);
-  rem_w = (rem_w & ((1 << lef_w) - 1));
+  rem_w = CUT_END(rem_w, lef_w);
   map_w = han_u->map_w;
 
-  if ( !(map_w & (1 << bit_w)) ) {
+  if ( !BIT_SET(map_w, bit_w) ) {
     return c3n;
   }
   else {
-    c3_w inx_w = _ch_popcount(map_w & ((1 << bit_w) - 1));
+    c3_w inx_w = _ch_popcount(CUT_END(map_w, bit_w));
     c3_w sot_w = han_u->sot_w[inx_w];
 
     if ( _(u3h_slot_is_noun(sot_w)) ) {
@@ -476,7 +484,7 @@ u3h_hum(u3p(u3h_root) har_p, c3_w mug_w)
 {
   u3h_root* har_u = u3to(u3h_root, har_p);
   c3_w      inx_w = (mug_w >> 25);
-  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      rem_w = CUT_END(mug_w, 25);
   c3_w      sot_w = har_u->sot_w[inx_w];
 
   if ( _(u3h_slot_is_null(sot_w)) ) {
@@ -524,14 +532,14 @@ _ch_node_git(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun key)
 
   lef_w -= 5;
   bit_w = (rem_w >> lef_w);
-  rem_w = (rem_w & ((1 << lef_w) - 1));
+  rem_w = CUT_END(rem_w, lef_w);
   map_w = han_u->map_w;
 
-  if ( !(map_w & (1 << bit_w)) ) {
+  if ( !BIT_SET(map_w, bit_w) ) {
     return u3_none;
   }
   else {
-    c3_w inx_w = _ch_popcount(map_w & ((1 << bit_w) - 1));
+    c3_w inx_w = _ch_popcount(CUT_END(map_w, bit_w));
     c3_w sot_w = han_u->sot_w[inx_w];
 
     if ( _(u3h_slot_is_noun(sot_w)) ) {
@@ -565,7 +573,7 @@ u3h_git(u3p(u3h_root) har_p, u3_noun key)
   u3h_root* har_u = u3to(u3h_root, har_p);
   c3_w      mug_w = u3r_mug(key);
   c3_w      inx_w = (mug_w >> 25);
-  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      rem_w = CUT_END(mug_w, 25);
   c3_w      sot_w = har_u->sot_w[inx_w];
 
   if ( _(u3h_slot_is_null(sot_w)) ) {
@@ -629,14 +637,14 @@ _ch_node_gut(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun key)
 
   lef_w -= 5;
   bit_w = (rem_w >> lef_w);
-  rem_w = (rem_w & ((1 << lef_w) - 1));
+  rem_w = CUT_END(rem_w, lef_w);
   map_w = han_u->map_w;
 
-  if ( !(map_w & (1 << bit_w)) ) {
+  if ( !BIT_SET(map_w, bit_w) ) {
     return u3_none;
   }
   else {
-    c3_w inx_w = _ch_popcount(map_w & ((1 << bit_w) - 1));
+    c3_w inx_w = _ch_popcount(CUT_END(map_w, bit_w));
     c3_w sot_w = han_u->sot_w[inx_w];
 
     if ( _(u3h_slot_is_noun(sot_w)) ) {
@@ -670,7 +678,7 @@ u3h_gut(u3p(u3h_root) har_p, u3_noun key)
   u3h_root* har_u = u3to(u3h_root, har_p);
   c3_w      mug_w = u3r_mug(key);
   c3_w      inx_w = (mug_w >> 25);
-  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      rem_w = CUT_END(mug_w, 25);
   c3_w      sot_w = har_u->sot_w[inx_w];
 
   if ( _(u3h_slot_is_null(sot_w)) ) {

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -233,6 +233,26 @@ u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val)
   }
 }
 
+/* _ch_uni_with(): key/value callback, put into [*wit]
+*/
+static void
+_ch_uni_with(u3_noun kev, void* wit)
+{
+  u3p(u3h_root) har_p = *(u3p(u3h_root)*)wit;
+  u3_noun key, val;
+  u3x_cell(kev, &key, &val);
+
+  u3h_put(har_p, key, u3k(val));
+}
+
+/* u3h_uni(): unify hashtables, copying [rah_p] into [har_p]
+*/
+void
+u3h_uni(u3p(u3h_root) har_p, u3p(u3h_root) rah_p)
+{
+  u3h_walk_with(rah_p, _ch_uni_with, &har_p);
+}
+
 /* _ch_trim_node(): trim one entry from a node slot or its children
 */
 static c3_o

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -214,6 +214,25 @@ _ch_slot_put(u3h_slot* sot_w, u3_noun kev, c3_w lef_w, c3_w rem_w, c3_w* use_w)
   }
 }
 
+/* u3h_put(): insert in hashtable.
+**
+** `key` is RETAINED; `val` is transferred.
+*/
+void
+u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val)
+{
+  u3h_root* har_u = u3to(u3h_root, har_p);
+  u3_noun   kev   = u3nc(u3k(key), val);
+  c3_w      mug_w = u3r_mug(key);
+  c3_w      inx_w = (mug_w >> 25);  //  6 bits
+  c3_w      rem_w = CUT_END(mug_w, 25);
+
+  _ch_slot_put(&(har_u->sot_w[inx_w]), kev, 25, rem_w, &(har_u->use_w));
+  if ( har_u->max_w > 0 ) {
+    u3h_trim_to(har_p, har_u->max_w);
+  }
+}
+
 /* _ch_trim_node(): trim one entry from a node slot or its children
 */
 static c3_o
@@ -392,25 +411,6 @@ u3h_trim_to(u3p(u3h_root) har_p, c3_w n_w)
       har_u->arm_u.inx_w = 0;
     }
     */
-  }
-}
-
-/* u3h_put(): insert in hashtable.
-**
-** `key` is RETAINED; `val` is transferred.
-*/
-void
-u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val)
-{
-  u3h_root* har_u = u3to(u3h_root, har_p);
-  u3_noun   kev   = u3nc(u3k(key), val);
-  c3_w      mug_w = u3r_mug(key);
-  c3_w      inx_w = (mug_w >> 25);  //  6 bits
-  c3_w      rem_w = CUT_END(mug_w, 25);
-
-  _ch_slot_put(&(har_u->sot_w[inx_w]), kev, 25, rem_w, &(har_u->use_w));
-  if ( har_u->max_w > 0 ) {
-    u3h_trim_to(har_p, har_u->max_w);
   }
 }
 

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -137,9 +137,8 @@ _ch_buck_add(u3h_buck* hab_u, u3_noun kev, c3_w *use_w)
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kov = u3h_slot_to_noun(hab_u->sot_w[i_w]);
     if ( c3y == u3r_sing(u3h(kev), u3h(kov)) ) {
-      u3a_lose(kov);
       hab_u->sot_w[i_w] = u3h_noun_to_slot(kev);
-
+      u3z(kov);
       return hab_u;
     }
   }
@@ -600,7 +599,7 @@ u3h_get(u3p(u3h_root) har_p, u3_noun key)
   u3_noun pro = u3h_git(har_p, key);
 
   if ( u3_none != pro ) {
-    u3a_gain(pro);
+    u3k(pro);
   }
   return pro;
 }
@@ -615,7 +614,7 @@ _ch_buck_gut(u3h_buck* hab_u, u3_noun key)
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kev = u3h_slot_to_noun(hab_u->sot_w[i_w]);
     if ( _(u3r_sung(key, u3h(kev))) ) {
-      return u3a_gain(u3t(kev));
+      return u3k(u3t(kev));
     }
   }
   return u3_none;
@@ -644,7 +643,7 @@ _ch_node_gut(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun key)
       u3_noun kev = u3h_slot_to_noun(sot_w);
 
       if ( _(u3r_sung(key, u3h(kev))) ) {
-        return u3a_gain(u3t(kev));
+        return u3k(u3t(kev));
       }
       else {
         return u3_none;
@@ -682,7 +681,7 @@ u3h_gut(u3p(u3h_root) har_p, u3_noun key)
 
     if ( _(u3r_sung(key, u3h(kev))) ) {
       har_u->sot_w[inx_w] = u3h_noun_be_warm(sot_w);
-      return u3a_gain(u3t(kev));
+      return u3k(u3t(kev));
     }
     else {
       return u3_none;
@@ -703,7 +702,7 @@ _ch_free_buck(u3h_buck* hab_u)
   c3_w i_w;
 
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
-    u3a_lose(u3h_slot_to_noun(hab_u->sot_w[i_w]));
+    u3z(u3h_slot_to_noun(hab_u->sot_w[i_w]));
   }
   u3a_wfree(hab_u);
 }
@@ -722,9 +721,7 @@ _ch_free_node(u3h_node* han_u, c3_w lef_w)
     c3_w sot_w = han_u->sot_w[i_w];
 
     if ( _(u3h_slot_is_noun(sot_w)) ) {
-      u3_noun kev = u3h_slot_to_noun(sot_w);
-
-      u3a_lose(kev);
+      u3z(u3h_slot_to_noun(sot_w));
     }
     else {
       void* hav_v = u3h_slot_to_node(sot_w);
@@ -751,9 +748,7 @@ u3h_free(u3p(u3h_root) har_p)
     c3_w sot_w = har_u->sot_w[i_w];
 
     if ( _(u3h_slot_is_noun(sot_w)) ) {
-      u3_noun kev = u3h_slot_to_noun(sot_w);
-
-      u3a_lose(kev);
+      u3z(u3h_slot_to_noun(sot_w));
     }
     else if ( _(u3h_slot_is_node(sot_w)) ) {
       u3h_node* han_u = u3h_slot_to_node(sot_w);

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -400,11 +400,11 @@ u3h_trim_to(u3p(u3h_root) har_p, c3_w n_w)
 void
 u3h_put(u3p(u3h_root) har_p, u3_noun key, u3_noun val)
 {
-  u3h_root*   har_u = u3to(u3h_root, har_p);
-  u3_noun     kev   = u3nc(u3k(key), val);
-  c3_w        mug_w = u3r_mug(key);
-  c3_w        inx_w = (mug_w >> 25);  //  6 bits
-  c3_w        rem_w = (mug_w & ((1 << 25) - 1));
+  u3h_root* har_u = u3to(u3h_root, har_p);
+  u3_noun   kev   = u3nc(u3k(key), val);
+  c3_w      mug_w = u3r_mug(key);
+  c3_w      inx_w = (mug_w >> 25);  //  6 bits
+  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
 
   _ch_slot_put(&(har_u->sot_w[inx_w]), kev, 25, rem_w, &(har_u->use_w));
   if ( har_u->max_w > 0 ) {
@@ -475,9 +475,9 @@ c3_o
 u3h_hum(u3p(u3h_root) har_p, c3_w mug_w)
 {
   u3h_root* har_u = u3to(u3h_root, har_p);
-  c3_w        inx_w = (mug_w >> 25);
-  c3_w        rem_w = (mug_w & ((1 << 25) - 1));
-  c3_w        sot_w = har_u->sot_w[inx_w];
+  c3_w      inx_w = (mug_w >> 25);
+  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      sot_w = har_u->sot_w[inx_w];
 
   if ( _(u3h_slot_is_null(sot_w)) ) {
     return c3n;
@@ -668,10 +668,10 @@ u3_weak
 u3h_gut(u3p(u3h_root) har_p, u3_noun key)
 {
   u3h_root* har_u = u3to(u3h_root, har_p);
-  c3_w mug_w        = u3r_mug(key);
-  c3_w inx_w        = (mug_w >> 25);
-  c3_w rem_w        = (mug_w & ((1 << 25) - 1));
-  c3_w sot_w        = har_u->sot_w[inx_w];
+  c3_w      mug_w = u3r_mug(key);
+  c3_w      inx_w = (mug_w >> 25);
+  c3_w      rem_w = (mug_w & ((1 << 25) - 1));
+  c3_w      sot_w = har_u->sot_w[inx_w];
 
   if ( _(u3h_slot_is_null(sot_w)) ) {
     return u3_none;

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -614,7 +614,7 @@ _ch_buck_gut(u3h_buck* hab_u, u3_noun key)
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kev = u3h_slot_to_noun(hab_u->sot_w[i_w]);
     if ( _(u3r_sung(key, u3h(kev))) ) {
-      return u3k(u3t(kev));
+      return u3t(kev);
     }
   }
   return u3_none;
@@ -643,7 +643,7 @@ _ch_node_gut(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun key)
       u3_noun kev = u3h_slot_to_noun(sot_w);
 
       if ( _(u3r_sung(key, u3h(kev))) ) {
-        return u3k(u3t(kev));
+        return u3t(kev);
       }
       else {
         return u3_none;
@@ -689,8 +689,14 @@ u3h_gut(u3p(u3h_root) har_p, u3_noun key)
   }
   else {
     u3h_node* han_u = u3h_slot_to_node(sot_w);
+    u3_weak     pro = _ch_node_gut(han_u, 25, rem_w, key);
 
-    return _ch_node_gut(han_u, 25, rem_w, key);
+    if ( u3_none == pro ) {
+      return u3_none;
+    }
+    else {
+      return u3k(pro);
+    }
   }
 }
 

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -1387,6 +1387,49 @@ u3j_rite_copy(u3j_rite* dst_u, u3j_rite* src_u, c3_o los_o)
   }
 }
 
+/* u3j_rite_take(): copy junior rite references. [dst_u] is uninitialized
+*/
+void
+u3j_rite_take(u3j_rite* dst_u, u3j_rite* src_u)
+{
+  if ( u3_none == src_u->clu ) {
+    dst_u->clu   = u3_none;
+    dst_u->fin_p = 0;
+    dst_u->own_o = c3n;
+  }
+  else {
+    dst_u->clu   = u3a_take(src_u->clu);
+    dst_u->own_o = src_u->own_o;
+    dst_u->fin_p = ( c3n == src_u->own_o )
+                   ? src_u->fin_p
+                   : u3of(u3j_fink, _cj_fink_take(u3to(u3j_fink, src_u->fin_p)));
+  }
+}
+
+/* u3j_rite_merge(): copy rite references from src_u to dst_u,
+**                  losing old references
+*/
+void
+u3j_rite_merge(u3j_rite* dst_u, u3j_rite* src_u)
+{
+  if ( u3_none != src_u->clu ) {
+    if ( u3_none != dst_u->clu ) {
+      u3z(dst_u->clu);
+    }
+
+    dst_u->clu = src_u->clu;
+
+    if ( dst_u->fin_p != src_u->fin_p ) {
+      if ( c3y == dst_u->own_o ) {
+        _cj_fink_free(dst_u->fin_p);
+      }
+
+      dst_u->fin_p = src_u->fin_p;
+      dst_u->own_o = src_u->own_o;
+    }
+  }
+}
+
 /* u3j_site_copy(): copy site references from src_u to dst_u,
 **                  losing old references if los_o is yes
 */
@@ -1444,6 +1487,72 @@ u3j_site_copy(u3j_site* dst_u, u3j_site* src_u, c3_o los_o)
           _cj_fink_free(fon_p);
         }
       }
+    }
+  }
+}
+
+/* u3j_site_take(): copy junior site references. [dst_u] is uninitialized
+*/
+void
+u3j_site_take(u3j_site* dst_u, u3j_site* src_u)
+{
+  dst_u->axe   = u3a_take(src_u->axe);
+  dst_u->bat   = u3_none;
+  dst_u->bas   = u3_none;
+  dst_u->pog_p = 0;
+
+  if ( u3_none == src_u->loc ) {
+    dst_u->loc   = u3_none;
+    dst_u->lab   = u3_none;
+    dst_u->jet_o = c3n;
+    dst_u->cop_u = NULL;
+    dst_u->ham_u = NULL;
+    dst_u->fin_p = 0;
+    dst_u->fon_o = c3n;
+  }
+  else {
+    dst_u->loc   = u3a_take(src_u->loc);
+    dst_u->lab   = u3a_take(src_u->lab);
+    dst_u->jet_o = src_u->jet_o;
+    dst_u->cop_u = src_u->cop_u;
+    dst_u->ham_u = src_u->ham_u;
+
+    if ( c3y == src_u->fon_o ) {
+      dst_u->fin_p = u3of(u3j_fink, _cj_fink_take(u3to(u3j_fink, src_u->fin_p)));
+      dst_u->fon_o = c3y;
+    }
+    else {
+      dst_u->fin_p = src_u->fin_p;
+      dst_u->fon_o = c3n;
+    }
+  }
+}
+
+/* u3j_site_merge(): copy site references from src_u to dst_u,
+**                  losing old references
+*/
+void
+u3j_site_merge(u3j_site* dst_u, u3j_site* src_u)
+{
+  u3z(dst_u->axe);
+  dst_u->axe = src_u->axe;
+
+  if ( u3_none != src_u->loc ) {
+    u3z(dst_u->loc);
+    u3z(dst_u->lab);
+    dst_u->loc   = src_u->loc;
+    dst_u->lab   = src_u->lab;
+    dst_u->cop_u = src_u->cop_u;
+    dst_u->ham_u = src_u->ham_u;
+    dst_u->jet_o = src_u->jet_o;
+
+    if ( dst_u->fin_p != src_u->fin_p ) {
+      if ( c3y == dst_u->fon_o )  {
+        _cj_fink_free(dst_u->fin_p);
+      }
+
+      dst_u->fin_p = src_u->fin_p;
+      dst_u->fon_o = src_u->fon_o;
     }
   }
 }

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -1359,34 +1359,6 @@ _cj_fink_free(u3p(u3j_fink) fin_p)
   u3a_wfree(fin_u);
 }
 
-/* u3j_rite_copy(): copy rite references from src_u to dst_u,
-**                  losing old references if los_o is yes
-*/
-void
-u3j_rite_copy(u3j_rite* dst_u, u3j_rite* src_u, c3_o los_o)
-{
-  if ( u3_none == src_u->clu ) {
-    dst_u->clu   = u3_none;
-    dst_u->fin_p = 0;
-  }
-  else {
-    u3p(u3j_fink) fon_p = dst_u->fin_p;
-    u3_noun   old   = dst_u->clu;
-    c3_o      own_o = dst_u->own_o;
-    if ( c3y == src_u->own_o ) {
-      dst_u->own_o = c3y;
-      dst_u->clu   = u3a_take(src_u->clu);
-      dst_u->fin_p = u3of(u3j_fink, _cj_fink_take(u3to(u3j_fink, src_u->fin_p)));
-      if ( (c3y == los_o) &&
-          (u3_none != old) &&
-          (c3y == own_o) ) {
-        u3z(old);
-        _cj_fink_free(fon_p);
-      }
-    }
-  }
-}
-
 /* u3j_rite_take(): copy junior rite references. [dst_u] is uninitialized
 */
 void
@@ -2074,83 +2046,99 @@ u3j_rite_mine(u3j_rite* rit_u, u3_noun clu, u3_noun cor)
   u3t_off(glu_o);
 }
 
-/* _cj_warm_reap(): reap key and value from warm table.
+/* _cj_take_hank_cb(): u3h_take_with cb for taking hanks
+*/
+static u3p(_cj_hank)
+_cj_take_hank_cb(u3p(_cj_hank) nah_p)
+{
+  _cj_hank* nah_u = u3to(_cj_hank, nah_p);
+  _cj_hank* han_u = u3a_walloc(c3_wiseof(_cj_hank));
+
+  if ( u3_none == nah_u->hax ) {
+    han_u->hax = u3_none;
+    // han_u->sit_u left uninitialized, will be ignored
+  }
+  else {
+    han_u->hax = u3a_take(nah_u->hax);
+    u3j_site_take(&(han_u->sit_u), &(nah_u->sit_u));
+  }
+
+  return u3of(_cj_hank, han_u);
+}
+
+/* u3j_take(): copy junior jet state.
+*/
+u3a_jets
+u3j_take(u3a_jets jed_u)
+{
+  jed_u.cod_p = u3h_take(jed_u.cod_p);
+
+  // call sites must be reaped before the warm dashboard, because they may
+  // contain references to labels on this road
+  jed_u.han_p = u3h_take_with(jed_u.han_p, _cj_take_hank_cb);
+
+  jed_u.war_p = u3h_take(jed_u.war_p);
+  jed_u.bas_p = u3h_take(jed_u.bas_p);
+
+  return jed_u;
+}
+
+/* _cj_merge_hank_cb(): u3h_uni_with cb for integrating taken hanks
+**  NB "transfers" or frees hanks in jed_u.han_p
 */
 static void
-_cj_warm_reap(u3_noun kev)
+_cj_merge_hank_cb(u3_noun kev, void* wit)
 {
-  u3_noun loc = u3a_take(u3h(kev));
-  u3_noun act = u3a_take(u3t(kev));
-  u3h_put(u3R->jed.war_p, loc, act);
-  u3z(loc);
-}
+  u3p(u3h_root) han_p = *(u3p(u3h_root)*)wit;
+  _cj_hank* nah_u;
+  u3_noun key;
+  u3p(_cj_hank) nah_p;
+  u3x_cell(kev, &key, &nah_p);
 
-/* _cj_cold_reap(): reap cold dashboard entries.
- */
-static void
-_cj_cold_reap(u3_noun kev)
-{
-  u3_noun bat = u3a_take(u3h(kev));
-  u3_noun reg = u3a_take(u3t(kev));
-  u3h_put(u3R->jed.cod_p, bat, reg);
-  u3z(bat);
-}
+  nah_u = u3to(_cj_hank, nah_p);
 
-/* _cj_bash_reap(): reap battery hashes.
- */
-static void
-_cj_bash_reap(u3_noun kev)
-{
-  u3_noun key = u3a_take(u3h(kev)),
-          val = u3a_take(u3t(kev));
-  u3h_put(u3R->jed.bas_p, key, val);
-  u3z(key);
-}
+  if ( u3_none == nah_u->hax ) {
+    u3a_wfree(nah_u);
+  }
+  else {
+    _cj_hank* han_u;
+    u3_weak     got = u3h_git(u3R->jed.han_p, key);
 
-/* _cj_hank_reap(): reap hook resolutions.
- */
-static void
-_cj_hank_reap(u3_noun kev)
-{
-  u3_noun   key   = u3a_take(u3h(kev));
-  u3_noun   got   = u3h_git(u3R->jed.han_p, key);
-  _cj_hank* nah_u = u3to(_cj_hank, u3t(kev));
-  _cj_hank* han_u;
-
-  if ( u3_none != got ) {
-    if ( u3_none != nah_u->hax ) {
-      u3_weak old;
-      han_u = u3to(_cj_hank, got);
-      old = han_u->hax;
-      han_u->hax = u3a_take(nah_u->hax);
-      u3j_site_copy(&(han_u->sit_u), &(nah_u->sit_u), c3y);
-      if ( u3_none != old ) {
-        u3z(old);
-      }
+    if ( u3_none == got )  {
+      han_u = nah_u;
     }
-  }
-  else if ( u3_none != nah_u->hax ) {
-    han_u      = u3a_walloc(c3_wiseof(_cj_hank));
-    han_u->hax = u3a_take(nah_u->hax);
-    u3j_site_copy(&(han_u->sit_u), &(nah_u->sit_u), c3n);
-    u3h_put(u3R->jed.han_p, key, u3a_outa(han_u));
-  }
+    else {
+      han_u = u3to(_cj_hank, got);
 
-  u3z(key);
+      if ( u3_none != han_u->hax ) {
+        u3z(han_u->hax);
+      }
+      han_u->hax = nah_u->hax;
+
+      u3j_site_merge(&(han_u->sit_u), &(nah_u->sit_u));
+      u3a_wfree(nah_u);
+    }
+
+    u3h_put(han_p, key, u3of(_cj_hank, han_u));
+  }
 }
 
 /* u3j_reap(): promote jet state.
 */
 void
-u3j_reap(u3p(u3h_root) cod_p, u3p(u3h_root) war_p, u3p(u3h_root) han_p, u3p(u3h_root) bas_p)
+u3j_reap(u3a_jets jed_u)
 {
-  u3h_walk(cod_p, _cj_cold_reap);
+  u3h_uni(u3R->jed.cod_p, jed_u.cod_p);
+  u3h_free(jed_u.cod_p);
 
-  // call sites must be reaped before the warm dashboard, because they may
-  // contain references to labels on this road
-  u3h_walk(han_p, _cj_hank_reap);
-  u3h_walk(war_p, _cj_warm_reap);
-  u3h_walk(bas_p, _cj_bash_reap);
+  u3h_walk_with(jed_u.han_p, _cj_merge_hank_cb, &u3R->jed.han_p);
+  u3h_free(jed_u.han_p);
+
+  u3h_uni(u3R->jed.war_p, jed_u.war_p);
+  u3h_free(jed_u.war_p);
+
+  u3h_uni(u3R->jed.bas_p, jed_u.bas_p);
+  u3h_free(jed_u.bas_p);
 }
 
 /* _cj_ream(): ream list of battery [bash registry] pairs. RETAIN.

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -2017,15 +2017,10 @@ _cj_take_hank_cb(u3p(_cj_hank) nah_p)
 u3a_jets
 u3j_take(u3a_jets jed_u)
 {
-  jed_u.cod_p = u3h_take(jed_u.cod_p);
-
-  // call sites must be reaped before the warm dashboard, because they may
-  // contain references to labels on this road
-  jed_u.han_p = u3h_take_with(jed_u.han_p, _cj_take_hank_cb);
-
   jed_u.war_p = u3h_take(jed_u.war_p);
+  jed_u.cod_p = u3h_take(jed_u.cod_p);
+  jed_u.han_p = u3h_take_with(jed_u.han_p, _cj_take_hank_cb);
   jed_u.bas_p = u3h_take(jed_u.bas_p);
-
   return jed_u;
 }
 
@@ -2074,14 +2069,14 @@ _cj_merge_hank_cb(u3_noun kev, void* wit)
 void
 u3j_reap(u3a_jets jed_u)
 {
+  u3h_uni(u3R->jed.war_p, jed_u.war_p);
+  u3h_free(jed_u.war_p);
+
   u3h_uni(u3R->jed.cod_p, jed_u.cod_p);
   u3h_free(jed_u.cod_p);
 
   u3h_walk_with(jed_u.han_p, _cj_merge_hank_cb, &u3R->jed.han_p);
   u3h_free(jed_u.han_p);
-
-  u3h_uni(u3R->jed.war_p, jed_u.war_p);
-  u3h_free(jed_u.war_p);
 
   u3h_uni(u3R->jed.bas_p, jed_u.bas_p);
   u3h_free(jed_u.bas_p);

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -1079,6 +1079,7 @@ _cj_hank_find(u3_noun pre, u3_noun tam)
 {
   u3_noun key = u3nc(u3k(pre), u3k(tam));
   u3_noun got = u3h_git(u3R->jed.han_p, key);
+
   if ( u3_none != got ) {
     u3z(key);
     return u3to(_cj_hank, got);
@@ -1086,20 +1087,26 @@ _cj_hank_find(u3_noun pre, u3_noun tam)
   else {
     _cj_hank* new_u = u3a_walloc(c3_wiseof(_cj_hank));
     u3a_road* rod_u = u3R;
+
     while ( rod_u->par_p && u3_none == got ) {
       rod_u = u3to(u3a_road, rod_u->par_p);
-      got   = u3h_git(u3R->jed.han_p, key);
+      got   = u3h_git(rod_u->jed.han_p, key);
     }
+
     if ( u3_none == got ) {
       new_u->hax = u3_none;
     }
     else {
       _cj_hank* old_u = u3to(_cj_hank, got);
       if ( u3_none != (new_u->hax = old_u->hax) ) {
-        u3j_site_copy(&(new_u->sit_u), &(old_u->sit_u), c3n);
+        //  it's unusual but safe to "take" here, because
+        //  u3a_take will no-op on senior nouns (just as u3k would)
+        //
+        u3j_site_take(&(new_u->sit_u), &(old_u->sit_u));
       }
     }
-    u3h_put(u3R->jed.han_p, key, u3a_outa(new_u));
+
+    u3h_put(u3R->jed.han_p, key, u3of(_cj_hank, new_u));
     u3z(key);
     return new_u;
   }
@@ -1398,67 +1405,6 @@ u3j_rite_merge(u3j_rite* dst_u, u3j_rite* src_u)
 
       dst_u->fin_p = src_u->fin_p;
       dst_u->own_o = src_u->own_o;
-    }
-  }
-}
-
-/* u3j_site_copy(): copy site references from src_u to dst_u,
-**                  losing old references if los_o is yes
-*/
-void
-u3j_site_copy(u3j_site* dst_u, u3j_site* src_u, c3_o los_o)
-{
-  u3_noun old = dst_u->axe;
-  dst_u->axe  = u3a_take(src_u->axe);
-
-  if ( c3y == los_o ) {
-    u3z(old);
-  }
-  else {
-    dst_u->bat   = u3_none;
-    dst_u->bas   = u3_none;
-    dst_u->pog_p = 0;
-    dst_u->loc   = u3_none;
-    dst_u->lab   = u3_none;
-    dst_u->jet_o = c3n;
-    dst_u->fon_o = c3n;
-    dst_u->cop_u = NULL;
-    dst_u->ham_u = NULL;
-    dst_u->fin_p = 0;
-  }
-
-  if ( u3_none != src_u->loc ) {
-    u3_noun  lob   = dst_u->lab,
-             lod   = dst_u->loc;
-    c3_o     fon_o = dst_u->fon_o;
-    u3p(u3j_fink) fon_p = dst_u->fin_p;
-
-    dst_u->loc   = u3a_take(src_u->loc);
-    dst_u->lab   = u3a_take(src_u->lab);
-    dst_u->cop_u = src_u->cop_u;
-    dst_u->ham_u = src_u->ham_u;
-    dst_u->jet_o = src_u->jet_o;
-
-    if ( c3y == src_u->fon_o ) {
-      dst_u->fin_p = u3of(u3j_fink, _cj_fink_take(u3to(u3j_fink, src_u->fin_p)));
-      dst_u->fon_o = c3y;
-    }
-    else if ( fon_p != src_u->fin_p ) {
-      dst_u->fin_p = src_u->fin_p;
-      dst_u->fon_o = c3n;
-    }
-    else {
-      fon_o = c3n;
-    }
-
-    if ( c3y == los_o ) {
-      if ( u3_none != lod ) {
-        u3z(lod);
-        u3z(lob);
-        if ( c3y == fon_o ) {
-          _cj_fink_free(fon_p);
-        }
-      }
     }
   }
 }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -829,32 +829,30 @@ u3m_hate(c3_w pad_w)
 u3_noun
 u3m_love(u3_noun pro)
 {
-  //  save junior road cache pointers
+  //  save cache pointers from current road
   //
   u3p(u3h_root) byc_p = u3R->byc.har_p;
   u3a_jets      jed_u = u3R->jed;
 
-  //  fallback to senior
+  //  fallback to parent road (child heap on parent's stack)
   //
   u3m_fall();
 
-  //  copy products off our stack
-  //
-  //    this order is important! see u3j_take().
+  //  copy product and caches off our stack
   //
   pro   = u3a_take(pro);
-  byc_p = u3n_take(byc_p);
   jed_u = u3j_take(jed_u);
-
-  //  integrate junior caches
-  //
-  u3n_reap(byc_p);
-  u3j_reap(jed_u);
+  byc_p = u3n_take(byc_p);
 
   //  pop the stack
   //
   u3R->cap_p = u3R->ear_p;
   u3R->ear_p = 0;
+
+  //  integrate junior caches
+  //
+  u3j_reap(jed_u);
+  u3n_reap(byc_p);
 
   return pro;
 }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -829,24 +829,37 @@ u3m_hate(c3_w pad_w)
 u3_noun
 u3m_love(u3_noun pro)
 {
-  {
-    u3p(u3h_root) cod_p = u3R->jed.cod_p;
-    u3p(u3h_root) war_p = u3R->jed.war_p;
-    u3p(u3h_root) han_p = u3R->jed.han_p;
-    u3p(u3h_root) bas_p = u3R->jed.bas_p;
-    u3p(u3h_root) byc_p = u3R->byc.har_p;
+  //  save junior road cache pointers
+  //
+  u3p(u3h_root) byc_p = u3R->byc.har_p;
+  u3p(u3h_root) cod_p = u3R->jed.cod_p;
+  u3p(u3h_root) war_p = u3R->jed.war_p;
+  u3p(u3h_root) han_p = u3R->jed.han_p;
+  u3p(u3h_root) bas_p = u3R->jed.bas_p;
 
-    u3m_fall();
+  //  fallback to senior
+  //
+  u3m_fall();
 
-    pro = u3a_take(pro);
+  //  copy products off our stack
+  //
+  //    this order is important! see u3j_reap().
+  //
+  pro   = u3a_take(pro);
+  byc_p = u3n_take(byc_p);
 
-    // call sites first: see u3j_reap().
-    u3n_reap(byc_p);
-    u3j_reap(cod_p, war_p, han_p, bas_p);
+  //  integrate junior caches
+  //
+  //    this order is important! see u3j_reap().
+  //
+  u3n_reap(byc_p);
+  u3j_reap(cod_p, war_p, han_p, bas_p);
 
-    u3R->cap_p = u3R->ear_p;
-    u3R->ear_p = 0;
-  }
+  //  pop the stack
+  //
+  u3R->cap_p = u3R->ear_p;
+  u3R->ear_p = 0;
+
   return pro;
 }
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -832,10 +832,7 @@ u3m_love(u3_noun pro)
   //  save junior road cache pointers
   //
   u3p(u3h_root) byc_p = u3R->byc.har_p;
-  u3p(u3h_root) cod_p = u3R->jed.cod_p;
-  u3p(u3h_root) war_p = u3R->jed.war_p;
-  u3p(u3h_root) han_p = u3R->jed.han_p;
-  u3p(u3h_root) bas_p = u3R->jed.bas_p;
+  u3a_jets      jed_u = u3R->jed;
 
   //  fallback to senior
   //
@@ -843,17 +840,16 @@ u3m_love(u3_noun pro)
 
   //  copy products off our stack
   //
-  //    this order is important! see u3j_reap().
+  //    this order is important! see u3j_take().
   //
   pro   = u3a_take(pro);
   byc_p = u3n_take(byc_p);
+  jed_u = u3j_take(jed_u);
 
   //  integrate junior caches
   //
-  //    this order is important! see u3j_reap().
-  //
   u3n_reap(byc_p);
-  u3j_reap(cod_p, war_p, han_p, bas_p);
+  u3j_reap(jed_u);
 
   //  pop the stack
   //


### PR DESCRIPTION
This PR was motivated by problems encountered in #1741. In short: promoting values out of inner roads is complicated, and was made much more complicated by our use of hashtables. (This manifested in #1741 as an existential dependence on leaking references while unifying nouns.)

This PR phases transitions from inner to outer roads; first we promote them (and don't do anything else with them), then we do whatever we need to do with them. Specifically, there are no hashtable lookups or equality comparisons during the promotion phase (`u3a_take()` and friends). To do this, I added hashtable promotion (`u3h_take()` and parameterized `u3h_take_with()`) and merge (`u3h_uni()`). I also refactored the internals of the bytecode interpreter and jet dashboard program/registration/cache promotion, splitting into these phases ("take" and "reap").

Along the way, I performed some minor refactoring of the hashtable implementation. Once this PR is merged, I'll update #1741 to include these changes. We'll then be able to remove the `u3h_gut()`, which will be entirely equivalent to `u3h_get()`.

I'm deeply indebted to @frodwith for his help in designing and making these changes.