### PR TITLE
Added store, hook, and JSON marks for both Groups and Permissions

### DIFF
--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -1,0 +1,259 @@
+::  group-hook: allow syncing group data from foreign paths to local paths
+::
+/-  *group-store, *group-hook
+|%
++$  move  [bone card]
+::
++$  card
+  $%  [%diff [%group-update group-update]]
+      [%quit ~]
+      [%poke wire dock [%group-action group-action]]
+      [%pull wire dock ~]
+      [%peer wire dock path]
+  ==
+::
++$  state
+  $%  [%0 state-zero]
+  ==
+::
++$  state-zero
+  $:  synced=(map path ship)
+      boned=(map wire (list bone))
+  ==
+::
+--
+::
+|_  [bol=bowl:gall state]
+::
+++  this  .
+::
+++  prep
+  |=  old=(unit state)
+  ^-  (quip move _this)
+  ?~  old
+    [~ this]
+  [~ this(+<+ u.old)]
+::
+++  poke-group-hook-action
+  |=  act=group-hook-action
+  ^-  (quip move _this)
+  ?-  -.act
+      %add
+    ?.  =(src.bol our.bol)
+      [~ this]
+    =/  group-path  [%group path.act]
+    =/  group-wire  [(scot %p ship.act) group-path]
+    ?:  (~(has by synced) path.act)
+      [~ this]
+    =.  synced  (~(put by synced) path.act ship.act)
+    :_  (track-bone group-wire)
+    ?:  =(ship.act our.bol)
+      [ost.bol %peer group-wire [ship.act %group-store] group-path]~
+    [ost.bol %peer group-wire [ship.act %group-hook] group-path]~
+  ::
+      %remove
+    =/  ship  (~(get by synced) path.act)
+    ?~  ship
+      [~ this]
+    ?:  &(=(u.ship our.bol) =(our.bol src.bol))
+      ::  delete one of our own paths
+      =/  group-wire  [(scot %p our.bol) %group path.act]
+      :_  this(synced (~(del by synced) path.act))
+      %+  weld
+        (pull-wire group-wire path.act)
+      ^-  (list move)
+      %+  turn  (prey:pubsub:userlib [%group path.act] bol)
+      |=  [=bone *]
+      ^-  move
+      [bone %quit ~]
+    ?:  |(=(u.ship src.bol) =(our.bol src.bol))
+      ::  delete a foreign ship's path
+      =/  group-wire  [(scot %p u.ship) %group path.act]
+      :_  this(synced (~(del by synced) path.act))
+      (pull-wire group-wire path.act)
+    :: don't allow
+    [~ this]
+  ::
+  ==
+::
+++  peer-group
+  |=  pax=path
+  ^-  (quip move _this)
+  ?~  pax  !!
+  ?.  (~(has by synced) pax)  !!
+  =/  grp=(unit group)  (group-scry pax)
+  ?~  grp  !!
+  :_  this
+  [ost.bol %diff [%group-update [%path u.grp pax]]]~
+::
+++  diff-group-update
+  |=  [wir=wire diff=group-update]
+  ^-  (quip move _this)
+  ?:  =(src.bol our.bol)
+    (handle-local diff)
+  (handle-foreign diff)
+::
+++  handle-local
+  |=  diff=group-update
+  ^-  (quip move _this)
+  ?-  -.diff
+      %keys    [~ this]
+      %path    [~ this]
+      %bundle  [~ this]
+      %add
+    :_  this
+    %+  turn  (prey:pubsub:userlib [%group pax.diff] bol)
+    |=  [=bone *]
+    ^-  move
+    [bone %diff [%group-update diff]]
+  ::
+      %remove
+    :_  this
+    %+  turn  (prey:pubsub:userlib [%group pax.diff] bol)
+    |=  [=bone *]
+    ^-  move
+    [bone %diff [%group-update diff]]
+  ::
+      %unbundle
+    :_  this(synced (~(del by synced) pax.diff))
+    %+  weld
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib [%group pax.diff] bol)
+    |=  [=bone *]
+    ^-  move
+    [bone %diff [%group-update diff]]
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib [%group pax.diff] bol)
+    |=  [=bone *]
+    ^-  move
+    [bone %quit ~]
+  ::
+  ==
+::
+++  handle-foreign
+  |=  diff=group-update
+  ^-  (quip move _this)
+  ?-  -.diff
+      %keys    [~ this]
+      %bundle  [~ this]
+  ::
+      %path
+    ?~  pax.diff
+      [~ this]
+    =/  ship  (~(get by synced) pax.diff)
+    ?~  ship
+      [~ this]
+    ?.  =(src.bol u.ship)
+      [~ this]
+    :_  this
+    :~  (group-poke pax.diff [%unbundle pax.diff])
+        (group-poke pax.diff [%bundle pax.diff])
+        (group-poke pax.diff [%add members.diff pax.diff])
+    ==
+  ::
+      %add
+    ?~  pax.diff
+      [~ this]
+    =/  ship  (~(get by synced) pax.diff)
+    ?~  ship
+      [~ this]
+    ?.  =(src.bol u.ship)
+      [~ this]
+    :_  this
+    :~  (group-poke pax.diff diff)
+    ==
+  ::
+      %remove
+    ?~  pax.diff
+      [~ this]
+    =/  ship  (~(get by synced) pax.diff)
+    ?~  ship
+      [~ this]
+    ?.  =(src.bol u.ship)
+      [~ this]
+    :_  this
+    :~  (group-poke pax.diff diff)
+    ==
+  ::
+      %unbundle
+    ?~  pax.diff
+      [~ this]
+    =/  ship  (~(get by synced) pax.diff)
+    ?~  ship
+      [~ this]
+    ?.  =(src.bol u.ship)
+      [~ this]
+    :_  this(synced (~(del by synced) pax.diff))
+    :~  (group-poke pax.diff diff)
+    ==
+  ::
+  ==
+::
+++  quit
+  |=  wir=wire
+  ^-  (quip move _this)
+  =/  wir  `(list @tas)`wir
+  =/  =ship  (slav %p &1:wir)
+  =.  wir  ?^  wir  t.wir  ~
+  =.  wir  ?^  wir  t.wir  ~
+  ?:  (~(has by synced) wir)
+    =/  group-path  [%group wir]
+    =/  group-wire  [(scot %p ship) group-path]
+    :_  (track-bone group-wire)
+    [ost.bol %peer group-wire [ship %group-hook] group-path]~
+  ::  no-op
+  [~ this]
+::
+++  reap
+  |=  [wir=wire saw=(unit tang)]
+  ^-  (quip move _this)
+  ?~  saw
+    [~ this]
+  =/  wir  `(list @tas)`wir
+  =/  =ship  (slav %p &1:wir)
+  =.  wir  ?^  wir  t.wir  ~
+  =.  wir  ?^  wir  t.wir  ~
+  ~&  %insufficient-permissions-for-group
+  [((slog u.saw) ~) this(synced (~(del by synced) wir))]
+::
+++  group-poke
+  |=  [pax=path action=group-action]
+  ^-  move
+  [ost.bol %poke pax [our.bol %group-store] [%group-action action]]
+::
+++  group-scry
+  |=  pax=path
+  ^-  (unit group)
+  =.  pax  ;:  weld
+    `path`/=group-store/(scot %da now.bol)
+    pax
+    `path`/noun
+  ==
+  .^((unit group) %gx pax)
+::
+++  track-bone
+  |=  wir=wire
+  ^+  this
+  =/  bnd  (~(get by boned) wir)
+  ?^  bnd
+    this(boned (~(put by boned) wir (snoc u.bnd ost.bol)))
+  this(boned (~(put by boned) wir [ost.bol]~))
+::
+++  pull-wire
+  |=  [wir=wire pax=path]
+  ^-  (list move)
+  =/  bnd  (~(get by boned) wir)
+  ?~  bnd
+    ~
+  =/  shp  (~(get by synced) pax)
+  ?~  shp
+    ~
+  %+  turn  u.bnd
+  |=  ost=bone
+  ^-  move
+  ?:  =(u.shp our.bol)
+    [ost %pull wir [our.bol %group-store] ~]
+  [ost %pull wir [u.shp %group-hook] ~]
+::
+--
+

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -1,0 +1,152 @@
+::  group-store: data store for groups of ships 
+::
+/-  *group-store
+|%
++$  move  [bone [%diff diff]]
+::
++$  state
+  $%  [%0 state-zero]
+  ==
+::
++$  state-zero
+  $:  =groups
+  ==
+::
++$  diff
+  $%  [%group-update group-update]
+      [%group-initial groups]
+  ==
+--
+::
+|_  [bol=bowl:gall state]
+::
+++  this  .
+::
+++  prep
+  |=  old=(unit state)
+  ^-  (quip move _this)
+  ?~  old
+    [~ this]
+  [~ this(+<+ u.old)]
+::
+++  peek-x
+  |=  pax=path
+  ^-  (unit (unit [%noun (unit group)]))
+  ?~  pax
+    [~ ~ %noun ~]
+  =/  grp=(unit group)  (~(get by groups) pax)
+  [~ ~ %noun grp]
+::
+++  peer-all
+  |=  pax=path
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)  !!
+  ::  we now proxy all events to this path
+  :_  this
+  [ost.bol %diff %group-initial groups]~
+::
+++  peer-keys
+  |=  pax=path
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)  !!
+  ::  we send the list of keys then send events when they change
+  :_  this
+  [ost.bol %diff %group-update [%keys ~(key by groups)]]~
+::
+++  peer-group
+  |=  pax=path
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)  !!
+  =/  grp=(unit group)  (~(get by groups) pax)
+  ?~  grp  !!
+  :_  this
+  [ost.bol %diff %group-update [%path u.grp pax]]~
+::
+++  poke-group-action
+  |=  action=group-action
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)
+    [~ this]
+  ?-  -.action
+      %add       (handle-add action)
+      %remove    (handle-remove action)
+      %bundle    (handle-bundle action)
+      %unbundle  (handle-unbundle action)
+  ==
+::
+++  handle-add
+  |=  act=group-action
+  ^-  (quip move _this)
+  ?>  ?=(%add -.act)
+  ?~  pax.act
+    [~ this]
+  ?.  (~(has by groups) pax.act)
+    [~ this]
+  =/  members=group  (~(got by groups) pax.act)
+  =.  members  (~(uni in members) members.act)
+  ?:  =(members (~(got by groups) pax.act))
+    [~ this]
+  :-  (send-diff pax.act act)
+  this(groups (~(put by groups) pax.act members))
+::
+++  handle-remove
+  |=  act=group-action
+  ^-  (quip move _this)
+  ?>  ?=(%remove -.act)
+  ?~  pax.act
+    [~ this]
+  ?.  (~(has by groups) pax.act)
+    [~ this]
+  =/  members  (~(got by groups) pax.act)
+  =.  members  (~(dif in members) members.act)
+  ?:  =(members (~(got by groups) pax.act))
+    [~ this]
+  :-  (send-diff pax.act act)
+  this(groups (~(put by groups) pax.act members))
+::
+++  handle-bundle
+  |=  act=group-action
+  ^-  (quip move _this)
+  ?>  ?=(%bundle -.act)
+  ?~  pax.act
+    [~ this]
+  ?:  (~(has by groups) pax.act)
+    [~ this]
+  :-  (send-diff pax.act act)
+  this(groups (~(put by groups) pax.act *group))
+::
+++  handle-unbundle
+  |=  act=group-action
+  ^-  (quip move _this)
+  ?>  ?=(%unbundle -.act)
+  ?~  pax.act
+    [~ this]
+  ?.  (~(has by groups) pax.act)
+    [~ this]
+  :-  (send-diff pax.act act)
+  this(groups (~(del by groups) pax.act))
+::
+++  send-diff
+  |=  [pax=path action=group-action]
+  ^-  (list move)
+  ;:  weld
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib /all bol)
+    |=  [=bone *]
+    [bone %diff %group-update action]
+  ::
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib [%group pax] bol)
+    |=  [=bone *]
+    [bone %diff %group-update action]
+  ::
+    ^-  (list move)
+    ?.  |(=(%bundle -.action) =(%unbundle -.action))
+      ~
+    %+  turn  (prey:pubsub:userlib /keys bol)
+    |=  [=bone *]
+    [bone %diff %group-update action]
+  ==
+::
+--
+

--- a/pkg/arvo/app/permission-group-hook.hoon
+++ b/pkg/arvo/app/permission-group-hook.hoon
@@ -1,0 +1,196 @@
+::  permission-group-hook:
+::  mirror the ships in some group to some set of permission paths
+::
+/-  *group-store, *permission-group-hook
+/+  *permission-json
+|%
++$  move  [bone card]
+::
++$  card
+  $%  [%diff [%group-update group-update]]
+      [%poke wire dock poke]
+      [%pull wire dock ~]
+      [%peer wire dock path]
+  ==
+::
++$  state
+  $%  [%0 state-zero]
+  ==
+::
++$  group-path  path
+::
++$  permission-path  path
+::
++$  state-zero
+  $:  relation=(map group-path (set permission-path))
+  ==
+::
++$  poke
+  $%  [%permission-action permission-action]
+  ==
+::
+--
+::
+|_  [bol=bowl:gall state]
+::
+++  this  .
+::
+++  prep
+  |=  old=(unit state)
+  ^-  (quip move _this)
+  ?~  old
+    [~ this]
+  [~ this(+<+ u.old)]
+::
+++  poke-json
+  |=  =json
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)
+    [~ this]
+  (poke-permission-group-hook-action (json-to-perm-group-hook-action json))
+::
+++  poke-permission-group-hook-action
+  |=  act=permission-group-hook-action
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)
+    [~ this]
+  ?-  -.act
+      %associate   (handle-associate group.act permissions.act)
+      %dissociate  (handle-dissociate group.act permissions.act)
+  ==
+::
+++  handle-associate
+  |=  [group=path permission-paths=(set [path kind])]
+  ^-  (quip move _this)
+  =/  perms  (~(get by relation) group)
+  ::  if relation does not exist, create it and subscribe.
+  =/  permissions
+    %-  silt
+    %+  turn  ~(tap in permission-paths)
+    |=  [=path =kind]
+    path
+  ?~  perms
+    =/  group-path  [%group group]
+    :_  this(relation (~(put by relation) group permissions))
+    [ost.bol %peer group-path [our.bol %group-store] group-path]~
+  =.  u.perms  (~(uni in u.perms) permissions)
+  :_  this(relation (~(put by relation) group u.perms))
+  %+  weld
+    %+  turn  ~(tap in permissions)
+    |=  =path
+    ^-  move
+    (permission-poke path [%delete path])
+  %+  turn  ~(tap in permission-paths)
+  |=  [=path =kind]
+  ^-  move
+  =/  pem  *permission
+  =.  kind.pem  kind
+  (permission-poke path [%create path pem])
+::
+++  handle-dissociate
+  |=  [group=path permissions=(set path)]
+  ^-  (quip move _this)
+  =/  perms  (~(get by relation) group)
+  ?~  perms
+    [~ this]
+  =.  permissions  (~(del in u.perms) permissions)
+  ?~  permissions
+    :_  this(relation (~(del by relation) group))
+    :~  (group-pull [%group group])
+    ==
+  :-  ~
+  this(relation (~(put by relation) group permissions))
+::
+++  diff-group-update
+  |=  [wir=wire diff=group-update]
+  ^-  (quip move _this)
+  ?-  -.diff
+      %keys
+    [~ this]
+      %bundle
+    [~ this]
+      %path
+    ::  set all permissions paths
+    =/  perms  (~(get by relation) pax.diff)
+    ?~  perms
+      [~ this]
+    :_  this
+    %+  turn  ~(tap in u.perms)
+    |=  =path
+    ^-  move
+    (permission-poke path [%add path members.diff])
+  ::
+      %add
+    ::  set all permissions paths
+    =/  perms  (~(get by relation) pax.diff)
+    ?~  perms
+      [~ this]
+    :_  this
+    %+  turn  ~(tap in u.perms)
+    |=  =path
+    ^-  move
+    (permission-poke path [%add path members.diff])
+  ::
+      %remove
+    ::  set all permissions paths
+    =/  perms  (~(get by relation) pax.diff)
+    ?~  perms
+      [~ this]
+    :_  this
+    %+  turn  ~(tap in u.perms)
+    |=  =path
+    ^-  move
+    (permission-poke path [%remove path members.diff])
+  ::
+      %unbundle
+    ::  pull subscriptions
+    =/  perms  (~(get by relation) pax.diff)
+    ?~  perms
+      :_  this(relation (~(del by relation) pax.diff))
+      :~  (group-pull [%group pax.diff])
+      ==
+    :_  this(relation (~(del by relation) pax.diff))
+    :-  (group-pull [%group pax.diff])
+    %+  turn  ~(tap in u.perms)
+    |=  =path
+    ^-  move
+    (permission-poke path [%delete path])
+  ::
+  ==
+::
+++  quit
+  |=  wir=wire
+  ^-  (quip move _this)
+  ::  no-op
+  [~ this]
+::
+++  reap
+  |=  [wir=wire saw=(unit tang)]
+  ^-  (quip move _this)
+  ?~  saw
+    [~ this]
+  =.  wir  ?^(wir t.wir ~)
+  ~&  %reap-permission-group-hook
+  [((slog u.saw) ~) this(relation (~(del by relation) wir))]
+::
+++  permission-poke
+  |=  [pax=path action=permission-action]
+  ^-  move
+  [ost.bol %poke pax [our.bol %permission-store] [%permission-action action]]
+::
+++  group-pull
+  |=  =path
+  ^-  move
+  [ost.bol %pull [%group path] [our.bol %group-store] ~]
+::
+++  permission-scry
+  |=  pax=path
+  ^-  (unit permission)
+  =.  pax  ;:  weld
+    `path`/=permission-store/(scot %da now.bol)/permission
+    pax
+    `path`/noun
+  ==
+  .^((unit permission) %gx pax)
+::
+--

--- a/pkg/arvo/app/permission-store.hoon
+++ b/pkg/arvo/app/permission-store.hoon
@@ -1,0 +1,178 @@
+::  permission-store: data store for keeping track of permissions
+::  permissions are white lists or black lists of ships
+::
+/-  *permission-store
+::
+|%
++$  move  [bone [%diff diff]]
+::
++$  diff
+  $%  [%permission-initial =permission-map]
+      [%permission-update =permission-update]
+  ==
+::
++$  state
+  $:  permissions=permission-map
+  ==
+--
+::
+|_  [bol=bowl:gall %v0 state]
+::
+++  this  .
+::
+::  gall interface
+::
+++  peer-all
+  |=  =path
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)  !!
+  ::  we now proxy all events to this path
+  :_  this
+  [ost.bol %diff %permission-initial permissions]~
+::
+++  peer-permission
+  |=  =path
+  ^-  (quip move _this)
+  ?~  path  !!
+  ?.  =(src.bol our.bol)  !!
+  ?.  (~(has by permissions) path)  !!
+  :_  this
+  [ost.bol %diff %permission-update [%create path (~(got by permissions) path)]]~
+::
+++  peek-x-keys
+  |=  pax=path
+  ^-  (unit (unit [%noun (set path)]))
+  [~ ~ %noun ~(key by permissions)]
+::
+++  peek-x-permission
+  |=  =path
+  ^-  (unit (unit [%noun (unit permission)]))
+  ?~  path
+    ~
+  [~ ~ %noun (~(get by permissions) path)]
+::
+++  peek-x-permitted
+  |=  =path
+  ^-  (unit (unit [%noun ?]))
+  ?~  path
+    ~
+  =/  pem  (~(get by permissions) t.path)
+  ?~  pem
+    ~
+  =/  who  (slav %p i.path)
+  =/  has  (~(has in who.u.pem) who)
+  :^  ~  ~  %noun
+  ?-(kind.u.pem %black !has, %white has)
+::
+++  poke-permission-action
+  |=  action=permission-action
+  ^-  (quip move _this)
+  ?.  =(src.bol our.bol)
+    [~ this]
+  ?-  -.action
+      %add     (handle-add action)
+      %remove  (handle-remove action)
+      %create  (handle-create action)
+      %delete  (handle-delete action)
+      %allow   (handle-allow action)
+      %deny    (handle-deny action)
+  ==
+::
+++  handle-add
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%add -.act)
+  ?~  path.act
+    [~ this]
+  ::  TODO: calculate diff
+  ::  =+  new=(~(dif in who.what.action) who.u.pem)
+  ::  ?~(new ~ `what.action(who new))
+  ?.  (~(has by permissions) path.act)
+    [~ this]
+  :-  (send-diff path.act act)
+  =/  perm  (~(got by permissions) path.act)
+  =.  who.perm  (~(uni in who.perm) who.act)
+  this(permissions (~(put by permissions) path.act perm))
+::
+++  handle-remove
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%remove -.act)
+  ?~  path.act
+    [~ this]
+  ?.  (~(has by permissions) path.act)
+    [~ this]
+  =/  perm  (~(got by permissions) path.act)
+  =.  who.perm  (~(dif in who.perm) who.act)
+  ::  TODO: calculate diff
+  ::  =+  new=(~(int in who.what.action) who.u.pem)
+  ::  ?~(new ~ `what.action(who new))
+  :-  (send-diff path.act act)
+  this(permissions (~(put by permissions) path.act perm))
+::
+++  handle-create
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%create -.act)
+  ?~  path.act
+    [~ this]
+  ?:  (~(has by permissions) path.act)
+    [~ this]
+  :: TODO: calculate diff
+  :-  (send-diff path.act act)
+  this(permissions (~(put by permissions) path.act permission.act))
+::
+++  handle-delete
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%delete -.act)
+  ?~  path.act
+    [~ this]
+  ?.  (~(has by permissions) path.act)
+    [~ this]
+  :-  (send-diff path.act act)
+  this(permissions (~(del by permissions) path.act))
+::
+++  handle-allow
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%allow -.act)
+  ?~  path.act
+    [~ this]
+  =/  perm  (~(get by permissions) path.act)
+  ?~  perm
+    [~ this]
+  ?:  =(kind.u.perm %white)
+    (handle-add [%add +.act])
+  (handle-remove [%remove +.act])
+::
+++  handle-deny
+  |=  act=permission-action
+  ^-  (quip move _this)
+  ?>  ?=(%deny -.act)
+  ?~  path.act
+    [~ this]
+  =/  perm  (~(get by permissions) path.act)
+  ?~  perm
+    [~ this]
+  ?:  =(kind.u.perm %black)
+    (handle-add [%add +.act])
+  (handle-remove [%remove +.act])
+::
+++  send-diff
+  |=  [pax=path update=permission-update]
+  ^-  (list move)
+  ;:  weld
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib /all bol)
+    |=  [=bone *]
+    [bone %diff %permission-update update]
+  ::
+    ^-  (list move)
+    %+  turn  (prey:pubsub:userlib [%permission pax] bol)
+    |=  [=bone *]
+    [bone %diff %permission-update update]
+  ::
+  ==
+::
+--

--- a/pkg/arvo/lib/group-json.hoon
+++ b/pkg/arvo/lib/group-json.hoon
@@ -1,0 +1,19 @@
+/-  *group-store
+|%
+++  groups-to-json
+  |=  grp=groups
+  ^-  json
+  =,  enjs:format
+  %+  frond  %group-initial
+  %-  pairs
+  %+  turn  ~(tap by grp)
+  |=  [pax=^path =group]
+  ^-  [@t json]
+  :-  (spat pax)
+  (set-to-array group ship:enjs:format)
+::
+++  set-to-array
+  |*  {a/(set) b/$-(* json)}
+  ^-  json
+  [%a (turn ~(tap in a) b)]
+--

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -93,6 +93,10 @@
       [%home %publish]
       [%home %clock]
       [%home %weather]
+      [%home %group-store]
+      [%home %group-hook]
+      [%home %permission-store]
+      [%home %permission-group-hook]
   ==
   :~  [%home %lens]
       [%home %acme]
@@ -106,6 +110,10 @@
       [%home %publish]
       [%home %clock]
       [%home %weather]
+      [%home %group-store]
+      [%home %group-hook]
+      [%home %permission-store]
+      [%home %permission-group-hook]
       [%home %azimuth-tracker]
   ==
 ::

--- a/pkg/arvo/lib/permission-json.hoon
+++ b/pkg/arvo/lib/permission-json.hoon
@@ -1,0 +1,56 @@
+/-  *permission-store
+|%
+++  permission-to-json
+  |=  pem=permission-map
+  =,  enjs:format
+  ^-  json
+  %+  frond  %permission-initial
+  %-  pairs
+  %+  turn  ~(tap by pem)
+  |=  [pax=^path =permission]
+  ^-  [cord json]
+  :-  (spat pax)
+  %-  pairs
+  :~  [%kind s+kind.permission]
+      [%who [%a (turn ~(tap in who.permission) ship)]]
+  ==
+::
+++  ki
+  =,  dejs:format
+  ^-  $-(json kind)
+  (su (perk %black %white ~))
+::
+++  json-to-set-path-kind
+  =,  dejs:format
+  %-  as
+  %-  ot
+  :~  [%path pa]
+      [%kind ki]
+  ==
+::
+++  json-to-perm-group-hook-action
+  |=  jon=json
+  =,  dejs:format
+  =<  (parse-action jon)
+  |%
+  ++  parse-action
+    %-  of
+    :~  [%associate associate]
+        [%dissociate dissociate]
+    ==
+  ::
+  ++  associate
+    %-  ot
+    :~  [%group pa]
+        [%permissions json-to-set-path-kind]
+    ==
+  ::
+  ++  dissociate
+    %-  ot
+    :~  [%group pa]
+        [%permissions (as pa)]
+    ==
+  ::
+  --
+--
+

--- a/pkg/arvo/mar/group-hook-action.hoon
+++ b/pkg/arvo/mar/group-hook-action.hoon
@@ -1,0 +1,25 @@
+/-  *group-hook
+=,  dejs:format
+|_  act=group-hook-action
+++  grab
+  |%
+  ++  noun  group-hook-action
+  ++  json
+    |=  jon=^json
+    =<  (parse-action jon)
+    |%
+    ++  parse-action
+      %-  of
+      :~
+        [%add add-action]
+        [%remove pa]
+      ==
+    ::
+    ++  add-action
+      %-  ot
+      :~  [%ship (su ;~(pfix sig fed:ag))]
+          [%path pa]
+      ==
+    --
+  --
+--

--- a/pkg/arvo/mar/group/action.hoon
+++ b/pkg/arvo/mar/group/action.hoon
@@ -1,0 +1,33 @@
+/+  *group-json
+=,  dejs:format
+|_  act=group-action
+++  grab
+  |%
+  ++  noun  group-action
+  ++  json
+    |=  jon=^json
+    =<  (parse-group-action jon)
+    |%
+    ++  parse-group-action
+      %-  of
+      :~
+        [%add add-action]
+        [%remove remove-action]
+        [%bundle pa]
+        [%unbundle pa]
+      ==
+    ::
+    ++  add-action
+      %-  ot
+      :~  [%members (as (su ;~(pfix sig fed:ag)))]
+          [%path pa]
+      ==
+    ::
+    ++  remove-action
+      %-  ot
+      :~  [%members (as (su ;~(pfix sig fed:ag)))]
+          [%path pa]
+      ==
+    --
+  --
+--

--- a/pkg/arvo/mar/group/initial.hoon
+++ b/pkg/arvo/mar/group/initial.hoon
@@ -1,0 +1,14 @@
+/+  *group-json
+|_  grp=groups
+::
+++  grow
+  |%
+  ++  json  (groups-to-json grp)
+  --
+::
+++  grab
+  |%
+  ++  noun  groups
+  --
+::
+--

--- a/pkg/arvo/mar/group/update.hoon
+++ b/pkg/arvo/mar/group/update.hoon
@@ -1,0 +1,62 @@
+/+  *group-json
+|_  upd=group-update
+++  grab
+  |%
+  ++  noun  group-update
+  --
+++  grow
+  |%
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    %+  frond  %group-update
+    %-  pairs
+    :~
+      ::
+      ::  %add
+      ?:  =(%add -.upd)
+        ?>  ?=(%add -.upd)
+        :-  %add
+        %-  pairs
+        :~  [%members (set-to-array members.upd ship)]
+            [%path (path pax.upd)]
+        ==
+      ::
+      ::  %remove
+      ?:  =(%remove -.upd)
+        ?>  ?=(%remove -.upd)
+        :-  %remove
+        %-  pairs
+        :~  [%members (set-to-array members.upd ship)]
+            [%path (path pax.upd)]
+        ==
+      ::
+      ::  %bundle
+      ?:  =(%bundle -.upd)
+        ?>  ?=(%bundle -.upd)
+        [%bundle (pairs [%path (path pax.upd)]~)]
+      ::
+      ::  %unbundle
+      ?:  =(%unbundle -.upd)
+        ?>  ?=(%unbundle -.upd)
+        [%unbundle (pairs [%path (path pax.upd)]~)]
+      ::
+      ::  %keys
+      ?:  =(%keys -.upd)
+        ?>  ?=(%keys -.upd)
+        [%keys (pairs [%keys (set-to-array keys.upd path)]~)]
+      ::
+      ::  %path
+      ?:  =(%path -.upd)
+        ?>  ?=(%path -.upd)
+        :-  %path
+        %-  pairs
+        :~  [%members (set-to-array members.upd ship)]
+            [%path (path pax.upd)]
+        ==
+      ::
+      ::  %noop
+      [*@t *^json]
+    ==
+  --
+--

--- a/pkg/arvo/mar/permission-group-hook-action.hoon
+++ b/pkg/arvo/mar/permission-group-hook-action.hoon
@@ -1,0 +1,11 @@
+/-  *permission-group-hook
+/+  *permission-json
+|_  act=permission-group-hook-action
+++  grab
+  |%
+  ++  noun  permission-group-hook-action
+  ++  json  
+    |=  jon=^json
+    (json-to-perm-group-hook-action jon)
+  --
+--

--- a/pkg/arvo/mar/permission/action.hoon
+++ b/pkg/arvo/mar/permission/action.hoon
@@ -1,0 +1,57 @@
+/+  *permission-json
+=,  dejs:format
+|_  act=permission-action
+++  grab
+  |%
+  ++  noun  permission-action
+  ++  json  
+    |=  jon=^json
+    =<  (parse-permission-action jon)
+    |%
+    ++  parse-permission-action
+      %-  of
+      :~  [%create create]
+          [%delete delete]
+          [%add add]
+          [%remove remove]
+          [%allow allow]
+          [%deny deny]
+      ==
+    ::
+    ++  create
+      %-  ot
+      :~  [%path pa]
+          [%kind ki]
+          [%who (as pa)]
+      ==
+    ::
+    ++  delete
+      (ot [%path pa]~)
+    ::
+    ++  add
+      %-  ot
+      :~  [%path pa]
+          [%who (as (su ;~(pfix sig fed:ag)))]
+      ==
+    ::
+    ++  remove
+      %-  ot
+      :~  [%path pa]
+          [%who (as (su ;~(pfix sig fed:ag)))]
+      ==
+    ::
+    ++  allow
+      %-  ot
+      :~  [%path pa]
+          [%who (as (su ;~(pfix sig fed:ag)))]
+      ==
+    ::
+    ++  deny
+      %-  ot
+      :~  [%path pa]
+          [%who (as (su ;~(pfix sig fed:ag)))]
+      ==
+    ::
+    --
+  --
+--

--- a/pkg/arvo/mar/permission/initial.hoon
+++ b/pkg/arvo/mar/permission/initial.hoon
@@ -1,0 +1,14 @@
+/+  *permission-json
+|_  pem=permission-map
+::
+++  grow
+  |%
+  ++  json  (permission-to-json pem)
+  --
+::
+++  grab
+  |%
+  ++  noun  permission-map
+  --
+::
+--

--- a/pkg/arvo/mar/permission/update.hoon
+++ b/pkg/arvo/mar/permission/update.hoon
@@ -1,0 +1,56 @@
+/+  *permission-json
+|_  upd=permission-update
+::
+++  grow
+  |%
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    %+  frond  %permission-update
+    %-  pairs
+    :~
+      ::
+      ::  %create
+      ?:  =(%create -.upd)
+        ?>  ?=(%create -.upd)
+        :-  %create
+        %-  pairs
+        :~  [%path (path path.upd)]
+            [%kind s+kind.permission.upd]
+            [%who [%a (turn ~(tap in who.permission.upd) ship)]]
+        ==
+      ::
+      ::  %delete
+      ?:  =(%delete -.upd)
+        ?>  ?=(%delete -.upd)
+        [%delete (path path.upd)]
+      ::
+      ::  %add
+      ?:  =(%add -.upd)
+        ?>  ?=(%add -.upd)
+        :-  %add
+        %-  pairs
+        :~  [%path (path path.upd)]
+            [%who [%a (turn ~(tap in who.upd) ship)]]
+        ==
+      ::
+      ::  %remove
+      ?:  =(%remove -.upd)
+        ?>  ?=(%remove -.upd)
+        :-  %remove
+        %-  pairs
+        :~  [%path (path path.upd)]
+            [%who [%a (turn ~(tap in who.upd) ship)]]
+        ==
+      ::
+      ::  %noop
+      [*@t *^json]
+    ==
+  --
+::
+++  grab
+  |%
+  ++  noun  permission-update
+  --
+::
+--

--- a/pkg/arvo/sur/group-hook.hoon
+++ b/pkg/arvo/sur/group-hook.hoon
@@ -1,0 +1,12 @@
+|%
++$  group-hook-action
+  $%  [%add =ship =path]             :: if ship is our, make the group publicly
+                                     :: available for other ships to sync
+                                     :: if ship is foreign, delete any local
+                                     :: group at that path and mirror the
+                                     :: foreign group at our local path
+                                     :: 
+      [%remove =path]                :: remove the path.
+  ==
+--
+

--- a/pkg/arvo/sur/group-store.hoon
+++ b/pkg/arvo/sur/group-store.hoon
@@ -1,0 +1,19 @@
+|%
++$  group  (set ship)
+::
++$  group-action
+  $%  [%add members=group pax=path]                :: add member to group
+      [%remove members=group pax=path]             :: remove member from group
+      [%bundle pax=path]                           :: create group at path
+      [%unbundle pax=path]                         :: delete group at path
+  ==
+::
++$  group-update
+  $%  [%keys keys=(set path)]                      :: keys have changed
+      [%path members=group pax=path]
+      group-action
+  ==
+::
++$  groups  (map path group)
+--
+

--- a/pkg/arvo/sur/permission-group-hook.hoon
+++ b/pkg/arvo/sur/permission-group-hook.hoon
@@ -1,0 +1,17 @@
+|%
++$  kind  ?(%black %white)
+::
++$  permission-group-hook-action
+  $%  ::  %associate: cause a group of ships to be mirrored onto some
+      ::  set of permission paths.
+      ::  note: this deletes any existing data at those permission paths first.
+      ::
+      [%associate group=path permissions=(set [path kind])]
+      ::
+      ::  %dissociate: stop mirroring between a group and a set
+      ::  of permission paths.
+      ::
+      [%dissociate group=path permissions=(set path)]
+  ==
+--
+

--- a/pkg/arvo/sur/permission-store.hoon
+++ b/pkg/arvo/sur/permission-store.hoon
@@ -1,0 +1,27 @@
+|%
++$  kind  ?(%black %white)
+::
++$  permission
+  $:  =kind
+      who=(set ship)
+  ==
+::
++$  permission-map  (map path permission)
+::
++$  permission-update
+  $%  [%create =path =permission]              ::  create perm at path
+      [%delete =path]                          ::  delete perm at path
+      [%add =path who=(set ship)]              ::  add ships to perm path
+      [%remove =path who=(set ship)]           ::  remove ships from perm path
+  ==
+::
++$  permission-action
+  $%  permission-update
+      [%allow =path who=(set ship)]            ::  if %black, remove
+                                               ::  if %white, add
+      [%deny =path who=(set ship)]             ::  if %black, add
+                                               ::  if %white, remove
+  ==
+::
+--
+


### PR DESCRIPTION
Added working and tested stores, hooks, and JSON marks. These have TODOs in them to no-op in a few cases where they don't currently (they send an update even though they did nothing), but apart from that, these are done.

Also, once some version of #1757 goes in, the group-json and permission-json can be refactored to use the functions in standard lib instead of using their own implementations. In the meantime, putting this out for review.