### PR TITLE
hood: remove hall dependency.

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -2,7 +2,7 @@
 ::::  /hoon/drum/hood/lib                               ::  ::
   ::                                                    ::  ::
 /?    310                                               ::  version
-/-    *sole, hall
+/-    *sole
 /+    sole
 ::                                                      ::  ::
 ::::                                                    ::  ::
@@ -146,7 +146,6 @@
 =>  |%                                                ::  arvo structures
     ++  pear                                          ::  request
       $%  {$sole-action p/sole-action}                ::
-          {$hall-command command:hall}                ::
       ==                                              ::
     ++  lime                                          ::  update
       $%  {$dill-blit dill-blit:dill}                ::
@@ -393,7 +392,7 @@
 ++  se-dump                                           ::  print tanks
   |=  tac/(list tank)
   ^+  +>
-  ?.  se-ably  (se-hall tac)
+  ?.  se-ably  ((slog tac) +>.$)
   =/  wol/wall
     (zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
   |-  ^+  +>.^$
@@ -471,21 +470,13 @@
   |=  mov/move
   %_(+> moz [mov moz])
 ::
-++  se-hall
-  |=  tac/(list tank)
-  ^+  +>
-  :: XX hall should be usable for stack traces, see urbit#584 which this change
-  :: closed for the problems there
-  ((slog (flop tac)) +>)
-  ::(se-emit 0 %poke /drum/hall [our.hid %hall] (said:hall our.hid %drum now.hid eny.hid tac))
-::
 ++  se-text                                           ::  return text
   |=  txt/tape
   ^+  +>
   ?.  ((sane %t) (crip txt))  :: XX upstream validation
     ~&  bad-text+<`*`txt>
     +>
-  ?.  se-ably  (se-hall [%leaf txt]~)
+  ?.  se-ably  ((slog [%leaf txt]~) +>.$)
   (se-blit %out (tuba txt))
 ::
 ++  se-poke                                           ::  send a poke

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -2,7 +2,7 @@
 ::::  /hoon/helm/hood/lib                               ::  ::
   ::                                                    ::  ::
 /?    310                                               ::  version
-/-    sole, hall
+/-    sole
 /+    pill
 ::                                                      ::  ::
 ::::                                                    ::  ::
@@ -53,7 +53,6 @@
       $%  {$hood-unsync desk ship desk}                 ::
           {$helm-hi cord}                               ::
           {$drum-start well:gall}                       ::
-          {$hall-action action:hall}                    ::
       ==                                                ::
     --
 =+  moz=((list move))

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -2,7 +2,6 @@
 ::::  /hoon/kiln/hood/lib                               ::  ::
   ::                                                    ::  ::
 /?  310                                                 ::  version
-/-  hall
 ::                                                      ::  ::
 ::::                                                    ::  ::
   ::                                                    ::  ::
@@ -79,8 +78,7 @@
           {$warp wire ship riff}                        ::
       ==                                                ::
     ++  pear                                            ::  poke fruit
-      $%  {$hall-command command:hall}                  ::
-          {$kiln-merge kiln-merge}                      ::
+      $%  {$kiln-merge kiln-merge}                      ::
           {$helm-reload (list term)}                    ::
           {$helm-reset ~}                              ::
       ==                                                ::
@@ -391,8 +389,6 @@
 ++  spam
   |=  mes/(list tank)
   ((slog mes) ..spam)
-::     %-  emit :: XX not displayed/immediately
-::     [%poke /kiln/spam [our %hall] (said our %kiln now eny mes)]
 ::
 ++  auto
   |=  kiln-sync


### PR DESCRIPTION
I had previously removed Hall and Talk from the apps that are started up upon the ship starting. I have now updated this branch to remove Hall dependencies from Hood but Hall and Talk are still started up upon boot. This should be an acceptable change since Hood shouldn't depend on Hall anyway.