### PR TITLE
u3: adds memory-pressure threshold detection

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:585c83b1389eb11336a53b6cb711d33d5d510b8c982efd3fe526cc09ecfbaa91
-size 15602738
+oid sha256:17ddfcc6ac026f6eea2d8fcff0641076adc190a6697139b8c5c42446191ff12c
+size 15681393

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -778,6 +778,17 @@
   ?:  ?=(?(%veer %verb %wack %warn) -.q.ovo)
     [[ovo ~] +>.$]
   ::
+  ::  These external events (currently only %trim) are global
+  ::  notifications, spammed to every vane
+  ::
+  ?:  ?=(%trim -.q.ovo)
+    =>  .(ovo ;;((pair wire [%trim @ud]) ovo))
+    =^  zef  vanes
+      (~(spam (is our vil eny bud vanes) now) lac ovo)
+    [zef +>.$]
+  ::
+  ::  Normal events are routed to a single vane
+  ::
   =^  zef  vanes
     (~(hurl (is our vil eny bud vanes) now) lac ovo)
   [zef +>.$]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1597,6 +1597,9 @@
           ~&  [%block p.kyz]
           fox(bad (~(put in bad.fox) p.kyz))
         ::
+            %trim
+          [~ fox]
+        ::
             %vega
           ::  re-initialize our cryptosuite B cores
           ::

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -93,6 +93,9 @@
       ::  if we errored, drop it
       event-core
     event-core(moves [duct %give %meta drip]~)
+  ::  +trim: in response to memory pressue
+  ::
+  ++  trim  [moves state]
   ::  +vega: learn of a kernel upgrade
   ::
   ++  vega  [moves state]
@@ -251,6 +254,7 @@
       %crud  (crud:event-core [p q]:task)
       %rest  (rest:event-core date=p.task)
       %drip  (drip:event-core move=p.task)
+      %trim  trim:event-core
       %vega  vega:event-core
       %wait  (wait:event-core date=p.task)
       %wake  (wake:event-core error=~)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4315,6 +4315,8 @@
       abet:(perm:den pax.req rit.req)
     [mos ..^$]
   ::
+      %trim  [~ ..^$]
+  ::
       %vega  [~ ..^$]
   ::
       ?(%warp %werp)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -553,9 +553,9 @@
     =?  p.task  ?=([%crud %hax-heft ~] p.task)  [%heft ~]
     ::
     $(hen u.hey.all, wrapped-task p.task)
-  ::  a %vega notification on kernel upgrade comes in on an unfamiliar duct
+  ::  %vega and %trim notifications come in on an unfamiliar duct
   ::
-  ?:  ?=(%vega -.task)
+  ?:  ?=(?(%trim %vega) -.task)
     [~ ..^$]
   ::
   =/  nus  (ax hen)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1908,6 +1908,10 @@
           [[~ /~/channel] duct [%channel ~]]
       ==
     [~ http-server-gate]
+  ::  %trim: in response to memory pressure
+  ::
+  ?:  ?=(%trim -.task)
+    [~ http-server-gate]
   ::  %vega: notifies us of a completed kernel upgrade
   ::
   ?:  ?=(%vega -.task)

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6169,6 +6169,14 @@
     ::
     [moves ford-gate]
   ::
+      ::  %trim: in response to memory pressure
+      ::
+      ::    XX clear cache
+      ::
+      %trim
+    ::
+    [~ ford-gate]
+  ::
       ::  %vega: learn of kernel upgrade
       ::
       ::    XX clear cache, rebuild live builds

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2477,6 +2477,9 @@
     =/  payload  gall-payload(system-duct.agents.state duct)
     [~ payload]
   ::
+      %trim
+    [~ gall-payload]
+  ::
       %vega
     [~ gall-payload]
   ::

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -317,6 +317,10 @@
     =/  moves=(list move)
       [[duct %slip %d %flog task] ~]
     [moves light-gate]
+  ::  %trim: in response to memory pressure
+  ::
+  ?:  ?=(%trim -.task)
+    [~ light-gate]
   ::  %vega: notifies us of a completed kernel upgrade
   ::
   ?:  ?=(%vega -.task)

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -456,6 +456,11 @@
     ::    [%vega ~]
     ::
         %vega
+      +>.$::
+    ::  in response to memory pressure
+    ::    [%trim p=@ud]
+    ::
+        %trim
       +>.$
     ::
     ::  watch private keys

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -203,6 +203,9 @@
       ::  boot completed (XX legacy)
       ::
       [%init p=ship]
+      ::  trim state (in response to memory pressure)
+      ::
+      [%trim p=@ud]
       ::  kernel upgraded
       ::
       [%vega ~]
@@ -390,6 +393,7 @@
           $>(%init vane-task)                           ::  report install
           {$kick p/@da}                                 ::  wake up
           {$nuke p/@p}                                  ::  toggle auto-block
+          $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           {$wake ~}                                     ::  timer activate
           $>(%wegh vane-task)                           ::  report memory
@@ -571,6 +575,7 @@
           $>(%crud vane-task)                           ::  error with trace
           [%rest p=@da]                                 ::  cancel alarm
           [%drip p=vase]                                ::  give in next event
+          $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           [%wait p=@da]                                 ::  set alarm
           [%wake ~]                                     ::  timer activate
@@ -624,6 +629,7 @@
           {$dirk des/desk}                              ::  mark mount dirty
           {$ogre pot/$@(desk beam)}                     ::  delete mount point
           {$perm des/desk pax/path rit/rite}            ::  change permissions
+          $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           {$warp wer/ship rif/riff}                     ::  internal file req
           {$werp who/ship wer/ship rif/riff}            ::  external file req
@@ -793,6 +799,7 @@
           {$talk p/tank}                                ::
           {$text p/tape}                                ::
           {$veer p/@ta q/path r/@t}                     ::  install vane
+          $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           {$verb ~}                                     ::  verbose mode
       ==                                                ::
@@ -896,6 +903,9 @@
           ::  new unix process
           ::
           $>(%born vane-task)
+          ::  trim state (in response to memory pressure)
+          ::
+          $>(%trim vane-task)
           ::  report upgrade
           ::
           $>(%vega vane-task)
@@ -1176,6 +1186,9 @@
           ::  %kill: stop a build; send on same duct as original %build request
           ::
           [%kill ~]
+          ::  trim state (in response to memory pressure)
+          ::
+          $>(%trim vane-task)
           ::  %vega: report kernel upgrade
           ::
           $>(%vega vane-task)
@@ -1870,6 +1883,7 @@
       $%  {$conf p/dock q/dock}                         ::  configure app
           $>(%init vane-task)                           ::  set owner
           {$deal p/sock q/internal-task}                ::  full transmission
+          $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           $>(%west vane-task)                           ::  network request
           [%wash ~]                                     ::  clear caches
@@ -1956,6 +1970,9 @@
           ::  system started up; reset open connections
           ::
           $>(%born vane-task)
+          ::  trim state (in response to memory pressure)
+          ::
+          $>(%trim vane-task)
           ::  report upgrade
           ::
           $>(%vega vane-task)
@@ -2075,6 +2092,7 @@
           [%private-keys ~]                             ::  sub to privates
           [%public-keys ships=(set ship)]               ::  sub to publics
           [%rekey =life =ring]                          ::  update private keys
+          $>(%trim vane-task)                           ::  trim state
           [%turf ~]                                     ::  view domains
           $>(%vega vane-task)                           ::  report upgrade
           $>(%wegh vane-task)                           ::  memory usage request

--- a/pkg/urbit/include/c/motes.h
+++ b/pkg/urbit/include/c/motes.h
@@ -1134,6 +1134,7 @@
 #   define c3__trel   c3_s4('t','r','e','l')
 #   define c3__trex   c3_s4('t','r','e','x')
 #   define c3__trib   c3_s4('t','r','i','b')
+#   define c3__trim   c3_s4('t','r','i','m')
 #   define c3__trip   c3_s4('t','r','i','p')
 #   define c3__trol   c3_s4('t','r','o','l')
 #   define c3__trop   c3_s4('t','r','o','p')

--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -438,6 +438,11 @@
           c3_w
           u3a_mark_road(FILE* fil_u);
 
+        /* u3a_idle(): measure free-lists in [rod_u]
+        */
+          c3_w
+          u3a_idle(u3a_road* rod_u);
+
         /* u3a_sweep(): sweep a fully marked road.
         */
           c3_w

--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -214,9 +214,30 @@
 #     define  u3a_is_north(r)  __(r->cap_p > r->hat_p)
 #     define  u3a_is_south(r)  !u3a_is_north(r)
 
-#     define  u3a_open(r)      ( (c3y == u3a_is_north(r)) \
-                                  ? (c3_w)(r->cap_p - r->hat_p) \
-                                  : (c3_w)(r->hat_p - r->cap_p) )
+    /* u3a_open(): words of contiguous free space in [r]
+    */
+#     define  u3a_open(r)  ( (c3y == u3a_is_north(r)) \
+                             ? (c3_w)(r->cap_p - r->hat_p) \
+                             : (c3_w)(r->hat_p - r->cap_p) )
+
+    /* u3a_full(): words of [r];
+    ** u3a_full(r) == u3a_heap(r) + u3a_temp(r) + u3a_open(r)
+    */
+#     define  u3a_full(r)  ( (c3y == u3a_is_north(r)) \
+                             ? (c3_w)(r->mat_p - r->rut_p) \
+                             : (c3_w)(r->rut_p - r->mat_p) )
+
+    /* u3a_heap(): words of heap in [r]
+    */
+#     define  u3a_heap(r)  ( (c3y == u3a_is_north(r)) \
+                             ? (c3_w)(r->hat_p - r->rut_p) \
+                             : (c3_w)(r->rut_p - r->hat_p) )
+
+    /* u3a_temp(): words of stack in [r]
+    */
+#     define  u3a_temp(r)  ( (c3y == u3a_is_north(r)) \
+                             ? (c3_w)(r->mat_p - r->cap_p) \
+                             : (c3_w)(r->cap_p - r->mat_p) )
 
 #     define  u3a_north_is_senior(r, dog) \
                 __((u3a_to_off(dog) < r->rut_p) ||  \

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1840,6 +1840,28 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_ws use_ws)
 
 #endif
 
+/* u3a_idle(): measure free-lists in [rod_u]
+*/
+c3_w
+u3a_idle(u3a_road* rod_u)
+{
+  u3a_fbox* fox_u;
+  c3_w i_w, fre_w = 0;
+
+  for ( i_w = 0; i_w < u3a_fbox_no; i_w++ ) {
+    u3p(u3a_fbox) fre_p = rod_u->all.fre_p[i_w];
+
+    while ( fre_p ) {
+      u3a_fbox* fox_u = u3to(u3a_fbox, fre_p);
+
+      fre_w += fox_u->box_u.siz_w;
+      fre_p  = fox_u->nex_p;
+    }
+  }
+
+  return fre_w;
+}
+
 /* u3a_sweep(): sweep a fully marked road.
 */
 c3_w
@@ -1851,19 +1873,8 @@ u3a_sweep(void)
   */
   {
     c3_w end_w = u3a_heap(u3R);
-    c3_w fre_w = 0;
-    c3_w i_w;
+    c3_w fre_w = u3a_idle(u3R);
 
-    for ( i_w = 0; i_w < u3a_fbox_no; i_w++ ) {
-      u3p(u3a_fbox) fre_p = u3R->all.fre_p[i_w];
-
-      while ( fre_p ) {
-        u3a_fbox* fre_u = u3to(u3a_fbox, fre_p);
-
-        fre_w += fre_u->box_u.siz_w;
-        fre_p = fre_u->nex_p;
-      }
-    }
 #ifdef U3_CPU_DEBUG
     if ( fre_w != u3R->all.fre_w ) {
       u3l_log("fre discrepancy (%x): %x, %x, %x\r\n", u3R->par_p,

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -56,7 +56,7 @@ static u3a_box*
 _box_make(void* box_v, c3_w siz_w, c3_w use_w)
 {
   u3a_box* box_u = box_v;
-  c3_w*      box_w = box_v;
+  c3_w*    box_w = box_v;
 
   c3_assert(siz_w >= u3a_minimum);
 
@@ -894,7 +894,6 @@ u3a_free2(void* tox_v, size_t siz_i)
   return u3a_free(tox_v);
 }
 
-#if 1
 /* _me_wash_north(): clean up mug slots after copy.
 */
 static void _me_wash_north(u3_noun dog);
@@ -980,16 +979,13 @@ u3a_wash(u3_noun som)
     }
   }
 }
-#endif
-
-extern u3_noun BDA, BDB;
 
 /* _me_gain_use(): increment use count.
 */
 static void
 _me_gain_use(u3_noun dog)
 {
-  c3_w* dog_w      = u3a_to_ptr(dog);
+  c3_w*    dog_w = u3a_to_ptr(dog);
   u3a_box* box_u = u3a_botox(dog_w);
 
   if ( 0x7fffffff == box_u->use_w ) {
@@ -1002,44 +998,10 @@ _me_gain_use(u3_noun dog)
     box_u->use_w += 1;
 
 #ifdef U3_MEMORY_DEBUG
+    //  enable to (maybe) help track down leaks
+    //
     // if ( u3_Code && !box_u->cod_w ) { box_u->cod_w = u3_Code; }
-
-#if 0
-    if ( u3r_mug(dog) == 0x15d47649 ) {
-      static c3_w bug_w = 0;
-
-      u3l_log("bad %x %d %d\r\n", dog, bug_w, box_u->use_w);
-      if ( bug_w == 0 ) { abort(); }
-      bug_w++;
-    }
 #endif
-#if 0
-    {
-      static c3_w bug_w = 0;
-
-      if ( BDA == dog ) {
-        u3l_log("BDA %d %d\r\n", bug_w, box_u->use_w);
-        // if ( bug_w == 0 ) { abort(); }
-        bug_w++;
-      }
-    }
-#endif
-
-#if 0
-    {
-      static c3_w bug_w = 0;
-
-      if ( FOO && u3a_botox(u3a_to_ptr(dog)) == (void *)0x200dfe3e4 ) {
-        u3a_box* box_u = u3a_botox(u3a_to_ptr(dog));
-
-        u3l_log("GAIN %d %d\r\n", bug_w, box_u->use_w);
-        if ( bug_w == 8 ) { abort(); }
-        bug_w++;
-      }
-    }
-#endif
-#endif
-
   }
 }
 
@@ -1485,7 +1447,7 @@ u3a_use(u3_noun som)
     return 1;
   }
   else {
-    c3_w* dog_w      = u3a_to_ptr(som);
+    c3_w*    dog_w = u3a_to_ptr(som);
     u3a_box* box_u = u3a_botox(dog_w);
 
     return box_u->use_w;
@@ -2054,9 +2016,9 @@ u3a_slaq(c3_g met_g, c3_w len_w)
 u3_noun
 u3a_malt(c3_w* sal_w)
 {
-  c3_w*       nov_w = (sal_w - c3_wiseof(u3a_atom));
+  c3_w*     nov_w = (sal_w - c3_wiseof(u3a_atom));
   u3a_atom* nov_u = (void *)nov_w;
-  c3_w        len_w;
+  c3_w      len_w;
 
   for ( len_w = nov_u->len_w; len_w; len_w-- ) {
     if ( 0 != nov_u->buf_w[len_w - 1] ) {
@@ -2126,7 +2088,7 @@ c3_d
 u3a_detect(u3_noun fum, u3_noun som)
 {
   u3p(u3h_root) har_p = u3h_new();
-  c3_o            ret_o;
+  c3_o          ret_o;
 
   ret_o = _ca_detect(har_p, fum, som, 1);
   u3h_free(har_p);
@@ -2140,7 +2102,7 @@ u3a_detect(u3_noun fum, u3_noun som)
 u3_noun
 u3a_mint(c3_w* sal_w, c3_w len_w)
 {
-  c3_w*       nov_w = (sal_w - c3_wiseof(u3a_atom));
+  c3_w*     nov_w = (sal_w - c3_wiseof(u3a_atom));
   u3a_atom* nov_u = (void*)nov_w;
 
   /* See if we can free the slab entirely.

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1698,7 +1698,11 @@ u3m_boot_lite(void)
 void
 u3m_reclaim(void)
 {
+  c3_assert( &(u3H->rod_u) == u3R );
+
   //  clear the u3v_wish cache
+  //
+  //    NB: this will leak if not on the home road
   //
   u3z(u3A->yot);
   u3A->yot = u3_nul;
@@ -1713,11 +1717,11 @@ u3m_reclaim(void)
   u3h_free(u3R->jed.bas_p);
   u3R->jed.bas_p = u3h_new();
 
-  //  XX we can't clear the warm jet state
-  //  -- _cj_nail expects it to be present ...
+  //  re-establish the warm jet state
   //
-  // u3h_free(u3R->jed.war_p);
-  // u3R->jed.war_p = u3h_new();
+  //    XX might this reduce fragmentation?
+  //
+  // u3j_ream();
 
   //  clear the jet hank cache
   //

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -900,8 +900,8 @@ u3m_water(c3_w* low_w, c3_w* hig_w)
 {
   c3_assert(u3R == &u3H->rod_u);
 
-  *low_w = (u3H->rod_u.hat_p - u3H->rod_u.rut_p);
-  *hig_w = (u3H->rod_u.mat_p - u3H->rod_u.cap_p) + c3_wiseof(u3v_home);
+  *low_w = u3a_heap(u3R);
+  *hig_w = u3a_temp(u3R) + c3_wiseof(u3v_home);
 }
 
 /* u3m_soft_top(): top-level safety wrapper.

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -358,12 +358,12 @@ u3v_mark(FILE* fil_u)
   u3v_arvo* arv_u = &(u3H->arv_u);
   c3_w tot_w = 0;
 
-  tot_w += u3a_maid(fil_u, "  wish cache", u3a_mark_noun(arv_u->yot));
+  tot_w += u3a_maid(fil_u, "  kernel", u3a_mark_noun(arv_u->roc));
   tot_w += u3a_maid(fil_u, "  date", u3a_mark_noun(arv_u->now));
   tot_w += u3a_maid(fil_u, "  formatted date", u3a_mark_noun(arv_u->wen));
   tot_w += u3a_maid(fil_u, "  instance string", u3a_mark_noun(arv_u->sen));
   tot_w += u3a_maid(fil_u, "  identity", u3a_mark_noun(arv_u->our));
   tot_w += u3a_maid(fil_u, "  fake", u3a_mark_noun(arv_u->fak));
-  tot_w += u3a_maid(fil_u, "  kernel", u3a_mark_noun(arv_u->roc));
+  tot_w += u3a_maid(fil_u, "  wish cache", u3a_mark_noun(arv_u->yot));
   return   u3a_maid(fil_u, "total arvo stuff", tot_w);
 }

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -142,6 +142,19 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
   c3_assert(!"not reached"); return 0;
 }
 
+/* _reck_kick_arvo(): apply loopback effects.
+*/
+static u3_noun
+_reck_kick_arvo(u3_pier* pir_u, u3_noun pox, u3_noun fav)
+{
+  if ( c3__trim == u3h(fav) ) {
+    u3_pier_work(pir_u, pox, fav);
+    return c3y;
+  }
+
+  u3z(pox); u3z(fav); return c3n;
+}
+
 /* _reck_kick_behn(): apply packet network outputs.
 */
 static u3_noun
@@ -325,6 +338,10 @@ _reck_kick_spec(u3_pier* pir_u, u3_noun pox, u3_noun fav)
     }
     else switch ( it_pox ) {
       default: u3z(pox); u3z(fav); return c3n;
+
+      case c3__arvo: {
+        return _reck_kick_arvo(pir_u, pox, fav);
+      } break;
 
       case c3__behn: {
         return _reck_kick_behn(pir_u, pox, fav);

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -588,21 +588,30 @@ _worker_work_live(c3_d evt_d, u3_noun job)
     //    XX refactor: we should measure memory after losing the old kernel
     //
     {
+      u3_noun pri = u3_none;
       c3_w pos_w = u3a_open(u3R);
       c3_w low_w = (1 << 27);
       c3_w hig_w = (1 << 22);
 
       if ( (pre_w > low_w) && !(pos_w > low_w) ) {
-        //  XX emit low-priority trim event
         //  XX set flag in u3V so we don't repeat endlessly?
         //
         rec_o = c3y;
+        pri   = 1;
       }
       else if ( (pre_w > hig_w) && !(pos_w > hig_w) ) {
-        //  XX emit high-priority trim event
         //  XX we should probably jam/cue our entire state at this point
         //
         rec_o = c3y;
+        pri   = 0;
+      }
+
+      //  notify daemon of memory pressure via "fake" effect
+      //
+      if ( u3_none != pri ) {
+        u3_noun cad = u3nc(u3nt(u3_blip, c3__arvo, u3_nul),
+                           u3nc(c3__trim, pri));
+        vir = u3nc(cad, vir);
       }
     }
 

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -494,8 +494,8 @@ _worker_sure(u3_noun ovo, u3_noun vir, u3_noun cor)
 static void
 _worker_work_live(c3_d evt_d, u3_noun job)
 {
-  u3_noun now, ovo, gon;
-  u3_noun last_date;
+  u3_noun now, ovo, gon, last_date;
+  c3_w pre_w = u3a_open(u3R);
 
   c3_assert(evt_d == u3V.dun_d + 1ULL);
   u3V.sen_d = evt_d;
@@ -537,9 +537,9 @@ _worker_work_live(c3_d evt_d, u3_noun job)
   }
 #endif
 
+  //  event rejected
+  //
   if ( u3_blip != u3h(gon) ) {
-    //  event rejected
-    //
     u3V.sen_d = u3V.dun_d;
     //  restore previous time
     //
@@ -554,11 +554,10 @@ _worker_work_live(c3_d evt_d, u3_noun job)
 
     _worker_lame(evt_d, nex, ovo, why, tan);
   }
+  //  event accepted
+  //
   else {
-    //  event accepted
-    //
-    u3V.dun_d = u3V.sen_d;
-    u3z(last_date);
+    c3_o rec_o = c3n;
 
     //  vir/(list ovum)  list of effects
     //  cor/arvo         arvo core
@@ -567,17 +566,48 @@ _worker_work_live(c3_d evt_d, u3_noun job)
     u3x_trel(gon, 0, &vir, &cor);
 
     u3k(ovo); u3k(vir); u3k(cor);
-    u3z(gon); u3z(job);
+    u3z(gon); u3z(job); u3z(last_date);
+
+    u3V.dun_d = u3V.sen_d;
+
+    //  after a successful event, we check for memory pressure.
+    //
+    //    if we've exceeded either of two thresholds, we reclaim
+    //    from our persistent caches, and notify the daemon
+    //    (via a "fake" effect) that arvo should trim state
+    //    (trusting that the daemon will enqueue an appropriate event).
+    //    For future flexibility, the urgency of the notification is represented
+    //    by a *decreasing* number: 0 is maximally urgent, 1 less so, &c.
+    //
+    //    high-priority: 2^22 contiguous words remaining (~8 MB)
+    //    low-priority:  2^27 contiguous words remaining (~536 MB)
+    //    XX maybe use 2^23 (~16 MB) and 2^26 (~268 MB?
+    //
+    //    XX refactor: we should measure memory after losing the old kernel
+    //
+    {
+      c3_w pos_w = u3a_open(u3R);
+      c3_w low_w = (1 << 27);
+      c3_w hig_w = (1 << 22);
+
+      if ( (pre_w > low_w) && !(pos_w > low_w) ) {
+        //  XX emit low-priority trim event
+        //  XX set flag in u3V so we don't repeat endlessly?
+        //
+        rec_o = c3y;
+      }
+      else if ( (pre_w > hig_w) && !(pos_w > hig_w) ) {
+        //  XX emit high-priority trim event
+        //  XX we should probably jam/cue our entire state at this point
+        //
+        rec_o = c3y;
+      }
+    }
 
     _worker_sure(ovo, vir, cor);
 
-    //  reclaim memory from persistent caches periodically
-    //
-    //    XX this is a hack to work around the fact that
-    //    the bytecode caches grow rapidly and are not
-    //    able to be simply capped (due to internal posts).
-    //
-    if ( 0 == (evt_d % 1000ULL) ) {
+
+    if ( c3y == rec_o ) {
       u3m_reclaim();
     }
   }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -308,6 +308,8 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
     u3a_print_memory(fil_u, "total marked", tot_w);
     u3a_print_memory(fil_u, "sweep", u3a_sweep());
 
+    fflush(fil_u);
+
 #ifdef U3_MEMORY_LOG
     {
       fclose(fil_u);


### PR DESCRIPTION
... and handling in both vere and arvo.

In vere, we simply clear all persistent caches, at either threshold. More precise cache management remains a goal. The current thresholds are roughly `75%` and `90%` of linear home-road use -- they do not take free-lists into account. Threshold detection is stateless, so it's possible that some resource usage patterns could result in frequent crossing/recrossing of a threshold.

In Arvo, we "spam" a `%trim` notification to every vane. That notification includes a *priority* `@ud` -- `0` is maximally urgent, `1` is less so. This scheme will let us simply add lower priority levels in the future as needed.

The vane `%trim` task handlers are currently all stubs. Top reclamation targets include the build cache in `%ford`, the compiler caches in `%gall` and arvo proper, foreign desks and various caches in `%clay`, and so on. I intend to PR minimum-viable reclamations for those separately.

This PR also includes some minor refactoring in the allocator.