### PR TITLE
u3: refactors memoization patterns for safer reference-counting

### DIFF
--- a/pkg/urbit/include/noun/zave.h
+++ b/pkg/urbit/include/noun/zave.h
@@ -12,22 +12,27 @@
   ***
   ***  Memo functions RETAIN keys and transfer values.
   **/
-    /* u3z_find*(): find in memo cache.
+    /* u3z_key*(): construct a memo cache-key.  Arguments retained.
     */
-      u3_weak u3z_find(c3_m, u3_noun);
-      u3_weak u3z_find_2(c3_m, u3_noun, u3_noun);
-      u3_weak u3z_find_3(c3_m, u3_noun, u3_noun, u3_noun);
-      u3_weak u3z_find_4(c3_m, u3_noun, u3_noun, u3_noun, u3_noun);
+      u3_noun u3z_key(c3_m, u3_noun);
+      u3_noun u3z_key_2(c3_m, u3_noun, u3_noun);
+      u3_noun u3z_key_3(c3_m, u3_noun, u3_noun, u3_noun);
+      u3_noun u3z_key_4(c3_m, u3_noun, u3_noun, u3_noun, u3_noun);
 
-    /* u3z_save*(): save in memo cache.
+    /* u3z_find*(): find in memo cache. Arguments retained
     */
-      u3_noun u3z_save(c3_m, u3_noun, u3_noun);
-      u3_noun u3z_save_2(c3_m, u3_noun, u3_noun, u3_noun);
-      u3_noun u3z_save_3(c3_m, u3_noun, u3_noun, u3_noun, u3_noun);
-      u3_noun u3z_save_4(c3_m, u3_noun, u3_noun, u3_noun, u3_noun, u3_noun);
+      u3_weak u3z_find(u3_noun key);
+      u3_weak u3z_find_m(c3_m fun_m, u3_noun one);
+
+    /* u3z_save(): save in memo cache. TRANSFER key; RETAIN val;
+    */
+      u3_noun u3z_save(u3_noun key, u3_noun val);
+
+    /* u3z_save_m(): save in memo cache. Arguments retained
+    */
+      u3_noun u3z_save_m(c3_m fun_m, u3_noun one, u3_noun val);
 
     /* u3z_uniq(): uniquify with memo cache.
     */
       u3_noun
       u3z_uniq(u3_noun som);
-

--- a/pkg/urbit/jets/f/ut_crop.c
+++ b/pkg/urbit/jets/f/ut_crop.c
@@ -3,26 +3,28 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_crop(u3_noun cor)
+u3_noun
+u3wfu_crop(u3_noun cor)
+{
+  u3_noun sut, ref, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, ref, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__crop + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__crop + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_2(fun_m, sut, ref);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_2(fun_m, sut, ref, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_fish.c
+++ b/pkg/urbit/jets/f/ut_fish.c
@@ -3,27 +3,29 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_fish(u3_noun cor)
+u3_noun
+u3wfu_fish(u3_noun cor)
+{
+  u3_noun sut, axe, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam, &axe, u3x_con, &van, 0)) ||
+       (c3n == u3ud(axe)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, axe, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__fish + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_2(fun_m, sut, axe);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &axe, u3x_con, &van, 0)) ||
-         (c3n == u3ud(axe)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__fish + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_2(fun_m, sut, axe);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor))); 
-
-        return u3z_save_2(fun_m, sut, axe, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor))); 
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_fond.c
+++ b/pkg/urbit/jets/f/ut_fond.c
@@ -3,30 +3,32 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_fond(u3_noun cor)
+u3_noun
+u3wfu_fond(u3_noun cor)
+{
+  u3_noun sut, way, hyp, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &way,
+                             u3x_sam_3, &hyp,
+                             u3x_con, &van,
+                             0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, way, hyp, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__fond + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_3(fun_m, sut, way, hyp);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &way,
-                               u3x_sam_3, &hyp,
-                               u3x_con, &van,
-                               0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__fond + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_3(fun_m, sut, way, hyp);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_3(fun_m, sut, way, hyp, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}
 

--- a/pkg/urbit/jets/f/ut_fuse.c
+++ b/pkg/urbit/jets/f/ut_fuse.c
@@ -3,26 +3,28 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_fuse(u3_noun cor)
+u3_noun
+u3wfu_fuse(u3_noun cor)
+{
+  u3_noun sut, ref, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, ref, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__fuse + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__fuse + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_2(fun_m, sut, ref);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_2(fun_m, sut, ref, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_mint.c
+++ b/pkg/urbit/jets/f/ut_mint.c
@@ -3,30 +3,32 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_mint(u3_noun cor)
+u3_noun
+u3wfu_mint(u3_noun cor)
+{
+  u3_noun sut, gol, gen, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
+                             u3x_sam_3, &gen,
+                             u3x_con, &van,
+                             0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, gol, gen, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__mint;
+    u3_noun vrf = u3r_at(u3qfu_van_vrf, van);
+    u3_noun key = u3z_key_4(fun_m, vrf, sut, gol, gen);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                               u3x_sam_3, &gen,
-                               u3x_con, &van,
-                               0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__mint;
-      u3_noun vrf   = u3r_at(u3qfu_van_vrf, van);
-      u3_noun pro   = u3z_find_4(fun_m, vrf, sut, gol, gen);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_4(fun_m, vrf, sut, gol, gen, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_mull.c
+++ b/pkg/urbit/jets/f/ut_mull.c
@@ -3,30 +3,32 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_mull(u3_noun cor)
+u3_noun
+u3wfu_mull(u3_noun cor)
+{
+  u3_noun sut, gol, dox, gen, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
+                             u3x_sam_6, &dox,
+                             u3x_sam_7, &gen,
+                             u3x_con, &van,
+                             0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, gol, dox, gen, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__mull + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_4(fun_m, sut, gol, dox, gen);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                               u3x_sam_6, &dox,
-                               u3x_sam_7, &gen,
-                               u3x_con, &van,
-                               0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__mull + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_4(fun_m, sut, gol, dox, gen);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_4(fun_m, sut, gol, dox, gen, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_nest.c
+++ b/pkg/urbit/jets/f/ut_nest.c
@@ -3,41 +3,46 @@
 */
 #include "all.h"
 
+u3_noun
+u3wfu_nest_dext(u3_noun dext_core)
+{
+  u3_noun nest_in_core, nest_core;
+  u3_noun sut, ref, van, seg, reg, gil;
 
-  u3_noun
-  u3wfu_nest_dext(u3_noun dext_core)
+  if ( (u3_none == (nest_in_core = u3r_at(3, dext_core))) ||
+       (c3n == u3r_mean(nest_in_core, u3x_sam_2, &seg,
+                                      u3x_sam_6, &reg,
+                                      u3x_sam_7, &gil,
+                                      7, &nest_core,
+                                      0)) ||
+       (c3n == u3r_mean(nest_core, u3x_sam_3, &ref,
+                                   u3x_con, &van,
+                                   0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun nest_in_core, nest_core;
-    u3_noun sut, ref, van, seg, reg, gil;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__dext + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak pro = u3z_find(key);
 
-    if ( (u3_none == (nest_in_core = u3r_at(3, dext_core))) ||
-         (c3n == u3r_mean(nest_in_core, u3x_sam_2, &seg,
-                                        u3x_sam_6, &reg,
-                                        u3x_sam_7, &gil,
-                                        7, &nest_core,
-                                        0)) ||
-         (c3n == u3r_mean(nest_core, u3x_sam_3, &ref,
-                                     u3x_con, &van,
-                                     0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__dext + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_2(fun_m, sut, ref);
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(dext_core), u3k(u3x_at(u3x_bat, dext_core)));
 
-      if ( u3_none != pro ) {
-        return pro;
+      if ( ((c3y == pro) && (u3_nul == reg)) ||
+           ((c3n == pro) && (u3_nul == seg)) )
+      {
+        return u3z_save(key, pro);
       }
       else {
-        pro = u3n_nock_on(u3k(dext_core), u3k(u3x_at(u3x_bat, dext_core)));
-
-        if ( ((c3y == pro) && (u3_nul == reg)) ||
-             ((c3n == pro) && (u3_nul == seg)) )
-        {
-          return u3z_save_2(fun_m, sut, ref, pro);
-        }
-        else return pro;
+        u3z(key);
+        return pro;
       }
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_peek.c
+++ b/pkg/urbit/jets/f/ut_peek.c
@@ -3,30 +3,32 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_peek(u3_noun cor)
+u3_noun
+u3wfu_peek(u3_noun cor)
+{
+  u3_noun sut, way, axe, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &way,
+                             u3x_sam_3, &axe,
+                             u3x_con, &van,
+                             0)) ||
+       (c3n == u3ud(axe)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, way, axe, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__peek + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_3(fun_m, sut, way, axe);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &way,
-                               u3x_sam_3, &axe,
-                               u3x_con, &van,
-                               0)) ||
-         (c3n == u3ud(axe)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__peek + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_3(fun_m, sut, way, axe);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_3(fun_m, sut, way, axe, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_play.c
+++ b/pkg/urbit/jets/f/ut_play.c
@@ -3,27 +3,29 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_play(u3_noun cor)
+u3_noun
+u3wfu_play(u3_noun cor)
+{
+  u3_noun sut, gen, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam, &gen, u3x_con, &van, 0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, gen, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__play;
+    u3_noun vrf = u3r_at(u3qfu_van_vrf, van);
+    u3_noun key = u3z_key_3(fun_m, vrf, sut, gen);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &gen, u3x_con, &van, 0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__play;
-      u3_noun vrf   = u3r_at(u3qfu_van_vrf, van);
-      u3_noun pro   = u3z_find_3(fun_m, vrf, sut, gen);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_3(fun_m, vrf, sut, gen, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/jets/f/ut_rest.c
+++ b/pkg/urbit/jets/f/ut_rest.c
@@ -3,26 +3,28 @@
 */
 #include "all.h"
 
-  u3_noun
-  u3wfu_rest(u3_noun cor)
+u3_noun
+u3wfu_rest(u3_noun cor)
+{
+  u3_noun sut, leg, van;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam, &leg, u3x_con, &van, 0)) ||
+       (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
-    u3_noun sut, leg, van;
+    return u3m_bail(c3__fail);
+  }
+  else {
+    c3_m  fun_m = 141 + c3__rest + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
+    u3_noun key = u3z_key_2(fun_m, sut, leg);
+    u3_weak pro = u3z_find(key);
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &leg, u3x_con, &van, 0)) ||
-         (u3_none == (sut = u3r_at(u3x_sam, van))) )
-    {
-      return u3m_bail(c3__fail);
-    } else {
-      c3_m    fun_m = 141 + c3__rest + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-      u3_noun pro   = u3z_find_2(fun_m, sut, leg);
-
-      if ( u3_none != pro ) {
-        return pro;
-      }
-      else {
-        pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
-
-        return u3z_save_2(fun_m, sut, leg, pro);
-      }
+    if ( u3_none != pro ) {
+      u3z(key);
+      return pro;
+    }
+    else {
+      pro = u3n_nock_on(u3k(cor), u3k(u3x_at(u3x_bat, cor)));
+      return u3z_save(key, pro);
     }
   }
+}

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -2197,7 +2197,7 @@ _n_burn(u3n_prog* pog_u, u3_noun bus, c3_ys mov, c3_ys off)
     skim_out:
       o     = u3k(mem_u->key);
       x     = u3nc(x, o);
-      o     = u3z_find(144 + c3__nock, x);
+      o     = u3z_find_m(144 + c3__nock, x);
       if ( u3_none == o ) {
         _n_push(mov, off, x);
         _n_push(mov, off, u3k(u3h(x)));
@@ -2214,7 +2214,7 @@ _n_burn(u3n_prog* pog_u, u3_noun bus, c3_ys mov, c3_ys off)
       top = _n_peek(off);
       o   = *top;
       if ( &(u3H->rod_u) != u3R ) {
-        u3z_save(144 + c3__nock, o, x);
+        u3z_save_m(144 + c3__nock, o, x);
       }
       *top = x;
       u3z(o);

--- a/pkg/urbit/noun/zave.c
+++ b/pkg/urbit/noun/zave.c
@@ -3,87 +3,63 @@
 */
 #include "all.h"
 
+/* u3z_key(): construct a memo cache-key.  Arguments retained.
+*/
+u3_noun
+u3z_key(c3_m fun, u3_noun one)
+{
+  return u3nc(fun, u3k(one));
+}
+u3_noun
+u3z_key_2(c3_m fun, u3_noun one, u3_noun two)
+{
+  return u3nt(fun, u3k(one), u3k(two));
+}
+u3_noun
+u3z_key_3(c3_m fun, u3_noun one, u3_noun two, u3_noun tri)
+{
+  return u3nq(fun, u3k(one), u3k(two), u3k(tri));
+}
+u3_noun
+u3z_key_4(c3_m fun, u3_noun one, u3_noun two, u3_noun tri, u3_noun qua)
+{
+  return u3nc(fun, u3nq(u3k(one), u3k(two), u3k(tri), u3k(qua)));
+}
+
 /* u3z_find(): find in memo cache.  Arguments retained.
 */
 u3_weak
-u3z_find(c3_m fun, u3_noun one)
+u3z_find(u3_noun key)
+{
+  return u3h_get(u3R->cax.har_p, key);
+}
+u3_weak
+u3z_find_m(c3_m fun, u3_noun one)
 {
   u3_noun key = u3nc(fun, u3k(one));
-  u3_noun val;
-
-  val = u3h_get(u3R->cax.har_p, key);
-  u3z(key);
-  return val;
-}
-u3_weak
-u3z_find_2(c3_m fun, u3_noun one, u3_noun two)
-{
-  u3_noun key = u3nt(fun, u3k(one), u3k(two));
-  u3_noun val;
-
-  val = u3h_get(u3R->cax.har_p, key);
-  u3z(key);
-  return val;
-}
-u3_weak
-u3z_find_3(c3_m fun, u3_noun one, u3_noun two, u3_noun tri)
-{
-  u3_noun key = u3nq(fun, u3k(one), u3k(two), u3k(tri));
-  u3_noun val;
-
-  val = u3h_get(u3R->cax.har_p, key);
-  u3z(key);
-  return val;
-}
-u3_weak
-u3z_find_4(c3_m fun, u3_noun one, u3_noun two, u3_noun tri, u3_noun qua)
-{
-  u3_noun key = u3nc(fun, u3nq(u3k(one), u3k(two), u3k(tri), u3k(qua)));
-  u3_noun val;
+  u3_weak val;
 
   val = u3h_get(u3R->cax.har_p, key);
   u3z(key);
   return val;
 }
 
-/* u3z_save*(): save in memo cache.
+/* u3z_save(): save in memo cache. TRANSFER key; RETAIN val
 */
 u3_noun
-u3z_save(c3_m fun, u3_noun one, u3_noun val)
+u3z_save(u3_noun key, u3_noun val)
+{
+  u3h_put(u3R->cax.har_p, key, u3k(val));
+  u3z(key);
+  return val;
+}
+
+/* u3z_save_m(): save in memo cache. Arguments retained.
+*/
+u3_noun
+u3z_save_m(c3_m fun, u3_noun one, u3_noun val)
 {
   u3_noun key = u3nc(fun, u3k(one));
-
-  u3h_put(u3R->cax.har_p, key, u3k(val));
-  u3z(key);
-  return val;
-}
-u3_noun
-u3z_save_2(c3_m fun, u3_noun one, u3_noun two, u3_noun val)
-{
-  u3_noun key = u3nt(fun, u3k(one), u3k(two));
-
-  u3h_put(u3R->cax.har_p, key, u3k(val));
-  u3z(key);
-  return val;
-}
-u3_noun
-u3z_save_3(c3_m fun, u3_noun one, u3_noun two, u3_noun tri, u3_noun val)
-{
-  u3_noun key = u3nq(fun, u3k(one), u3k(two), u3k(tri));
-
-  u3h_put(u3R->cax.har_p, key, u3k(val));
-  u3z(key);
-  return val;
-}
-u3_noun
-u3z_save_4(c3_m fun,
-             u3_noun one,
-             u3_noun two,
-             u3_noun tri,
-             u3_noun qua,
-             u3_noun val)
-{
-  u3_noun key = u3nc(fun, u3nq(u3k(one), u3k(two), u3k(tri), u3k(qua)));
 
   u3h_put(u3R->cax.har_p, key, u3k(val));
   u3z(key);


### PR DESCRIPTION
Specifically, this change avoids uncounted references in the "decapitated" memoizing compiler jet stubs.

These issues have been latent in the code for a long time, but they were "activated" by the unifying-equality changes in #1741, and surfaced in #1757.
