### PR TITLE
gall: remove %gall-booting printf

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6205835e39ce2a3f995c042ac3b46a34e492c464db20b6e7604b08b828744215
-size 15831246
+oid sha256:31ca4bd0c41fbe176093b81e08a942d5d0b8cebb6c797ea7c96ddc5fb7600583
+size 15901599

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2459,7 +2459,6 @@
       ~&  [%gall-not-ours ship]
       [~ gall-payload]
     ::
-    ~&  [%gall-booting q.dock q.task]
     =>  (mo-boot:initialised q.dock q.task)
     mo-abet
   ::


### PR DESCRIPTION
%gall currently prints

```
  [%gall-booting <app> p=<ship> q=<desk>]
```

whenever it receives a %conf (i.e., when it boots an app).  This turns up in many of the places the old, less-informative `%mo-not-running` printf did, but it's of similarly little use, and mainly serves to create redundant line noise.  This (trivial) PR just removes it.