### PR TITLE
arvo: trim vane in response to memory pressure

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31ca4bd0c41fbe176093b81e08a942d5d0b8cebb6c797ea7c96ddc5fb7600583
-size 15901599
+oid sha256:b216f4a1f018c0c4e3494bbb8c557ff8e16762edfeff11e3953e00f72c425e0a
+size 16014429

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -782,9 +782,14 @@
   ::  notifications, spammed to every vane
   ::
   ?:  ?=(%trim -.q.ovo)
-    =>  .(ovo ;;((pair wire [%trim @ud]) ovo))
+    =>  .(ovo ;;((pair wire [%trim p=@ud]) ovo))
     =^  zef  vanes
       (~(spam (is our vil eny bud vanes) now) lac ovo)
+    ::  clear compiler caches if high-priority
+    ::
+    =?  vanes  =(0 p.q.ovo)
+      ~>  %slog.[0 leaf+"arvo: trim: clearing caches"]
+      (turn vanes |=([a=@tas =vane] [a vase.vane *worm]))
     [zef +>.$]
   ::
   ::  Normal events are routed to a single vane

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6171,10 +6171,27 @@
   ::
       ::  %trim: in response to memory pressure
       ::
-      ::    XX clear cache
-      ::
       %trim
     ::
+    ?.  =(0 p.task)
+      ::  low-priority: remove 50% of cache/stored-builds
+      ::
+      ~>  %slog.[0 leaf+"ford: trim: pruning caches"]
+      =.  state.ax  (wipe:this-event 50)
+      [~ ford-gate]
+    ::
+    ::  high-priority: remove 100% of cache/stored-builds
+    ::
+    ::    We use %keep to ensure that cache-keys are also purged,
+    ::    then restore original limits to allow future caching.
+    ::
+    ::    XX cancel in-progress builds?
+    ::
+    ~>  %slog.[0 leaf+"ford: trim: clearing caches"]
+    =/  b-max  max-size.queue.build-cache.state.ax
+    =/  c-max  max-size.compiler-cache.state.ax
+    =.  state.ax  (keep:this-event 0 0)
+    =.  state.ax  (keep:this-event c-max b-max)
     [~ ford-gate]
   ::
       ::  %vega: learn of kernel upgrade

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2478,7 +2478,13 @@
     [~ payload]
   ::
       %trim
-    [~ gall-payload]
+    ::  reuse %wash task to clear caches on memory-pressure
+    ::
+    ::    XX cancel subscriptions if =(0 trim-priority) ?
+    ::
+    ~>  %slog.[0 leaf+"gall: trim: clearing caches"]
+    =/  =move  [duct %pass / %g [%wash ~]]
+    [[move ~] gall-payload]
   ::
       %vega
     [~ gall-payload]


### PR DESCRIPTION
Following on #1773, this PR fills out (some of) the `%trim` memory-pressure notification handlers.

- in arvo proper, we clear compiler caches at high priority
- in %eyre, we close all inactive channels
- in %ford, we clear half of the cache(s) at low priority, all at high
- in %gall, we clear compiler caches

Some potential improvements are noted in comments; for instance, we may want to cancel active %ford builds or close active %eyre channels at high priority.

%clay remains a good candidate for further improvements, as it could discard or tombstone foreign desks. But I think reclaiming from its blob store would require a GC-style pass over the entire state.

/cc @philipcmonk, @eglaysher 