### PR TITLE
Add Nix Attributes to Build Container Images

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -20,9 +20,20 @@ let
       inherit (deps) secp256k1 h2o ivory-header ca-header;
     };
 
-  urbit       = mkUrbit { debug=false; };
-  urbit-debug = mkUrbit { debug=true; };
+  urbit       = mkUrbit { debug = false; };
+  urbit-debug = mkUrbit { debug = true; };
+
+  mkImage = { debug }:
+    import ./urbit/image.nix {
+      inherit pkgs;
+
+      name  = if debug then "urbit-debug" else "urbit";
+      urbit = if debug then  urbit-debug  else  urbit;
+    };
+
+  urbit-image       = mkImage { debug = false; };
+  urbit-image-debug = mkImage { debug = true; };
 
 in
 
-{ inherit ent ge-additions arvo herb urbit urbit-debug; }
+{ inherit ent ge-additions arvo herb urbit urbit-debug urbit-image urbit-image-debug; }

--- a/nix/pkgs/urbit/image.nix
+++ b/nix/pkgs/urbit/image.nix
@@ -1,0 +1,36 @@
+{ pkgs
+, name
+, urbit
+}:
+
+pkgs.dockerTools.buildImage {
+  inherit name;
+
+  runAsRoot = ''
+    #!${pkgs.stdenv.shell}
+
+    set -euo pipefail
+
+    export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
+    ${pkgs.dockerTools.shadowSetup}
+
+    mkdir /data /tmp
+  '';
+
+  config = {
+    Entrypoint = [ "${urbit}/bin/urbit" ];
+
+    WorkingDir = "/data";
+
+    Volumes = {
+      "/data" = {};
+      "/tmp" = {};
+    };
+
+    ExposedPorts = {
+      "80/tcp" = {};
+      "443/tcp" = {};
+    };
+ };
+}

--- a/sh/image
+++ b/sh/image
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Creating non-debug container image..."
+image=$(nix-build default.nix --no-out-link -A urbit-image)
+
+echo "Loading $image into Docker..."
+docker load --input $image


### PR DESCRIPTION
Adds `urbit-image` and `urbit-image-debug` to the top-level attributes exposed via `default.nix`. These respectively cook urbit and the debug variant into Docker-compatible images which can be loaded into the Docker daemon or alternative runtime. The images are tagged using the Nix store hash and time-stamped with the Unix epoch (1970-01-01) for reproducibility.

The additional script `sh/image` encodes the build and Docker-related load steps for convenience.

Following a successful build/load, you can boot the urbit image using the Nix store hash as the image tag and passing any urbit-related flags:

```
docker run --tty urbit:xd5q0b2d4cyq2h7mh6q3f01arfai37i9 -F zod zod   
```

Future work will include baking the correct pill into the image and pushing images to hub.docker.com in conjunction with tagged releases.