### PR TITLE
Remove Fuzz Testing Option

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -95,7 +95,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:J:B:K:A:H:I:w:u:e:E:f:F:k:p:LljabcCdgqsvxPDRS")) )
+                 "G:J:B:K:A:H:I:w:u:e:E:F:k:p:LljabcCdgqsvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'J': {
@@ -146,12 +146,6 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 'x': {
         u3_Host.ops_u.tex = c3y;
-        break;
-      }
-      case 'f': {
-        if ( c3n == _main_readw(optarg, 100, &u3_Host.ops_u.fuz_w) ) {
-          return c3n;
-        }
         break;
       }
       case 'K': {
@@ -386,7 +380,6 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-d            Daemon mode\n",
     "-e url        Ethereum gateway\n",
     "-F ship       Fake keys; also disables networking\n",
-    "-f            Fuzz testing\n",
     "-g            Set GC flag\n",
     "-j file       Create json trace file\n",
     "-K stage      Start at Hoon kernel version stage\n",

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -14,7 +14,6 @@
 #include <ncurses/term.h>
 #include <dirent.h>
 #include <openssl/ssl.h>
-#include <openssl/rand.h>
 #include <h2o.h>
 #include <curl/curl.h>
 #include <argon2.h>
@@ -676,10 +675,6 @@ main(c3_i   argc,
   if ( c3y == u3_Host.ops_u.dem && c3n == u3_Host.ops_u.bat ) {
     printf("boot: running as daemon\n");
   }
-
-  //  Seed prng. Don't panic -- just for fuzz testing.
-  //
-  srand(getpid());
 
   //  Instantiate process globals.
   {

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -551,7 +551,6 @@
         c3_c*   ets_c;                      //  -E, eth snapshot
         c3_c*   eth_c;                      //  -e, ethereum node url
         c3_c*   fak_c;                      //  -F, fake ship
-        c3_w    fuz_w;                      //  -f, fuzz testing
         c3_c*   gen_c;                      //  -G, czar generator
         c3_o    gab;                        //  -g, test garbage collection
         c3_c*   dns_c;                      //  -H, ames bootstrap domain

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -313,11 +313,6 @@ u3_ames_ef_send(u3_pier* pir_u, u3_noun lan, u3_noun pac)
 {
   u3_ames* sam_u = pir_u->sam_u;
 
-  if ( u3_Host.ops_u.fuz_w && ((rand() % 100) < u3_Host.ops_u.fuz_w) ) {
-    u3z(lan); u3z(pac);
-    return;
-  }
-
   if ( c3n == sam_u->liv ) {
     u3l_log("ames: not yet live, dropping outbound\r\n");
     u3z(lan); u3z(pac);


### PR DESCRIPTION
Removes the `-f` (Fuzz testing) flag. My assumption is that this behavior is neither used nor implemented in a sufficiently useful manner, please correct me + add context if that is not the case.

