### PR TITLE
Bake Solid Pill Into Container Images

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -27,8 +27,7 @@ let
     import ./urbit/image.nix {
       inherit pkgs;
 
-      name  = if debug then "urbit-debug" else "urbit";
-      urbit = if debug then  urbit-debug  else  urbit;
+      urbit = if debug then urbit-debug else urbit;
     };
 
   urbit-image       = mkImage { debug = false; };

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -21,6 +21,7 @@ in
 pkgs.stdenv.mkDerivation {
   name    = name;
   exename = name;
+  meta    = { inherit debug; };
   src     = ../../../pkg/urbit;
   builder = ./builder.sh;
 

--- a/nix/pkgs/urbit/image.nix
+++ b/nix/pkgs/urbit/image.nix
@@ -1,7 +1,27 @@
 { pkgs
-, name
+, pill ? ../../../bin/solid.pill
 , urbit
 }:
+
+let
+  name  = urbit.meta.name;
+  debug = urbit.meta.debug;
+
+  entrypoint = "${urbit}/bin/${name}";
+
+  coredump = pkgs.writeScript "entrypoint.sh" ''
+    #!${pkgs.stdenv.shell}
+
+    set -euo pipefail
+
+    ulimit -c unlimited
+
+    ${entrypoint} -B ${pill} "$@" || \
+      $${pkgs.gdb}/bin/gdb -ex "thread apply all bt" -ex "set pagination 0" -batch \
+      ${entrypoint} \
+      /tmp/cores/core*
+  '';
+in
 
 pkgs.dockerTools.buildImage {
   inherit name;
@@ -15,11 +35,11 @@ pkgs.dockerTools.buildImage {
 
     ${pkgs.dockerTools.shadowSetup}
 
-    mkdir /data /tmp
+    mkdir -p /data /tmp/cores
   '';
 
   config = {
-    Entrypoint = [ "${urbit}/bin/urbit" ];
+    Entrypoint = if debug then [ coredump ] else [ entrypoint ];
 
     WorkingDir = "/data";
 

--- a/sh/image
+++ b/sh/image
@@ -2,8 +2,22 @@
 
 set -euo pipefail
 
-echo "Creating non-debug container image..."
-image=$(nix-build default.nix --no-out-link -A urbit-image)
+build=${1:-}
 
-echo "Loading $image into Docker..."
-docker load --input $image
+if [[ -z "$build" ]]; then
+    build="urbit-image"
+fi
+
+say() {
+  echo "$1" >&2
+}
+
+say "Building $build..."
+image="$(nix-build default.nix --no-out-link -A $build)"
+
+say "Loading $image into Docker..."
+tag="$(docker load --quiet --input $image)"
+tag="${tag#Loaded image: }"
+
+# Output only the tag on stdout for subsequent pipes/tooling.
+echo $tag


### PR DESCRIPTION
Bakes the `bin/solid.pill` into `urbit` and `urbit-debug` container images. This ensures that any image built within the current tree is (or should be) in a working state when pushed to a remote repository.

Additionally the `urbit-debug` image now logs the coredump which is useful primarly for our hosting environment. Locally the `/tmp` mount can be inspected to extract the coredump if desired.