### PR TITLE
Add Option to Disable Terminal/TTY Assumptions

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -87,13 +87,14 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.pro = c3n;
   u3_Host.ops_u.qui = c3n;
   u3_Host.ops_u.rep = c3n;
+  u3_Host.ops_u.tem = c3n;
   u3_Host.ops_u.tex = c3n;
   u3_Host.ops_u.tra = c3n;
   u3_Host.ops_u.veb = c3n;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:J:B:K:A:H:I:w:u:e:F:k:p:LljabcdgqsvxPDRS")) )
+                 "G:J:B:K:A:H:I:w:u:e:F:k:p:LljabcdgqstvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'J': {
@@ -176,6 +177,7 @@ _main_getopt(c3_i argc, c3_c** argv)
       case 'v': { u3_Host.ops_u.veb = c3y; break; }
       case 's': { u3_Host.ops_u.git = c3y; break; }
       case 'S': { u3_Host.ops_u.has = c3y; break; }
+      case 't': { u3_Host.ops_u.tem = c3y; break; }
       case '?': default: {
         return c3n;
       }
@@ -225,6 +227,12 @@ _main_getopt(c3_i argc, c3_c** argv)
   if ( c3y == u3_Host.ops_u.bat ) {
     u3_Host.ops_u.dem = c3y;
     u3_Host.ops_u.nuu = c3y;
+  }
+
+  //  daemon mode (-d) implies disabling terminal assumptions (-t)
+  //
+  if ( c3y == u3_Host.ops_u.dem ) {
+    u3_Host.ops_u.tem = c3y;
   }
 
   //  make -c optional, catch invalid boot of existing pier
@@ -365,7 +373,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-b            Batch create\n",
     "-c pier       Create a new urbit in pier/\n",
     "-D            Recompute from events\n",
-    "-d            Daemon mode\n",
+    "-d            Daemon mode; implies -t\n",
     "-e url        Ethereum gateway\n",
     "-F ship       Fake keys; also disables networking\n",
     "-g            Set GC flag\n",
@@ -380,6 +388,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-S            Disable battery hashing\n",
     // XX find a way to re-enable
     // "-s            Pill URL from arvo git hash\n",
+    "-t            Disable terminal/tty assumptions\n",
     "-u url        URL from which to download pill\n",
     "-v            Verbose\n",
     "-w name       Boot as ~name\n",

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -564,6 +564,7 @@
         c3_o    qui;                        //  -q, quiet
         c3_o    rep;                        //  -R, report build info
         c3_o    has;                        //  -S, Skip battery hashes
+        c3_o    tem;                        //  -t, Disable terminal/tty assumptions
         c3_o    git;                        //  -s, pill url from arvo git hash
         c3_c*   url_c;                      //  -u, pill url
         c3_o    vno;                        //  -V, replay without reboots

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -99,7 +99,7 @@ u3_term_io_init()
 {
   u3_utty* uty_u = c3_calloc(sizeof(u3_utty));
 
-  if ( c3y == u3_Host.ops_u.dem ) {
+  if ( c3y == u3_Host.ops_u.tem ) {
     uty_u->fid_i = 1;
 
     uv_pipe_init(u3L, &(uty_u->pop_u), 0);
@@ -237,7 +237,7 @@ u3_term_io_init()
     u3_Host.uty_u = uty_u;
   }
 
-  if ( c3n == u3_Host.ops_u.dem ) {
+  if ( c3n == u3_Host.ops_u.tem ) {
     //  Start raw input.
     //
     {
@@ -249,9 +249,9 @@ u3_term_io_init()
       }
     }
 
-    //  initialize spinner timeout (if not in daemon-mode)
+    //  initialize spinner timeout (if terminal/tty is enabled)
     //
-    if ( c3n == u3_Host.ops_u.dem ) {
+    if ( c3n == u3_Host.ops_u.tem ) {
       uv_timer_init(u3L, &uty_u->tat_u.sun_u.tim_u);
       uty_u->tat_u.sun_u.tim_u.data = uty_u;
     }
@@ -268,7 +268,7 @@ u3_term_io_talk(void)
 void
 u3_term_io_exit(void)
 {
-  if ( c3y == u3_Host.ops_u.dem ) {
+  if ( c3y == u3_Host.ops_u.tem ) {
     uv_close((uv_handle_t*)&u3_Host.uty_u->pop_u, 0);
   }
   else {
@@ -490,7 +490,7 @@ _term_it_refresh_line(u3_utty* uty_u)
 static void
 _term_it_show_more(u3_utty* uty_u)
 {
-  if ( c3y == u3_Host.ops_u.dem ) {
+  if ( c3y == u3_Host.ops_u.tem ) {
     _term_it_write_str(uty_u, "\n");
   } else {
     _term_it_write_str(uty_u, "\r\n");
@@ -831,7 +831,7 @@ _term_spin_timer_cb(uv_timer_t* tim_u)
 void
 u3_term_start_spinner(c3_c* why_c, c3_o now_o)
 {
-  if ( c3n == u3_Host.ops_u.dem ) {
+  if ( c3n == u3_Host.ops_u.tem ) {
     u3_utty* uty_u = _term_main();
     u3_utat* tat_u = &uty_u->tat_u;
 
@@ -861,7 +861,7 @@ u3_term_start_spinner(c3_c* why_c, c3_o now_o)
 void
 u3_term_stop_spinner(void)
 {
-  if ( c3n == u3_Host.ops_u.dem ) {
+  if ( c3n == u3_Host.ops_u.tem ) {
     u3_utty* uty_u = _term_main();
     u3_utat* tat_u = &uty_u->tat_u;
 
@@ -991,20 +991,20 @@ _term_ef_blit(u3_utty* uty_u,
     default: break;
 
     case c3__bel: {
-      if ( c3n == u3_Host.ops_u.dem ) {
+      if ( c3n == u3_Host.ops_u.tem ) {
         _term_it_write_txt(uty_u, uty_u->ufo_u.out.bel_y);
       }
     } break;
 
     case c3__clr: {
-      if ( c3n == u3_Host.ops_u.dem ) {
+      if ( c3n == u3_Host.ops_u.tem ) {
         _term_it_show_blank(uty_u);
         _term_it_refresh_line(uty_u);
       }
     } break;
 
     case c3__hop: {
-      if ( c3n == u3_Host.ops_u.dem ) {
+      if ( c3n == u3_Host.ops_u.tem ) {
         _term_it_show_cursor(uty_u, u3t(blt));
       }
     } break;
@@ -1022,7 +1022,7 @@ _term_ef_blit(u3_utty* uty_u,
         }
       }
 
-      if ( c3n == u3_Host.ops_u.dem ) {
+      if ( c3n == u3_Host.ops_u.tem ) {
         _term_it_show_clear(uty_u);
         _term_it_show_line(uty_u, lin_w, len_w);
       } else {
@@ -1108,7 +1108,7 @@ u3_term_io_hija(void)
       c3_assert(0);
     }
     else {
-      if ( c3n == u3_Host.ops_u.dem ) {
+      if ( c3n == u3_Host.ops_u.tem ) {
         if ( 0 != _term_tcsetattr(1, TCSADRAIN, &uty_u->bak_u) ) {
           perror("hija-tcsetattr-1");
           c3_assert(!"hija-tcsetattr");
@@ -1150,7 +1150,7 @@ u3_term_io_loja(int x)
       c3_assert(0);
     }
     else {
-      if ( c3y == u3_Host.ops_u.dem ) {
+      if ( c3y == u3_Host.ops_u.tem ) {
         fflush(stdout);
       }
       else {

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -919,10 +919,13 @@ u3_term_get_blew(c3_l tid_l)
   c3_l           col_l, row_l;
 
   struct winsize siz_u;
-  if ( uty_u && (0 == ioctl(uty_u->fid_i, TIOCGWINSZ, &siz_u)) ) {
+  if ( (c3y == u3_Host.ops_u.tem) &&
+       uty_u && (0 == ioctl(uty_u->fid_i, TIOCGWINSZ, &siz_u)) )
+  {
     col_l = siz_u.ws_col;
     row_l = siz_u.ws_row;
-  } else {
+  }
+  else {
     col_l = 80;
     row_l = 24;
   }


### PR DESCRIPTION
Currently `-d` (daemon mode) disables terminal/tty assumptions and calls `fork()` to background the daemon process. In the hosting environment the former is required/desirable as no terminal is attached/present for containerized ships - but the parent process is required to stay in the foreground, as PID 1 within the container.

This PR toggles the terminal guards under `term.c` using the new `-t` option, and keeps the existing `-d` option to enable the call to `fork()`, with the latter implying the former. That is:

*  `-d` calls `fork()` and disables terminal assumptions.
*  `-t` only disables terminal assumptions.

An additional guard on `-t` has been placed around the terminal column/row calculation in `term.c:u3_term_get_blew`, which is in response to a `SIGABRT` that occurs when no terminal is attached.