### PR TITLE
behn: print error message if %drip event fails

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c000c0a377fc6540d696db3a0f47a5c8fc0d53a4a09af357f7ef68de937ea710
-size 16160245
+oid sha256:0014c7b001af8217f808e4d1dce21b0e7c059d4836338012e6080305b11f0f6a
+size 16234385

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -91,6 +91,7 @@
     =.  movs.drips.state  (~(del by movs.drips.state) num)
     ?^  error
       ::  if we errored, drop it
+      %-  (slog leaf/"drip failed" u.error)
       event-core
     event-core(moves [duct %give %meta drip]~)
   ::  +trim: in response to memory pressue


### PR DESCRIPTION
Per @philipcmonk's suggestion in #1481, as discussed in #1790. This change *does not* handle the error of a failing %drip, as there's no way to route that error notification right now. But printing it will at least let us debug...