### PR TITLE
vere: adds some minor cleanup of cli args

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -716,6 +716,8 @@ main(c3_i   argc,
       }
 
       /*  Set dry-run flag.
+      **
+      **    XX also exit immediately?
       */
       if ( _(u3_Host.ops_u.dry) ) {
         u3C.wag_w |= u3o_dryrun;

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -70,7 +70,6 @@ _main_getopt(c3_i argc, c3_c** argv)
   c3_w arg_w;
 
   u3_Host.ops_u.abo = c3n;
-  u3_Host.ops_u.bat = c3n;
   u3_Host.ops_u.dem = c3n;
   u3_Host.ops_u.dry = c3n;
   u3_Host.ops_u.gab = c3n;
@@ -94,7 +93,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "G:J:B:K:A:H:I:w:u:e:F:k:p:LljabcdgqstvxPDRS")) )
+                 "G:J:B:K:A:H:I:w:u:e:F:k:p:LljacdgqstvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'J': {
@@ -167,7 +166,6 @@ _main_getopt(c3_i argc, c3_c** argv)
       case 'l': { u3_Host.ops_u.lit = c3y; break; }
       case 'j': { u3_Host.ops_u.tra = c3y; break; }
       case 'a': { u3_Host.ops_u.abo = c3y; break; }
-      case 'b': { u3_Host.ops_u.bat = c3y; break; }
       case 'c': { u3_Host.ops_u.nuu = c3y; break; }
       case 'd': { u3_Host.ops_u.dem = c3y; break; }
       case 'g': { u3_Host.ops_u.gab = c3y; break; }
@@ -222,11 +220,6 @@ _main_getopt(c3_i argc, c3_c** argv)
     }
 
     u3_Host.dir_c = strdup(argv[optind]);
-  }
-
-  if ( c3y == u3_Host.ops_u.bat ) {
-    u3_Host.ops_u.dem = c3y;
-    u3_Host.ops_u.nuu = c3y;
   }
 
   //  daemon mode (-d) implies disabling terminal assumptions (-t)
@@ -370,7 +363,6 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     // XX find a way to re-enable
     // "-A dir        Use dir for initial galaxy sync\n",
     "-B pill       Bootstrap from this pill\n",
-    "-b            Batch create\n",
     "-c pier       Create a new urbit in pier/\n",
     "-D            Recompute from events\n",
     "-d            Daemon mode; implies -t\n",
@@ -670,7 +662,7 @@ main(c3_i   argc,
   u3K.certs_c = strdup("/tmp/urbit-ca-cert-XXXXXX");
   _setup_cert_store(u3K.certs_c);
 
-  if ( c3y == u3_Host.ops_u.dem && c3n == u3_Host.ops_u.bat ) {
+  if ( c3y == u3_Host.ops_u.dem ) {
     printf("boot: running as daemon\n");
   }
 

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -565,6 +565,14 @@ _fork_into_background_process()
   exit(WEXITSTATUS(status));
 }
 
+/* _stop_on_boot_completed_cb(): exit gracefully after boot is complete
+*/
+static void
+_stop_on_boot_completed_cb()
+{
+  u3_pier_exit(u3_pier_stub());
+}
+
 c3_i
 main(c3_i   argc,
      c3_c** argv)
@@ -594,6 +602,10 @@ main(c3_i   argc,
   if ( c3y == u3_Host.ops_u.rep ) {
     report();
     return 0;
+  }
+
+  if ( c3y == u3_Host.ops_u.tex ) {
+    u3_Host.bot_f = _stop_on_boot_completed_cb;
   }
 
 #if 0

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -543,7 +543,6 @@
         c3_c*   arv_c;                      //  -A, initial sync from
         c3_o    abo;                        //  -a, abort aggressively
         c3_c*   pil_c;                      //  -B, bootstrap from
-        c3_o    bat;                        //  -b, batch create
         c3_o    nuu;                        //  -c, new pier
         c3_o    dry;                        //  -D, dry compute, no checkpoint
         c3_o    dem;                        //  -d, daemon
@@ -567,7 +566,6 @@
         c3_o    tem;                        //  -t, Disable terminal/tty assumptions
         c3_o    git;                        //  -s, pill url from arvo git hash
         c3_c*   url_c;                      //  -u, pill url
-        c3_o    vno;                        //  -V, replay without reboots
         c3_o    veb;                        //  -v, verbose (inverse of -q)
         c3_c*   who_c;                      //  -w, begin with ticket
         c3_o    tex;                        //  -x, exit after loading

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -840,6 +840,8 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
   u3P.nor_u.nam_c = "north";
   u3P.sou_u.nam_c = "south";
 
+  //  XX review dryrun requirements, enable or remove
+  //
 #if 0
   if ( u3C.wag_w & u3o_dryrun ) {
     return c3y;

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -10,6 +10,8 @@
 
 #include "all.h"
 
+//  XX stack-overflow recovery should be gated by -a
+//
 #undef NO_OVERFLOW
 
       /* (u3_noun)setjmp(u3R->esc.buf): setjmp within road.
@@ -610,6 +612,8 @@ c3_w Exit;
 **        [%2 trace]
 **        [%3 code trace]
 **    ==
+**
+**  XX several of these abort() calls should be gated by -a
 */
 c3_i
 u3m_bail(u3_noun how)


### PR DESCRIPTION
Specifically, this PR

- removes `-b` ("batch create") and `-V` ("replay without kernel resets")
- implements `-x` ("exit after boot")
- and adds some comments (hopefully) clarifying unimplemented-but-desirable `-a` ("abort aggressively") and incomplete `-d` ("dry-run")