### PR TITLE
Claz: batch invites

### DIFF
--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -42,6 +42,11 @@
       ::  %deed: deed ships based on json, assumes spawnable
       ::
       [%deed deeds-json=cord]
+      ::  %invites: sendPoint for every ship in ship,ticket,owner file
+      ::
+      ::    to generate such a file, try +claz|invites ~star 1 10
+      ::
+      [%invites as-who=ship file=path]
       ::  %lock-prep: prepare for lockup by transfering ships to the ceremony address
       ::
       [%lock-prep what=(list ship)]
@@ -77,6 +82,8 @@
       [%transfer-ship who=ship to=address]
       [%set-transfer-proxy who=ship proxy=address]
       [%adopt who=ship]
+    ::
+      [%send-point as=ship point=ship to=address]
   ==
 ::
 ::  monadic structures
@@ -224,7 +231,8 @@
 ::
 ::  constants
 ::
-++  ecliptic  `address`0x6ac0.7b7c.4601.b5ce.11de.8dfe.6335.b871.c7c4.dd4d
+++  ecliptic           0x6ac0.7b7c.4601.b5ce.11de.8dfe.6335.b871.c7c4.dd4d
+++  delegated-sending  0xf790.8ab1.f1e3.52f8.3c5e.bc75.051c.0565.aeae.a5fb
 --
 ::
 |_  [=bowl:gall state]
@@ -411,6 +419,7 @@
   ?-  -.batch
     %single     [(single nonce network as +.batch) ~]
     %deed       (deed nonce network as +.batch)
+    %invites    (invites nonce network as +.batch)
     %lock-prep  (lock-prep nonce network as +.batch)
     %lock       (lock nonce network as +.batch)
     ::
@@ -484,6 +493,8 @@
     %transfer-ship  (transfer-ship:dat +.call)
     %set-transfer-proxy  (set-transfer-proxy:dat +.call)
     %adopt  (adopt:dat +.call)
+  ::
+    %send-point  (send-point:dat +.call)
   ==
 ::
 ++  deed
@@ -527,6 +538,33 @@
     :_  txs
     (do network (add nonce (lent txs)) ecliptic dat)
   --
+::
+++  invites
+  |=  [nonce=@ud =network as=address as-who=ship file=path]
+  ^-  (list transaction)
+  =/  friends=(list [=ship @q =address])
+    =+  txt=.^((list cord) %cx file)
+    %+  turn  txt
+    |=  line=cord
+    ~|  line
+    %+  rash  line
+    ;~  (glue com)
+      ;~(pfix sig fed:ag)
+      ;~(pfix sig feq:ag)
+      ;~(pfix (jest '0x') hex)
+    ==
+  =|  txs=(list transaction)
+  |-
+  ?~  friends  (flop txs)
+  =*  friend  i.friends
+  =;  tx=transaction
+    $(txs [tx txs], friends t.friends)
+  %-  do
+  :*  network
+      (add nonce (lent txs))
+      delegated-sending
+      (send-point:dat as-who [ship address]:friend)
+  ==
 ::
 ++  parse-registration
   |=  reg=cord
@@ -711,10 +749,13 @@
   ++  set-dns-domains         (enc set-dns-domains:cal)
   ++  upgrade-to              (enc upgrade-to:cal)
   ++  transfer-ownership      (enc transfer-ownership:cal)
-  ++  adopt                  (enc adopt:cal)
+  ++  adopt                   (enc adopt:cal)
+  ::
   ++  register-linear         (enc register-linear:cal)
   ++  register-conditional    (enc register-conditional:cal)
   ++  deposit                 (enc deposit:cal)
+  ::
+  ++  send-point              (enc send-point:cal)
   --
 ::
 ++  cal
@@ -862,6 +903,15 @@
     :-  'deposit(address,uint16)'
     :~  [%address to]
         [%uint `@`star]
+    ==
+  ::
+  ++  send-point
+    |=  [as=ship point=ship to=address]
+    ^-  call-data
+    :-  'sendPoint(uint32,uint32,address)'
+    :~  [%uint `@`as]
+        [%uint `@`point]
+        [%address to]
     ==
   --
 ::

--- a/pkg/arvo/gen/hood/claz-invites.hoon
+++ b/pkg/arvo/gen/hood/claz-invites.hoon
@@ -1,0 +1,37 @@
+::  |claz-invites:
+::
+/+  keygen
+=,  ethereum
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [star=ship min-child=@ud max-child=@ud out=path ~]
+        ~
+    ==
+?:  (gth min-child max-child)
+  ~|  [%weird-range min=min-child max=max-child]
+  !!
+?:  (gth max-child 0xffff)
+  ~|  [%max-beyond-planet-space max-child]
+  !!
+~&  'patience, slow derivation...'
+:-  %kiln-info
+:-  "wrote generated invites to {(spud out)}"
+%-  some
+%+  foal:space:userlib  out
+:-  %txt
+!>
+%+  turn  (gulf min-child max-child)
+|=  child=@ud
+=/  who=ship  (cat 4 star child)
+=/  ticket=@q  (end 3 8 (shas who eny))
+=/  owner=address
+  =<  addr.keys
+  ::NOTE  ~zod because invite wallet convention
+  (ownership-wallet-from-ticket:keygen ~zod 8^ticket ~)
+%-  crip
+;:  weld
+  (scow %p who)  ","
+  (slag 1 (scow %q ticket))  ","
+  (address-to-hex:ethereum owner)
+==

--- a/pkg/arvo/lib/keygen.hoon
+++ b/pkg/arvo/lib/keygen.hoon
@@ -36,6 +36,12 @@
   ::  hash again to prevent length extension attacks
   (sha-256l:sha 32 -)
 ::
+++  ownership-wallet-from-ticket
+  |=  [who=ship ticket=byts pass=(unit @t)]
+  ^-  node
+  =+  master-seed=(argon2u who ticket)
+  (child-node-from-seed master-seed "ownership" pass)
+::
 ++  full-wallet-from-ticket
   ::  who:    username
   ::  ticket: password


### PR DESCRIPTION
For ship distribution purposes, we want to be able to send out large amounts of planet invites (using Delegated Sending). This PR implements logic in Claz for generating those transactions.

It takes a `.txt` file as input, with every line being `~ship,~ticket,0xaddress`. To generate these for some planets under some star, a generator is provided.  
`|claz-invites ~marzod 1 10 %/invites/txt` does this for ~marzod's first through tenth child.

That file can be taken out of the Urbit and used to, for example, print out invite wallets.

Those wallets won't be useful until you've sent the matching invite transactions.  
`:claz [%generate %/out/eth-txs %ropsten 0xsender %invites ~palfun-foslup %/invites/txt]` generates transactions for sending those using ~palfun-foslup as the invite-sender. (Make sure they have the correct/enough invites!)

Lastly, this sneaks in an addition to keygen.hoon that matches what we've done in the js version.