### PR TITLE
eyre: fix missing cancel-heartbeat-move cases

### DIFF
--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -1038,9 +1038,14 @@
       call-args=[duct=~[/http-get-open] ~ %cancel-request ~]
       ^=  expected-moves
         ^-  (list move:http-server-gate)
-        ::  closing the channel restarts the timeout timer
+        ::  closing the channel cancels the sse heartbeat
+        ::  (initialized in results5 above) and restarts the timeout timer
         ::
         :~  :*  duct=~[/http-get-open]  %pass
+                /channel/heartbeat/'0123456789abcdef'
+                %b  %rest  :(add ~1111.1.2 ~m3 ~s20)
+            ==
+            :*  duct=~[/http-get-open]  %pass
                 /channel/timeout/'0123456789abcdef'
                 %b  %wait  :(add ~1111.1.2 ~h12 ~m4)
         ==  ==
@@ -1682,9 +1687,14 @@
       call-args=[duct=~[/http-get-open] ~ %cancel-request ~]
       ^=  expected-moves
         ^-  (list move:http-server-gate)
-        ::  closing the channel restarts the timeout timer
+        ::  closing the channel cancels the sse heartbeat
+        ::  (initialized in results4 above) and restarts the timeout timer
         ::
         :~  :*  duct=~[/http-get-open]  %pass
+                /channel/heartbeat/'0123456789abcdef'
+                %b  %rest  :(add ~1111.1.2 ~m3 ~s20)
+            ==
+            :*  duct=~[/http-get-open]  %pass
                 /channel/timeout/'0123456789abcdef'
                 %b  %wait  :(add ~1111.1.2 ~h12 ~m6)
         ==  ==


### PR DESCRIPTION
Addresses #1811.

I can reproduce the issue by shutting down a pier before disconnecting from landscape and then restarting it. This results in `%invalid-outstanding-connection` every 20 seconds since the heartbeat move is never cancelled.

This is due to me being sloppy and only canceling heartbeat moves on `%disconnect`. Now we cancel heartbeats in `on-cancel-request` (fixing the above case, this is called on %born) and in `on-channel-timeout`. Let me know if there are other cases that I have missed.

This might fix #1812 as well, not sure of how to reproduce that one, though.

I'm still having trouble with nix (as mentioned [here](https://github.com/urbit/urbit/pull/1687#issuecomment-538802626))  so I can't run tests nor create pills locally. I suspect some tests will fail here, so I'll just force push fixes here if needed.