### PR TITLE
ames: skip timers if unix duct is unset

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1385,6 +1385,13 @@
       [[gad.fox [%give %send p.bon q.bon]] ~]
     ::
         %pito
+      ::  ignore/unset timer if we haven't yet learned a unix duct
+      ::
+      ::     Only happens during first boot.
+      ::
+      ?~  gad.fox
+        [~ fox(tim ~)]
+      ::
       :_  fox(tim `p.bon)
       %-  flop
       ^-  (list move)


### PR DESCRIPTION
This fixes a bug whereby %behn timers were being set on an empty duct, and the subsequent %wake was being routed to unix as an effect. These are safe to drop, as any subsequent messages sent or packets received will reset the timer, which will pick up all "pending" packets. (There's also a fallback %ames timer in vere, but it's presence doesn't change this analysis.)