### PR TITLE
claz: %single %send-point to correct contract

### DIFF
--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -482,7 +482,11 @@
 ++  single
   |=  [nonce=@ud =network as=address =call]
   ^-  transaction
-  =-  (do network nonce ecliptic -)
+  =-  (do network nonce contract data)
+  ^-  [contract=address data=tape]  ::TODO  =;
+  :-  ?+  -.call  ecliptic
+        %send-point  delegated-sending
+      ==
   ?-  -.call
     %create-galaxy  (create-galaxy:dat +.call)
     %spawn  (spawn:dat +.call)


### PR DESCRIPTION
09cb5f2 added a %send-point call, which is meant to target the delegated sending
contract. For %invites batches, this was the case. Handling of %single, however,
still sent all calls to the ecliptic contract.

This looks at the call tag to determine the target contract.

Thanks @philipcmonk for catching this!