### PR TITLE
build: urbit derivation debug metadata

### DIFF
--- a/nix/ops/brass/default.nix
+++ b/nix/ops/brass/default.nix
@@ -1,19 +1,11 @@
-{ pkgs, tlon, deps, pier, arvo, debug }:
-
-let
-
-  urbitExe = if debug
-             then "${tlon.urbit-debug}/bin/urbit-debug -g"
-             else "${tlon.urbit}/bin/urbit";
-
-in
+{ pkgs, herb, urbit, pier, arvo }:
 
 pkgs.stdenv.mkDerivation rec {
   name        = "brass";
   builder     = ./builder.sh;
-  buildInputs = [ tlon.herb pkgs.coreutils ];
+  buildInputs = [ herb pkgs.coreutils ];
 
-  URBIT = urbitExe;
+  URBIT = ubit.meta.exe;
   PIER  = pier;
   ARVO  = arvo;
 }

--- a/nix/ops/default.nix
+++ b/nix/ops/default.nix
@@ -2,29 +2,29 @@
 
 let
 
-  deps  = import ../deps { inherit pkgs; };
   tlon  = import ../pkgs { inherit pkgs; };
   arvo  = tlon.arvo;
-  urbit = tlon.urbit;
+  herb  = tlon.herb;
+  urbit = if debug then tlon.urbit-debug else tlon.urbit;
 
   bootbrass = ../../bin/brass.pill;
   bootsolid = ../../bin/solid.pill;
 
   rawzod = import ./fakeship {
-    inherit pkgs tlon deps debug;
+    inherit pkgs herb urbit;
     pill = bootsolid;
     ship = "zod";
     arvo = null;
   };
 
   zod = import ./fakeship {
-    inherit pkgs tlon deps arvo debug;
+    inherit pkgs herb urbit arvo;
     pill = bootsolid;
     ship = "zod";
   };
 
   bus = import ./fakeship {
-    inherit pkgs tlon deps arvo debug;
+    inherit pkgs herb urbit arvo;
     pill = bootsolid;
     ship = "bus";
   };
@@ -34,23 +34,28 @@ in
 rec {
 
   test = import ./test {
-    inherit pkgs tlon deps debug;
+    inherit pkgs herb urbit;
     ship = bus;
   };
 
   solid = import ./solid {
-    inherit arvo pkgs tlon deps debug;
+    inherit pkgs herb urbit arvo;
     pier = rawzod;
   };
 
   brass = import ./brass {
-    inherit arvo pkgs tlon deps debug;
+    inherit pkgs herb urbit arvo;
     pier = zod;
   };
 
   ivory = import ./ivory {
-    inherit arvo pkgs tlon deps debug;
+    inherit pkgs herb urbit arvo;
     pier = zod;
+  };
+
+  image = import ./image {
+    inherit pkgs urbit;
+    pill = bootsolid;
   };
 
 }

--- a/nix/ops/fakeship/default.nix
+++ b/nix/ops/fakeship/default.nix
@@ -1,18 +1,10 @@
-{ pkgs, tlon, deps, pill, ship, arvo, debug }:
-
-let
-
-  urbitExe = if debug
-             then "${tlon.urbit-debug}/bin/urbit-debug -g"
-             else "${tlon.urbit}/bin/urbit";
-
-in
+{ pkgs, herb, urbit, pill, ship, arvo }:
 
 pkgs.stdenv.mkDerivation {
   name        = "fake" + ship;
   builder     = ./builder.sh;
-  buildInputs = [ tlon.herb ];
-  URBIT       = urbitExe;
+  buildInputs = [ herb ];
+  URBIT       = urbit.meta.exe;
   ARVO        = arvo;
   PILL        = pill;
   SHIP        = ship;

--- a/nix/ops/ivory/default.nix
+++ b/nix/ops/ivory/default.nix
@@ -1,19 +1,11 @@
-{ pkgs, tlon, deps, pier, arvo, debug }:
-
-let
-
-  urbitExe = if debug
-             then "${tlon.urbit-debug}/bin/urbit-debug -g"
-             else "${tlon.urbit}/bin/urbit";
-
-in
+{ pkgs, herb, urbit, pier, arvo }:
 
 pkgs.stdenv.mkDerivation rec {
   name        = "ivory";
   builder     = ./builder.sh;
-  buildInputs = [ tlon.herb pkgs.coreutils ];
+  buildInputs = [ herb pkgs.coreutils ];
 
-  URBIT = urbitExe;
+  URBIT = urbit.meta.exe;
   PIER  = pier;
   ARVO  = arvo;
 }

--- a/nix/ops/solid/default.nix
+++ b/nix/ops/solid/default.nix
@@ -1,19 +1,11 @@
-{ pkgs, tlon, deps, pier, arvo, debug }:
-
-let
-
-  urbitExe = if debug
-             then "${tlon.urbit-debug}/bin/urbit-debug -g"
-             else "${tlon.urbit}/bin/urbit";
-
-in
+{ pkgs, herb, urbit, pier, arvo }:
 
 pkgs.stdenv.mkDerivation rec {
   name        = "solid";
   builder     = ./builder.sh;
-  buildInputs = [ tlon.herb ];
+  buildInputs = [ herb ];
 
-  URBIT = urbitExe;
+  URBIT = urbit.exe;
   PIER  = pier;
   ARVO  = arvo;
 }

--- a/nix/ops/test/default.nix
+++ b/nix/ops/test/default.nix
@@ -1,18 +1,10 @@
-{ pkgs, tlon, deps, ship, debug }:
-
-let
-
-  urbitExe = if debug
-             then "${tlon.urbit-debug}/bin/urbit-debug -g"
-             else "${tlon.urbit}/bin/urbit";
-
-in
+{ pkgs, herb, urbit, ship }:
 
 pkgs.stdenv.mkDerivation rec {
   name        = "test";
   builder     = ./builder.sh;
-  buildInputs = [ tlon.herb ];
+  buildInputs = [ herb ];
 
-  URBIT = urbitExe;
+  URBIT = urbit.meta.exe;
   SHIP  = ship;
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -23,16 +23,6 @@ let
   urbit       = mkUrbit { debug = false; };
   urbit-debug = mkUrbit { debug = true; };
 
-  mkImage = { debug }:
-    import ./urbit/image.nix {
-      inherit pkgs;
-
-      urbit = if debug then urbit-debug else urbit;
-    };
-
-  urbit-image       = mkImage { debug = false; };
-  urbit-image-debug = mkImage { debug = true; };
-
 in
 
-{ inherit ent ge-additions arvo herb urbit urbit-debug urbit-image urbit-image-debug; }
+{ inherit ent ge-additions arvo herb urbit urbit-debug; }

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -9,6 +9,13 @@ let
   name =
     if debug then "urbit-debug" else "urbit";
 
+  meta = rec {
+    inherit debug;
+    bin   = "${urbit}/bin/${name}";
+    flags = if debug then "-g" else "";
+    exe   = "${meta.bin} ${meta.flags}";
+  };
+
   deps =
     with pkgs;
     [ curl gmp libsigsegv ncurses openssl zlib lmdb ];
@@ -16,22 +23,22 @@ let
   vendor =
     [ argon2 softfloat3 ed25519 ent ge-additions h2o scrypt uv murmur3 secp256k1 sni ivory-header ca-header ];
 
+  urbit = pkgs.stdenv.mkDerivation {
+    inherit name meta;
+    exename = name;
+    src     = ../../../pkg/urbit;
+    builder = ./builder.sh;
+    nativeBuildInputs = deps ++ vendor;
+
+    # See https://github.com/NixOS/nixpkgs/issues/18995
+    hardeningDisable = if debug then [ "all" ] else [];
+
+    CFLAGS           = if debug then "-O3 -g -Werror" else "-O3 -Werror";
+    MEMORY_DEBUG     = debug;
+    CPU_DEBUG        = debug;
+    EVENT_TIME_DEBUG = false;
+  };
+
 in
 
-pkgs.stdenv.mkDerivation {
-  name    = name;
-  exename = name;
-  meta    = { inherit debug; };
-  src     = ../../../pkg/urbit;
-  builder = ./builder.sh;
-
-  nativeBuildInputs = deps ++ vendor;
-
-  # See https://github.com/NixOS/nixpkgs/issues/18995
-  hardeningDisable = if debug then [ "all" ] else [];
-
-  CFLAGS           = if debug then "-O3 -g -Werror" else "-O3 -Werror";
-  MEMORY_DEBUG     = debug;
-  CPU_DEBUG        = debug;
-  EVENT_TIME_DEBUG = false;
-}
+urbit

--- a/sh/image
+++ b/sh/image
@@ -2,12 +2,6 @@
 
 set -euo pipefail
 
-build=${1:-}
-
-if [[ -z "$build" ]]; then
-    build="urbit-image"
-fi
-
 say() {
   echo "$1" >&2
 }
@@ -19,17 +13,18 @@ git_branch="$(git branch --show-current)"
 
 git_tag="${git_branch}-${git_sha}"
 
-say "Building $build..."
-nix_out="$(nix-build default.nix --no-out-link -A $build)"
+say "Building nix/ops/image..."
+nix_out="$(nix-build nix/ops -A image --no-out-link "$@")"
 
 say "Loading $nix_out into Docker..."
 nix_name="$(docker load --quiet --input $nix_out)"
 nix_name="${nix_name#Loaded image: }"
 
-say "Re-tagging with current git branch:$git_branch and SHA:$git_sha"
+say "Re-tagging with git metadata..."
 image_repo="$(docker images $nix_name --format '{{.Repository}}')"
 image_name="${image_repo}:${git_tag}"
 docker tag $nix_name $image_name
 
-# Output only the tag on stdout for subsequent pipes/tooling.
+# Output only the new tag on stdout for subsequent pipes/tooling.
+say $nix_name
 echo $image_name


### PR DESCRIPTION
Rather than reconstructing the `urbitExe` path/argument string using a debug conditional in every ops expression, attaches the following information to the `urbit` derivation's `.meta` attribute:

* `urbit.meta.debug` - whether this derivation is a debug build.
* `urbit.meta.bin` - the binary path/name, such as `/nix/store/urbit/bin/urbit` or `/nix/store/urbit/bin/urbit-debug`.
* `urbit.meta.flags` - any flags this particular build should be invoked with, such as `-g`.
* `urbit.meta.exe` - the combination of `urbit.meta.bin` and `urbit.meta.flags`.

The `nix/pkgs/image` expression has also been moved into `nix/ops` to take advantage of these changes as it also makes use of this debug metadata, as well as an update to the `sh/image` build script.