### PR TITLE
jael: retrieve first sponsor instead of last

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b1d887b11132200dbc3dd48889b8a8d8731cfd25128eb41f477ed64820d6724
-size 16944223
+oid sha256:b9e0554df7caddfa58bbd8139c51a14cdde4c4ffdf2e364c0769a0a722ec4dcc
+size 17227069

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -255,7 +255,9 @@
         =/  cub  (nol:nu:crub:crypto key.seed.tac)
         %+  ~(put by pos.zim.pki)
           our
-        =/  spon-ship  ?~(spon.tac ~ `ship.i.spon.tac)
+        =/  spon-ship
+          =/  flopped-spon  (flop spon.tac)
+          ?~(flopped-spon ~ `ship.i.flopped-spon)
         [1 lyf.seed.tac (my [lyf.seed.tac [1 pub:ex:cub]] ~) spon-ship]
       ::  our initial private key
       ::


### PR DESCRIPTION
New ships on the network are coming up synced to their galaxy instead of their star because I was grabbing their furthest sponsor instead of their most immediate.  This fixes that.

Consider this another vote in favor of updating the released pill instead of relying on all future updates to be OTA.