### PR TITLE
publish: remove unused %disconnect card

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -58,7 +58,6 @@
       [%kill wire ~]
       [%connect wire binding:eyre term]
       [%http-response http-event:http]
-      [%disconnect binding:eyre]
   ==
 ::
 +$  poke


### PR DESCRIPTION
Trying to mimic it misled me for a quick second, until I realized you really want `[%disconnect wire binding:eyre]` here. Since publish isn't using it anyway, might as well take it out.