### PR TITLE
arvo: improves move type specialization (by spec'ing incrementally)

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bead6dee4a038a878ee788820cf0f2f1b5cd56103cedfbc94789c5769ac5290
-size 17239324
+oid sha256:8c4fda3bc0e859790e5eca57eb1c4bbce8457f36b1d62f75493a74d6a0741b0d
+size 17311859

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -326,7 +326,8 @@
           ?.  ((sane %tas) lal)  ~
           %+  biff  ((soft path) p.q.caq)
           |=  pax/path
-          =^  yav  worm.vane  (~(spot wa worm.vane) 15 caq)
+          =^  xav  worm.vane  (~(spot wa worm.vane) 7 caq)
+          =^  yav  worm.vane  (~(spot wa worm.vane) 3 xav)
           %+  bind  (song yav)
           |=  {hil/mill vel/worm}
           [%& [%pass pax lal hil] vel]
@@ -343,7 +344,8 @@
           %+  biff  ((soft @) p.q.caq)
           |=  lal/@tas
           ?.  ((sane %tas) lal)  ~
-          =^  yav  worm.vane  (~(spot wa worm.vane) 7 caq)
+          =^  xav  worm.vane  (~(spot wa worm.vane) 3 caq)
+          =^  yav  worm.vane  (~(spot wa worm.vane) 3 xav)
           %+  bind  (song yav)
           |=  {hil/mill vel/worm}
           [%& [%slip lal hil] vel]


### PR DESCRIPTION
fixes #1835 (confirmed through local testing).