### PR TITLE
ames: don't crash on jael update

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -956,8 +956,9 @@
                 =/  mex  ;;(full:pact (cue msg))
                 =.  diz  (deng law.mex)
                 =/  wug  cluy:diz
+                ~|  [from=her expected-her-life=lyf.wug got-her-life=from.lyf.mex]
                 ?>  =(lyf.wug from.lyf.mex)
-                ~|  from=her
+                ~|  [from=her got-our-life=to.lyf.mex]
                 =/  gey  (sev:gus to.lyf.mex)
                 =/  sem  (need (tear:as:q.gey pub:ex:cub.wug txt.mex))
                 =/  mes  ;;((pair @ @) (cue sem))
@@ -970,6 +971,7 @@
                 =/  mex  ;;(open:pact (cue msg))
                 =.  diz  (deng law.mex)
                 =/  wug  cluy:diz
+                ~|  [from=her expected-her-life=lyf.wug got-her-life=from.lyf.mex]
                 ?>  =(lyf.wug from.lyf.mex)
                 =/  mes  (need (sure:as:cub.wug txt.mex))
                 =.  puz  (bilk:puz now)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -957,6 +957,7 @@
                 =.  diz  (deng law.mex)
                 =/  wug  cluy:diz
                 ?>  =(lyf.wug from.lyf.mex)
+                ~|  from=her
                 =/  gey  (sev:gus to.lyf.mex)
                 =/  sem  (need (tear:as:q.gey pub:ex:cub.wug txt.mex))
                 =/  mes  ;;((pair @ @) (cue sem))
@@ -1468,8 +1469,10 @@
             (~(get by points.public-keys-result.sih) her)
           ?~  a-point
             ~
-          =/  a-pass=pass  pass:(~(got by keys.u.a-point) life.u.a-point)
-          `[life.u.a-point a-pass oath=~]
+          =/  k  (~(get by keys.u.a-point) life.u.a-point)
+          ?~  k
+            ~
+          `[life.u.a-point pass.u.k oath=~]
         ?>  ?=(%keys -.diff.public-keys-result.sih)
         ?>  =(her who.public-keys-result.sih)
         =/  a-key-update=key-update:point:able:jael


### PR DESCRIPTION
Sometimes Jael sends an update about a ship that has no keys, eg if you try to talk to a ship we don't believe exists yet.  In this ames, was crashing, which was killing the azimuth-tracker http receive event, so ~zod wasn't getting up to date.

This just turns that into a no-op.