### PR TITLE
updates vere memory management heuristics and debug info

### DIFF
--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -341,10 +341,6 @@ _worker_send(u3_noun job)
 static void
 _worker_send_replace(c3_d evt_d, u3_noun job)
 {
-  u3l_log("worker_send_replace %" PRIu64 " %s\r\n",
-          evt_d,
-          u3r_string(u3h(u3t(u3t(job)))));
-
   _worker_send(u3nt(c3__work,
                     u3i_chubs(1, &evt_d),
                     u3ke_jam(u3nc(u3V.mug_l, job))));

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -306,6 +306,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
     tot_w += u3a_maid(fil_u, "effects", u3a_mark_noun(vir));
 
     u3a_print_memory(fil_u, "total marked", tot_w);
+    u3a_print_memory(fil_u, "free lists", u3a_idle(u3R));
     u3a_print_memory(fil_u, "sweep", u3a_sweep());
 
     fflush(fil_u);

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -606,6 +606,15 @@ _worker_work_live(c3_d evt_d, u3_noun job)
         rec_o = c3y;
         pri   = 0;
       }
+      //  reclaim memory from persistent caches periodically
+      //
+      //    XX this is a hack to work two things
+      //    - bytecode caches grow rapidly and can't be simply capped
+      //    - we don't make very effective use of our free lists
+      //
+      else {
+        rec_o = _(0 == (evt_d % 1000ULL));
+      }
 
       //  notify daemon of memory pressure via "fake" effect
       //


### PR DESCRIPTION
This PR restores the old heuristic of purging vere caches every 1k events. We don't make sufficiently efficient use of free space to just depend on the memory pressure thresholds.

Additionally, this updates the `|mass` handler to also print the size of the free lists, and adds static memory measurement on startup, for cases where we can't evaluate `|mass` (currently run on every startup where < 1/2 of the loom is contiguously free).