### PR TITLE
build: always include debug symbols

### DIFF
--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -33,7 +33,7 @@ let
     # See https://github.com/NixOS/nixpkgs/issues/18995
     hardeningDisable = if debug then [ "all" ] else [];
 
-    CFLAGS           = if debug then "-O3 -g -Werror" else "-O3 -Werror";
+    CFLAGS           = "-O3 -g -Werror";
     MEMORY_DEBUG     = debug;
     CPU_DEBUG        = debug;
     EVENT_TIME_DEBUG = false;


### PR DESCRIPTION
We've been stymied by there absence a few times, no reason not to always include them at this stage.