### PR TITLE
build: simplify image build interface

### DIFF
--- a/nix/ops/image/default.nix
+++ b/nix/ops/image/default.nix
@@ -2,33 +2,18 @@
 
 let
 
-  name  = urbit.meta.name;
-  debug = urbit.meta.debug;
-  exe   = ''${urbit.meta.exe} "$@"'';
-
-  coredump = ''
-    ulimit -c unlimited
-
-    ${exe} || \
-      ${pkgs.gdb}/bin/gdb -ex "thread apply all bt" -ex "set pagination 0" -batch \
-      ${urbit.meta.bin} \
-      /tmp/cores/core*
-  '';
-
   entrypoint = pkgs.writeScript "entrypoint.sh" ''
     #!${pkgs.stdenv.shell}
 
     set -euo pipefail
 
-    ${pkgs.coreutils}/bin/ln -sf ${pill} /data/urbit.pill
-
-    ${if debug then coredump else exe}
+    ${urbit.meta.exe} "$@"
   '';
 
 in
 
 pkgs.dockerTools.buildImage {
-  inherit name;
+  name = urbit.meta.name;
 
   runAsRoot = ''
     #!${pkgs.stdenv.shell}
@@ -39,17 +24,21 @@ pkgs.dockerTools.buildImage {
 
     ${pkgs.dockerTools.shadowSetup}
 
-    mkdir -p /data /tmp/cores
+    mkdir -p /bin /share /data /tmp
+
+    ${pkgs.coreutils}/bin/ln -sf ${pill} /share/urbit.pill
+    ${pkgs.coreutils}/bin/ln -sf ${entrypoint} /bin/urbit
   '';
 
   config = {
-    Entrypoint = entrypoint;
+    Entrypoint = [ "urbit" ];
 
     WorkingDir = "/data";
 
+    Env = [ "PATH=/bin" ];
+
     Volumes = {
       "/data" = {};
-      "/tmp" = {};
     };
 
     ExposedPorts = {

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -12,8 +12,8 @@ let
   meta = rec {
     inherit debug;
     bin   = "${urbit}/bin/${name}";
-    flags = if debug then "-g" else "";
-    exe   = "${meta.bin} ${meta.flags}";
+    flags = if debug then [ "-g" ] else [];
+    exe   = ''${meta.bin} ${pkgs.lib.strings.concatStringsSep " " meta.flags}'';
   };
 
   deps =

--- a/sh/image
+++ b/sh/image
@@ -6,13 +6,6 @@ say() {
   echo "$1" >&2
 }
 
-git_sha="$(git rev-parse HEAD)"
-git_sha="${git_sha:0:8}"
-
-git_branch="$(git branch --show-current)"
-
-git_tag="${git_branch}-${git_sha}"
-
 say "Building nix/ops/image..."
 nix_out="$(nix-build nix/ops -A image --no-out-link "$@")"
 
@@ -20,11 +13,5 @@ say "Loading $nix_out into Docker..."
 nix_name="$(docker load --quiet --input $nix_out)"
 nix_name="${nix_name#Loaded image: }"
 
-say "Re-tagging with git metadata..."
-image_repo="$(docker images $nix_name --format '{{.Repository}}')"
-image_name="${image_repo}:${git_tag}"
-docker tag $nix_name $image_name
-
-# Output only the new tag on stdout for subsequent pipes/tooling.
-say $nix_name
-echo $image_name
+# Output only the tag on stdout for subsequent pipes/tooling.
+echo $nix_name


### PR DESCRIPTION
* Removes the baked in coredump inspection and wrapper scripts in favour of using `FROM <image>` downstream.
* Symlinks the binary wrapper to `/bin/urbit` ands it to the `PATH` - discoverable by downstream configuration.
* Symlinks the baked in pill to `/share/urbit.pill` - discoverable by downstream configuration.
* Changes the urbit expressions metadata to retain flags (such as `-g`) as a list.
* Removes the git tagging of images and relies on intentional re-tagging by the user, to avoid constant overlap when repeatedly building images for a specific SHA.