### PR TITLE
vere: restore terminal dimensions measurement

### DIFF
--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -919,7 +919,7 @@ u3_term_get_blew(c3_l tid_l)
   c3_l           col_l, row_l;
 
   struct winsize siz_u;
-  if ( (c3y == u3_Host.ops_u.tem) &&
+  if ( (c3n == u3_Host.ops_u.tem) &&
        uty_u && (0 == ioctl(uty_u->fid_i, TIOCGWINSZ, &siz_u)) )
   {
     col_l = siz_u.ws_col;


### PR DESCRIPTION
The condition, added in #1793 (as part of `-t`, which disables features that require a tty), was precisely backwards. I missed it on review.