### PR TITLE
gall: fix bug in +ap-peek

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8409523d9ada2b962b1f9ac4c996ff957f27c273d373e6ca50197e6abb66bacd
-size 9063441
+oid sha256:78a42e19573a5726c1045efe31ecdb6821afe7d5cf2ba7b34a06a3f56980c9d2
+size 9071562

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1287,11 +1287,11 @@
       ::
       =/  slammed
         =/  index  p.u.maybe-arm
-        =/  term  q.u.maybe-arm
+        =/  name  q.u.maybe-arm
         =/  =vase
           =/  =path  [term tyl]
           !>  (slag index path)
-        (ap-slam term p.arm vase)
+        (ap-slam name p.arm vase)
       ::
       =^  possibly-vase  ap-core  slammed
       ?:  ?=(%.n -.possibly-vase)


### PR DESCRIPTION
fc7901d2 refactored much of +ap-peek, but introduced a bug in the process.  The relevant diff from that commit is as follows:

```
         =/  slammed
-        =/  =path  [ren tyl]
-        =/  =vase  !>((slag p.u.cug path))
-        (ap-slam q.u.cug p.arm vase)
+        =/  index  p.u.maybe-arm
+        =/  term  q.u.maybe-arm
+        =/  =vase
+          =/  =path  [term tyl]
+          =/  raw  (slag index path)
+          !>  raw
+        (ap-slam term p.arm vase)
```
Note that [ren tyl] was replaced with [term tyl], where 'term' and 'ren' are not equal.  This commit merely rights that wrong.

(/cc @philipcmonk as this is probably still relevant on your static gall branch)