### PR TITLE
u3: cleans up error messages

### DIFF
--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -119,17 +119,23 @@ _box_detach(u3a_box* box_u)
   _box_count(-(box_u->siz_w));
 
   if ( nex_p ) {
-    c3_assert(u3to(u3a_fbox, nex_p)->pre_p == fre_p);
+    if ( u3to(u3a_fbox, nex_p)->pre_p != fre_p ) {
+      c3_assert(!"loom: corrupt");
+    }
     u3to(u3a_fbox, nex_p)->pre_p = pre_p;
   }
   if ( pre_p ) {
-    c3_assert(u3to(u3a_fbox, pre_p)->nex_p == fre_p);
+    if( u3to(u3a_fbox, pre_p)->nex_p != fre_p ) {
+      c3_assert(!"loom: corrupt");
+    }
     u3to(u3a_fbox, pre_p)->nex_p = nex_p;
   }
   else {
     c3_w sel_w = _box_slot(box_u->siz_w);
 
-    c3_assert(fre_p == u3R->all.fre_p[sel_w]);
+    if ( fre_p != u3R->all.fre_p[sel_w] ) {
+      c3_assert(!"loom: corrupt");
+    }
     u3R->all.fre_p[sel_w] = nex_p;
   }
 }
@@ -468,14 +474,18 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
           siz_w += pad_w;
           _box_count(-(box_u->siz_w));
           {
+            if ( (0 != u3to(u3a_fbox, *pfr_p)->pre_p) &&
+                 (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->pre_p)->nex_p
+                    != (*pfr_p)) )
             {
-              c3_assert((0 == u3to(u3a_fbox, *pfr_p)->pre_p) ||
-                  (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->pre_p)->nex_p
-                        == (*pfr_p)));
+              c3_assert(!"loom: corrupt");
+            }
 
-              c3_assert((0 == u3to(u3a_fbox, *pfr_p)->nex_p) ||
-                  (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->nex_p)->pre_p
-                        == (*pfr_p)));
+            if( (0 != u3to(u3a_fbox, *pfr_p)->nex_p) &&
+                (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->nex_p)->pre_p
+                   != (*pfr_p)) )
+            {
+              c3_assert(!"loom: corrupt");
             }
 
             if ( 0 != u3to(u3a_fbox, *pfr_p)->nex_p ) {

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1570,7 +1570,7 @@ void
 u3a_luse(u3_noun som)
 {
   if ( 0 == u3a_use(som) ) {
-    u3l_log("luse: insane %d 0x%x\r\n", som, som);
+    fprintf(stderr, "loom: insane %d 0x%x\r\n", som, som);
     abort();
   }
   if ( _(u3du(som)) ) {
@@ -1618,7 +1618,7 @@ u3a_mark_ptr(void* ptr_v)
     c3_ws use_ws = (c3_ws)box_u->use_w;
 
     if ( use_ws == 0 ) {
-      u3l_log("%p is bogus\r\n", ptr_v);
+      fprintf(stderr, "%p is bogus\r\n", ptr_v);
       siz_w = 0;
     }
     else {
@@ -1652,7 +1652,6 @@ u3a_mark_mptr(void* ptr_v)
   c3_w  pad_w = ptr_w[-1];
   c3_w* org_w = ptr_w - (pad_w + 1);
 
-  // u3l_log("free %p %p\r\n", org_w, ptr_w);
   return u3a_mark_ptr(org_w);
 }
 
@@ -1887,8 +1886,8 @@ u3a_sweep(void)
 
 #ifdef U3_CPU_DEBUG
     if ( fre_w != u3R->all.fre_w ) {
-      u3l_log("fre discrepancy (%x): %x, %x, %x\r\n", u3R->par_p,
-              fre_w, u3R->all.fre_w, (u3R->all.fre_w - fre_w));
+      fprintf(stderr, "fre discrepancy (%x): %x, %x, %x\r\n", u3R->par_p,
+                      fre_w, u3R->all.fre_w, (u3R->all.fre_w - fre_w));
     }
 #endif
     neg_w = (end_w - fre_w);

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -148,10 +148,10 @@ u3e_fault(void* adr_v, c3_i ser_i)
     if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
       fprintf(stderr, "strange page: %d, at %p, off %x\r\n",
               pag_w, adr_w, off_w);
-      abort();
+      c3_assert(0);
+      return 0;
     }
 
-    c3_assert(0 == (u3P.dit_w[blk_w] & (1 << bit_w)));
     u3P.dit_w[blk_w] |= (1 << bit_w);
 
     if ( -1 == mprotect((void *)(u3_Loom + (pag_w << u3a_page)),

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -185,14 +185,14 @@ _ce_image_open(u3e_image* img_u)
 
   snprintf(ful_c, 8192, "%s/.urb/chk/%s.bin", u3P.dir_c, img_u->nam_c);
   if ( -1 == (img_u->fid_i = open(ful_c, mod_i, 0666)) ) {
-    u3l_log("loom: open %s: %s\r\n", ful_c, strerror(errno));
+    fprintf(stderr, "loom: open %s: %s\r\n", ful_c, strerror(errno));
     return c3n;
   }
   else {
     struct stat buf_u;
 
     if ( -1 == fstat(img_u->fid_i, &buf_u) ) {
-      u3l_log("loom: stat %s: %s\r\n", ful_c, strerror(errno));
+      fprintf(stderr, "loom: stat %s: %s\r\n", ful_c, strerror(errno));
       c3_assert(0);
       return c3n;
     }
@@ -206,7 +206,7 @@ _ce_image_open(u3e_image* img_u)
       }
       else {
         if ( siz_d != (pgs_d << (c3_d)(u3a_page + 2)) ) {
-          u3l_log("%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
+          fprintf(stderr, "%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
           return c3n;
         }
         img_u->pgs_w = (c3_w) pgs_d;
@@ -276,13 +276,13 @@ _ce_patch_create(u3_ce_patch* pat_u)
 
   snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
   if ( -1 == (pat_u->ctl_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    u3l_log("loom: patch open control.bin: %s\r\n", strerror(errno));
+    fprintf(stderr, "loom: patch open control.bin: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 
   snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
   if ( -1 == (pat_u->mem_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    u3l_log("loom: patch open memory.bin: %s\r\n", strerror(errno));
+    fprintf(stderr, "loom: patch open memory.bin: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 }
@@ -314,12 +314,12 @@ _ce_patch_verify(u3_ce_patch* pat_u)
     c3_w mem_w[1 << u3a_page];
 
     if ( -1 == lseek(pat_u->mem_i, (i_w << (u3a_page + 2)), SEEK_SET) ) {
-      u3l_log("loom: patch seek: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch seek: %s\r\n", strerror(errno));
       c3_assert(0);
       return c3n;
     }
     if ( -1 == read(pat_u->mem_i, mem_w, (1 << (u3a_page + 2))) ) {
-      u3l_log("loom: patch read: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch read: %s\r\n", strerror(errno));
       c3_assert(0);
       return c3n;
     }
@@ -327,8 +327,8 @@ _ce_patch_verify(u3_ce_patch* pat_u)
       c3_w nug_w = u3r_mug_words(mem_w, (1 << u3a_page));
 
       if ( mug_w != nug_w ) {
-        u3l_log("_ce_patch_verify: mug mismatch %d/%d; (%x, %x)\r\n",
-            pag_w, i_w, mug_w, nug_w);
+        fprintf(stderr, "loom: patch mug mismatch %d/%d; (%x, %x)\r\n",
+                        pag_w, i_w, mug_w, nug_w);
         c3_assert(0);
         return c3n;
       }
@@ -623,7 +623,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     c3_w ret_w;
     ret_w = ftruncate(u3P.nor_u.fid_i, u3P.nor_u.pgs_w << (u3a_page + 2));
     if (ret_w){
-      u3l_log("loom: patch apply truncate north: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch apply truncate north: %s\r\n", strerror(errno));
       c3_assert(0);
     }
   }
@@ -633,7 +633,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     c3_w ret_w;
     ret_w = ftruncate(u3P.sou_u.fid_i, u3P.sou_u.pgs_w << (u3a_page + 2));
     if (ret_w){
-      u3l_log("loom: patch apply truncate south: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch apply truncate south: %s\r\n", strerror(errno));
       c3_assert(0);
     }
   }
@@ -643,7 +643,7 @@ _ce_patch_apply(u3_ce_patch* pat_u)
        (-1 == lseek(u3P.nor_u.fid_i, 0, SEEK_SET)) ||
        (-1 == lseek(u3P.sou_u.fid_i, 0, SEEK_SET)) )
   {
-    u3l_log("loom: patch apply seek 0: %s\r\n", strerror(errno));
+    fprintf(stderr, "loom: patch apply seek 0: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 
@@ -663,16 +663,16 @@ _ce_patch_apply(u3_ce_patch* pat_u)
     }
 
     if ( -1 == read(pat_u->mem_i, mem_w, (1 << (u3a_page + 2))) ) {
-      u3l_log("loom: patch apply read: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch apply read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
     else {
       if ( -1 == lseek(fid_i, (off_w << (u3a_page + 2)), SEEK_SET) ) {
-        u3l_log("loom: patch apply seek: %s\r\n", strerror(errno));
+        fprintf(stderr, "loom: patch apply seek: %s\r\n", strerror(errno));
         c3_assert(0);
       }
       if ( -1 == write(fid_i, mem_w, (1 << (u3a_page + 2))) ) {
-        u3l_log("loom: patch apply write: %s\r\n", strerror(errno));
+        fprintf(stderr, "loom: patch apply write: %s\r\n", strerror(errno));
         c3_assert(0);
       }
     }
@@ -694,7 +694,7 @@ _ce_image_blit(u3e_image* img_u,
   lseek(img_u->fid_i, 0, SEEK_SET);
   for ( i_w=0; i_w < img_u->pgs_w; i_w++ ) {
     if ( -1 == read(img_u->fid_i, ptr_w, (1 << (u3a_page + 2))) ) {
-      u3l_log("loom: image blit read: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: image blit read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
 #if 0
@@ -726,7 +726,7 @@ _ce_image_fine(u3e_image* img_u,
     c3_w mem_w, fil_w;
 
     if ( -1 == read(img_u->fid_i, buf_w, (1 << (u3a_page + 2))) ) {
-      u3l_log("loom: image fine read: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: image fine read: %s\r\n", strerror(errno));
       c3_assert(0);
     }
     mem_w = u3r_mug_words(ptr_w, (1 << u3a_page));
@@ -735,11 +735,11 @@ _ce_image_fine(u3e_image* img_u,
     if ( mem_w != fil_w ) {
       c3_w pag_w = (ptr_w - u3_Loom) >> u3a_page;
 
-      u3l_log("mismatch: page %d, mem_w %x, fil_w %x, K %x\r\n",
-              pag_w,
-              mem_w,
-              fil_w,
-              u3K.mug_w[pag_w]);
+      fprintf(stderr, "mismatch: page %d, mem_w %x, fil_w %x, K %x\r\n",
+                     pag_w,
+                     mem_w,
+                     fil_w,
+                     u3K.mug_w[pag_w]);
       abort();
     }
     ptr_w += stp_ws;
@@ -781,12 +781,9 @@ u3e_save(void)
   }
 
   // u3a_print_memory(stderr, "sync: save", 4096 * pat_u->con_u->pgs_w);
+
   _ce_patch_sync(pat_u);
-
-  // u3l_log("_ce_patch_verify\r\n");
   _ce_patch_verify(pat_u);
-
-  // u3l_log("_ce_patch_apply\r\n");
   _ce_patch_apply(pat_u);
 
 #ifdef U3_SNAPSHOT_VALIDATION
@@ -804,14 +801,9 @@ u3e_save(void)
   }
 #endif
 
-  // u3l_log("_ce_image_sync\r\n");
   _ce_image_sync(&u3P.nor_u);
   _ce_image_sync(&u3P.sou_u);
-
-  // u3l_log("_ce_patch_delete\r\n");
   _ce_patch_delete();
-
-  // u3l_log("_ce_patch_free\r\n");
   _ce_patch_free(pat_u);
 }
 
@@ -846,16 +838,10 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
       /* Load any patch files; apply them to images.
       */
       if ( 0 != (pat_u = _ce_patch_open()) ) {
-        u3l_log("boot: _ce_patch_apply\r\n");
         _ce_patch_apply(pat_u);
-
-        u3l_log("boot: _ce_image_sync\r\n");
         _ce_image_sync(&u3P.nor_u);
         _ce_image_sync(&u3P.sou_u);
-
-        u3l_log("boot: _ce_patch_delete\r\n");
         _ce_patch_delete();
-        u3l_log("boot: _ce_patch_free\r\n");
         _ce_patch_free(pat_u);
       }
 


### PR DESCRIPTION
And ensures that they're printed, especially when the errors in question are fatal (`u3l_log()` is especially unsuitable for these, as it may send over a pipe, and the message may never be delivered).