### PR TITLE
Dr. Tobin is prescribing you more pills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all install cross release test pills clean
+.PHONY: build build-all install cross release test pills ropsten-pills clean
 
 build:
 	nix-build -A urbit -A herb --no-out-link
@@ -22,6 +22,9 @@ pills:
 	sh/update-solid-pill
 	sh/update-brass-pill
 	sh/update-ivory-pill
+
+ropsten-pills:
+	sh/create-ropsten-pills
 
 interface:
 	sh/build-interface

--- a/nix/ops/default.nix
+++ b/nix/ops/default.nix
@@ -2,10 +2,11 @@
 
 let
 
-  tlon  = import ../pkgs { inherit pkgs; };
-  arvo  = tlon.arvo;
-  herb  = tlon.herb;
-  urbit = if debug then tlon.urbit-debug else tlon.urbit;
+  tlon         = import ../pkgs { inherit pkgs; };
+  arvo         = tlon.arvo;
+  arvo-ropsten = tlon.arvo-ropsten;
+  herb         = tlon.herb;
+  urbit        = if debug then tlon.urbit-debug else tlon.urbit;
 
   bootbrass = ../../bin/brass.pill;
   bootsolid = ../../bin/solid.pill;
@@ -15,6 +16,13 @@ let
     pill = bootsolid;
     ship = "zod";
     arvo = null;
+  };
+
+  ropzod = import ./fakeship {
+    inherit pkgs herb urbit;
+    pill = bootsolid;
+    ship = "zod";
+    arvo = arvo-ropsten;
   };
 
   zod = import ./fakeship {
@@ -48,9 +56,21 @@ rec {
     pier = zod;
   };
 
+  brass-ropsten = import ./brass {
+    inherit pkgs herb urbit;
+    arvo = arvo-ropsten;
+    pier = ropzod;
+  };
+
   ivory = import ./ivory {
     inherit pkgs herb urbit arvo;
     pier = zod;
+  };
+
+  ivory-ropsten = import ./ivory {
+    inherit pkgs herb urbit;
+    arvo = arvo-ropsten;
+    pier = ropzod;
   };
 
   image = import ./image {

--- a/nix/pkgs/arvo-ropsten/builder.sh
+++ b/nix/pkgs/arvo-ropsten/builder.sh
@@ -1,0 +1,26 @@
+source $stdenv/setup
+
+cp -r $src tmp
+chmod -R u+w tmp
+
+ZUSE=tmp/sys/zuse.hoon
+AMES=tmp/sys/vane/ames.hoon
+ACME=tmp/app/acme.hoon
+
+# replace the mainnet azimuth contract with the ropsten contract
+sed --in-place \
+  's/\(\+\+  contracts  \)mainnet\-contracts/\1ropsten-contracts/' \
+  $ZUSE
+
+# increment the %ames protocol version
+sed -r --in-place \
+  's/^(=\+  protocol\-version=)([0-9])/echo "\1$(echo "(\2+1) % 8" | bc)"/e' \
+  $AMES
+
+# use the staging API in :acme
+sed --in-place \
+  's_https://acme-v02.api.letsencrypt.org/directory_https://acme-staging-v02.api.letsencrypt.org/directory_' \
+  $ACME
+
+cp -r tmp $out
+chmod -R u+w $out

--- a/nix/pkgs/arvo-ropsten/default.nix
+++ b/nix/pkgs/arvo-ropsten/default.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+pkgs.stdenv.mkDerivation {
+  name = "arvo-ropsten";
+  buildInputs = [ pkgs.bc ];
+  builder = ./builder.sh;
+  src = pkgs.buildRustCrateHelpers.exclude [ ".git" ] ../../../pkg/arvo;
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -6,6 +6,7 @@ let
 
   ent          = import ./ent          { inherit pkgs; };
   arvo         = import ./arvo         { inherit pkgs; };
+  arvo-ropsten = import ./arvo-ropsten { inherit pkgs; };
   herb         = import ../../pkg/herb { inherit pkgs; };
 
   ge-additions = import ./ge-additions {
@@ -25,4 +26,4 @@ let
 
 in
 
-{ inherit ent ge-additions arvo herb urbit urbit-debug; }
+{ inherit ent ge-additions arvo arvo-ropsten herb urbit urbit-debug; }

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -298,7 +298,7 @@ _main_getopt(c3_i argc, c3_c** argv)
            && u3_Host.ops_u.url_c == 0
            && u3_Host.ops_u.git == c3n ) {
     u3_Host.ops_u.url_c =
-      "https://bootstrap.urbit.org/urbit-" URBIT_VERSION ".pill";
+      "https://bootstrap.urbit.org/urbit-v" URBIT_VERSION ".pill";
   }
   else if ( u3_Host.ops_u.nuu == c3y
            && u3_Host.ops_u.url_c == 0

--- a/sh/create-ropsten-pills
+++ b/sh/create-ropsten-pills
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+sha=$(git rev-parse $(git branch --show-current))
+
+brass=$(nix-build nix/ops -A brass-ropsten --no-out-link)
+ivory=$(nix-build nix/ops -A ivory-ropsten --no-out-link)
+
+cp $brass ./brass-ropsten-${sha:0:5}.pill
+cp $ivory ./ivory-ropsten-${sha:0:5}.pill


### PR DESCRIPTION
This PR makes a number of changes around pill management.  See the individual commit descriptions for more details, but the TLDR is:

* has `/sh/release` spit out a brass pill artifact as `urbit-vx.y.z.pill`
* changes the pill format in the vere bootstrap URI from `urbit-$URBIT_VERSION.pill` to `urbit-v$URBIT_VERSION.pill`
* adds a Nix derivation for Arvo specialised to Ropsten (i.e. a testnet), as well as derivations for brass & ivory testnet pills
* has `sh/release` spit out testnet pills as well

This automates a lot of mundane tasks that are currently required when one sets up a testnet.