### PR TITLE
lens: clear state in +poke-noun

### DIFF
--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -234,6 +234,8 @@
   |=  a=*
   ^-  (quip move _this)
   ~&  poke+a
+  ?:  ?=  %cancel  a
+    [~ this(job.state ~)]
   [~ this]
 ::
 --


### PR DESCRIPTION
if you use herb to send a dojo command that doesn't compile, the lens state doesn't clear and herb no longer works. this just adds a simple way to clear that state.