### PR TITLE
chat-hook: use sender's timestamp

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -69,9 +69,7 @@
   ::  scry permissions to check if write is permitted
   ?.  (permitted-scry [(scot %p src.bol) %chat (weld path.act /write)])
     ~
-  =:  author.envelope.act  src.bol
-      when.envelope.act  now.bol
-  ==
+  =.  author.envelope.act  src.bol
   [ost.bol %poke / [our.bol %chat-store] [%chat-action act]]~
 ::
 ++  poke-chat-hook-action


### PR DESCRIPTION
No longer overwrite messages' timestamp on-receive, instead keeping whatever
timestamp was set by the sender.

This behavior matches that of the late Hall.