### PR TITLE
Pool group hook

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78a42e19573a5726c1045efe31ecdb6821afe7d5cf2ba7b34a06a3f56980c9d2
-size 9071562
+oid sha256:4cb9e8dedc7c8fd148e504d5568d2875f296a2054db0231125e27908ba010823
+size 9065391

--- a/pkg/arvo/app/pool-group-hook.hoon
+++ b/pkg/arvo/app/pool-group-hook.hoon
@@ -1,0 +1,162 @@
+::  pool-group-hook: maintain groups based on invite pool
+::
+/-  group-store
+/+  tapp, stdio, ethio
+=,  ethereum-types
+=,  able:jael
+::
+=>  |%
+    ++  group-path    /invite-peers
+    ++  refresh-rate  ~m15
+    --
+::
+=>  |%
+    +$  app-state
+      $:  %0
+          url=_'http://eth-mainnet.urbit.org:8545'
+          inviter=ship
+          invited=(set ship)
+      ==
+    ::
+    +$  peek-data  ~
+    +$  in-poke-data  ~
+    +$  out-poke-data
+      [%group-action group-action:group-store]
+    +$  in-peer-data   ~
+    +$  out-peer-data  ~
+    ++  tapp
+      %:  ^tapp
+        app-state
+        peek-data
+        in-poke-data
+        out-poke-data
+        in-peer-data
+        out-peer-data
+      ==
+    ++  tapp-async  tapp-async:tapp
+    ++  stdio  (^stdio out-poke-data out-peer-data)
+    ++  ethio  (^ethio out-poke-data out-peer-data)
+    --
+::
+::  Async helpers
+::
+=>  |%
+    ++  get-invited-by
+      |=  [url=@t who=ship]
+      =/  m  (async:stdio ,ship)
+      ^-  form:m
+      ;<  res=@t  bind:m
+        %+  read-contract:ethio  url
+        :+  `'invitedBy'
+          delegated-sending:contracts:azimuth
+        :-  'invitedBy(uint32)'
+        :~  [%uint `@`who]
+        ==
+      %-  pure:m
+      ^-  ship  ^-  @
+      %+  decode-results:abi:ethereum  res
+      [%uint]~
+    ::
+    ++  get-invited
+      |=  [url=@ta who=ship]
+      =/  m  (async:stdio ,(list ship))
+      ^-  form:m
+      ;<  res=@t  bind:m
+        %+  read-contract:ethio  url
+        :+  `'getInvited'
+          delegated-sending:contracts:azimuth
+        :-  'getInvited(uint32)'
+        :~  [%uint `@`who]
+        ==
+      %-  pure:m
+      ;;  (list ship)
+      %+  decode-results:abi:ethereum  res
+      [%array %uint]~
+    ::
+    ++  send-poke
+      |=  [our=ship =group-action:group-store]
+      =/  m  (async:stdio ,~)
+      ^-  form:m
+      %+  poke-app:stdio
+        [our %group-store]
+      [%group-action group-action]
+    --
+::
+::  Main loop
+::
+=>  |%
+    ++  start
+      |=  [state=app-state our=ship]
+      =/  m  tapp-async
+      ^-  form:m
+      ;<  inviter=ship  bind:m  (get-invited-by url.state our)
+      ?:  =(0 inviter)
+        ::  we're done here, don't do anything ever again
+        (pure:m state)
+      =.  inviter.state  inviter
+      ::  create the group
+      ;<  ~  bind:m  (send-poke our %bundle group-path)
+      ::  start update timer loop
+      ;<  ~  bind:m  set-timer
+      ::  go ahead and update for the first time
+      (update state our)
+    ::
+    ::  Get updates since last checked
+    ::
+    ++  update
+      |=  [state=app-state our=ship]
+      =/  m  tapp-async
+      ^-  form:m
+      ;<  invited=(list ship)  bind:m  (get-invited [url inviter]:state)
+      =/  new=(list ship)
+        %+  skip  invited
+        ~(has in invited.state)
+      ;<  ~  bind:m
+        ?:  =(~ new)  (pure:(async:stdio ,~) ~)
+        (send-poke our %add (sy new) group-path)
+      %-  pure:m
+      state(invited (~(gas in invited.state) new))
+    ::
+    ::  Set update timer
+    ::
+    ++  set-timer
+      =/  m  (async:tapp ,~)
+      ^-  form:m
+      ;<  now=@da  bind:m  get-time:stdio
+      =/  next=@da  (add now refresh-rate)
+      ::NOTE  we use +send-raw-card here to ensure we always set a new timer,
+      ::      regardless of what happens further on in the flow.
+      (send-raw-card:stdio %wait /effect/(scot %da next) next)
+    --
+::
+::  Main
+::
+=*  default-tapp  default-tapp:tapp
+%-  create-tapp-all:tapp
+|_  [=bowl:gall state=app-state]
+++  handle-init
+  =/  m  tapp-async
+  ^-  form:m
+  (start state our.bowl)
+::
+++  handle-take
+  |=  =sign:tapp
+  =/  m  tapp-async
+  ^-  form:m
+  ?+  -.sign  ~|([%strange-sign -.sign] !!)
+      %coup
+    ?~  error.sign  (pure:m state)
+    %-  (slog [leaf+"pool-group-hook effect failed" u.error.sign])
+    (pure:m state)
+  ::
+      %wake
+    ;<  ~  bind:m
+      set-timer
+    (update state our.bowl)
+  ==
+::
+++  handle-poke  handle-poke:default-tapp
+++  handle-diff  handle-diff:default-tapp
+++  handle-peer  handle-peer:default-tapp
+++  handle-peek  handle-peek:default-tapp
+--

--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -102,4 +102,17 @@
     =,  dejs-soft:format
     (ot id+so error+(ot code+no message+so ~) ~)
   --
+::  +read-contract: calls a read function on a contract, produces result hex
+::
+++  read-contract
+  |=  [url=@t proto-read-request:rpc:ethereum]
+  =/  m  (async:stdio ,@t)
+  ;<  =json  bind:m
+    %^  request-rpc  url  id
+    :+  %eth-call
+      ^-  call:rpc:ethereum
+      [~ to ~ ~ ~ `tape`(encode-call:rpc:ethereum function arguments)]
+    [%label %latest]
+  ?.  ?=(%s -.json)  (async-fail:stdio %request-rpc-fail >json< ~)
+  (pure:m p.json)
 --

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7654,6 +7654,9 @@
         ++  conditional-star-release
           0x8c24.1098.c3d3.498f.e126.1421.633f.d579.86d7.4aea
         ::
+        ++  delegated-sending
+          0xf790.8ab1.f1e3.52f8.3c5e.bc75.051c.0565.aeae.a5fb
+        ::
         ::  launch: block number of azimuth deploy
         ::
         ++  launch  6.784.800


### PR DESCRIPTION
Depends/builds on #1895. Targets that branch since that hasn't been merged into master yet.

Implements `/app/pool-group-hook` which, if you were invited by someone, creates and maintains an `/invite-peers` group that contains all ships invited by the same person as you. In other words, your siblings in the invite tree.

(CI failure because muh pills I think. cc @jtobin)