### PR TITLE
chat-cli: Update ;help link

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -866,7 +866,7 @@
     ++  help
       ^-  (quip move _this)
       =-  [[- ~] this]
-      (print:sh-out "see https://urbit.org/docs/using/messaging/")
+      (print:sh-out "see https://urbit.org/using/operations/using-your-ship/#messaging")
     --
   --
 ::


### PR DESCRIPTION
The link currently used in chat-cli resolves with a 301 to the proper page on urbit.org for messaging usage instructions, but not actually the 'messaging' section of that page. 

This commit provides a more direct link to the exact instructions.