### PR TITLE
build: give arvo a high priority

### DIFF
--- a/nix/pkgs/arvo/default.nix
+++ b/nix/pkgs/arvo/default.nix
@@ -4,4 +4,7 @@ pkgs.stdenv.mkDerivation {
   name = "arvo";
   builder = ./builder.sh;
   src = pkgs.buildRustCrateHelpers.exclude [ ".git" ] ../../../pkg/arvo;
+  meta = {
+    priority = 0;
+  };
 }


### PR DESCRIPTION
0bdced981e4 introduced the 'arvo-ropsten' derivation.  Attempting to install both 'arvo' and 'arvo-ropsten' via nix-env will result in a priority error; this assigns a higher priority to 'arvo' to resolve the
conflict.

Fixes #1912.