### PR TITLE
gall: adds %goad to force agent rebuilds

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27983a88317d0a15ff14104e38b54ca592f390ed904f7805c68a477c3e5cdfd7
-size 8884127
+oid sha256:9d53345c5a4993d284bdf18f5a778d47c5ac62f22e3dd43d46a338813f139bab
+size 8891517

--- a/pkg/arvo/app/goad.hoon
+++ b/pkg/arvo/app/goad.hoon
@@ -1,0 +1,7 @@
+|_  [=bowl:gall ~]
+++  poke-noun
+  |=  a=*
+  :_  ..poke-noun
+  =/  force  ?=(%force a)
+  [[ost.bowl %goad /goad force ~] ~]
+--

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -187,6 +187,7 @@
 ++  poke-kiln-keep-ford       (wrap poke-keep-ford):from-kiln
 ++  poke-kiln-autoload        (wrap poke-autoload):from-kiln
 ++  poke-kiln-overload        (wrap poke-overload):from-kiln
+++  poke-kiln-goad-gall       (wrap poke-goad-gall):from-kiln
 ++  poke-kiln-wash-gall       (wrap poke-wash-gall):from-kiln
 ++  poke-kiln-unmount         (wrap poke-unmount):from-kiln
 ++  poke-kiln-unsync          (wrap poke-unsync):from-kiln

--- a/pkg/arvo/gen/hood/goad-gall.hoon
+++ b/pkg/arvo/gen/hood/goad-gall.hoon
@@ -1,0 +1,14 @@
+::  Kiln: force Gall to rebuild agents
+::
+::::  /hoon/goad-gall/hood/gen
+  ::
+/?    310
+::
+::::
+  !:
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        ~
+        [force=_| agent=term]
+    ==
+[%kiln-goad-gall force ?:(?=(%$ agent) ~ (some agent))]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -63,6 +63,7 @@
     ++  card                                            ::
       $%  {$build wire ? schematic:ford}                ::
           {$drop wire @tas}                             ::
+          [%goad wire force=? agent=(unit dude:gall)]   ::
           {$info wire @tas nori}                        ::
           {$mont wire @tas beam}                        ::
           {$dirk wire @tas}                             ::
@@ -287,6 +288,10 @@
 ++  poke-keep-ford
   |=  [compiler-cache-size=@ud build-cache-size=@ud]
   abet:(emit %keep /kiln compiler-cache-size build-cache-size)
+::
+++  poke-goad-gall
+  |=  [force=? agent=(unit dude:gall)]
+  abet:(emit %goad /kiln force agent)
 ::
 ++  poke-wash-gall  |=(* abet:(emit %wash /kiln ~))
 ::

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -8,10 +8,11 @@
 --                                                      ::
 =>  |%                                                  ::  console protocol
 ++  axle                                                ::
-  $:  $1                                                ::
+  $:  $2                                                ::
       hey/(unit duct)                                   ::  default duct
       dug/(map duct axon)                               ::  conversations
       lit/?                                             ::  boot in lite mode
+      dog/_|                                            ::  auto-goad
       $=  hef                                           ::  other weights
       $:  a/(unit mass)                                 ::
           b/(unit mass)                                 ::
@@ -46,7 +47,10 @@
           $>(%wegh task:able:ames)                      ::
       ==                                                ::
       $:  %b                                            ::
-          $>(%wegh task:able:behn)                      ::
+          $>  $?  %wait                                 ::
+                  %wegh                                 ::
+              ==                                        ::
+          task:able:behn                                ::
       ==                                                ::
       $:  %c                                            ::
           $>  $?  %merg                                 ::  merge desks
@@ -76,6 +80,7 @@
       $:  %g                                            ::
           $>  $?  %conf                                 ::
                   %deal                                 ::
+                  %goad                                 ::
                   %wegh                                 ::
               ==                                        ::
           task:able:gall                                ::
@@ -100,7 +105,10 @@
               gift:able:ames                            ::
       ==  ==                                            ::
       $:  %b                                            ::
-          $%  $>(%mass gift:able:behn)                  ::
+          $%  $>  $?  %mass                             ::
+                      %wake                             ::
+                  ==                                    ::
+              gift:able:behn                            ::
               $>(%writ gift:able:clay)                  ::  XX %slip
       ==  ==                                            ::
       $:  %c                                            ::
@@ -149,13 +157,46 @@
         ^-  {(list move) axle}
         [(flop moz) all(dug (~(put by dug.all) hen +<+))]
       ::
+      ++  auto                                          ::  stage automation
+        ^+  .
+        ?.  dog.all  .
+        =.  dog.all  |
+        (pass /auto/one [%b %wait +(now)])
+      ::
+      ++  auto-wake                                     ::  resume automation
+        |=  [=wire error=(unit tang)]
+        ?+  wire
+          ?~  error
+            ~|(behn-bad-wake+wire !!)
+          (crud %wake u.error)
+        ::
+            [%auto %one ~]
+          ?~  error
+            ~&  %behn-goad
+            (pass / [%g %goad force=| ~])
+          ::  %goad crashed, wait again, then force
+          ::
+          ~&  %behn-goad-retry
+          %.  [/auto/two [%b %wait +(now)]]
+          pass:(crud %goad u.error)
+        ::
+            [%auto %two ~]
+          ?~  error
+            ~&  %behn-goad-again
+            (pass / [%g %goad force=& ~])
+          ::  %goad crashed again, bail out
+          ::
+          ~&  %behn-goad-fail
+          (crud %goad u.error)
+        ==
+      ::
       ++  call                                          ::  receive input
         |=  kyz/task:able
         ^+  +>
         ?+    -.kyz  ~&  [%strange-kiss -.kyz]  +>
           $flow  +>
           $harm  +>
-          $hail  (send %hey ~)
+          $hail  auto:(send %hey ~)
           $belt  (send `dill-belt`p.kyz)
           $text  (from %out (tuba p.kyz))
           $crud  ::  (send `dill-belt`[%cru p.kyz q.kyz])
@@ -293,7 +334,7 @@
             $c  '6'
             $w  '7'
             ~  '9'
-          ==
+           ==
         --
       ::
       ++  heft
@@ -371,7 +412,7 @@
         (deal / [%pump ~])
       ::
       ++  take                                          ::  receive
-        |=  sih/sign
+        |=  {tea/wire sih/sign}
         ^+  +>
         ?-    sih
             {?($a $b $c $e $f $g $i $j) $mass *}
@@ -425,6 +466,9 @@
         ::
             {$d $blit *}
           (done +.sih)
+        ::
+            {$b $wake *}
+          (auto-wake tea error.sih)
         ==
       ::  +wegh: receive a memory report from a vane and maybe emit full report
       ::
@@ -554,8 +598,38 @@
   [moz ..^$]
 ::
 ++  load                                                ::  import old state
-  |=  old/axle
-  ..^$(all old)
+  =>  |%
+      ::  without .dog
+      ::
+      ++  axle-one
+        $:  $1
+            hey/(unit duct)
+            dug/(map duct axon)
+            lit/?
+            $=  hef
+            $:  a/(unit mass)
+                b/(unit mass)
+                c/(unit mass)
+                e/(unit mass)
+                f/(unit mass)
+                g/(unit mass)
+                i/(unit mass)
+                j/(unit mass)
+            ==
+            $=  veb
+            $~  (~(put by *(map @tas log-level)) %hole %soft)
+            (map @tas log-level)
+        ==
+      ::
+      ++  axle-both
+        $%(axle-one axle)
+      --
+  ::
+  |=  old=axle-both
+  ?-  -.old
+    %1  $(old [%2 [hey dug lit dog=& hef veb]:old])
+    %2  ..^$(all old)
+  ==
 ::
 ++  scry
   |=  {fur/(unit (set monk)) ren/@tas why/shop syd/desk lot/coin tyl/path}
@@ -576,6 +650,6 @@
     ::
     ~&  [%dill-take-no-flow hen -.q.hin +<.q.hin]
     [~ ..^$]
-  =^  moz  all  abet:(take:u.nus q.hin)
+  =^  moz  all  abet:(take:u.nus tea q.hin)
   [moz ..^$]
 --

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -196,6 +196,14 @@
         |=  git/gift:able
         +>(moz :_(moz [hen %give git]))
       ::
+      ++  deal                                          ::  pass to %gall
+        |=  [=wire act=agent-action:gall]
+        (pass wire [%g %deal [our our] ram act])
+      ::
+      ++  pass                                          ::  pass note
+        |=  [=wire =note]
+        +>(moz :_(moz [hen %pass wire note]))
+      ::
       ++  from                                          ::  receive belt
         |=  bit/dill-blit
         ^+  +>
@@ -289,19 +297,15 @@
         --
       ::
       ++  heft
-        %_    .
-            moz
-          :*  [hen %pass /heft/ames %a %wegh ~]
-              [hen %pass /heft/behn %b %wegh ~]
-              [hen %pass /heft/clay %c %wegh ~]
-              [hen %pass /heft/eyre %e %wegh ~]
-              [hen %pass /heft/ford %f %wegh ~]
-              [hen %pass /heft/gall %g %wegh ~]
-              [hen %pass /heft/iris %i %wegh ~]
-              [hen %pass /heft/jael %j %wegh ~]
-              moz
-          ==
-        ==
+        =<  (pass /heft/ames [%a %wegh ~])
+        =<  (pass /heft/behn [%b %wegh ~])
+        =<  (pass /heft/clay [%c %wegh ~])
+        =<  (pass /heft/eyre [%e %wegh ~])
+        =<  (pass /heft/ford [%f %wegh ~])
+        =<  (pass /heft/gall [%g %wegh ~])
+        =<  (pass /heft/iris [%i %wegh ~])
+        =<  (pass /heft/jael [%j %wegh ~])
+        .
       ::  XX move
       ::
       ++  sein
@@ -312,25 +316,21 @@
         [[151 %noun] %j our %sein da+now /(scot %p who)]
       ::
       ++  init                                          ::  initialize
-        ^+  .
-        =.  moz
-          :_  moz
-          [hen %pass /merg/home %c %merg %home our %base da+now %init]
-        .
+        (pass /merg/home [%c %merg %home our %base da+now %init])
       ::
       ++  mere                                          ::  continue init
         ^+  .
         =/  myt  (flop (fall tem ~))
         =/  can  (clan:title our)
         =.  tem  ~
-        =.  moz  :_(moz [hen %pass ~ %g %conf [[our ram] our %home]])
+        =.  +>  (pass / [%g %conf [[our ram] our %home]])
         =.  +>  (sync %home our %base)
-        =.  +>  ?:  ?=(?($czar $pawn) can)  +>
-                (sync %base (sein our) %kids)
-        =.  +>  ?.  ?=(?($duke $king $czar) can)  +>
-                ::  make kids desk publicly readable, so syncs work.
-                ::
-                (show %kids):(sync %kids our %base)
+        =?  +>  ?=(?($earl $duke $king) can)
+          (sync %base (sein our) %kids)
+        =?  +>  ?=(?($duke $king $czar) can)
+          ::  make kids desk publicly readable, so syncs work.
+          ::
+          (show %kids):(sync %kids our %base)
         =.  +>  autoload
         =.  +>  hood-set-boot-apps
         =.  +>  peer
@@ -340,71 +340,35 @@
       ::
       ++  into                                          ::  preinitialize
         |=  gyl/(list gill)
-        %_    +>
-            tem  `(turn gyl |=(a/gill [%yow a]))
-            moz
-          :_  moz
-          [hen %pass / %c %warp our %base `[%sing %y [%ud 1] /]]
-        ==
+        =.  tem  `(turn gyl |=(a/gill [%yow a]))
+        (pass / [%c %warp our %base `[%sing %y [%ud 1] /]])
       ::
       ++  send                                          ::  send action
         |=  bet/dill-belt
         ^+  +>
         ?^  tem
           +>(tem `[bet u.tem])
-        %_    +>
-            moz
-          :_  moz
-          [hen %pass ~ %g %deal [our our] ram %poke [%dill-belt -:!>(bet) bet]]
-        ==
+        (deal / [%poke [%dill-belt -:!>(bet) bet]])
       ::
       ++  hood-set-boot-apps
-        %_    .
-            moz
-          :_  moz
-          :*  hen  %pass  ~  %g  %deal  [our our]
-              ram  %poke  %drum-set-boot-apps  !>(lit.all)
-          ==
-        ==
+        (deal / [%poke %drum-set-boot-apps !>(lit.all)])
       ::
       ++  peer
-        %_    .
-            moz
-          :_(moz [hen %pass ~ %g %deal [our our] ram %peer /drum])
-        ==
+        (deal / [%peer /drum])
       ::
       ++  show                                          ::  permit reads on desk
         |=  des/desk
-        %_    +>.$
-            moz
-          :_  moz
-          [hen %pass /show %c %perm des / r+`[%black ~]]
-        ==
+        (pass /show [%c %perm des / r+`[%black ~]])
       ::
       ++  sync
         |=  syn/{desk ship desk}
-        %_    +>.$
-            moz
-          :_  moz
-          :*  hen  %pass  /sync  %g  %deal  [our our]
-              ram  %poke  %hood-sync  -:!>(syn)  syn
-          ==
-        ==
+        (deal /sync [%poke %hood-sync -:!>(syn) syn])
       ::
       ++  autoload
-        %_    .
-            moz
-          :_  moz
-          :*  hen  %pass  /autoload  %g  %deal  [our our]
-              ram  %poke  %kiln-start-autoload  [%atom %n `~]  ~
-          ==
-        ==
+        (deal /autoload [%poke %kiln-start-autoload [%atom %n `~] ~])
       ::
       ++  pump                                          ::  send diff ack
-        %_    .
-            moz
-          :_(moz [hen %pass ~ %g %deal [our our] ram %pump ~])
-        ==
+        (deal / [%pump ~])
       ::
       ++  take                                          ::  receive
         |=  sih/sign

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -561,7 +561,7 @@
     =*  duc  (need hey.all)
     =/  app  %hood
     =/  see  (tuba "<awaiting {(trip app)}, this may take a minute>")
-    =/  zon=axon  [app input=[~ ~] width=80 cursor=0 see]
+    =/  zon=axon  [app input=[~ ~] width=80 cursor=(lent see) see]
     ::
     =^  moz  all  abet:(~(into as duc zon) ~)
     [moz ..^$]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -968,6 +968,7 @@
         =/  task  [hen routes agent-action]
         (~(put to tasks) task)
       ::
+      ~&  >>  [%gall-not-running term -.agent-action]
       %_  mo-core
         blocked.agents.state  (~(put by blocked.agents.state) term blocked)
       ==

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -274,6 +274,48 @@
     =/  pass  [path note-arvo]
     (mo-pass pass)
   ::
+  ::  +mo-reboot: ask %ford to rebuild the specified agent
+  ::
+  ++  mo-reboot
+    |=  [force=? =term =ship]
+    ^+  mo-core
+    =/  gent  (~(got by running.agents.state) term)
+    =.  hen  control-duct.gent
+    =*  desk  q.beak.gent
+    ::  if we're forcing a reboot, we don't try to %kill the old build
+    ::
+    ?:  force
+      (mo-boot term ship desk)
+    ::
+    =/  =wire
+      =/  ship  (scot %p ship)
+      =/  case  (scot r.beak.gent)
+      /sys/core/[term]/[ship]/[desk]/[case]
+    %.  [term ship desk]
+    =<  mo-boot
+    =/  =note-arvo  [%f %kill ~]
+    (mo-pass wire note-arvo)
+    ::
+  ::
+  ::  +mo-goad: rebuild agent(s)
+  ::
+  ++  mo-goad
+    |=  [force=? agent=(unit dude)]
+    ^+  mo-core
+    ?^  agent
+      ~|  goad-gone+u.agent
+      (mo-reboot force u.agent our)
+    ::
+    =/  agents=(list term)
+      ~(tap in ~(key by running.agents.state))
+    |-  ^+  mo-core
+    ?~  agents
+      mo-core
+    %=  $
+      agents     t.agents
+      ..mo-core  (mo-reboot force i.agents our)
+    ==
+  ::
   ::  +mo-pass: prepend a standard %pass to the current list of moves.
   ::
   ++  mo-pass
@@ -2355,6 +2397,7 @@
         %dirk            `%c
         %drop            `%c
         %flog            `%d
+        %goad            `%g
         %info            `%c
         %keep            `%f
         %kill            `%f
@@ -2420,6 +2463,9 @@
     ::
     =>  (mo-handle-local:initialised p.sock internal-task)
     mo-abet
+  ::
+      %goad
+    mo-abet:(mo-goad:initialised force.task agent.task)
   ::
       %init
     =/  payload  gall-payload(system-duct.agents.state duct)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1884,6 +1884,7 @@
       $%  {$conf p/dock q/dock}                         ::  configure app
           $>(%init vane-task)                           ::  set owner
           {$deal p/sock q/internal-task}                ::  full transmission
+          [%goad force=? agent=(unit dude)]             ::  rebuild agent(s)
           $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           $>(%west vane-task)                           ::  network request


### PR DESCRIPTION
This PR follows #1914 in our efforts to fix the livenet. Specifically, it's a way to work around broken live builds in %ford, as reported in #1898.

%ford builds can get stuck if %ford crashes when processing the response from %clay -- the response is intermediated through %behn via a %drip task, which provides isolation but not (yet) error reporting. When this happens, %ford thinks it's waiting for %clay, and %clay thinks it's already responded. Both are technically correct.

To work around this state for %gall agents, we add a `%goad` task to %gall, which can cause it to goad %ford into restarting the build. The task can apply to one specific agent, or all that are running. %gall will cancel the current live build (as it may be stuck) and start a new one. Alternately, we can set `force` to `%.y` if the build is in an invalid state and can't be cleaned up by %ford. (This has been observed in testing, and is included for near-term durability. %ford should either a) never get into such a state, or b) be able to get out of it.)

The interface is straightforward:

```
> |goad-gall
> |goad-gall, =force &
> |goad-gall, =agent %hood
> |goad-gall, =force &, =agent %hood
```

The recommendation is simply to run `|goad-gall`, and only force or target specific apps as necessary. The `force` option will result in logically duplicate %ford builds (although one maybe blocked, in which case it's mostly irrelevant).

If one were so unlucky as to find `:hood` in this state (build blocked, so updates will not be applied to it), this command can *not* get you unstuck -- the command would be added in an update to :hood, which is precisely not an option. For such unlucky ones, this PR also includes a `:goad` app.

To use it, simply `|start %goad`. The equivalent of `|goad-gall` is then `:goad 1`. The equivalent of `|goad-gall, =force &` is `:goad %force`. No agent-specific option is provided.

I've tested this PR on (a local-only copy of) my planet; after the borked OTA, `:chat-cli` and `:dojo` were updated, while `:hood` was not. It restored full functionality. These changes also need to be tested on a ship in the opposite scenario (for instance, `:hood` updated, `:dojo` not) to confirm it works in either scenario.