### PR TITLE
apps: designate compiled js/css files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 bin/* filter=lfs diff=lfs merge=lfs -text
 bin/*/* filter=lfs diff=lfs merge=lfs -text
+pkg/arvo/**/*.js binary
+pkg/arvo/**/*.css binary


### PR DESCRIPTION
(I just happened to come across this technique while investigating the mechanics of smudge/clean for LFS-tracked files; it's worth adding.)

The 'index.js', 'tile.js', and 'index.css' files included in several Arvo apps are compiled, minified JS or CSS.  While they are technically text, they are not usefully diffable.  This PR designates such files as 'binary' in .gitattributes, which prevents git from attempting to create diffs for them in 'git log' and 'git show'.

Before:

```
$ git log -p -- pkg/arvo/app/chat
commit e06acb87bec18c8a7fafb4d96d13bfa533d06e2e
Author: Logan Allen <loganallc@gmail.com>
Date:   Thu Oct 24 14:31:40 2019 -0700

    chat-ui: fix image previews from url types

diff --git a/pkg/arvo/app/chat/js/index.js b/pkg/arvo/app/chat/js/index.js
index c06d0732f..faf75ad00 100644
--- a/pkg/arvo/app/chat/js/index.js
+++ b/pkg/arvo/app/chat/js/index.js
@@ -1 +1 @@
-!function(e,t){"object"==typeof exports&&"undefined"!=typeof[.. <enormous diff>]
```

After:

```
$ git log -p -- pkg/arvo/app/chat
commit e06acb87bec18c8a7fafb4d96d13bfa533d06e2e
Author: Logan Allen <loganallc@gmail.com>
Date:   Thu Oct 24 14:31:40 2019 -0700

    chat-ui: fix image previews from url types

diff --git a/pkg/arvo/app/chat/js/index.js b/pkg/arvo/app/chat/js/index.js
index c06d0732f..faf75ad00 100644
Binary files a/pkg/arvo/app/chat/js/index.js and b/pkg/arvo/app/chat/js/index.js differ
```