### PR TITLE
vere: flushes slog output to ensure style isolation

### DIFF
--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -2075,6 +2075,8 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
     fprintf(fil_u, "\033[0m");
   }
 
+  fflush(fil_u);
+
   u3_term_io_loja(0);
   u3z(blu);
   u3z(tac);


### PR DESCRIPTION
Without the flush, the style bleeds onto the spinning cursor prompt line, if present.