### PR TITLE
build: use HEAD in sh/create-ropsten-pills

### DIFF
--- a/sh/create-ropsten-pills
+++ b/sh/create-ropsten-pills
@@ -2,7 +2,7 @@
 
 set -e
 
-sha=$(git rev-parse $(git branch --show-current))
+sha=$(git rev-parse HEAD)
 
 brass=$(nix-build nix/ops -A brass-ropsten --no-out-link)
 ivory=$(nix-build nix/ops -A ivory-ropsten --no-out-link)


### PR DESCRIPTION
If we're not on a branch, e.g. if we've checked out an arbitrary revision, then 'git branch --show-current' sensibly won't give us any output, and thus the pills produced by sh/create-ropsten-pills will be misnamed.

Consuming HEAD with git-rev-parse has the same effect here, and should work in all cases of interest.