### PR TITLE
jael: don't update state until you've tested for breach

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63c31ab63feda55e69a5759411bcc3d4b762a158ab0e416dd2265f7661734032
-size 8933534
+oid sha256:ccb3dc7661a01ab606806bc2d2bf8dfca349ad37ac49432937336431f20b5880
+size 8935337

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -804,12 +804,11 @@
       |=  =public-keys-result
       ^+  ..feel
       ?:  ?=(%full -.public-keys-result)
-        =.  pos.zim  (~(uni by pos.zim) points.public-keys-result)
         =/  pointl=(list [who=ship =point])
           ~(tap by points.public-keys-result)
         |-  ^+  ..feel
         ?~  pointl
-          ..feel
+          ..feel(pos.zim (~(uni by pos.zim) points.public-keys-result))
         ::  if changing rift upward, then signal a breach
         ::
         =?    ..feel


### PR DESCRIPTION
We were updating our state and then using that when checking if the rift
had incremented.  This would never be true, since we'd already set the
new state.

Fixes #1852 again.

This should be sent out OTA.