### PR TITLE
Fix url explaining how to add swap space

### DIFF
--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1601,8 +1601,8 @@ u3m_init(void)
                          -1, 0);
 
       u3l_log("boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-      u3l_log("see urbit.org/docs/getting-started/installing-urbit/#swap"
               "for adding swap space\r\n");
+      u3l_log("find 'swap space' at urbit.org/using/install/"
       if ( -1 != (c3_ps)map_v ) {
         u3l_log("if porting to a new platform, try U3_OS_LoomBase %p\r\n",
                 dyn_v);

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1601,8 +1601,8 @@ u3m_init(void)
                          -1, 0);
 
       u3l_log("boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-              "for adding swap space\r\n");
       u3l_log("find 'swap space' at urbit.org/using/install/"
+              " for adding swap space\r\n");
       if ( -1 != (c3_ps)map_v ) {
         u3l_log("if porting to a new platform, try U3_OS_LoomBase %p\r\n",
                 dyn_v);


### PR DESCRIPTION
When running urbit on a machine without enough swap space, the message was

> see urbit.org/docs/getting-started/installing-urbit/#swapfor adding swap space

So I fixed the URL and added a space before "for"