### PR TITLE
vere: fix url explaining how to add swap space

### DIFF
--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1601,8 +1601,8 @@ u3m_init(void)
                          -1, 0);
 
       u3l_log("boot: mapping %dMB failed\r\n", (len_w / (1024 * 1024)));
-      u3l_log("see urbit.org/docs/getting-started/installing-urbit/#swap"
-              "for adding swap space\r\n");
+      u3l_log("see urbit.org/using/install/#about-swap-space"
+              " for adding swap space\r\n");
       if ( -1 != (c3_ps)map_v ) {
         u3l_log("if porting to a new platform, try U3_OS_LoomBase %p\r\n",
                 dyn_v);


### PR DESCRIPTION
When running urbit on a machine without enough swap space, the message was

see urbit.org/docs/getting-started/installing-urbit/#swapfor adding swap space

So I fixed the URL and added a space before "for"

This PR supercedes #1926 and hopefully fits the conventions better.