### PR TITLE
build: remove unused let binding from image expression

### DIFF
--- a/nix/ops/image/default.nix
+++ b/nix/ops/image/default.nix
@@ -1,17 +1,5 @@
 { pkgs, urbit, pill }:
 
-let
-
-  entrypoint = pkgs.writeScript "entrypoint.sh" ''
-    #!${pkgs.stdenv.shell}
-
-    set -euo pipefail
-
-    ${urbit.meta.exe} "$@"
-  '';
-
-in
-
 pkgs.dockerTools.buildImage {
   name = urbit.meta.name;
 


### PR DESCRIPTION
Seems there was an unused `entrypoint` binding lying around from the days when `debug` switched between invoking the binary directly and using a custom `entrypoint.sh`.