### PR TITLE
chat-cli: send invites on-;invite

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -10,7 +10,7 @@
 ::    and trust it to take care of the rest.
 ::
 /-  *chat-store, *chat-view, *chat-hook,
-    *permission-store, *group-store,
+    *permission-store, *group-store, *invite-store,
     sole-sur=sole
 /+  sole-lib=sole, chat-eval
 ::
@@ -74,6 +74,7 @@
       [%chat-view-action chat-view-action]
       [%chat-hook-action chat-hook-action]
       [%group-action group-action]
+      [%invite-action invite-action]
   ==
 --
 ::
@@ -592,6 +593,28 @@
           [our-self app]
           out-action
       ==
+    ::  +invite-move: build invite move
+    ::
+    ++  invite-move
+      |=  [where=path who=ship]
+      ^-  move
+      :*  ost.bowl
+          %poke
+          /cli-command/invite
+          [who %invite-hook]  ::NOTE  only place chat-cli pokes others
+          %invite-action
+        ::
+          ^-  invite-action
+          :^  %invite  /chat
+            (shax (jam [our-self where] who))
+          ^-  invite
+          =;  desc=cord
+            [our-self %chat-hook where who desc]
+          %-  crip
+          %+  weld
+            "You have been invited to chat at "
+          ~(full tr [our-self where])
+      ==
     ::  +set-target: set audience, update prompt
     ::
     ++  set-target
@@ -641,6 +664,11 @@
       |=  [allow=? rw=?(%r %w %rw) =path ships=(set ship)]
       ^-  (quip move _this)
       :_  this
+      =;  moves=(list move)
+        ?.  allow  moves
+        %+  weld  moves
+        %+  turn  ~(tap in ships)
+        (cury invite-move path)
       %+  murn
         ^-  (list term)
         ?-  rw
@@ -1005,7 +1033,12 @@
       (lth (lent path.one) (lent path.two))
     ::  if they're from different ships, neither ours, pick hierarchically.
     (lth (xeb ship.one) (xeb ship.two))
-  ::  +phat: render target fully
+  ::  +full: render target fully, always
+  ::
+  ++  full
+    ^-  tape
+    (weld (scow %p ship.one) (spud path.one))
+  ::  +phat: render target with local shorthand
   ::
   ::    renders as ~ship/path.
   ::    for local mailboxes, renders just /path.


### PR DESCRIPTION
This augments permission management with invite sending, when setting "positive"
permissions. This matches talk's behavior.

Also implements `+full:tr`, which renders as `~ship/path`, even for local targets.

@loganallenc This does more or less what the chat-js does, please confirm this is all sane. We generate the UID from chat-in-question and target, to avoid duplicate invites piling up if they're re-sent but neither accepted nor deleted.