### PR TITLE
jael: only listen to azimuth-tracker on boot

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e6a332c3f22b3448284437ab597a2f0a76649a2c380a558f16eb788769e25c0
-size 8958901
+oid sha256:325ab5e89de515f65a91c348a4f0a328fadd480bcd4c92f26c9cbb4c5da1e86e
+size 8956643

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -296,25 +296,13 @@
       ::
       ::  start subscriptions
       ::
+      ::  get everything from azimuth-tracker because jael subscriptions
+      ::  seem to be flaky for now
+      ::
       =.  +>.$  (poke-watch hen %azimuth-tracker nod.own.pki)
       =.  +>.$
-        ?-    (clan:title our)
-            %czar
-          %-  curd  =<  abet
-          (sources:~(feel su hen our pki etn) ~ [%| %azimuth-tracker])
-        ::
-            *
-          =/  spon-ship
-            ?>  ?=(^ spon.tac)
-            ship.i.spon.tac
-          =.  +>.$
-            %-  curd  =<  abet
-            %+  sources:~(feel su hen our pki etn)
-              (silt spon-ship ~)
-            [%| %azimuth-tracker]
-          %-  curd  =<  abet
-          (sources:~(feel su hen our pki etn) ~ [%& spon-ship])
-        ==
+        %-  curd  =<  abet
+        (sources:~(feel su hen our pki etn) ~ [%| %azimuth-tracker])
       ::
       =.  moz
         %+  weld  moz


### PR DESCRIPTION
For some reason Jael subscriptions aren't starting properly for many
people.  Until we can get to the bottom of it, this sets everyone to
start listening directly to the chain.