### PR TITLE
jael: process all ships in %full update

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89d6dcd3fbe0e9eeeb4c33e26d55cb59da26bc3675a960da6c613d2cc6b753ba
-size 8956664
+oid sha256:8d5434f92c35d11e4a8cb9f63d02c26cf4ac20fd0b454997a90f396c45f8639c
+size 8957682

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -808,9 +808,12 @@
           %+  public-keys-give
             (subscribers-on-ship who.i.pointl)
           [%breach who.i.pointl]
-        %+  public-keys-give
-          (subscribers-on-ship who.i.pointl)
-        [%full (my i.pointl ~)]
+        =.  ..feel
+          %+  public-keys-give
+            (subscribers-on-ship who.i.pointl)
+          [%full (my i.pointl ~)]
+        $(pointl t.pointl)
+      ::
       ?:  ?=(%breach -.public-keys-result)
         ::  we calculate our own breaches based on our local state
         ::


### PR DESCRIPTION
I have no idea why this sort of error seems to show up in Jael and never anywhere else.

There may be other bugs, but this one on its own could explain 90% of the key-related issues we've been seeing.  This explains why people have been booting into having nobody's key state except their sponsorship chain (I moved the state update to the base case of a recursion that didn't recurse).  It also explains why updates from other ships don't work well (same, plus it only propogated the first thing in the list).  The bug has been there since new jael was released, but it was made worse by #1925.

This is a lesson to me to build more pH tests and run them when I fix bugs like this.  I discovered this only by trying to get existing pH tests to work in static gall, but I think it would have been caught even with the pH tests on master after #1925.

This is OTA-able.