### PR TITLE
zuse, build: remove default testnet config

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2238c8c35351de9de2eccf80e5ee11d33617cd89074a99c0f2e6690cac7665d1
-size 9687357
+oid sha256:23b4c88c13642794dca17b6518714dc59c8e9c3d9f8beed36c1856cf616eb3b4
+size 9425547

--- a/nix/ops/default.nix
+++ b/nix/ops/default.nix
@@ -67,14 +67,6 @@ rec {
     pier = zod;
   };
 
-<<<<<<< HEAD
-  image = import ./image {
-    inherit pkgs urbit;
-    pill = bootsolid;
-  };
-
-||||||| merged common ancestors
-=======
   ivory-ropsten = import ./ivory {
     inherit pkgs herb urbit;
     arvo = arvo-ropsten;
@@ -86,5 +78,4 @@ rec {
     pill = bootsolid;
   };
 
->>>>>>> master
 }

--- a/nix/pkgs/arvo-ropsten/builder.sh
+++ b/nix/pkgs/arvo-ropsten/builder.sh
@@ -4,7 +4,7 @@ cp -r $src tmp
 chmod -R u+w tmp
 
 ZUSE=tmp/sys/zuse.hoon
-AMES=tmp/sys/vane/ames.hoon
+ALEF=tmp/sys/vane/alef.hoon
 ACME=tmp/app/acme.hoon
 
 # replace the mainnet azimuth contract with the ropsten contract
@@ -12,10 +12,10 @@ sed --in-place \
   's/\(\+\+  contracts  \)mainnet\-contracts/\1ropsten-contracts/' \
   $ZUSE
 
-# increment the %ames protocol version
+# increment the %alef protocol version
 sed -r --in-place \
-  's/^(=\+  protocol\-version=)([0-9])/echo "\1$(echo "(\2+1) % 8" | bc)"/e' \
-  $AMES
+  's_^(=/  protocol\-version=\?\(.*\)  %)([0-7])_echo "\1$(echo "(\2+1) % 8" | bc)"_e' \
+  $ALEF
 
 # use the staging API in :acme
 sed --in-place \

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7525,7 +7525,7 @@
       ::  #  constants
       ::
       ::  contract addresses
-      ++  contracts  ropsten-contracts
+      ++  contracts  mainnet-contracts
       ++  mainnet-contracts
         |%
         ::  azimuth: data contract


### PR DESCRIPTION
Returns the target %zuse contract configuration to mainnet, and also tweaks the 'arvo-ropsten' build to use %alef instead of %ames.

@belisarius222 I have some existing scripting for handling testnets such that one doesn't need to hard-code any testnet config in git.  It's desirable to patch things here so I can simply reuse that stuff.