### PR TITLE
hoon: refactor royl float parsers to separate arms

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d5434f92c35d11e4a8cb9f63d02c26cf4ac20fd0b454997a90f396c45f8639c
-size 8957682
+oid sha256:bccc640d030d2ec49b24a5f3413b305cb4823f1b5bf86f5d0dbfe7f6dc38ac2a
+size 8951763

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6124,47 +6124,54 @@
     ==
   ++  royl
     ~+
-    =+  ^=  moo
-      |=  a/tape
+    ;~  pose
+      (stag %rh royl-rh)
+      (stag %rq royl-rq)
+      (stag %rd royl-rd)
+      (stag %rs royl-rs)
+    ==
+  ::
+  ++  royl-rh  (cook rylh ;~(pfix ;~(plug sig sig) (cook royl-cell royl-rn)))
+  ++  royl-rq  (cook rylq ;~(pfix ;~(plug sig sig sig) (cook royl-cell royl-rn)))
+  ++  royl-rd  (cook ryld ;~(pfix sig (cook royl-cell royl-rn)))
+  ++  royl-rs  (cook ryls (cook royl-cell royl-rn))
+  ::
+  ++  royl-rn
+    =/  moo
+      |=  a=tape
       :-  (lent a)
       (scan a (bass 10 (plus sid:ab)))
-    =+  ^=  voy
-      %+  cook  royl-cell
-      ;~  pose
-        ;~  plug
-          (easy %d)
-          ;~  pose  (cold | hep)  (easy &)  ==
-          ;~  plug  dim:ag
-            ;~  pose
-              ;~(pfix dot (cook moo (plus (shim '0' '9'))))
-              (easy [0 0])
-            ==
-            ;~  pose
-              ;~  pfix
-                (just 'e')
-                ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
-              ==
-              (easy [& 0])
-            ==
+    ;~  pose
+      ;~  plug
+        (easy %d)
+        ;~(pose (cold | hep) (easy &))
+        ;~  plug  dim:ag
+          ;~  pose
+            ;~(pfix dot (cook moo (plus (shim '0' '9'))))
+            (easy [0 0])
           ==
-        ==
-        ;~  plug
-          (easy %i)
-          ;~  sfix
-            ;~  pose  (cold | hep)  (easy &)  ==
-            (jest 'inf')
+          ;~  pose
+            ;~  pfix
+              (just 'e')
+              ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
+            ==
+            (easy [& 0])
           ==
-        ==
-        ;~  plug
-          (easy %n)
-          (cold ~ (jest 'nan'))
         ==
       ==
-    ;~  pose
-      (stag %rh (cook rylh ;~(pfix ;~(plug sig sig) voy)))
-      (stag %rq (cook rylq ;~(pfix ;~(plug sig sig sig) voy)))
-      (stag %rd (cook ryld ;~(pfix sig voy)))
-      (stag %rs (cook ryls voy))
+      ::
+      ;~  plug
+        (easy %i)
+        ;~  sfix
+          ;~(pose (cold | hep) (easy &))
+          (jest 'inf')
+        ==
+      ==
+      ::
+      ;~  plug
+        (easy %n)
+        (cold ~ (jest 'nan'))
+      ==
     ==
   ::
   ++  royl-cell


### PR DESCRIPTION
Immediately useful for implemeting json `@rd` parsing, which is basically
`++royl-rd` minus pfix sig. The increased separation also allows for running
stuff like `(rash '3.22e-47' royl-rn:so)` from the dojo.

Not sure who should look at this, ping @jtobin.