### PR TITLE
publish: add subscribe generator

### DIFF
--- a/pkg/arvo/gen/publish/subscribe.hoon
+++ b/pkg/arvo/gen/publish/subscribe.hoon
@@ -1,0 +1,9 @@
+::  subscribe to a publish notebook
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=ship name=term ~] ~]
+    ==
+:-  %publish-action
+[%subscribe ship name]
+


### PR DESCRIPTION
As per @joemfb's suggestion: `:publish|subscribe ~palfun-foslup %urbit-only-exclusive-tweets`.