### PR TITLE
sur: added identity structure with support for ship signatures or ring signatures

### DIFF
--- a/pkg/arvo/sur/identity.hoon
+++ b/pkg/arvo/sur/identity.hoon
@@ -1,0 +1,8 @@
+/-  *ring
+|%
++$  ship-identity  [=ship =life]
++$  identity
+  $%  [%ship ship-identity]
+      [%ring =ring-group]
+  ==
+--

--- a/pkg/arvo/sur/ring.hoon
+++ b/pkg/arvo/sur/ring.hoon
@@ -34,4 +34,14 @@
       ::
       raw=raw-ring-signature
   ==
+::
++$  ring-group
+  $:  ::  a ring signature is computed over a set of public keys. the
+      ::  participants set is not those keys, but static references to them.
+      ::
+      participants=(set [ship=@p =life])
+      ::  the linkage scope this signature was made on
+      ::
+      link-scope=(unit *)
+  ==
 --


### PR DESCRIPTION
Hi there, Elliot and I have been discussing the creation of general data structures for representing identity that can be used across different data stores and hooks. Based on our conversations, I created this sur file, whose first consumer will be the contacts app.

`%ship`: When receiving a message, tweet, or other piece of data from a hosted chat/blog/microblog, it is important to be able to associate signed messages from ships that verify that the ship in question created the data. We should start by writing validation into our hooks that checks ship public keys and lives against signatures sent in their messages to us from external contexts. (If ~dopzod is hosting a chatroom, ~dopzod could theoretically say ~marzod sent a message criticizing ~bus). Ship-based signatures verifying message contents are an important first step towards removing this possibility.

`%ring`: When receiving a message from a context that uses ring signatures, it is important to have a primitive representing a "ring-group".

I'm envisioning this `identity` structure replacing most of the places where we use =ship in the current data-stores. This is just a first step.