### PR TITLE
Modernise syntax throughout Arvo type definitions

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bccc640d030d2ec49b24a5f3413b305cb4823f1b5bf86f5d0dbfe7f6dc38ac2a
-size 8951763
+oid sha256:3c52219afc820cfea1a27c8aee80f9013855c9973d1f7528de959d6f1c85f1e0
+size 9628626

--- a/doc/spec/u3.md
+++ b/doc/spec/u3.md
@@ -1495,32 +1495,29 @@ core?  Slightly pseudocoded:
 
     ++  arvo
       |%
-      ++  come  |=  [yen=@ ova=(list ovum) nyf=pone]  ::  11
+      ++  come  |=  [yen=@ ova=(list ovum) nyf=pone]  ::  4
                 ^-  [(list ovum) _+>]
                 !!
-      ++  keep  |=  [now=@da hap=path]                ::  4
-                ^-  (unit ,@da)
-                !!
-      ++  load  |=  [yen=@ ova=(list ovum) nyf=pane]  ::  86
+      ++  load  |=  [yen=@ ova=(list ovum) nyf=pane]  ::  10
                 ^-  [(list ovum) _+>]
                 !!
-      ++  peek  |=  [now=@da path]                    ::  87
+      ++  peek  |=  [now=@da path]                    ::  46
                 ^-  (unit)
                 !!
-      ++  poke  |=  [now=@da ovo=ovum]                ::  42
+      ++  poke  |=  [now=@da ovo=ovum]                ::  47
                 ^-  [(list ovum) _+>]
                 !!
-      ++  wish  |=  txt=@ta                           ::  20
+      ++  wish  |=  txt=@ta                           ::  22
                 ^-  *
                 !!
       --
-    ++  card  ,[p=@tas q=*]                           ::  typeless card
-    ++  ovum  ,[p=wire q=card]                        ::  Arvo event
-    ++  wire  path                                    ::  event cause
+    +$  card  [p=term q=noun]                         ::  typeless card
+    +$  wire  path                                    ::  event cause
+    +$  ovum  [p=wire q=card]                         ::  Arvo event
 
 This is the Arvo ABI in a very real sense.  Arvo is a core with
-these six arms.  To use these arms, we hardcode the axis of the
-formula (`11`, `4`, `86`, etc) into the C code that calls Arvo,
+these five arms.  To use these arms, we hardcode the axis of the
+formula (`4`, `10`, `46`, etc) into the C code that calls Arvo,
 because otherwise we'd need type metadata - which we can get, by
 calling Arvo.
 
@@ -1537,10 +1534,6 @@ ova and a new Arvo core.
 
 `++peek` dereferences the Arvo namespace.  It takes a date and a
 key, and produces `~` (`0`) or `[~ value]`.
-
-`++keep` asks Arvo the next time it wants to be woken up, for the
-given `wire`.  (This input will probably be eliminated in favor
-of a single global timer.)
 
 `++wish` compiles a string of Hoon source.  While just a
 convenience, it's a very convenient convenience.

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1,85 +1,83 @@
-::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
-::::::  ::::::    Postface                              ::::::
-::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::  postface
+::
 ~>  %slog.[0 leaf+"%arvo-assembly"]
 =-  ~>  %slog.[0 leaf+"%arvo-assembled"]
     -
-=<  ::
-    ::  Arvo formal interface
-    ::
-    ::    this lifecycle wrapper makes the arvo door (multi-armed core)
-    ::    look like a gate (function or single-armed core), to fit
-    ::    urbit's formal lifecycle function. a practical interpreter
-    ::    can ignore it.
-    ::
-    |=  [now=@da ovo=*]
-    ^-  *
-    ~>  %slog.[0 leaf+"arvo-event"]
-    .(+> +:(poke now ovo))
-::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
-::::::  ::::::    volume 3, Arvo models and skeleton    ::::::
-::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
+=<
+::  arvo formal interface
+::
+::    this lifecycle wrapper makes the arvo door look like a gate to fit
+::    urbit's formal lifecycle function. a practical interpreter
+::    can ignore it.
+::
+|=  [now=@da ovo=*]
+^-  *
+~>  %slog.[0 leaf+"arvo-event"]
+.(+> +:(poke now ovo))
+::
 =>
+::  volume 3, arvo models and skeleton
+::
 |%
-++  arch  {fil/(unit @uvI) dir/(map @ta $~)}            ::  fundamental node
-++  arvo  (wind {p/term q/mill} mill)                   ::  arvo card
-++  beam  {{p/ship q/desk r/case} s/path}               ::  global name
-++  beak  {p/ship q/desk r/case}                        ::  garnish with beak
-++  bone  @ud                                           ::  opaque duct
-++  case                                                ::  version
-          $%  {$da p/@da}                               ::  date
-              {$tas p/@tas}                             ::  label
-              {$ud p/@ud}                               ::  sequence
-          ==                                            ::
-++  desk  @tas                                          ::  ship desk case spur
-++  dock  (pair @p term)                                ::  message target
-++  cage  (cask vase)                                   ::  global metadata
-++  cask  |*(a/mold (pair mark a))                      ::  global data
-++  curd  {p/@tas q/*}                                  ::  typeless card
-++  duct  (list wire)                                   ::  causal history
-++  hypo  |*(a/mold (pair type a))                      ::  type associated
-++  hobo  |*  a/mold                                    ::  kiss wrapper
-          $?  $%  {$soft p/*}                           ::
-              ==                                        ::
-              a                                         ::
-          ==                                            ::
-++  mark  @tas                                          ::  content type
++$  arch  [fil=(unit @uvI) dir=(map @ta %~)]            ::  fundamental node
++$  arvo  (wind [p=term q=mill] mill)                   ::  arvo card
++$  beam  [[p=ship q=desk r=case] s=path]               ::  global name
++$  beak  [p=ship q=desk r=case]                        ::  garnish with beak
++$  bone  @ud                                           ::  opaque duct
++$  case                                                ::  version
+  $%  [%da p=@da]                                       ::  date
+      [%tas p=@tas]                                     ::  label
+      [%ud p=@ud]                                       ::  sequence
+  ==
++$  desk  @tas                                          ::  ship desk case spur
++$  dock  (pair @p term)                                ::  message target
++$  cage  (cask vase)                                   ::  global metadata
++*  cask  [a]  (pair mark a)                            ::  global data
++$  curd  [p=@tas q=*]                                  ::  typeless card
++$  duct  (list wire)                                   ::  causal history
++*  hypo  [a]  (pair type a)                            ::  type associated
++*  hobo  [a]                                           ::  kiss wrapper
+  $?  $%  [%soft p=*]
+      ==
+      a
+  ==
++$  mark  @tas                                          ::  content type
 ++  mash  |=(* (mass +<))                               ::  producing mass
-++  mass  $~  [%$ [%& ~]]                               ::  memory usage
-          (pair cord (each noun (list mash)))           ::
-++  mill  (each vase milt)                              ::  vase+metavase
-++  milt  {p/* q/*}                                     ::  metavase
-++  monk  (each ship {p/@tas q/@ta})                    ::  general identity
-++  muse  {p/@tas q/duct r/arvo s/@ud}                  ::  sourced move
-++  move  {p/duct q/arvo}                               ::  arvo move
-++  ovum  {p/wire q/curd}                               ::  typeless ovum
-++  pane  (list {p/@tas q/vase})                        ::  kernel modules
-++  pone  (list {p/@tas q/vise})                        ::  kernel modules old
++$  mass  $~  [%$ [%& ~]]                               ::  memory usage
+          (pair cord (each noun (list mash)))
++$  mill  (each vase milt)                              ::  vase+metavase
++$  milt  [p=* q=*]                                     ::  metavase
++$  monk  (each ship [p=@tas q=@ta])                    ::  general identity
++$  muse  [p=@tas q=duct r=arvo s=@ud]                  ::  sourced move
++$  move  [p=duct q=arvo]                               ::  arvo move
++$  ovum  [p=wire q=curd]                               ::  typeless ovum
++$  pane  (list [p=@tas q=vase])                        ::  kernel modules
++$  pone  (list [p=@tas q=vise])                        ::  kernel modules old
 +$  scry-sample
   [fur=(unit (set monk)) ren=@tas why=shop syd=desk lot=coin tyl=path]
 +$  vane-sample
   [our=ship now=@da eny=@uvJ ski=slyd]
-++  ship  @p                                            ::  network identity
-++  sink  (trel bone ship path)                         ::  subscription
-++  sley  $-  {* (unit (set monk)) term beam}           ::  namespace function
-          (unit (unit cage))                            ::
-++  slyd  $-  {* (unit (set monk)) term beam}           ::  super advanced
-          (unit (unit (cask milt)))                     ::
-++  slyt  $-({* *} (unit (unit)))                       ::  old namespace
++$  ship  @p                                            ::  network identity
++$  sink  (trel bone ship path)                         ::  subscription
++$  sley  $-  [* (unit (set monk)) term beam]           ::  namespace function
+          (unit (unit cage))
++$  slyd  $-  [* (unit (set monk)) term beam]           ::  super advanced
+          (unit (unit (cask milt)))
++$  slyt  $-([* *] (unit (unit)))                       ::  old namespace
 +$  vane  [=vase =worm]
-++  vile                                                ::  reflexive constants
-          $:  typ/type                                  ::  -:!>(*type)
-              duc/type                                  ::  -:!>(*duct)
-              pah/type                                  ::  -:!>(*path)
-              mev/type                                  ::  -:!>([%meta *vase])
-          ==                                            ::
-++  wind                                                ::  new kernel action
-          |*  {a/mold b/mold}                           ::  forward+reverse
-          $%  {$pass p/path q/a}                        ::  advance
-              {$slip p/a}                               ::  lateral
-              {$give p/b}                               ::  retreat
-          ==                                            ::
-++  wire  path                                          ::  event pretext
++$  vile                                                ::  reflexive constants
+  $:  typ=type                                          ::  -:!>(*type)
+      duc=type                                          ::  -:!>(*duct)
+      pah=type                                          ::  -:!>(*path)
+      mev=type                                          ::  -:!>([%meta *vase])
+  ==
++*  wind                                                ::  new kernel action
+      [a b]                                             ::  forward+reverse
+  $%  [%pass p=path q=a]                                ::  advance
+      [%slip p=a]                                       ::  lateral
+      [%give p=b]                                       ::  retreat
+  ==
++$  wire  path                                          ::  event pretext
 --
 =>
 ~%  %hex  +>  ~

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -693,7 +693,7 @@
               =^  rey  +>+  (^load +<)
               [rey +>.$]
     ::
-    ++  peek  |=(* (^peek ;;([@da path] +<)))      ::  46
+    ++  peek  |=(* (^peek ;;([@da path] +<)))           ::  46
     ::
     ++  poke  |=  *                                     ::  47
               ^-  [(list ovum) *]
@@ -716,7 +716,7 @@
               =?  out  ?=(^ vov)  [+.vov out]
               $(ova t.ova)
     ::
-    ++  wish  |=(* (^wish ;;(@ta +<)))             ::  22
+    ++  wish  |=(* (^wish ;;(@ta +<)))                  ::  22
     --
 ::  Arvo implementation core
 ::


### PR DESCRIPTION
Minor housekeeping on arvo.hoon and related.

Changes:

* The u3 spec was out of date, describing a since-removed +keep arm as a member of the Arvo structural core.  Additionally, the hardcoded formula axes were out-of-sync with the current ones.

* Fixes the deprecated comment style that existed in Arvo's header, rewriting all comments verbatim in the modern "breathing" style.

* Modernises syntax in Arvo's type definitions.  That is:
  * replaces old syntax (kel, ker, fas) with modern (sel, ser, tis)
  * replaces all `++` arms with `+$` or `+*` as appropriate
  * changes instances of `$foo` to `%foo`
