### PR TITLE
zuse: implement json number to @rd parsing

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bccc640d030d2ec49b24a5f3413b305cb4823f1b5bf86f5d0dbfe7f6dc38ac2a
-size 8951763
+oid sha256:82e6ed4950cf9e492fad8551155e845c1dd720028db0f26f20aa32e8f4e71d34
+size 9620494

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5570,10 +5570,11 @@
       ?~(jon ~ (some (wit jon)))
     ::                                                  ::  ++ne:dejs:format
     ++  ne                                              ::  number as real
+      =,  ^so
       |=  jon/json
-      ^-  (unit @rd)
-      ::  please implement me, it's not that hard!
-      !!
+      ^-  @rd
+      ?>  ?=([%n *] jon)
+      (rash p.jon (cook ryld (cook royl-cell royl-rn)))
     ::                                                  ::  ++ni:dejs:format
     ++  ni                                              ::  number as integer
       |=  jon/json
@@ -5782,9 +5783,11 @@
       ?~(jon (some ~) (bind (wit jon) some))
     ::
     ++  ne                                              ::  number as real
+      =,  ^so
       |=  jon/json
       ^-  (unit @rd)
-      !!
+      ?.  ?=([%n *] jon)  ~
+      (rush p.jon (cook ryld (cook royl-cell royl-rn)))
     ::
     ++  ni                                              ::  number as integer
       |=  jon/json


### PR DESCRIPTION
As prepared by #1966.

Note that this is the first thing in the codebase to parse floats using something else than `++royl`, and is therefore the only place where the parser is not cached with `~+`. That may or may not be a problem, someone smarter than me could weigh in on this!