### PR TITLE
eth: two enhancements

### DIFF
--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -88,7 +88,7 @@
   ^-  card:agent:gall
   =/  args=vase  !>
     :*  %watch  /[dap]
-        url.state  launch:contracts:azimuth
+        ~m5  url.state  launch:contracts:azimuth
         ~[azimuth:contracts:azimuth]
         (topics whos.state)
     ==

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -8,7 +8,7 @@
 =>  |%
     +$  card  card:agent:gall
     +$  app-state
-      $:  %0
+      $:  %1
           dogs=(map path watchdog)
       ==
     ::
@@ -71,8 +71,45 @@
 ++  on-save   !>(state)
 ++  on-load
   |=  old=vase
-  =+  !<(old-state=app-state old)
-  `this(state old-state)
+  |^
+  =+  !<(old-state=app-states old)
+  =?  old-state  ?=(%0 -.old-state)
+    ^-  app-state
+    %=    old-state
+        -  %1
+        dogs
+      %-  ~(run by dogs.old-state)
+      |=  dog=watchdog-0
+      %=  dog
+        ->  [~m5 ->.dog]
+      ==
+    ==
+  `this(state ?>(?=(%1 -.old-state) old-state))
+  ::
+  +$  app-states
+    $%(app-state-0 app-state)
+  ::
+  +$  app-state-0
+    $:  %0
+        dogs=(map path watchdog-0)
+    ==
+  ::
+  +$  watchdog-0
+    $:  config-0
+        running=(unit =tid:spider)
+        =number:block
+        =pending-logs
+        =history
+        blocks=(list block)
+    ==
+  ::
+  +$  config-0
+    $:  url=@ta
+        from=number:block
+        contracts=(list address:ethereum)
+        =topics
+    ==
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]

--- a/pkg/arvo/sur/eth-watcher.hoon
+++ b/pkg/arvo/sur/eth-watcher.hoon
@@ -4,6 +4,7 @@
 |%
 +$  config
   $:  url=@ta
+      refresh-rate=@dr
       from=number:block
       contracts=(list address:ethereum)
       =topics

--- a/pkg/arvo/ted/eth-watcher.hoon
+++ b/pkg/arvo/ted/eth-watcher.hoon
@@ -79,9 +79,16 @@
   =/  m  (strand:strandio ,watchpup)
   ^-  form:m
   =/  zoom-margin=number:block  100
+  =/  zoom-step=number:block  100.000
   ?:  (lth latest-number (add number.pup zoom-margin))
     (pure:m pup)
-  =/  to-number=number:block  (sub latest-number zoom-margin)
+  =/  up-to-number=number:block  (sub latest-number zoom-margin)
+  |-
+  =*  loop  $
+  ?:  (gth number.pup up-to-number)
+    (pure:m pup(blocks ~))
+  =/  to-number=number:block
+    (min up-to-number (add number.pup zoom-step))
   ;<  =loglist  bind:m  ::  oldest first
     %:  get-logs-by-range:ethio
       url.pup
@@ -92,7 +99,5 @@
     ==
   =?  pending-logs.pup  ?=(^ loglist)
     (~(put by pending-logs.pup) to-number loglist)
-  =.  number.pup  +(to-number)
-  =.  blocks.pup  ~
-  (pure:m pup)
+  loop(number.pup +(to-number))
 --


### PR DESCRIPTION
Put these in while working on porting userspace Ethereum tools to static gall. Figured it might be nice to get these into the release candidate if possible.

- Add support for batch requests to `/lib/ethio`. If any request in the batch fails, the entire batch is considered a lost cause.
- Add support for custom refresh rates to `/app/eth-watcher`. Useful for low-priority watchdogs, or cases where you need a long timeout time to deal with big requests/responses.