### PR TITLE
jael: add %lyfe and %ryft scrys (unitized %life and %rift) and use in…

### DIFF
--- a/pkg/arvo/gen/trouble.hoon
+++ b/pkg/arvo/gen/trouble.hoon
@@ -24,14 +24,18 @@
   =/  o=@ta  (scot %p our)
   =/  n=@ta  (scot %da now)
   ?~  b  ~[o a n]
-    ~[o a n (scot %p u.b)]
+  ~[o a n (scot %p u.b)]
 ::
 ++  info
   |=  [=term =ship]
+  ::  unitized life and rift
+  =/  lyfe  .^((unit @ud) %j (pathify ~.lyfe `ship))
+  =/  ryft  .^((unit @ud) %j (pathify ~.ryft `ship))
   :*  term
       ship=ship
       point=(crip (slag 2 (scow %ui ship)))
-      life=.^(* %j (pathify ~.life `ship))
-      rift=.^(* %j (pathify ~.rift `ship))
+      ::  report as units
+      life=lyfe
+      rift=ryft
   ==
 --

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -997,6 +997,22 @@
     ?~  pub  ~
     ``[%atom !>(life.u.pub)]
   ::
+      %lyfe                                             ::  unitized %life
+    ?.  ?=([@ ~] tyl)  [~ ~]
+    ?.  =([%& our] why)
+      [~ ~]
+    =/  who  (slaw %p i.tyl)
+    ?~  who  [~ ~]
+    ::  fake ships always have life=1
+    ::
+    ?:  fak.own.pki.lex
+      ``[%noun !>((some 1))]
+    ?:  =(u.who p.why)
+      ``[%noun !>((some lyf.own.pki.lex))]
+    =/  pub  (~(get by pos.zim.pki.lex) u.who)
+    ?~  pub  ``[%noun !>(~)]
+    ``[%noun !>((some life.u.pub))]
+  ::
       %rift
     ?.  ?=([@ ~] tyl)  [~ ~]
     ?.  =([%& our] why)
@@ -1010,6 +1026,20 @@
     =/  pos  (~(get by pos.zim.pki.lex) u.who)
     ?~  pos  ~
     ``[%atom !>(rift.u.pos)]
+  ::
+      %ryft                                             ::  unitized %rift
+    ?.  ?=([@ ~] tyl)  [~ ~]
+    ?.  =([%& our] why)
+      [~ ~]
+    =/  who  (slaw %p i.tyl)
+    ?~  who  [~ ~]
+    ::  fake ships always have rift=1
+    ::
+    ?:  fak.own.pki.lex
+      ``[%noun !>((some 1))]
+    =/  pos  (~(get by pos.zim.pki.lex) u.who)
+    ?~  pos  ``[%noun !>(~)]
+    ``[%noun !>((some rift.u.pos))]
   ::
       %vein
     ?.  ?=([@ ~] tyl)  [~ ~]


### PR DESCRIPTION
… +trouble

See https://github.com/urbit/urbit/issues/2000#issuecomment-559342340

Thanks @philipcmonk for the advice.  I took a slightly different approach by producing units instead of booleans.

## Test procedure

I put this PR into my `pkg/arvo`.

Make fake `~zod` and reload `jael`:
```
urbit -A pkg/arvo -B bin/solid.pill -F zod
|reload %j
```

Test new `scry`s and `+trouble` (all `1`s because fake ship):
```
.^((unit) %j /=lyfe=/(scot %p ~dirwex-dosrev))
[~ 1]

.^((unit) %j /=ryft=/(scot %p ~dirwex-dosrev))
[~ 1]

+trouble
[ [%base-hash 0v1r.komgg.m1900.cq0lb.3e9rs.8oknm.mtgd7.dqabu.bbucr.erdmb.s7rbm]
  [%home-hash 0v1r.komgg.m1900.cq0lb.3e9rs.8oknm.mtgd7.dqabu.bbucr.erdmb.s7rbm]
  [%our ship=~zod point='0' life=[~ 1] rift=[~ 1]]
  [%sponsor ship=~zod point='0' life=[~ 1] rift=[~ 1]]
  [%dopzod ship=~dopzod point='4608' life=[~ 1] rift=[~ 1]]
  "Compare lifes and rifts to values here:"
  "https://etherscan.io/address/azimuth.eth#readContract"
  "  life - getKeyRevisionNumber"
  "  rift - getContinuityNumber"
  ~
]
```

`+solid` a pill for testing on a comet:
```
.lyfe-ryft/pill +solid
^d
```

Boot a comet using new pill:
```
urbit -B zod/.urb/put/lyfe-ryft.pill -c mycomet
.^((unit) %j /=lyfe=/(scot %p ~dirwex-dosrev))
~

.^((unit) %j /=ryft=/(scot %p ~dirwex-dosrev))
~

+trouble
[ [%base-hash 0v1m.84db5.m28q2.ji3ue.ehve2.vf2uc.pdecj.4fln6.amf6r.dtfdo.b2o1e]
  [%home-hash 0v1m.84db5.m28q2.ji3ue.ehve2.vf2uc.pdecj.4fln6.amf6r.dtfdo.b2o1e]
  [ %our
    ship=~fodsed-bosseb-hocmut-miglud--difdeb-marfel-litrev-marzod
    point='329553375105705021008355081706367811840'
    life=[~ 1]
    rift=[~ 1]
  ]
  [%sponsor ship=~marzod point='256' life=[~ 3] rift=[~ 0]]
  [%dopzod ship=~dopzod point='4608' life=~ rift=~]
  "Compare lifes and rifts to values here:"
  "https://etherscan.io/address/azimuth.eth#readContract"
  "  life - getKeyRevisionNumber"
  "  rift - getContinuityNumber"
  ~
]
```

Get key info (this was messy but seemed to work):
```
|start %azimuth-tracker
RETURN
:azimuth-tracker +tapp-admin/cancel
:azimuth-tracker|listen ~ %app %azimuth-tracker
|start %eth-watcher
RETURN
```

Ignore all output and wait a while:
```
.^((unit) %j /=lyfe=/(scot %p ~dirwex-dosrev))
[~ 7]

.^((unit) %j /=ryft=/(scot %p ~dirwex-dosrev))
[~ 1]

+trouble
[ [%base-hash 0v1m.84db5.m28q2.ji3ue.ehve2.vf2uc.pdecj.4fln6.amf6r.dtfdo.b2o1e]
  [%home-hash 0v1m.84db5.m28q2.ji3ue.ehve2.vf2uc.pdecj.4fln6.amf6r.dtfdo.b2o1e]
  [ %our
    ship=~fodsed-bosseb-hocmut-miglud--difdeb-marfel-litrev-marzod
    point='329553375105705021008355081706367811840'
    life=[~ 1]
    rift=[~ 1]
  ]
  [%sponsor ship=~marzod point='256' life=[~ 3] rift=[~ 0]]
  [%dopzod ship=~dopzod point='4608' life=[~ 1] rift=[~ 0]]
  "Compare lifes and rifts to values here:"
  "https://etherscan.io/address/azimuth.eth#readContract"
  "  life - getKeyRevisionNumber"
  "  rift - getContinuityNumber"
  ~
]
```

It's working as I would expect.

## Question

In the top half (above the fake ship comment) of `%life` and `%rift`, `[~ ~]` is sometimes produced.  I don't know what to do here for `%lyfe` and `%ryft` so I tested by forcing the last line of `%lyfe` to produce `[~ ~]` instead of:
```
``[%noun !>((some life.u.pub))]
```

```
|mount /=home=

    ...edit %lyfe jael.hoon...
    [~ ~]  ::::  <- testing edit  ::::  ``[%noun !>((some life.u.pub))]

|commit %home

.^((unit) %j /=lyfe=/(scot %p ~dirwex-dosrev))
/ j
  ~fodsed-bosseb-hocmut-miglud--difdeb-marfel-litrev-marzod
  lyfe
  ~2019.11.29..00.07.15..8f8a
  ~dirwex-dosrev
ford: %ride failed to execute:

.^(* %j /=lyfe=/(scot %p ~dirwex-dosrev))
/ j
  ~fodsed-bosseb-hocmut-miglud--difdeb-marfel-litrev-marzod
  lyfe
  ~2019.11.29..00.07.45..6547
  ~dirwex-dosrev
ford: %ride failed to execute:
```

So I changed `[~ ~]` to:
```
``[%noun !>(~)]
```
in the top half of `%lyfe` and `%ryft`.  Is this the correct thing to do?
