### PR TITLE
behn.c: backstop timer

### DIFF
--- a/pkg/urbit/vere/behn.c
+++ b/pkg/urbit/vere/behn.c
@@ -42,6 +42,21 @@ _behn_time_cb(uv_timer_t* tim_u)
   u3_behn* teh_u = pir_u->teh_u;
   teh_u->alm = c3n;
 
+  //  start another timer for 10 minutes
+  //
+  //  This is a backstop to deal with the case where a %doze is not
+  //  properly sent, for example after a crash.  If the timer continues
+  //  to fail, we can't proceed with the timers, but if it was a
+  //  transient error, this will get us past it.
+  //
+  {
+    c3_d gap_d = 10 * 60 * 1000;
+    teh_u->alm = c3y;
+    uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
+  }
+
+  // send timer event
+  //
   {
     u3_pier_work
       (pir_u,


### PR DESCRIPTION
I've observed two cases of ~marzod on the testnet hanging by not processing its timers.  In each case, running `-time ~s1` gets it going again, which suggests that for some reason the timer isn't getting reset correctly.

I've eliminated every deterministic case that I can tell where ames could be causing this, but it's always possible for this to happen if the error case of `%wake` crashes non-deterministically.  Since nondeterministic errors could happen at any time, we must handle this case.

This resets our timer to 10 minutes every time a timer fires, instead of clearing it.  This means if we don't hear a `%doze` that explicitly tells us to set or cancel our timer, we'll send a `%wake` after 10 minutes of timer inactivity.  Behn.hoon is already required to no-op on spurious timer updates, so this will have no effect if the timer wasn't expected.