### PR TITLE
chat: improve eval implementation

### DIFF
--- a/pkg/arvo/lib/chat/eval.hoon
+++ b/pkg/arvo/lib/chat/eval.hoon
@@ -2,15 +2,21 @@
 ++  eval
   |=  [=bowl:gall =hoon]
   ^-  (list tank)
-  =/  subj=[our=@p now=@da eny=@uvJ]
+  =/  fowl=[our=@p now=@da eny=@uvJ]
     :+  our.bowl
       now.bowl
     (shaz (cat 3 (mix [now eny]:bowl) %eny))
   ::
-  ;;  (list tank)
-  =<  +>
-  %+  mong
-    :-  mute
-    |.([(sell (slap (slop !>(subj) !>(..zuse)) hoon))]~)
-  |=(^ ~)
+  =/  subject  [fowl ..zuse]
+  =/  minted=(each [=type =nock] (list tank))
+    %-  mule  |.
+    (~(mint ut -:!>(subject)) %noun hoon)
+  ?:  ?=(%| -.minted)  p.minted
+  =/  =toon
+    (mock [subject nock.p.minted] |=(^ ~))
+  ?-  -.toon
+    %0  [(sell type.p.minted p.toon) ~]
+    %1  [leaf+"scries unsupported in chat eval" ~]
+    %2  [leaf+"crash!" p.toon]
+  ==
 --

--- a/pkg/arvo/lib/chat/eval.hoon
+++ b/pkg/arvo/lib/chat/eval.hoon
@@ -16,7 +16,8 @@
     (mock [subject nock.p.minted] |=(^ ~))
   ?-  -.toon
     %0  [(sell type.p.minted p.toon) ~]
-    %1  [leaf+"scries unsupported in chat eval" ~]
+    %1  :-  leaf+".^ unsupported in chat eval"
+        (turn ;;((list path) p.toon) smyt)
     %2  [leaf+"crash!" p.toon]
   ==
 --


### PR DESCRIPTION
Previous implementation was doing double virtualization, which gave issues
around scries. By reimplementing with mint and mock, we get to catch all
possible failure cases and produce an appropriate output for each.

Previously, as seen through chat-cli:

```
~zod# (need ~)
     _/~zod/home/~2019.12.2..22.51.57..1c0e/app/chat-cli/hoo
bail: 4
~zod# (sein:title our now our)
```

Now:

```
~zod# (need ~)
      crash!
~zod# (sein:title our now our)
      .^ unsupported in chat eval
```

(Note that the stack trace for the "crash" case is still included with the message. We just prepend something guaranteed-readable now.)

Special thanks to @frodwith for writing & helping me understand the core logic here.