### PR TITLE
chat-cli: our-self with bowl set

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -82,7 +82,7 @@
     ^-  (quip card _this)
     :-  [connect:tc]~
     %_  this
-      audience  [[our-self /] ~ ~]
+      audience  [[our-self:tc /] ~ ~]
       settings  (sy %showtime %notify ~)
       width  80
     ==


### PR DESCRIPTION
We were calling it directly, rather than through the (initialized) tc core,
causing the bowl in its context to be the *bowl, resulting in [~zod /] audience.

As briefly discussed with @philipcmonk.