### PR TITLE
vere: filter out content-length header from eyre

### DIFF
--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -518,12 +518,14 @@ _http_start_respond(u3_hreq* req_u,
   c3_i has_len_i = 0;
 
   while ( 0 != hed_u ) {
-    h2o_add_header_by_str(&rec_u->pool, &rec_u->res.headers,
-                          hed_u->nam_c, hed_u->nam_w, 0, 0,
-                          hed_u->val_c, hed_u->val_w);
-
     if ( 0 == strncmp(hed_u->nam_c, "content-length", 14) ) {
       has_len_i = 1;
+    }
+
+    else {
+      h2o_add_header_by_str(&rec_u->pool, &rec_u->res.headers,
+                            hed_u->nam_c, hed_u->nam_w, 0, 0,
+                            hed_u->val_c, hed_u->val_w);
     }
 
     hed_u = hed_u->nex_u;


### PR DESCRIPTION
Fixes #2003.

`curl -I -X GET http://localhost:80/~/login`
```
HTTP/1.1 200 ok
Date: Wed, 04 Dec 2019 15:13:56 GMT
Connection: keep-alive
Content-Length: 1817
Server: urbit/vere-0.10.0
content-type: text/html
```
`curl -I -X GET http://localhost:80/~/i-dont-exist`
```
HTTP/1.1 307 moved
Date: Wed, 04 Dec 2019 15:26:36 GMT
Connection: close
Server: urbit/vere-0.10.0
location: /~/login?redirect=/~/i-dont-exist
```