### PR TITLE
Ames sponsor scry

### DIFF
--- a/bin/brass.pill
+++ b/bin/brass.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d1524ee205cba7d434a61920a0ec7c1bdaef4a79688bd7087fd979c32591e41
-size 7143501
+oid sha256:4faacbf1212e83ca6952195cb718df42e6d82be7bb809bbfc2e9da74b6f4ea61
+size 7143502

--- a/bin/brass.pill
+++ b/bin/brass.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b5e6792a827754fd31d7cc2a6054920ce47efae44bca09775c7e04fb9c3711a
-size 7143125
+oid sha256:4d1524ee205cba7d434a61920a0ec7c1bdaef4a79688bd7087fd979c32591e41
+size 7143501

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7352e0e38fd21e291b66c607b3971b448a6d738fece48a60c8158b7be3678489
-size 9502771
+oid sha256:5dc5780d37c7bf3c7204e1feb9cb3446b01e3ab92dada5aa016ed205731f2fd1
+size 9503911

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4416fd52a3422ca29cdfb88b313a38b11d1468d6b7db884e103f11dc2450597
-size 9492136
+oid sha256:e908c27b69beb1f2ed4cac4b48586dd436a2cb253cef4f0eeef75ebe4c3e139e
+size 9501810

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e908c27b69beb1f2ed4cac4b48586dd436a2cb253cef4f0eeef75ebe4c3e139e
-size 9501810
+oid sha256:730a7824e3215a61f36ae21cacd0c7add31f678ba50ce311c1746ce57e3f9d2a
+size 9502678

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:730a7824e3215a61f36ae21cacd0c7add31f678ba50ce311c1746ce57e3f9d2a
-size 9502678
+oid sha256:7352e0e38fd21e291b66c607b3971b448a6d738fece48a60c8158b7be3678489
+size 9502771

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -898,7 +898,7 @@
         ~>  %slog.0^leaf/"ames: larva drain crash"
         %-  (slog leaf/(trip tag.u.error.sign) tang.u.error.sign)
         ::
-        =.  moves  :_(moves [duct %pass /larva %b %wait (add now ~s5))
+        =.  moves  :_(moves [duct %pass /larva %b %wait (add now ~s5)])
         [moves larval-gate]
       ::  normal drain timer; dequeue and run event
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1513,7 +1513,7 @@
         =|  =point
         =.  life.point     life
         =.  keys.point     (my [life crypto-suite public-key]~)
-        =.  sponsor.point  `(^sein:title ship)
+        =.  sponsor.point  `(scry-for-sponsor ship)
         ::
         (on-publ-full (my [ship point]~))
       ::
@@ -1555,6 +1555,9 @@
           ?~  points  event-core
           ::
           =+  ^-  [=ship =point]  i.points
+          ::
+          ?.  (~(has by keys.point) life.point)
+            $(points t.points)
           ::
           =/  old-ship-state  (~(get by peers.ames-state) ship)
           ::
@@ -1610,7 +1613,10 @@
       =.  life.peer-state           life.point
       =.  public-key.peer-state     public-key
       =.  symmetric-key.peer-state  symmetric-key
-      =.  sponsor.peer-state        (fall sponsor.point (^sein:title ship))
+      =.  sponsor.peer-state
+        ?^  sponsor.point
+          u.sponsor.point
+        (scry-for-sponsor ship)
       ::  automatically set galaxy route, since unix handles lookup
       ::
       =?  route.peer-state  ?=(%czar (clan:title ship))
@@ -1620,6 +1626,15 @@
         (~(put by peers.ames-state) ship %known peer-state)
       ::
       event-core
+    ::  +scry-for-sponsor: ask jael for .who's sponsoring ship
+    ::
+    ++  scry-for-sponsor
+      |=  who=ship
+      ^-  ship
+      ;;  ship
+      =<  q.q  %-  need  %-  need
+      %-  scry-gate
+      [[%141 %noun] ~ %j `beam`[[our %sein %da now] /(scot %p who)]]
     --
   ::  +on-take-turf: relay %turf move from jael to unix
   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -892,12 +892,23 @@
       ?.  ?=([%b %wake *] sign)
         ~>  %slog.0^leaf/"ames: larva: strange sign"
         [~ larval-gate]
-      ::  if crashed, print, back off a little, and retry
+      ::  if crashed, print, dequeue, and set next drainage timer
+      ::
+      ::    TODO: cleanup duplicate iteration logic
       ::
       ?^  error.sign
         ~>  %slog.0^leaf/"ames: larva drain crash"
         %-  (slog u.error.sign)
-        =/  moves  [duct %pass /larva %b %wait (add now ~s5)]~
+        =.  queued-events  +:~(get to queued-events)
+        ::  .queued-events has been cleared; metamorphose
+        ::
+        ?~  queued-events
+          ~>  %slog.0^leaf/"ames: metamorphosis"
+          [~ adult-gate]
+        ::  set timer to drain next event
+        ::
+        ~>  %slog.0^leaf/"ames: larva: drain"
+        =/  moves  [duct %pass /larva %b %wait now]~
         [moves larval-gate]
       ::  normal drain timer; dequeue and run event
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -897,8 +897,6 @@
       ::    TODO: cleanup duplicate iteration logic
       ::
       ?^  error.sign
-        ~>  %slog.0^leaf/"ames: larva drain crash"
-        %-  (slog u.error.sign)
         =.  queued-events  +:~(get to queued-events)
         ::  .queued-events has been cleared; metamorphose
         ::
@@ -907,8 +905,11 @@
           [~ adult-gate]
         ::  set timer to drain next event
         ::
-        ~>  %slog.0^leaf/"ames: larva: drain"
-        =/  moves  [duct %pass /larva %b %wait now]~
+        =/  moves
+          =/  =tang  [leaf/"ames: larva: drain crash" u.error.sign]
+          :~  [duct %pass /larva-crash %d %flog %crud %larva tang]
+              [duct %pass /larva %b %wait now]
+          ==
         [moves larval-gate]
       ::  normal drain timer; dequeue and run event
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -892,6 +892,16 @@
       ?.  ?=([%b %wake *] sign)
         ~>  %slog.0^leaf/"ames: larva: strange sign"
         [~ larval-gate]
+      ::  if crashed, print, back off a little, and retry
+      ::
+      ?^  error.sign
+        ~>  %slog.0^leaf/"ames: larva drain crash"
+        %-  (slog leaf/(trip tag.u.error.sign) tang.u.error.sign)
+        ::
+        =.  moves  :_(moves [duct %pass /larva %b %wait (add now ~s5))
+        [moves larval-gate]
+      ::  normal drain timer; dequeue and run event
+      ::
       =^  first-event  queued-events  ~(get to queued-events)
       =^  moves  adult-gate
         ?-  -.first-event

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -894,9 +894,15 @@
         [~ larval-gate]
       ::  if crashed, print, dequeue, and set next drainage timer
       ::
-      ::    TODO: cleanup duplicate iteration logic
-      ::
       ?^  error.sign
+        ::  .queued-events should never be ~ here, but if it is, don't crash
+        ::
+        ?:  =(~ queued-events)
+          =/  =tang  [leaf/"ames: cursed metamorphosis" u.error.sign]
+          =/  moves  [duct %pass /larva-crash %d %flog %crud %larva tang]~
+          [moves adult-gate]
+        ::  dequeue and discard crashed event
+        ::
         =.  queued-events  +:~(get to queued-events)
         ::  .queued-events has been cleared; metamorphose
         ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -896,9 +896,8 @@
       ::
       ?^  error.sign
         ~>  %slog.0^leaf/"ames: larva drain crash"
-        %-  (slog leaf/(trip tag.u.error.sign) tang.u.error.sign)
-        ::
-        =.  moves  :_(moves [duct %pass /larva %b %wait (add now ~s5)])
+        %-  (slog u.error.sign)
+        =/  moves  [duct %pass /larva %b %wait (add now ~s5)]~
         [moves larval-gate]
       ::  normal drain timer; dequeue and run event
       ::

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -374,9 +374,9 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   if ( 0 == nrd_i ) {
     _ames_free(buf_u->base);
   }
-  //  check header's fourth most significant bit to ignore old protocols
+  //  check protocol version in header matches 0
   //
-  else if ( 0 != (1 & (*((c3_w*)buf_u->base) >> 28)) ) {
+  else if ( 0 != (0x7 & *((c3_w*)buf_u->base)) ) {
     _ames_free(buf_u->base);
   }
   else {

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -374,6 +374,11 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   if ( 0 == nrd_i ) {
     _ames_free(buf_u->base);
   }
+  //  check header's fourth most significant bit to ignore old protocols
+  //
+  else if ( 0 != (1 & (*((c3_w*)buf_u->base) >> 28)) ) {
+    _ames_free(buf_u->base);
+  }
   else {
     {
       u3_noun msg = u3i_bytes((c3_w)nrd_i, (c3_y*)buf_u->base);

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -473,6 +473,7 @@ _worker_lame(u3_noun now, u3_noun ovo, u3_noun why, u3_noun tan)
     u3_noun lef = u3nc(c3__leaf, u3kb_weld(u3i_tape("bail: "),
                                            u3qc_rip(3, why)));
     u3_noun nat = u3kb_weld(u3k(tan), u3nc(lef, u3_nul));
+    u3m_p("FAIL", nat);
     rep = u3nc(u3k(wir), u3nt(c3__crud, u3k(tag), nat));
   }
 


### PR DESCRIPTION
Don't crash on a %public-keys response from Jael that includes a sponsor change but no keys.  Instead, ignore that update.  When we need the sponsor later, scry the up-to-date sponsor from Jael.