### PR TITLE
ames: scry for sponsor and don't crash on jael response

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1486,7 +1486,7 @@
         =|  =point
         =.  life.point     life
         =.  keys.point     (my [life crypto-suite public-key]~)
-        =.  sponsor.point  `(^sein:title ship)
+        =.  sponsor.point  `(scry-for-sponsor ship)
         ::
         (on-publ-full (my [ship point]~))
       ::
@@ -1528,6 +1528,9 @@
           ?~  points  event-core
           ::
           =+  ^-  [=ship =point]  i.points
+          ::
+          ?.  (~(has by keys.point) life.point)
+            $(points t.points)
           ::
           =/  old-ship-state  (~(get by peers.ames-state) ship)
           ::
@@ -1583,7 +1586,10 @@
       =.  life.peer-state           life.point
       =.  public-key.peer-state     public-key
       =.  symmetric-key.peer-state  symmetric-key
-      =.  sponsor.peer-state        (fall sponsor.point (^sein:title ship))
+      =.  sponsor.peer-state
+        ?^  sponsor.point
+          u.sponsor.point
+        (scry-for-sponsor ship)
       ::  automatically set galaxy route, since unix handles lookup
       ::
       =?  route.peer-state  ?=(%czar (clan:title ship))
@@ -1593,6 +1599,15 @@
         (~(put by peers.ames-state) ship %known peer-state)
       ::
       event-core
+    ::  +scry-for-sponsor: ask jael for .who's sponsoring ship
+    ::
+    ++  scry-for-sponsor
+      |=  who=ship
+      ^-  ship
+      ;;  ship
+      =<  q.q  %-  need  %-  need
+      %-  scry-gate
+      [[%141 %noun] ~ %j `beam`[[our %sein %da now] /(scot %p who)]]
     --
   ::  +on-take-turf: relay %turf move from jael to unix
   ::


### PR DESCRIPTION
Don't crash on a %public-keys response from Jael that includes a sponsor change but no keys. Instead, ignore that update. When we need the sponsor later, scry the up-to-date sponsor from Jael.