### PR TITLE
eth-watcher: be quieter about parse errors

### DIFF
--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -124,6 +124,7 @@
     =.  url.state  url.poke
     [[(start state [our dap]:bowl) ~] this]
   ==
+::
 ++  on-watch
   |=  =path
   ^-  (quip card:agent:gall _this)

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -398,7 +398,6 @@
 ++  thread-fail
   |=  [=yarn =term =tang]
   ^-  (quip card ^state)
-  %-  (slog leaf+"strand {<yarn>} failed" leaf+<term> tang)
   =/  =tid  (yarn-to-tid yarn)
   =/  fail-cards  (thread-say-fail tid term tang)
   =^  cards  state  (thread-clean yarn)

--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -126,28 +126,30 @@
   =/  m  (strand:strandio ,block)
   ^-  form:m
   |^
+  %+  (retry:strandio ,block)  `10
+  =/  m  (strand:strandio ,(unit block))
+  ^-  form:m
   ;<  =json  bind:m
     %+  request-rpc  url
     :-  `'block by number'
     [%eth-get-block-by-number number |]
-  =/  =block  (parse-block json)
-  ?.  =(number number.id.block)
-    (strand-fail:strandio %reorg-detected >number< >block< ~)
-  (pure:m block)
+  (pure:m (parse-block json))
   ::
   ++  parse-block
     |=  =json
-    ^-  block
-    =<  [[&1 &2] |2]
-    ^-  [@ @ @]
+    ^-  (unit block)
+    =<  ?~(. ~ `[[&1 &2] |2]:u)
+    ^-  (unit [@ @ @])
     ~|  json
     %.  json
-    =,  dejs:format
+    =,  dejs-soft:format
     %-  ot
-    :~  hash+parse-hex-result:rpc:ethereum
-        number+parse-hex-result:rpc:ethereum
-        'parentHash'^parse-hex-result:rpc:ethereum
+    :~  hash+parse-hex
+        number+parse-hex
+        'parentHash'^parse-hex
     ==
+  ::
+  ++  parse-hex  |=(=json `(unit @)`(some (parse-hex-result:rpc:ethereum json)))
   --
 ::
 ++  get-logs-by-hash


### PR DESCRIPTION
This is a fix for those transient loud errors where the node is giving `~` in the response to the block number request.  This parses without crashing, retrying if the parse fails.

This also silences spider's crash printing.  That's the responsibility of whoever started the thread -- maybe you expected it to crash.  This is why that stack trace was printing twice.

This is fine to OTA