### PR TITLE
drum: boot to dojo and start acme

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -88,7 +88,8 @@
     ==
   ?:  lit
     ~
-  :~  %lens
+  :~  %acme
+      %lens
       %clock
       %dojo
       %launch
@@ -289,7 +290,7 @@
 ++  se-adit                                           ::  update servers
   ^+  .
   ::  ensure dojo connects after talk
-  =*  dojo-on-top  aor
+  =*  dojo-on-top  |=([a=* b=*] |(=(%dojo a) &(!=(%dojo b) (aor a b))))
   %+  roll  (sort ~(tap in ray) dojo-on-top)
   =<  .(con +>)
   |:  $:{wel/well:gall con/_..se-adit}  ^+  con


### PR DESCRIPTION
In some circumstances, we seem to boot to chat-cli instead of dojo, since we were sorting them alphabetically (cf talk came after dojo).  This sorts with `%dojo` always in front.

We also want to start acme on startup.  This won't apply to ships that have already booted, but they can just `|start %acme` if they need it.