### PR TITLE
ames: don't overwrite lane if already direct

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7352e0e38fd21e291b66c607b3971b448a6d738fece48a60c8158b7be3678489
-size 9502771
+oid sha256:fdb2fce980015e3789b0bf5a4e90a468227e6b2a0c97a7448de6edb6cde175c9
+size 9503162

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1309,7 +1309,10 @@
     ?>  =(rcvr-life.shut-packet our-life.channel)
     ::  non-galaxy: update route with heard lane or forwarded lane
     ::
-    =?  route.peer-state  !=(%czar (clan:title her.channel))
+    =?  route.peer-state
+        ?&  !=(%czar (clan:title her.channel))
+            !=([~ %& *] route.peer-state)
+        ==
       ?~  origin.packet
         `[direct=%.y lane]
       `[direct=%.n u.origin.packet]
@@ -1689,6 +1692,7 @@
     |=  [=ship =blob]
     ::
     %-  (trace rot.veb |.("send-blob: to {<ship>}"))
+    |-
     |^  ^+  event-core
         ::
         =/  ship-state  (~(get by peers.ames-state) ship)


### PR DESCRIPTION
This is why basically all packets are going through the galaxies right now.  Most of the time, the flow right now is:

- talking to ~dopzod but don't know where it is, so ask ~zod to forward, which it does
- ~dopzod responds both directly (on the origin lane) and through ~zod
- (if NAT, the direct response doesn't get back, but the one through  ~zod does.  Then you respond directly to ~dopzod because their lane piggybacked on the response.  ~dopzod responds both directly and through ~zod, and the story picks up the same as if you weren't behind a NAT)
- now you have a direct lane to ~dopzod, so all is well.
- now the duplicate response from ~dopzod through ~zod comes in (takes a little longer because it's bouncing off ~zod), resetting your lane to "provisional"
- since your lane is provisional, you send your next packet both directly and through ~zod
- GOTO 2

This change says "if I already have a direct lane, don't overwrite it with a provisional one".  This way, the only way the direct lane can be overwritten is if they stop responding on it (cleared on "not responding; still trying").

I also added `|-` to +send-blob to make `|ames-verb %rot` less confusing.

@jtobin This is OTA-friendly.