### PR TITLE
u3: cross-platform fix for setting max open files

### DIFF
--- a/nix/deps/ivory-header/builder.sh
+++ b/nix/deps/ivory-header/builder.sh
@@ -13,7 +13,7 @@ fi
 
 #  first 7 bytes != "version" (start of an lfs pointer)
 #
-if [ "$(cat "$IVORY" | head -c 7)" = "version" ]; then
+if [ "$(head -c 7 "$IVORY")" = "version" ]; then
   echo "$IVORY is an LFS pointer (it starts with 'version')"
   echo "to fix, run: git lfs install"
   exit 1

--- a/pkg/urbit/include/c/portable.h
+++ b/pkg/urbit/include/c/portable.h
@@ -53,6 +53,7 @@
 #     include <stdio.h>
 #     include <sys/time.h>
 #     include <sys/resource.h>
+#     include <sys/syslimits.h>
 #     include <sys/mman.h>
 
 #   elif defined(U3_OS_bsd)


### PR DESCRIPTION
And removes an unnecessary use of `cat` in the ivory-header build. Fixes #2026

/cc @dpc