### PR TITLE
nix: enables debug symbols in release builds

### DIFF
--- a/nix/pkgs/urbit/release.nix
+++ b/nix/pkgs/urbit/release.nix
@@ -20,7 +20,7 @@ let
 in
 
 env.make_derivation {
-  CFLAGS           = if debug then "-O0 -g" else "-O3";
+  CFLAGS           = if debug then "-O0 -g" else "-O3 -g";
   LDFLAGS          = if debug then "" else "-s";
   MEMORY_DEBUG     = debug;
   CPU_DEBUG        = debug;


### PR DESCRIPTION
I meant to do this in #1848. We periodically need these.