### PR TITLE
build: support for releasing cross-compiled debug binaries

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -19,9 +19,13 @@ let
   ge-additions = env:
     import ./pkgs/ge-additions/cross.nix env;
 
-  urbit = env:
-    import ./pkgs/urbit/release.nix env
-      { ent = ent env; ge-additions = ge-additions env; debug = false; name = "urbit"; };
+  urbit = { env, debug }:
+    import ./pkgs/urbit/release.nix env {
+      inherit debug;
+      name         = if debug then "urbit-debug" else "urbit";
+      ent          = ent env;
+      ge-additions = ge-additions env;
+    };
 
   builds-for-platform = plat:
     plat.deps // {
@@ -29,7 +33,8 @@ let
       inherit (plat.env) cmake_toolchain;
       ent          = ent          plat;
       ge-additions = ge-additions plat;
-      urbit        = urbit        plat;
+      urbit        = urbit { env = plat; debug = false; };
+      urbit-debug  = urbit { env = plat; debug = true;  };
     };
 
   darwin_extra = {


### PR DESCRIPTION
`sh/cross` can now be invoked as follows:

```
sh/cross urbit linux64
sh/cross urbit darwin

sh/cross urbit-debug linux64
sh/cross urbit-debug darwin
```

Note: this seems orthogonal to #2029, as it to builds a _separate_ `urbit-debug` binary.