### PR TITLE
ames: don't crash on missing queued larval event

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -894,9 +894,15 @@
         [~ larval-gate]
       ::  if crashed, print, dequeue, and set next drainage timer
       ::
-      ::    TODO: cleanup duplicate iteration logic
-      ::
       ?^  error.sign
+        ::  .queued-events should never be ~ here, but if it is, don't crash
+        ::
+        ?:  =(~ queued-events)
+          =/  =tang  [leaf/"ames: cursed metamorphosis" u.error.sign]
+          =/  moves  [duct %pass /larva-crash %d %flog %crud %larva tang]~
+          [moves adult-gate]
+        ::  dequeue and discard crashed event
+        ::
         =.  queued-events  +:~(get to queued-events)
         ::  .queued-events has been cleared; metamorphose
         ::


### PR DESCRIPTION
@jtobin, this is what I pushed to ~zod today.  The diff below is somewhat misleading, the actual changes are what was in philip/p2p, but apparently this commit (cherry-picked from bee0b580) was already on ~zod.  Feel free to close this after the next OTA that contains these changes or do whatever you want with the history.

Incidentally, the git action would have been clearer if these changes hadn't been rebased on top of philip/p2p since it would have been a simple history-preserving merge, no cherry-picks.  I guess that's the cost of a revisionist linear history.