### PR TITLE
drum: print tangs in order

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -438,7 +438,7 @@
   |=  tac/(list tank)
   ^+  +>
   =/  wol/wall
-    (zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
+    (zing (turn tac |=(a/tank (~(win re a) [0 edg]))))
   |-  ^+  +>.^$
   ?~  wol  +>.^$
   ?.  ((sane %t) (crip i.wol))  :: XX upstream validation


### PR DESCRIPTION
Tangs were being printed in reverse order because they weren't updated after I removed the double-reversing action of hood to bring it in conformance with accepted standards.

OTA-able