### PR TITLE
nix: actually enables debug symbols in release builds

### DIFF
--- a/nix/pkgs/urbit/release.nix
+++ b/nix/pkgs/urbit/release.nix
@@ -21,7 +21,8 @@ in
 
 env.make_derivation {
   CFLAGS           = if debug then "-O0 -g" else "-O3 -g";
-  LDFLAGS          = if debug then "" else "-s";
+  # binary stripping disabled
+  # LDFLAGS          = if debug then "" else "-s";
   MEMORY_DEBUG     = debug;
   CPU_DEBUG        = debug;
   EVENT_TIME_DEBUG = false;


### PR DESCRIPTION
Well, this is embarrassing -- the third time's the charm ... I've tested this on MacOs; function names are present in the static binaries, line numbers are not. 

See #2029 and #1848