### PR TITLE
eth-watcher: silence printfs

### DIFF
--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -69,11 +69,9 @@
     =/  array=(unit (list response:rpc:jstd))
       ((ar:dejs-soft:format parse-one-response) u.jon)
     ?~  array
-      ~&  %incomplete-batch
       (strand-fail:strandio %rpc-result-incomplete-batch >u.jon< ~)
     =-  ?~  err
           (pure:m `res)
-        ~&  [%error-results err]
         (pure:m ~)
     %+  roll  u.array
     |=  $:  rpc=response:rpc:jstd


### PR DESCRIPTION
These show up occasionally but don't constitute an error unless the caller determines they're an error.  This silences the over-eager printfs.

fixes #2048 