### PR TITLE
chat: don't crash on tab in an empty buffer

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -382,7 +382,9 @@
     ?:  ?|  =(~ buf.state.cli)
             !=(';' -.buf.state.cli)
         ==
-      [~ all-state]
+      :_  all-state
+      [(effect:sh-out [%bel ~]) ~]
+    ::
     =+  (get-id:auto pos (tufa buf.state.cli))
     =/  needle=term
       (fall id '')
@@ -400,7 +402,7 @@
     =?  moves  ?=(^ options)
       [(tab:sh-out options) moves]
     =|  fxs=(list sole-effect:sole-sur)
-    |-
+    |-  ^-  (quip card state)
     ?~  to-send
       [(flop moves) all-state]
     =^  char  state.cli

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -379,7 +379,9 @@
   ++  tab
     |=  pos=@ud
     ^-  (quip card state)
-    ?.  =(';' (snag 0 buf.state.cli))
+    ?:  ?|  =(~ buf.state.cli)
+            !=(';' -.buf.state.cli)
+        ==
       [~ all-state]
     =+  (get-id:auto pos (tufa buf.state.cli))
     =/  needle=term


### PR DESCRIPTION
Fixes a bug introduced in #1995.

Also rings the terminal bell on tab in an empty buffer. That seems right to me, but I'm open to counterarguments.

/cc @liam-fitzgerald 