### PR TITLE
ames: honor -p for non-galaxies

### DIFF
--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -417,13 +417,17 @@ _ames_io_start(u3_pier* pir_u)
     c3_c* imp_c = u3r_string(imp);
     c3_y  num_y = (c3_y)pir_u->who_d[0];
 
+    if ( 0 != por_s ) {
+      u3l_log("ames: czar: -p %d ignored\n", por_s);
+    }
+
     por_s = _ames_czar_port(num_y);
 
     if ( c3y == u3_Host.ops_u.net ) {
-      u3l_log("ames: czar: %s on %d\n", imp_c, por_s);
+      u3l_log("ames: czar: %s live on %d\n", imp_c, por_s);
     }
     else {
-      u3l_log("ames: czar: %s on %d (localhost only)\n", imp_c, por_s);
+      u3l_log("ames: czar: %s live on %d (localhost only)\n", imp_c, por_s);
     }
 
     u3z(imp);
@@ -465,7 +469,13 @@ _ames_io_start(u3_pier* pir_u)
     sam_u->por_s = ntohs(add_u.sin_port);
   }
 
-  // u3l_log("ames: on localhost, UDP %d.\n", sam_u->por_s);
+  if ( c3y == u3_Host.ops_u.net ) {
+    u3l_log("ames: live on %d\n", por_s);
+  }
+  else {
+    u3l_log("ames: live on %d (localhost only)\n", por_s);
+  }
+
   uv_udp_recv_start(&sam_u->wax_u, _ames_alloc, _ames_recv_cb);
 
   sam_u->liv = c3y;

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -408,30 +408,21 @@ static void
 _ames_io_start(u3_pier* pir_u)
 {
   u3_ames* sam_u = pir_u->sam_u;
-  c3_s por_s     = pir_u->por_s;
-  u3_noun who    = u3i_chubs(2, pir_u->who_d);
-  u3_noun rac    = u3do("clan:title", u3k(who));
+  c3_s     por_s = pir_u->por_s;
+  u3_noun    who = u3i_chubs(2, pir_u->who_d);
+  u3_noun    rac = u3do("clan:title", u3k(who));
 
   if ( c3__czar == rac ) {
-    u3_noun imp = u3dc("scot", 'p', u3k(who));
-    c3_c* imp_c = u3r_string(imp);
-    c3_y  num_y = (c3_y)pir_u->who_d[0];
+    c3_y num_y = (c3_y)pir_u->who_d[0];
+    c3_s zar_s = _ames_czar_port(num_y);
 
-    if ( 0 != por_s ) {
-      u3l_log("ames: czar: -p %d ignored\n", por_s);
+    if ( 0 == por_s ) {
+      por_s = zar_s;
     }
-
-    por_s = _ames_czar_port(num_y);
-
-    if ( c3y == u3_Host.ops_u.net ) {
-      u3l_log("ames: czar: %s live on %d\n", imp_c, por_s);
+    else if ( por_s != zar_s ) {
+      u3l_log("ames: czar: overriding port %d with -p %d\n", zar_s, por_s);
+      u3l_log("ames: czar: WARNING: %d required for discoverability\n", zar_s);
     }
-    else {
-      u3l_log("ames: czar: %s live on %d (localhost only)\n", imp_c, por_s);
-    }
-
-    u3z(imp);
-    free(imp_c);
   }
 
   int ret;

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -411,6 +411,7 @@ _ames_io_start(u3_pier* pir_u)
   c3_s     por_s = pir_u->por_s;
   u3_noun    who = u3i_chubs(2, pir_u->who_d);
   u3_noun    rac = u3do("clan:title", u3k(who));
+  c3_i     ret_i;
 
   if ( c3__czar == rac ) {
     c3_y num_y = (c3_y)pir_u->who_d[0];
@@ -425,9 +426,8 @@ _ames_io_start(u3_pier* pir_u)
     }
   }
 
-  int ret;
-  if ( 0 != (ret = uv_udp_init(u3L, &sam_u->wax_u)) ) {
-    u3l_log("ames: init: %s\n", uv_strerror(ret));
+  if ( 0 != (ret_i = uv_udp_init(u3L, &sam_u->wax_u)) ) {
+    u3l_log("ames: init: %s\n", uv_strerror(ret_i));
     c3_assert(0);
   }
 
@@ -443,14 +443,17 @@ _ames_io_start(u3_pier* pir_u)
                               htonl(INADDR_LOOPBACK);
     add_u.sin_port = htons(por_s);
 
-    int ret;
-    if ( (ret = uv_udp_bind(&sam_u->wax_u,
-                            (const struct sockaddr*) & add_u, 0)) != 0 ) {
-      u3l_log("ames: bind: %s\n",
-              uv_strerror(ret));
-      if (UV_EADDRINUSE == ret){
+    if ( (ret_i = uv_udp_bind(&sam_u->wax_u,
+                              (const struct sockaddr*)&add_u, 0)) != 0 )
+    {
+      u3l_log("ames: bind: %s\n", uv_strerror(ret_i));
+
+      if ( (c3__czar == rac) &&
+           (UV_EADDRINUSE == ret_i) )
+      {
         u3l_log("    ...perhaps you've got two copies of vere running?\n");
       }
+
       u3_pier_exit(pir_u);
     }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1770,6 +1770,7 @@ _pier_create(c3_w wag_w, c3_c* pax_c)
   pir_u->sat_e = u3_psat_init;
 
   pir_u->sam_u = c3_calloc(sizeof(u3_ames));
+  pir_u->por_s = u3_Host.ops_u.por_s;
   pir_u->teh_u = c3_calloc(sizeof(u3_behn));
   pir_u->unx_u = c3_calloc(sizeof(u3_unix));
   pir_u->sav_u = c3_calloc(sizeof(u3_save));


### PR DESCRIPTION
This was never properly wired up in cc-release. Also adds port printfs for all ships.