### PR TITLE
chat-hook: no-op on /backlog kick if not synced

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -402,6 +402,7 @@
   ::
   ?:  ?=([%backlog @ *] wir)
     =/  pax  `path`(oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
+    ?.  (~(has by synced) pax)  [~ state]
     =/  mailbox=(unit mailbox)  (chat-scry pax)
     =.  pax  ?~(mailbox wir [%mailbox pax])
     :_  state


### PR DESCRIPTION
This matches the behavior that's used for +kick on /mailbox, among other flows.