### PR TITLE
vere: print arg to c3_malloc() et. al. on failure

### DIFF
--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -86,21 +86,27 @@
     /* Asserting allocators.
     */
 #     define c3_free(s) free(s)
-#     define c3_malloc(s) ({          \
-        void* rut = malloc(s);        \
-        if ( 0 == rut ) {             \
-          c3_assert(!"memory lost");  \
-        }                             \
+#     define c3_malloc(s) ({                                    \
+        void* rut = malloc(s);                                  \
+        if ( 0 == rut ) {                                       \
+          fprintf(stderr, "c3_malloc(%" PRIu64 ") failed\r\n",  \
+                          (c3_d)s);                             \
+          c3_assert(!"memory lost");                            \
+        }                                                       \
         rut;})
-#     define c3_calloc(s) ({          \
-        void* rut = calloc(1,s);      \
-        if ( 0 == rut ) {             \
-          c3_assert(!"memory lost");  \
-        }                             \
+#     define c3_calloc(s) ({                                    \
+        void* rut = calloc(1,s);                                \
+        if ( 0 == rut ) {                                       \
+          fprintf(stderr, "c3_calloc(%" PRIu64 ") failed\r\n",  \
+                          (c3_d)s);                             \
+          c3_assert(!"memory lost");                            \
+        }                                                       \
         rut;})
-#     define c3_realloc(a, b) ({      \
-        void* rut = realloc(a, b);    \
-        if ( 0 == rut ) {             \
-          c3_assert(!"memory lost");  \
-        }                             \
+#     define c3_realloc(a, b) ({                                \
+        void* rut = realloc(a, b);                              \
+        if ( 0 == rut ) {                                       \
+          fprintf(stderr, "c3_realloc(%" PRIu64 ") failed\r\n", \
+                          (c3_d)b);                             \
+          c3_assert(!"memory lost");                            \
+        }                                                       \
         rut;})


### PR DESCRIPTION
This should help debug the mysterious "memory lost" printfs we've been seeing on our infrastructure nodes.