### PR TITLE
drum: revert tang ordering change

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -936,7 +936,8 @@
       ?+    p.cage.sign  ~|([%dojo-thread-bad-mark-result p.cage.sign] !!)
           %thread-fail
         =+  !<([=term =tang] q.cage.sign)
-        (he-diff(poy ~) %tan leaf+"thread failed: {<term>}" tang)
+        %+  he-diff(poy ~)  %tan
+        (flop `^tang`[leaf+"thread failed: {<term>}" tang])
       ::
           %thread-done
         ?>  ?=(^ poy)

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -438,7 +438,7 @@
   |=  tac/(list tank)
   ^+  +>
   =/  wol/wall
-    (zing (turn tac |=(a/tank (~(win re a) [0 edg]))))
+    (zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
   |-  ^+  +>.^$
   ?~  wol  +>.^$
   ?.  ((sane %t) (crip i.wol))  :: XX upstream validation


### PR DESCRIPTION
Turns out this wasn't a regression, it was intended behavior.  I
continue to believe it's the wrong behavior, but that will require a
longer discussion.

See #2035.