### PR TITLE
gall: remove message type from wire

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b4c64d4be73ca2331d8f846f83a431c57143fafc85b6f96beeee6618d444be5
-size 9510112
+oid sha256:3d9a450a061b24c53a1a374e29d544247ee9782f0e5306bb18efc8abf95bfcb4
+size 9518723


### PR DESCRIPTION
%leave over the network didn't work because we included the message type
in the wire from gall, so the duct for the initial %watch and the %leave
were different.  We need to know the message type so we can route the
acknowledgment as %poke-ack, %watch-ack, or no-op.

This moves this piece of information to a piece of state, where we queue
up the message types per [duct wire].  Ames guarantees that
acknowledgments will come in order.

This also includes an easy state adapter.  The more interesting part of
the upgrade is that we likely have outstanding subscriptions with the
old wire format.  The disadvantage of storing information in wires is
that it can't be upgraded in +load.  So, here we listen for updates on
the old wire format, and when we get them we kill the old subscription,
so that it will be recreated with the new wire format.

As an aside, this is a good example of what we mean when we say
subscriptions may be killed at any time, so apps must handle this case.

Finally, this fixes the "attributing" ship to ~zod for agent requests.
This information was ignored for agent requests, but including it causes
spurious duct mismatches.

This is OTA-able.  cc @Fang-, who reported the bug.