### PR TITLE
gall: no-op on duplicate watch-ack

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1886,6 +1886,9 @@
         (run-message-sink bone %hear lane shut-packet ok)
       ::  ignore .ok for |message-pump; just try again on error
       ::
+      ::    Note this implies that vanes should never crash on %done,
+      ::    since we have no way to continue using the flow if they do.
+      ::
       (run-message-pump bone %hear [message-num +.meat]:shut-packet)
     ::  +on-memo: handle request to send message
     ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1233,13 +1233,19 @@
           [agent-wire dock]
         %+  ~(jab by outgoing.subscribers.current-agent)  [agent-wire dock]
         |=  [acked=? =path]
-        ~|  [%already-acked agent-name wire dock path]
-        ?<  acked
+        =.  .
+          ?.  acked
+            .
+          %-  =/  =tape
+                "{<agent-name>}: received 2nd watch-ack on {<wire dock path>}"
+              (slog leaf+tape ~)
+          .
         [& path]
       ::
       =^  maybe-tang  ap-core
         %+  ap-ingest  ~  |.
         (on-agent:ap-agent-core agent-wire sign)
+      ::  if failed %fact handling, kill subscription
       ::
       =?  ap-core  ?=(%fact -.sign)
         (ap-update-subscription =(~ maybe-tang) p.dock q.dock agent-wire)


### PR DESCRIPTION
See #2070 for rationale.  Fixes #2070.

Also send a %leave if we receive a watch-ack we didn't expect so we clean up the subscription on the other side.

OTA-able