### PR TITLE
vere: updates the test build targets to be generic

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -5,6 +5,7 @@ noun = $(wildcard noun/*.c)
 vere = $(wildcard vere/*.c)
 daemon = $(wildcard daemon/*.c)
 worker = $(wildcard worker/*.c)
+tests  = $(wildcard tests/*.c)
 
 common  = $(jets) $(noun) $(vere)
 headers = $(shell find include -type f)
@@ -15,9 +16,9 @@ worker_objs = $(shell echo $(worker) | sed 's/\.c/.o/g')
 
 all_objs = $(common_objs) $(daemon_objs) $(worker_objs)
 all_srcs = $(common) $(daemon) $(worker)
-all_exes = ./build/ames_tests ./build/mug_tests ./build/jam_tests \
-	./build/noun_tests ./build/hashtable_tests \
-	./build/urbit ./build/urbit-worker
+
+test_exes = $(shell echo $(tests) | sed 's/tests\//.\/build\//g' | sed 's/\.c//g')
+all_exes  = $(test_exes) ./build/urbit ./build/urbit-worker
 
 # -Werror promotes all warnings that are enabled into errors (this is on)
 # -Wall issues all types of errors.  This is off (for now)
@@ -31,13 +32,8 @@ CFLAGS := $(CFLAGS)
 
 all: $(all_exes)
 
-test: build/ames_tests build/hashtable_tests build/jam_tests build/mug_tests build/newt_tests build/noun_tests
-	./build/ames_tests
-	./build/hashtable_tests
-	./build/jam_tests
-	./build/mug_tests
-	./build/newt_tests
-	./build/noun_tests
+test: $(test_exes)
+	for x in $^; do echo "\n$$x" && ./$$x; done
 
 clean:
 	rm -f ./tags $(all_objs) $(all_exes)
@@ -47,32 +43,7 @@ mrproper: clean
 
 ################################################################################
 
-build/ames_tests: $(common_objs) tests/ames_tests.o
-	@echo CC -o $@
-	@mkdir -p ./build
-	@$(CC) $^ $(LDFLAGS) -o $@
-
-build/hashtable_tests: $(common_objs) tests/hashtable_tests.o
-	@echo CC -o $@
-	@mkdir -p ./build
-	@$(CC) $^ $(LDFLAGS) -o $@
-
-build/jam_tests: $(common_objs) tests/jam_tests.o
-	@echo CC -o $@
-	@mkdir -p ./build
-	@$(CC) $^ $(LDFLAGS) -o $@
-
-build/mug_tests: $(common_objs) tests/mug_tests.o
-	@echo CC -o $@
-	@mkdir -p ./build
-	@$(CC) $^ $(LDFLAGS) -o $@
-
-build/newt_tests: $(common_objs) tests/newt_tests.o
-	@echo CC -o $@
-	@mkdir -p ./build
-	@$(CC) $^ $(LDFLAGS) -o $@
-
-build/noun_tests: $(common_objs) tests/noun_tests.o
+build/%_tests: $(common_objs) tests/%_tests.o
 	@echo CC -o $@
 	@mkdir -p ./build
 	@$(CC) $^ $(LDFLAGS) -o $@

--- a/pkg/urbit/tests/ames_tests.c
+++ b/pkg/urbit/tests/ames_tests.c
@@ -39,6 +39,6 @@ main(int argc, char* argv[])
 
   _test_ames();
 
-  fprintf(stderr, "ames okeedokee");
+  fprintf(stderr, "ames okeedokee\n");
   return 0;
 }


### PR DESCRIPTION
The duplication in the Makefile was irritating, this instead builds based on the naming conventions in `./tests/`, and runs the tests via same naming conventions in `./build/`.

/cc @benjamin-tlon, do you see any issues with this approach?