### PR TITLE
Eth apps: gaze and claz

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d9a450a061b24c53a1a374e29d544247ee9782f0e5306bb18efc8abf95bfcb4
-size 9518723
+oid sha256:bc1c1b97f4c22ab328772d3e9da34f7b34ee5b4686b9d6543c9e26574bafa656
+size 16401588

--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -1,0 +1,435 @@
+::  claz: command line azimuth, for the power-user
+::
+/+  *claz, verb, default-agent
+::
+=,  ethereum
+=,  azimuth
+::
+|%
+++  state-0
+  $:  %0
+      in-progress=(unit command)
+  ==
+::
+::  internal types
+::
++$  rpc-result  [id=@t res=@t]
++$  card  card:agent:gall
+::
+::  constants
+::TODO  from zuse instaed`
+::
+++  node-url           'http://eth-mainnet.urbit.org:8545'
+--
+::
+=|  state-0
+=*  state  -
+%+  verb  &
+=<
+  |_  =bowl:gall
+  +*  this  .
+      do    ~(. +> bowl)
+      def   ~(. (default-agent this %|) bowl)
+  ::
+  ++  on-init   on-init:def
+  ++  on-save   !>(state)
+  ++  on-load   on-load:def
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    ?.  ?=(%noun mark)  [~ this]
+    ?^  in-progress
+      ~&  %still-running-please-try-again-later
+      [~ this]
+    =/  =command  !<(command vase)
+    :_  this(in-progress `command)
+    (prepare-for-command:do command)
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    ?.  ?=([%prepare *] wire)
+      (on-agent:def wire sign)
+    ?-  -.sign
+        %poke-ack
+      ?~  p.sign
+        [~ this]
+      %-  (slog leaf+"{(trip dap.bowl)} couldn't start thread" u.p.sign)
+      :_  this(in-progress ~)
+      [(leave-spider:do wire our.bowl)]~
+    ::
+        %watch-ack
+      ?~  p.sign
+        [~ this]
+      =/  =tank  leaf+"{(trip dap.bowl)} couldn't start listen to thread"
+      %-  (slog tank u.p.sign)
+      [~ this(in-progress ~)]
+    ::
+        %kick
+      [~ this(in-progress ~)]
+    ::
+        %fact
+      ?+  p.cage.sign  (on-agent:def wire sign)
+          %thread-fail
+        =+  !<([=term =tang] q.cage.sign)
+        %-  (slog leaf+"{(trip dap.bowl)} failed" leaf+<term> tang)
+        [~ this(in-progress ~)]
+      ::
+          %thread-done
+        =+  prep=!<(prep-result q.cage.sign)
+        ?~  in-progress
+          ~&  [dap.bowl 'did preparations, but lost command']
+          [~ this]
+        :_  this(in-progress ~)
+        [(generate:do u.in-progress prep)]~
+      ==
+    ==
+  ::
+  ++  on-peek   on-peek:def
+  ++  on-watch  on-watch:def
+  ++  on-leave  on-leave:def
+  ++  on-arvo   on-arvo:def
+  ++  on-fail   on-fail:def
+  --
+::
+|_  =bowl:gall
+::
+++  poke-spider
+  |=  [=path our=@p =cage]
+  ^-  card
+  [%pass path %agent [our %spider] %poke cage]
+::
+++  watch-spider
+  |=  [=path our=@p =sub=path]
+  ^-  card
+  [%pass path %agent [our %spider] %watch sub-path]
+::
+++  leave-spider
+  |=  [=path our=@p]
+  ^-  card
+  [%pass path %agent [our %spider] %leave ~]
+::
+++  prepare-for-command
+  |=  =command
+  ^-  (list card)
+  =/  new-tid=@ta
+    :((cury cat 3) dap.bowl '--' (scot %uv eny.bowl))
+  =/  args
+    [~ `new-tid %claz-prep-command !>([node-url command])]
+  :~  (watch-spider /prepare our.bowl /thread-result/[new-tid])
+      (poke-spider /prepare our.bowl %spider-start !>(args))
+  ==
+::
+::  transaction generation logic
+::
+++  generate
+  |=  [=command prep=prep-result]
+  ^-  card
+  ?>  ?=(%nonce -.prep)
+  ?-  -.command
+      %generate
+    %+  write-file-transactions
+      path.command
+    (batch-to-transactions nonce.prep [network as batch]:command)
+  ==
+::
+++  batch-to-transactions
+  |=  [nonce=@ud =network as=address =batch]
+  ^-  (list transaction:rpc)
+  ?-  -.batch
+    %single     [(single nonce network as +.batch) ~]
+    %deed       (deed nonce network as +.batch)
+    %invites    (invites nonce network as +.batch)
+    %lock-prep  (lock-prep nonce network as +.batch)
+    %lock       (lock nonce network as +.batch)
+    ::
+      %more
+    =|  txs=(list transaction:rpc)
+    =*  batches  batches.batch
+    |-
+    ?~  batches  txs
+    =/  new-txs=(list transaction:rpc)
+      ^$(batch i.batches)
+    %_  $
+      txs      (weld txs new-txs)
+      nonce    (add nonce (lent new-txs))
+      batches  t.batches
+    ==
+  ==
+::
+++  tape-to-ux
+  |=  t=tape
+  (scan t zero-ux)
+::
+++  zero-ux
+  ;~(pfix (jest '0x') hex)
+::
+++  write-file-transactions
+  |=  [=path tox=(list transaction:rpc)]
+  ^-  card
+  ?>  ?=([@ desk @ *] path)
+  =-  [%pass [%write path] %arvo %c %info -]
+  :-  `desk`i.t.path
+  =-  &+[t.t.t.path -]~
+  =/  y  .^(arch %cy path)
+  ?~  fil.y
+    ins+eth-txs+!>(tox)
+  mut+eth-txs+!>(tox)
+::
+++  do
+  ::TODO  maybe reconsider encode-call interface, if we end up wanting @ux
+  ::      as or more often than we want tapes
+  |=  [=network nonce=@ud to=address dat=$@(@ux tape)]
+  ^-  transaction:rpc
+  :*  nonce
+      8.000.000.000  ::TODO  global config
+      600.000  ::TODO  global config
+      to
+      0
+      `@`?@(dat dat (tape-to-ux dat))
+    ::
+      ?-  network
+        %mainnet    0x1
+        %ropsten    0x3
+        %fakenet    `@ux``@`1.337
+        [%other *]  id.network
+      ==
+  ==
+::
+++  single
+  |=  [nonce=@ud =network as=address =call]
+  ^-  transaction:rpc
+  =-  (do network nonce contract data)
+  ^-  [data=tape contract=address]
+  :-  (encode-claz-call call)
+  =/  contracts  (get-contracts network)
+  ?+  -.call  ecliptic:contracts
+    %send-point  delegated-sending:contracts
+  ==
+::
+++  deed
+  |=  [nonce=@ud =network as=address deeds-json=cord]
+  ^-  (list transaction:rpc)
+  =/  deeds=(list [=ship rights])
+    (parse-registration deeds-json)
+  ::TODO  split per spawn proxy
+  =|  txs=(list transaction:rpc)
+  |^  ::  $
+    ?~  deeds  (flop txs)
+    =*  deed  i.deeds
+    =.  txs
+      ?.  ?=(%czar (clan:title ship.deed))
+        %-  do-here
+        (spawn:dat ship.deed as)
+      ~|  %galaxy-held-by-ceremony
+      ?>  =(0x740d.6d74.1711.163d.3fca.cecf.1f11.b867.9a7c.7964 as)
+      ~&  [%assuming-galaxy-owned-by-ceremony ship.deed]
+      txs
+    =?  txs  ?=(^ net.deed)
+      %-  do-here
+      (configure-keys:dat [ship u.net]:deed)
+    =?  txs  ?=(^ manage.deed)
+      %-  do-here
+      (set-management-proxy:dat [ship u.manage]:deed)
+    =?  txs  ?=(^ voting.deed)
+      %-  do-here
+      (set-voting-proxy:dat [ship u.voting]:deed)
+    =?  txs  ?=(^ spawn.deed)
+      %-  do-here
+      (set-spawn-proxy:dat [ship u.spawn]:deed)
+    =.  txs
+      %-  do-here
+      (transfer-ship:dat [ship own]:deed)
+    $(deeds t.deeds)
+  ::
+  ::TODO  maybe-do, take dat gat and unit argument
+  ++  do-here
+    |=  dat=tape
+    :_  txs
+    (do network (add nonce (lent txs)) ecliptic:(get-contracts network) dat)
+  --
+::
+++  invites
+  |=  [nonce=@ud =network as=address as-who=ship file=path]
+  ^-  (list transaction:rpc)
+  =/  friends=(list [=ship @q =address])
+    (read-invites file)
+  =|  txs=(list transaction:rpc)
+  |-
+  ?~  friends  (flop txs)
+  =*  friend  i.friends
+  =;  tx=transaction:rpc
+    $(txs [tx txs], friends t.friends)
+  %-  do
+  :*  network
+      (add nonce (lent txs))
+      delegated-sending:(get-contracts network)
+      (send-point:dat as-who [ship address]:friend)
+  ==
+::
+++  parse-registration
+  |=  reg=cord
+  ^-  (list [=ship rights])
+  ~|  %registration-json-insane
+  =+  jon=(need (de-json:html reg))
+  ~|  %registration-json-invalid
+  ?>  ?=(%o -.jon)
+  =.  p.jon  (~(del by p.jon) 'idCode')
+  %+  turn  ~(tap by p.jon)
+  |=  [who=@t deed=json]
+  ^-  [ship rights]
+  :-  (rash who dum:ag)
+  ?>  ?=(%a -.deed)
+  ::  array has contents of:
+  ::  [owner, transfer, spawn, mgmt, delegate, auth_key, crypt_key]
+  ~|  [%registration-incomplete deed (lent p.deed)]
+  ?>  =(7 (lent p.deed))
+  =<  :*  (. 0 %address)       ::  owner
+          (. 3 %unit-address)  ::  management
+          (. 4 %unit-address)  ::  voting
+          (. 1 %unit-address)  ::  transfer
+          (. 2 %unit-address)  ::  spawn
+          (both (. 6 %key) (. 5 %key))  ::  crypt, auth
+      ==
+  |*  [i=@ud what=?(%address %unit-address %key)]
+  =+  j=(snag i p.deed)
+  ~|  [%registration-invalid-value what j]
+  ?>  ?=(%s -.j)
+  %+  rash  p.j
+  =+  adr=;~(pfix (jest '0x') hex)
+  ?-  what
+    %address       adr
+    %unit-address  ;~(pose (stag ~ adr) (cold ~ (jest '')))
+    %key           ;~(pose (stag ~ hex) (cold ~ (jest '')))
+  ==
+::
+++  lock-prep
+  |=  [nonce=@ud =network as=address what=(list ship)]
+  ^-  (list transaction:rpc)
+  ~&  %assuming-lockup-on-mainnet
+  =|  txs=(list transaction:rpc)
+  |^
+    ?~  what  (flop txs)
+    =.  txs
+      %-  do-here
+      (spawn:dat i.what as)
+    =.  txs
+      %-  do-here
+      %+  transfer-ship:dat  i.what
+      ~&  %assuming-lockup-done-by-ceremony
+      0x740d.6d74.1711.163d.3fca.cecf.1f11.b867.9a7c.7964
+    $(what t.what)
+  ++  do-here
+    |=  dat=tape
+    :_  txs
+    (do network (add nonce (lent txs)) ecliptic:mainnet-contracts dat)
+  --
+::
+::TODO  support distinguishing/switching between usable lockup methods
+::      automagically
+++  lock
+  |=  $:  nonce=@ud
+          =network
+          as=address
+          how=?(%spawn %transfer)
+          what=(list ship)
+          to=address
+          =lockup
+      ==
+  ^-  (list transaction:rpc)
+  ::  verify lockup sanity
+  ::
+  ~|  %invalid-lockup-ships
+  ?>  ?|  ?=(%linear -.lockup)
+          =(`@`(lent what) :(add b1.lockup b2.lockup b3.lockup))
+      ==
+  ::  expand galaxies into stars
+  ::
+  =.  what
+    %-  zing
+    %+  turn  what
+    |=  s=ship
+    ^-  (list ship)
+    ?.  =(%czar (clan:title s))  [s]~
+    (turn (gulf 1 255) |=(k=@ud (cat 3 s k)))
+  =/  lockup-contract=address
+    ?-  -.lockup
+      %linear       0x86cd.9cd0.992f.0423.1751.e376.1de4.5cec.ea5d.1801
+      %conditional  0x8c24.1098.c3d3.498f.e126.1421.633f.d579.86d7.4aea
+    ==
+  %-  flop
+  =|  txs=(list transaction:rpc)
+  ^+  txs
+  |^
+    ::  registration
+    ::
+    =.  txs
+      %+  do-here  lockup-contract
+      ?-  -.lockup
+        %linear       (register-linear to (lent what) +.lockup)
+        %conditional  (register-conditional to +.lockup)
+      ==
+    ::  context-dependent setup
+    ::
+    =.  txs
+      ?-  how
+        ::  %spawn: set spawn proxy of parents
+        ::
+          %spawn
+        ~&  %assuming-ceremony-controls-parents
+        =/  parents
+          =-  ~(tap in -)
+          %+  roll  what
+          |=  [s=ship ss=(set ship)]
+          ?>  =(%king (clan:title s))
+          (~(put in ss) (^sein:title s))
+        |-
+        ?~  parents  txs
+        =.  txs
+          %+  do-here  ecliptic:mainnet-contracts
+          (set-spawn-proxy:dat i.parents lockup-contract)
+        $(parents t.parents)
+      ::
+        ::  %transfer: set transfer proxy of stars
+        ::
+          %transfer
+        ~&  %assuming-ceremony-controls-stars
+        |-
+        ?~  what  txs
+        =.  txs
+          %+  do-here  ecliptic:mainnet-contracts
+          (set-transfer-proxy:dat i.what lockup-contract)
+        $(what t.what)
+      ==
+    ::  depositing
+    ::
+    |-
+    ?~  what  txs
+    =.  txs
+      %+  do-here  lockup-contract
+      (deposit:dat to i.what)
+    $(what t.what)
+  ++  do-here
+    |=  [contract=address dat=tape]
+    :_  txs
+    (do network (add nonce (lent txs)) contract dat)
+  --
+::
+++  register-linear
+  |=  [to=address stars=@ud windup-years=@ud unlock-years=@ud]
+  %-  register-linear:dat
+  :*  to
+      (mul windup-years yer:yo)
+      stars
+      (div (mul unlock-years yer:yo) stars)
+      1
+  ==
+::
+++  register-conditional
+  |=  [to=address [b1=@ud b2=@ud b3=@ud] unlock-years-per-batch=@ud]
+  %-  register-conditional:dat
+  =-  [`address`to b1 b2 b3 `@ud`- 1]
+  (div (mul unlock-years-per-batch yer:yo) :(add b1 b2 b3))
+::
+--

--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -6,25 +6,20 @@
 =,  azimuth
 ::
 |%
-++  state-0
++$  state-0
   $:  %0
       in-progress=(unit command)
   ==
 ::
-::  internal types
-::
 +$  rpc-result  [id=@t res=@t]
 +$  card  card:agent:gall
-::
-::  constants
-::TODO  from zuse instaed`
 ::
 ++  node-url           'http://eth-mainnet.urbit.org:8545'
 --
 ::
 =|  state-0
 =*  state  -
-%+  verb  &
+%+  verb  |
 =<
   |_  =bowl:gall
   +*  this  .

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -1,0 +1,613 @@
+::  gaze: azimuth statistics
+::
+::    general flow:
+::    - receive events
+::    - process events whose timestamp is known
+::    - request timestamps for unknown block numbers (if not already running)
+::    - receive timestamps, process events
+::
+/-  eth-watcher
+/+  default-agent, verb
+=,  ethereum
+=,  azimuth
+::
+=>  |%
+    +$  state-0
+      $:  %0
+          ::  qued: event logs waiting on block timestamp, oldest first
+          ::  time: timstamps of block numbers
+          ::  seen: events sorted by timestamp, newest first
+          ::  days: stats by day, newest first
+          ::
+          running=(unit @ta)
+          qued=loglist
+          time=(map @ud @da)
+          seen=(list [wen=@da wat=event])
+          days=(list [day=@da sat=stats])
+      ==
+    ::
+    +$  loglist  loglist:eth-watcher
+    +$  event
+      $%  [%azimuth who=ship dif=diff-point]
+          [%invite by=ship of=ship gift=ship to=address]
+      ==
+    ::
+    +$  stats
+      $:  spawned=(list @p)
+          activated=(list @p)
+          transfer-p=(list @p)
+          transferred=(list @p)
+          configured=(list @p)
+          breached=(list @p)
+          request=(list @p)
+          sponsor=(list @p)
+          management-p=(list @p)
+          voting-p=(list @p)
+          spawn-p=(list @p)
+          invites-senders=(list @p)
+      ==
+    ::
+    +$  card  card:agent:gall
+    ::
+    ++  node-url  'http://eth-mainnet.urbit.org:8545'
+    ++  refresh-rate  ~h1
+    --
+::
+=|  state-0
+=*  state  -
+::
+%+  verb  |
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this  .
+      do    ~(. +> bowl)
+      def   ~(. (default-agent this %|) bowl)
+  ::
+  ++  on-init
+    ^-  (quip card _this)
+    [setup-cards:do this]
+  ::
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  old=vase
+    ^-  (quip card _this)
+    [~ this(state !<(state-0 old))]
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    ?>  ?=(%noun mark)
+    =/  =noun  !<(noun vase)
+    |-  ^-  [cards=(list card) =_this]
+    ?+  noun  ~|([dap.bowl %unknown-poke noun] !!)
+        %reconnect
+      :_  this
+      :~  leave-eth-watcher:do
+          watch-eth-watcher:do
+      ==
+    ::
+        %reload
+      :-  cards:$(noun %reconnect)
+      this(qued ~, seen ~, days ~)
+    ::
+        %rewatch
+      :_  this:$(noun %reset)
+      :~  leave-eth-watcher:do
+          clear-eth-watcher:do
+          setup-eth-watcher:do
+          await-eth-watcher:do
+      ==
+    ::
+        %export
+      [export:do this]
+    ::
+        %debug
+      ~&  latest=(turn (scag 5 seen) head)
+      ~&  oldest=(turn (slag (sub (max 5 (lent seen)) 5) seen) head)
+      ~&  :-  'order is'
+          =-  ?:(sane 'sane' 'insane')
+          %+  roll  seen
+          |=  [[this=@da *] last=@da sane=?]
+          :-  this
+          ?:  =(*@da last)  &
+          (lte this last)
+      ~&  time=~(wyt by time)
+      ~&  qued=(lent qued)
+      ~&  days=(lent days)
+      [~ this]
+    ==
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    ?+  -.sign  (on-agent:def wire sign)
+        %kick
+      ?.  =(/watcher wire)  [~ this]
+      [[watch-eth-watcher:do]~ this]
+    ::
+        %fact
+      ?+  wire  (on-agent:def wire sign)
+          [%watcher ~]
+        ?.  ?=(%eth-watcher-diff p.cage.sign)
+          (on-agent:def wire sign)
+        =^  cards  state
+          %-  handle-eth-watcher-diff:do
+          !<(diff:eth-watcher q.cage.sign)
+        [cards this]
+      ::
+          [%timestamps @ ~]
+        ?+  p.cage.sign  (on-agent:def wire sign)
+            %thread-fail
+          =+  !<([=term =tang] q.cage.sign)
+          =/  =tank  leaf+"{(trip dap.bowl)} thread failed; will retry"
+          %-  (slog tank leaf+<term> tang)
+          =^  cards  state
+            request-timestamps:do
+          [cards this]
+        ::
+            %thread-done
+          =^  cards  state
+            %-  save-timestamps:do
+            !<((list [@ud @da]) q.cage.sign)
+          [cards this]
+        ==
+      ==
+    ==
+  ::
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card _this)
+    ?+  +<.sign-arvo  ~|([dap.bowl %strange-arvo-sign +<.sign-arvo] !!)
+        %wake
+      ?:  =(/export wire)
+        [[wait-export:do export:do] this]
+      ?:  =(/watch wire)
+        [[watch-eth-watcher:do]~ this]
+      ~&  [dap.bowl %strange-wake wire]
+      [~ this]
+    ==
+  ::
+  ++  on-peek   on-peek:def
+  ++  on-watch  on-watch:def
+  ++  on-leave  on-leave:def
+  ++  on-fail   on-fail:def
+  --
+::
+|_  =bowl:gall
+++  setup-cards
+  ^-  (list card)
+  :~  wait-export
+      setup-eth-watcher
+      ::  we punt on subscribing to the eth-watcher for a little while.
+      ::  this way we get a %history diff containing all past events,
+      ::  instead of so many individual %log diffs that we bail meme.
+      ::  (to repro, replace this with `watch-eth-watcher`)
+      ::
+      await-eth-watcher
+  ==
+::
+++  wait
+  |=  [=wire =@dr]
+  ^-  card
+  [%pass wire %arvo %b %wait (add now.bowl dr)]
+::
+++  wait-export  (wait /export refresh-rate)
+::
+++  to-eth-watcher
+  |=  [=wire =task:agent:gall]
+  ^-  card
+  [%pass wire %agent [our.bowl %eth-watcher] task]
+::
+++  setup-eth-watcher
+  %+  to-eth-watcher  /setup
+  :+  %poke   %eth-watcher-poke
+  !>  ^-  poke:eth-watcher
+  :+  %watch  /[dap.bowl]
+  :*  node-url
+      refresh-rate
+      public:mainnet-contracts
+      ~[azimuth delegated-sending]:mainnet-contracts
+      ~
+  ==
+::
+::  see also comment in +setup-cards
+++  await-eth-watcher  (wait /watch ~m30)
+::
+++  watch-eth-watcher
+  %+  to-eth-watcher  /watcher
+  [%watch /logs/[dap.bowl]]
+::
+++  leave-eth-watcher
+  %+  to-eth-watcher  /watcher
+  [%leave ~]
+::
+++  clear-eth-watcher
+  %+  to-eth-watcher  /clear
+  :+  %poke  %eth-watcher-poke
+  !>  ^-  poke:eth-watcher
+  [%clear /logs/[dap.bowl]]
+::
+++  poke-spider
+  |=  [=wire =cage]
+  ^-  card
+  [%pass wire %agent [our.bowl %spider] %poke cage]
+::
+++  watch-spider
+  |=  [=wire =sub=path]
+  ^-  card
+  [%pass wire %agent [our.bowl %spider] %watch sub-path]
+::
+::  +handle-eth-watcher-diff: process new logs, clear state on rollback
+::
+::    processes logs for which we know the timestamp
+::    adds timestamp-less logs to queue
+::
+++  handle-eth-watcher-diff
+  |=  =diff:eth-watcher
+  ^-  (quip card _state)
+  =^  logs  state
+    ^-  [loglist _state]
+    ?-  -.diff
+      %history  ~&  [%got-history (lent loglist.diff)]
+                [loglist.diff state(qued ~, seen ~)]
+      %log      ~&  %got-log
+                [[event-log.diff ~] state]
+      %disavow  ~&  %disavow-unimplemented
+                [~ state]
+    ==
+  %-  process-logs
+  %+  skip  logs
+  |=  =event-log:rpc
+  %-  is-lockup-block
+  block-number:(need mined.event-log)
+::
+::  +is-lockup-block: whether the block contains lockup/ignorable transactions
+::
+::    this is the stupid dumb equivalent to actually identifying lockup
+::    transactions procedurally, which is still in git history, but didn't
+::    work quite right for unidentified reasons
+::
+++  is-lockup-block
+  |=  num=@ud
+  ^-  ?
+  %+  roll
+    ^-  (list [@ud @ud])
+    :~  [7.050.978 7.051.038]
+    ==
+  |=  [[start=@ud end=@ud] in=_|]
+  ?:  in  &
+  &((gte num start) (lte num end))
+::
+::  +request-timestamps: request block timestamps for the logs as necessary
+::
+::    will come back as a thread result
+::
+++  request-timestamps
+  ^-  (quip card _state)
+  ?~  qued  [~ state]
+  ?^  running  [~ state]
+  =/  tid=@ta
+    %+  scot  %ta
+    :((cury cat 3) dap.bowl '_' (scot %uv eny.bowl))
+  :_  state(running `tid)
+  :~  (watch-spider /timestamps/[tid] /thread-result/[tid])
+    ::
+      %+  poke-spider  /timestamps/[tid]
+      :-  %spider-start
+      =-  !>([~ `tid %eth-get-timestamps -])
+      !>  ^-  [@t (list @ud)]
+      :-  node-url
+      =-  ~(tap in -)
+      %-  ~(gas in *(set @ud))
+      ^-  (list @ud)
+      %+  turn  qued
+      |=  log=event-log:rpc
+      block-number:(need mined.log)
+  ==
+::
+::  +save-timestamps: store timestamps into state
+::
+++  save-timestamps
+  |=  timestamps=(list [@ud @da])
+  ^-  (quip card _state)
+  =.  time     (~(gas by time) timestamps)
+  =.  running   ~
+  (process-logs ~)
+::
+::  +process-logs: handle new incoming logs
+::
+++  process-logs
+  |=  new=loglist  ::  oldest first
+  ^-  (quip card _state)
+  =.  qued  (weld qued new)
+  ?~  qued  [~ state]
+  =-  %_  request-timestamps
+        qued  (flop rest)  ::  oldest first
+        seen  (weld logs seen)  ::  newest first
+        days  (count-events (flop logs))  ::  oldest first
+      ==
+  %+  roll  `loglist`qued
+  |=  [log=event-log:rpc [rest=loglist logs=(list [wen=@da wat=event])]]
+  ::  to ensure logs are processed in sane order,
+  ::  stop processing as soon as we skipped one
+  ::
+  ?^  rest  [[log rest] logs]
+  =/  tim=(unit @da)
+    %-  ~(get by time)
+    block-number:(need mined.log)
+  ?~  tim  [[log rest] logs]
+  :-  rest
+  =+  ven=(event-log-to-event log)
+  ?~  ven  logs
+  [[u.tim u.ven] logs]
+::
+::  +event-log-to-event: turn raw log into gaze noun
+::
+++  event-log-to-event
+  |=  log=event-log:rpc
+  ^-  (unit event)
+  ?:  =(azimuth:mainnet-contracts address.log)
+    =+  (event-log-to-point-diff log)
+    ?~  -  ~
+    `azimuth+u
+  ?:  =(delegated-sending:mainnet-contracts address.log)
+    ?.  .=  i.topics.log
+        0x4763.8e3c.ddee.2204.81e4.c3f9.183d.639c.
+          0efe.a7f0.5fcd.2df4.1888.5572.9f71.5419
+      ~
+    =+  ^-  [of=@ pool=@]  ::TODO  =/
+      ~|  t.topics.log
+      %+  decode-topics:abi:ethereum  t.topics.log
+      ~[%uint %uint]
+    =+  ^-  [by=@ gift=@ to=@]  ::TODO  =/
+      ~|  data.log
+      %+  decode-topics:abi:ethereum
+        %+  rash  data.log
+        =-  ;~(pfix (jest '0x') -)
+        %+  stun  [3 3]
+        (bass 16 (stun [64 64] hit))
+      ~[%uint %uint %address]
+    `invite+[by of gift to]
+  ~
+::
+::  +count-events: add events to the daily stats
+::
+++  count-events
+  |=  logs=_seen  ::  oldest first
+  ^+  days
+  =/  head=[day=@da sat=stats]
+    ?^  days  i.days
+    *[@da stats]
+  =+  tail=?~(days ~ t.days)
+  |-
+  ::  when done, store updated head, but only if it's set
+  ::
+  ?~  logs
+    ?:  =(*[@da stats] head)  tail
+    [head tail]
+  =*  log  i.logs
+  ::  calculate day for current event, set head if unset
+  ::
+  =/  day=@da
+    (sub wen.log (mod wen.log ~d1))
+  =?  day.head  =(*@da day.head)  day
+  ::  same day as head, so add to it
+  ::
+  ?:  =(day day.head)
+    %_  $
+      sat.head  (count-event wat.log sat.head)
+      logs      t.logs
+    ==
+  ~|  [%weird-new-day old=day.head new=day]
+  ?>  (gth day day.head)
+  ::  newer day than head of days, so start new head
+  ::
+  %_  $
+    tail  [head tail]
+    head  [day *stats]
+  ==
+::
+::  +count-event: add event to the stats, if it's relevant
+::
+++  count-event
+  |=  [eve=event sat=stats]
+  ^-  stats
+  ?-  -.eve
+    %invite  sat(invites-senders [by.eve invites-senders.sat])
+  ::
+      %azimuth
+    ?+  -.dif.eve  sat
+      %spawned           sat(spawned [who.dif.eve spawned.sat])
+      %activated         sat(activated [who.eve activated.sat])
+      %transfer-proxy    ?:  =(0x0 new.dif.eve)  sat
+                         sat(transfer-p [who.eve transfer-p.sat])
+      %owner             sat(transferred [who.eve transferred.sat])
+      %keys              sat(configured [who.eve configured.sat])
+      %continuity        sat(breached [who.eve breached.sat])
+      %escape            ?~  new.dif.eve  sat
+                         sat(request [who.eve request.sat])
+      %sponsor           ?.  has.new.dif.eve  sat
+                         sat(sponsor [who.eve sponsor.sat])
+      %management-proxy  sat(management-p [who.eve management-p.sat])
+      %voting-proxy      sat(voting-p [who.eve voting-p.sat])
+      %spawn-proxy       sat(spawn-p [who.eve spawn-p.sat])
+    ==
+  ==
+::
+::
+::  +export: periodically export data
+::
+++  export
+  ^-  (list card)
+  :~  (export-move %days (export-days days))
+      (export-move %months (export-months days))
+      (export-move %events export-raw)
+  ==
+::
+::  +export-move: %info move to write exported .txt
+::
+++  export-move
+  |=  [nom=@t dat=(list @t)]
+  ^-  card
+  =-  [%pass /export/[nom] %arvo %c %info -]
+  %+  foal:space:userlib
+    /(scot %p our.bowl)/home/(scot %da now.bowl)/gaze-exports/[nom]/txt
+  [%txt !>(dat)]
+::
+::  +peek-x: accept gall scry
+::
+::    %/days/txt:   per day, digest stats
+::    %/months/txt: per month, digest stats
+::    %/raw/txt:    all observed events
+::
+++  peek-x  ::TODO
+  |=  pax=path
+  ^-  (unit (unit (pair mark *)))
+  ?~  pax  ~
+  ?:  =(%days i.pax)
+    :^  ~  ~  %txt
+    (export-days days)
+  ?:  =(%months i.pax)
+    :^  ~  ~  %txt
+    (export-months days)
+  ?:  =(%raw i.pax)
+    ``txt+export-raw
+  ~
+::
+::  +export-months: generate a csv of stats per month
+::
+++  export-months
+  |=  =_days
+  %-  export-days
+  ^+  days
+  %+  roll  (flop days)
+  |=  [[day=@da sat=stats] mos=(list [mod=@da sat=stats])]
+  ^+  mos
+  =/  mod=@da
+    %-  year
+    =+  (yore day)
+    -(d.t 1)
+  ?~  mos  [mod sat]~
+  ?:  !=(mod mod.i.mos)
+    [[mod sat] mos]
+  :_  t.mos
+  :-  mod
+  ::TODO  this is hideous. can we make a wet gate do this?
+  :*  (weld spawned.sat spawned.sat.i.mos)
+      (weld activated.sat activated.sat.i.mos)
+      (weld transfer-p.sat transfer-p.sat.i.mos)
+      (weld transferred.sat transferred.sat.i.mos)
+      (weld configured.sat configured.sat.i.mos)
+      (weld breached.sat breached.sat.i.mos)
+      (weld request.sat request.sat.i.mos)
+      (weld sponsor.sat sponsor.sat.i.mos)
+      (weld management-p.sat management-p.sat.i.mos)
+      (weld voting-p.sat voting-p.sat.i.mos)
+      (weld spawn-p.sat spawn-p.sat.i.mos)
+      (weld invites-senders.sat invites-senders.sat.i.mos)
+  ==
+::
+::  +export-days: generate a csv of stats per day
+::
+++  export-days
+  |=  =_days
+  :-  %-  crip
+      ;:  weld
+        "date,"
+        "spawned,"
+        "activated,"
+        "transfer proxy,"
+        "transferred,"
+        "transferred (unique),"
+        "configured,"
+        "configured (unique),"
+        "escape request,"
+        "sponsor change,"
+        "invites,"
+        "invites (unique senders)"
+      ==
+  |^  ^-  (list @t)
+      %+  turn  days
+      |=  [day=@da stats]
+      %-  crip
+      ;:  weld
+        (scow %da day)            ","
+        (count spawned)           ","
+        (count activated)         ","
+        (count transfer-p)        ","
+        (unique transferred)      ","
+        (unique configured)       ","
+        (count request)           ","
+        (count sponsor)           ","
+        (unique invites-senders)
+      ==
+  ::
+  ++  count
+    |*  l=(list)
+    (num (lent l))
+  ::
+  ++  unique
+    |*  l=(list)
+    ;:  weld
+      (count l)
+      ","
+      (num ~(wyt in (~(gas in *(set)) l)))
+    ==
+  ::
+  ++  num  (d-co:co 1)
+  --
+::
+::  +export-raw: generate a csv of individual transactions
+::
+++  export-raw
+  :-  %-  crip
+      ;:  weld
+        "date,"
+        "point,"
+        "event,"
+        "field 1,field2,field3"
+      ==
+  |^  ^-  (list @t)
+      %+  turn  seen
+      :: (cork tail event-to-row crip)
+      |=  [wen=@da =event]
+      (crip "{(scow %da wen)},{(event-to-row event)}")
+  ::
+  ++  event-to-row
+    |=  =event
+    ?-  -.event
+      %azimuth  (point-diff-to-row +.event)
+      %invite   (invite-to-row +.event)
+    ==
+  ::
+  ++  point-diff-to-row
+    |=  [who=ship dif=diff-point]
+    ^-  tape
+    %+  weld  "{(pon who)},"
+    ?-  -.dif
+      %full               "full,"
+      %owner              "owner,{(adr new.dif)}"
+      %activated          "activated,"
+      %spawned            "spawned,{(pon who.dif)}"
+      %keys               "keys,{(num life.dif)}"
+      %continuity         "breached,{(num new.dif)}"
+      %sponsor            "sponsor,{(spo has.new.dif)},{(pon who.new.dif)}"
+      %escape             "escape-req,{(req new.dif)}"
+      %management-proxy   "management-p,{(adr new.dif)}"
+      %voting-proxy       "voting-p,{(adr new.dif)}"
+      %spawn-proxy        "spawn-p,{(adr new.dif)}"
+      %transfer-proxy     "transfer-p,{(adr new.dif)}"
+    ==
+  ::
+  ++  invite-to-row
+    |=  [by=ship of=ship ship to=address]
+    "{(pon by)},invite,{(pon of)},{(adr to)}"
+  ::
+  ++  num  (d-co:co 1)
+  ++  pon  (cury scow %p)
+  ++  adr  |=(a=@ ['0' 'x' ((x-co:co (mul 2 20)) a)])
+  ++  spo  |=(h=? ?:(h "escaped to" "detached from"))
+  ++  req  |=(r=(unit @p) ?~(r "canceled" (pon u.r)))
+  --
+--

--- a/pkg/arvo/lib/claz.hoon
+++ b/pkg/arvo/lib/claz.hoon
@@ -1,0 +1,280 @@
+::  claz: call data generation
+::
+/-  *claz
+::
+=,  ethereum
+::
+|%
+++  read-invites  ::TODO  lib
+  |=  file=path
+  ^-  (list [=ship ticket=@q =address])
+  =+  txt=.^((list cord) %cx file)
+  %+  murn  txt
+  |=  line=cord
+  ^-  (unit [ship @q address])
+  ?:  =('' line)  ~
+  %-  some
+  ~|  line
+  %+  rash  line
+  ;~  (glue com)
+    ;~(pfix sig fed:ag)
+    ;~(pfix sig feq:ag)
+    ;~(pfix (jest '0x') hex)
+  ==
+::
+++  get-contracts
+  |=  =network
+  ?+  network  ~&(%careful-fallback-contracts mainnet-contracts:azimuth)
+    %mainnet  mainnet-contracts:azimuth
+    %ropsten  ropsten-contracts:azimuth
+  ==
+::
+++  encode-claz-call
+  |=  =call
+  ?-  -.call
+    %create-galaxy         (create-galaxy:dat +.call)
+    %spawn                 (spawn:dat +.call)
+    %configure-keys        (configure-keys:dat +.call)
+    %set-management-proxy  (set-management-proxy:dat +.call)
+    %set-voting-proxy      (set-voting-proxy:dat +.call)
+    %set-spawn-proxy       (set-spawn-proxy:dat +.call)
+    %transfer-ship         (transfer-ship:dat +.call)
+    %set-transfer-proxy    (set-transfer-proxy:dat +.call)
+    %adopt                 (adopt:dat +.call)
+    %start-document-poll   (start-document-poll:dat +.call)
+    %cast-document-vote    (cast-document-vote:dat +.call)
+  ::
+    %send-point  (send-point:dat +.call)
+  ==
+::
++$  call-data  call-data:rpc
+++  dat
+  |%
+  ++  enc
+    |*  cal=$-(* call-data)
+    (cork cal encode-call:rpc)
+  ::
+  ++  create-galaxy           (enc create-galaxy:cal)
+  ++  spawn                   (enc spawn:cal)
+  ++  configure-keys          (enc configure-keys:cal)
+  ++  set-spawn-proxy         (enc set-spawn-proxy:cal)
+  ++  transfer-ship           (enc transfer-ship:cal)
+  ++  set-management-proxy    (enc set-management-proxy:cal)
+  ++  set-voting-proxy        (enc set-voting-proxy:cal)
+  ++  set-transfer-proxy      (enc set-transfer-proxy:cal)
+  ++  set-dns-domains         (enc set-dns-domains:cal)
+  ++  upgrade-to              (enc upgrade-to:cal)
+  ++  transfer-ownership      (enc transfer-ownership:cal)
+  ++  adopt                   (enc adopt:cal)
+  ++  start-document-poll     (enc start-document-poll:cal)
+  ++  cast-document-vote      (enc cast-document-vote:cal)
+  ::
+  ++  register-linear         (enc register-linear:cal)
+  ++  register-conditional    (enc register-conditional:cal)
+  ++  deposit                 (enc deposit:cal)
+  ::
+  ++  send-point              (enc send-point:cal)
+  --
+::
+::TODO  lib
+++  cal
+  |%
+  ++  create-galaxy
+    |=  [gal=ship to=address]
+    ^-  call-data
+    ?>  =(%czar (clan:title gal))
+    :-  'createGalaxy(uint8,address)'
+    :~  [%uint `@`gal]
+        [%address to]
+    ==
+  ::
+  ++  spawn
+    |=  [who=ship to=address]
+    ^-  call-data
+    ?>  ?=(?(%king %duke) (clan:title who))
+    :-  'spawn(uint32,address)'
+    :~  [%uint `@`who]
+        [%address to]
+    ==
+  ::
+  ++  configure-keys
+    |=  [who=ship crypt=@ auth=@]
+    ^-  call-data
+    ::TODO  maybe disable asserts?
+    ?>  (lte (met 3 crypt) 32)
+    ?>  (lte (met 3 auth) 32)
+    :-  'configureKeys(uint32,bytes32,bytes32,uint32,bool)'
+    :~  [%uint `@`who]
+        [%bytes-n 32^crypt]
+        [%bytes-n 32^auth]
+        [%uint 1]
+        [%bool |]
+    ==
+  ::
+  ++  set-management-proxy
+    |=  [who=ship proxy=address]
+    ^-  call-data
+    :-  'setManagementProxy(uint32,address)'
+    :~  [%uint `@`who]
+        [%address proxy]
+    ==
+  ::
+  ++  set-voting-proxy
+    |=  [who=ship proxy=address]
+    ^-  call-data
+    :-  'setVotingProxy(uint8,address)'
+    :~  [%uint `@`who]
+        [%address proxy]
+    ==
+  ::
+  ++  set-spawn-proxy
+    |=  [who=ship proxy=address]
+    ^-  call-data
+    :-  'setSpawnProxy(uint16,address)'
+    :~  [%uint `@`who]
+        [%address proxy]
+    ==
+  ::
+  ++  transfer-ship
+    |=  [who=ship to=address]
+    ^-  call-data
+    :-  'transferPoint(uint32,address,bool)'
+    :~  [%uint `@`who]
+        [%address to]
+        [%bool |]
+    ==
+  ::
+  ++  set-transfer-proxy
+    |=  [who=ship proxy=address]
+    ^-  call-data
+    :-  'setTransferProxy(uint32,address)'
+    :~  [%uint `@`who]
+        [%address proxy]
+    ==
+  ::
+  ++  start-document-poll
+    |=  [gal=ship hash=@]
+    ^-  call-data
+    ?>  =(%czar (clan:title gal))
+    :-  'startDocumentPoll(uint8,bytes32)'
+    :~  [%uint `@`gal]
+        [%bytes-n 32^hash]
+    ==
+  ::
+  ++  cast-document-vote
+    |=  [gal=ship hash=@ support=?]
+    ^-  call-data
+    ?>  =(%czar (clan:title gal))
+    :-  'castDocumentVote(uint8,bytes32,bool)'
+    :~  [%uint `@`gal]
+        [%bytes-n 32^hash]
+        [%bool support]
+    ==
+  ::
+  ::
+  ++  set-dns-domains
+    |=  [pri=tape sec=tape ter=tape]
+    ^-  call-data
+    :-  'setDnsDomains(string,string,string)'
+    :~  [%string pri]
+        [%string sec]
+        [%string ter]
+    ==
+  ::
+  ++  upgrade-to
+    |=  to=address
+    ^-  call-data
+    :-  'upgradeTo(address)'
+    :~  [%address to]
+    ==
+  ::
+  ::
+  ++  transfer-ownership  ::  of contract
+    |=  to=address
+    ^-  call-data
+    :-  'transferOwnership(address)'
+    :~  [%address to]
+    ==
+  ::
+  ++  adopt
+    |=  who=ship
+    ^-  call-data
+    :-  'adopt(uint32)'
+    :~  [%uint `@`who]
+    ==
+  ::
+  ::
+  ++  register-linear
+    |=  $:  to=address
+            windup=@ud
+            stars=@ud
+            rate=@ud
+            rate-unit=@ud
+        ==
+    ^-  call-data
+    :-  'register(address,uint256,uint16,uint16,uint256)'
+    :~  [%address to]
+        [%uint windup]
+        [%uint stars]
+        [%uint rate]
+        [%uint rate-unit]
+    ==
+  ::
+  ++  register-conditional
+    |=  $:  to=address
+            b1=@ud
+            b2=@ud
+            b3=@ud
+            rate=@ud
+            rate-unit=@ud
+        ==
+    ^-  call-data
+    :-  'register(address,uint16[],uint16,uint256)'
+    :~  [%address to]
+        [%array ~[uint+b1 uint+b2 uint+b3]]
+        [%uint rate]
+        [%uint rate-unit]
+    ==
+  ::
+  ++  deposit
+    |=  [to=address star=ship]
+    ^-  call-data
+    :-  'deposit(address,uint16)'
+    :~  [%address to]
+        [%uint `@`star]
+    ==
+  ::
+  ++  send-point
+    |=  [as=ship point=ship to=address]
+    ^-  call-data
+    :-  'sendPoint(uint32,uint32,address)'
+    :~  [%uint `@`as]
+        [%uint `@`point]
+        [%address to]
+    ==
+  ::
+  ::  read calls
+  ::
+  ++  rights
+    |=  =ship
+    ^-  call-data
+    :-  'rights(uint32)'
+    :~  [%uint `@`ship]
+    ==
+  ::
+  ++  get-pool
+    |=  =ship
+    ^-  call-data
+    :-  'getPool(uint32)'
+    :~  [%uint `@`ship]
+    ==
+  ::
+  ++  pools
+    |=  [pool=@ud star=ship]
+    ^-  call-data
+    :-  'pools(uint32,uint16)'
+    :~  [%uint pool]
+        [%uint `@`star]
+    ==
+  --
+--

--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -222,4 +222,14 @@
     ==
   %-  pure:m
   (parse-event-logs:rpc:ethereum json)
+::
+++  get-next-nonce
+  |=  [url=@ta =address]
+  =/  m  (strand:strandio ,@ud)
+  ^-  form:m
+  ;<  =json  bind:m
+    %^  request-rpc  url  `'nonce'
+    [%eth-get-transaction-count address [%label %latest]]
+  %-  pure:m
+  (parse-eth-get-transaction-count:rpc:ethereum json)
 --

--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -18,11 +18,12 @@
     (request-batch-rpc-strict url [id req]~)
   ?:  ?=([* ~] res)
     (pure:m json.i.res)
-  ~|  [%ethio %unexpected-results (lent res)]
-  !!
+  %+  strand-fail:strandio
+    %unexpected-multiple-results
+  [>(lent res)< ~]
 ::  +request-batch-rpc-strict: send rpc request, with retry
 ::
-::    sends a batch requests. produces results for all requests in the batch,
+::    sends a batch request. produces results for all requests in the batch,
 ::    but only if all of them are successful.
 ::
 ++  request-batch-rpc-strict

--- a/pkg/arvo/sur/claz.hoon
+++ b/pkg/arvo/sur/claz.hoon
@@ -1,0 +1,76 @@
+::  claz:  command & call structures
+::
+::TODO  contract structures might go into stdlib
+::
+=,  ethereum-types
+::
+|%
+++  command
+  $%  [%generate =path =network as=address =batch]
+  ==
+::
+++  network
+  $?  %mainnet
+      %ropsten
+      %fakenet
+      [%other id=@]
+  ==
+::
+++  batch
+  $~  [%deed '{}']
+  $%  ::  %single: execute a single ecliptic function call
+      ::
+      [%single =call]
+      ::  %deed: deed ships based on json, assumes spawnable
+      ::
+      [%deed deeds-json=cord]
+      ::  %invites: sendPoint for every ship in ship,ticket,owner file
+      ::
+      ::    to generate such a file, try |claz-invites ~star 1 10 %/out/txt
+      ::
+      [%invites as-who=ship file=path]
+      ::  %lock-prep: prepare for lockup by transfering ships to the ceremony address
+      ::
+      [%lock-prep what=(list ship)]
+      ::  %lock: put ships into lockup for the target address
+      ::
+      [%lock how=?(%spawn %transfer) what=(list ship) to=address =lockup]
+      ::  %more: multiple batches sequentially
+      ::
+      [%more batches=(list batch)]
+  ==
+::
+++  lockup
+  $%  [%linear windup-years=@ud unlock-years=@ud]
+      [%conditional [b1=@ud b2=@ud b3=@ud] unlock-years-per-batch=@ud]
+  ==
+::
+++  rights
+  $:  own=address
+      manage=(unit address)
+      voting=(unit address)
+      transfer=(unit address)
+      spawn=(unit address)
+      net=(unit [crypt=@ux auth=@ux])
+  ==
+::
+++  call
+  $%  [%create-galaxy gal=ship to=address]
+      [%spawn who=ship to=address]
+      [%configure-keys who=ship crypt=@ auth=@]
+      [%set-management-proxy who=ship proxy=address]
+      [%set-voting-proxy who=ship proxy=address]
+      [%set-spawn-proxy who=ship proxy=address]
+      [%transfer-ship who=ship to=address]
+      [%set-transfer-proxy who=ship proxy=address]
+      [%adopt who=ship]
+      [%start-document-poll gal=ship hash=@]
+      [%cast-document-vote gal=ship hash=@ vote=?]
+    ::
+      [%send-point as=ship point=ship to=address]
+  ==
+::
+++  prep-result
+  $%  [%nonce nonce=@ud]
+  ==
+--

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7632,6 +7632,9 @@
         ++  azimuth
           0x223c.067f.8cf2.8ae1.73ee.5caf.ea60.ca44.c335.fecb
         ::
+        ++  ecliptic
+          0x6ac0.7b7c.4601.b5ce.11de.8dfe.6335.b871.c7c4.dd4d
+        ::
         ++  linear-star-release
           0x86cd.9cd0.992f.0423.1751.e376.1de4.5cec.ea5d.1801
         ::
@@ -7657,10 +7660,20 @@
         ++  azimuth
           0x308a.b6a6.024c.f198.b57e.008d.0ac9.ad02.1988.6579
         ::
+        ++  ecliptic
+          0x8b9f.86a2.8921.d9c7.05b3.113a.755f.b979.e1bd.1bce
+        ::
+        ++  linear-star-release
+          0x1f8e.dd03.1ee4.1474.0aed.b39b.84fb.8f2f.66ca.422f
+        ::
+        ++  conditional-star-release
+          0x0
+        ::
         ++  delegated-sending
-          0x1000.0000.0000.0000.0000.0000.0000.0000.0000.0000
+          0x3e8c.a510.354b.c2fd.bbd6.1502.52d9.3105.c9c2.7bbe
         ::
         ++  launch  4.601.630
+        ++  public  launch
         --
       ::
         ::  ++  azimuth  0x863d.9c2e.5c4c.1335.96cf.ac29.d552.55f0.d0f8.6381  ::  local bridge

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -8376,7 +8376,7 @@
                   top=(list ?(@ux (list @ux)))
               ==
               [%eth-get-filter-changes fid=@ud]
-              [%eth-get-transaction-count adr=address]
+              [%eth-get-transaction-count adr=address =block]
               [%eth-get-transaction-receipt txh=@ux]
               [%eth-send-raw-transaction dat=@ux]
           ==
@@ -8597,7 +8597,10 @@
         ['eth_getFilterChanges' (tape (num-to-hex fid.req)) ~]
       ::
           %eth-get-transaction-count
-        ['eth_getTransactionCount' (tape (address-to-hex adr.req)) ~]
+        :-  'eth_getTransactionCount'
+        :~  (tape (address-to-hex adr.req))
+            (block-to-json block.req)
+        ==
       ::
           %eth-get-transaction-receipt
         ['eth_getTransactionReceipt' (tape (transaction-to-hex txh.req)) ~]
@@ -8671,6 +8674,8 @@
     ++  parse-eth-block-number  parse-hex-result
     ::
     ++  parse-transaction-hash  parse-hex-result
+    ::
+    ++  parse-eth-get-transaction-count  parse-hex-result
     ::
     ++  parse-event-logs
       (ar:dejs:format parse-event-log)

--- a/pkg/arvo/ted/claz/prep-command.hoon
+++ b/pkg/arvo/ted/claz/prep-command.hoon
@@ -1,0 +1,119 @@
+::  claz/pre-command: sanity-check command and gather prerequisites
+::
+/-  *claz
+/+  *claz, ethio, strandio
+=,  ethereum-types
+=,  able:jael
+::
+|=  args=vase
+=+  ^-  [url=@t =command]
+  !<([@t command] args)
+=/  m  (strand:strandio ,vase)
+^-  form:m
+?.  ?=(%generate -.command)  !!  ::TODO
+|^  ;<  err=(unit tang)  bind:m
+      ::  sanity-check command
+      ::
+      ?+  -.batch.command  (pure:(strand:strandio (unit tang)) ~)
+        %invites  (check-invites +.batch.command)
+      ==
+    ?^  err  (strand-fail:strandio %claz-pre-command u.err)
+    ::  gather prerequisites
+    ::
+    ~&  [%gonna-get-nonce url as.command]
+    ;<  nonce=@ud  bind:m
+      (get-next-nonce:ethio url as.command)
+    ~&  [%got-nonce nonce]
+    (pure:m !>([%nonce nonce]))
+::
+++  check-invites
+  |=  [as=ship file=path]
+  =/  m  (strand:strandio ,(unit tang))
+  ^-  form:m
+  =/  friends=(list ship)
+    %+  turn
+      (read-invites file)
+    head
+  ;<  err=(unit tang)  bind:m
+    (are-available friends)
+  ?^  err  (pure:m err)
+  (has-invites-for as friends)
+::
+++  are-available
+  |=  ships=(list ship)
+  =/  m  (strand:strandio ,(unit tang))
+  ^-  form:m
+  ;<  responses=(list [@t @t])  bind:m
+    %+  batch-read-contract-strict:ethio  url
+    %+  turn  ships
+    |=  =ship
+    ^-  proto-read-request:rpc
+    :+  `(scot %p ship)
+      ::TODO  argument?
+      azimuth:contracts:azimuth
+    (rights:cal ship)
+  =/  taken=(list ship)
+    %+  murn  responses
+    |=  [id=@t res=@t]
+    ^-  (unit ship)
+    =/  rights=[owner=address *]
+      %+  decode-results:rpc  res
+      ::NOTE  using +reap nest-fails
+      [%address %address %address %address %address ~]
+    ?:  =(0x0 owner.rights)  ~
+    `(slav %p id)
+  %-  pure:m
+  ?:  =(~ taken)  ~
+  :-  ~
+  :~  leaf+"some ships already taken:"
+      >taken<
+  ==
+::
+++  has-invites-for
+  |=  [as=ship ships=(list ship)]
+  =/  m  (strand:strandio ,(unit tang))
+  ^-  form:m
+  =/  counts=(map ship @ud)
+    %+  roll  ships
+    |=  [s=ship counts=(map ship @ud)]
+    =+  p=(^sein:title s)
+    %+  ~(put by counts)  p
+    +((~(gut by counts) p 0))
+  ;<  pool=@ud  bind:m
+    =/  n  (strand:strandio ,@ud)
+    ;<  res=@t  bind:n
+      %+  read-contract:ethio  url
+      :+  `'pool'
+        ::TODO pass in as argument
+        delegated-sending:contracts:azimuth
+      (get-pool:cal as)
+    %-  pure:n
+    (decode-results:rpc res [%uint]~)
+  ;<  responses=(list [id=@t res=@t])  bind:m
+    %+  batch-read-contract-strict:ethio  url
+    %+  turn  ~(tap by counts)
+    |=  [=ship @ud]
+    ^-  proto-read-request:rpc
+    :+  `(scot %p ship)
+      ::TODO pass in as argument
+      delegated-sending:contracts:azimuth
+    (pools:cal pool ship)
+  =/  missing=(list [star=ship have=@ud needed=@ud])
+    %+  murn  responses
+    |=  [id=@t res=@t]
+    ^-  (unit [ship @ud @ud])
+    =/  =ship
+      (slav %p id)
+    =/  pool-size=@ud
+      (decode-results:rpc res [%uint]~)
+    =/  need=@ud
+      (~(got by counts) ship)
+    ?:  (gte pool-size need)  ~
+    `[ship pool-size need]
+  ?:  =(~ missing)
+    (pure:m ~)
+  %+  strand-fail:strandio  %lacking-invites
+  :~  leaf+"not enough invites from stars:"
+      >missing<
+  ==
+--

--- a/pkg/arvo/ted/eth/get-timestamps.hoon
+++ b/pkg/arvo/ted/eth/get-timestamps.hoon
@@ -1,0 +1,44 @@
+::  eth/get-timestamps: query ethereum block timestamps
+::
+::    produces list of @da result
+::
+/+  ethio, strandio
+=,  ethereum-types
+=,  able:jael
+::
+|=  args=vase
+=+  !<([url=@t blocks=(list @ud)] args)
+=/  m  (strand:strandio ,vase)
+=|  out=(list [block=@ud timestamp=@da])
+|^  ^-  form:m
+    =*  loop  $
+    ?:  =(~ blocks)  (pure:m !>(out))  ::TODO  TMI
+    ;<  res=(list [@t json])  bind:m
+      (request-blocks (scag 100 blocks))
+    %_  loop
+      out     (weld out (parse-results res))
+      blocks  (slag 100 blocks)
+    ==
+::
+++  request-blocks
+  |=  blocks=(list @ud)
+  %+  request-batch-rpc-strict:ethio  url
+  %+  turn  blocks
+  |=  block=@ud
+  ^-  [(unit @t) request:rpc:ethereum]
+  :-  `(scot %ud block)
+  [%eth-get-block-by-number block |]
+::
+++  parse-results
+  |=  res=(list [@t json])
+  ^+  out
+  %+  turn  res
+  |=  [id=@t =json]
+  ^-  [@ud @da]
+  :-  (slav %ud id)
+  %-  from-unix:chrono:userlib
+  %-  parse-hex-result:rpc:ethereum
+  ~|  json
+  ?>  ?=(%o -.json)
+  (~(got by p.json) 'timestamp')
+--


### PR DESCRIPTION
Ports two of our Ethereum tools to static gall.

Gaze does Azimuth statistics tracking. It now makes sure to do reasonably-sized batch requests, and keeps track of invite events.

Claz does Azimuth transaction generation. It gets support for document voting functions, but otherwise maintains feature parity with the original. Did split it up into /sur, /lib, and /ted files as appropriate. Perhaps in the future some of that will be consolidates into a /lib/azimuth.

eth-txs sender app and/or strand still pending, but I believe we have the old one still available to us where needed. Figured I should get this PR in while I do a quick side-quest.