### PR TITLE
goad: recompile apps after changes to /sys

### DIFF
--- a/pkg/arvo/app/clock.hoon
+++ b/pkg/arvo/app/clock.hoon
@@ -22,8 +22,20 @@
   :~  [%pass / %arvo %e %connect [~ /'~clock'] %clock]
       [%pass /clock %agent [our.bowl %launch] %poke launcha]
   ==
-++  on-save   on-save:def
-++  on-load   on-load:def
+::  bootstrapping to get %goad started OTA
+::
+++  on-save   !>(%1)
+++  on-load
+  |=  old-state=vase
+  =/  old  !<(?(~ %1) old-state)
+  =^  cards  this
+    ?.  ?=(~ old)
+      `this
+    :_  this  :_  ~
+    [%pass /behn %arvo %b %wait +(now.bowl)]
+  ::
+  [cards this]
+::
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card:agent:gall _this)
@@ -63,6 +75,13 @@
 ++  on-arvo
   |=  [=wire =sign-arvo]
   ^-  (quip card:agent:gall _this)
+  ?:  ?=(%wake +<.sign-arvo)
+    ?^  error.sign-arvo
+      :_  this  :_  ~
+      [%pass /dill %arvo %d %flog %crud %clock-fail u.error.sign-arvo]
+    :_  this  :_  ~
+    [%pass /gall %arvo %g %goad | `%hood]
+  ::
   ?.  ?=(%bound +<.sign-arvo)
     (on-arvo:def wire sign-arvo)
   [~ this]

--- a/pkg/arvo/app/goad.hoon
+++ b/pkg/arvo/app/goad.hoon
@@ -1,0 +1,57 @@
+/+  default-agent, verb
+%+  verb  |
+^-  agent:gall
+=>
+  |%
+  ++  warp
+    |=  =bowl:gall
+    [%pass /clay %arvo %c %warp our.bowl %home ~ %next %z da+now.bowl /sys]
+  ::
+  ++  wait
+    |=  =bowl:gall
+    [%pass /behn %arvo %b %wait +(now.bowl)]
+  ::
+  ++  goad
+    :~  [%pass /gall %arvo %g %goad | ~]
+    ==
+  --
+::
+|_  =bowl:gall
++*  this  .
+    def  ~(. (default-agent this %|) bowl)
+++  on-init
+  ::  subscribe to /sys and do initial goad
+  ::
+  [[(warp bowl) goad] this]
+::
+++  on-save   on-save:def
+++  on-load   on-load:def
+++  on-poke   on-poke:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-arvo
+  |=  [=wire =sign-arvo]
+  ?+    wire  (on-arvo:def wire sign-arvo)
+      [%clay ~]
+    ::  on writ, wait
+    ::
+    ?>  ?=(%writ +<.sign-arvo)
+    :_  this
+    :~  (warp bowl)
+        (wait bowl)
+    ==
+  ::
+      [%behn ~]
+    ::  on wake, goad
+    ::
+    ?>  ?=(%wake +<.sign-arvo)
+    ?^  error.sign-arvo
+      :_  this  :_  ~
+      [%pass /dill %arvo %d %flog %crud %goad-fail u.error.sign-arvo]
+    [goad this]
+  ==
+::
+++  on-fail   on-fail:def
+--

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -43,9 +43,9 @@
 !:
 =>  |%                                                  ::
     ++  hood-old                                        ::  unified old-state
-      {?($0 $1) lac/(map @tas hood-part-old)}           ::
+      {?($1 $2) lac/(map @tas hood-part-old)}           ::
     ++  hood-1                                          ::  unified state
-      {$1 lac/(map @tas hood-part)}                     ::
+      {$2 lac/(map @tas hood-part)}                     ::
     ++  hood-good                                       ::  extract specific
       =+  hed=$:hood-head
       |@  ++  $
@@ -140,12 +140,17 @@
   `..on-init
 ::
 ++  on-save
-  !>([%1 lac])
+  !>([%2 lac])
 ::
 ++  on-load
   |=  =old-state=vase
-  =/  old-state  !<(hood-1 old-state-vase)
-  `..on-init(lac lac.old-state)
+  =/  old-state  !<(hood-old old-state-vase)
+  =^  cards  lac
+    =.  lac  lac.old-state
+    ?.  ?=(%1 -.old-state)
+      `lac
+    ((wrap on-load):from-drum:(help hid) %1)
+  [cards ..on-init]
 ::
 ++  on-poke
   |=  [=mark =vase]

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -85,6 +85,7 @@
         %eth-watcher
         %azimuth-tracker
         %ping
+        %goad
     ==
   ?:  lit
     ~
@@ -211,6 +212,11 @@
     %drum-start          =;(f (f !<(_+<.f vase)) poke-start)
     %drum-set-boot-apps  =;(f (f !<(_+<.f vase)) poke-set-boot-apps)
   ==
+::
+++  on-load
+  |=  %1
+  =<  se-abet  =<  se-view
+  (se-born %home %goad)
 ::
 ++  reap-phat                                         ::  ack connect
   |=  {way/wire saw/(unit tang)}

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -229,7 +229,6 @@
     =<  mo-boot
     =/  =note-arvo  [%f %kill ~]
     (mo-pass wire note-arvo)
-    ::
   ::
   ::  +mo-goad: rebuild agent(s)
   ::
@@ -1574,9 +1573,6 @@
   ::  +all-state: upgrade path
   ::
   ++  all-state  $%(state-0 state-1 ^state)
-  ::
-  ::  Note that if you change sign-arvo, you must ensure that spider
-  ::  gets reloaded.
   ::
   ++  state-1-to-2
     |=  =state-1


### PR DESCRIPTION
OTAs commonly end up in an inconsistent state if apps depend on changes
to /sys.  For example, the %sift changes break on OTA because %spider
needs to be reloaded so that it's aware of the new thread type.  This
adds a %goad app, which reloads all apps after every change to /sys.

Getting this to start OTA is nontrivial, but this pattern should work
for apps in the future.  The changes to clock shouldn't generally be
necessary; they are only necessary here because we can't rely on hood to
start goad, since hood fails to compile if it's run before zuse is
reloaded.  Once goad is active, this will cease to be a problem.