### PR TITLE
vere: dynamic allocation cleanup

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -50,7 +50,7 @@ _main_readw(const c3_c* str_c, c3_w max_w, c3_w* out_w)
 c3_c*
 _main_presig(c3_c* txt_c)
 {
-  c3_c* new_c = malloc(2 + strlen(txt_c));
+  c3_c* new_c = c3_malloc(2 + strlen(txt_c));
 
   if ( '~' == *txt_c ) {
     strcpy(new_c, txt_c);
@@ -663,15 +663,15 @@ main(c3_i   argc,
     // allocates more memory as needed if the path is too large
     //
     while ( abs_c != getcwd(abs_c, mprint_i) ) {
-      free(abs_c);
+      c3_free(abs_c);
       mprint_i *= 2;
       abs_c = c3_malloc(mprint_i);
     }
     printf("boot: home is %s/%s\n", abs_c, u3_Host.dir_c);
-    free(abs_c);
+    c3_free(abs_c);
   } else {
     printf("boot: home is %s\n", abs_c);
-    free(abs_c);
+    c3_free(abs_c);
   }
   // printf("vere: hostname is %s\n", u3_Host.ops_u.nam_c);
 

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1815,7 +1815,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
   if ( box_u->cod_w ) {
     c3_c* cod_c = u3m_pretty(box_u->cod_w);
     fprintf(stderr, "code: %s\r\n", cod_c);
-    free(cod_c);
+    c3_free(cod_c);
   }
 
   u3a_print_memory(stderr, "    size", box_u->siz_w);
@@ -1823,7 +1823,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
   {
     c3_c* dat_c = _ca_print_box(box_u);
     fprintf(stderr, "    data: %s\r\n", dat_c);
-    free(dat_c);
+    c3_free(dat_c);
   }
 }
 
@@ -1843,7 +1843,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_ws use_ws)
   {
     c3_c* dat_c = _ca_print_box(box_u);
     fprintf(stderr, "    data: %s\r\n", dat_c);
-    free(dat_c);
+    c3_free(dat_c);
   }
 }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -249,12 +249,12 @@ _ce_patch_read_control(u3_ce_patch* pat_u)
     len_w = (c3_w) buf_u.st_size;
   }
 
-  pat_u->con_u = malloc(len_w);
+  pat_u->con_u = c3_malloc(len_w);
   if ( (len_w != read(pat_u->ctl_i, pat_u->con_u, len_w)) ||
         (len_w != sizeof(u3e_control) +
                   (pat_u->con_u->pgs_w * sizeof(u3e_line))) )
   {
-    free(pat_u->con_u);
+    c3_free(pat_u->con_u);
     pat_u->con_u = 0;
     return c3n;
   }
@@ -347,10 +347,10 @@ _ce_patch_verify(u3_ce_patch* pat_u)
 static void
 _ce_patch_free(u3_ce_patch* pat_u)
 {
-  free(pat_u->con_u);
+  c3_free(pat_u->con_u);
   close(pat_u->ctl_i);
   close(pat_u->mem_i);
-  free(pat_u);
+  c3_free(pat_u);
 }
 
 /* _ce_patch_open(): open patch, if any.
@@ -380,7 +380,7 @@ _ce_patch_open(void)
     _ce_patch_delete();
     return 0;
   }
-  pat_u = malloc(sizeof(u3_ce_patch));
+  pat_u = c3_malloc(sizeof(u3_ce_patch));
   pat_u->ctl_i = ctl_i;
   pat_u->mem_i = mem_i;
   pat_u->con_u = 0;
@@ -388,7 +388,7 @@ _ce_patch_open(void)
   if ( c3n == _ce_patch_read_control(pat_u) ) {
     close(pat_u->ctl_i);
     close(pat_u->mem_i);
-    free(pat_u);
+    c3_free(pat_u);
 
     _ce_patch_delete();
     return 0;
@@ -566,11 +566,11 @@ _ce_patch_compose(void)
     return 0;
   }
   else {
-    u3_ce_patch* pat_u = malloc(sizeof(u3_ce_patch));
+    u3_ce_patch* pat_u = c3_malloc(sizeof(u3_ce_patch));
     c3_w i_w, pgc_w;
 
     _ce_patch_create(pat_u);
-    pat_u->con_u = malloc(sizeof(u3e_control) + (pgs_w * sizeof(u3e_line)));
+    pat_u->con_u = c3_malloc(sizeof(u3e_control) + (pgs_w * sizeof(u3e_line)));
     pgc_w = 0;
 
     for ( i_w = 0; i_w < nor_w; i_w++ ) {

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -65,7 +65,7 @@ u3i_chubs(c3_w        a_w,
     b_w[(2 * i_w) + 1] = b_d[i_w] >> 32ULL;
   }
   p = u3i_words((a_w * 2), b_w);
-  free(b_w);
+  c3_free(b_w);
   return p;
 }
 

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -414,7 +414,7 @@ _cj_chum(u3_noun chu)
       memset(buf, 0, 33);
       snprintf(buf, 32, "%s%d", h_chu_c, t_chu);
 
-      free(h_chu_c);
+      c3_free(h_chu_c);
       return strdup(buf);
     }
   }
@@ -440,7 +440,7 @@ _cj_je_fsck(u3_noun clu)
     q_clu = u3t(u3t(q_clu));
   }
   if ( !_(u3du(q_clu)) ) {
-    u3z(clu); free(nam_c); return u3_none;
+    u3z(clu); c3_free(nam_c); return u3_none;
   }
 
   if ( (1 == u3h(q_clu)) && (0 == u3t(q_clu)) ) {
@@ -448,7 +448,7 @@ _cj_je_fsck(u3_noun clu)
   }
   else {
     if ( (0 != u3h(q_clu)) || !_(u3a_is_cat(axe_l = u3t(q_clu))) ) {
-      u3z(clu); free(nam_c); return u3_none;
+      u3z(clu); c3_free(nam_c); return u3_none;
     }
   }
 
@@ -462,7 +462,7 @@ _cj_je_fsck(u3_noun clu)
            (c3n == u3r_cell(ir_clu, &pir_clu, &qir_clu)) ||
            (c3n == u3ud(pir_clu)) )
       {
-        u3z(huk); u3z(clu); free(nam_c); return u3_none;
+        u3z(huk); u3z(clu); c3_free(nam_c); return u3_none;
       }
       huk = u3kdb_put(huk, u3k(pir_clu), u3k(qir_clu));
       r_clu = tr_clu;
@@ -472,7 +472,7 @@ _cj_je_fsck(u3_noun clu)
 
   {
     u3_noun pro = u3nt(u3i_string(nam_c), axe_l, huk);
-    free(nam_c);
+    c3_free(nam_c);
     return pro;
   }
 }
@@ -825,7 +825,7 @@ u3j_boot(c3_o nuu_o)
   u3D.len_l =_cj_count(0, u3D.dev_u);
   u3D.all_l = (2 * u3D.len_l) + 1024;     //  horrid heuristic
 
-  u3D.ray_u = (u3j_core*) malloc(u3D.all_l * sizeof(u3j_core));
+  u3D.ray_u = c3_malloc(u3D.all_l * sizeof(u3j_core));
   memset(u3D.ray_u, 0, (u3D.all_l * sizeof(u3j_core)));
 
   if ( c3n == nuu_o ) {

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -417,12 +417,12 @@ u3m_file(c3_c* pas_c)
   close(fid_i);
 
   if ( fln_w != red_w ) {
-    free(pad_y);
+    c3_free(pad_y);
     return u3m_bail(c3__fail);
   }
   else {
     u3_noun pad = u3i_bytes(fln_w, (c3_y *)pad_y);
-    free(pad_y);
+    c3_free(pad_y);
 
     return pad;
   }
@@ -1354,7 +1354,7 @@ _cm_in_pretty(u3_noun som, c3_o sel_o, c3_c* str_c)
       }
       else {
         c3_w len_w = u3r_met(3, som);
-        c3_c *buf_c = malloc(2 + (2 * len_w) + 1);
+        c3_c *buf_c = c3_malloc(2 + (2 * len_w) + 1);
         c3_w i_w = 0;
         c3_w a_w = 0;
 
@@ -1376,7 +1376,7 @@ _cm_in_pretty(u3_noun som, c3_o sel_o, c3_c* str_c)
 
         if ( str_c ) { strcpy(str_c, buf_c); str_c += len_w; }
 
-        free(buf_c);
+        c3_free(buf_c);
         return len_w;
       }
     }
@@ -1389,7 +1389,7 @@ c3_c*
 u3m_pretty(u3_noun som)
 {
   c3_w len_w = _cm_in_pretty(som, c3y, 0);
-  c3_c* pre_c = malloc(len_w + 1);
+  c3_c* pre_c = c3_malloc(len_w + 1);
 
   _cm_in_pretty(som, c3y, pre_c);
   pre_c[len_w] = 0;
@@ -1439,7 +1439,7 @@ c3_c*
 u3m_pretty_path(u3_noun som)
 {
   c3_w len_w = _cm_in_pretty_path(som, NULL);
-  c3_c* pre_c = malloc(len_w + 1);
+  c3_c* pre_c = c3_malloc(len_w + 1);
 
   _cm_in_pretty_path(som, pre_c);
   pre_c[len_w] = 0;
@@ -1454,7 +1454,7 @@ u3m_p(const c3_c* cap_c, u3_noun som)
   c3_c* pre_c = u3m_pretty(som);
 
   u3l_log("%s: %s\r\n", cap_c, pre_c);
-  free(pre_c);
+  c3_free(pre_c);
 }
 
 /* u3m_tape(): dump a tape to stdout.

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -397,7 +397,7 @@ u3t_nock_trace_pop()
             start_time,
             duration);
 
-    free(name);
+    c3_free(name);
     u3_Host.tra_u.con_w++;
   }
 

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -145,7 +145,7 @@ _cv_nock_poke(u3_noun ovo)
     c3_c*   tox_c = u3r_string(tox);
 
     u3l_log("poke: %%%s (%x) on %s\r\n", ovi_c, u3r_mug(ovo), tox_c);
-    free(tox_c); free(ovi_c); u3z(tox);
+    c3_free(tox_c); c3_free(ovi_c); u3z(tox);
   }
 #endif
 
@@ -162,7 +162,7 @@ _cv_nock_poke(u3_noun ovo)
     } else {
       u3l_log("  happy: %s: %d\r\n", ovi_c, u3kb_lent(u3k(u3h(pro))));
     }
-    free(ovi_c);
+    c3_free(ovi_c);
   }
 #endif
 

--- a/pkg/urbit/tests/mug_tests.c
+++ b/pkg/urbit/tests/mug_tests.c
@@ -89,6 +89,9 @@ _test_mug(void)
       fprintf(stderr, "fail (i) (4)\r\n");
       exit(1);
     }
+
+    c3_free(str_y);
+    c3_free(str_w);
   }
 
   fprintf(stderr, "test_mug: ok\n");

--- a/pkg/urbit/tests/noun_tests.c
+++ b/pkg/urbit/tests/noun_tests.c
@@ -268,6 +268,7 @@ _test_cells()
       printf("*** _test_imprison: fail-4\n");
     }
 
+    c3_free(output_y);
     c3_free(rand_a);
     c3_free(rand_b);
   }
@@ -721,6 +722,7 @@ _test_imprison_complex()
       printf("*** u3r_string: in '%s'; out '%s'\n", in_c, out_c);
     }
 
+    c3_free(out_c);
     in_c = "ab";
     noun = u3i_string(in_c);
     out_c = u3r_string(noun);
@@ -729,6 +731,7 @@ _test_imprison_complex()
       printf("*** u3r_string: in '%s'; out '%s'\n", in_c, out_c);
     }
 
+    c3_free(out_c);
     in_c = "abcd";
     noun = u3i_string(in_c);
     out_c = u3r_string(noun);
@@ -737,6 +740,7 @@ _test_imprison_complex()
       printf("*** u3r_string: in '%s'; out '%s'\n", in_c, out_c);
     }
 
+    c3_free(out_c);
     in_c = "this is a test";
     noun = u3i_string(in_c);
     out_c = u3r_string(noun);
@@ -744,6 +748,8 @@ _test_imprison_complex()
     if (0 != strcmp(in_c, out_c)){
       printf("*** u3r_string: in '%s'; out '%s'\n", in_c, out_c);
     }
+
+    c3_free(out_c);
   }
 
   // tape
@@ -756,6 +762,8 @@ _test_imprison_complex()
     if (0 != memcmp(in_c, out_y, strlen(in_c))){
       printf("*** u3r_tape 1\n");
     }
+
+    c3_free(out_y);
 
     // tape stores each byte in the string as one atom in the tree
     u3_noun lent = u3qb_lent(noun);

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -31,23 +31,14 @@ _ames_alloc(uv_handle_t* had_u,
   *buf = uv_buf_init(ptr_v, 2048);
 }
 
-/* _ames_free(): contrasting free.
-*/
-static void
-_ames_free(void* ptr_v)
-{
-//  u3l_log("free %p\n", ptr_v);
-  free(ptr_v);
-}
-
 /* _ames_pact_free(): free packet struct.
 */
 static void
 _ames_pact_free(u3_pact* pac_u)
 {
-  free(pac_u->hun_y);
-  free(pac_u->dns_c);
-  free(pac_u);
+  c3_free(pac_u->hun_y);
+  c3_free(pac_u->dns_c);
+  c3_free(pac_u);
 }
 
 /* _ames_send_cb(): send callback.
@@ -178,7 +169,7 @@ _ames_czar_cb(uv_getaddrinfo_t* adr_u,
 
         u3l_log("ames: czar %s: ip %s\n", pac_u->dns_c, nam_c);
 
-        free(nam_c); u3z(nam);
+        c3_free(nam_c); u3z(nam);
       }
 #endif
 
@@ -189,7 +180,7 @@ _ames_czar_cb(uv_getaddrinfo_t* adr_u,
     rai_u = rai_u->ai_next;
   }
 
-  free(adr_u);
+  c3_free(adr_u);
   uv_freeaddrinfo(aif_u);
 }
 
@@ -245,7 +236,7 @@ _ames_czar(u3_pact* pac_u, c3_c* bos_c)
     c3_c*  nam_c = u3r_string(nam);
     u3l_log("ames: no galaxy domain for %s, no-op\r\n", nam_c);
 
-    free(nam_c);
+    c3_free(nam_c);
     u3z(nam);
     return;
   }
@@ -269,7 +260,7 @@ _ames_czar(u3_pact* pac_u, c3_c* bos_c)
     snprintf(pac_u->dns_c, 256, "%s.%s", nam_c + 1, bos_c);
     // u3l_log("czar %s, dns %s\n", nam_c, pac_u->dns_c);
 
-    free(nam_c);
+    c3_free(nam_c);
     u3z(nam);
 
     {
@@ -372,12 +363,12 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   // u3l_log("ames: rx %p\r\n", buf_u.base);
 
   if ( 0 == nrd_i ) {
-    _ames_free(buf_u->base);
+    c3_free(buf_u->base);
   }
   //  check protocol version in header matches 0
   //
   else if ( 0 != (0x7 & *((c3_w*)buf_u->base)) ) {
-    _ames_free(buf_u->base);
+    c3_free(buf_u->base);
   }
   else {
     {
@@ -398,7 +389,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
       u3_pier_plan(u3nt(u3_blip, c3__ames, u3_nul), mov);
 #endif
     }
-    _ames_free(buf_u->base);
+    c3_free(buf_u->base);
   }
 }
 

--- a/pkg/urbit/vere/cttp.c
+++ b/pkg/urbit/vere/cttp.c
@@ -32,7 +32,7 @@ _cttp_bods_free(u3_hbod* bod_u)
   while ( bod_u ) {
     u3_hbod* nex_u = bod_u->nex_u;
 
-    free(bod_u);
+    c3_free(bod_u);
     bod_u = nex_u;
   }
 }
@@ -102,7 +102,7 @@ _cttp_bods_to_octs(u3_hbod* bod_u)
     }
   }
   cos = u3i_bytes(len_w, buf_y);
-  free(buf_y);
+  c3_free(buf_y);
   return u3nc(len_w, cos);
 }
 
@@ -177,9 +177,9 @@ _cttp_heds_free(u3_hhed* hed_u)
   while ( hed_u ) {
     u3_hhed* nex_u = hed_u->nex_u;
 
-    free(hed_u->nam_c);
-    free(hed_u->val_c);
-    free(hed_u);
+    c3_free(hed_u->nam_c);
+    c3_free(hed_u->val_c);
+    c3_free(hed_u);
     hed_u = nex_u;
   }
 }
@@ -258,7 +258,7 @@ static void
 _cttp_cres_free(u3_cres* res_u)
 {
   _cttp_bods_free(res_u->bod_u);
-  free(res_u);
+  c3_free(res_u);
 }
 
 /* _cttp_cres_new(): create a response
@@ -521,12 +521,12 @@ _cttp_creq_free(u3_creq* ceq_u)
     _cttp_cres_free(ceq_u->res_u);
   }
 
-  free(ceq_u->hot_c);
-  free(ceq_u->por_c);
-  free(ceq_u->met_c);
-  free(ceq_u->url_c);
-  free(ceq_u->vec_u);
-  free(ceq_u);
+  c3_free(ceq_u->hot_c);
+  c3_free(ceq_u->por_c);
+  c3_free(ceq_u->met_c);
+  c3_free(ceq_u->url_c);
+  c3_free(ceq_u->vec_u);
+  c3_free(ceq_u);
 }
 
 /* _cttp_creq_new(): create a u3_creq from an +http-request 
@@ -663,7 +663,7 @@ _cttp_creq_fire(u3_creq* ceq_u)
     }
 
     _cttp_creq_fire_body(ceq_u, _cttp_bod_new(len_w, hos_c));
-    free(hos_c);
+    c3_free(hos_c);
   }
 
   _cttp_creq_fire_heds(ceq_u, ceq_u->hed_u);
@@ -844,7 +844,7 @@ _cttp_creq_connect(u3_creq* ceq_u)
     c3_c* hot_c = c3_malloc(len_w);
     strncpy(hot_c, ceq_u->hot_c, len_w);
 
-    free(ceq_u->cli_u->ssl.server_name);
+    c3_free(ceq_u->cli_u->ssl.server_name);
     ceq_u->cli_u->ssl.server_name = hot_c;
   }
 
@@ -875,7 +875,7 @@ _cttp_creq_resolve_cb(uv_getaddrinfo_t* adr_u,
     _cttp_creq_connect(ceq_u);
   }
 
-  free(adr_u);
+  c3_free(adr_u);
   uv_freeaddrinfo(aif_u);
 }
 
@@ -1023,6 +1023,6 @@ void
 u3_cttp_io_exit(void)
 {
     SSL_CTX_free(u3_Host.ctp_u.tls_u);
-    free(u3_Host.ctp_u.ctx_u->io_timeout);
-    free(u3_Host.ctp_u.ctx_u);
+    c3_free(u3_Host.ctp_u.ctx_u->io_timeout);
+    c3_free(u3_Host.ctp_u.ctx_u);
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -600,7 +600,7 @@ _boothack_key(u3_noun kef)
     if ( u3_nul == des ) {
       c3_c* kef_c = u3r_string(kef);
       u3l_log("dawn: invalid private keys: %s\r\n", kef_c);
-      free(kef_c);
+      c3_free(kef_c);
       exit(1);
     }
 
@@ -631,7 +631,7 @@ _boothack_key(u3_noun kef)
               u3_Host.ops_u.who_c, how_c);
 
       u3z(how);
-      free(how_c);
+      c3_free(how_c);
       exit(1);
     }
 
@@ -973,7 +973,7 @@ u3_daemon_grab(void* vod_p)
     fil_u = fopen(man_c, "w");
     fprintf(fil_u, "%s\r\n", wen_c);
 
-    free(wen_c);
+    c3_free(wen_c);
     u3z(wen);
   }
 #else

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -490,7 +490,13 @@ _daemon_get_atom(c3_c* url_c)
 
   curl_easy_cleanup(curl);
 
-  return u3i_bytes(buf_u.len, (const c3_y*)buf_u.base);
+  {
+    u3_noun pro = u3i_bytes(buf_u.len, (const c3_y*)buf_u.base);
+
+    c3_free(buf_u.base);
+
+    return pro;
+  }
 }
 
 /* _get_cmd_output(): Run a shell command and capture its output.

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -205,7 +205,7 @@ _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
   u3m_p("pre-boot error", u3t(sas));
 
   u3z(how);
-  free(how_c);
+  c3_free(how_c);
   exit(1);
 }
 
@@ -440,7 +440,7 @@ u3_dawn_vent(u3_noun seed)
       c3_c* who_c = u3r_string(who);
       u3l_log("boot: retrieving keys for sponsor %s\r\n", who_c);
       u3z(who);
-      free(who_c);
+      c3_free(who_c);
     }
 
     //  retrieve +point:azimuth of pos (sponsor of ship)
@@ -519,12 +519,12 @@ _dawn_come(u3_noun stars)
         fclose(fil_u);
       }
 
-      free(key_c);
+      c3_free(key_c);
       u3z(key);
     }
 #endif
 
-    free(who_c);
+    c3_free(who_c);
     u3z(who);
   }
 

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -154,6 +154,8 @@ _dawn_get_jam(c3_c* url_c)
   u3_noun jammed = u3k(u3t(octs));
   u3z(octs);
 
+  c3_free(buf_u.base);
+
   return u3ke_cue(jammed);
 }
 
@@ -162,7 +164,12 @@ _dawn_get_jam(c3_c* url_c)
 static u3_noun
 _dawn_eth_rpc(c3_c* url_c, u3_noun oct)
 {
-  return _dawn_buf_to_oct(_dawn_post_json(url_c, _dawn_oct_to_buf(oct)));
+  uv_buf_t buf_u = _dawn_post_json(url_c, _dawn_oct_to_buf(oct));
+  u3_noun    pro = _dawn_buf_to_oct(buf_u);
+
+  c3_free(buf_u.base);
+
+  return pro;
 }
 
 /* _dawn_fail(): pre-boot validation failed

--- a/pkg/urbit/vere/lmdb.c
+++ b/pkg/urbit/vere/lmdb.c
@@ -135,7 +135,7 @@ c3_o _perform_put_on_database_noun(MDB_txn* transaction_u,
 
   // copy the jammed noun into a byte buffer we can hand to lmdb
   c3_w  len_w   = u3r_met(3, mat);
-  c3_y* bytes_y = (c3_y*) malloc(len_w);
+  c3_y* bytes_y = c3_malloc(len_w);
   u3r_bytes(0, len_w, bytes_y, mat);
 
   c3_o ret = _perform_put_on_database_raw(
@@ -145,7 +145,7 @@ c3_o _perform_put_on_database_noun(MDB_txn* transaction_u,
       key, strlen(key),
       bytes_y, len_w);
 
-  free(bytes_y);
+  c3_free(bytes_y);
   u3z(mat);
 
   return ret;
@@ -230,11 +230,11 @@ u3_lmdb_build_write_request(u3_writ* event_u, c3_d count)
 */
 void u3_lmdb_free_write_request(struct u3_lmdb_write_request* request) {
   for (c3_d i = 0; i < request->event_count; ++i)
-    free(request->malloced_event_data[i]);
+    c3_free(request->malloced_event_data[i]);
 
-  free(request->malloced_event_data);
-  free(request->malloced_event_data_size);
-  free(request);
+  c3_free(request->malloced_event_data);
+  c3_free(request->malloced_event_data_size);
+  c3_free(request);
 }
 
 /* _write_request_data: callback struct for u3_lmdb_write_event()
@@ -344,8 +344,8 @@ static void _u3_lmdb_write_event_after_cb(uv_work_t* req, int status) {
                     data->request->event_count);
 
   u3_lmdb_free_write_request(data->request);
-  free(data);
-  free(req);
+  c3_free(data);
+  c3_free(req);
 }
 
 /* u3_lmdb_write_event(): Asynchronously writes events to the database.

--- a/pkg/urbit/vere/newt.c
+++ b/pkg/urbit/vere/newt.c
@@ -312,8 +312,8 @@ _newt_write_cb(uv_write_t* wri_u, c3_i sas_i)
   void*       vod_p = req_u->vod_p;
   u3_mojo*    moj_u = req_u->moj_u;
 
-  free(req_u->buf_y);
-  free(req_u);
+  c3_free(req_u->buf_y);
+  c3_free(req_u);
 
   if ( 0 != sas_i ) {
     u3l_log("newt: bad write %d\r\n", sas_i);

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -803,7 +803,7 @@ _pier_work_stdr(u3_writ* wit_u, u3_noun cord)
 {
   c3_c* str = u3r_string(cord);
   u3C.stderr_log_f(str);
-  free(str);
+  c3_free(str);
 }
 
 /* _pier_work_slog(): print directly.
@@ -1341,7 +1341,7 @@ _pier_boot_dispose(u3_boot* bot_u)
 
   u3z(bot_u->pil);
   u3z(bot_u->ven);
-  free(bot_u);
+  c3_free(bot_u);
   pir_u->bot_u = 0;
 }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1041,13 +1041,10 @@ _pier_work_create(u3_pier* pir_u)
   {
     c3_c* arg_c[5];
     c3_c* bin_c = u3_Host.wrk_c;
-    c3_c* pax_c;
+    c3_c* pax_c = pir_u->pax_c;
     c3_c  key_c[256];
     c3_c  wag_c[11];
     c3_i  err_i;
-
-    pax_c = c3_malloc(1 + strlen(pir_u->pax_c));
-    strcpy(pax_c, pir_u->pax_c);
 
     sprintf(key_c, "%" PRIx64 ":%" PRIx64 ":%" PRIx64 ":%" PRIx64 "",
                    pir_u->key_d[0],

--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -67,7 +67,7 @@ _reck_orchid(u3_noun fot, u3_noun txt, c3_l* tid_l)
 {
   c3_c* str = u3r_string(txt);
   c3_d ato_d = strtol(str, NULL, 10);
-  free(str);
+  c3_free(str);
 
   if ( ato_d >= 0x80000000ULL ) {
     return c3n;

--- a/pkg/urbit/vere/term.c
+++ b/pkg/urbit/vere/term.c
@@ -88,7 +88,7 @@ _term_close_cb(uv_handle_t* han_t)
     u3_pier_plan(u3k(pax), u3nc(c3__hook, u3_nul));
     u3z(pax);
   }
-  free(tty_u);
+  c3_free(tty_u);
 }
 #endif
 
@@ -325,8 +325,8 @@ _term_write_cb(uv_write_t* wri_u, c3_i sas_i)
     u3l_log("term: write: %s\n", uv_strerror(sas_i));
   }
 
-  free(wri_u->data);
-  free(wri_u);
+  c3_free(wri_u->data);
+  c3_free(wri_u);
 }
 
 /* _term_it_write_buf(): write buffer uv style.
@@ -363,7 +363,7 @@ _term_it_write_old(u3_utty* uty_u,
     memcpy(buf_y, old_u->hun_y, old_u->len_w);
     buf_u = uv_buf_init((c3_c*)buf_y, old_u->len_w);
 
-    free(old_u);
+    c3_free(old_u);
   }
   _term_it_write_buf(uty_u, buf_u);
 }
@@ -406,7 +406,7 @@ _term_it_show_wide(u3_utty* uty_u, c3_w len_w, c3_w* txt_w)
   c3_c*   txt_c = u3r_string(txt);
 
   _term_it_write_str(uty_u, txt_c);
-  free(txt_c);
+  c3_free(txt_c);
   u3z(txt);
 
   uty_u->tat_u.mir.cus_w += len_w;
@@ -465,7 +465,7 @@ _term_it_show_line(u3_utty* uty_u, c3_w* lin_w, c3_w len_w)
 
   if ( lin_w != uty_u->tat_u.mir.lin_w ) {
     if ( uty_u->tat_u.mir.lin_w ) {
-      free(uty_u->tat_u.mir.lin_w);
+      c3_free(uty_u->tat_u.mir.lin_w);
     }
     uty_u->tat_u.mir.lin_w = lin_w;
   }
@@ -569,8 +569,8 @@ _term_it_save(u3_noun pax, u3_noun pad)
 
   u3_walk_save(pax_c, 0, pad, bas_c, xap);
 
-  free(pax_c);
-  free(bas_c);
+  c3_free(pax_c);
+  c3_free(bas_c);
 }
 
 /* _term_io_belt(): send belt.
@@ -731,7 +731,7 @@ _term_read_cb(uv_stream_t* tcp_u,
 {
   u3_utty* uty_u = (u3_utty*)(void*)tcp_u;
   _term_suck(uty_u, (const c3_y*)buf_u->base, siz_i);
-  free(buf_u->base);
+  c3_free(buf_u->base);
 }
 
 /* _term_spin_write_str(): write null-terminated string
@@ -835,7 +835,7 @@ u3_term_start_spinner(c3_c* why_c, c3_o now_o)
     u3_utty* uty_u = _term_main();
     u3_utat* tat_u = &uty_u->tat_u;
 
-    free(tat_u->  sun_u.why_c);
+    c3_free(tat_u->  sun_u.why_c);
     tat_u->sun_u.why_c = why_c;
 
     tat_u->sun_u.eve_d = 0;
@@ -1058,7 +1058,7 @@ _term_ef_blit(u3_utty* uty_u,
 
         _term_it_show_clear(uty_u);
         _term_it_write_str(uty_u, txt_c);
-        free(txt_c);
+        c3_free(txt_c);
 
         _term_it_show_more(uty_u);
         _term_it_refresh_line(uty_u);

--- a/pkg/urbit/vere/unix.c
+++ b/pkg/urbit/vere/unix.c
@@ -195,7 +195,7 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
   }
 
   close(fid_i);
-  free(dat_y);
+  c3_free(dat_y);
 
   return mug_w;
 }
@@ -242,7 +242,7 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
       u3l_log("wrong # of bytes read in file %s: %d %d\r\n",
               fil_u->pax_c, len_ws, red_ws);
     }
-    free(old_y);
+    c3_free(old_y);
     u3z(mim);
     return;
   }
@@ -251,12 +251,12 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
 
   if ( old_w != fil_u->gum_w ) {
     fil_u->gum_w = u3r_mug(u3t(u3t(mim))); // XXX this might fail with
-    free(old_y);                           //     trailing zeros
+    c3_free(old_y);                           //     trailing zeros
     u3z(mim);
     return;
   }
 
-  free(old_y);
+  c3_free(old_y);
 
 _unix_write_file_soft_go:
   fil_u->gum_w = _unix_write_file_hard(fil_u->pax_c, mim);
@@ -301,7 +301,7 @@ _unix_get_mount_point(u3_pier *pir_u, u3_noun mon)
 
   }
   else {
-    free(nam_c);
+    c3_free(nam_c);
   }
 
   u3z(mon);
@@ -351,12 +351,12 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
       if ( 0 != stat(pax_c, &buf_u) ) {
         u3l_log("can't stat pier directory %s: %s\r\n",
                 mon_u->dir_u.pax_c, strerror(errno));
-        free(pax_c);
+        c3_free(pax_c);
         continue;
       }
       if ( S_ISDIR(buf_u.st_mode) ) {
         if ( out_u->d_name[len_w] != '\0' ) {
-          free(pax_c);
+          c3_free(pax_c);
           continue;
         }
         else {
@@ -371,7 +371,7 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
              || ('#' == out_u->d_name[0] &&
                  '#' == out_u->d_name[strlen(out_u->d_name) - 1])
 	     ) {
-          free(pax_c);
+          c3_free(pax_c);
           continue;
         }
         else {
@@ -380,7 +380,7 @@ _unix_scan_mount_point(u3_pier *pir_u, u3_umon* mon_u)
         }
       }
 
-      free(pax_c);
+      c3_free(pax_c);
     }
   }
 }
@@ -397,8 +397,8 @@ _unix_free_file(u3_ufil *fil_u)
     c3_assert(0);
   }
 
-  free(fil_u->pax_c);
-  free(fil_u);
+  c3_free(fil_u->pax_c);
+  c3_free(fil_u);
 }
 
 /* _unix_free_dir(): free directory, deleting everything within
@@ -414,8 +414,8 @@ _unix_free_dir(u3_udir *dir_u)
   else {
     // fprintf(stderr, "i'm a lone, lonely loner %s\r\n", dir_u->pax_c);
   }
-  free(dir_u->pax_c);
-  free(dir_u); // XXX this might be too early, how do we
+  c3_free(dir_u->pax_c);
+  c3_free(dir_u); // XXX this might be too early, how do we
                //     know we've freed all the children?
                //     i suspect we should do this only if
                //     our kid list is empty
@@ -483,9 +483,9 @@ _unix_free_mount_point(u3_pier *pir_u, u3_umon* mon_u)
     nod_u = nex_u;
   }
 
-  free(mon_u->dir_u.pax_c);
-  free(mon_u->nam_c);
-  free(mon_u);
+  c3_free(mon_u->dir_u.pax_c);
+  c3_free(mon_u->nam_c);
+  c3_free(mon_u);
 }
 
 /* _unix_delete_mount_point(): remove mount point from list and free
@@ -530,7 +530,7 @@ _unix_delete_mount_point(u3_pier *pir_u, u3_noun mon)
   _unix_free_mount_point(pir_u, tem_u);
 
 _delete_mount_point_out:
-  free(nam_c);
+  c3_free(nam_c);
   u3z(mon);
 }
 
@@ -603,7 +603,7 @@ _unix_create_dir(u3_udir* dir_u, u3_udir* par_u, u3_noun nam)
   strncpy(pax_c + pax_w + 1, nam_c, nam_w);
   pax_c[pax_w + 1 + nam_w] = '\0';
 
-  free(nam_c);
+  c3_free(nam_c);
   u3z(nam);
 
   _unix_mkdir(pax_c);
@@ -666,18 +666,18 @@ _unix_update_file(u3_pier *pir_u, u3_ufil* fil_u)
       u3l_log("wrong # of bytes read in file %s: %d %d\r\n",
               fil_u->pax_c, len_ws, red_ws);
     }
-    free(dat_y);
+    c3_free(dat_y);
     return u3_nul;
   }
   else {
     c3_w mug_w = u3r_mug_bytes(dat_y, len_ws);
     if ( mug_w == fil_u->mug_w ) {
-      free(dat_y);
+      c3_free(dat_y);
       return u3_nul;
     }
     else if ( mug_w == fil_u->gum_w ) {
       fil_u->mug_w = mug_w;
-      free(dat_y);
+      c3_free(dat_y);
       return u3_nul;
     }
     else {
@@ -687,7 +687,7 @@ _unix_update_file(u3_pier *pir_u, u3_ufil* fil_u)
       u3_noun mim = u3nt(c3__text, u3i_string("plain"), u3_nul);
       u3_noun dat = u3nt(mim, len_ws, u3i_bytes(len_ws, dat_y));
 
-      free(dat_y);
+      c3_free(dat_y);
       return u3nc(u3nt(pax, u3_nul, dat), u3_nul);
     }
   }
@@ -793,7 +793,7 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
 
       if ( 0 != stat(pax_c, &buf_u) ) {
         u3l_log("can't stat %s: %s\r\n", pax_c, strerror(errno));
-        free(pax_c);
+        c3_free(pax_c);
         continue;
       }
       else {
@@ -823,7 +823,7 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
                  || ('#' == out_u->d_name[0] &&
                      '#' == out_u->d_name[strlen(out_u->d_name) - 1])
                ) {
-              free(pax_c);
+              c3_free(pax_c);
               continue;
             }
 
@@ -838,7 +838,7 @@ _unix_update_dir(u3_pier *pir_u, u3_udir* dir_u)
         }
       }
 
-      free(pax_c);
+      c3_free(pax_c);
     }
   }
 
@@ -932,7 +932,7 @@ _unix_initial_update_file(c3_c* pax_c, c3_c* bas_c)
       u3l_log("wrong # of bytes read in initial file %s: %d %d\r\n",
               pax_c, len_ws, red_ws);
     }
-    free(dat_y);
+    c3_free(dat_y);
     return u3_nul;
   }
   else {
@@ -942,7 +942,7 @@ _unix_initial_update_file(c3_c* pax_c, c3_c* bas_c)
     u3_noun mim = u3nt(c3__text, u3i_string("plain"), u3_nul);
     u3_noun dat = u3nt(mim, len_ws, u3i_bytes(len_ws, dat_y));
 
-    free(dat_y);
+    c3_free(dat_y);
     return u3nc(u3nt(pax, u3_nul, dat), u3_nul);
   }
 }
@@ -987,7 +987,7 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
       if ( 0 != stat(pox_c, &buf_u) ) {
         u3l_log("initial can't stat %s: %s\r\n",
                 pox_c, strerror(errno));
-        free(pox_c);
+        c3_free(pox_c);
         continue;
       }
       else {
@@ -997,7 +997,7 @@ _unix_initial_update_dir(c3_c* pax_c, c3_c* bas_c)
         else {
           can = u3kb_weld(_unix_initial_update_file(pox_c, bas_c), can);
         }
-        free(pox_c);
+        c3_free(pox_c);
       }
     }
   }
@@ -1045,7 +1045,7 @@ _unix_sync_file(u3_pier *pir_u, u3_udir* par_u, u3_noun nam, u3_noun ext, u3_nou
   strncpy(pax_c + par_w + 1 + nam_w + 1, ext_c, ext_w);
   pax_c[par_w + 1 + nam_w + 1 + ext_w] = '\0';
 
-  free(nam_c); free(ext_c);
+  c3_free(nam_c); c3_free(ext_c);
   u3z(nam); u3z(ext);
 
   // check whether we already know about this file
@@ -1079,7 +1079,7 @@ _unix_sync_file(u3_pier *pir_u, u3_udir* par_u, u3_noun nam, u3_noun ext, u3_nou
     }
   }
 
-  free(pax_c);
+  c3_free(pax_c);
 
 _unix_sync_file_out:
   u3z(mim);
@@ -1261,7 +1261,7 @@ u3_unix_acquire(c3_c* pax_c)
   }
 
   fclose(loq_u);
-  free(paf_c);
+  c3_free(paf_c);
 }
 
 /* u3_unix_release(): release a lockfile.
@@ -1272,7 +1272,7 @@ u3_unix_release(c3_c* pax_c)
   c3_c* paf_c = _unix_down(pax_c, ".vere.lock");
 
   unlink(paf_c);
-  free(paf_c);
+  c3_free(paf_c);
 }
 
 /* u3_unix_ef_bake(): initial effects for new process.

--- a/pkg/urbit/vere/walk.c
+++ b/pkg/urbit/vere/walk.c
@@ -57,12 +57,12 @@ u3_walk_safe(c3_c* pas_c)
   close(fid_i);
 
   if ( fln_w != red_w ) {
-    free(pad_y);
+    c3_free(pad_y);
     return 0;
   }
   else {
     u3_noun pad = u3i_bytes(fln_w, (c3_y *)pad_y);
-    free(pad_y);
+    c3_free(pad_y);
 
     return pad;
   }
@@ -89,12 +89,12 @@ u3_walk_load(c3_c* pas_c)
   close(fid_i);
 
   if ( fln_w != red_w ) {
-    free(pad_y);
+    c3_free(pad_y);
     return u3m_bail(c3__fail);
   }
   else {
     u3_noun pad = u3i_bytes(fln_w, (c3_y *)pad_y);
-    free(pad_y);
+    c3_free(pad_y);
 
     return pad;
   }
@@ -130,7 +130,7 @@ _walk_mkdirp(c3_c* bas_c, u3_noun pax)
   }
 
   _walk_mkdirp(pax_c, u3t(pax));
-  free(pax_c);
+  c3_free(pax_c);
 }
 
 /* u3_walk_save(): save file or bail.
@@ -160,7 +160,7 @@ u3_walk_save(c3_c* pas_c, u3_noun tim, u3_atom pad, c3_c* bas_c, u3_noun pax)
 
   rit_w = write(fid_i, pad_y, fln_w);
   close(fid_i);
-  free(pad_y);
+  c3_free(pad_y);
 
   if ( rit_w != fln_w ) {
     u3l_log("%s: %s\n", pas_c, strerror(errno));
@@ -218,7 +218,7 @@ _walk_in(const c3_c* dir_c, c3_w len_w)
       pat_c[lef_w] = '\0';
 
       if ( 0 != stat(pat_c, &buf_b) ) {
-        free(pat_c);
+        c3_free(pat_c);
       } else {
         u3_noun tim = c3_stat_mtime(&buf_b);
 
@@ -244,8 +244,8 @@ _walk_in(const c3_c* dir_c, c3_w len_w)
             get = u3kdb_put(get, ext, u3nt(c3y, hax, dat));
             map = u3kdb_put(map, nam, u3nc(c3n, get));
           }
-          free(nam_c);
-          free(ext_c);
+          c3_free(nam_c);
+          c3_free(ext_c);
         }
         else {
           u3_noun dir = _walk_in(pat_c, lef_w);
@@ -256,7 +256,7 @@ _walk_in(const c3_c* dir_c, c3_w len_w)
           }
           else u3z(tim);
         }
-        free(pat_c);
+        c3_free(pat_c);
       }
     }
   }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -796,9 +796,17 @@ _worker_poke_work(c3_d    evt_d,              //  event number
     u3_noun wir = u3h(u3t(job));
     u3_noun cad = u3h(u3t(u3t(job)));
 
+    //  XX these allocations should only be performed if tracing is enabled
+    //
     c3_c lab_c[2048];
-    snprintf(lab_c, 2048, "event %" PRIu64 ": [%s %s]", evt_d,
-             u3m_pretty_path(wir), u3m_pretty(cad));
+    {
+      c3_c* cad_c = u3m_pretty(cad);
+      c3_c* wir_c = u3m_pretty_path(wir);
+      snprintf(lab_c, 2048, "event %" PRIu64 ": [%s %s]",
+                            evt_d, wir_c, cad_c);
+      c3_free(cad_c);
+      c3_free(wir_c);
+    }
 
     u3t_event_trace(lab_c, 'B');
     _worker_work_live(evt_d, job);

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -169,7 +169,7 @@ _worker_prof(FILE* fil_u, c3_w den, u3_noun mas)
     {
       c3_c* lab_c = u3m_pretty(h_mas);
       fprintf(fil_u, "h_mas: %s", lab_c);
-      free(lab_c);
+      c3_free(lab_c);
     }
     return tot_w;
   }
@@ -179,7 +179,7 @@ _worker_prof(FILE* fil_u, c3_w den, u3_noun mas)
     {
       c3_c* lab_c = u3m_pretty(h_mas);
       fprintf(fil_u, "%s: ", lab_c);
-      free(lab_c);
+      c3_free(lab_c);
     }
 
     u3_noun it_mas, tt_mas;
@@ -277,7 +277,7 @@ _worker_grab(u3_noun sac, u3_noun ovo, u3_noun vir)
       fil_u = fopen(man_c, "w");
       fprintf(fil_u, "%s\r\n", wen_c);
 
-      free(wen_c);
+      c3_free(wen_c);
       u3z(wen);
     }
 #else
@@ -668,7 +668,7 @@ _worker_work_live(c3_d evt_d, u3_noun job)
               clr_w, txt_c, evt_d, ms_w,
               (int) (d0.tv_usec % 1000) / 10);
     }
-    free(txt_c);
+    c3_free(txt_c);
   }
 #endif
 
@@ -831,7 +831,7 @@ _worker_poke_exit(c3_w cod_w)                 //  exit code
 
       fil_u = fopen(man_c, "w");
 
-      free(wen_c);
+      c3_free(wen_c);
       u3z(wen);
     }
 


### PR DESCRIPTION
This PR includes fixes for some minor memory leaks, a bunch of cleanup. The leaks were discovered by running the daemon under valgrind, which is made possible the change to loom base pointer.

There are many other issues flagged by valgrind, predominantly due to a) insufficient cleanup on exit (especially in http.c and pier.c), b) openssl's use of uninitialized memory (well established), and c) valgrind's view that the loom is uninitialized memory.

I intend to produce a suppression file to make it practical to run the daemon periodically. Doing so with the worker is not currently viable, as it segfaults immediately under valgrind. I assume this has to do with snapshot initialization or restoration, but I haven't been able to track it down yet. Valgrind supports custom allocators, but it'll be a nontrivial amount of work.

These changes are not high priority.