### PR TITLE
goad: make startup resilient to errors

### DIFF
--- a/pkg/arvo/app/clock.hoon
+++ b/pkg/arvo/app/clock.hoon
@@ -24,12 +24,12 @@
   ==
 ::  bootstrapping to get %goad started OTA
 ::
-++  on-save   !>(%1)
+++  on-save   !>(%2)
 ++  on-load
   |=  old-state=vase
-  =/  old  !<(?(~ %1) old-state)
+  =/  old  !<(?(~ %1 %2) old-state)
   =^  cards  this
-    ?.  ?=(~ old)
+    ?:  ?=(%2 old)
       `this
     :_  this  :_  ~
     [%pass /behn %arvo %b %wait +(now.bowl)]

--- a/pkg/arvo/app/goad.hoon
+++ b/pkg/arvo/app/goad.hoon
@@ -12,7 +12,8 @@
     [%pass /behn %arvo %b %wait +(now.bowl)]
   ::
   ++  goad
-    :~  [%pass /gall %arvo %g %goad | ~]
+    |=  force=?
+    :~  [%pass /gall %arvo %g %goad force ~]
     ==
   --
 ::
@@ -22,11 +23,18 @@
 ++  on-init
   ::  subscribe to /sys and do initial goad
   ::
-  [[(warp bowl) goad] this]
+  [[(warp bowl) (wait bowl) ~] this]
 ::
 ++  on-save   on-save:def
 ++  on-load   on-load:def
-++  on-poke   on-poke:def
+++  on-poke
+  |=  [=mark =vase]
+  ?:  ?=([%noun * %go] +<)
+    [(goad |) this]
+  ?:  ?=([%noun * %force] +<)
+    [(goad &) this]
+  (on-poke:def mark vase)
+::
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
 ++  on-peek   on-peek:def
@@ -50,7 +58,8 @@
     ?^  error.sign-arvo
       :_  this  :_  ~
       [%pass /dill %arvo %d %flog %crud %goad-fail u.error.sign-arvo]
-    [goad this]
+    %-  (slog leaf+"goad: recompiling all apps" ~)
+    [(goad |) this]
   ==
 ::
 ++  on-fail   on-fail:def

--- a/pkg/arvo/gen/hood/reboot.hoon
+++ b/pkg/arvo/gen/hood/reboot.hoon
@@ -10,4 +10,4 @@
 |=  $:  {now/@da eny/@uvJ bec/beak}
         {arg/~ ~}
     ==
-[%helm-reload ~[%z %a %b %c %d %f %g %j %l]]
+[%helm-reload ~[%z %a %b %c %d %e %f %g %i %j]]


### PR DESCRIPTION
By not running the risky %goad card in on-init.  Also includes some qol fixes.

For some reason the zuse didn't get properly updated.  This seems to have fixed the issue.

Already deployed, but cc @joemfb 