### PR TITLE
eyre: turn sigpam into flog

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1590,8 +1590,8 @@
       =/  channel=(unit channel)
         (~(get by session.channel-state.state) channel-id)
       ?~  channel
-        ~&  [%received-event-for-nonexistent-channel channel-id]
-        [~ state]
+        :_  state  :_  ~
+        [duct %pass /flog %d %flog %crud %eyre-no-channel >id=channel-id< ~]
       ::
       =/  event-id  next-id.u.channel
       ::


### PR DESCRIPTION
This error is mostly harmless, but it does indicate we aren't cleaning
up our subscriptions properly.  This lets you silence with |knob.

fixes #2088