### PR TITLE
vere: fix use-after-free in http responses

### DIFF
--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -420,7 +420,6 @@ static void
 _http_hgen_send(u3_hgen* gen_u)
 {
   c3_assert( c3y == gen_u->red );
-  c3_assert( 0 == gen_u->nud_u );
 
   u3_hreq* req_u = gen_u->req_u;
   h2o_req_t* rec_u = req_u->rec_u;
@@ -434,6 +433,7 @@ _http_hgen_send(u3_hgen* gen_u)
 
   //  stash [bod_u] to free later
   //
+  _cttp_bods_free(gen_u->nud_u);
   gen_u->nud_u = gen_u->bod_u;
   gen_u->bod_u = 0;
 
@@ -483,11 +483,6 @@ _http_hgen_proceed(h2o_generator_t* neg_u, h2o_req_t* rec_u)
 
   gen_u->red = c3y;
 
-  _http_heds_free(gen_u->hed_u);
-  gen_u->hed_u = 0;
-  _cttp_bods_free(gen_u->nud_u);
-  gen_u->nud_u = 0;
-
   if ( 0 != gen_u->bod_u || c3y == gen_u->dun ) {
     _http_hgen_send(gen_u);
   }
@@ -523,6 +518,7 @@ _http_start_respond(u3_hreq* req_u,
                       "hosed";
 
   u3_hhed* hed_u = _http_heds_from_noun(u3k(headers));
+  u3_hhed* deh_u = hed_u;
 
   c3_i has_len_i = 0;
 
@@ -530,7 +526,6 @@ _http_start_respond(u3_hreq* req_u,
     if ( 0 == strncmp(hed_u->nam_c, "content-length", 14) ) {
       has_len_i = 1;
     }
-
     else {
       h2o_add_header_by_str(&rec_u->pool, &rec_u->res.headers,
                             hed_u->nam_c, hed_u->nam_w, 0, 0,
@@ -548,7 +543,7 @@ _http_start_respond(u3_hreq* req_u,
   gen_u->bod_u = ( u3_nul == data ) ?
                  0 : _cttp_bod_from_octs(u3k(u3t(data)));
   gen_u->nud_u = 0;
-  gen_u->hed_u = hed_u;
+  gen_u->hed_u = deh_u;
   gen_u->req_u = req_u;
 
   //  if we don't explicitly set this field, h2o will send with

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -325,9 +325,9 @@ _http_req_done(void* ptr_v)
 {
   u3_hreq* req_u = (u3_hreq*)ptr_v;
 
-  // client canceled request
-  if ( (u3_rsat_plan == req_u->sat_e ) ||
-       (0 != req_u->gen_u && c3n == ((u3_hgen*)req_u->gen_u)->dun )) {
+  //  client canceled request before response
+  //
+  if ( u3_rsat_plan == req_u->sat_e ) {
     _http_req_kill(req_u);
   }
 
@@ -461,7 +461,13 @@ _http_hgen_send(u3_hgen* gen_u)
 static void
 _http_hgen_stop(h2o_generator_t* neg_u, h2o_req_t* rec_u)
 {
-  // kill request in %light
+  u3_hgen* gen_u = (u3_hgen*)neg_u;
+
+  //  response not complete, enqueue cancel
+  //
+  if ( c3n == gen_u->dun ) {
+    _http_req_kill(gen_u->req_u);
+  }
 }
 
 /* _http_hgen_proceed(): h2o is ready for more response data.


### PR DESCRIPTION
As discovered with clang's ASan. This supersedes #2090.

The thing I had missed, causing #2032, is that `h2o_send()` with `H2O_SEND_STATE_FINAL` *synchronously* finalizes/disposes the request and all associated resources.

There's a second use-after-free fixed in this PR. The response generator is disposed before the request, but I trying to inspect it on request-dispose in order to cancel the request in %eyre. That is now handled through the response generator as it should be.