### PR TITLE
build: trimming unnecessary image configuration

### DIFF
--- a/nix/ops/image/default.nix
+++ b/nix/ops/image/default.nix
@@ -8,22 +8,19 @@ pkgs.dockerTools.buildImage {
 
     set -euo pipefail
 
-    export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
-
     ${pkgs.dockerTools.shadowSetup}
 
-    mkdir -p /bin /share /data /tmp
+    mkdir -p /share /data /tmp
 
     ${pkgs.coreutils}/bin/ln -sf ${pill} /share/urbit.pill
-    ${pkgs.coreutils}/bin/ln -sf ${entrypoint} /bin/urbit
   '';
 
+  contents = [ urbit ];
+
   config = {
-    Entrypoint = [ "urbit" ];
+    Entrypoint = [ urbit.meta.name ];
 
     WorkingDir = "/data";
-
-    Env = [ "PATH=/bin" ];
 
     Volumes = {
       "/data" = {};


### PR DESCRIPTION
Removes the `/bin` creation + symlink and related dockerfile `ENV` setting in favour of using the `nix.dockerTools.contents` attriubute to ensure `urbit` + `urbit-worker` or the debug variants are locatable via `PATH`.