### PR TITLE
hoon: support =/ (and friends) without face

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:802628572edd2f8305dbbb723215fec89f46a9a63f40f4a0421cfb38f0285b0b
-size 9646301
+oid sha256:7f7f34e9ca7fe2b45c96e34e1bbef09801cb85c19c6a5114b57b7560019bf788
+size 9646645

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f7f34e9ca7fe2b45c96e34e1bbef09801cb85c19c6a5114b57b7560019bf788
-size 9646645
+oid sha256:23ec7d497dd53f180b8753bd196f92695c7d60dad52f2b57061fc8642cdae4e2
+size 9645510

--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -57,16 +57,16 @@
     `[who id %rift num]
   ?:  =(changed-keys i.topics.event-log)
     =/  who=@  (decode-topics t.topics.event-log ~[%uint])
-    =+  ^-  [enc=octs aut=octs sut=@ud rev=@ud]
+    =/  [enc=octs aut=octs sut=@ud rev=@ud]
         %+  decode-results  data.event-log
         ~[[%bytes-n 32] [%bytes-n 32] %uint %uint]
     `[who id %keys rev sut (pass-from-eth:azimuth enc aut sut)]
   ?:  =(lost-sponsor i.topics.event-log)
-    =+  ^-  [who=@ pos=@]
+    =/  [who=@ pos=@]
         (decode-topics t.topics.event-log ~[%uint %uint])
     `[who id %spon ~]
   ?:  =(escape-accepted i.topics.event-log)
-    =+  ^-  [who=@ wer=@]
+    =/  [who=@ wer=@]
         (decode-topics t.topics.event-log ~[%uint %uint])
     `[who id %spon `wer]
   ~&  [%bad-topic event-log]

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -1387,7 +1387,7 @@
   |=  [txt=tape wid=@ud]
   ^-  (list tape)
   ?~  txt  ~
-  =+  ^-  [end=@ud nex=?]
+  =/  [end=@ud nex=?]
     ?:  (lte (lent txt) wid)  [(lent txt) &]
     =+  ace=(find " " (flop (scag +(wid) `tape`txt)))
     ?~  ace  [wid |]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -968,7 +968,7 @@
   ++  he-lens
     |=  com/command:lens
     ^+  +>
-    =+  ^-  source/dojo-source
+    =/  source=dojo-source
         =|  num/@
         =-  ?.  ?=($send-api -.sink.com)  ::  XX  num is incorrect
               sor
@@ -1109,7 +1109,7 @@
     |=  pos=@ud
     ^+  +>
     =*  res  +>
-    =+  ^-  [back-pos=@ud fore-pos=@ud txt=tape]
+    =/  [back-pos=@ud fore-pos=@ud txt=tape]
         (insert-magic:auto (add (lent buf) pos) :(weld buf (tufa buf.say)))
     =/  id-len  (sub fore-pos back-pos)
     =/  fore-pos-diff  (sub fore-pos pos)

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -357,11 +357,11 @@
         0x4763.8e3c.ddee.2204.81e4.c3f9.183d.639c.
           0efe.a7f0.5fcd.2df4.1888.5572.9f71.5419
       ~
-    =+  ^-  [of=@ pool=@]  ::TODO  =/
+    =/  [of=@ pool=@]
       ~|  t.topics.log
       %+  decode-topics:abi:ethereum  t.topics.log
       ~[%uint %uint]
-    =+  ^-  [by=@ gift=@ to=@]  ::TODO  =/
+    =/  [by=@ gift=@ to=@]
       ~|  data.log
       %+  decode-topics:abi:ethereum
         %+  rash  data.log

--- a/pkg/arvo/app/link-server-hook.hoon
+++ b/pkg/arvo/app/link-server-hook.hoon
@@ -120,10 +120,9 @@
     %-  parse-request-line
     url.request.inbound-request
   =*  req-head  header-list.request.inbound-request
-  =-  ::TODO  =;  [cards=(list card) =simple-payload:http]
+  =;  [cards=(list card) =simple-payload:http]
     %+  weld  cards
     (give-simple-payload:app eyre-id simple-payload)
-  ^-  [cards=(list card) =simple-payload:http]
   ?+  method.request.inbound-request  [~ not-found:gen]
       %'OPTIONS'
     [~ (include-cors-headers req-head [[200 ~] `*octs])]
@@ -138,7 +137,7 @@
 ++  handle-post
   |=  [request-headers=header-list:http =request-line body=(unit octs)]
   ^-  [(list card) simple-payload:http]
-  =-  ::TODO  =;  [success=? cards=(list card)]
+  =;  [success=? cards=(list card)]
     :-  cards
     %+  include-cors-headers
       request-headers
@@ -146,7 +145,6 @@
     ::      sending this response right away... but link-store pokes can't
     ::      actually fail right now, so it's fine.
     [[?:(success 200 400) ~] `*octs]
-  ^-  [success=? cards=(list card)]
   ?~  body  [| ~]
   ?+  request-line  [| ~]
       [[~ [%'~link' %add ^]] ~]

--- a/pkg/arvo/gen/reload-event.hoon
+++ b/pkg/arvo/gen/reload-event.hoon
@@ -15,7 +15,7 @@
     ~(tap by dir:.^(arch %cy (welp top /sys/vane)))
   ?.  =(1 (met 3 tam))
     tam
-  =+  ^-  zaz=(list [p=knot ~])
+  =/  zaz=(list [p=knot ~])
       (skim van |=([a=term ~] =(tam (end 3 1 a))))
   ?>  ?=([[@ ~] ~] zaz)
   `term`p.i.zaz

--- a/pkg/arvo/lib/base64.hoon
+++ b/pkg/arvo/lib/base64.hoon
@@ -59,7 +59,7 @@
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   ::
   |^  |=  bs=octs  ^-  cord
-      =+  ^-  [padding=@ blocks=(list word24)]
+      =/  [padding=@ blocks=(list word24)]
           (octs-to-blocks bs)
       (crip (flop (unpad padding (encode-blocks blocks))))
   ::

--- a/pkg/arvo/lib/bip32.hoon
+++ b/pkg/arvo/lib/bip32.hoon
@@ -114,7 +114,7 @@
     ~|  %know-no-private-key
     !!
   ::  derive child at i
-  =+  ^-  [left=@ right=@]  ::TODO  =/ w/o face
+  =/  [left=@ right=@]
     =-  [(cut 3 [32 32] -) (cut 3 [0 32] -)]
     %+  hmac-sha512l  [32 cad]
     :-  37
@@ -143,7 +143,7 @@
     ~|  %cant-derive-hardened-public-key
     !!
   ::  derive child at i
-  =+  ^-  [left=@ right=@]  ::TODO  =/  w/o face
+  =/  [left=@ right=@]
     =-  [(cut 3 [32 32] -) (cut 3 [0 32] -)]
     %+  hmac-sha512l  [32 cad]
     37^(can 3 ~[4^i 33^(ser-p pub)])

--- a/pkg/arvo/lib/der.hoon
+++ b/pkg/arvo/lib/der.hoon
@@ -185,7 +185,7 @@
     ::  nex: offset of value bytes from fuz
     ::  len: length of value bytes
     ::
-    =+  ^-  [nex=@ len=@]
+    =/  [nex=@ len=@]
       ::  faz: meaningful bits in fuz
       ::
       =/  faz  (end 0 7 fuz)

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -146,7 +146,7 @@
     =.  nam
     ?.  =(1 (met 3 nam))
       nam
-    =+  ^-  zaz/(list {p/knot ~})
+    =/  zaz/(list {p/knot ~})
         (skim van |=({a/term ~} =(nam (end 3 1 a))))
     ?>  ?=({{@ ~} ~} zaz)
     `term`p.i.zaz

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -378,7 +378,7 @@
 ++  take-mere-sync                                    ::
   |=  {way/wire mes/(each (set path) (pair term tang))}
   ?>  ?=({@ @ @ *} way)
-  =+  ^-  hos/kiln-sync
+  =/  hos/kiln-sync
       :*  syd=(slav %tas i.way)
           her=(slav %p i.t.way)
           sud=(slav %tas i.t.t.way)
@@ -388,7 +388,7 @@
 ++  take-writ-find-ship                               ::
   |=  {way/wire rot/riot}
   ?>  ?=({@ @ @ *} way)
-  =+  ^-  hos/kiln-sync
+  =/  hos/kiln-sync
       :*  syd=(slav %tas i.way)
           her=(slav %p i.t.way)
           sud=(slav %tas i.t.t.way)
@@ -398,7 +398,7 @@
 ++  take-writ-sync                                    ::
   |=  {way/wire rot/riot}
   ?>  ?=({@ @ @ *} way)
-  =+  ^-  hos/kiln-sync
+  =/  hos/kiln-sync
       :*  syd=(slav %tas i.way)
           her=(slav %p i.t.way)
           sud=(slav %tas i.t.t.way)
@@ -549,7 +549,7 @@
 ::
 ++  work                                              ::  state machine
   |=  syd/desk
-  =+  ^-  per-desk
+  =/  ,per-desk
       %+  ~(gut by rem)  syd
       =+  *per-desk
       %_(- cas [%da now])
@@ -644,7 +644,7 @@
               [%scry %c %x [[our syd] (flop pax)]]
             =/  dali=schematic  [%diff [our syd] base alis]
             =/  dbob=schematic  [%diff [our syd] base bobs]
-            =+  ^-  for/mark
+            =/  for=mark
                 =+  (slag (dec (lent pax)) pax)
                 ?~(- %$ i.-)
             ^-  schematic
@@ -713,7 +713,7 @@
       =+  "failed to mash"
       lose:(spam leaf+- message.build-result.result)
     ?>  ?=([%complete %success %list *] result)
-    =+  ^-  can/(list (pair path (unit miso)))
+    =/  can=(list (pair path (unit miso)))
         %+  turn  results.build-result.result
         |=  res=build-result:ford
         ^-  (pair path (unit miso))
@@ -731,7 +731,7 @@
     =+  annotated=(turn `(list (pair path *))`-.notated head)
     =+  unnotated=(turn `(list (pair path *))`+.notated head)
     =+  `desk`(cat 3 syd '-scratch')
-    =+  ^-  tan/(list tank)
+    =/  tan=(list tank)
         %-  zing
         ^-  (list (list tank))
         :~  %-  tape-to-tanks

--- a/pkg/arvo/mar/snip.hoon
+++ b/pkg/arvo/mar/snip.hoon
@@ -23,7 +23,7 @@
     |-  ^-  {rem/@u res/marl}
     ?~  mal  [lim ~]
     ?~  lim  [0 ~]
-    =+  ^-  {lam/@u hed/manx}
+    =/  {lam/@u hed/manx}
       ?:  ?=(_;/(**) i.mal)
         [lim ;/(tay)]:(deword lim v.i.a.g.i.mal)
       [rem ele(c res)]:[ele=i.mal $(mal c.i.mal)]

--- a/pkg/arvo/mar/txt.hoon
+++ b/pkg/arvo/mar/txt.hoon
@@ -119,7 +119,7 @@
           [i.bob $(ali t.ali, bob t.bob)]
         ?:  (gth p.i.ali (lent p.i.bob))
           [i.bob $(p.i.ali (sub p.i.ali (lent p.i.bob)), bob t.bob)]
-        =+  ^-  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
+        =/  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
             (resolve ali bob)
         [fic $(ali ali, bob bob)]
         ::  ~   ::  here, alice is good for a while, but not for the whole
@@ -128,7 +128,7 @@
         %|
       ?-  -.i.bob
           %|
-        =+  ^-  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
+        =/  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
             (resolve ali bob)
         [fic $(ali ali, bob bob)]
       ::
@@ -137,7 +137,7 @@
           [i.ali $(ali t.ali, bob t.bob)]
         ?:  (gth p.i.bob (lent p.i.ali))
           [i.ali $(ali t.ali, p.i.bob (sub p.i.bob (lent p.i.ali)))]
-        =+  ^-  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
+        =/  {fic/(unce cord) ali/(urge cord) bob/(urge cord)}
             (resolve ali bob)
         [fic $(ali ali, bob bob)]
       ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2238,7 +2238,7 @@
   ::
 ::
 ++  fl                                                  ::  arb. precision fp
-  =+  ^-  {{p/@u v/@s w/@u} r/$?($n $u $d $z $a) d/$?($d $f $i)}
+  =/  {{p/@u v/@s w/@u} r/$?($n $u $d $z $a) d/$?($d $f $i)}
     [[113 -16.494 32.765] %n %d]
   ::  p=precision:     number of bits in arithmetic form; must be at least 2
   ::  v=min exponent:  minimum value of e
@@ -4108,7 +4108,7 @@
 ::
 ++  fa                                                  ::  base58check
   =+  key='123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-  =+  ^-  yek/@ux  ~+
+  =/  yek/@ux  ~+
       =-  yek:(roll (rip 3 key) -)
       =+  [a=*char b=*@ yek=`@ux`(fil 3 256 0xff)]
       |.
@@ -7897,7 +7897,7 @@
     ::
     |=  gen/hoon
     ^-  hoon
-    =+  ^-  wing
+    =/  ,wing
         ?:  =(1 dom)
           hay
         (weld hay `wing`[[%& dom] ~])
@@ -9869,7 +9869,7 @@
                 ?~  fid  ~
                 ?:  ?=({%| %& *} fid)
                   $(q.zot t.q.zot, p.heg p.p.fid)
-                =+  ^-  vat/(pair type nock)
+                =/  vat/(pair type nock)
                     ?-    -.fid
                       %&  (fine %& p.fid)
                       %|  (fine %| p.p.fid)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -14254,6 +14254,7 @@
           [%name term %spec spec %base %noun]
         wyde
       ==
+    ::
       %+  cook
         |=  [=term =(unit spec)]
         ^-  skin
@@ -14265,6 +14266,12 @@
         ::
         (punt ;~(pfix ;~(pose net tis) wyde))
       ==
+    ::
+      %+  cook
+        |=  =spec
+        ^-  skin
+        [%spec spec %base %noun]
+      wyde
     ==
   ++  tall                                              ::  full tall form
     %+  knee  *hoon

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -879,7 +879,7 @@
       ;<  res=made-result:ford    bind:m  expect-ford
       ;<  hashes=(map path lobe)  bind:m
         |=  clad-input
-        =+  ^-  cat/(list (pair path cage))
+        =/  cat=(list (pair path cage))
             %+  turn  (made-result-to-cages:util res)
             |=  {pax/cage cay/cage}
             ?.  ?=($path p.pax)
@@ -924,7 +924,7 @@
       |=  [wen=@da =dork]
       =/  m  (clad ,[=suba _this-cor])
       ^-  form:m
-      =+  ^-  sim=(list (pair path misu))
+      =/  sim=(list (pair path misu))
           ;:  weld
             ^-  (list (pair path misu))
             (turn del.dork |=(pax/path [pax %del ~]))
@@ -972,7 +972,7 @@
         =/  message  (made-result-as-error:ford res)
         (clad-fail %checkout-fail leaf+"clay patch failed" message)
       ::
-      =+  ^-  cat/(list (trel path lobe cage))
+      =/  cat/(list (trel path lobe cage))
           %+  turn  (made-result-to-cages:util res)
           |=  {pax/cage cay/cage}
           ?.  ?=($path-hash p.pax)
@@ -992,7 +992,7 @@
       =+  must=(must-ergo:util our syd mon (turn suba head))
       ?:  =(~ must)
         (pure:m mim)
-      =+  ^-  all-paths/(set path)
+      =/  all-paths/(set path)
           %+  roll
             (turn ~(tap by must) (corl tail tail))
           |=  {pak/(set path) acc/(set path)}
@@ -2295,7 +2295,7 @@
       |=  [local=? disc=disc:ford pax=path lob=lobe]
       ^-  schematic:ford
       ::
-      =+  ^-  hat/(map path lobe)
+      =/  hat/(map path lobe)
           ?:  =(let.dom 0)
             ~
           q:(aeon-to-yaki let.dom)
@@ -2631,7 +2631,7 @@
   ::
   =*  ruf  |4.+6.^$
   ::
-  =+  ^-  [mow=(list move) hun=(unit duct) rede]
+  =/  [mow=(list move) hun=(unit duct) rede]
       ?.  =(our her)
         ::  no duct, foreign +rede or default
         ::
@@ -2993,7 +2993,7 @@
   ++  start-request
     |=  [for=(unit ship) rav=rave]
     ^+  ..start-request
-    =+  ^-  [new-sub=(unit rove) sub-results=(list sub-result)]
+    =/  [new-sub=(unit rove) sub-results=(list sub-result)]
         (try-fill-sub for (rave-to-rove rav))
     =.  ..start-request  (send-sub-results sub-results [hen ~ ~])
     ?~  new-sub
@@ -3392,7 +3392,7 @@
       ::  drop forgotten roves
       ::
       $(old-subs t.old-subs)
-    =+  ^-  [new-sub=(unit rove) sub-results=(list sub-result)]
+    =/  [new-sub=(unit rove) sub-results=(list sub-result)]
         (try-fill-sub wove.i.old-subs)
     =.  ..wake  (send-sub-results sub-results ducts.i.old-subs)
     =.  new-subs
@@ -3752,7 +3752,7 @@
       |=  {a/(unit tako) b/tako}
       ^-  {(set yaki) (set plop)}
       =+  old=?~(a ~ (reachable-takos:util u.a))
-      =+  ^-  yal/(set tako)
+      =/  yal/(set tako)
           %-  silt
           %+  skip
             ~(tap in (reachable-takos:util b))
@@ -3983,7 +3983,7 @@
       =+  yak=(tako-to-yaki u.tak)
       =+  len=(lent pax)
       :: ~&  read-z+[yon=yon qyt=~(wyt by q.yak) pax=pax]
-      =+  ^-  descendants/(list (pair path lobe))
+      =/  descendants/(list (pair path lobe))
           ::  ~&  %turning
           ::  =-  ~&  %turned  -
           %+  turn
@@ -4205,7 +4205,7 @@
     =+  bem=(~(get by mon.ruf) des.req)
     ?:  &(?=(~ bem) !=(%$ des.req))
       ~|([%bad-mount-point-from-unix des.req] !!)
-    =+  ^-  bem/beam
+    =/  bem/beam
         ?^  bem
           u.bem
         [[our %base %ud 1] ~]
@@ -4214,7 +4214,7 @@
       !!  ::  fire next in queue
     ?:  =(0 let.dom.u.dos)
       =+  cos=(mode-to-soba ~ s.bem all.req fis.req)
-      =+  ^-  [one=soba two=soba]
+      =/  [one=soba two=soba]
           %+  skid  cos
           |=  [a=path b=miso]
           ?&  ?=(%ins -.b)
@@ -4607,7 +4607,7 @@
       ~
     =+  mad=(malt mod)
     =+  len=(lent pax)
-    =+  ^-  descendants/(list path)
+    =/  descendants/(list path)
         %+  turn
           %+  skim  ~(tap by hat)
           |=  {paf/path lob/lobe}

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4946,7 +4946,7 @@
         $(rob (put-word rob col -), sin +(sin))
       ::
       ::  c1, c2: prns for picking reference block
-      =+  ^-  [c1=@ c2=@]  ::TODO  =/ w/o face
+      =/  [c1=@ c2=@]
         ?:  do-i  (snag sin rands)
         =+  =-  (snag - rob)
             ?:  =(0 col)  (dec columns)
@@ -6632,7 +6632,7 @@
         [~ ~]
       ?^  t.rax
         [p.pok [ire q.pok]]:[pok=$(rax t.rax) ire=i.rax]
-      =+  ^-  raf/(like term)
+      =/  raf/(like term)
           =>  |=(a/@ ((sand %tas) (crip (flop (trip a)))))
           (;~(sfix (sear . sym) dot) [1^1 (flop (trip i.rax))])
       ?~  q.raf
@@ -7814,7 +7814,7 @@
     ~?  ?=(~ mined.log)  %processing-unmined-event
     ::
     ?:  =(i.topics.log owner-changed)
-      =+  ^-  [who=@ wer=address]
+      =/  [who=@ wer=address]
           (decode-topics t.topics.log ~[%uint %address])
       `[who %owner wer]
     ::
@@ -7824,12 +7824,12 @@
       `[who %activated who]
     ::
     ?:  =(i.topics.log spawned)
-      =+  ^-  [pre=@ who=@]
+      =/  [pre=@ who=@]
           (decode-topics t.topics.log ~[%uint %uint])
       `[pre %spawned who]
     ::
     ?:  =(i.topics.log escape-requested)
-      =+  ^-  [who=@ wer=@]
+      =/  [who=@ wer=@]
           (decode-topics t.topics.log ~[%uint %uint])
       `[who %escape `wer]
     ::
@@ -7838,18 +7838,18 @@
       `[who %escape ~]
     ::
     ?:  =(i.topics.log escape-accepted)
-      =+  ^-  [who=@ wer=@]
+      =/  [who=@ wer=@]
           (decode-topics t.topics.log ~[%uint %uint])
       `[who %sponsor & wer]
     ::
     ?:  =(i.topics.log lost-sponsor)
-      =+  ^-  [who=@ pos=@]
+      =/  [who=@ pos=@]
           (decode-topics t.topics.log ~[%uint %uint])
       `[who %sponsor | pos]
     ::
     ?:  =(i.topics.log changed-keys)
       =/  who=@  (decode-topics t.topics.log ~[%uint])
-      =+  ^-  [enc=octs aut=octs sut=@ud rev=@ud]
+      =/  [enc=octs aut=octs sut=@ud rev=@ud]
           %+  decode-results  data.log
           ~[[%bytes-n 32] [%bytes-n 32] %uint %uint]
       `[who %keys rev (pass-from-eth enc aut sut)]
@@ -7860,22 +7860,22 @@
       `[who %continuity num]
     ::
     ?:  =(i.topics.log changed-management-proxy)
-      =+  ^-  [who=@ sox=address]
+      =/  [who=@ sox=address]
           (decode-topics t.topics.log ~[%uint %address])
       `[who %management-proxy sox]
     ::
     ?:  =(i.topics.log changed-voting-proxy)
-      =+  ^-  [who=@ tox=address]
+      =/  [who=@ tox=address]
           (decode-topics t.topics.log ~[%uint %address])
       `[who %voting-proxy tox]
     ::
     ?:  =(i.topics.log changed-spawn-proxy)
-      =+  ^-  [who=@ sox=address]
+      =/  [who=@ sox=address]
           (decode-topics t.topics.log ~[%uint %address])
       `[who %spawn-proxy sox]
     ::
     ?:  =(i.topics.log changed-transfer-proxy)
-      =+  ^-  [who=@ tox=address]
+      =/  [who=@ tox=address]
           (decode-topics t.topics.log ~[%uint %address])
       `[who %transfer-proxy tox]
     ::

--- a/pkg/arvo/ted/azimuth-tracker.hoon
+++ b/pkg/arvo/ted/azimuth-tracker.hoon
@@ -96,16 +96,16 @@
     `[who id %rift num]
   ?:  =(changed-keys i.topics.event-log)
     =/  who=@  (decode-topics t.topics.event-log ~[%uint])
-    =+  ^-  [enc=octs aut=octs sut=@ud rev=@ud]
+    =/  [enc=octs aut=octs sut=@ud rev=@ud]
         %+  decode-results  data.event-log
         ~[[%bytes-n 32] [%bytes-n 32] %uint %uint]
     `[who id %keys rev sut (pass-from-eth:azimuth enc aut sut)]
   ?:  =(lost-sponsor i.topics.event-log)
-    =+  ^-  [who=@ pos=@]
+    =/  [who=@ pos=@]
         (decode-topics t.topics.event-log ~[%uint %uint])
     `[who id %spon ~]
   ?:  =(escape-accepted i.topics.event-log)
-    =+  ^-  [who=@ wer=@]
+    =/  [who=@ wer=@]
         (decode-topics t.topics.event-log ~[%uint %uint])
     `[who id %spon `wer]
   ~&  [%bad-topic event-log]

--- a/pkg/arvo/ted/claz/prep-command.hoon
+++ b/pkg/arvo/ted/claz/prep-command.hoon
@@ -6,7 +6,7 @@
 =,  able:jael
 ::
 |=  args=vase
-=+  ^-  [url=@t =command]
+=/  [url=@t =command]
   !<([@t command] args)
 =/  m  (strand:strandio ,vase)
 ^-  form:m


### PR DESCRIPTION
This has been getting on my nerves for the longest time, and today I finally snapped. Turns out it really isn't that hard!

This updates the `+wise` parser, used for `=;` and `=^` (and everything that compiles down to them, which is just `=/` I think) to accept molds (`+wyde`) without a specified face.

This allows for constructions such as:

```hoon
=/  [x=@ y=@]
  [5 6]
-  ::  [x=5 y=6]
```

Note that if you want to use "`some-type`" this way, you need to prefix with the `,` to avoid having it parsed as a face instead.

```hoon
=/  ,octs
  [2 'hi']
-  ::  [p=2 q='hi']
```

I've gone ahead and replaced all instances of `=+  ^-` with `=/`, and similarly cleaned up my own todo's for doing the same with `=-  ...  ^-` and `=;`.