### PR TITLE
ames: handle misordered crashing boons

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2217,17 +2217,29 @@
         ^+  peer-core
         ::  send ack unconditionally
         ::
+        =.  peer-core  (emit (got-duct bone) %give %boon message)
         =.  peer-core  (run-message-sink bone %done ok=%.y)
         ::
         ?.  ?=([%hear * * ok=%.n] task)
           ::  fresh boon; give message to client vane
           ::
-          %-  (trace msg.veb |.("boon {<her.channel^bone>}"))
-          (emit (got-duct bone) %give %boon message)
+          %-  (trace msg.veb |.("boon {<her.channel^bone -.task>}"))
+          peer-core
         ::  we previously crashed on this message; notify client vane
         ::
-        %-  (trace msg.veb |.("crashed on boon {<her.channel^bone>}"))
-        (emit (got-duct bone) %give %lost ~)
+        %-  (trace msg.veb |.("crashed on boon {<her.channel^bone -.task>}"))
+        boon-to-lost
+      ::  +boon-to-lost: convert all boons to losts
+      ::
+      ++  boon-to-lost
+        ^+  peer-core
+        =.  moves
+          %+  turn  moves
+          |=  =move
+          ?.  ?=([* %give %boon *] move)
+            move
+          [duct.move %give %lost ~]
+        peer-core
       ::  +on-sink-nack-trace: handle nack-trace received by |message-sink
       ::
       ++  on-sink-nack-trace

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -205,7 +205,7 @@
   ::
     %+  expect-eq
       !>  [~[/g/talk] %give %boon [%post 'first1!!']]
-      !>  (snag 1 `(list move:ames)`moves6)
+      !>  (snag 0 `(list move:ames)`moves6)
   ==
 ::
 ++  test-nack  ^-  tang


### PR DESCRIPTION
Two bugs fixed here: first, if the %done reentrancy triggered another
%boon, that wasn't getting translated to a %lost, even though it could
have been the reason the event crashed in the first place.

Second, the %done reentrancy needs to happen after we emit our move, so
that we don't invert the order of the %boon's we produce.