### PR TITLE
ford: clear build results on +load

### DIFF
--- a/bin/brass.pill
+++ b/bin/brass.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18d492d912068e7fefef48006105d39c1c8f56aa756b7aeae48387c2254c1b91
-size 7153239
+oid sha256:407a763f44eb91db0dd4a1ec2dbd12ed4332b48decefd3999c4313844daa2c0b
+size 7226043

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04735cc4764f9a3e6c4fb5b046a6b9590664fe9f644578c58f3bc6acc911b723
-size 9606039
+oid sha256:a1eefcccc270aa4fce80bfe2b8a3edc74b1958326ac4df988b6f1fe47590bcec
+size 9609018

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6108,6 +6108,7 @@
 ::  and a namespace function
 ::
 |=  [our=ship now=@da eny=@uvJ scry-gate=sley]
+=*  ford-gate  .
 ::  allow jets to be registered within this core
 ::
 ~%  %ford  ..is  ~
@@ -6332,12 +6333,16 @@
   --
 ::  +load: migrate old state to new state (called on vane reload)
 ::
+::    Trim builds completely in case a change to our code invalidated an
+::    old build result.
+::
 ++  load
   |=  old=axle
-  ^+  ..^$
+  ^+  ford-gate
   ::
-  ~!  %loading
-  ..^$(ax old)
+  =.  ax  old
+  =.  ford-gate  +:(call ~[/ford-load-self] *type %trim 0)
+  ford-gate
 ::  +stay: produce current state
 ::
 ++  stay  `axle`ax
@@ -6346,9 +6351,4 @@
 ++  scry
   |=  *
   [~ ~]
-::  %utilities
-::
-::+|
-::
-++  ford-gate  ..$
 --


### PR DESCRIPTION
Fixes https://github.com/urbit/urbit/issues/2109 by clearing the cache whenever Ford reloads.  Note that this also assumes Ford will be reloaded every time Zuse reloads.  That's an assumption we might want to relax eventually, but for now this, in combination with the recent :goad call from :dill, should fix OTAs.

I've confirmed that this reloads Ford properly on a fakezod.  Testing the bug repro on a comet locally at the moment.