### PR TITLE
build: allow baking multiple pills into docker images

### DIFF
--- a/nix/ops/default.nix
+++ b/nix/ops/default.nix
@@ -74,8 +74,13 @@ rec {
   };
 
   image = import ./image {
-    inherit pkgs urbit;
-    pill = bootsolid;
+    inherit pkgs herb urbit solid;
+  };
+
+  image-ropsten = import ./image {
+    inherit pkgs herb urbit;
+    brass = brass-ropsten;
+    ivory = ivory-ropsten;
   };
 
 }

--- a/nix/ops/image/default.nix
+++ b/nix/ops/image/default.nix
@@ -1,6 +1,17 @@
-{ pkgs, urbit, pill }:
+{ pkgs
+, herb
+, urbit
+, solid ? null
+, brass ? null
+, ivory ? null
+}:
 
-pkgs.dockerTools.buildImage {
+let
+  link = pill: path:
+    if pill == null then ""
+                    else "${pkgs.coreutils}/bin/ln -sf ${pill} ${path}";
+
+in pkgs.dockerTools.buildImage {
   name = urbit.meta.name;
 
   runAsRoot = ''
@@ -12,10 +23,12 @@ pkgs.dockerTools.buildImage {
 
     mkdir -p /share /data /tmp
 
-    ${pkgs.coreutils}/bin/ln -sf ${pill} /share/urbit.pill
+    ${link solid "/share/solid.pill"}
+    ${link brass "/share/brass.pill"}
+    ${link ivory "/share/ivory.pill"}
   '';
 
-  contents = [ urbit ];
+  contents = [ urbit herb ];
 
   config = {
     Entrypoint = [ urbit.meta.name ];


### PR DESCRIPTION
By baking (potentially) multiple pills into an image, we can provide mainnet vs ropsten images. It is still up to the operator to pass along the pill path(s) to the entrypoint.

For example, using Docker:

```
docker run --tty urbit -B /share/brass.pill -J /share/ivory.pill ...
```

The main `image` attribute still uses only the solid pill and `image-ropsten` has been provided with brass and ivory pills.

Additionally, herb has been added to the image for convenience.