### PR TITLE
clay: implement %u care

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2c08caf6f69f9fa349003da923d0b6507a8b6df763a0ee491f195a937630843
-size 9620244
+oid sha256:4185a43f4acbcc6f70fb9ac7c68b4b04a08545ff9a20f5c61d1542feb48fdb5a
+size 14078527

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -3890,12 +3890,18 @@
     ::  at any of its children.
     ::
     ++  read-u
-      |=  {yon/aeon pax/path}
-      ^-  (unit (unit (each {$null (hypo ~)} lobe)))
-      =+  tak=(~(get by hit.dom) yon)
-      ?~  tak
+      |=  [yon=aeon pax=path]
+      ^-  (unit (unit (each [%flag (hypo ?)] lobe)))
+      ::  if asked for a future version, we don't have an answer
+      ::
+      ?~  tak=(~(get by hit.dom) yon)
         ~
-      ``[%& %null [%atom %n ~] ~]
+      ::  look up the yaki snapshot based on the version
+      ::
+      =/  yak=yaki  (tako-to-yaki u.tak)
+      ::  produce the result based on whether or not there's a file at :pax
+      ::
+      ``[%& %flag -:!>(*?) (~(has by q.yak) pax)]
     ::
     ::  Gets the dome (desk state) at a particular aeon.
     ::


### PR DESCRIPTION
Previously, it would always produce ~, regardless of the path asked
about.

Now, it produces a loobean, based on whether or not a file exists at the
specified path.

This largely mimics the surrounding code. It takes care to specify the actual output type (with a fake `%loob` mark) in the `^-` of `+read-u`.
Specifying just `cage` there allows us to do a simple `!>` on the actual result. However, with the `hypo` construction, this doesn't nest. I'm not sure why, so we just do as the surrounding code does: get the type using the type spear, and put in the result noun as-is. This can probably be simplified, happy to take suggestions.