### PR TITLE
chat-cli hotfix: reconnect to chat-store when appropriate

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -102,7 +102,7 @@
     ^-  (quip card _this)
     =^  cards  all-state
       ?+  mark        (on-poke:def mark vase)
-        %noun         (poke-noun:tc mark !<(* vase))
+        %noun         (poke-noun:tc !<(* vase))
         %sole-action  (poke-sole-action:tc !<(sole-action:sole-sur vase))
       ==
     [cards this]

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -122,7 +122,7 @@
       ?-    -.sign
           %poke-ack   [- all-state]:(on-agent:def wire sign)
           %watch-ack  [- all-state]:(on-agent:def wire sign)
-          %kick       ~&  %chat-cli-kicked  `all-state
+          %kick       [?:(?=([%chat-store ~] wire) ~[connect] ~) all-state]
           %fact
         ?+  p.cage.sign  ~|([%chat-cli-bad-sub-mark wire p.cage.sign] !!)
           %chat-update  (diff-chat-update:tc wire !<(chat-update q.cage.sign))
@@ -141,7 +141,10 @@
   |=  old=(unit state)
   ^-  (quip card state)
   ?^  old
-    [~ u.old]
+    :_  u.old
+    ?:  (~(has by wex.bowl) [/chat-store our-self %chat-store])
+      ~
+    ~[connect]
   =^  cards  all-state
     %_  catch-up
       audience  [[our-self /] ~ ~]

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -1352,6 +1352,7 @@
         ~(glyph tr source)
       =/  lis=(list tape)
         %+  simple-wrap
+          ~|  [%weird-text `@`+.letter]
           `tape``(list @)`(tuba (trip +.letter))
         (sub wyd (min (div wyd 2) (lent pef)))
       =+  lef=(lent pef)


### PR DESCRIPTION
Crashes such as #2125 cause chat-cli to get its chat-store subscription kicked (as per gall's "you crash on it, you lose it" behavior). Chat-cli doesn't handle the `%kick` case in on-agent however, causing it to stop receiving messages until the user manually reconnects it.

That manual reconnecting, however, got broken during static gall conversion. Were were passing `[%noun the-noun]` into `+poke-noun`, instead of just `the-noun` like it expects. Of course, since it takes a noun as argument, this doesn't type fail, and so managed to sneak in undetected.

This PR fixes both of those, and also adds a `~|` to the path that hit #2125, so that we can look further into that when it next occurs.

This is intended to go OTA as a hotfix. I will go ahead and self-merge as such. I applied this update to ~palfun-foslup, who was affected, and it got back into a working state without issue.