### PR TITLE
gall: (list path) in %fact and %kick

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23ec7d497dd53f180b8753bd196f92695c7d60dad52f2b57061fc8642cdae4e2
-size 9645510
+oid sha256:db17380940f4f10dab139b385cf5f752282e069b290cdb5255c8510e5cc36ea7
+size 14122439

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -256,8 +256,8 @@
     %-  zing
     %+  turn  ufs
     |=  uf=unix-effect
-    :~  [%give %fact `/effect %aqua-effect !>(`aqua-effect`[ship uf])]
-        [%give %fact `/effect/[-.q.uf] %aqua-effect !>(`aqua-effect`[ship uf])]
+    :~  [%give %fact ~[/effect] %aqua-effect !>(`aqua-effect`[ship uf])]
+        [%give %fact ~[/effect/[-.q.uf]] %aqua-effect !>(`aqua-effect`[ship uf])]
     ==
   ::
   =.  this
@@ -265,7 +265,7 @@
     %-  emit-cards
     %+  turn  ~(tap by unix-effects)
     |=  [=ship ufs=(list unix-effect)]
-    [%give %fact `path %aqua-effects !>(`aqua-effects`[ship (flop ufs)])]
+    [%give %fact ~[path] %aqua-effects !>(`aqua-effects`[ship (flop ufs)])]
   ::
   =.  this
     %-  emit-cards
@@ -275,28 +275,28 @@
     =/  =path  /effect/(scot %p ship)
     %+  turn  ufs
     |=  uf=unix-effect
-    [%give %fact `path %aqua-effect !>(`aqua-effect`[ship uf])]
+    [%give %fact ~[path] %aqua-effect !>(`aqua-effect`[ship uf])]
   ::
   =.  this
     %-  emit-cards
     %+  turn  ~(tap by unix-effects)
     |=  [=ship ufs=(list unix-effect)]
     =/  =path  /effects/(scot %p ship)
-    [%give %fact `path %aqua-effects !>(`aqua-effects`[ship (flop ufs)])]
+    [%give %fact ~[path] %aqua-effects !>(`aqua-effects`[ship (flop ufs)])]
   ::
   =.  this
     %-  emit-cards
     %+  turn  ~(tap by unix-events)
     |=  [=ship ve=(list unix-timed-event)]
     =/  =path  /events/(scot %p ship)
-    [%give %fact `path %aqua-events !>(`aqua-events`[ship (flop ve)])]
+    [%give %fact ~[path] %aqua-events !>(`aqua-events`[ship (flop ve)])]
   ::
   =.  this
     %-  emit-cards
     %+  turn  ~(tap by unix-boths)
     |=  [=ship bo=(list unix-both)]
     =/  =path  /boths/(scot %p ship)
-    [%give %fact `path %aqua-boths !>(`aqua-boths`[ship (flop bo)])]
+    [%give %fact ~[path] %aqua-boths !>(`aqua-boths`[ship (flop bo)])]
   ::
   [(flop cards) all-state]
 ::

--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -78,8 +78,8 @@
   ?~  udiffs
     ~
   =/  =path  /(scot %p ship.i.udiffs)
-  :*  [%give %fact `/ %azimuth-udiff !>(i.udiffs)]
-      [%give %fact `path %azimuth-udiff !>(i.udiffs)]
+  :*  [%give %fact ~[/] %azimuth-udiff !>(i.udiffs)]
+      [%give %fact ~[path] %azimuth-udiff !>(i.udiffs)]
       $(udiffs t.udiffs)
   ==
 ::

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -1044,7 +1044,7 @@
     |=  fec=sole-effect:sole-sur
     ^-  card
     ::TODO  don't hard-code session id 'drum' here
-    [%give %fact `/sole/drum %sole-effect !>(fec)]
+    [%give %fact ~[/sole/drum] %sole-effect !>(fec)]
   ::  +tab: print tab-complete list
   ::
   ++  tab

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -186,7 +186,7 @@
       :~  (pull-wire [%backlog (weld path.act /0)])
           (pull-wire [%mailbox path.act])
           (delete-permission [%chat path.act])
-          [%give %kick `[%mailbox path.act] ~]~
+          [%give %kick [%mailbox path.act]~ ~]~
       ==
     ?.  |(=(u.ship src.bol) (team:title our.bol src.bol))
       ::  if neither ship = source or source = us, do nothing
@@ -229,7 +229,7 @@
     ?:  ?&(?=(^ backlog-start) (~(got by allow-history) pas))
       (paginate-messages pas u.box u.backlog-start)
     ~
-    [%give %kick `[%backlog pax] `src.bol]~
+    [%give %kick [%backlog pax]~ `src.bol]~
   ==
 ::
 ++  paginate-messages
@@ -302,7 +302,7 @@
   ::  if ship is not permitted, kick their subscription
   =/  mail-path
     (oust [(dec (lent t.pax)) (lent t.pax)] `(list @t)`t.pax)
-  [%give %kick `[%mailbox mail-path] `ship]~
+  [%give %kick [%mailbox mail-path]~ `ship]~
 ::
 ++  fact-chat-update
   |=  [wir=wire fact=chat-update]
@@ -327,11 +327,11 @@
   ::
       %message
     :_  state
-    [%give %fact `[%mailbox path.fact] %chat-update !>(fact)]~
+    [%give %fact [%mailbox path.fact]~ %chat-update !>(fact)]~
   ::
       %messages
     :_  state
-    [%give %fact `[%mailbox path.fact] %chat-update !>(fact)]~
+    [%give %fact [%mailbox path.fact]~ %chat-update !>(fact)]~
   ==
 ::
 ++  handle-foreign

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -245,7 +245,7 @@
 ++  update-subscribers
   |=  [pax=path update=chat-update]
   ^-  (list card)
-  [%give %fact `pax %chat-update !>(update)]~
+  [%give %fact ~[pax] %chat-update !>(update)]~
 ::
 ++  send-diff
   |=  [pax=path upd=chat-update]

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -239,8 +239,8 @@
   ^-  (list card)
   =/  updates-json  (update-to-json upd)
   =/  configs-json  (configs-to-json configs-scry)
-  :~  [%give %fact `/primary %json !>(updates-json)]
-      [%give %fact `/configs %json !>(configs-json)]
+  :~  [%give %fact ~[/primary] %json !>(updates-json)]
+      [%give %fact ~[/configs] %json !>(configs-json)]
   ==
 ::
 ::  +utilities

--- a/pkg/arvo/app/dns-collector.hoon
+++ b/pkg/arvo/app/dns-collector.hoon
@@ -28,7 +28,7 @@
 ++  give-result
   |=  [=the=path =cage]
   ^-  card
-  [%give %fact `the-path cage]
+  [%give %fact ~[the-path] cage]
 --
 ::
 ^-  agent:gall

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -830,7 +830,7 @@
   ++  he-diff                                           ::  emit update
     |=  fec/sole-effect
     ^+  +>
-    (he-card %give %fact `/sole/[id] %sole-effect !>(fec))
+    (he-card %give %fact ~[/sole/[id]] %sole-effect !>(fec))
   ::
   ++  he-stop                                           ::  abort work
     ^+  .

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -337,7 +337,7 @@
     :_  dog(history actual-history)
     %+  turn  actual-vows
     |=  =id:block
-    [%give %fact `[%logs path] %eth-watcher-diff !>([%disavow id])]
+    [%give %fact [%logs path]~ %eth-watcher-diff !>([%disavow id])]
   ::
   ++  release-logs
     |=  [=path dog=watchdog]
@@ -362,7 +362,7 @@
       %+  turn  loglist
       |=  =event-log:rpc:ethereum
       ^-  card
-      [%give %fact `[%logs path] %eth-watcher-diff !>([%log event-log])]
+      [%give %fact [%logs path]~ %eth-watcher-diff !>([%log event-log])]
     =^  cards-2  dog  $(numbers t.numbers)
     [(weld cards-1 cards-2) dog]
   --

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -126,7 +126,7 @@
       :_  state(synced (~(del by synced.state) path.act))
       %+  snoc
         (pull-wire group-wire path.act)
-      [%give %kick `[%group path.act] ~]
+      [%give %kick [%group path.act]~ ~]
     ?:  |(=(u.ship src.bol) (team:title our.bol src.bol))
       ::  delete a foreign ship's path
       =/  group-wire  [(scot %p u.ship) %group path.act]
@@ -150,7 +150,7 @@
     :_  state(synced (~(del by synced.state) pax.diff))
     %+  snoc
       (update-subscribers [%group pax.diff] diff)
-    [%give %kick `[%group pax.diff] ~]
+    [%give %kick [%group pax.diff]~ ~]
   ==
 ::
 ++  handle-foreign
@@ -212,7 +212,7 @@
 ++  update-subscribers
   |=  [pax=path diff=group-update]
   ^-  (list card)
-  [%give %fact `pax %group-update !>(diff)]~
+  [%give %fact ~[pax] %group-update !>(diff)]~
 ::
 ++  pull-wire
   |=  [wir=wire pax=path]

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -148,7 +148,7 @@
 ++  update-subscribers
   |=  [pax=path act=group-action]
   ^-  (list card)
-  [%give %fact `pax %group-update !>(act)]~
+  [%give %fact ~[pax] %group-update !>(act)]~
 ::
 ++  send-diff
   |=  [pax=path act=group-action]

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -169,7 +169,7 @@
 ++  update-subscribers
   |=  [pax=path upd=invite-update]
   ^-  card
-  [%give %fact `pax %invite-update !>(upd)]
+  [%give %fact ~[pax] %invite-update !>(upd)]
 ::
 ++  send-diff
   |=  [pax=path upd=invite-update]

--- a/pkg/arvo/app/invite-view.hoon
+++ b/pkg/arvo/app/invite-view.hoon
@@ -59,7 +59,7 @@
     ?>  ?=(%invite-update p.cage.sign)
     :~  :*
       %give   %fact
-      `/primary  %json
+      ~[/primary]  %json
       !>((update-to-json !<(invite-update q.cage.sign)))
     ==  ==
   ==

--- a/pkg/arvo/app/launch.hoon
+++ b/pkg/arvo/app/launch.hoon
@@ -153,7 +153,7 @@
   =/  dat=(unit [json url=@t])  (~(get by data) name)
   ?~  dat  [~ this]
   :_  this(data (~(put by data) name [jon url.u.dat]))
-  [%give %fact `/main %json !>((frond:enjs:format name jon))]~
+  [%give %fact ~[/main] %json !>((frond:enjs:format name jon))]~
 ::
 ++  on-arvo
   |=  [wir=wire sin=sign-arvo]

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -165,14 +165,14 @@
 ++  kick-proxy
   |=  [who=ship =path]
   ^-  card
-  [%give %kick `path `who]
+  [%give %kick ~[path] `who]
 ::
 ++  handle-proxy-sign
   |=  [=path =sign:agent:gall]
   ^-  (quip card _state)
   ?-  -.sign
     %poke-ack     ~|([dap.bowl %unexpected-poke-ack path] !!)
-    %fact         [[%give %fact `path cage.sign]~ state]
+    %fact         [[%give %fact ~[path] cage.sign]~ state]
     %kick         [[(proxy-pass-link-store path %watch path)]~ state]
   ::
       %watch-ack

--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -131,7 +131,7 @@
   :_  state
   :_  cards
   :+  %give  %fact
-  :+  `[%local-pages path]
+  :+  [%local-pages path]~
     %link-update
   !>([%local-pages path [page]~])
 ::  +hear-submission: record page someone else saved
@@ -154,7 +154,7 @@
   :_  state
   :_  ~
   :+  %give  %fact
-  :+  `[%submissions path]
+  :+  [%submissions path]~
     %link-update
   !>([%submissions path [submission]~])
 ::

--- a/pkg/arvo/app/permission-hook.hoon
+++ b/pkg/arvo/app/permission-hook.hoon
@@ -140,7 +140,7 @@
         ==
       ::  delete the permission path and its subscriptions from this hook.
       ::
-      :-  :-  [%give %kick `[%permission path.act] ~]
+      :-  :-  [%give %kick [%permission path.act]~ ~]
           (leave-permission path.act)
       %_  state
         synced  (~(del by synced) path.act)
@@ -278,7 +278,7 @@
   ^-  (list card)
   %+  turn  ~(tap in access-paths)
   |=  access-path=path
-  [%give %kick `[%permission access-path] `check-ship]
+  [%give %kick [%permission access-path]~ `check-ship]
 ::
 ++  permission-scry
   |=  pax=path
@@ -313,7 +313,7 @@
 ++  update-subscribers
   |=  [=path upd=permission-update]
   ^-  card
-  [%give %fact `path %permission-update !>(upd)]
+  [%give %fact ~[path] %permission-update !>(upd)]
 ::
 ++  leave-permission
   |=  =path

--- a/pkg/arvo/app/permission-store.hoon
+++ b/pkg/arvo/app/permission-store.hoon
@@ -184,7 +184,7 @@
 ++  update-subscribers
   |=  [pax=path upd=permission-update]
   ^-  (list card)
-  [%give %fact `pax %permission-update !>(upd)]~
+  [%give %fact ~[pax] %permission-update !>(upd)]~
 ::
 ++  send-diff
   |=  [pax=path upd=permission-update]

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -730,15 +730,15 @@
 ++  affection-primary
   |=  del=delta
   ^-  (list card)
-  [%give %fact `/primary %publish-rumor !>(del)]~
+  [%give %fact ~[/primary] %publish-rumor !>(del)]~
 ::  +affection: rumors to interested
 ::
 ++  affection
   |=  del=delta
   ^-  (list card)
   =/  wir=wire  /collection/[col.del]
-  :~  [%give %fact `/primary %publish-rumor !>(del)]
-      [%give %fact `wir %publish-rumor !>(del)]
+  :~  [%give %fact ~[/primary] %publish-rumor !>(del)]
+      [%give %fact ~[wir] %publish-rumor !>(del)]
   ==
 ::
 ++  get-post-by-index
@@ -1263,7 +1263,7 @@
     =/  upd=update  [%invite %.y src.bol coll.act title.act]
     :_  state
     %+  welp  make-tile-moves
-    [%give %fact `/primary %publish-update !>(upd)]~
+    [%give %fact ~[/primary] %publish-update !>(upd)]~
   ::
   ::  %reject-invite: remove invite from list, acceptance is handled by
   ::                  %subscribe action
@@ -1276,7 +1276,7 @@
     =/  upd=update  [%invite %.n who.act coll.act u.title]
     :_  state
     %+  welp  make-tile-moves
-    [%give %fact `/primary %publish-update !>(upd)]~
+    [%give %fact ~[/primary] %publish-update !>(upd)]~
   ::
   ::  %serve:
   ::
@@ -1406,7 +1406,7 @@
       [%pass wir %agent [who.act %publish] %watch wir]~
       ?~  title  ~
       =/  upd=update  [%invite %.n who.act coll.act u.title]
-      [%give %fact `/primary %publish-update !>(upd)]~
+      [%give %fact ~[/primary] %publish-update !>(upd)]~
     ==
   ::
   ::  %unsubscribe: unsub from a foreign blog, delete all state related to it
@@ -1435,7 +1435,7 @@
     :-  [%pass wir %agent [who.act %publish] %leave ~]
     %+  welp  make-tile-moves
     =/  rum=rumor  [%remove who.act coll.act ~]
-    [%give %fact `/primary %publish-rumor !>(rum)]~
+    [%give %fact ~[/primary] %publish-rumor !>(rum)]~
   ::
   ::  %read: notify that we've seen a post
   ::
@@ -1445,7 +1445,7 @@
     %+  welp  make-tile-moves
     ::
     =/  upd=update  [%unread %.n (sy [who.act coll.act post.act] ~)]
-    [%give %fact `/primary %publish-update !>(upd)]~
+    [%give %fact ~[/primary] %publish-update !>(upd)]~
   ::
   ==
 ::
@@ -1597,7 +1597,7 @@
 ::
 ++  make-tile-moves
   ^-  (list card)
-  [%give %fact `/publishtile %json !>(make-tile-json)]~
+  [%give %fact ~[/publishtile] %json !>(make-tile-json)]~
 ::
 ++  make-tile-json
   ^-  json

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -1,5 +1,3 @@
-::  Thread manager
-::
 /-  spider
 /+  libstrand=strand, default-agent, verb
 =,  strand=strand:libstrand
@@ -127,9 +125,6 @@
     |-  ^-  (quip card _this)
     ?~  yarns
       `this
-    ?.  ?=([@ ~] i.yarns)
-      $(yarns t.yarns)
-    ~|  killing=i.yarns
     =^  cards-1  state
       (handle-stop-thread:sc (yarn-to-tid i.yarns) |)
     =^  cards-2  this
@@ -139,8 +134,6 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?:  ?=(%spider-kill mark)
-      (on-load on-save)
     =^  cards  state
       ?+  mark  (on-poke:def mark vase)
         %spider-input  (on-poke-input:sc !<(input vase))
@@ -357,15 +350,12 @@
     ^-  ^card
     ?+  card  card
         [%pass * *]  [%pass [%thread tid p.card] q.card]
-        [%give %fact *]
-      ?~  path.p.card
-        card
-      card(path.p `[%thread tid u.path.p.card])
-    ::
-        [%give %kick *]
-      ?~  path.p.card
-        card
-      card(path.p `[%thread tid u.path.p.card])
+        [%give ?(%fact %kick) *]
+      =-  card(paths.p -)
+      %+  turn  paths.p.card
+      |=  =path
+      ^-  ^path
+      [%thread tid path]
     ==
   =.  cards  (weld cards cards.r)
   =^  final-cards=(list card)  state
@@ -391,13 +381,14 @@
 ++  thread-say-fail
   |=  [=tid =term =tang]
   ^-  (list card)
-  :~  [%give %fact `/thread-result/[tid] %thread-fail !>([term tang])]
-      [%give %kick `/thread-result/[tid] ~]
+  :~  [%give %fact ~[/thread-result/[tid]] %thread-fail !>([term tang])]
+      [%give %kick ~[/thread-result/[tid]] ~]
   ==
 ::
 ++  thread-fail
   |=  [=yarn =term =tang]
   ^-  (quip card ^state)
+  %-  (slog leaf+"strand {<yarn>} failed" leaf+<term> tang)
   =/  =tid  (yarn-to-tid yarn)
   =/  fail-cards  (thread-say-fail tid term tang)
   =^  cards  state  (thread-clean yarn)
@@ -409,8 +400,8 @@
   ::  %-  (slog leaf+"strand {<yarn>} finished" (sell vase) ~)
   =/  =tid  (yarn-to-tid yarn)
   =/  done-cards=(list card)
-    :~  [%give %fact `/thread-result/[tid] %thread-done vase]
-        [%give %kick `/thread-result/[tid] ~]
+    :~  [%give %fact ~[/thread-result/[tid]] %thread-done vase]
+        [%give %kick ~[/thread-result/[tid]] ~]
     ==
   =^  cards  state  (thread-clean yarn)
   [(weld done-cards cards) state]

--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -135,7 +135,7 @@
     currently+(~(got by p.u.ujon) 'currently')
     daily+(~(got by p.u.ujon) 'daily')
   ==
-  :-  [%give %fact `/weathertile %json !>(jon)]~
+  :-  [%give %fact ~[/weathertile] %json !>(jon)]~
   %=  state
     data  jon
     time  now.bol

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -291,7 +291,7 @@
   ?~  biz  (flop moz)
   :_  (flop moz)
   =/  =dill-blit:dill  ?~(t.biz i.biz [%mor (flop biz)])
-  [%give %fact `/drum %dill-blit !>(dill-blit)]
+  [%give %fact ~[/drum] %dill-blit !>(dill-blit)]
 ::
 ++  se-adit                                           ::  update servers
   ^+  .
@@ -478,7 +478,7 @@
 ::
 ++  se-blit-sys                                       ::  output to system
   |=  bil/dill-blit:dill  ^+  +>
-  (se-emit %give %fact `/drum %dill-blit !>(bil))
+  (se-emit %give %fact ~[/drum] %dill-blit !>(bil))
 ::
 ++  se-show                                           ::  show buffer, raw
   |=  lin/(pair @ud stub)

--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -49,9 +49,9 @@
       [%http-response-header !>(response-header.simple-payload)]
     =/  data-cage
       [%http-response-data !>(data.simple-payload)]
-    :~  [%give %fact `/http-response/[eyre-id] header-cage]
-        [%give %fact `/http-response/[eyre-id] data-cage]
-        [%give %kick `/http-response/[eyre-id] ~]
+    :~  [%give %fact ~[/http-response/[eyre-id]] header-cage]
+        [%give %fact ~[/http-response/[eyre-id]] data-cage]
+        [%give %kick ~[/http-response/[eyre-id]] ~]
     ==
   --
 ++  gen

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -54,7 +54,7 @@
 ++  state
   $:  :: state version
       ::
-      %2
+      %3
       :: agents by ship
       ::
       =agents
@@ -904,7 +904,7 @@
           %give
         =/  =gift:agent  p.card
         ?:  ?=(%kick -.gift)
-          =/  ducts=(list duct)  (ap-ducts-from-path path.gift ship.gift)
+          =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ship.gift)
           %+  turn  ducts
           |=  =duct
           ~?  &(=(duct system-duct.agents.state) !=(agent-name %hood))
@@ -914,7 +914,7 @@
         ?.  ?=(%fact -.gift)
           [agent-duct %give %unto gift]~
         ::
-        =/  ducts=(list duct)  (ap-ducts-from-path path.gift ~)
+        =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ~)
         =/  =cage  cage.gift
         %+  turn  ducts
         |=  =duct
@@ -1010,6 +1010,17 @@
     ::
     ++  ap-agent-core
       ~(. agent.current-agent ap-construct-bowl)
+    ::  +ap-ducts-from-paths: get ducts subscribed to paths
+    ::
+    ++  ap-ducts-from-paths
+      |=  [target-paths=(list path) target-ship=(unit ship)]
+      ^-  (list duct)
+      ?:  &(?=(~ target-paths) ?=(~ target-ship))
+        ~[agent-duct]
+      %-  zing
+      %+  turn  target-paths
+      |=  =path
+      (ap-ducts-from-path `path target-ship)
     ::  +ap-ducts-from-path: get ducts subscribed to path
     ::
     ++  ap-ducts-from-path
@@ -1567,16 +1578,177 @@
   =?  all-state  ?=(%1 -.all-state)
     (state-1-to-2 all-state)
   ::
-  ?>  ?=(%2 -.all-state)
+  =?  all-state  ?=(%2 -.all-state)
+    (state-2-to-3 all-state)
+  ::
+  ?>  ?=(%3 -.all-state)
   gall-payload(state all-state)
   ::
   ::  +all-state: upgrade path
   ::
-  ++  all-state  $%(state-0 state-1 ^state)
+  ++  all-state  $%(state-0 state-1 state-2 ^state)
+  ::
+  ++  state-2-to-3
+    |=  =state-2
+    ^-  ^state
+    %=    state-2
+        -  %3
+        running.agents-2
+      %-  ~(run by running.agents-2.state-2)
+      |=  =running-agent-2
+      ^-  running-agent
+      %=  running-agent-2
+        agent-2  (agent-2-to-3 agent-2.running-agent-2)
+      ==
+    ==
+  ::
+  ++  agent-2-to-3
+    |=  =agent-2
+    ^-  agent
+    =>  |%
+        ++  cards-2-to-3
+          |=  cards=(list card:^agent-2)
+          ^-  (list card:agent)
+          %+  turn  cards
+          |=  =card:^agent-2
+          ^-  card:agent
+          ?.  ?=([%give ?(%fact %kick) *] card)  card
+          %=(card path.p (drop path.p.card))
+        --
+    |_  =bowl:gall
+    +*  this  .
+        pass  ~(. agent-2 bowl)
+    ++  on-init
+      =^  cards  agent-2  on-init:pass
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-save
+      on-save:pass
+    ::
+    ++  on-load
+      |=  old-state=vase
+      =^  cards  agent-2  (on-load:pass old-state)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-poke
+      |=  [=mark =vase]
+      =^  cards  agent-2  (on-poke:pass mark vase)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-watch
+      |=  =path
+      =^  cards  agent-2  (on-watch:pass path)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-leave
+      |=  =path
+      =^  cards  agent-2  (on-leave:pass path)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-peek
+      |=  =path
+      (on-peek:pass path)
+    ::
+    ++  on-agent
+      |=  [=wire =sign:agent:gall]
+      =^  cards  agent-2  (on-agent:pass wire sign)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-arvo
+      |=  [=wire =sign-arvo]
+      =^  cards  agent-2  (on-arvo:pass wire sign-arvo)
+      [(cards-2-to-3 cards) this]
+    ::
+    ++  on-fail
+      |=  [=term =tang]
+      =^  cards  agent-2  (on-fail:pass term tang)
+      [(cards-2-to-3 cards) this]
+    --
+  ::
+  ++  state-2
+    $:  %2
+        =agents-2
+    ==
+  ::
+  ++  agents-2
+    $:  system-duct=duct
+        outstanding=(map [wire duct] (qeu remote-request))
+        contacts=(set ship)
+        running=(map term running-agent-2)
+        blocked=(map term blocked)
+    ==
+  ::
+  ++  running-agent-2
+    $:  cache=worm
+        control-duct=duct
+        live=?
+        =stats
+        =subscribers
+        =agent-2
+        =beak
+        marks=(map duct mark)
+    ==
+  ::
+  ++  agent-2
+    =<  form
+    |%
+    +$  step  (quip card form)
+    +$  card  (wind note gift)
+    +$  note  note:agent
+    +$  task  task:agent
+    +$  sign  sign:agent
+    +$  gift
+      $%  [%fact path=(unit path) =cage]
+          [%kick path=(unit path) ship=(unit ship)]
+          [%watch-ack p=(unit tang)]
+          [%poke-ack p=(unit tang)]
+      ==
+    ++  form
+      $_  ^|
+      |_  bowl
+      ++  on-init
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-save
+        *vase
+      ::
+      ++  on-load
+        |~  old-state=vase
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-poke
+        |~  [mark vase]
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-watch
+        |~  path
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-leave
+        |~  path
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-peek
+        |~  path
+        *(unit (unit cage))
+      ::
+      ++  on-agent
+        |~  [wire sign]
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-arvo
+        |~  [wire sign-arvo]
+        *(quip card _^|(..on-init))
+      ::
+      ++  on-fail
+        |~  [term tang]
+        *(quip card _^|(..on-init))
+      --
+    --
   ::
   ++  state-1-to-2
     |=  =state-1
-    ^-  ^state
+    ^-  state-2
     %=    state-1
         -           %2
         +.agents-1  [~ +.agents-1.state-1]
@@ -1590,7 +1762,7 @@
   ++  agents-1
     $:  system-duct=duct
         contacts=(set ship)
-        running=(map term running-agent)
+        running=(map term running-agent-2)
         blocked=(map term blocked)
     ==
   ::
@@ -1602,7 +1774,7 @@
         running.agents-0
       %-  ~(run by running.agents-0.state-0)
       |=  =running-agent-0
-      ^-  running-agent
+      ^-  running-agent-2
       %=  running-agent-0
         agent-0  (agent-0-to-1 agent-0.running-agent-0)
       ==
@@ -1610,7 +1782,7 @@
   ::
   ++  agent-0-to-1
     |=  =agent-0
-    ^-  agent
+    ^-  agent-2
     |_  =bowl:gall
     +*  this  .
         pass  ~(. agent-0 bowl)
@@ -1692,7 +1864,7 @@
     +$  card  (wind note gift)
     +$  note  note:agent
     +$  task  task:agent
-    +$  gift  gift:agent
+    +$  gift  gift:agent-2
     +$  sign  sign:agent
     ++  form
       $_  ^|

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1887,8 +1887,8 @@
           [%poke-as =mark =cage]
       ==
     +$  gift
-      $%  [%fact path=(unit path) =cage]
-          [%kick path=(unit path) ship=(unit ship)]
+      $%  [%fact paths=(list path) =cage]
+          [%kick paths=(list path) ship=(unit ship)]
           [%watch-ack p=(unit tang)]
           [%poke-ack p=(unit tang)]
       ==

--- a/pkg/arvo/ted/azimuth-tracker.hoon
+++ b/pkg/arvo/ted/azimuth-tracker.hoon
@@ -120,8 +120,8 @@
     (pure:m ~)
   =/  =path  /(scot %p ship.i.udiffs)
   =/  cards
-    :~  [%give %fact `/ %azimuth-udiff !>(i.udiffs)]
-        [%give %fact `path %azimuth-udiff !>(i.udiffs)]
+    :~  [%give %fact ~[/] %azimuth-udiff !>(i.udiffs)]
+        [%give %fact ~[path] %azimuth-udiff !>(i.udiffs)]
     ==
   ;<  ~  bind:m  (send-raw-cards:strandio cards)
   loop(udiffs t.udiffs)


### PR DESCRIPTION
As discussed with @philipcmonk.

Instead of providing a `(unit path)`, allows for `(list path)`, which better supports the "update to path and subpath" cases.

For example, if `/things` wants updates about everything, and `/things/specific` wants updates about the specific thing, they'll both need to receive a `%fact` when the specific thing changes.
Previously, these would have been two separate moves. Now, gall handles the multi-targeting for you.

This seems to apply fine on top of ships with the previous gall version. Lots of userspace files give compile errors prior to `goad: recompiling all apps`, but that itself completes silently. Pretty sure this is known and harmless.