### PR TITLE
chat-cli: reconnect with actual bowl

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -122,7 +122,7 @@
       ?-    -.sign
           %poke-ack   [- all-state]:(on-agent:def wire sign)
           %watch-ack  [- all-state]:(on-agent:def wire sign)
-          %kick       [?:(?=([%chat-store ~] wire) ~[connect] ~) all-state]
+          %kick       [?:(?=([%chat-store ~] wire) ~[connect:tc] ~) all-state]
           %fact
         ?+  p.cage.sign  ~|([%chat-cli-bad-sub-mark wire p.cage.sign] !!)
           %chat-update  (diff-chat-update:tc wire !<(chat-update q.cage.sign))


### PR DESCRIPTION
This, uh, fell into the same old case of using an arm from a `|_` without initializing that core with a sample first. In this case, that resulted in the `bowl` in `connect` being the default bowl here. This is fine for `~zod`, since it's the default ship, but gives incorrect behavior for anyone else.

(This is what I get for self-merging #2128 without review.)