### PR TITLE
invite-hook: fixed incorrect assertion about outgoing invites

### DIFF
--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -54,7 +54,7 @@
       ?:  (team:title our.bowl src.bowl)
         ::  outgoing. we must be inviting another ship. send them the invite.
         ::
-        ?>  !(team:title our.bowl ship.invite.act)
+        ?>  !(team:title our.bowl recipient.invite.act)
         [(invite-hook-poke:do recipient.invite.act act)]~
       ::  else incoming. ensure invitatory exists and invite is not a duplicate.
       ::


### PR DESCRIPTION
Discovered this while tracking down bugs in the invite flow of the new publish app. Looks like this codepath is not actually hit in chat because the frontend pokes json directly, without passing it through the invite-action mark.