### PR TITLE
lens: don't prematurely flush state

### DIFF
--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -94,7 +94,8 @@
     ::
         %fact
       =^  cards  this  (take-export !<(* q.cage.sign))
-      :_  this  :_  cards
+      :_  this(job.state ~)
+      :_  cards
       ?>  ?=(^ job.state)
       ?>  ?=(%export -.source.com.u.job.state)
       [%pass /export %agent [our.bowl app.source.com.u.job.state] %leave ~]
@@ -135,7 +136,7 @@
       =/  enc  (en:base64 octs)
       (pairs:enjs:format file+s+output data+s+enc ~)
     ::
-    :_  this(job.state ~)
+    :_  this
     %+  give-simple-payload:app  eyre-id.u.job.state
     (json-response:gen (json-to-octs jon))
   ::


### PR DESCRIPTION
Flushing the state in the +take-export arm causes the assertion to fail on line 98. So flush it after instead.