### PR TITLE
ames: actually maintain direct routes

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db17380940f4f10dab139b385cf5f752282e069b290cdb5255c8510e5cc36ea7
-size 14122439
+oid sha256:c7473fe654d5f3fd04207e9da559bceaf89899f04e9f3897704c4ffc29c90ba9
+size 9617890

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1418,10 +1418,15 @@
     ?>  =(rcvr-life.shut-packet our-life.channel)
     ::  non-galaxy: update route with heard lane or forwarded lane
     ::
-    =?  route.peer-state
-        ?&  !=(%czar (clan:title her.channel))
-            !=([~ %& *] route.peer-state)
-        ==
+    =?    route.peer-state
+        ?:  =(%czar (clan:title her.channel))
+          %.n
+        =/  is-old-direct=?  ?=([~ %& *] route.peer-state)
+        =/  is-new-direct=?  ?=(~ origin.packet)
+        ::  old direct takes precedence over new indirect
+        ::
+        |(is-new-direct !is-old-direct)
+      ::
       ?~  origin.packet
         `[direct=%.y lane]
       `[direct=%.n u.origin.packet]


### PR DESCRIPTION
There was a typo in the routing logic that was comparing equality against a value where it should have been doing a pattern match.  The value compared against contained the literal `*` gate, which would never match `route.peer-state`, so this condition was always true, meaning the fix that had added this  extra condition (https://github.com/urbit/urbit/commit/5406f0609273fa4db1bd84bf600a401d1c114ae2#) did not actually change the behavior from what it been previously.

If only this had caused a type error ...