### PR TITLE
u3: clear cached mugs on cell edit

### DIFF
--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -329,6 +329,7 @@ _mutate_cat(u3_noun big, c3_l axe_l, u3_noun som)
         *tar = _edit_or_mutate_cat(*tar, u3x_mas(axe_l), som);
       }
     }
+    cel_u->mug_w = 0;
   }
 }
 
@@ -348,6 +349,7 @@ _mutate(u3_noun big, u3_noun axe, u3_noun som)
                  ? &(cel_u->hed)
                  : &(cel_u->tel);
     *tar = _edit_or_mutate(*tar, mor, som);
+    cel_u->mug_w = 0;
     u3z(mor);
   }
 }


### PR DESCRIPTION
This PR fixes a bug wherein cached mugs were wrongfully retained on editing cells, producing a jet mismatch in `+mug`. @eglaysher found the mismatched values while tracking down a potentially related bug in jaque.

The extent of the impact of fixing this bug is not yet clear; many things depend on mugs, and it's possible that something was depending on a (deterministically) wrong mug. More testing will be required before these changes can be released.

/cc @frodwith 