### PR TITLE
vere: fixes Makefile test-runner, exiting on failed test

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -33,7 +33,12 @@ CFLAGS := $(CFLAGS)
 all: $(all_exes)
 
 test: $(test_exes)
-	for x in $^; do echo "\n$$x" && ./$$x; done
+	@FAIL=0;                                         \
+	for x in $^;                                     \
+	do echo "\n$$x" && ./$$x;                        \
+	if [ $$? != 0 ]; then FAIL=1; fi;                \
+	done;                                            \
+	if [ $$FAIL != 0 ]; then echo "\n" && exit 1; fi;
 
 clean:
 	rm -f ./tags $(all_objs) $(all_exes)


### PR DESCRIPTION
This continues to run all vere tests, as before, but now sets a non-zero exit code on test failure.