### PR TITLE
vere: cleanup resources on exit

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -13,6 +13,9 @@
 #include <termios.h>
 #include <ncurses/term.h>
 #include <dirent.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+#include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <h2o.h>
 #include <curl/curl.h>
@@ -744,12 +747,27 @@ main(c3_i   argc,
       }
     }
 
-    /*  Initialize OpenSSL for client and server
-    */
-    SSL_library_init();
-    SSL_load_error_strings();
+    //  Initialize OpenSSL for client and server
+    //
+    {
+      SSL_library_init();
+      SSL_load_error_strings();
+    }
 
     u3_daemon_commence();
+
+    //  uninitialize OpenSSL
+    //
+    //    see https://wiki.openssl.org/index.php/Library_Initialization
+    //
+    {
+      ENGINE_cleanup();
+      CONF_modules_unload(1);
+      EVP_cleanup();
+      CRYPTO_cleanup_all_ex_data();
+      SSL_COMP_free_compression_methods();
+      ERR_free_strings();
+    }
   }
 
   return 0;

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -754,7 +754,18 @@ main(c3_i   argc,
       SSL_load_error_strings();
     }
 
+    //  initialize curl
+    //
+    if ( 0 != curl_global_init(CURL_GLOBAL_DEFAULT) ) {
+      u3l_log("boot: curl initialization failed\r\n");
+      exit(1);
+    }
+
     u3_daemon_commence();
+
+    //  uninitialize curl
+    //
+    curl_global_cleanup();
 
     //  uninitialize OpenSSL
     //

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -231,7 +231,8 @@
     */
       typedef struct _u3_cttp {
         u3_creq*         ceq_u;             //  request list
-        h2o_http1client_ctx_t*              //
+        h2o_timeout_t    tim_u;             //  request timeout
+        h2o_http1client_ctx_t               //
                          ctx_u;             //  h2o client ctx
         void*            tls_u;             //  client SSL_CTX*
       } u3_cttp;

--- a/pkg/urbit/vere/ames.c
+++ b/pkg/urbit/vere/ames.c
@@ -576,7 +576,6 @@ u3_ames_io_exit(u3_pier* pir_u)
   u3_ames* sam_u = pir_u->sam_u;
 
   if ( c3y == sam_u->liv ) {
-    // XX remove had_u/wax_u union, cast and close wax_u
     uv_close(&sam_u->had_u, 0);
   }
 }

--- a/pkg/urbit/vere/behn.c
+++ b/pkg/urbit/vere/behn.c
@@ -31,6 +31,8 @@ u3_behn_io_init(u3_pier *pir_u)
 void
 u3_behn_io_exit(u3_pier *pir_u)
 {
+  u3_behn* teh_u = pir_u->teh_u;
+  uv_close((uv_handle_t*)&teh_u->tim_u, 0);
 }
 
 /* _behn_time_cb(): timer callback.

--- a/pkg/urbit/vere/cttp.c
+++ b/pkg/urbit/vere/cttp.c
@@ -835,7 +835,7 @@ _cttp_creq_connect(u3_creq* ceq_u)
                ( c3y == ceq_u->sec ) ? 443 : 80;
 
   // connect by IP
-  h2o_http1client_connect(&ceq_u->cli_u, ceq_u, u3_Host.ctp_u.ctx_u, ipf_u,
+  h2o_http1client_connect(&ceq_u->cli_u, ceq_u, &u3_Host.ctp_u.ctx_u, ipf_u,
                           por_s, c3y == ceq_u->sec, _cttp_creq_on_connect);
 
   // set hostname for TLS handshake
@@ -947,22 +947,6 @@ _cttp_init_tls()
   return tls_u;
 }
 
-/* _cttp_init_h2o: initialize h2o client ctx and timeout
-*/
-static h2o_http1client_ctx_t*
-_cttp_init_h2o()
-{
-  h2o_timeout_t* tim_u = c3_malloc(sizeof(*tim_u));
-
-  h2o_timeout_init(u3L, tim_u, 300 * 1000);
-
-  h2o_http1client_ctx_t* ctx_u = c3_calloc(sizeof(*ctx_u));
-  ctx_u->loop = u3L;
-  ctx_u->io_timeout = tim_u;
-
-  return ctx_u;
-};
-
 /* u3_cttp_ef_http_client(): send an %http-client (outgoing request) to cttp.
 */
 void
@@ -1011,9 +995,26 @@ u3_cttp_ef_bake()
 void
 u3_cttp_io_init()
 {
+  //  zero-initialize h2o ctx
+  //
+  memset(&u3_Host.ctp_u.ctx_u, 0, sizeof(u3_Host.ctp_u.ctx_u));
+
+  //  link to event loop
+  //
+  u3_Host.ctp_u.ctx_u.loop = u3L;
+
+  //  link to initialized request timeout
+  //
+  h2o_timeout_init(u3L, &u3_Host.ctp_u.tim_u, 300 * 1000);
+  u3_Host.ctp_u.ctx_u.io_timeout = &u3_Host.ctp_u.tim_u;
+
+  //  link to initialized tls ctx
+  //
   u3_Host.ctp_u.tls_u = _cttp_init_tls();
-  u3_Host.ctp_u.ctx_u = _cttp_init_h2o();
-  u3_Host.ctp_u.ctx_u->ssl_ctx = u3_Host.ctp_u.tls_u;
+  u3_Host.ctp_u.ctx_u.ssl_ctx = u3_Host.ctp_u.tls_u;
+
+  //  zero-initialize request list
+  //
   u3_Host.ctp_u.ceq_u = 0;
 }
 
@@ -1022,7 +1023,19 @@ u3_cttp_io_init()
 void
 u3_cttp_io_exit(void)
 {
-    SSL_CTX_free(u3_Host.ctp_u.tls_u);
-    c3_free(u3_Host.ctp_u.ctx_u->io_timeout);
-    c3_free(u3_Host.ctp_u.ctx_u);
+  //  cancel requests
+  //
+  {
+    u3_creq* ceq_u = u3_Host.ctp_u.ceq_u;
+
+    while ( ceq_u ) {
+      _cttp_creq_quit(ceq_u);
+      ceq_u = ceq_u->nex_u;
+    }
+  }
+
+  //  dispose of global resources
+  //
+  h2o_timeout_dispose(u3L, &u3_Host.ctp_u.tim_u);
+  SSL_CTX_free(u3_Host.ctp_u.tls_u);
 }

--- a/pkg/urbit/vere/daemon.c
+++ b/pkg/urbit/vere/daemon.c
@@ -928,8 +928,8 @@ u3_daemon_commence()
     }
   }
 
-  /* listen on command socket
-  */
+  //  listen on command socket
+  //
   {
     c3_c buf_c[256];
 
@@ -948,7 +948,6 @@ u3_daemon_commence()
   uv_run(u3L, UV_RUN_DEFAULT);
 
   _daemon_loop_exit();
-  exit(0);
 }
 
 /* u3_daemon_bail(): immediately shutdown.

--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -1764,14 +1764,15 @@ u3_http_io_talk(void)
 void
 u3_http_io_exit(void)
 {
-  // Note: nothing in this codepath can print to uH!
-  // it will seriously mess up your terminal
+  //  dispose of configuration to avoid restarts
+  //
+  _http_form_free();
 
-  // u3_http* htp_u;
-
-  // for ( htp_u = u3_Host.htp_u; htp_u; htp_u = htp_u->nex_u ) {
-  //   _http_serv_close_hard(htp_u);
-  // }
+  //  close all servers
+  //
+  for ( u3_http* htp_u = u3_Host.htp_u; htp_u; htp_u = htp_u->nex_u ) {
+    _http_serv_close(htp_u);
+  }
 
   // XX close u3_Host.fig_u.cli_u and con_u
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1261,16 +1261,16 @@ _pier_loop_exit(u3_pier* pir_u)
   //  XX legacy handlers, not yet scoped to a pier
   //
   {
-    cod_l = u3a_lush(c3__term);
-    u3_term_io_exit();
-    u3a_lop(cod_l);
-
     cod_l = u3a_lush(c3__http);
     u3_http_io_exit();
     u3a_lop(cod_l);
 
     cod_l = u3a_lush(c3__cttp);
     u3_cttp_io_exit();
+    u3a_lop(cod_l);
+
+    cod_l = u3a_lush(c3__term);
+    u3_term_io_exit();
     u3a_lop(cod_l);
   }
 }

--- a/pkg/urbit/vere/save.c
+++ b/pkg/urbit/vere/save.c
@@ -63,4 +63,6 @@ u3_save_io_init(u3_pier *pir_u)
 void
 u3_save_io_exit(u3_pier *pir_u)
 {
+  u3_save* sav_u = pir_u->sav_u;
+  uv_close((uv_handle_t*)&sav_u->tim_u, 0);
 }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -850,6 +850,10 @@ _worker_poke_exit(c3_w cod_w)                 //  exit code
     }
   }
 
+  //  XX move to jets.c
+  //
+  c3_free(u3D.ray_u);
+
   exit(cod_w);
 }
 


### PR DESCRIPTION
These changes properly un/initialize openssl and curl. And fill out the i/o driver exit handlers, removing unnecessary dynamic allocations along the way. I made these changes to remove noise from valgrind. More to come on the tooling/testing front ...