### PR TITLE
vere: adds support for ASan

### DIFF
--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -17,16 +17,27 @@
   **/
     /* Assert.  Good to capture.
     */
-#     define c3_assert(x)                       \
-        do {                                    \
-          if (!(x)) {                           \
-            fprintf(stderr, "\rAssertion '%s' " \
-                    "failed in %s:%d\n",        \
-                    #x, __FILE__, __LINE__);    \
-            c3_cooked();                        \
-            assert(x);                          \
-          }                                     \
-        } while(0)
+
+#     if defined(ASAN_ENABLED) && defined(__clang__)
+#       define c3_assert(x)                       \
+          do {                                    \
+            if (!(x)) {                           \
+              c3_cooked();                        \
+              assert(x);                          \
+            }                                     \
+          } while(0)
+#     else
+#       define c3_assert(x)                       \
+          do {                                    \
+            if (!(x)) {                           \
+              fprintf(stderr, "\rAssertion '%s' " \
+                      "failed in %s:%d\n",        \
+                      #x, __FILE__, __LINE__);    \
+              c3_cooked();                        \
+              assert(x);                          \
+            }                                     \
+          } while(0)
+#endif
 
     /* Stub.
     */

--- a/pkg/urbit/include/c/portable.h
+++ b/pkg/urbit/include/c/portable.h
@@ -74,14 +74,29 @@
 
 #   else
       #error "port: headers"
+#   endif
 
+#   ifndef __has_feature
+#     define __has_feature(x) 0
+#   endif
+
+#   if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#     define ASAN_ENABLED
 #   endif
 
   /** Address space layout.
   **/
 #   if defined(U3_OS_linux)
-#     define U3_OS_LoomBase 0x36000000
-#     define U3_OS_LoomBits 29              //  ie, 2^29 words == 2GB
+#     ifdef __LP64__
+#       ifdef ASAN_ENABLED
+#         define U3_OS_LoomBase 0x10007ffff000
+#       else
+#         define U3_OS_LoomBase 0x200000000
+#       endif
+#     else
+#       define U3_OS_LoomBase 0x36000000
+#     endif
+#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
 #   elif defined(U3_OS_osx)
 #     ifdef __LP64__
 #       define U3_OS_LoomBase 0x200000000

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -472,7 +472,6 @@ u3i_list(u3_weak one, ...);
     return cut_t ? cut_w : i_w;
   }
 
-  __attribute__((no_sanitize_address))
   static u3_noun                            //  transfer
   _molt_apply(u3_noun            som,       //  retain
               c3_w               len_w,
@@ -498,7 +497,6 @@ u3i_list(u3_weak one, ...);
     }
   }
 
-__attribute__((no_sanitize_address))
 u3_noun
 u3i_molt(u3_noun som, ...)
 {

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1535,6 +1535,7 @@ _cm_limits(void)
 
   // Moar core.
   //
+# ifndef ASAN_ENABLED
   {
     getrlimit(RLIMIT_CORE, &rlm);
     rlm.rlim_cur = RLIM_INFINITY;
@@ -1545,6 +1546,7 @@ _cm_limits(void)
       u3l_log("boot: core limit: %s\r\n", strerror(errno));
     }
   }
+# endif
 }
 
 /* _cm_signals(): set up interrupts, etc.

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -161,7 +161,6 @@ u3r_at(u3_atom a, u3_noun b)
     }
   }
 
-__attribute__((no_sanitize_address))
 c3_o
 u3r_vmean(u3_noun som, va_list ap)
 {


### PR DESCRIPTION
- moves the loom base pointer on linux-64 (thereby also supporting valgrind)
- fixes a compilation issue in c3_assert (something about inlining and fprintf)
- skips core dump ulimit increase (ASan uses tons of memory)
- removes obsolete `no_sanitize_address` attributes

This PR is just the bare minimum to be able to use ASan and Valgrind. I intend to enable ASan in CI, the only remaining obstacles are threading the build and test config through nix. In the meantime, these tools can now be used locally.

------

To use this, build vere directly from within nix-shell:

```
cd pkg/urbit
nix-shell
CFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Wno-macro-redefined" LDFLAGS="-fsanitize=address -fno-omit-frame-pointer -Wno-macro-redefined" ./configure 
make -j 8
export ASAN_OPTIONS="detect_leaks=1:allow_user_segv_handler=1"
./build/urbit -F zod
```

`allow_user_segv_handler` is on by default for MacOS (or at least clang), and `detect_leaks` is on by default for Linux (or at least gcc). It can also be convenient to log ASan output to a separate file:

```
export ASAN_OPTIONS="detect_leaks=1:allow_user_segv_handler=1:log_path=./asan.log"
```

To run under valgrind:

```
cd pkg/urbit
nix-shell
CFLAGS="-g -O1" ./configure 
make -j 8
valgrind --leak-check=full --error-limit=no --undef-value-errors=no --gen-suppressions=all --log-file=./valgrind.log ./build/urbit -F zod
```

The valgrind output is full of noise with `--undef-value-errors=no` due to OpenSSL's internal patterns. Even with that, it's dominated by allocations that are leaked on exit. #2173 helps with many of these, but there's more to be done.