### PR TITLE
nix: enable ASan during tests

### DIFF
--- a/nix/ops/fakeship/builder.sh
+++ b/nix/ops/fakeship/builder.sh
@@ -2,11 +2,19 @@ source $stdenv/setup
 
 set -ex
 
+export ASAN_OPTIONS="detect_leaks=1:allow_user_segv_handler=1:log_path=asan.log"
+
 if [ -z "$ARVO" ]
 then
     $URBIT -d -F $SHIP -B "$PILL" $out
 else
     $URBIT -d -F $SHIP -A "$ARVO" -B "$PILL" $out
+fi
+
+if ! [ -f $out/.vere.lock ]
+then
+    echo "Lockfile missing."
+    exit 1
 fi
 
 check () {
@@ -20,6 +28,22 @@ then
 else
     echo "Boot failure." >&2
     kill $(< $out/.vere.lock) || true
+    exit 1
+fi
+
+while [ -f $out/.vere.lock ]
+do
+    echo "... awaiting exit"
+    sleep 3
+done
+
+if [ -n "$(find . -maxdepth 1 -type f -name 'asan.log.*' -print -quit)" ]
+then
+    for f in ./asan.log.*
+    do
+        echo "    $f:"
+        cat "$f"
+    done
     exit 1
 fi
 

--- a/nix/ops/test/builder.sh
+++ b/nix/ops/test/builder.sh
@@ -55,7 +55,7 @@ herb ./ship -d '~&  ~  ~&  %start-pack  ~'
 herb ./ship -p hood -d '+hood/pack'
 herb ./ship -d '~&  ~  ~&  %finish-pack  ~'
 
-shutdown
+herb ./ship -p hood -d '+hood/exit' || true
 
 while [ -f ship/.vere.lock ]
 do

--- a/nix/pkgs/urbit/builder.sh
+++ b/nix/pkgs/urbit/builder.sh
@@ -8,6 +8,8 @@ bash ./configure
 
 make clean
 make all -j8
+
+export ASAN_OPTIONS="detect_leaks=1:allow_user_segv_handler=1"
 make test
 
 mkdir -p $out/bin

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -33,7 +33,10 @@ let
     # See https://github.com/NixOS/nixpkgs/issues/18995
     hardeningDisable = if debug then [ "all" ] else [];
 
-    CFLAGS           = "-O3 -g -Werror";
+    # CFLAGS           = "-O3 -g -Werror";
+    CFLAGS           = "-g -fsanitize=address -fno-omit-frame-pointer";
+    LDFLAGS          = "-fsanitize=address -fno-omit-frame-pointer";
+
     MEMORY_DEBUG     = debug;
     CPU_DEBUG        = debug;
     EVENT_TIME_DEBUG = false;


### PR DESCRIPTION
This PR enables ASan unconditionally in the relevant nix derivations, so as to run it in CI. The right approach is to parameterize the build and test derivations so that the appropriate flags and environment variables can be threaded through. (I only know how to do that in a dumb, explicit way, so I've held off. Maybe `pkg.overrideAttrs` could help?)

This currently includes merges of various open PRs on which it depends, I'll rebase those out once they're merged.