### PR TITLE
/lib/dbug agent wrapper

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -12,7 +12,7 @@
 /-  *chat-store, *chat-view, *chat-hook,
     *permission-store, *group-store, *invite-store,
     sole-sur=sole
-/+  sole-lib=sole, chat-eval, default-agent, verb,
+/+  sole-lib=sole, chat-eval, default-agent, verb, dbug,
     auto=language-server-complete
 ::
 |%
@@ -70,9 +70,11 @@
 --
 =|  state
 =*  all-state  -
+::
+%-  agent:dbug
+%+  verb  |
+^-  agent:gall
 =<
-  %+  verb  |
-  ^-  agent:gall
   |_  =bowl:gall
   +*  this       .
       talk-core  +>

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -3,7 +3,7 @@
 ::  allow sending chat messages to foreign paths based on write perms
 ::
 /-  *permission-store, *chat-hook, *invite-store
-/+  *chat-json, default-agent, verb
+/+  *chat-json, default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -31,6 +31,8 @@
 --
 =|  state-zero
 =*  state  -
+::
+%-  agent:dbug
 %+  verb  |
 ^-  agent:gall
 =<

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -1,6 +1,6 @@
 :: chat-store: data store that holds linear sequences of chat messages
 ::
-/+  *chat-json, *chat-eval, default-agent
+/+  *chat-json, *chat-eval, default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -21,6 +21,9 @@
 ::
 =|  state-zero
 =*  state  -
+::
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -6,7 +6,7 @@
     *group-store,
     *permission-group-hook,
     *chat-hook
-/+  *server, *chat-json, default-agent
+/+  *server, *chat-json, default-agent, verb, dbug
 /=  index
   /^  octs
   /;  as-octs:mimes:html
@@ -51,6 +51,8 @@
       [%permission-group-hook-action permission-group-hook-action]
   ==
 --
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  bol=bowl:gall

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -1,7 +1,7 @@
 ::  group-hook: allow syncing group data from foreign paths to local paths
 ::
 /-  *group-store, *group-hook
-/+  default-agent
+/+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -19,6 +19,9 @@
 ::
 =|  state-zero
 =*  state  -
+::
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -1,7 +1,7 @@
 ::  group-store: data store for groups of ships
 ::
 /-  *group-store
-/+  default-agent
+/+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -22,6 +22,9 @@
 ::
 =|  state-zero
 =*  state  -
+::
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/permission-hook.hoon
+++ b/pkg/arvo/app/permission-hook.hoon
@@ -5,7 +5,7 @@
 ::    configured for them as `access-control`.
 ::
 /-  *permission-hook
-/+  *permission-json, default-agent
+/+  *permission-json, default-agent, verb, dbug
 ::
 |%
 +$  state
@@ -26,6 +26,8 @@
 =|  state-0
 =*  state  -
 ::
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/permission-store.hoon
+++ b/pkg/arvo/app/permission-store.hoon
@@ -1,7 +1,7 @@
 ::  permission-store: track black- and whitelists of ships
 ::
 /-  *permission-store
-/+  default-agent
+/+  default-agent, verb, dbug
 ::
 |%
 +$  card  card:agent:gall
@@ -17,6 +17,9 @@
 --
 =|  state-zero
 =*  state  -
+::
+%-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -19,11 +19,14 @@
         *
         ::  inline arguments
         ::
-        args=?(~ [=what =about ~])
+        args=?(~ [what=?(%bowl %state) ~] [=what =about ~])
         ::  named arguments
         ::
         ~
     ==
 :-  %dbug
-?~  args  [%bowl *about]
-[what.args about.args]
+?-  args
+  ~        [%bowl *about]
+  [@ ~]    [what.args *about]
+  [@ * ~]  [what about]:args
+==

--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -1,0 +1,29 @@
+::  +dbug: tell /lib/dbug app to print some generic state
+::
+::    :app +dbug
+::      the entire bowl
+::    :app +dbug [direction] [specifics]
+::      all in subs matching the parameters
+::      direction: %incoming or %outgoing
+::      specifics:
+::        [%ship ~ship]  subscriptions to/from this ship
+::        [%path /path]  subscriptions on path containing /path
+::        [%wire /wire]  subscriptions on wire containing /wire
+::        [%term %name]  subscriptions to app %name
+::
+/+  *dbug
+::
+:-  %say
+|=  $:  ::  environment
+        ::
+        *
+        ::  inline arguments
+        ::
+        args=?(~ [=what =about ~])
+        ::  named arguments
+        ::
+        ~
+    ==
+:-  %dbug
+?~  args  [%bowl *about]
+[what.args about.args]

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -1,0 +1,112 @@
+::  dbug: agent wrapper for generic debugging tools
+::
+::    usage: %-(agent:dbug your-agent)
+::
+|%
++$  what
+  $?  %bowl
+      %incoming
+      %outgoing
+  ==
+::
++$  about
+  $%  [%ship =ship]
+      [%path =path]
+      [%wire =wire]
+      [%term =term]
+  ==
+::
+++  agent
+  |=  =agent:gall
+  ^-  agent:gall
+  |_  =bowl:gall
+  +*  this  .
+      ag    ~(. agent bowl)
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card:agent:gall agent:gall)
+    ?.  ?=(%dbug mark)
+      =^  cards  agent  (on-poke:ag mark vase)
+      [cards this]
+    =/  dbug
+      !<([=what =about] vase)
+    =;  out
+      ((slog >out< ~) [~ this])
+    ?-  what.dbug
+      %bowl  bowl
+    ::
+        %incoming
+      %+  murn  ~(tap by sup.bowl)
+      |=  sub=[=duct [=ship =path]]
+      ^-  (unit _sub)
+      =;  relevant=?
+        ?:(relevant `sub ~)
+      ?-  -.about.dbug
+        %ship  =(ship.sub ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path.sub))
+        %wire  %+  lien  duct.sub
+               |=(=wire ?=(^ (find wire.about.dbug wire)))
+        %term  !!
+      ==
+    ::
+        %outgoing
+      %+  murn  ~(tap by wex.bowl)
+      |=  sub=[[=wire =ship =term] [acked=? =path]]
+      ^-  (unit _sub)
+      =;  relevant=?
+        ?:(relevant `sub ~)
+      ?-  -.about.dbug
+        %ship  =(ship.sub ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path.sub))
+        %wire  ?=(^ (find wire.about.dbug wire.sub))
+        %term  =(term.sub term.about.dbug)
+      ==
+    ==
+  ::
+  ++  on-init
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  on-init:ag
+    [cards this]
+  ::
+  ++  on-save   on-save:ag
+  ::
+  ++  on-load
+    |=  old-state=vase
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-load:ag old-state)
+    [cards this]
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-watch:ag path)
+    [cards this]
+  ::
+  ++  on-leave
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-leave:ag path)
+    [cards this]
+  ::
+  ++  on-peek  on-peek:ag
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-agent:ag wire sign)
+    [cards this]
+  ::
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-arvo:ag wire sign-arvo)
+    [cards this]
+  ::
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-fail:ag term tang)
+    [cards this]
+  --
+--

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -5,6 +5,7 @@
 |%
 +$  what
   $?  %bowl
+      %state
       %incoming
       %outgoing
   ==
@@ -31,12 +32,14 @@
       [cards this]
     =/  dbug
       !<([=what =about] vase)
-    =;  out
-      ((slog >out< ~) [~ this])
+    =;  out=^vase
+      ((slog (sell out) ~) [~ this])
     ?-  what.dbug
-      %bowl  bowl
+      %bowl   !>(bowl)
+      %state  on-save:ag
     ::
         %incoming
+      !>
       %+  murn  ~(tap by sup.bowl)
       |=  sub=[=duct [=ship =path]]
       ^-  (unit _sub)
@@ -51,6 +54,7 @@
       ==
     ::
         %outgoing
+      !>
       %+  murn  ~(tap by wex.bowl)
       |=  sub=[[=wire =ship =term] [acked=? =path]]
       ^-  (unit _sub)


### PR DESCRIPTION
This implements `/lib/dbug`, an agent wrapper in the style of `/lib/verb`, that gives you some generic ways of looking at application state. More concretely, you can look at the entire bowl, or see if there are any subscriptions matching your specified conditions.

Example:

```hoon
> :chat-store +dbug %incoming ship+our
[ i=[duct=[i=/g/use/chat-view/~zod/out/~zod/chat-store/updates t=~[/d //term/1]] ship=~zod path=/updates]
  t=[i=[duct=[i=/g/use/chat-cli/~zod/out/~zod/chat-store/chat-store t=~[/d //term/1]] ship=~zod path=/updates] t=~]
]
```

The lists don't always print very prettily (ie above, they explicitly include list faces), but trying to cast those always kills the pretty-printer in a weird way. In any case, this should suffice for now.

I went ahead and included this in a couple applications, also adding `/lib/verb` where it wasn't in use yet.