### PR TITLE
/sys: use +harden on vane tasks

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6232e5bcb64be057ccd9b4c23bbd636814d50778e4f3a01fbf2ee0042fe3d44
-size 9635072
+oid sha256:cc80ac4de50bb5be47c6545289d883ad7e334f19464fb61a91fe96a5dcbfd4be
+size 9633328

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -918,11 +918,7 @@
     ++  call
       |=  [=duct type=* wrapped-task=(hobo task)]
       ::
-      =/  =task
-        ?.  ?=(%soft -.wrapped-task)
-          wrapped-task
-        ~|  our^%ames-fail-soft
-        ;;(task p.wrapped-task)
+      =/  =task  ((harden task) wrapped-task)
       ::  %born: set .unix-duct and start draining .queued-events
       ::
       ?:  ?=(%born -.task)
@@ -1056,11 +1052,7 @@
   |=  [=duct type=* wrapped-task=(hobo task)]
   ^-  [(list move) _ames-gate]
   ::
-  =/  =task
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ~|  %ames-bad-task^p.wrapped-task
-    ;;(task p.wrapped-task)
+  =/  =task  ((harden task) wrapped-task)
   ::
   =/  event-core  (per-event [our now eny scry-gate] duct ames-state)
   ::

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -251,10 +251,7 @@
       ==
   ^-  [(list move) _behn-gate]
   ::
-  =/  =task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ;;(task:able p.wrapped-task)
+  =/  =task:able  ((harden task:able) wrapped-task)
   ::
   =/  event-core  (per-event [our now hen] state)
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4068,11 +4068,7 @@
       ==
   ^-  [(list move) _..^$]
   ::
-  =/  req=task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ;;(task:able p.wrapped-task)
-  ::
+  =/  req=task:able  ((harden task:able) wrapped-task)
   ::  only one of these should be going at once, so queue
   ::
   ?:  ?=(?(%info %merg %mont) -.req)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -516,10 +516,7 @@
           wrapped-task=(hobo task:able)
       ==
   ^+  [*(list move) ..^$]
-  =/  task=task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ;;(task:able p.wrapped-task)
+  =/  task=task:able  ((harden task:able) wrapped-task)
   ::  the boot event passes thru %dill for initial duct distribution
   ::
   ?:  ?=(%boot -.task)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1985,11 +1985,7 @@
   |=  [=duct type=* wrapped-task=(hobo task:able)]
   ^-  [(list move) _http-server-gate]
   ::
-  =/  task=task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ~|  [%p-wrapped-task p.wrapped-task]
-    ;;(task:able p.wrapped-task)
+  =/  task=task:able  ((harden task:able) wrapped-task)
   ::  %crud: notifies us of an event failure
   ::
   ?:  ?=(%crud -.task)

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6128,12 +6128,8 @@
 ++  call
   |=  [=duct type=* wrapped-task=(hobo task:able)]
   ^-  [(list move) _ford-gate]
-  ::  unwrap :task from :wrapped-task
   ::
-  =/  task=task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ;;(task:able p.wrapped-task)
+  =/  task=task:able  ((harden task:able) wrapped-task)
   ::  we wrap +per-event with a call that binds our event args
   ::
   =*  this-event  (per-event [our duct now scry-gate] state.ax)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1476,12 +1476,7 @@
   ^-  [(list move) _gall-payload]
   ::
   ~|  [%gall-call-failed duct q.hic]
-  ::  make sure our task is hard
-  ::
-  =/  =task:able
-    ?.  ?=(%soft -.q.hic)
-      q.hic
-    ;;  task:able  p.q.hic
+  =/  =task:able  ((harden task:able) q.hic)
   ::
   =/  initialised  (mo-abed:mo duct)
   ?-    -.task

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -306,11 +306,7 @@
   |=  [=duct type=* wrapped-task=(hobo task:able)]
   ^-  [(list move) _light-gate]
   ::
-  =/  task=task:able
-    ?.  ?=(%soft -.wrapped-task)
-      wrapped-task
-    ~|  [%p-wrapped-task p.wrapped-task]
-    ;;(task:able p.wrapped-task)
+  =/  task=task:able  ((harden task:able) wrapped-task)
   ::  %crud: notifies us of an event failure
   ::
   ?:  ?=(%crud -.task)

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -968,10 +968,7 @@
           hic/(hypo (hobo task:able))
       ==
   ^-  [(list move) _..^$]
-  =/  =task:able
-    ?.  ?=($soft -.q.hic)
-      q.hic
-    (task:able p.q.hic)
+  =/  =task:able  ((harden task:able) q.hic)
   =^  did  lex
     abet:(~(call of [our now eny] lex) hen task)
   [did ..^$]


### PR DESCRIPTION
Uses Zuse's previously unused +harden helper function to streamline +task unwrapping in vanes.

Arguably, in landlocked vanes like Ford, we should crash if we get a %soft task, since no events should be coming in directly from the outside.  I decided not to change any functionality in this PR, though.