### PR TITLE
ford: dequeue orphans

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6232e5bcb64be057ccd9b4c23bbd636814d50778e4f3a01fbf2ee0042fe3d44
-size 9635072
+oid sha256:8ca3d44142cebd027a8c7d7326342f5ca2fca921034293ac1fd05646ea00cc30
+size 9636208

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -5817,6 +5817,11 @@
       ?:  verified.build-relation
         ~
       `sub
+    ::  dequeue orphans in case we were about to run them
+    ::
+    =/  orphan-set        (~(gas in *(set ^build)) orphans)
+    =.  next-builds       (~(dif in next-builds) orphan-set)
+    =.  candidate-builds  (~(dif in candidate-builds) orphan-set)
     ::  remove links to orphans in :build's +build-status
     ::
     =^  build-status  builds.state


### PR DESCRIPTION
@ixv recently uncovered a bug (https://github.com/urbit/urbit/issues/2180) in Ford that caused certain rebuilds to crash.  @Fang- and I believe this change should fix the bug, and we have confirmed that the reproduction that used to fail about two thirds of the time now has not failed at all in the ten or so times we've run it since then.  @Fang- is still running more tests to confirm the fix with more certainty.

It turned out the cause was that (depending on the rebuild order, which is unspecified and should not need to be specified), Ford could enqueue a provisional sub-build to be run but then, later in the same +gather call, discover that the sub-build was in fact an orphan and delete it from `builds.state` accordingly.  Then when Ford tried to run the sub-build, it would have already been deleted from the state, so Ford would crash when trying to process its result in `+reduce`.

The fix was to make sure that when we discover a provisional sub-build is orphaned, dequeue it from `candidate-builds` and `next-builds` to make sure we don't try to run it.  I'm about 95% sure this fix completely solves the bug.

I worried a bit about whether asynchronicity could break this check somehow -- if we run +gather across multiple Ford activations because something blocked, could we still end up running an orphaned build?  But I think the answer is no, because whenever Ford determines a build is an orphan, it'll make sure we don't try to run it in that event.  If a future event were to enqueue the build to be run, it could only be because some other build had established this build as a sub-build, in which case it would have to add it to the state again before enqueueing it.  If this analysis holds, as I believe it does, we're in the clear.