### PR TITLE
publish: fix new-comment name parsing for @da-case

### DIFF
--- a/pkg/arvo/mar/publish/action.hoon
+++ b/pkg/arvo/mar/publish/action.hoon
@@ -69,7 +69,7 @@
       %-  ot:dejs
       :~  who+(su:dejs fed:ag)
           coll+so:dejs
-          name+(su:dejs sym)
+          name+so:dejs
           content+so:dejs
       ==
     ::


### PR DESCRIPTION
Fixes #2085.

The root of the problem is that the frontend uses `stringToSymbol` (interface/publish/src/js/lib/util.js) to attempt converting any old post titles to `@tas` post id:s, inserting hyphens and such. If the title starts with a number, it just defaults to generating the current `@da`.

Why this fix works:

```
((su:dejs:format sym) [%s '~2020.1.29..16.45.41'])
{1 1}
syntax error
`@tas`(so:dejs:format [%s '~2020.1.29..16.45.41'])
%~2020.1.29..16.45.41
```

Everything works now, but given what [I've recently learned](https://github.com/urbit/urbit/pull/2195#issuecomment-578901192) I'm left wondering whether that's an actual `@tas`, though. 

```
`@tas`~2020.1.29..16.45.41
```

relinks the dojo. The dojo parser accepts typing the symbol out, though.