### PR TITLE
link: listening & comments

### DIFF
--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -19,6 +19,21 @@
       ::      makes adding any state in the future easier.
   ==
 ::
++$  target
+  $:  what=%local-pages  ::TODO  %annotations
+      who=ship
+      where=path
+  ==
+++  wire-to-target
+  |=  =wire
+  ^-  target
+  ?>  ?=([%local-pages @ ^] wire)  ::TODO  %annotations
+  [i.wire (slav %p i.t.wire) t.t.wire]
+++  target-to-wire
+  |=  target
+  ^-  wire
+  [what (scot %p who) where]
+::
 +$  card  card:agent:gall
 --
 ::
@@ -52,9 +67,9 @@
       =^  cards  state
         (take-groups-sign:do sign)
       [cards this]
-    ?:  ?=([%links @ ^] wire)
+    ?:  ?=([%links @ @ ^] wire)
       =^  cards  state
-        (take-links-sign:do (slav %p i.t.wire) t.t.wire sign)
+        (take-links-sign:do (wire-to-target t.wire) sign)
       [cards this]
     ?:  ?=([%forward ^] wire)
       =^  cards  state
@@ -141,7 +156,7 @@
     ?:  =(our.bowl i.whos)
       $(whos t.whos)
     :_  $(whos t.whos)
-    %.  [i.whos pax.upd]
+    %.  [%local-pages i.whos pax.upd]  ::TODO  %annotations
     ?:  ?=(%remove -.upd)
       end-link-subscription
     start-link-subscription
@@ -150,33 +165,33 @@
 ::  link subscriptions
 ::
 ++  start-link-subscription
-  |=  [who=ship where=path]
+  |=  =target
   ^-  card
   :*  %pass
-      [%links (scot %p who) where]
+      [%links (target-to-wire target)]
       %agent
-      [who %link-proxy-hook]
+      [who.target %link-proxy-hook]
       %watch
-      [%local-pages where]
+      [what where]:target
   ==
 ::
 ++  end-link-subscription
-  |=  [who=ship where=path]
+  |=  =target
   ^-  card
   :*  %pass
-      [%links (scot %p who) where]
+      [%links (target-to-wire target)]
       %agent
-      [who %link-proxy-hook]
+      [who.target %link-proxy-hook]
       %leave
       ~
   ==
 ::
 ++  take-links-sign
-  |=  [who=ship where=path =sign:agent:gall]
+  |=  [=target =sign:agent:gall]
   ^-  (quip card _state)
   ?-  -.sign
-    %poke-ack   ~|([dap.bowl %unexpected-poke-ack /links who where] !!)
-    %kick       [[(start-link-subscription who where)]~ state]
+    %poke-ack   ~|([dap.bowl %unexpected-poke-ack /links target] !!)
+    %kick       [[(start-link-subscription target)]~ state]
   ::
       %watch-ack
     ?~  p.sign  [~ state]
@@ -192,21 +207,23 @@
     =*  mark  p.cage.sign
     =*  vase  q.cage.sign
     ?+  mark  ~|([dap.bowl %unexpected-mark mark] !!)
-      %link-update  (handle-link-update who where !<(update vase))
+        %link-update
+      %-  handle-link-update
+      [who.target where.target !<(update vase)]
     ==
   ==
 ::
 ++  handle-link-update
   |=  [who=ship where=path =update]
   ^-  (quip card _state)
-  ?>  ?=(%local-pages -.update)
+  ?>  ?=(%local-pages -.update)  ::TODO  %annotations
   ?>  =(src.bowl who)
   :_  state
   %+  turn  pages.update
   |=  =page
   ^-  card
   :*  %pass
-      [%forward (scot %p who) where]
+      [%forward -.update (scot %p who) where]
       %agent
       [our.bowl %link-store]
       %poke

--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -6,7 +6,7 @@
 ::    and forwards all entries into our link as submissions.
 ::
 /-  *link, group-store
-/+  default-agent, verb
+/+  default-agent, verb, dbug
 ::
 |%
 +$  state-0
@@ -25,6 +25,7 @@
 =|  state-0
 =*  state  -
 ::
+%-  agent:dbug
 %+  verb  |
 ^-  agent:gall
 =<

--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -19,15 +19,17 @@
       ::      makes adding any state in the future easier.
   ==
 ::
+::TODO  revert to annotations with new link-store subscription model
++$  what-target  ?(%local-pages %allotations)
 +$  target
-  $:  what=%local-pages  ::TODO  %annotations
+  $:  what=what-target
       who=ship
       where=path
   ==
 ++  wire-to-target
   |=  =wire
   ^-  target
-  ?>  ?=([%local-pages @ ^] wire)  ::TODO  %annotations
+  ?>  ?=([what-target @ ^] wire)
   [i.wire (slav %p i.t.wire) t.t.wire]
 ++  target-to-wire
   |=  target
@@ -155,11 +157,13 @@
     ::
     ?:  =(our.bowl i.whos)
       $(whos t.whos)
-    :_  $(whos t.whos)
-    %.  [%local-pages i.whos pax.upd]  ::TODO  %annotations
     ?:  ?=(%remove -.upd)
-      end-link-subscription
-    start-link-subscription
+      %+  weld
+        $(whos t.whos)
+      (end-link-subscriptions i.whos pax.upd)
+    :+  (start-link-subscription %local-pages i.whos pax.upd)
+      (start-link-subscription %allotations i.whos pax.upd)
+    $(whos t.whos)
   ==
 ::
 ::  link subscriptions
@@ -175,16 +179,21 @@
       [what where]:target
   ==
 ::
-++  end-link-subscription
-  |=  =target
-  ^-  card
-  :*  %pass
-      [%links (target-to-wire target)]
-      %agent
-      [who.target %link-proxy-hook]
-      %leave
-      ~
-  ==
+++  end-link-subscriptions
+  |=  [who=ship where=path]
+  ^-  (list card)
+  |^  ~[(end %local-pages) (end %allotations)]
+  ::
+  ++  end
+    |=  what=what-target
+    :*  %pass
+        [%links (target-to-wire what who where)]
+        %agent
+        [who %link-proxy-hook]
+        %leave
+        ~
+    ==
+  --
 ::
 ++  take-links-sign
   |=  [=target =sign:agent:gall]
@@ -216,19 +225,34 @@
 ++  handle-link-update
   |=  [who=ship where=path =update]
   ^-  (quip card _state)
-  ?>  ?=(%local-pages -.update)  ::TODO  %annotations
   ?>  =(src.bowl who)
   :_  state
-  %+  turn  pages.update
-  |=  =page
-  ^-  card
-  :*  %pass
-      [%forward -.update (scot %p who) where]
-      %agent
-      [our.bowl %link-store]
-      %poke
-      %link-action
-      !>([%hear where src.bowl page])
+  ?+  -.update  ~|([dap.bowl %unexpected-update -.update] !!)
+      %local-pages
+    %+  turn  pages.update
+    |=  =page
+    ^-  card
+    :*  %pass
+        [%forward -.update (scot %p who) where]
+        %agent
+        [our.bowl %link-store]
+        %poke
+        %link-action
+        !>([%hear where src.bowl page])
+    ==
+  ::
+      %annotations
+    %+  turn  notes.update
+    |=  =note
+    ^-  card
+    :*  %pass
+        [%forward -.update (scot %p who) where]
+        %agent
+        [our.bowl %link-store]
+        %poke
+        %link-action
+        !>([%read where url.update src.bowl note])
+    ==
   ==
 ::
 ++  take-forward-sign

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -21,7 +21,7 @@
 ::    to touch are +permitted, +initial-response, & maybe +handle-group-update.
 ::
 /-  group-store
-/+  *link, default-agent, verb
+/+  *link, default-agent, verb, dbug
 |%
 +$  state-0
   $:  %0
@@ -36,6 +36,7 @@
 =|  state-0
 =*  state  -
 ::
+%-  agent:dbug
 %+  verb  |
 ^-  agent:gall
 =<

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -102,7 +102,7 @@
   ::  we only expose /local-pages and /annotations,
   ::  and only to ships in the relevant group
   ::
-  ?.  ?=([?(%local-pages %annotations %allotations) ^] path)
+  ?.  ?=([?(%local-pages %annotations %allotations) ^] path)  |
   =;  group
     ?&  ?=(^ group)
         (~(has in u.group) who)

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -102,7 +102,7 @@
   ::  we only expose /local-pages and /annotations,
   ::  and only to ships in the relevant group
   ::
-  ?.  ?=([?(%local-pages %annotations) ^] path)  |
+  ?.  ?=([?(%local-pages %annotations %allotations) ^] path)
   =;  group
     ?&  ?=(^ group)
         (~(has in u.group) who)

--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -14,8 +14,11 @@
 ::    /local-pages/[some-group]        all pages we saved by recency
 ::    /submissions/[some-group]        all submissions by recency
 ::      comments
+::    /allotations/[some-group]             TMP all our comments in group
 ::    /annotations/[some-group]/[b64(url)]  all our comments on url by recency
 ::    /discussions/[some-group]/[b64(url)]  all known comments on url by recency
+::
+::TODO  continue work from m/uplink-broad branch!
 ::
 /+  *link, default-agent, verb, dbug
 ::
@@ -114,6 +117,14 @@
           %+  give  %link-update
           [%submissions t.path (get-submissions:do t.path)]
         ::
+            [%allotations ^]
+          %+  turn
+            %~  tap  by
+            (~(gut by discussions) t.path *(map url discussion))
+          |=  [=url =discussion]
+          %+  give-single  %link-update
+          [%annotations t.path url ours.discussion]
+        ::
             [%annotations @ ^]
           %+  give  %link-update
           [%annotations t.path (get-annotations:do t.path)]
@@ -127,6 +138,11 @@
       |*  [=mark =noun]
       ^-  (list card)
       [%give %fact ~ mark !>(noun)]~
+    ::
+    ++  give-single
+      |*  [=mark =noun]
+      ^-  card
+      [%give %fact ~ mark !>(noun)]
     --
   ::
   ++  on-leave  on-leave:def
@@ -198,7 +214,7 @@
     :-  %link-update
     !>([%annotations path url [note]~])
   :*  [%give %fact [%annotations (snoc path url)]~ fact]
-      [%give %fact [%annotations path]~ fact]
+      [%give %fact [%allotations path]~ fact]
       cards
   ==
 ::  +hear-submission: record page someone else saved

--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -17,7 +17,7 @@
 ::    /annotations/[some-group]/[b64(url)]  all our comments on url by recency
 ::    /discussions/[some-group]/[b64(url)]  all known comments on url by recency
 ::
-/+  *link, default-agent, verb
+/+  *link, default-agent, verb, dbug
 ::
 |%
 +$  state-0
@@ -44,6 +44,7 @@
 =|  state-0
 =*  state  -
 ::
+%-  agent:dbug
 %+  verb  |
 ^-  agent:gall
 =<

--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -19,11 +19,14 @@
         *
         ::  inline arguments
         ::
-        args=?(~ [=what =about ~])
+        args=?(~ [what=?(%bowl %state) ~] [=what =about ~])
         ::  named arguments
         ::
         ~
     ==
 :-  %dbug
-?~  args  [%bowl *about]
-[what.args about.args]
+?-  args
+  ~        [%bowl *about]
+  [@ ~]    [what.args *about]
+  [@ * ~]  [what about]:args
+==

--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -1,0 +1,29 @@
+::  +dbug: tell /lib/dbug app to print some generic state
+::
+::    :app +dbug
+::      the entire bowl
+::    :app +dbug [direction] [specifics]
+::      all in subs matching the parameters
+::      direction: %incoming or %outgoing
+::      specifics:
+::        [%ship ~ship]  subscriptions to/from this ship
+::        [%path /path]  subscriptions on path containing /path
+::        [%wire /wire]  subscriptions on wire containing /wire
+::        [%term %name]  subscriptions to app %name
+::
+/+  *dbug
+::
+:-  %say
+|=  $:  ::  environment
+        ::
+        *
+        ::  inline arguments
+        ::
+        args=?(~ [=what =about ~])
+        ::  named arguments
+        ::
+        ~
+    ==
+:-  %dbug
+?~  args  [%bowl *about]
+[what.args about.args]

--- a/pkg/arvo/gen/link-store/note.hoon
+++ b/pkg/arvo/gen/link-store/note.hoon
@@ -1,0 +1,10 @@
+::  link-store|note: write a note on a link in a path
+::
+/-  *link
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=path =url note=@t ~] ~]
+    ==
+:-  %link-action
+^-  action
+[%note path url note]

--- a/pkg/arvo/gen/link-store/save.hoon
+++ b/pkg/arvo/gen/link-store/save.hoon
@@ -1,4 +1,4 @@
-::  link-store|add: save a link to a path
+::  link-store|save: save a link to a path
 ::
 /-  *link
 :-  %say

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -1,0 +1,112 @@
+::  dbug: agent wrapper for generic debugging tools
+::
+::    usage: %-(agent:dbug your-agent)
+::
+|%
++$  what
+  $?  %bowl
+      %incoming
+      %outgoing
+  ==
+::
++$  about
+  $%  [%ship =ship]
+      [%path =path]
+      [%wire =wire]
+      [%term =term]
+  ==
+::
+++  agent
+  |=  =agent:gall
+  ^-  agent:gall
+  |_  =bowl:gall
+  +*  this  .
+      ag    ~(. agent bowl)
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card:agent:gall agent:gall)
+    ?.  ?=(%dbug mark)
+      =^  cards  agent  (on-poke:ag mark vase)
+      [cards this]
+    =/  dbug
+      !<([=what =about] vase)
+    =;  out
+      ((slog >out< ~) [~ this])
+    ?-  what.dbug
+      %bowl  bowl
+    ::
+        %incoming
+      %+  murn  ~(tap by sup.bowl)
+      |=  sub=[=duct [=ship =path]]
+      ^-  (unit _sub)
+      =;  relevant=?
+        ?:(relevant `sub ~)
+      ?-  -.about.dbug
+        %ship  =(ship.sub ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path.sub))
+        %wire  %+  lien  duct.sub
+               |=(=wire ?=(^ (find wire.about.dbug wire)))
+        %term  !!
+      ==
+    ::
+        %outgoing
+      %+  murn  ~(tap by wex.bowl)
+      |=  sub=[[=wire =ship =term] [acked=? =path]]
+      ^-  (unit _sub)
+      =;  relevant=?
+        ?:(relevant `sub ~)
+      ?-  -.about.dbug
+        %ship  =(ship.sub ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path.sub))
+        %wire  ?=(^ (find wire.about.dbug wire.sub))
+        %term  =(term.sub term.about.dbug)
+      ==
+    ==
+  ::
+  ++  on-init
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  on-init:ag
+    [cards this]
+  ::
+  ++  on-save   on-save:ag
+  ::
+  ++  on-load
+    |=  old-state=vase
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-load:ag old-state)
+    [cards this]
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-watch:ag path)
+    [cards this]
+  ::
+  ++  on-leave
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-leave:ag path)
+    [cards this]
+  ::
+  ++  on-peek  on-peek:ag
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-agent:ag wire sign)
+    [cards this]
+  ::
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-arvo:ag wire sign-arvo)
+    [cards this]
+  ::
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-fail:ag term tang)
+    [cards this]
+  --
+--

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -5,6 +5,7 @@
 |%
 +$  what
   $?  %bowl
+      %state
       %incoming
       %outgoing
   ==
@@ -31,12 +32,14 @@
       [cards this]
     =/  dbug
       !<([=what =about] vase)
-    =;  out
-      ((slog >out< ~) [~ this])
+    =;  out=^vase
+      ((slog (sell out) ~) [~ this])
     ?-  what.dbug
-      %bowl  bowl
+      %bowl   !>(bowl)
+      %state  on-save:ag
     ::
         %incoming
+      !>
       %+  murn  ~(tap by sup.bowl)
       |=  sub=[=duct [=ship =path]]
       ^-  (unit _sub)
@@ -51,6 +54,7 @@
       ==
     ::
         %outgoing
+      !>
       %+  murn  ~(tap by wex.bowl)
       |=  sub=[[=wire =ship =term] [acked=? =path]]
       ^-  (unit _sub)


### PR DESCRIPTION
Broadly, the commits herein address two issues.

- Comments weren't being synced by link-listen-hook at all.  
2e8fb88 makes that so, but depends on 69c86d7, which is an ugly hack that would not have been needed had the link-store API rewrite from the `m/uplink-broad` branch been in use. That work requires a partial rewrite of the frontend logic, however, so that will have to wait for a bit longer. The hack is "good enough for now" and I fully intend to see its removal through.

- Link-listen-hook would not retry if rejected due to out-of-date group definition.  
8723dc6 implements retry logic with exponential backoff, so that we attempt to recover from rejected subscriptions.

Commits not directly addressed above are largely administrative in nature. This includes a couple cherry-picked commits from master relating to `/lib/dbug`, which proved useful for debugging here.

(CI is failing because the branch this is based on fails CI. There are no errors relating to this PR in the logs.)