### PR TITLE
Make release tarballs extract to a release directory

### DIFF
--- a/sh/release
+++ b/sh/release
@@ -12,12 +12,22 @@ else
   ver="$(git rev-parse HEAD)"
 fi
 
+traced () {
+  echo '$' "$@" >&2; "$@"
+}
+
 mkdir -p release
 
 for plat in linux64 darwin
 do
   sh/cross urbit "$plat"
 
+  tmp=$(mktemp -d)
+  mkdir -p $tmp/urbit-$plat-$ver
+  traced cp -r cross/$plat/* $tmp/urbit-$plat-$ver
+
   echo "packaging release/urbit-$plat-$ver.tgz"
-  (cd cross/$plat; tar cz .) > release/urbit-$plat-$ver.tgz
+  (cd $tmp; tar cz urbit-$plat-$ver) > release/urbit-$plat-$ver.tgz
+
+  rm -rf $tmp
 done


### PR DESCRIPTION
Fixes #1400.

Release tarballs previously didn't include a release directory, so the files would be unceremoniously dumped into the user's current directory when extracted.  No longer!

Before:

```
$ tar xzf urbit-linux64-v0.10.3.tgz
$ ls
urbit    urbit-linux64-v0.10.3.tgz    urbit-terminfo    urbit-worker
```

After:

```
$ tar xzf urbit-linux64-v0.10.3.tgz
$ ls
urbit-linux64-v0.10.3    urbit-linux64-v0.10.3.tgz
$ ls urbit-linux64-v0.10.3
urbit    urbit-terminfo    urbit-worker
```

