### PR TITLE
chat: fix double message bug

### DIFF
--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -45,6 +45,8 @@ export class ChatScreen extends Component {
  componentDidUpdate(prevProps, prevState) {
    const { props, state } = this;
 
+   const station = `/${props.match.params.ship}/${props.match.params.station}`
+
    if (
      prevProps.match.params.station !== props.match.params.station ||
      prevProps.match.params.ship !== props.match.params.ship
@@ -55,7 +57,7 @@ export class ChatScreen extends Component {
 
      this.setState(
        {
-         station: `/${props.match.params.ship}/${props.match.params.station}`,
+         station: station,
          scrollLocked: false
        },
        () => {
@@ -67,7 +69,7 @@ export class ChatScreen extends Component {
          this.updateReadNumber();
        }
      );
-   } else if (Object.keys(props.inbox).length === 0) {
+   } else if (props.chatInitialized && !(station in props.inbox)) {
      props.history.push("/~chat");
    } else if (
      props.envelopes.length - prevProps.envelopes.length >=

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -171,6 +171,7 @@ export class Root extends Component {
                     pendingMessages={state.pendingMessages}
                     popout={popout}
                     sidebarShown={state.sidebarShown}
+                    chatInitialized={state.chatInitialized}
                     {...props}
                   />
                 </Skeleton>

--- a/pkg/interface/chat/src/js/reducers/initial.js
+++ b/pkg/interface/chat/src/js/reducers/initial.js
@@ -6,6 +6,7 @@ export class InitialReducer {
     let data = _.get(json, 'chat-initial', false);
     if (data) {
       state.inbox = data;
+      state.chatInitialized = true;
     }
 
     data = _.get(json, 'group-initial', false);

--- a/pkg/interface/chat/src/js/store.js
+++ b/pkg/interface/chat/src/js/store.js
@@ -17,7 +17,8 @@ class Store {
       invites: {},
       spinner: false,
       sidebarShown: true,
-      pendingMessages: new Map([])
+      pendingMessages: new Map([]),
+      chatInitialized: false
     };
 
     this.initialReducer = new InitialReducer();


### PR DESCRIPTION
Fixes #2212.

Also kicks you back to the main screen if the current station is not in your inbox, instead of just doing it if there are no stations in the inbox.