### PR TITLE
publish group paths

### DIFF
--- a/pkg/arvo/mar/publish/action.hoon
+++ b/pkg/arvo/mar/publish/action.hoon
@@ -116,8 +116,13 @@
       ==
     ++  group-info
       %-  of
-      :~  old+(ot writers+pa subscribers+pa ~)
-          new+(ot writers+set-ship subscribers+set-ship sec+so ~)
+      :~  old+(ot write-pax+pa read-pax+pa ~)
+          :-  %new
+          %-  ot
+          :~  write-grp+set-ship  write-pax+pa
+              read-grp+set-ship   read-pax+pa
+              sec+so
+          ==
       ==
     ++  set-ship  (ar (su fed:ag))
     --

--- a/pkg/arvo/sur/publish.hoon
+++ b/pkg/arvo/sur/publish.hoon
@@ -2,8 +2,12 @@
 |%
 ::
 +$  group-info
-  $%  [%old writers=path subscribers=path]
-      [%new writers=(set ship) subscribers=(set ship) sec=rw-security]
+  $%  [%old write-pax=path read-pax=path]
+      $:  %new
+          write-grp=(set ship)  write-pax=path
+          read-grp=(set ship)   read-pax=path
+          sec=rw-security
+      ==
   ==
 ::
 ::

--- a/pkg/interface/publish/src/js/components/lib/new-post.js
+++ b/pkg/interface/publish/src/js/components/lib/new-post.js
@@ -22,7 +22,7 @@ export class NewPost extends Component {
   postSubmit() {
     let newNote = {
       "new-note": {
-        who: this.props.host.slice(1),
+        who: this.props.ship.slice(1),
         book: this.props.book,
         note: stringToSymbol(this.state.title),
         title: this.state.title,
@@ -45,7 +45,7 @@ export class NewPost extends Component {
     let notebook = this.props.notebooks[this.props.ship][this.props.book];
     if (notebook.notes[this.state.awaiting]) {
       let redirect =
-     `/~publish/note/${this.props.host}/${this.props.book}/${this.state.awaiting}`;
+     `/~publish/note/${this.props.ship}/${this.props.book}/${this.state.awaiting}`;
       this.props.history.push(redirect);
     }
   }

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -88,7 +88,7 @@ export class Root extends Component {
               notebooks={state.notebooks}>
                 <NewPost
                   notebooks={state.notebooks}
-                  host={ship}
+                  ship={ship}
                   book={notebook}
                   {...props}
                 />


### PR DESCRIPTION
Changed the publish api so that group paths are passed through from the frontend rather than generated on the backend (except in cases where they must be generated on the backend).

also included a minor bugfix in this PR.