### PR TITLE
chat: filter empty groups from peer search

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -36,7 +36,9 @@ export class InviteSearch extends Component {
     let peers = [],
     peerSet = new Set();
     Object.keys(this.props.groups).map(group => {
-      peerSet.add(...this.props.groups[group]);
+      if (this.props.groups[group].size > 0) {
+        peerSet.add(...this.props.groups[group]);
+      }
     });
     peers = Array.from(peerSet);
 


### PR DESCRIPTION
In invite-search.js, empty groups being mapped into a set (in order deduplicate known peers) return as `undefined`, which doesn't have an `includes` method ... which led to errors. This additional check doesn't map those empty groups.