### PR TITLE
link: minimum viable un/seen status

### DIFF
--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -6,28 +6,28 @@
 ::    primitive ui implementations.
 ::
 ::    urls in paths are expected to be encoded using +wood, for @ta sanity.
-::    use /lib/link's +build-discussion-path.
+::    generally, use /lib/link's +build-discussion-path.
 ::
 ::    see link-listen-hook to see what's synced in, and similarly
 ::    see link-proxy-hook to see what's exposed.
 ::
 ::  scry and subscription paths:
 ::
-::      (map path pages)
+::      (map path pages)                      %local-pages
 ::    /local-pages                          our saved pages
 ::    /local-pages/some-path                our saved pages on path
 ::
-::      (map path submissions)
+::      (map path submissions)                %submissions
 ::    /submissions                          all submissions we've seen
 ::    /submissions/some-path                all submissions we've seen on path
 ::
-::      (map path (map url notes))
+::      (map path (map url notes))            %annotations
 ::    /annotations                          our comments
 ::    /annotations/wood-url                 our comments on url
 ::    /annotations/wood-url/some-path       our comments on url on path
 ::    /annotations//some-path               our comments on path
 ::
-::      (map path (map url comments))
+::      (map path (map url comments))         %discussions
 ::    /discussions                          all comments
 ::    /discussions/wood-url                 all comments on url
 ::    /discussions/wood-url/some-path       all comments on url on path

--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -202,7 +202,7 @@
 ++  save-page
   |=  [=path title=@t =url]
   ^-  (quip card _state)
-  ?<  =(~ path)
+  ?<  |(=(~ path) =(~ title) =(~ url))
   ::  add page to group ours
   ::
   =/  =links  (~(gut by by-group) path *links)
@@ -228,6 +228,7 @@
 ++  note-note
   |=  [=path =url udon=@t]
   ^-  (quip card _state)
+  ?<  |(=(~ path) =(~ url) =(~ udon))
   ::  add note to discussion ours
   ::
   =/  urls  (~(gut by discussions) path *(map ^url discussion))

--- a/pkg/arvo/lib/link.hoon
+++ b/pkg/arvo/lib/link.hoon
@@ -124,6 +124,12 @@
           'url'^s+url.upd
           'comments'^a+(turn comments.upd comment)
       ==
+    ::
+        %observation
+      %-  pairs
+      :~  'path'^(path path.upd)
+          'urls'^a+(turn ~(tap in urls.upd) |=(=url s+url))
+      ==
     ==
   ::
   ++  submission
@@ -181,6 +187,11 @@
       :-  %note
       %.  q.n.p.json
       (ot 'path'^pa 'url'^so 'udon'^so ~)
+    ::
+        [%o [%seen *] ~ ~]
+      :-  %seen
+      %.  q.n.p.json
+      (ot 'path'^pa 'url'^(mu so) ~)
     ==
   --
 --

--- a/pkg/arvo/sur/link.hoon
+++ b/pkg/arvo/sur/link.hoon
@@ -58,6 +58,9 @@
       ::  %note: save a note for a url
       ::
       [%note =path =url udon=@t]
+      ::  %seen: mark item as read (~ for all in path)
+      ::
+      [%seen =path url=(unit url)]
       ::    hook actions
       ::
       ::  %hear: hear about page at path on other ship
@@ -85,5 +88,6 @@
       [%submissions =path =submissions]
       [%annotations =path =url =notes]
       [%discussions =path =url =comments]
+      [%observation =path urls=(set url)]
   ==
 --

--- a/pkg/interface/link/src/js/api.js
+++ b/pkg/interface/link/src/js/api.js
@@ -160,6 +160,13 @@ class UrbitApi {
     });
   }
 
+  // leave url as null to mark all under path as read
+  seenLink(path, url = null) {
+    return this.linkAction({
+      'seen': { path, url }
+    });
+  }
+
   sidebarToggle() {
     let sidebarBoolean = true;
     if (store.state.sidebarShown === true) {

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -11,6 +11,7 @@ export class LinkItem extends Component {
     this.state = {
       timeSinceLinkPost: this.getTimeSinceLinkPost()
     };
+    this.markPostAsSeen = this.markPostAsSeen.bind(this);
   }
 
   componentDidMount() {
@@ -32,6 +33,10 @@ export class LinkItem extends Component {
       : '';
   }
 
+  markPostAsSeen() {
+    api.seenLink(this.props.groupPath, this.props.url);
+  }
+
   render() {
 
     let props = this.props;
@@ -41,6 +46,13 @@ export class LinkItem extends Component {
     let URLparser = new RegExp(/((?:([\w\d\.-]+)\:\/\/?){1}(?:(www)\.?){0,1}(((?:[\w\d-]+\.)*)([\w\d-]+\.[\w\d]+))){1}(?:\:(\d+)){0,1}((\/(?:(?:[^\/\s\?]+\/)*))(?:([^\?\/\s#]+?(?:.[^\?\s]+){0,1}){0,1}(?:\?([^\s#]+)){0,1})){0,1}(?:#([^#\s]+)){0,1}/);
 
     let hostname = URLparser.exec(props.url);
+
+    const seenState = props.seen
+      ? "grey2"
+      : "green2 pointer";
+    const seenAction = props.seen
+      ? ()=>{}
+      : this.markPostAsSeen
 
     if (hostname) {
       hostname = hostname[4];
@@ -60,7 +72,8 @@ export class LinkItem extends Component {
         <div className="flex flex-column ml2">
           <a href={props.url}
           className="w-100 flex"
-          target="_blank">
+          target="_blank"
+          onClick={this.markPostAsSeen}>
             <p className="f8 truncate">{props.title}
               <span className="gray2 dib truncate-m mw4-m v-btm ml2">{hostname} ↗</span>
             </p>
@@ -69,10 +82,15 @@ export class LinkItem extends Component {
             <span className={"f9 pr2 v-mid " + mono}>{(props.nickname)
             ? props.nickname
             : "~" + props.ship}</span>
-          <span className="f9 inter gray2 pr3 v-mid">{this.state.timeSinceLinkPost}</span>
+          <span
+            className={seenState + " f9 inter pr3 v-mid"}
+            onClick={this.markPostAsSeen}>
+            {this.state.timeSinceLinkPost}
+          </span>
           <Link to=
           {"/~link" + props.popout + props.groupPath + "/" + props.page + "/" + props.linkIndex + "/" + encodedUrl}
-          className="v-top">
+          className="v-top"
+          onClick={this.markPostAsSeen}>
             <span className="f9 inter gray2">
                 {comments}
               </span>

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -11,6 +11,10 @@ import { uxToHex } from '../lib/util';
 
 //TODO Avatar support once it's in
 export class Links extends Component {
+  constructor(props) {
+    super(props);
+    this.markAllAsSeen = this.markAllAsSeen.bind(this);
+  }
 
   componentDidMount() {
     this.componentDidUpdate();
@@ -24,6 +28,10 @@ export class Links extends Component {
     ) {
       api.getPage(this.props.groupPath, this.props.page);
     }
+  }
+
+  markAllAsSeen() {
+    api.seenLink(this.props.groupPath);
   }
 
   render() {
@@ -47,6 +55,7 @@ export class Links extends Component {
     .map((linkIndex) => {
       let linksObj = props.links[linkPage];
       let { title, url, time, ship } = linksObj[linkIndex];
+      const seen = props.seen[url];
       let members = {};
 
       const commentCount = props.comments[url]
@@ -79,6 +88,7 @@ export class Links extends Component {
         linkIndex={linkIndex}
         url={url}
         timestamp={time}
+        seen={seen}
         nickname={nickname}
         ship={ship}
         color={color}
@@ -127,6 +137,11 @@ export class Links extends Component {
               <LinkSubmit groupPath={props.groupPath}/>
             </div>
             <div className="pb4">
+            <span
+              className="f9 inter gray2 ba b--gray2 br2 dib pa1 pointer"
+              onClick={this.markAllAsSeen}>
+              mark all as seen
+            </span>
             {LinkList}
             <Pagination
             {...props}

--- a/pkg/interface/link/src/js/components/root.js
+++ b/pkg/interface/link/src/js/components/root.js
@@ -34,6 +34,7 @@ export class Root extends Component {
 
     let links = !!state.links ? state.links : {};
     let comments = !!state.comments ? state.comments : {};
+    const seen = !!state.seen ? state.seen : {};
 
     return (
       <BrowserRouter>
@@ -76,6 +77,10 @@ export class Root extends Component {
                 ? comments[groupPath]
                 : {};
 
+              const channelSeen = !!seen[groupPath]
+                ? seen[groupPath]
+                : {};
+
               return (
                 <Skeleton
                   spinner={state.spinner}
@@ -91,6 +96,7 @@ export class Root extends Component {
                   members={groupMembers}
                   links={channelLinks}
                   comments={channelComments}
+                  seen={channelSeen}
                   page={page}
                   groupPath={groupPath}
                   popout={popout}

--- a/pkg/interface/link/src/js/reducers/link-update.js
+++ b/pkg/interface/link/src/js/reducers/link-update.js
@@ -11,6 +11,7 @@ export class LinkUpdateReducer {
     this.submissionsUpdate(json, state);
     this.discussionsPage(json, state);
     this.discussionsUpdate(json, state);
+    this.observationUpdate(json, state);
   }
 
   submissionsPage(json, state) {
@@ -40,6 +41,15 @@ export class LinkUpdateReducer {
         state.links[path].local[page] = false;
         state.links[path].totalPages = here.totalPages;
         state.links[path].totalItems = here.totalItems;
+
+        // write seen status to a separate structure,
+        // for easier modification later.
+        if (!state.seen[path]) {
+          state.seen[path] = {};
+        }
+        here.page.map(submission => {
+          state.seen[path][submission.url] = submission.seen;
+        });
       }
     }
   }
@@ -117,6 +127,27 @@ export class LinkUpdateReducer {
       state.comments[path][url] = this._addNewItems(
         data.comments, state.comments[path][url]
       );
+    }
+  }
+
+  observationUpdate(json, state) {
+    const data = _.get(json, 'observation', false);
+    if (data) {
+      //  { "observation": {
+      //    path: /~ship/path
+      //    urls: ['https://urbit.org']
+      //  } }
+
+      const path = data.path;
+      if (!state.seen[path]) {
+        state.seen[path] = {};
+      }
+      let seen = state.seen[path];
+
+      // mark urls as seen
+      data.urls.map(url => {
+        seen[url] = true;
+      });
     }
   }
 

--- a/pkg/interface/link/src/js/store.js
+++ b/pkg/interface/link/src/js/store.js
@@ -13,6 +13,7 @@ class Store {
       groups: {},
       links: {},
       comments: {},
+      seen: {},
       permissions: {},
       sidebarShown: true,
       spinner: false

--- a/pkg/interface/link/src/js/subscription.js
+++ b/pkg/interface/link/src/js/subscription.js
@@ -24,6 +24,13 @@ export class Subscription {
 
     // open a subscription for all submissions
     api.getPage('', 0);
+
+    // open a subscription for seen notifications
+    api.bindLinkView('/json/seen',
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this)
+    );
   }
 
   handleEvent(diff) {


### PR DESCRIPTION
Colors the relative time on items in the link list green if we haven't interacted with them yet. Allows you to clear this on everything at once with a simple button.

![unread](https://user-images.githubusercontent.com/3829764/74065390-1668bf00-49f5-11ea-8a61-cdd7d92c8281.gif)

I want to do more work on this to get unread counts in the sidebar (and hide the "mark all as seen" button if there's nothing new), but want to get this merged in so that @vvisigoth has a stable backend state type to test against.