### PR TITLE
OS1: publish, multiple fixes

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { CommentItem } from './comment-item';
 
-//TODO map comments into comment-items;
 export class Comments extends Component {
   constructor(props){
     super(props);
@@ -20,6 +19,8 @@ export class Comments extends Component {
        body: this.state.commentBody
      }
    };
+
+   this.textArea.value = '';
    window.api.action("publish", "publish-action", comment);
 
  }
@@ -37,15 +38,28 @@ export class Comments extends Component {
       );
     })
 
+    let disableComment = this.state.commentBody === '';
+    let commentClass = (disableComment)
+      ?  "f9 pa2 bg-white br1 ba b--gray2 gray2"
+      :  "f9 pa2 bg-white br1 ba b--gray2 black pointer";
+
     return (
       <div>
         <div className="mt8">
           <div>
-            <textarea style={{resize:'vertical'}} id="comment" name="comment" placeholder="Leave a comment here" className="f9 db border-box w-100 ba b--gray3 pt3 ph3 pb8 br1 mb2" aria-describedby="comment-desc" onChange={this.commentChange}>
-
+            <textarea style={{resize:'vertical'}}
+              ref={(el) => {this.textArea = el}}
+              id="comment"
+              name="comment"
+              placeholder="Leave a comment here"
+              className="f9 db border-box w-100 ba b--gray3 pt3 ph3 pb8 br1 mb2"
+              aria-describedby="comment-desc"
+              onChange={this.commentChange}>
             </textarea>
           </div>
-          <button onClick={this.commentSubmit} className="f9 pa2 bg-white br1 ba b--gray2 gray2 pointer">
+          <button disabled={disableComment}
+            onClick={this.commentSubmit}
+            className={commentClass}>
             Add comment
           </button>
         </div>

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -58,20 +58,29 @@ export class NewScreen extends Component {
   onClickCreate() {
     const { props, state } = this;
     let bookId = stringToSymbol(state.idName);
-    let groupInfo = (state.invites.groups.length > 0)
-      ? {
-          "group-path": state.invites.groups[0],
-          "invitees": [],
-          "use-preexisting": true,
-          "make-managed": false,
-        }
-      : {
-          //  TODO remove /~ and set make-managed on toggle
-          "group-path": `/~/publish/~${window.ship}/${bookId}`,
-          "invitees": state.invites.ships,
-          "use-preexisting": false,
-          "make-managed": false,
-        };
+    let groupInfo = null;
+    if (state.invites.groups.length > 0) {
+      groupInfo = {
+        "group-path": state.invites.groups[0],
+        "invitees": [],
+        "use-preexisting": true,
+        "make-managed": false,
+      };
+    } else if  (this.state.createGroup) {
+      groupInfo = {
+        "group-path": `/~${window.ship}/${bookId}`,
+        "invitees": state.invites.ships,
+        "use-preexisting": false,
+        "make-managed": true,
+      };
+    } else {
+      groupInfo = {
+        "group-path": `/~/publish/~${window.ship}/${bookId}`,
+        "invitees": state.invites.ships,
+        "use-preexisting": false,
+        "make-managed": false,
+      };
+    }
 
     let action = {
       "new-book": {
@@ -87,32 +96,30 @@ export class NewScreen extends Component {
   }
 
   render() {
-    // let createGroupClasses = this.state.createGroup
-    //   ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
-    //   : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
+     let createGroupClasses = this.state.createGroup
+       ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
+       : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
 
     let createClasses = "pointer db f9 green2 bg-gray0-d ba pv3 ph4 mv7 b--green2";
     if (!this.state.idName) {
       createClasses = "pointer db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 mv7 b--gray3";
     }
 
-    // let createGroupToggle = <div/>
-    // if ((this.state.invites.ships.length > 0) && (this.state.invites.groups.length === 0)) {
-    //   createGroupToggle = (
-    //     <div className="mv7">
-    //       <input
-    //         type="checkbox"
-    //         style={{ WebkitAppearance: "none", width: 28 }}
-    //         className={createGroupClasses}
-    //         onChange={this.createGroupChange}
-    //       />
-    //       <span className="dib f9 white-d inter ml3">Create Group</span>
-    //       <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
-    //         Participants will share this group across applications
-    //       </p>
-    //     </div>
-    //   );
-    // }
+    let createGroupToggle =
+      !((this.state.invites.ships.length > 0) && (this.state.invites.groups.length === 0))
+    ?  null
+    :  <div className="mv7">
+         <input
+           type="checkbox"
+           style={{ WebkitAppearance: "none", width: 28 }}
+           className={createGroupClasses}
+           onChange={this.createGroupChange}
+         />
+         <span className="dib f9 white-d inter ml3">Create Group</span>
+         <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
+           Participants will share this group across applications
+         </p>
+       </div>;
 
 
     let idErrElem = <span />;
@@ -176,7 +183,7 @@ export class NewScreen extends Component {
             invites={this.state.invites}
             setInvite={this.setInvite}
           />
-          {/* {createGroupToggle} */}
+          {createGroupToggle}
           <button
           onClick={this.onClickCreate.bind(this)}
           className={createClasses}>

--- a/pkg/interface/publish/src/js/components/lib/notebook.js
+++ b/pkg/interface/publish/src/js/components/lib/notebook.js
@@ -59,6 +59,7 @@ export class Notebook extends Component {
 
   render() {
     let notebook = this.props.notebooks[this.props.ship][this.props.book];
+
     let tabStyles = {
       posts: "bb b--gray4 gray2 pv4 ph2",
       about: "bb b--gray4 gray2 pv4 ph2"
@@ -96,15 +97,19 @@ export class Notebook extends Component {
     let settings = base + '/settings';
     let newUrl = base + '/new';
 
-    let newPost = !(window.ship === this.props.ship.slice(1))
-      // XX TODO check based on authorized writers instead
-      ?  null
-      :  <Link to={newUrl} className="NotebookButton bg-light-green green2">
+    let newPost = null;
+    if (notebook["writers-group-path"] in this.props.groups){
+      let writers = notebook["writers-group-path"];
+      if (this.props.groups[writers].has(window.ship)) {
+        newPost =
+         <Link to={newUrl} className="NotebookButton bg-light-green green2">
            New Post
          </Link>
+      }
+    }
 
     let unsub = (window.ship === this.props.ship.slice(1))
-      ? null
+      ?  null
       :  <button onClick={this.unsubscribe}
              className="NotebookButton bg-white black ba b--black ml3">
            Unsubscribe

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -123,6 +123,7 @@ export class Root extends Component {
                   view={view}
                   ship={ship}
                   book={notebook}
+                  groups={state.groups}
                   {...props}
                 />
               </Skeleton>


### PR DESCRIPTION
This PR contains the following changes. They're all fairly distinct and divided by commit, so it might be easiest to review one commit at at time.

- invite/kick user from a notebook when they're added/removed from related group
- added the "New Post" button for all writers of a notebook, not just the host
- added "create group" toggle on notebook creation page
- made comment box clear on submit