### PR TITLE
link: unread counters in sidebar

### DIFF
--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -40,8 +40,11 @@
 ::
 ::  scry-only paths:
 ::
+::      (set url)
+::    /seen//some-path                      the ones we've seen here
+::
 ::      ?
-::    /seen/wood-url/some-path              have we seen this here (scry only)
+::    /seen/wood-url/some-path              have we seen this here
 ::
 /+  *link, default-agent, verb, dbug
 ::
@@ -151,6 +154,9 @@
     ::
         [%x %seen @ ^]
       ``noun+!>((is-seen t.t.path))
+    ::
+        [%x %unseen *]
+      ``noun+!>((get-unseen t.t.path))
     ==
   ::
   ++  on-watch
@@ -371,6 +377,17 @@
   ::
   %+  ~(put by *(map ^path submissions))  path
   submissions:(~(gut by by-group) path *links)
+::
+++  get-unseen
+  |=  =path
+  ^-  (set url)
+  =/  =links
+    (~(gut by by-group) path *links)
+  %-  ~(gas in *(set url))
+  %+  murn  submissions.links
+  |=  submission
+  ?:  (~(has in seen.links) url)  ~
+  (some url)
 ::
 ++  is-seen
   |=  =path

--- a/pkg/arvo/app/link-view.hoon
+++ b/pkg/arvo/app/link-view.hoon
@@ -248,6 +248,16 @@
   |=  [=^path =submissions]
   ^-  [@t json]
   :-  (spat path)
+  =;  =json
+    ::  add unseen count
+    ::
+    ?>  ?=(%o -.json)
+    :-  %o
+    %+  ~(put by p.json)  'unseenCount'
+    %-  numb:enjs:format
+    %~  wyt  in
+    %+  scry-for  (set url)
+    [%unseen path]
   %^  page-to-json  p
     %+  get-paginated  `p
     submissions

--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -18,6 +18,9 @@ export class ChannelsSidebar extends Component {
         let name = "Private"
         let selected = (props.selected === path);
         let linkCount = !!props.links[path] ? props.links[path].totalItems : 0;
+        const unseenCount = !!props.links[path]
+          ? props.links[path].unseenCount
+          : linkCount
         return (
           <ChannelsItem
             key={path}
@@ -25,6 +28,7 @@ export class ChannelsSidebar extends Component {
             members={props.paths[path]}
             selected={selected}
             linkCount={linkCount}
+            unseenCount={unseenCount}
             name={name}/>
         )
       })

--- a/pkg/interface/link/src/js/components/lib/channels-item.js
+++ b/pkg/interface/link/src/js/components/lib/channels-item.js
@@ -11,6 +11,9 @@ export class ChannelsItem extends Component {
     : "b--transparent";
     
     let memberCount = Object.keys(props.members).length;
+    const unseenCount = props.unseenCount > 0
+      ? <span className="green2">{" " + props.unseenCount + " unread"}</span>
+      : null;
 
     return (
       <Link to={"/~link" + props.link}>
@@ -21,6 +24,7 @@ export class ChannelsItem extends Component {
           </p>
           <p className="f9 pb1">
             {props.linkCount + " link" + ((props.linkCount === 1) ? "" : "s")}
+            {unseenCount}
           </p>
         </div>
       </Link>

--- a/pkg/interface/link/src/js/reducers/link-update.js
+++ b/pkg/interface/link/src/js/reducers/link-update.js
@@ -41,6 +41,7 @@ export class LinkUpdateReducer {
         state.links[path].local[page] = false;
         state.links[path].totalPages = here.totalPages;
         state.links[path].totalItems = here.totalItems;
+        state.links[path].unseenCount = here.unseenCount;
 
         // write seen status to a separate structure,
         // for easier modification later.
@@ -74,6 +75,8 @@ export class LinkUpdateReducer {
       state.links[path] = this._addNewItems(
         data.pages, state.links[path]
       );
+      state.links[path].unseenCount =
+        state.links[path].unseenCount + data.pages.length;
     }
   }
 
@@ -148,6 +151,10 @@ export class LinkUpdateReducer {
       data.urls.map(url => {
         seen[url] = true;
       });
+      if (state.links[path]) {
+        state.links[path].unseenCount =
+          state.links[path].unseenCount - data.urls.length;
+      }
     }
   }
 


### PR DESCRIPTION
Adds little unread counters to the link counts in the sidebar. (Disappear if there's nothing new.)

<img width="161" alt="image" src="https://user-images.githubusercontent.com/3829764/74182145-cc751880-4c42-11ea-8454-8b0ffa9006b6.png">
