### PR TITLE
publish: "new post" button controlled in state

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/notebook.js
+++ b/pkg/interface/publish/src/js/components/lib/notebook.js
@@ -11,6 +11,9 @@ import { Settings } from './settings';
 export class Notebook extends Component {
   constructor(props){
     super(props);
+    this.state = {
+      canWrite: false
+    };
 
     this.onScroll = this.onScroll.bind(this);
     this.unsubscribe = this.unsubscribe.bind(this);
@@ -41,10 +44,30 @@ export class Notebook extends Component {
   }
 
   componentDidMount() {
+    this.canWriteCheck();
     if (this.props.notebooks[this.props.ship][this.props.book].notes) {
       this.onScroll();
     }
   }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps !== this.props) {
+      this.canWriteCheck();
+    }
+  }
+
+  canWriteCheck() {
+      let notebook = this.props.notebooks[this.props.ship][this.props.book];
+      if (this.props.ship === `~${window.ship}`) {
+        this.setState({canWrite: true});
+      }
+      if (notebook["writers-group-path"] in this.props.groups) {
+        let writers = notebook["writers-group-path"];
+        if (this.props.groups[writers].has(window.ship)) {
+          this.setState({canWrite: true});
+        }
+      }
+    }
 
   unsubscribe() {
     let action = {
@@ -98,14 +121,13 @@ export class Notebook extends Component {
     let newUrl = base + '/new';
 
     let newPost = null;
-    if (notebook["writers-group-path"] in this.props.groups){
-      let writers = notebook["writers-group-path"];
-      if (this.props.groups[writers].has(window.ship)) {
-        newPost =
-         <Link to={newUrl} className="NotebookButton bg-light-green green2">
-           New Post
-         </Link>
-      }
+
+    if (this.state.canWrite === true) {
+        newPost = (
+          <Link to={newUrl} className="NotebookButton bg-light-green green2">
+            New Post
+          </Link>
+        );
     }
 
     let unsub = (window.ship === this.props.ship.slice(1))


### PR DESCRIPTION
Previously, if you created a new notebook, you won't see "new post" until you refresh; it's done once on render.

This moves the check for write permissions to its own function, and calls that function on component mount and update; it also short circuits the check if the notebook belongs to your ship. 

This is a tradeoff; I can't think of a good edge case where you own a notebook you can't write to at the moment (*especially* outside a pre-existing group context, which is the only time when a write group will be created and thus not appear in time for the update check — and the only time in which the check for the write group prop fails anyway is *immediately after* creating a notebook without a pre-existing group).