### PR TITLE
contacts: design tweaks for share sheet

### DIFF
--- a/pkg/interface/contacts/src/css/custom.css
+++ b/pkg/interface/contacts/src/css/custom.css
@@ -90,8 +90,8 @@ a {
 }
 
 /* dark */
-@media all and (prefers-color-scheme: dark) {
+/* @media all and (prefers-color-scheme: dark) {
   .invert-d {
     filter: invert(1);
   }
-}
+} */

--- a/pkg/interface/contacts/src/js/components/lib/share-sheet.js
+++ b/pkg/interface/contacts/src/js/components/lib/share-sheet.js
@@ -13,7 +13,7 @@ export class ShareSheet extends Component {
 
     return (
       <div>
-        <p className="pt2 pb2 pl3 pr3 f8 gray3">Share Your Profile</p>
+        <p className="pt4 pb2 pl3 pr3 f8 gray2 f9">Share Your Profile</p>
         <ContactItem
           key={props.ship}
           ship={props.ship}
@@ -22,11 +22,11 @@ export class ShareSheet extends Component {
           path={props.path}
           selected={props.selected}
           share={true} />
-        <p className="pt2 pb3 pl3 pr3 f8">
+        <p className="pt2 pb3 pl3 pr3 f9">
            Your personal information is hidden to others in this group
            by default.
         </p>
-        <p className="pl3 pr3 f8">
+        <p className="pl3 pr3 f9">
           Share whenever you are ready, or edit its contents for this group.
         </p>
       </div>


### PR DESCRIPTION
Just lining it up with the group sidebar's header padding; consistent font size and color.

<img width="641" alt="image" src="https://user-images.githubusercontent.com/20846414/74206825-0cd89480-4c4b-11ea-927f-a05fee42caf6.png">
