### PR TITLE
link fe: properly downscale wide images to fit screen

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -74,9 +74,8 @@ export class LinkPreview extends Component {
     if (imgMatch) {
       embed = <a href={props.url}
                 target="_blank"
-                className="db m0a"
                 style={{width: "max-content"}}>
-        <img src={props.url} style={{maxHeight: "500px", maxWidth: "500px"}}/>
+        <img src={props.url} style={{maxHeight: "500px", maxWidth: "100%"}}/>
       </a>
     }
 
@@ -97,7 +96,7 @@ export class LinkPreview extends Component {
     return (
       <div className="pb6 w-100">
         <div
-          className={"w-100 " + (ytMatch ? "embed-container" : "")}>
+          className={"w-100 tc " + (ytMatch ? "embed-container" : "")}>
           {embed}
         </div>
         <div className="flex flex-column ml2 pt6">


### PR DESCRIPTION
We no longer downscale to 500px wide, but rather however wide fits
within the container, and doesn't exceed 500px in height.

<img width="416" alt="image" src="https://user-images.githubusercontent.com/3829764/74266070-f6424400-4d03-11ea-85fc-fcadf0e3337c.png">

<img width="406" alt="image" src="https://user-images.githubusercontent.com/3829764/74266096-fe9a7f00-4d03-11ea-94b5-eb0cc2972727.png">

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/3829764/74266124-0d813180-4d04-11ea-952a-ec5ba80a1715.png">
