### PR TITLE
hoon: clarify comments for +rep:in and +rep:by

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1337,7 +1337,7 @@
       a(r c)
     c(l a(r l.c))
   ::
-  ++  rep                                               ::  replace by product
+  ++  rep                                               ::  reduce to product
     |*  b/_=>(~ |=({* *} +<+))
     |-
     ?~  a  +<+.b
@@ -1592,7 +1592,7 @@
       a(r d)
     d(l a(r l.d))
   ::
-  ++  rep                                               ::  replace by product
+  ++  rep                                               ::  reduce to product
     |*  b/_=>(~ |=({* *} +<+))
     |-
     ?~  a  +<+.b


### PR DESCRIPTION
This has bitten me often enough that it's actually _really_ annoying now. I'm pretty sure this comment is at least _equally_ correct, and hopefully _more_.

"Replace" suggests this function either produces an updated set/map when done,
like `+snap`, or changes all values in-place, like `+turn`. In truth, it's more
similar to `+roll`, which does reduction/accumulation.

("Reduce" specifically was chosen because it maintains the mnemonic relation to
the arm name.)