### PR TITLE
metadata-store: associate groups with resources within apps, and allow various types of queries

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -1,23 +1,10 @@
 ::  metadata-store: data store for application metadata and mappings 
 ::  between groups and application data (chatrooms, publish notebooks, etc)
 ::
+/-  *metadata-store
 /+  default-agent
 |%
 +$  card  card:agent:gall
-+$  group-path  path
-+$  app-name  @tas
-+$  app-path  path
-+$  metadata
-  $:  title=@t
-      description=@t
-      color=@ux
-  ==
-::
-+$  metadata-action
-  $%  [%add =group-path =app-name =app-path =metadata]
-      [%remove =group-path =app-name =app-path]
-  ==
-+$  metadata-update  metadata-action
 ::
 +$  versioned-state
   $%  state-zero
@@ -37,10 +24,10 @@
 ^-  agent:gall
 =<
   |_  =bowl:gall
-  +*  this        .
+  +*  this           .
       metadata-core  +>
-      mc          ~(. metadata-core bowl)
-      def         ~(. (default-agent this %|) bowl)
+      mc             ~(. metadata-core bowl)
+      def            ~(. (default-agent this %|) bowl)
   ::
   ++  on-init            on-init:def
   ++  on-save   !>(state)
@@ -65,7 +52,8 @@
     |^
     =/  cards=(list card)
       ?+  path  (on-watch:def path)
-          [%all ~]  (give %metadata-initial !>(associated))
+          [%all ~]      (give %metadata-initial !>(associated))
+          [%updates ~]  ~
       ==
     [cards this]
     ::

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -1,0 +1,164 @@
+::  metadata-store: data store for application metadata and mappings 
+::  between groups and application data (chatrooms, publish notebooks, etc)
+::
+/+  default-agent
+|%
++$  card  card:agent:gall
++$  group-path  path
++$  app-name  @tas
++$  app-path  path
++$  metadata
+  $:  title=@t
+      description=@t
+      color=@ux
+  ==
+::
++$  metadata-action
+  $%  [%add =group-path =app-name =app-path =metadata]
+      [%remove =group-path =app-name =app-path]
+  ==
++$  metadata-update  metadata-action
+::
++$  versioned-state
+  $%  state-zero
+  ==
+::
++$  state-zero
+  $:  %0
+      associated=(map [group-path app-name app-path] metadata)
+      group-indices=(jug group-path [app-name app-path])
+      app-name-indices=(jug app-name [app-path group-path])
+      app-path-indices=(map [app-name app-path] group-path)
+  ==
+--
+::
+=|  state-zero
+=*  state  -
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this        .
+      metadata-core  +>
+      mc          ~(. metadata-core bowl)
+      def         ~(. (default-agent this %|) bowl)
+  ::
+  ++  on-init            on-init:def
+  ++  on-save   !>(state)
+  ++  on-load
+    |=  old=vase
+    `this(state !<(state-zero old))
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    ?>  (team:title our.bowl src.bowl)
+    =^  cards  state
+      ?:  ?=(%metadata-action mark)
+        (poke-metadata-action:mc !<(metadata-action vase))
+      (on-poke:def mark vase)
+    [cards this]
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card _this)
+    ?>  (team:title our.bowl src.bowl)
+    |^
+    =/  cards=(list card)
+      ?+  path  (on-watch:def path)
+          [%all ~]  (give %metadata-initial !>(associated))
+      ==
+    [cards this]
+    ::
+    ++  give
+      |=  =cage
+      ^-  (list card)
+      [%give %fact ~ cage]~
+    --
+  ::
+  ++  on-leave  on-leave:def
+  ::
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?+  path  (on-peek:def path)
+        [%x %all ~]            ``noun+!>(associated)
+        [%x %group-indices ~]  ``noun+!>(group-indices)
+        [%x %app-name-indices ~]    ``noun+!>(app-name-indices)
+        [%x %app-path-indices ~]    ``noun+!>(app-path-indices)
+        [%x %metadata * * *]
+      ::  TODO: figure out the best way to do this with two
+      ::  variable-length arguments, talk to mark?
+      !!
+    ==
+  ::
+  ++  on-agent  on-agent:def
+  ++  on-arvo   on-arvo:def
+  ++  on-fail   on-fail:def
+  --
+::
+|_  bol=bowl:gall
+::
+++  poke-metadata-action
+  |=  act=metadata-action
+  ^-  (quip card _state)
+  ?>  (team:title our.bol src.bol)
+  ?-  -.act
+      %add
+    (handle-add group-path.act app-name.act app-path.act metadata.act)
+  ::
+      %remove
+    (handle-remove group-path.act app-name.act app-path.act)
+  ==
+::
+++  handle-add
+  |=  [=group-path =app-name =app-path =metadata]
+  ^-  (quip card _state)
+  ?<  (~(has by app-path-indices) [app-name app-path])
+  :-  (send-diff [%add group-path app-name app-path metadata])
+  %=  state
+      associated
+    (~(put by associated) [group-path app-name app-path] metadata)
+  ::
+      group-indices
+    (~(put ju group-indices) group-path [app-name app-path])
+  ::
+      app-name-indices
+    (~(put ju app-name-indices) app-name [app-path group-path])
+  ::
+      app-path-indices
+    (~(put by app-path-indices) [app-name app-path] group-path)
+  ==
+::
+++  handle-remove
+  |=  [=group-path =app-name =app-path]
+  ^-  (quip card _state)
+  :-  (send-diff [%remove group-path app-name app-path])
+  %=  state
+      associated
+    (~(del by associated) [group-path app-name app-path])
+  ::
+      group-indices
+    (~(del ju group-indices) group-path [app-name app-path])
+  ::
+      app-name-indices
+    (~(del ju app-name-indices) app-name [app-path group-path])
+  ::
+      app-path-indices
+    (~(del by app-path-indices) [app-name app-path])
+  ==
+::
+++  send-diff
+  |=  act=metadata-action
+  ^-  (list card)
+  |^
+  %-  zing
+  :~  (update-subscribers /all act)
+      (update-subscribers /updates act)
+  ==
+  ::
+  ++  update-subscribers
+    |=  [pax=path act=metadata-action]
+    ^-  (list card)
+    [%give %fact ~[pax] %metadata-update !>(act)]~
+  --
+--

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -4,18 +4,21 @@
 ::  group-paths are expected to be an existing group path
 ::  resources are expected to correspond to existing app paths
 ::
+::  note: when scrying for metadata, to make the arguments safe in paths,
+::  encode group-path and app-path using (scot %t (spat group-path))
+::
 ::  +watch paths:
 ::  /all                                  assocations + updates
 ::  /updates                              just updates
 ::  /app-name/%app-name                   specific app's associations + updates
 ::
 ::  +peek paths:
-::  /associations                                          all associations
-::  /group-indices                                         all group indices
-::  /app-indices                                           all app indices
-::  /resource-indices                                      all resource indices
-::  /metadata/(spat group-path)/%app-name/(spat app-path)  specific metadatum
-::  /app-name/%app-name                                    associations for app
+::  /associations                                  all associations
+::  /group-indices                                 all group indices
+::  /app-indices                                   all app indices
+::  /resource-indices                              all resource indices
+::  /metadata/%group-path/%app-name/%app-path      specific metadatum
+::  /app-name/%app-name                            associations for app
 ::
 /-  *metadata-store
 /+  default-agent
@@ -89,18 +92,18 @@
     |=  =path
     ^-  (unit (unit cage))
     ?+  path  (on-peek:def path)
-        [%y %associations ~]      ``noun+!>(associations)
         [%y %group-indices ~]     ``noun+!>(group-indices)
         [%y %app-indices ~]       ``noun+!>(app-indices)
         [%y %resource-indices ~]  ``noun+!>(resource-indices)
-        [%x %metadata @ @ @ ~]
-      =/  =group-path  (stab i.t.t.path)
-      =/  =resource    [`@tas`i.t.t.t.path (stab i.t.t.t.t.path)]
-      ``noun+!>((~(got by associations) [group-path resource]))
-    ::
+        [%x %associations ~]      ``noun+!>(associations)
         [%x %app-name @ ~]
       =/  =app-name  i.t.t.path
       ``noun+!>((metadata-for-app:mc app-name))
+    ::
+        [%x %metadata @ @ @ ~]
+      =/  =group-path  (stab (slav %t i.t.t.path))
+      =/  =resource    [`@tas`i.t.t.t.path (stab (slav %t i.t.t.t.t.path))]
+      ``noun+!>((~(got by associations) [group-path resource]))
     ==
   ::
   ++  on-agent  on-agent:def
@@ -109,7 +112,6 @@
   --
 ::
 |_  =bowl:gall
-::
 ++  poke-metadata-action
   |=  act=metadata-action
   ^-  (quip card _state)
@@ -129,7 +131,6 @@
       ?.  (~(has by resource-indices) resource)
         [%add group-path resource metadata]
       [%update-metadata group-path resource metadata]
-
   %=  state
       associations
     (~(put by associations) [group-path resource] metadata)

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -12,9 +12,9 @@
 ::
 +$  state-zero
   $:  %0
-      associated=(map [group-path app-name app-path] metadata)
+      =associated
       group-indices=(jug group-path [app-name app-path])
-      app-name-indices=(jug app-name [app-path group-path])
+      app-name-indices=(jug app-name [group-path app-path])
       app-path-indices=(map [app-name app-path] group-path)
   ==
 --
@@ -29,8 +29,8 @@
       mc             ~(. metadata-core bowl)
       def            ~(. (default-agent this %|) bowl)
   ::
-  ++  on-init            on-init:def
-  ++  on-save   !>(state)
+  ++  on-init  on-init:def
+  ++  on-save  !>(state)
   ++  on-load
     |=  old=vase
     `this(state !<(state-zero old))
@@ -54,6 +54,10 @@
       ?+  path  (on-watch:def path)
           [%all ~]      (give %metadata-initial !>(associated))
           [%updates ~]  ~
+          [%app-name @ ~]
+        =/  =app-name  i.t.path
+        =/  app-indices  (metadata-for-app:mc app-name)
+        (give %metadata-update !>([%app-indices app-indices]))
       ==
     [cards this]
     ::
@@ -69,14 +73,19 @@
     |=  =path
     ^-  (unit (unit cage))
     ?+  path  (on-peek:def path)
-        [%x %all ~]            ``noun+!>(associated)
-        [%x %group-indices ~]  ``noun+!>(group-indices)
-        [%x %app-name-indices ~]    ``noun+!>(app-name-indices)
-        [%x %app-path-indices ~]    ``noun+!>(app-path-indices)
-        [%x %metadata * * *]
-      ::  TODO: figure out the best way to do this with two
-      ::  variable-length arguments, talk to mark?
-      !!
+        [%x %all ~]               ``noun+!>(associated)
+        [%x %group-indices ~]     ``noun+!>(group-indices)
+        [%x %app-name-indices ~]  ``noun+!>(app-name-indices)
+        [%x %app-path-indices ~]  ``noun+!>(app-path-indices)
+        [%x %metadata @ @ @ ~]
+      =/  =group-path  (stab i.t.t.path)
+      =/  =app-name    `@tas`i.t.t.t.path
+      =/  =app-path    (stab i.t.t.t.t.path)
+      ``noun+!>((~(got by associated) [group-path app-name app-path]))
+    ::
+        [%x %app-name @ ~]
+      =/  =app-name  i.t.t.path
+      ``noun+!>((metadata-for-app:mc app-name))
     ==
   ::
   ++  on-agent  on-agent:def
@@ -84,12 +93,12 @@
   ++  on-fail   on-fail:def
   --
 ::
-|_  bol=bowl:gall
+|_  =bowl:gall
 ::
 ++  poke-metadata-action
   |=  act=metadata-action
   ^-  (quip card _state)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bowl src.bowl)
   ?-  -.act
       %add
     (handle-add group-path.act app-name.act app-path.act metadata.act)
@@ -101,8 +110,10 @@
 ++  handle-add
   |=  [=group-path =app-name =app-path =metadata]
   ^-  (quip card _state)
-  ?<  (~(has by app-path-indices) [app-name app-path])
-  :-  (send-diff [%add group-path app-name app-path metadata])
+  :-  %+  send-diff  app-name
+      ?.  (~(has by app-path-indices) [app-name app-path])
+        [%add group-path app-name app-path metadata]
+      [%update-metadata group-path app-name app-path metadata]
   %=  state
       associated
     (~(put by associated) [group-path app-name app-path] metadata)
@@ -111,7 +122,7 @@
     (~(put ju group-indices) group-path [app-name app-path])
   ::
       app-name-indices
-    (~(put ju app-name-indices) app-name [app-path group-path])
+    (~(put ju app-name-indices) app-name [group-path app-path])
   ::
       app-path-indices
     (~(put by app-path-indices) [app-name app-path] group-path)
@@ -120,7 +131,7 @@
 ++  handle-remove
   |=  [=group-path =app-name =app-path]
   ^-  (quip card _state)
-  :-  (send-diff [%remove group-path app-name app-path])
+  :-  (send-diff app-name [%remove group-path app-name app-path])
   %=  state
       associated
     (~(del by associated) [group-path app-name app-path])
@@ -129,24 +140,33 @@
     (~(del ju group-indices) group-path [app-name app-path])
   ::
       app-name-indices
-    (~(del ju app-name-indices) app-name [app-path group-path])
+    (~(del ju app-name-indices) app-name [group-path app-path])
   ::
       app-path-indices
     (~(del by app-path-indices) [app-name app-path])
   ==
 ::
+++  metadata-for-app
+  |=  =app-name
+  %-  ~(gas by *(map [group-path ^app-name app-path] metadata))
+  %+  turn  ~(tap in (~(got by app-name-indices) app-name))
+  |=  [=group-path =app-path]
+  :-  [group-path app-name app-path]
+  (~(got by associated) [group-path app-name app-path])
+::
 ++  send-diff
-  |=  act=metadata-action
+  |=  [=app-name upd=metadata-update]
   ^-  (list card)
   |^
   %-  zing
-  :~  (update-subscribers /all act)
-      (update-subscribers /updates act)
+  :~  (update-subscribers /all upd)
+      (update-subscribers /updates upd)
+      (update-subscribers [%app-name app-name ~] upd)
   ==
   ::
   ++  update-subscribers
-    |=  [pax=path act=metadata-action]
+    |=  [pax=path upd=metadata-update]
     ^-  (list card)
-    [%give %fact ~[pax] %metadata-update !>(act)]~
+    [%give %fact ~[pax] %metadata-update !>(upd)]~
   --
 --

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -116,6 +116,7 @@
       %link-proxy-hook
       %link-listen-hook
       %link-view
+      %metadata-store
   ==
 ::
 ++  deft-fish                                           ::  default connects

--- a/pkg/arvo/sur/metadata-store.hoon
+++ b/pkg/arvo/sur/metadata-store.hoon
@@ -1,0 +1,18 @@
+|%
++$  group-path  path
++$  app-name  @tas
++$  app-path  path
+::
++$  metadata
+  $:  title=@t
+      description=@t
+      color=@ux
+  ==
+::
++$  metadata-action
+  $%  [%add =group-path =app-name =app-path =metadata]
+      [%remove =group-path =app-name =app-path]
+  ==
+::
++$  metadata-update  metadata-action
+--

--- a/pkg/arvo/sur/metadata-store.hoon
+++ b/pkg/arvo/sur/metadata-store.hoon
@@ -2,6 +2,7 @@
 +$  group-path  path
 +$  app-name  @tas
 +$  app-path  path
++$  associated  (map [group-path app-name app-path] metadata)
 ::
 +$  metadata
   $:  title=@t
@@ -14,5 +15,9 @@
       [%remove =group-path =app-name =app-path]
   ==
 ::
-+$  metadata-update  metadata-action
++$  metadata-update
+  $%  metadata-action
+      [%app-indices app-indices=associated]
+      [%update-metadata =group-path =app-name =app-path =metadata]
+  ==
 --

--- a/pkg/arvo/sur/metadata-store.hoon
+++ b/pkg/arvo/sur/metadata-store.hoon
@@ -1,23 +1,26 @@
 |%
-+$  group-path  path
-+$  app-name  @tas
-+$  app-path  path
-+$  associated  (map [group-path app-name app-path] metadata)
++$  group-path    path
++$  app-name      @tas
++$  app-path      path
++$  resource      [=app-name =app-path]
++$  associations  (map [group-path resource] metadata)
 ::
 +$  metadata
   $:  title=@t
       description=@t
       color=@ux
+      date-created=@da
+      creator=@p
   ==
 ::
 +$  metadata-action
-  $%  [%add =group-path =app-name =app-path =metadata]
-      [%remove =group-path =app-name =app-path]
+  $%  [%add =group-path =resource =metadata]
+      [%remove =group-path =resource]
   ==
 ::
 +$  metadata-update
   $%  metadata-action
-      [%app-indices app-indices=associated]
-      [%update-metadata =group-path =app-name =app-path =metadata]
+      [%associations =associations]
+      [%update-metadata =group-path =resource =metadata]
   ==
 --


### PR DESCRIPTION
Added first pass of metadata-store, a data store for application metadata and mappings 
between groups and application data (chatrooms, publish notebooks, etc).

I will add documentation to this before merging it, but I wanted to put out this version for review. The hook will be started next and will be in a separate PR, then integration work will be merged in as its own PR.