### PR TITLE
chat: fix station string format

### DIFF
--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -44,7 +44,10 @@ export class ChatScreen extends Component {
  componentDidUpdate(prevProps, prevState) {
    const { props, state } = this;
 
-   const station = `/${props.match.params.ship}/${props.match.params.station}`
+   const station =
+     props.match.params[1] === undefined ?
+     `/${props.match.params.ship}/${props.match.params.station}` :
+     `/${props.match.params[1]}/${props.match.params.ship}/${props.match.params.station}`;
 
    if (
      prevProps.match.params.station !== props.match.params.station ||


### PR DESCRIPTION
The station format changed from `/~zod/lmao` to `/~/~zod/lmao` at some point. This breaks my stuff from #2221, and possibly other things in `chat.js` as well. Here's a fix.