### PR TITLE
link: correct unread color class

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -48,7 +48,7 @@ export class LinkItem extends Component {
     let hostname = URLparser.exec(props.url);
 
     const seenState = props.seen
-      ? "grey2"
+      ? "gray2"
       : "green2 pointer";
     const seenAction = props.seen
       ? ()=>{}


### PR DESCRIPTION
`seenState` was supplying `grey2` instead of `gray2`, making the read state black in both color schemes. This commit corrects that.