### PR TITLE
chat-cli: respect path structure during ;create

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -762,7 +762,7 @@
       :-  %chat-view-action
       !>  ^-  chat-view-action
       :*  %create
-          path
+          [(scot %p our-self) path]
           security
           ::  ensure we can read from/write to our own chats
           ::

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -762,7 +762,12 @@
       :-  %chat-view-action
       !>  ^-  chat-view-action
       :*  %create
+        ::
+          %+  weld
+            ?:  ?=(%village security)  ~
+            [~.~]~
           [(scot %p our-self) path]
+        ::
           security
           ::  ensure we can read from/write to our own chats
           ::


### PR DESCRIPTION
Chat paths need to be manually created with the /~ship/path structure now.

(Something something types.)