### PR TITLE
link: peer subscription fixes

### DIFF
--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -75,8 +75,24 @@
       =^  cards  state
         (take-forward-sign:do t.wire sign)
       [cards this]
+    ?:  ?=([%prod *] wire)
+      ~|  [%weird-sign -.sign]
+      ?>  ?=(%poke-ack -.sign)
+      ?~  p.sign  [~ this]
+      %-  (slog [leaf+"failed to prod" u.p.sign])
+      [~ this]
     ~|  [dap.bowl %weird-wire wire]
     !!
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ?.  ?=(%link-listen-poke mark)
+      (on-poke:def mark vase)
+    =/  =path  !<(path vase)
+    :_  this
+    %+  weld
+      (take-retry:do %local-pages src.bowl path)
+    (take-retry:do %annotations src.bowl path)
   ::
   ++  on-arvo
     |=  [=wire =sign-arvo]
@@ -98,7 +114,6 @@
       (take-retry:do (wire-to-target t.wire))
     ==
   ::
-  ++  on-poke   on-poke:def
   ++  on-peek   on-peek:def
   ++  on-watch  on-watch:def
   ++  on-leave  on-leave:def
@@ -168,8 +183,9 @@
       %+  weld
         $(whos t.whos)
       (end-link-subscriptions i.whos pax.upd)
-    :+  (start-link-subscription %local-pages i.whos pax.upd)
-      (start-link-subscription %annotations i.whos pax.upd)
+    :^    (start-link-subscription %local-pages i.whos pax.upd)
+        (start-link-subscription %annotations i.whos pax.upd)
+      (prod-other-listener i.whos pax.upd)
     $(whos t.whos)
   ==
 ::
@@ -204,6 +220,18 @@
         ~
     ==
   --
+::
+++  prod-other-listener
+  |=  [who=ship where=path]
+  ^-  card
+  :*  %pass
+      [%prod (scot %p who) where]
+      %agent
+      [who %link-listen-hook]
+      %poke
+      %link-listen-poke
+      !>(where)
+  ==
 ::
 ++  take-link-sign
   |=  [=target =sign:agent:gall]
@@ -261,7 +289,7 @@
     ?.  relevant  ~
     [(start-link-subscription target)]~
   ?:  %-  ~(has by wex.bowl)
-      [[%links (target-to-wire target)] who.target %group-store]
+      [[%links (target-to-wire target)] who.target %link-proxy-hook]
     |
   %.  who.target
   %~  has  in

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -114,13 +114,8 @@
     ?&  ?=(^ group)
         (~(has in u.group) who)
     ==
-  .^  (unit group:group-store)
-      %gx
-      (scot %p our.bowl)
-      %group-store
-      (scot %da now.bowl)
-      (snoc u.target %noun)
-  ==
+  %+  scry-for  (unit group:group-store)
+  [%group-store u.target]
 ::
 ::  groups subscription
 ::TODO  largely copied from link-listen-hook. maybe make a store-listener lib?
@@ -216,10 +211,14 @@
     [%give %fact ~ %link-initial !>(initial)]
   ?+  path  !!
       [%local-pages ^]
-    [%local-pages .^((map ^path pages) %gx path)]
+    :-  %local-pages
+    %+  scry-for  (map ^path pages)
+    [%link-store path]
   ::
-      [%annotations ~ ^]
-    [%annotations .^((per-path-url notes) %gx '' t.t.path)]
+      [%annotations %$ ^]
+    :-  %annotations
+    %+  scry-for  (per-path-url notes)
+    [%link-store path]
   ==
 ::
 ++  start-proxy
@@ -249,4 +248,14 @@
   ::  else, close the local subscription.
   ::
   [(proxy-pass-link-store path %leave ~)]~
+::
+++  scry-for
+  |*  [=mold app=term =path]
+  .^  mold
+    %gx
+    (scot %p our.bowl)
+    app
+    (scot %da now.bowl)
+    (snoc `^path`path %noun)
+  ==
 --

--- a/pkg/arvo/mar/link/listen-poke.hoon
+++ b/pkg/arvo/mar/link/listen-poke.hoon
@@ -1,0 +1,12 @@
+::  link-listen-poke: prod another listener into paying attention
+::
+|_  =path
+++  grow
+  |%
+  ++  noun  path
+  --
+++  grab
+  |%
+  ++  noun  ^path
+  --
+--


### PR DESCRIPTION
Broadly:
- Fixes incorrectly implemented subscription response in link-proxy-hook.
- Makes link-listen-hook instances kick each other into listening on-group-join. Retry mechanic already accounted for out-of-sync group definitions, this just expedites the process.