### PR TITLE
link: ensure content remains sorted by timestamp

### DIFF
--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -320,7 +320,8 @@
   ::  add link to group submissions
   ::
   =/  =links  (~(gut by by-group) path *links)
-  =.  submissions.links  [submission submissions.links]
+  =.  submissions.links
+    (submissions:merge submissions.links ~[submission])
   =.  by-group  (~(put by by-group) path links)
   ::  add submission to global sites
   ::
@@ -345,7 +346,8 @@
   ::
   =/  urls  (~(gut by discussions) path *(map ^url discussion))
   =/  =discussion  (~(gut by urls) url *discussion)
-  =.  comments.discussion  [comment comments.discussion]
+  =.  comments.discussion
+    (comments:merge comments.discussion ~[comment])
   =.  urls  (~(put by urls) url discussion)
   =.  discussions  (~(put by discussions) path urls)
   ::  send updates to subscribers

--- a/pkg/interface/link/src/js/reducers/link-update.js
+++ b/pkg/interface/link/src/js/reducers/link-update.js
@@ -177,6 +177,7 @@ export class LinkUpdateReducer {
       pages.local[i] = (page < pages.totalPages);
     }
     pages[i] = items.concat(pages[i]);
+    pages[i].sort((a, b) => b.time - a.time);
     pages.totalItems = pages.totalItems + items.length;
     if (pages[i].length <= PAGE_SIZE) {
       pages.totalPages = Math.ceil(pages.totalItems / PAGE_SIZE);


### PR DESCRIPTION
When pulling in submissions and comments from other ships, we want to make sure we integrate them properly into our latest-first data structures, on both the back- and frontend.