### PR TITLE
chat: immediately send read event for own messages

### DIFF
--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -77,6 +77,16 @@ class UrbitApi {
     });
   }
 
+  addReadReceiptPending(station) {
+    const m = store.state.myReadReceiptsPending.set(station, true);
+    store.setState({myReadReceiptsPending: m})
+  }
+
+  removeReadReceiptPending(station) {
+    const m = store.state.myReadReceiptsPending.set(station, false);
+    store.setState({myReadReceiptsPending: m})
+  }
+
   groupsAction(data) {
     this.action("group-store", "group-action", data);
   }
@@ -98,7 +108,7 @@ class UrbitApi {
   }
 
   chatAction(data) {
-    this.action("chat-store", "json", data);
+    return this.action("chat-store", "json", data);
   }
 
   chatMessage(path, author, when, letter) {
@@ -121,7 +131,7 @@ class UrbitApi {
   }
 
   chatRead(path, read) {
-    this.chatAction({ read: { path } });
+    return this.chatAction({ read: { path } });
   }
 
   chatViewAction(data) {

--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -147,6 +147,12 @@ export class ChatInput extends Component {
     );
     // perf: setTimeout(this.closure, 2000);
 
+    props.api.addReadReceiptPending(props.station)
+
+    props.api.chat.read(props.station).then(res => {
+      props.api.removeReadReceiptPending(props.station);
+    });
+
     this.setState({
       message: '',
     });

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -35,7 +35,9 @@ export class Root extends Component {
 
     let messagePreviews = {};
     let unreads = {};
+
     Object.keys(state.inbox).forEach((stat) => {
+
       let envelopes = state.inbox[stat].envelopes;
 
       if (envelopes.length === 0) {
@@ -45,7 +47,8 @@ export class Root extends Component {
       }
 
       unreads[stat] =
-        state.inbox[stat].config.length > state.inbox[stat].config.read;
+        state.inbox[stat].config.length > state.inbox[stat].config.read &&
+        !state.myReadReceiptsPending.get(stat);
     });
 
     let invites = '/chat' in state.invites ?

--- a/pkg/interface/chat/src/js/store.js
+++ b/pkg/interface/chat/src/js/store.js
@@ -18,6 +18,7 @@ class Store {
       spinner: false,
       sidebarShown: true,
       pendingMessages: new Map([]),
+      myReadReceiptsPending: new Map([]),
       chatInitialized: false
     };
 


### PR DESCRIPTION
Fixes #2182.

The gist of this PR is to send read receipts immediately after our own messages. We also ignore unread messages until this read receipt request completes to remove annoying blinking in the ui.