### PR TITLE
chat, publish: invite-search surfaces valid ship name as result

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -68,6 +68,18 @@ export class InviteSearch extends Component {
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
+
+      let isValid = true;
+      if (!urbitOb.isValidPatp("~" + searchTerm)) {
+        isValid = false;
+      }
+
+      if ((shipMatches.length === 0) && (isValid)) {
+        shipMatches.push(searchTerm);
+        this.setState({
+          searchResults: { groups: groupMatches, ships: shipMatches }
+        })
+      }
     }
   }
 

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -69,6 +69,18 @@ export class InviteSearch extends Component {
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
+
+      let isValid = true;
+      if (!urbitOb.isValidPatp("~" + searchTerm)) {
+        isValid = false;
+      }
+
+      if ((shipMatches.length === 0) && (isValid)) {
+        shipMatches.push(searchTerm);
+        this.setState({
+          searchResults: { groups: groupMatches, ships: shipMatches }
+        })
+      }
     }
   }
 


### PR DESCRIPTION
If we don't have any ship peers in the search results, and the search term is a valid ship name, show it as a result.

<img width="516" alt="Screen Shot 2020-02-18 at 11 29 23 PM" src="https://user-images.githubusercontent.com/20846414/74802149-f8c61000-52a6-11ea-90d1-e69dc36ccb4d.png">
