### PR TITLE
publish: add spinner, transition behaviours

### DIFF
--- a/pkg/arvo/app/publish/index.hoon
+++ b/pkg/arvo/app/publish/index.hoon
@@ -16,7 +16,6 @@
   ==
 ::
   ;body
-    ;div#header.w-100;
     ;div#root.w-100.h-100;
     ;script@"/~publish/index.js";
   ==

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -200,7 +200,7 @@ a {
   transform: rotate(180deg);
   position: absolute;
   right: 4px;
-  top: 6px;
+  top: 4px;
   color: #7f7f7f;
 }
 
@@ -259,4 +259,20 @@ a {
 
 md img {
   margin-bottom: 8px;
+}
+
+.spin-active {
+  animation: spin 2s infinite;
+}
+
+@keyframes spin {
+  0% {transform: rotate(0deg);}
+  25% {transform: rotate(90deg);}
+  50% {transform: rotate(180deg);}
+  75% {transform: rotate(270deg);}
+  100% {transform: rotate(360deg);}
+}
+
+.mix-blend-diff {
+  mix-blend-mode: difference;
 }

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -65,14 +65,11 @@ a {
   .db-ns {
     display: block;
   }
-  .flex-basis-30-ns {
-    flex-basis: 30vw;
+  .flex-basis-300-ns {
+    flex-basis: 300px;
   }
   .h-100-m-40-ns {
     height: calc(100% - 40px);
-  }
-  .mw-300-ns {
-    max-width: 300px;
   }
 }
 

--- a/pkg/interface/publish/src/index.js
+++ b/pkg/interface/publish/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HeaderBar } from '/components/lib/header-bar';
 import { Root } from '/components/root';
 import { api } from '/api';
 import { store } from '/store';
@@ -11,10 +10,6 @@ api.setAuthTokens({
 });
 
 subscription.start();
-
-ReactDOM.render((
-  <HeaderBar />
-), document.getElementById("header"));
 
 ReactDOM.render((
   <Root />

--- a/pkg/interface/publish/src/js/api.js
+++ b/pkg/interface/publish/src/js/api.js
@@ -130,6 +130,16 @@ class UrbitApi {
     });
   }
 
+  setSpinner(boolean) {
+    console.log("setspinner " + boolean)
+    store.handleEvent({
+      type: "local",
+      data: {
+        'spinner': boolean
+      }
+    });
+  }
+
 }
 
 export let api = new UrbitApi();

--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -5,7 +5,8 @@ export class Comments extends Component {
   constructor(props){
     super(props);
     this.state = {
-      commentBody: ''
+      commentBody: '',
+      disabled: false
     }
     this.commentSubmit = this.commentSubmit.bind(this);
     this.commentChange = this.commentChange.bind(this);
@@ -21,9 +22,14 @@ export class Comments extends Component {
    };
 
    this.textArea.value = '';
-   window.api.action("publish", "publish-action", comment);
-
- }
+   window.api.setSpinner(true);
+   this.setState({disabled: true});
+   let submit = window.api.action("publish", "publish-action", comment);
+   submit.then(() => {
+     window.api.setSpinner(false);
+     this.setState({ disabled: false, commentBody: "" });
+    })
+   }
 
   commentChange(evt){
     this.setState({
@@ -45,7 +51,7 @@ export class Comments extends Component {
       );
     })
 
-    let disableComment = this.state.commentBody === '';
+    let disableComment = ((this.state.commentBody === '') || (this.state.disabled === true));
     let commentClass = (disableComment)
       ?  "f9 pa2 bg-white br1 ba b--gray2 gray2"
       :  "f9 pa2 bg-white br1 ba b--gray2 black pointer";

--- a/pkg/interface/publish/src/js/components/lib/dropdown.js
+++ b/pkg/interface/publish/src/js/components/lib/dropdown.js
@@ -37,11 +37,22 @@ export class Dropdown extends Component {
   }
 
   render() {
+    let alignment = (!!this.props.align)
+      ? this.props.align : "right";
+
     let display = (this.state.open)
       ? "block" : "none";
 
     let optionsColor = (this.state.open)
       ? '#e6e6e6' : 'white';
+
+    let leftAlign = "";
+    let rightAlign = "0";
+
+    if (alignment === "left") {
+      leftAlign = "0"
+      rightAlign = ""
+    }
 
     let optionsList = this.props.options.map((val, i) => {
       return (
@@ -60,9 +71,9 @@ export class Dropdown extends Component {
                 onClick={this.toggleDropdown}>
           {this.props.buttonText}
         </button>
-        <div className="absolute flex flex-column pa4 ba b--gray4 br2 z-1 bg-white"
+        <div className="absolute flex flex-column pv2 ba b--gray4 br2 z-1 bg-white"
            ref={(el) => {this.optsList = el}}
-            style={{right:0, width:this.props.width, display: display}}>
+          style={{left: leftAlign, right: rightAlign, width:this.props.width, display: display}}>
           {optionsList}
         </div>
       </div>

--- a/pkg/interface/publish/src/js/components/lib/header-bar.js
+++ b/pkg/interface/publish/src/js/components/lib/header-bar.js
@@ -3,9 +3,12 @@ import { IconHome } from '/components/lib/icons/icon-home';
 import { Sigil } from '/components/lib/icons/sigil';
 
 export class HeaderBar extends Component {
-  render() {
+  constructor(props) {
+    super(props);
+  }
 
-    let popout = (window.location.href.includes("popout/")) 
+  render() {
+    let popout = (window.location.href.includes("popout/"))
     ? "dn"
     : "dn db-m db-l db-xl";
 
@@ -13,14 +16,23 @@ export class HeaderBar extends Component {
     ? ""
     : document.title;
 
+    let spinner = !!this.props.spinner
+      ? this.props.spinner : false;
+
+    let spinnerClasses = "";
+
+    if (spinner === true) {
+      spinnerClasses = "spin-active";
+    }
+
     return (
       <div className={"bg-white w-100 justify-between relative tc pt3 "
         + popout}
         style={{ height: 40 }}>
-        <a className="dib gray2 f9 inter absolute left-1"
+        <a className="dib gray2 f9 inter absolute left-0"
           href='/'
           style={{top: 14}}>
-          <IconHome/>
+          <IconHome classes={spinnerClasses}/>
           <span className="ml2 v-top lh-title"
           style={{paddingTop: 3}}>
           Home
@@ -33,14 +45,15 @@ export class HeaderBar extends Component {
         }}>
           {title}
         </span>
-        <div className="absolute right-1 lh-copy"
+        <div className="absolute right-0 lh-copy"
         style={{top: 12}}>
         <Sigil
           ship={"~" + window.ship}
+          classes="mix-blend-diff v-mid"
           size={16}
           color={"#000000"}
         />
-          <span className="mono f9 ml2 v-top">{"~" + window.ship}</span>
+          <span className="mono f9 ml2">{"~" + window.ship}</span>
         </div>
       </div>
     );

--- a/pkg/interface/publish/src/js/components/lib/icons/icon-home.js
+++ b/pkg/interface/publish/src/js/components/lib/icons/icon-home.js
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 
 export class IconHome extends Component {
   render() {
+
+    let classes = !!this.props.classes ? this.props.classes : "";
+
     return (
-      <img 
-      src="/~publish/Home.png" width={16} height={16} />
+      <img className={classes} src="/~publish/Home.png" width={16} height={16} />
     );
   }
 }

--- a/pkg/interface/publish/src/js/components/lib/new-post.js
+++ b/pkg/interface/publish/src/js/components/lib/new-post.js
@@ -98,7 +98,7 @@ export class NewPost extends Component {
             popout={props.popout}
           />
           <button
-            className={"v-mid w-100 mw7 tl h1 pl4"}
+            className={"v-mid w-100 mw6 tl h1 pl4"}
             disabled={!state.submit}
             style={submitStyle}
             onClick={this.postSubmit}>
@@ -114,7 +114,7 @@ export class NewPost extends Component {
             />
           </Link>
         </div>
-        <div className="overflow-container mw7 center">
+        <div className="overflow-container mw6 center">
           <div style={{ padding: 16 }}>
             <input
               autoFocus

--- a/pkg/interface/publish/src/js/components/lib/new-post.js
+++ b/pkg/interface/publish/src/js/components/lib/new-post.js
@@ -35,6 +35,7 @@ export class NewPost extends Component {
     this.setState({
       awaiting: newNote["new-note"].note
     }, () => {
+      window.api.setSpinner(true);
       window.api.action("publish", "publish-action", newNote);
     });
   }
@@ -46,6 +47,7 @@ export class NewPost extends Component {
   componentDidUpdate(prevProps, prevState) {
     let notebook = this.props.notebooks[this.props.ship][this.props.book];
     if (notebook.notes[this.state.awaiting]) {
+      window.api.setSpinner(false);
       let popout = (this.props.popout) ? "popout/" : "";
       let redirect =
      `/~publish/${popout}note/${this.props.ship}/${this.props.book}/${this.state.awaiting}`;

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -15,6 +15,7 @@ export class NewScreen extends Component {
         groups: [],
         ships: []
       },
+      disabled: false,
       createGroup: false,
       awaiting: false,
     };
@@ -29,6 +30,7 @@ export class NewScreen extends Component {
     const { props, state } = this;
     if (props.notebooks && (("~" + window.ship) in props.notebooks)) {
       if (state.awaiting in props.notebooks["~" + window.ship]) {
+        props.api.setSpinner(false);
         let notebook = `/~${window.ship}/${state.awaiting}`;
         props.history.push("/~publish/notebook" + notebook);
       }
@@ -92,7 +94,8 @@ export class NewScreen extends Component {
       }
     }
 
-    this.setState({awaiting: bookId}, () => {
+    this.setState({awaiting: bookId, disabled: true}, () => {
+      props.api.setSpinner(true);
       props.api.action("publish", "publish-action", action);
     });
   }
@@ -103,7 +106,7 @@ export class NewScreen extends Component {
        : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
 
     let createClasses = "pointer db f9 green2 bg-gray0-d ba pv3 ph4 mv7 b--green2";
-    if (!this.state.idName) {
+    if (!this.state.idName || this.state.disabled) {
       createClasses = "pointer db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 mv7 b--gray3";
     }
 
@@ -187,6 +190,7 @@ export class NewScreen extends Component {
           />
           {createGroupToggle}
           <button
+          disabled={this.state.disabled}
           onClick={this.onClickCreate.bind(this)}
           className={createClasses}>
           Create Notebook

--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -158,7 +158,7 @@ export class Note extends Component {
               popout={props.popout}
               sidebarShown={props.sidebarShown}
             />
-            <Link className="f9 w-100 mw6 tl" to={baseUrl}>
+            <Link className="f9 w-100 w-90-m w-90-l mw6 tl" to={baseUrl}>
               {"<- Notebook index"}
             </Link>
             <Link

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -137,8 +137,6 @@ export class Sidebar extends Component {
       );
     })
 
-    let notebooks = <div>{notebookItems}</div>
-
     return (
       <div
         className={
@@ -163,31 +161,32 @@ export class Sidebar extends Component {
             align="left"
             options={[
               {
-              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
-              txt: "Oldest Notebooks First",
-              action: () => {this.setState({sort: "oldest"})}
+                cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+                txt: "Oldest Notebooks First",
+                action: () => {this.setState({sort: "oldest"})}
               },
               {
-              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
-              txt: "Newest Notebooks First",
-              action: () => {this.setState({sort: "newest"})}
+                cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+                txt: "Newest Notebooks First",
+                action: () => {this.setState({sort: "newest"})}
               },
               {
-              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
-              txt: "Alphabetical A -> Z",
-              action: () => {this.setState({sort: "alphabetical"})}
+                cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+                txt: "Alphabetical A -> Z",
+                action: () => {this.setState({sort: "alphabetical"})}
               },
               {
-              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
-              txt: "Alphabetical Z -> A",
-              action: () => {this.setState({sort: "reverseAlphabetical"})}
+                cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+                txt: "Alphabetical Z -> A",
+                action: () => {this.setState({sort: "reverseAlphabetical"})}
               }
             ]}
             buttonText="Sort Notebooks"
           />
           </div>
         </div>
-        <div className="overflow-y-scroll h-100">
+        <div className="overflow-y-auto pb1"
+        style={{height: "calc(100% - 82px)"}}>
           {sidebarInvites}
           {notebookItems}
         </div>

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -141,9 +141,9 @@ export class Sidebar extends Component {
       <div
         className={
           "bn br-m br-l br-xl b--gray4 b--gray2-d lh-copy h-100 " +
-          "flex-shrink-0 mw-300-ns pt3 pt0-m pt0-l pt0-xl relative " +
+          "flex-shrink-0 pt3 pt0-m pt0-l pt0-xl relative " +
           "overflow-y-hidden " + activeClasses +
-          (hiddenClasses ? "flex-basis-100-s flex-basis-30-ns" : "dn")
+          (hiddenClasses ? "flex-basis-100-s flex-basis-300-ns" : "dn")
         }>
         <a className="db dn-m dn-l dn-xl f9 pb3 pl3" href="/">
           ⟵ Landscape

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { Route, Link } from 'react-router-dom';
+import { Dropdown } from './dropdown';
 import { NotebookItem } from './notebook-item';
 import { SidebarInvite } from './sidebar-invite';
 
@@ -149,24 +150,41 @@ export class Sidebar extends Component {
         <a className="db dn-m dn-l dn-xl f9 pb3 pl3" href="/">
           ⟵ Landscape
         </a>
-        <div className="w-100">
+        <div className="w-100 f9">
           <Link to="/~publish/new" className="green2 mr4 f9 pl4 pt4 dib">
             New Notebook
           </Link>
           <Link to="/~publish/join" className="f9 gray2">
             Join Notebook
           </Link>
-          <div className="dropdown relative bb b--gray4">
-            <select
-              style={{ WebkitAppearance: "none" }}
-              className="pl4 pv6 f9 bg-white bg-black-d white-d bn w-100 inter"
-              value={this.state.sort}
-              onChange={this.sortChange}>
-              <option value="oldest">Oldest Notebooks First</option>
-              <option value="newest">Newest Notebooks First</option>
-              <option value="alphabetical">Alphabetical A -> Z</option>
-              <option value="reverseAlphabetical">Alphabetical Z -> A</option>
-            </select>
+          <div className="pl2 pv2 bb b--gray4">
+          <Dropdown
+            width="16rem"
+            align="left"
+            options={[
+              {
+              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+              txt: "Oldest Notebooks First",
+              action: () => {this.setState({sort: "oldest"})}
+              },
+              {
+              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+              txt: "Newest Notebooks First",
+              action: () => {this.setState({sort: "newest"})}
+              },
+              {
+              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+              txt: "Alphabetical A -> Z",
+              action: () => {this.setState({sort: "alphabetical"})}
+              },
+              {
+              cls: "w-100 tl pointer db ph2 pv3 hover-bg-gray4",
+              txt: "Alphabetical Z -> A",
+              action: () => {this.setState({sort: "reverseAlphabetical"})}
+              }
+            ]}
+            buttonText="Sort Notebooks"
+          />
           </div>
         </div>
         <div className="overflow-y-scroll h-100">

--- a/pkg/interface/publish/src/js/components/lib/subscribers.js
+++ b/pkg/interface/publish/src/js/components/lib/subscribers.js
@@ -54,14 +54,14 @@ export class Subscribers extends Component {
           width = 258;
           let url = `/~contacts${writePath}`;
           options = [{
-            cls: "tl pointer",
+            cls: "tl pointer w-100 db hover-bg-gray4 ph2 pv3",
             txt: "Manage this group in the contacts view",
             action: () => {this.redirect(url)}
           }];
         } else {
           width = 157;
           options = [{
-            cls: "tl pointer",
+            cls: "tl pointer w-100 db hover-bg-gray4 ph2 pv3",
             txt: "Demote to subscriber",
             action: () => {this.removeUser(`~${who}`, writePath)}
           }];
@@ -92,11 +92,11 @@ export class Subscribers extends Component {
         let width = 162;
         subscribers = this.props.notebook.subscribers.map((who, i) => {
           let options = [
-            { cls: "tl mb2 pointer",
+            { cls: "tl pointer w-100 db hover-bg-gray4 ph2 pv3",
               txt: "Promote to participant",
               action: () => {this.addUser(who, writePath)}
             },
-            { cls: "tl red2 pointer",
+            { cls: "tl red2 pointer w-100 db hover-bg-gray4 ph2 pv3",
               txt: "Ban",
               action: () => {this.addUser(who, readPath)}
             },

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -33,6 +33,7 @@ export class Root extends Component {
               active={"sidebar"}
               rightPanelHide={true}
               sidebarShown={true}
+              spinner={state.spinner}
               invites={state.invites}
               notebooks={state.notebooks}
               contacts={contacts}>
@@ -56,6 +57,7 @@ export class Root extends Component {
             active={"rightPanel"}
             rightPanelHide={false}
             sidebarShown={state.sidebarShown}
+            spinner={state.spinner}
             invites={state.invites}
             notebooks={state.notebooks}
             contacts={contacts}>
@@ -76,6 +78,7 @@ export class Root extends Component {
                   active={"rightPanel"}
                   rightPanelHide={false}
                   sidebarShown={state.sidebarShown}
+                  spinner={state.spinner}
                   invites={state.invites}
                   notebooks={state.notebooks}
                   contacts={contacts}>
@@ -108,6 +111,7 @@ export class Root extends Component {
                 active={"rightPanel"}
                 rightPanelHide={false}
                 sidebarShown={state.sidebarShown}
+                spinner={state.spinner}
                 invites={state.invites}
                 notebooks={state.notebooks}
                 contacts={contacts}
@@ -130,6 +134,7 @@ export class Root extends Component {
                 active={"rightPanel"}
                 rightPanelHide={false}
                 sidebarShown={state.sidebarShown}
+                spinner={state.spinner}
                 invites={state.invites}
                 notebooks={state.notebooks}
                 contacts={contacts}
@@ -170,6 +175,7 @@ export class Root extends Component {
               active={"rightPanel"}
               rightPanelHide={false}
               sidebarShown={state.sidebarShown}
+              spinner={state.spinner}
               invites={state.invites}
               notebooks={state.notebooks}
               contacts={contacts}

--- a/pkg/interface/publish/src/js/components/skeleton.js
+++ b/pkg/interface/publish/src/js/components/skeleton.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { HeaderBar } from './lib/header-bar';
 import { Sidebar } from './lib/sidebar';
 
 export class Skeleton extends Component {
@@ -6,23 +7,20 @@ export class Skeleton extends Component {
     const { props, state } = this;
 
     let rightPanelHide = props.rightPanelHide
-    ? "dn-s"
-    : "";
+      ? "dn-s" : "";
 
     let popout = !!props.popout
-    ? props.popout
-    : false;
+      ? props.popout : false;
 
     let popoutWindow = (popout)
-    ? ""
-    : "h-100-m-40-ns ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl"
+      ? "" : "h-100-m-40-ns ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl"
 
     let popoutBorder = (popout)
-    ? ""
-    : "ba-m ba-l ba-xl b--gray2 br1"
+      ? "": "ba-m ba-l ba-xl b--gray2 br1"
 
     return (
-      <div className={"h-100 w-100 " + popoutWindow}>
+      <div className={"absolute h-100 w-100 " + popoutWindow}>
+      <HeaderBar spinner={this.props.spinner} />
         <div className={`cf w-100 h-100 flex ` + popoutBorder}>
           <Sidebar
             popout={popout}

--- a/pkg/interface/publish/src/js/reducers/response.js
+++ b/pkg/interface/publish/src/js/reducers/response.js
@@ -20,6 +20,8 @@ export class ResponseReducer {
         break;
       case "local":
         this.sidebarToggle(json, state);
+        this.setSpinner(json, state);
+        break;
       default:
         break;
     }
@@ -199,6 +201,13 @@ export class ResponseReducer {
     let data = _.has(json.data, 'sidebarToggle', false);
     if (data) {
         state.sidebarShown = json.data.sidebarToggle;
+    }
+  }
+
+  setSpinner(json, state) {
+    let data = _.has(json.data, 'spinner', false);
+    if (data) {
+      state.spinner = json.data.spinner;
     }
   }
 


### PR DESCRIPTION
Polish batch:

- new-post.js had `mw7` and the other views use `mw6`, so the views weren't consistent in use. Amended to all use `mw6`.
- Sidebar sorter uses the custom dropdown component. Dropdown component gets an `align` prop to flush itself left or right against its parent.
- Sidebar was too long to see all notebooks if you have a lot of notebooks. This is calc'd against the UI height now.
- header-bar moved back into skeleton a la Chat. Spinner added as an animation on the Home button.
![Feb-20-2020 00-17-24](https://user-images.githubusercontent.com/20846414/74903250-69882d80-5376-11ea-9a1c-78c9b7f9cd87.gif)
- header-bar sigil is now lined up properly with the ship name, and blends into its background regardless of theme.
- New posts, new notebooks, new comments all have proper button disabling transitions and spinner functionality.
- Adding some fixes for `-m` and `-l` viewports for sidebar and note.js navigation back to notebooks — the latter is using a `w-90-l w-90-m` shim for now...

