### PR TITLE
OS1 OTA: chat groups & permissions

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -598,6 +598,17 @@
 ++  chats-of-group
   |=  =group-path
   ^-  (list path)
+  ::  if metadata-store isn't running yet, we're still in the upgrade ota phase.
+  ::  we can't get chats from the metadata-store, but can make assumptions
+  ::  about group path shape, and the chat that would match it.
+  ::TODO  remove me at some point.
+  ::
+  ?.  .^(? %gu (scot %p our.bol) %metadata-store (scot %da now.bol) ~)
+    ?:  ?=([%'~' @ ^] group-path)
+      ~&  [%assuming-ported-legacy-group group-path]
+      [t.group-path]~
+    ~&  [%weird-group group-path]
+    ~
   %+  murn
     ^-  (list resource)
     =-  ~(tap in (~(gut by -) group-path ~))
@@ -616,6 +627,17 @@
 ++  groups-of-chat
   |=  chat=path
   ^-  (list group-path)
+  ::  if metadata-store isn't running yet, we're still in the upgrade ota phase.
+  ::  we can't get groups from the metadata-store, but can make assumptions
+  ::  about chat path shape, and the chat that would match it.
+  ::TODO  remove me at some point.
+  ::
+  ?.  .^(? %gu (scot %p our.bol) %metadata-store (scot %da now.bol) ~)
+    ?:  ?=([@ ^] chat)
+      ~&  [%assuming-ported-legacy-chat chat]
+      [%'~' chat]~
+    ~&  [%weird-chat chat]
+    ~
   =-  ~(tap in (~(gut by -) [%chat chat] ~))
   .^  (jug resource group-path)
     %gy

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -82,7 +82,7 @@
           (hookup-group new-group kind.newp)
           [(record-group new-group chat)]~
         ::
-          ?.  =(our.bol host)  ~
+          ?.  &(=(our.bol host) ?=(%white kind.newp))  ~
           (send-invites chat who.newp)
         ==
     ::

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -62,7 +62,6 @@
     ::
     :_  this(state [%1 +.old])
     %-  zing
-    ^-  (list (list card))
     %+  turn
       %~  tap  in
       %^  scry:cc  (set path)
@@ -92,24 +91,23 @@
       ?.  &(?=(^ read) ?=(^ write))
         ~&  [%missing-permission chat read=?=(~ read) write=?=(~ write)]
         [%white [(slav %p (snag 0 chat)) ~ ~]]
-      ::  village: exclusive to writers
+      ?+  [kind.u.read kind.u.write]  !!
+        ::  village: exclusive to writers
+        ::
+        [%white %white]  [%white who.u.write]
       ::
-      ?:  &(?=(%white kind.u.read) ?=(%white kind.u.write))
-        [%white who.u.write]
-      ::  channel: merge blacklists
+        ::  channel: merge blacklists
+        ::
+        [%black %black]  [%black (~(uni in who.u.read) who.u.write)]
       ::
-      ?:  &(?=(%black kind.u.read) ?=(%black kind.u.write))
-        [%black (~(uni in who.u.read) who.u.write)]
-      ::  journal: exclusive to writers
+        ::  journal: exclusive to writers
+        ::
+        [%black %white]  [%white who.u.write]
       ::
-      ?:  &(?=(%black kind.u.read) ?=(%white kind.u.write))
-        [%white who.u.write]
-      ::  mailbox: exclusive to readers
-      ::
-      ?:  &(?=(%white kind.u.read) ?=(%black kind.u.write))
-        [%white who.u.read]
-      ~|  [%weird-kinds kind.u.read kind.u.write]
-      !!
+        ::  mailbox: exclusive to readers
+        ::
+        [%white %black]  [%white who.u.read]
+      ==
     ::
     ++  get-permission
       |=  [chat=path what=?(%read %write)]
@@ -419,7 +417,6 @@
     |=  [kind=?(%add %remove) pax=path who=(set ship)]
     ^-  (list card)
     %-  zing
-    ^-  (list (list card))
     %+  turn
       (chats-of-group pax)
     |=  chat=path
@@ -628,7 +625,11 @@
     ~
   %+  murn
     ^-  (list resource)
-    =-  ~(tap in (~(gut by -) group-path ~))
+    =;  resources
+      %~  tap  in
+      %+  ~(gut by resources)
+        group-path
+      *(set resource)
     .^  (jug path resource)
       %gy
       (scot %p our.bol)
@@ -655,7 +656,11 @@
       [%'~' chat]~
     ~&  [%weird-chat chat]
     ~
-  =-  ~(tap in (~(gut by -) [%chat chat] ~))
+  =;  resources
+    %~  tap  in
+    %+  ~(gut by resources)
+      [%chat chat]
+    *(set group-path)
   .^  (jug resource group-path)
     %gy
     (scot %p our.bol)

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -2,8 +2,8 @@
 ::  mirror chat data from foreign to local based on read permissions
 ::  allow sending chat messages to foreign paths based on write perms
 ::
-/-  *permission-store, *chat-hook, *invite-store,
-    *metadata-store, *permission-group-hook, *group-store
+/-  *permission-store, *chat-hook, *invite-store, *metadata-store,
+    *permission-hook, *group-store, *permission-group-hook  ::TMP  for upgrade
 /+  *chat-json, *chat-eval, default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
@@ -79,10 +79,8 @@
           ==
         ::
           (create-group new-group who.newp)
-        ::
-          :~  (record-group new-group chat)
-              (hookup-group new-group kind.newp)
-          ==
+          (hookup-group new-group kind.newp)
+          [(record-group new-group chat)]~
         ==
     ::
     ++  unify-permissions
@@ -147,11 +145,20 @@
     ::
     ++  hookup-group
       |=  [group=path =kind]
-      ^-  card
-      %^  make-poke  %permission-group-hook
-        %permission-group-hook-action
-      !>  ^-  permission-group-hook-action
-      [%associate group [group^kind ~ ~]]
+      ^-  (list card)
+      :*  %^  make-poke  %permission-group-hook
+            %permission-group-hook-action
+          !>  ^-  permission-group-hook-action
+          [%associate group [group^kind ~ ~]]
+        ::
+          =/  =ship  (slav %p (snag 1 group))
+          ?.  =(our.bol ship)  ~
+          :_  ~
+          %^  make-poke  %permission-hook
+            %permission-hook-action
+          !>  ^-  permission-hook-action
+          [%add-owned group group]
+      ==
     ::
     ++  record-group
       |=  [group=path chat=path]

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -81,6 +81,9 @@
           (create-group new-group who.newp)
           (hookup-group new-group kind.newp)
           [(record-group new-group chat)]~
+        ::
+          ?.  =(our.bol host)  ~
+          (send-invites chat who.newp)
         ==
     ::
     ++  unify-permissions
@@ -182,6 +185,22 @@
         %metadata-action
       !>  ^-  metadata-action
       [%add group [%chat chat] metadata]
+    ::
+    ++  send-invites
+      |=  [chat=path who=(set ship)]
+      ^-  (list card)
+      %+  murn  ~(tap in who)
+      |=  =ship
+      ^-  (unit card)
+      ?:  =(our.bol ship)  ~
+      %-  some
+      %^  make-poke  %invite-hook
+        %invite-action
+      !>  ^-  invite-action
+      =/  =invite
+        =+  (crip "upgrade {(spud chat)} (please accept in OS1)")
+        [our.bol %chat-hook chat ship -]
+      [%invite /chat (sham chat ship eny.bol) invite]
     --
   ::
   ++  on-poke

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -464,19 +464,31 @@
 ++  chat-scry
   |=  pax=path
   ^-  (unit mailbox)
-  =.  pax  ;:(weld /=chat-store/(scot %da now.bol)/mailbox pax /noun)
-  .^((unit mailbox) %gx pax)
+  %^  scry  (unit mailbox)
+    %chat-store
+  [%mailbox pax]
 ::
 ++  invite-scry
   |=  uid=serial
   ^-  (unit invite)
-  =/  pax  /=invite-store/(scot %da now.bol)/invite/chat/(scot %uv uid)/noun
-  .^((unit invite) %gx pax)
+  %^  scry  (unit invite)
+    %invite-store
+  /invite/chat/(scot %uv uid)
 ::
 ++  permitted-scry
   |=  pax=path
   ^-  ?
   .^(? %gx ;:(weld /=permission-store/(scot %da now.bol)/permitted pax /noun))
+::
+++  scry
+  |*  [=mold app=term =path]
+  .^  mold
+    %gx
+    (scot %p our.bol)
+    app
+    (scot %da now.bol)
+    (snoc `^path`path %noun)
+  ==
 ::
 ++  pull-wire
   |=  pax=path

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -70,12 +70,13 @@
       /keys
     |^  |=  chat=path
         ^-  (list card)
+        =/  host=ship  (slav %p (snag 0 chat))
         =/  newp=permission  (unify-permissions chat)
         =/  old-group=path  [%chat chat]
         =/  new-group=path  [%'~' chat]
         ;:  weld
-          :~  (delete-group (snoc old-group %read))
-              (delete-group (snoc old-group %write))
+          :~  (delete-group host (snoc old-group %read))
+              (delete-group host (snoc old-group %write))
           ==
         ::
           (create-group new-group who.newp)
@@ -122,12 +123,21 @@
       [%pass /on-load/[app]/[mark] %agent [our.bol app] %poke mark vase]
     ::
     ++  delete-group
-      |=  group=path
+      |=  [host=ship group=path]
       ^-  card
-      %^  make-poke  %group-store
-        %group-action
-      !>  ^-  group-action
-      [%unbundle group]
+      ::  if we host the group, delete it directly
+      ::
+      ?:  =(our.bol host)
+        %^  make-poke  %group-store
+          %group-action
+        !>  ^-  group-action
+        [%unbundle group]
+      ::  else, just delete the sync in the hook
+      ::
+      %^  make-poke  %permission-hook
+        %permission-hook-action
+      !>  ^-  permission-hook-action
+      [%remove group]
     ::
     ++  create-group
       |=  [group=path who=(set ship)]

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -21,7 +21,7 @@
 ::  /app-name/%app-name                            associations for app
 ::
 /-  *metadata-store
-/+  default-agent
+/+  default-agent, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -40,6 +40,7 @@
 ::
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/permission-group-hook.hoon
+++ b/pkg/arvo/app/permission-group-hook.hoon
@@ -3,7 +3,7 @@
 ::    mirror the ships in specified groups to specified permission paths
 ::
 /-  *group-store, *permission-group-hook
-/+  *permission-json, default-agent, verb
+/+  *permission-json, default-agent, verb, dbug
 ::
 |%
 +$  state
@@ -25,6 +25,7 @@
 =*  state  -
 ::
 %+  verb  |
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -227,6 +227,7 @@
       %1
     =<  se-abet  =<  se-view
     =<  (se-born %home %goad)
+    =<  (se-born %home %metadata-store)
     =<  (se-born %home %contact-store)
     =<  (se-born %home %contact-hook)
     =<  (se-born %home %contact-view)
@@ -237,6 +238,7 @@
   ::
       %2
     =<  se-abet  =<  se-view
+    =<  (se-born %home %metadata-store)
     =<  (se-born %home %contact-store)
     =<  (se-born %home %contact-hook)
     =<  (se-born %home %contact-view)


### PR DESCRIPTION
As usual, see commit messages for deets. Primarily, this PR does two things:

- Make chat-hook depend on metadata-store for permission checks (specifically, to find the group(s) associated with the chat it wants to check permissions on).
- Add on-upgrade logic to chat-hook that will migrate "legacy" `/chat/~host/name` group (& permission) paths to the new `/~/~host/name` format. (We use the `/~` prefix here, signifying an "unmanaged" group, because these groups were created hidden from the user, and thus should remain as such.)

I've done some light testing on this, and nothing obvious breaks. That said, I want to put some more stress on this and see if it still holds up. Hence the draft status. Still, a preliminary review seems good to have here, given the nature of all this.

Thanks @loganallenc for advising on this. Please take a look!