### PR TITLE
chat-store: immediate handle-read on our %message

### DIFF
--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -152,9 +152,14 @@
   ?-  -.action
       %create    (handle-create action)
       %delete    (handle-delete action)
-      %message   (handle-message action)
-      %messages  (handle-messages action)
       %read      (handle-read action)
+      %messages  (handle-messages action)
+      %message
+        ?.  =(our.bol author.envelope.action)
+          (handle-message action)
+        =^  message-moves  state  (handle-message action)
+        =^  read-moves  state  (handle-read [%read path.action])
+        [(weld message-moves read-moves) state]
   ==
 ::
 ++  handle-create


### PR DESCRIPTION
Fixes #2182.

Same functionality as #2304, but as Logan pointed out this is better done in the store instead of the frontend.