### PR TITLE
metadata-hook: a hook for sending metadata over the network

### DIFF
--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -4,7 +4,7 @@
 /+  default-agent
 |%
 +$  card  card:agent:gall
-++  versioned-state
++$  versioned-state
   $%  state-zero
   ==
 ::
@@ -107,8 +107,27 @@
 ++  watch-group
   |=  =path
   ^-  (list card)
+  |^
   ?>  (~(has by synced) path)
-  ~
+  ?>  (is-permitted [(scot %p src.bowl) path])
+  %+  turn  ~(tap by (metadata-scry path))
+  |=  [[=group-path =resource] =metadata]
+  ^-  card
+  [%give %fact ~ %metadata-update !>([%add group-path resource metadata])]
+  ::
+  ++  is-permitted
+    |=  pax=^path
+    ^-  ?
+    =.  pax
+      ;:(weld /=permission-store/(scot %da now.bowl)/permitted pax /noun)
+    .^(? %gx pax)
+  ::
+  ++  metadata-scry
+    |=  pax=^path
+    ^-  associations
+    =.  pax  ;:(weld /=metadata-store/(scot %da now.bowl)/group pax /noun)
+    (need .^((unit associations) %gx pax))
+  --
 ::
 ++  fact-metadata-update
   |=  [wir=wire fact=metadata-update]
@@ -160,12 +179,22 @@
 ++  kick
   |=  wir=wire
   ^-  (quip card _state)
-  [~ state]
+  :_  state
+  ?+  wir  !!
+      [%updates ~]
+    [%pass /updates %agent [our.bowl %metadata-store] %watch /updates]~
+  ::
+      [%group @ *]
+    ?.  (~(has by synced) t.wir)  ~
+    =/  =ship  (~(got by synced) t.wir)
+    ?:  =(ship our.bowl)
+      [%pass wir %agent [our.bowl %metadata-store] %watch wir]~
+    [%pass wir %agent [ship %metadata-hook] %watch wir]~
+  ==
 ::
 ++  watch-ack
   |=  [wir=wire saw=(unit tang)]
   ^-  (quip card _state)
-  ?~  saw  [~ state]
   ?>  ?=(^ wir)
-  [~ state(synced (~(del by synced) t.wir))]
+  [~ ?~(saw state state(synced (~(del by synced) t.wir)))]
 --

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -1,5 +1,8 @@
 ::  metadata-hook: allow syncing foreign metadata
 ::
+::  watch paths:
+::  /group/%group-path                      all updates related to this group
+::
 /-  *metadata-store, *metadata-hook
 /+  default-agent
 |%
@@ -86,12 +89,11 @@
       %remove
     =/  ship  (~(get by synced) path.act)
     ?~  ship  [~ state]
-    ?:  &(?!(=(u.ship our.bowl)) ?!((team:title our.bowl src.bowl)))
+    ?:  &(!=(u.ship src.bowl) ?!((team:title our.bowl src.bowl)))
       [~ state]
     :_  state(synced (~(del by synced) path.act))
     %-  zing
     :~  (unsubscribe [%group path.act] u.ship)
-        ?.  &(=(u.ship our.bowl) (team:title our.bowl src.bowl))  ~
         [%give %kick ~[[%group path.act]] ~]~
     ==
   ==
@@ -108,18 +110,22 @@
   |=  =path
   ^-  (list card)
   |^
-  ?>  (~(has by synced) path)
-  ?>  (is-permitted [(scot %p src.bowl) path])
+  ?>  =(our.bowl (~(got by synced) path))
+  ?>  (is-permitted src.bowl path)
   %+  turn  ~(tap by (metadata-scry path))
   |=  [[=group-path =resource] =metadata]
   ^-  card
   [%give %fact ~ %metadata-update !>([%add group-path resource metadata])]
   ::
   ++  is-permitted
-    |=  pax=^path
+    |=  [=ship pax=^path]
     ^-  ?
     =.  pax
-      ;:(weld /=permission-store/(scot %da now.bowl)/permitted pax /noun)
+      ;:  weld
+          /=permission-store/(scot %da now.bowl)/permitted
+          [(scot %p ship) pax]
+          /noun
+      ==
     .^(? %gx pax)
   ::
   ++  metadata-scry

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -1,0 +1,89 @@
+::  metadata-hook: allow syncing foreign metadata
+::
+/-  *metadata-store
+/+  default-agent
+|%
++$  card  card:agent:gall
+::
+++  versioned-state
+  $%  state-zero
+  ==
+::
++$  state-zero
+  $:  %0
+      synced=(map [group-path resource] ship)
+  ==
+--
+=|  state-zero
+=*  state  -
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this        .
+      hook-core  +>
+      hc          ~(. hook-core bowl)
+      def         ~(. (default-agent this %|) bowl)
+  ::
+  ++  on-init  on-init:def
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  old=vase
+    `this(state !<(state-zero old))
+  ::
+  ++  on-leave  on-leave:def
+  ++  on-peek   on-peek:def
+  ++  on-arvo   on-arvo:def
+  ++  on-fail   on-fail:def
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    ?.  ?=(%metadata-hook-action mark)
+      (on-poke:def mark vase)
+    =^  cards  state
+      (poke-hook-action:gc !<(metadata-hook-action vase))
+    [cards this]
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card _this)
+    (on-watch:def path)
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    ?+  -.sign  (on-agent:def wire sign)
+        %watch-ack
+      =^  cards  state
+        (watch-ack:cc wire p.sign) 
+      [cards this]
+    ::
+        %kick
+      ?>  ?=([@ @ *] wire)
+      =/  =ship  (slav %p i.wire)
+      ?.  (~(has by synced.state) wire)
+        [~ this]
+      =/  group-path  [%group wire]
+      =/  group-wire  [i.wire group-path]
+      :_  this
+      [%pass group-wire %agent [ship %group-hook] %watch group-path]~
+    ::
+        %fact
+      ?+  p.cage.sign  (on-agent:def wire sign)
+          %metadata-update
+        =^  cards  state
+          (fact-metadata-update:cc wire !<(metadata-update q.cage.sign))
+        [cards this]
+      ==
+    ==
+  --
+::
+|_  bol=bowl:gall
+++  watch-ack
+  |=  [wir=wire saw=(unit tang)]
+  ^-  (quip card _state)
+  ?~  saw
+    [~ state]
+  ?>  ?=(^ wir)
+  [~ state(synced (~(del by synced) t.wir))]
+--

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -1,6 +1,6 @@
 ::  metadata-hook: allow syncing foreign metadata
 ::
-/-  *metadata-store
+/-  *metadata-store, *metadata-hook
 /+  default-agent
 |%
 +$  card  card:agent:gall
@@ -11,7 +11,7 @@
 ::
 +$  state-zero
   $:  %0
-      synced=(map [group-path resource] ship)
+      synced=(map group-path ship)
   ==
 --
 =|  state-zero
@@ -24,12 +24,11 @@
       hc          ~(. hook-core bowl)
       def         ~(. (default-agent this %|) bowl)
   ::
-  ++  on-init  on-init:def
-  ++  on-save  !>(state)
-  ++  on-load
-    |=  old=vase
-    `this(state !<(state-zero old))
+  ++  on-init
+    [[%pass /updates %agent [our.bol %metadata-store] %watch /updates]~ this]
   ::
+  ++  on-save   !>(state)
+  ++  on-load   |=(=vase `this(state !<(state-zero vase)))
   ++  on-leave  on-leave:def
   ++  on-peek   on-peek:def
   ++  on-arvo   on-arvo:def
@@ -38,52 +37,133 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?.  ?=(%metadata-hook-action mark)
-      (on-poke:def mark vase)
-    =^  cards  state
-      (poke-hook-action:gc !<(metadata-hook-action vase))
-    [cards this]
+    ?+  mark  (on-poke:def mark vase)
+        %metadata-hook-action
+      =^  cards  state
+        (poke-hook-action:hc !<(metadata-hook-action vase))
+      [cards this]
+    == 
   ::
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    (on-watch:def path)
+    ?+  path        (on-watch:def path)
+        [%group *]  [(watch-group:cc t.path) this]
+    ==
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
     ?+  -.sign  (on-agent:def wire sign)
-        %watch-ack
+        %kick
       =^  cards  state
-        (watch-ack:cc wire p.sign) 
+        (kick:hc wire)
       [cards this]
     ::
-        %kick
-      ?>  ?=([@ @ *] wire)
-      =/  =ship  (slav %p i.wire)
-      ?.  (~(has by synced.state) wire)
-        [~ this]
-      =/  group-path  [%group wire]
-      =/  group-wire  [i.wire group-path]
-      :_  this
-      [%pass group-wire %agent [ship %group-hook] %watch group-path]~
+        %watch-ack
+      =^  cards  state
+        (watch-ack:hc wire p.sign) 
+      [cards this]
     ::
         %fact
       ?+  p.cage.sign  (on-agent:def wire sign)
           %metadata-update
         =^  cards  state
-          (fact-metadata-update:cc wire !<(metadata-update q.cage.sign))
+          (fact-metadata-update:hc wire !<(metadata-update q.cage.sign))
         [cards this]
       ==
     ==
   --
 ::
 |_  bol=bowl:gall
+++  poke-hook-action
+  |=  act=metadata-hook-action
+  ^-  (quip card _state)
+  |^
+  ?-  -.act
+      %add-owned
+    ?>  (team:title our.bol src.bol)
+    :-  ~
+    ?:  (~(has by synced) path.act)  state
+    state(synced (~(put by synced) path.act our.bol))
+  ::
+      %add-synced
+    ?>  (team:title our.bol src.bol)
+    =/  =path  [%group path.act]
+    ?:  (~(has by synced) path.act)  [~ state]
+    :_  state(synced (~(put by synced) path.act ship.act))
+    [%pass path %agent [ship.act %metadata-hook] %watch path]~
+  ::
+      %remove
+    =/  ship  (~(get by synced) path.act)
+    ?~  ship  [~ state]
+    ?:  &(!(u.ship our.bol) !(team.title our.bol src.bol))
+      [~ state]
+    :_  state(synced (~(del by synced) path.act))
+    %-  zing
+    :~  (unsubscribe [%group path.act])
+        ?.  &(=(u.ship our.bol) (team:title our.bol src.bol))  ~
+        [%give %kick ~[[%group path.act]] ~]~
+    ==
+  ==
+  ::
+  ++  unsubscribe
+    |=  pax=path
+    ^-  (list card)
+    ?>  ?=(^ pax)
+    =/  shp  (~(get by synced) t.pax)
+    ?~  shp  ~
+    ?:  =(u.shp our.bol)
+      [%pass pax %agent [our.bol %chat-store] %leave ~]~
+    [%pass pax %agent [u.shp %chat-hook] %leave ~]~
+  --
+::
+++  watch-group
+  |=  =path
+  ^-  (list card)
+  ?>  (~(has by synced) path)
+  ~
+::
+++  fact-metadata-update
+  |=  [wir=wire fact=metadata-update]
+  ^-  (quip card _state)
+  |^
+  [?:((team:title our.bol src.bol) handle-local handle-foreign) state]
+  ::
+  ++  handle-local
+    ?+  -.fact  ~
+        %add
+      ~
+    ::
+        %update-metadata
+      ~
+    ::
+        %remove
+      ~
+    ==
+  ::
+  ++  handle-foreign
+    ?+  -.fact  ~
+        %add
+      ~
+    ::
+        %update-metadata
+      ~
+    ::
+        %remove
+      ~
+    ==
+  --
+::
+++  kick
+  |=  wir=wire
+  ^-  (quip card _state)
+  [~ state]
+::
 ++  watch-ack
   |=  [wir=wire saw=(unit tang)]
   ^-  (quip card _state)
-  ?~  saw
-    [~ state]
+  ?~  saw  [~ state]
   ?>  ?=(^ wir)
   [~ state(synced (~(del by synced) t.wir))]
 --

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -19,6 +19,7 @@
 ::  /resource-indices                              all resource indices
 ::  /metadata/%group-path/%app-name/%app-path      specific metadatum
 ::  /app-name/%app-name                            associations for app
+::  /group/%group-path                             associations for group
 ::
 /-  *metadata-store
 /+  default-agent
@@ -100,6 +101,10 @@
       =/  =app-name  i.t.t.path
       ``noun+!>((metadata-for-app:mc app-name))
     ::
+        [%x %group *]
+      =/  =group-path  t.t.path
+      ``noun+!>((metadata-for-group:mc group-path))
+    ::
         [%x %metadata @ @ @ ~]
       =/  =group-path  (stab (slav %t i.t.t.path))
       =/  =resource    [`@tas`i.t.t.t.path (stab (slav %t i.t.t.t.t.path))]
@@ -170,6 +175,14 @@
   |=  [=group-path =app-path]
   :-  [group-path [app-name app-path]]
   (~(got by associations) [group-path [app-name app-path]])
+::
+++  metadata-for-group
+  |=  =group-path
+  %-  ~(gas by *(map [^group-path resource] metadata))
+  %+  turn  ~(tap in (~(got by group-indices) group-path))
+  |=  =resource
+  :-  [group-path resource]
+  (~(got by associations) [group-path resource])
 ::
 ++  send-diff
   |=  [=app-name upd=metadata-update]

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -170,7 +170,7 @@
 ::
 ++  metadata-for-app
   |=  =app-name
-  %-  ~(gas by *(map [group-path resource] metadata))
+  %-  ~(gas by *^associations)
   %+  turn  ~(tap in (~(got by app-indices) app-name))
   |=  [=group-path =app-path]
   :-  [group-path [app-name app-path]]
@@ -178,7 +178,7 @@
 ::
 ++  metadata-for-group
   |=  =group-path
-  %-  ~(gas by *(map [^group-path resource] metadata))
+  %-  ~(gas by *^associations)
   %+  turn  ~(tap in (~(got by group-indices) group-path))
   |=  =resource
   :-  [group-path resource]

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -117,6 +117,7 @@
       %link-listen-hook
       %link-view
       %metadata-store
+      %metadata-hook
   ==
 ::
 ++  deft-fish                                           ::  default connects

--- a/pkg/arvo/sur/metadata-hook.hoon
+++ b/pkg/arvo/sur/metadata-hook.hoon
@@ -1,0 +1,15 @@
+|%
++$  metadata-hook-action
+  $%  ::  %add-owned: make a chatroom accessible to foreign ships
+      ::  specified by the rw-security model
+      ::
+      [%add-owned =path]
+      ::  %add-synced: mirror a foreign chatroom to our chat-store
+      ::
+      [%add-synced =ship =path]
+      ::  %remove: stop mirroring a foreign chatroom or allowing a local
+      ::  chatroom to be mirrored
+      ::
+      [%remove =path]
+  ==
+--

--- a/pkg/arvo/sur/metadata-hook.hoon
+++ b/pkg/arvo/sur/metadata-hook.hoon
@@ -1,14 +1,13 @@
 |%
 +$  metadata-hook-action
-  $%  ::  %add-owned: make a chatroom accessible to foreign ships
-      ::  specified by the rw-security model
+  $%  ::  %add-owned: make a group's associated metadata
+      ::  accessible to foreign ships in that group
       ::
       [%add-owned =path]
-      ::  %add-synced: mirror a foreign chatroom to our chat-store
+      ::  %add-synced: mirror a foreign-hosted group's associated metadata
       ::
       [%add-synced =ship =path]
-      ::  %remove: stop mirroring a foreign chatroom or allowing a local
-      ::  chatroom to be mirrored
+      ::  %remove: stop mirroring / making data accessible to others
       ::
       [%remove =path]
   ==


### PR DESCRIPTION
Added metadata-hook. This hook networks the metadata-store by making all resources related to a particular group-path accessible.

One can subscribe to the metadata-hook upon a group-path and receive updates any time a resource changes associated with that group-path.

I'll add better documentation before merging this, but am mostly interested in a quick review / sanity check of the functionality / logic itself.

I'll be moving into testing and integration with `chat` with my next set of PRs.