### PR TITLE
contacts: redirecting share view, sigil color fix

### DIFF
--- a/pkg/interface/contacts/src/js/components/lib/contact-card.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-card.js
@@ -342,7 +342,7 @@ export class ContactCard extends Component {
       : <Sigil
           ship={props.ship}
           size={128}
-          color={currentColor}
+          color={"#" + currentColor}
           key={"avatar" + currentColor} />;
 
     return (
@@ -411,7 +411,7 @@ export class ContactCard extends Component {
       <Sigil
         ship={props.ship}
         size={128}
-        color={hexColor}
+        color={"#" + hexColor}
         key={hexColor} />;
 
     let websiteHref =

--- a/pkg/interface/contacts/src/js/components/lib/contact-card.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-card.js
@@ -241,11 +241,13 @@ export class ContactCard extends Component {
       color: this.pickFunction(state.colorToSet, defaultVal.color),
       avatar: null
     };
-
+    api.setSpinner(true);
     api.contactView.share(
       `~${props.ship}`, props.path, `~${window.ship}`, contact
-    );
-    this.editToggle();
+    ).then(() => {
+      api.setSpinner(false);
+      props.history.push(`/~contacts/view${props.path}/${window.ship}`)
+    });
   }
 
   removeFromGroup() {
@@ -266,8 +268,13 @@ export class ContactCard extends Component {
       `~${props.ship}`, props.path, `~${window.ship}`, contact
     );
 
-    api.contactHook.remove(props.path, `~${props.ship}`);
-    props.history.push(`/~contacts${props.path}`);
+    api.setSpinner(true);
+    api.contactHook.remove(props.path, `~${props.ship}`).then(() => {
+      api.setSpinner(false);
+      let destination = (props.ship === window.ship)
+        ? "" : props.path;
+      props.history.push(`/~contacts${destination}`);
+    });
   }
 
   renderEditCard() {

--- a/pkg/interface/contacts/src/js/components/lib/contact-item.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-item.js
@@ -7,7 +7,7 @@ import { uxToHex } from '../../lib/util';
 export class ContactItem extends Component {
   render() {
     const { props } = this;
-    
+
     let selectedClass = (props.selected) ? "bg-gray4" : "";
     let hexColor = uxToHex(props.color);
     let name = (props.nickname) ? props.nickname : "~" + props.ship;
@@ -21,10 +21,10 @@ export class ContactItem extends Component {
         >
           <Sigil
             ship={props.ship}
-            color={hexColor}
+            color={"#" + hexColor}
             size={32}
             key={`${props.ship}.sidebar.${hexColor}`} />
-          <p 
+          <p
             className={
               "f9 w-70 dib v-mid ml2 nowrap " +
               ((props.nickname) ? "" : "mono")}

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -148,9 +148,6 @@ export class Root extends Component {
               let contact =
                 (window.ship in groupContacts) ?
                 groupContacts[window.ship] : {};
-              if (window.ship in groupContacts) {
-                props.history.push(`/~contacts/view${groupPath}/${window.ship}`);
-              }
               let group = groups[groupPath] || new Set([]);
 
               return (


### PR DESCRIPTION
- Clicking "share with group" would create the same double redirect silent crash that creating a new group would — just keeping the user in an unedited share view, but toggled, and having none of their changes propagate to the interface. This redirects the user to the "view card" view with a `.then()` after the api call, and adds spinner behaviour on top, which works as expected.

- I also added a similar `.then()` call for deleting a group and _then_ redirecting the history, and spinners there as well. It also now pushes you to `~contacts` and not to the (now vacant) group if you're deleting yourself.

- I think this might've been a regression I introduced by pasting in the sigil.js changes I've made from other applications (sorry). But sigils weren't updating to reflect their colours because they lacked a `#` prefixing the hex, so I added them in as prefixes when creating a sigil.