### PR TITLE
OS1: fix publish ford OTA issues

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -196,7 +196,7 @@
           =/  book=notebook-info
             [title.old '' =(%open comments.old) / /]
           =+  ^-  [grp-car=(list card) write-pax=path read-pax=path]
-            (make-groups book-name group-pax ~ %.n %.n)
+            (make-groups:main book-name group-pax ~ %.n %.n)
           =.  writers.book      write-pax
           =.  subscribers.book  read-pax
           =/  inv-car  (send-invites book-name (~(get ju old-subs) book-name))

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -173,15 +173,11 @@
   ==  ==
 --
 |%
-::  +axle: overall ford state
+::  +axle: overall ford state, tagged by version
 ::
 +=  axle
-  $:  ::  date: date at which ford's state was updated to this data structure
-      ::
-      date=%~2018.12.13
-      ::  state: all persistent state
-      ::
-      state=ford-state
+  $%  [%~2018.12.13 state=ford-state]
+      [%~2020.2.21 state=ford-state]
   ==
 ::  +ford-state: all state that ford maintains
 ::
@@ -6336,16 +6332,25 @@
       ::
       $(ducts t.ducts, moves (weld moves duct-moves))
   --
-::  +load: flush old state (called on vane reload)
+::  +load: either flush or migrate old state (called on vane reload)
 ::
-::    This is a temporary measure for the OS1 %publish update. We can flush all
-::    build state like this because only gall and %publish use ford live builds
-::    currently. :goad will handle remaking builds for gall, and the new
-::    %publish does not use ford.
+::    If it has the old state version, flush the ford state. Otherwise trim
+::    build results in case a change to our code invalidated an old build
+::    result.
+::
+::    Flushing state of the old version is a temporary measure for the OS1
+::    %publish update. We can flush all build state like this because only gall
+::    and %publish use ford live builds currently. :goad will handle remaking
+::    builds for gall, and the new %publish does not use ford.
 ::
 ++  load
   |=  old=axle
   ^+  ford-gate
+  ?:  =(%~2018.12.13 -.old)
+    =.  -.ax  %~2020.2.21
+    ford-gate
+  =.  ax  [%~2020.2.21 state.old]
+  =.  ford-gate  +:(call ~[/ford-load-self] *type %trim 0)
   ford-gate
 ::  +stay: produce current state
 ::

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6344,9 +6344,6 @@
 ++  load
   |=  old=axle
   ^+  ford-gate
-  ::
-  =.  ax  old
-  =.  ford-gate  +:(call ~[/ford-load-self] *type %trim 0)
   ford-gate
 ::  +stay: produce current state
 ::

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -6336,10 +6336,12 @@
       ::
       $(ducts t.ducts, moves (weld moves duct-moves))
   --
-::  +load: migrate old state to new state (called on vane reload)
+::  +load: flush old state (called on vane reload)
 ::
-::    Trim builds completely in case a change to our code invalidated an
-::    old build result.
+::    This is a temporary measure for the OS1 %publish update. We can flush all
+::    build state like this because only gall and %publish use ford live builds
+::    currently. :goad will handle remaking builds for gall, and the new
+::    %publish does not use ford.
 ::
 ++  load
   |=  old=axle


### PR DESCRIPTION
This PR fixes the issue described here: https://github.com/urbit/urbit/issues/2321

Of crucial importance: This needs to go on the network at the same time as the rest of the OS1 stuff. If this goes on the network as a separate step, it will not work.

cc-ing @jtobin to make sure you see this. With the recent talk about how parts of feature branches can go in at different times, I want to make sure this one does not go in at a different time.