### PR TITLE
permission-hook: clean up access-control on %delete

### DIFF
--- a/pkg/arvo/app/permission-hook.hoon
+++ b/pkg/arvo/app/permission-hook.hoon
@@ -195,7 +195,15 @@
       %delete
     ?.  (~(has by synced) path.diff)
       [~ state]
-    :_  state(synced (~(del by synced) path.diff))
+    =/  control=(unit path)
+      =+  (~(got by synced) path.diff)
+      ?.  =(our.bowl ship)  ~
+      `access-control
+    :_  %_  state
+          synced          (~(del by synced) path.diff)
+          access-control  ?~  control  access-control
+                          (~(del ju access-control) u.control path.diff)
+        ==
     :_  ~
     :*  %pass
         [%permission path.diff]


### PR DESCRIPTION
If we `%add-owned`, then we add an entry to the `access-control` jug matching the
data we put into the `synced` map. When a permission gets deleted, we remove it
from `synced`, but previously neglected to clean up the matching access-control
entry.

This ensures that if a permission was deleted, and we had it registered as
owned, that the relevant `access-control` entry is removed from state.

OS1 chat OTA depends on this change. In my testing so far, I haven't encountered any race conditions of this not being in by the time chat-hook gets to its upgrade logic, but don't feel comfortable guaranteeing it to be fine to go in _with_ OS1. Ideally, we can push this out to livenet beforehand. (It _is_ just a bugfix, after all.)