### PR TITLE
link-fe: truncate titles properly

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -99,12 +99,12 @@ export class LinkPreview extends Component {
           className={"w-100 tc " + (ytMatch ? "embed-container" : "")}>
           {embed}
         </div>
-        <div className="flex flex-column ml2 pt6">
+        <div className="flex flex-column ml2 pt6 flex-auto">
           <a href={props.url} className="w-100 flex" target="_blank">
-            <p className="f8 truncate" style={{overflow: "visible"}}>
+            <p className="f8 truncate flex-auto">
               {props.title}
-              <span className="gray2 ml2 flex-shrink-0">{hostname} ↗</span>
             </p>
+            <span className="gray2 ml2 f8 dib v-btm flex-shrink-0">{hostname} ↗</span>
           </a>
           <div className="w-100 pt1">
             <span className={"f9 pr2 white-d v-mid " + nameClass}>

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -69,14 +69,14 @@ export class LinkItem extends Component {
           size={36}
           color={"#" + props.color}
             />
-        <div className="flex flex-column ml2">
+        <div className="flex flex-column ml2 flex-auto">
           <a href={props.url}
           className="w-100 flex"
           target="_blank"
           onClick={this.markPostAsSeen}>
-            <p className="f8 truncate">{props.title}
-              <span className="gray2 dib truncate-m mw4-m v-btm ml2">{hostname} ↗</span>
+            <p className="f8 truncate flex-auto">{props.title}
             </p>
+            <span className="gray2 dib v-btm ml2 f8 flex-shrink-0">{hostname} ↗</span>
           </a>
           <div className="w-100 pt1">
             <span className={"f9 pr2 v-mid " + mono}>{(props.nickname)

--- a/pkg/interface/link/src/js/components/skeleton.js
+++ b/pkg/interface/link/src/js/components/skeleton.js
@@ -30,7 +30,7 @@ export class Skeleton extends Component {
             selected={this.props.selected}
             sidebarShown={this.props.sidebarShown}
             links={this.props.links}/>
-          <div className={"h-100 w-100 " + rightPanelHide} style={{
+          <div className={"h-100 w-100 flex-auto" + rightPanelHide} style={{
             flexGrow: 1,
           }}>
             {this.props.children}


### PR DESCRIPTION
Link items in the detail view and in the list view now properly truncate link titles to the maximum width of the page container.

The issue has to do with the implicit `min-width: auto` of flex items that allow them to overflow their parents. Since we have nested flexboxes, if one overflows *its* parent, then all its children will obey the overflow in turn. In this case, I had to attribute a `min-width` to both the link item to restrict it to the page container, and then add another `min-width` to the skeleton, which was overflowing its parent in turn.

![image](https://user-images.githubusercontent.com/20846414/75080048-d61b3d80-54d8-11ea-9b45-f82af7bd7ad4.png)
