### PR TITLE
chat: remove spinner.css from index.css

### DIFF
--- a/pkg/interface/chat/src/index.css
+++ b/pkg/interface/chat/src/index.css
@@ -1,5 +1,4 @@
 @import "css/indigo-static.css";
 @import "css/fonts.css";
-@import "css/spinner.css";
 @import "css/custom.css";
 


### PR DESCRIPTION
Three for three on missing the check-in for index files resulting in breakage. I'll be more careful.