### PR TITLE
publish: wrap or truncate title / snippet overflow

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/note-navigation.js
+++ b/pkg/interface/publish/src/js/components/lib/note-navigation.js
@@ -20,33 +20,33 @@ export class NoteNavigation extends Component {
       nextUrl = `/~publish/${popout}note/${this.props.ship}/${this.props.book}/${this.props.next.id}`;
       prevUrl = `/~publish/${popout}note/${this.props.ship}/${this.props.book}/${this.props.prev.id}`;
       nextComponent =
-      <Link to={nextUrl} className="di flex-column tr w-100 pv6 bt bb b--gray3">
+      <Link to={nextUrl} className="di flex-column flex-auto tr w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Next</div>
-        <div className="f9 mb1">{this.props.next.title}</div>
+        <div className="f9 mb1 truncate">{this.props.next.title}</div>
         <div className="f9 gray2">{this.props.next.date}</div>
       </Link>
 
       prevComponent =
-      <Link to={prevUrl} className="di flex-column w-100 pv6 bt br bb b--gray3">
+      <Link to={prevUrl} className="di flex-column flex-auto w-100 pv6 bt br bb b--gray3">
         <div className="f9 gray2 mb2">Previous</div>
-        <div className="f9 mb1">{this.props.prev.title}</div>
+        <div className="f9 mb1 truncate">{this.props.prev.title}</div>
         <div className="f9 gray2">{this.props.prev.date}</div>
       </Link>
 
     } else if (this.props.prev) {
       prevUrl = `/~publish/${popout}note/${this.props.ship}/${this.props.book}/${this.props.prev.id}`;
       prevComponent =
-      <Link to={prevUrl} className="di flex-column w-100 pv6 bt bb b--gray3">
+      <Link to={prevUrl} className="di flex-column flex-auto w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Previous</div>
-        <div className="f9 mb1">{this.props.prev.title}</div>
+        <div className="f9 mb1 truncate">{this.props.prev.title}</div>
         <div className="f9 gray2">{this.props.prev.date}</div>
       </Link>
     } else if (this.props.next) {
       nextUrl = `/~publish/${popout}note/${this.props.ship}/${this.props.book}/${this.props.next.id}`;
       nextComponent =
-      <Link to={nextUrl} className="di flex-column tr w-100 pv6 bt bb b--gray3">
+      <Link to={nextUrl} className="di flex-column flex-auto tr w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Next</div>
-        <div className="f9 mb1">{this.props.next.title}</div>
+        <div className="f9 mb1 truncate">{this.props.next.title}</div>
         <div className="f9 gray2">{this.props.next.date}</div>
       </Link>
 

--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -173,7 +173,8 @@ export class Note extends Component {
           </div>
           <div className="w-100 mw6 overflow-container">
             <div className="flex flex-column">
-              <div className="f9 mb1">{title}</div>
+              <div className="f9 mb1"
+              style={{overflowWrap: "break-word"}}>{title}</div>
               <div className="flex mb6">
                 <div
                   className={
@@ -184,7 +185,8 @@ export class Note extends Component {
                 <div className="di f9 gray2">{date}</div>
               </div>
             </div>
-            <div className="md">
+            <div className="md"
+            style={{overflowWrap: "break-word"}}>
               <ReactMarkdown source={newfile} />
             </div>
             <NoteNavigation

--- a/pkg/interface/publish/src/js/components/lib/notebook-posts.js
+++ b/pkg/interface/publish/src/js/components/lib/notebook-posts.js
@@ -61,8 +61,14 @@ export class NotebookPosts extends Component {
       notes.push(
         <Link key={i} to={url}>
           <div className="mv6">
-            <div className="mb1">{note.title}</div>
-            <p className="mb1">{note.snippet}</p>
+            <div className="mb1"
+            style={{overflowWrap: "break-word"}}>
+              {note.title}
+            </div>
+            <p className="mb1"
+            style={{overflowWrap: "break-word"}}>
+              {note.snippet}
+            </p>
             <div className="flex">
               <div className={((note.author === name) ? "mono" : "") +
                " gray2 mr3"}>{name}</div>


### PR DESCRIPTION
Wraps titles and snippets in Note headers and "All Posts" view, in addition to long, single-element blocks like `<a>` elements inside posts, so that nothing overflows the X-axis. 

Note navigation gets `flex-auto` to restrict itself to its parent and its titles get truncated.

<img width="623" alt="Screen Shot 2020-02-21 at 6 59 58 PM" src="https://user-images.githubusercontent.com/20846414/75081373-f220de00-54dc-11ea-8f32-92a51b5343f6.png">

<img width="582" alt="Screen Shot 2020-02-21 at 7 00 06 PM" src="https://user-images.githubusercontent.com/20846414/75081374-f3520b00-54dc-11ea-814d-58ab64177c7d.png">
