### PR TITLE
chat, contacts, link-fe, publish: black borders on focused input

### DIFF
--- a/pkg/interface/chat/src/js/components/join.js
+++ b/pkg/interface/chat/src/js/components/join.js
@@ -119,7 +119,8 @@ export class JoinScreen extends Component {
           <p className="f9 gray2 mb4">Chat names use lowercase, hyphens, and slashes.</p>
           <textarea
             ref={ e => { this.textarea = e; } }
-            className="f7 mono ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 mb2 db"
+            className={"f7 mono ba bg-gray0-d white-d pa3 mb2 db " +
+            "focus-b--black focus-b--white-d b--gray3 b--gray2-d"}
             placeholder="~zod/chatroom"
             spellCheck="false"
             rows={1}

--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -181,7 +181,8 @@ export class NewScreen extends Component {
       : "pointer db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3";
 
     let idClasses =
-      "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 ";
+      "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 " +
+      "focus-b--black focus-b--white-d ";
     if (state.groups.length > 0) {
       idClasses = idClasses + " o-40";
     }

--- a/pkg/interface/contacts/src/css/custom.css
+++ b/pkg/interface/contacts/src/css/custom.css
@@ -71,6 +71,10 @@ a {
   font-family: "Inter", sans-serif;
 }
 
+.focus-b--black:focus {
+  border-color: #000;
+}
+
 .spin-active {
   animation: spin 2s infinite;
 }

--- a/pkg/interface/contacts/src/js/components/lib/contact-card.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-card.js
@@ -313,7 +313,7 @@ export class ContactCard extends Component {
           style={{ width: "fit-content" }}>
           <p className="f9 gray2 lh-copy">Sigil Color</p>
           <textarea
-            className="b--gray4 black f7 ba db pl2"
+            className="b--gray4 black f7 ba db pl2 focus-b--black"
             onChange={this.sigilColorSet}
             defaultValue={defaultColor}
             key={"default" + defaultColor}

--- a/pkg/interface/contacts/src/js/components/lib/edit-element.js
+++ b/pkg/interface/contacts/src/js/components/lib/edit-element.js
@@ -29,7 +29,7 @@ export class EditElement extends Component {
           <div className="w-100 flex">
             <textarea
               ref={props.title}
-              className="w-100 ba pl3 b--gray4"
+              className="w-100 ba pl3 b--gray4 focus-b--black"
               style={ inputStyles }
               onChange={(e) => {
                 let val = (' ' + e.target.value).slice(1);

--- a/pkg/interface/contacts/src/js/components/new.js
+++ b/pkg/interface/contacts/src/js/components/new.js
@@ -102,7 +102,7 @@ export class NewScreen extends Component {
             Alphanumeric characters and hyphens only
           </p>
           <textarea
-            className="f7 ba b--gray3 w-100 pa3 ml3 mt2"
+            className="f7 ba b--gray3 w-100 pa3 ml3 mt2 focus-b--black"
             rows={1}
             placeholder="example-group-name"
             style={{

--- a/pkg/interface/link/src/css/custom.css
+++ b/pkg/interface/link/src/css/custom.css
@@ -72,6 +72,10 @@ a {
   mix-blend-mode: difference;
 }
 
+.focus-b--black:focus {
+  border-color: #000;
+}
+
 .embed-container {
   position: relative;
   height: 0;
@@ -162,6 +166,9 @@ a {
   }
   .b--gray2-d {
     border-color: #7f7f7f;
+  }
+  .b--white-d {
+    border-color: #fff;
   }
   .bb-d {
     border-bottom-width: 1px;

--- a/pkg/interface/link/src/js/components/lib/link-submit.js
+++ b/pkg/interface/link/src/js/components/lib/link-submit.js
@@ -7,7 +7,8 @@ export class LinkSubmit extends Component {
     this.state = {
       linkValue: "",
       linkTitle: "",
-      linkValid: false
+      linkValid: false,
+      submitFocus: false
     };
     this.setLinkValue = this.setLinkValue.bind(this);
     this.setLinkTitle = this.setLinkTitle.bind(this);
@@ -57,8 +58,12 @@ export class LinkSubmit extends Component {
   render() {
     let activeClasses = this.state.linkValid ? "green2 pointer" : "gray2";
 
+    let focus = (this.state.submitFocus)
+      ? "b--black b--white-d"
+      : "b--gray4 b--gray2-d"
+
     return (
-      <div className="relative ba b--gray4 b--gray2-d br1 w-100 mb6">
+      <div className={"relative ba br1 w-100 mb6 " + focus}>
         <textarea
           className="pl2 bg-gray0-d white-d w-100 f8"
           style={{
@@ -68,6 +73,8 @@ export class LinkSubmit extends Component {
           }}
           placeholder="Paste link here"
           onChange={this.setLinkValue}
+          onBlur={() => this.setState({submitFocus: false})}
+          onFocus={() => this.setState({submitFocus: true})}
           spellCheck="false"
           rows={1}
           onKeyPress={e => {
@@ -87,6 +94,8 @@ export class LinkSubmit extends Component {
           }}
           placeholder="Enter title"
           onChange={this.setLinkTitle}
+          onBlur={() => this.setState({ submitFocus: false })}
+          onFocus={() => this.setState({ submitFocus: true })}
           spellCheck="false"
           rows={1}
           onKeyPress={e => {

--- a/pkg/interface/link/src/js/components/link.js
+++ b/pkg/interface/link/src/js/components/link.js
@@ -12,7 +12,8 @@ export class LinkDetail extends Component {
     super(props);
     this.state = {
       comment: "",
-      data: props.data
+      data: props.data,
+      commentFocus: false
     };
 
     this.setComment = this.setComment.bind(this);
@@ -80,6 +81,10 @@ export class LinkDetail extends Component {
       ? "black white-d pointer"
       : "gray2 b--gray2";
 
+    let focus = (this.state.commentFocus)
+      ? "b--black b--white-d"
+      : "b--gray4 b--gray2-d"
+
     return (
       <div className="h-100 w-100 overflow-hidden flex flex-column">
         <div
@@ -111,7 +116,7 @@ export class LinkDetail extends Component {
               linkIndex={props.linkIndex}
               time={this.state.data.time}
             />
-            <div className="relative ba br1 b--gray4 b--gray2-d mt6 mb6">
+            <div className={"relative ba br1 mt6 mb6 " + focus}>
               <textarea
                 className="w-100 bg-gray0-d white-d f8 pa2 pr8"
                 style={{
@@ -120,6 +125,8 @@ export class LinkDetail extends Component {
                 }}
                 placeholder="Leave a comment on this link"
                 onChange={this.setComment}
+                onFocus={() => this.setState({commentFocus: true})}
+                onBlur={() => this.setState({commentFocus: false})}
                 value={this.state.comment}
               />
               <button

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -258,6 +258,10 @@ md img {
   margin-bottom: 8px;
 }
 
+.focus-b--black:focus {
+  border-color: #000;
+}
+
 .spin-active {
   animation: spin 2s infinite;
 }

--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -65,7 +65,8 @@ export class Comments extends Component {
               id="comment"
               name="comment"
               placeholder="Leave a comment here"
-              className="f9 db border-box w-100 ba b--gray3 pt3 ph3 pb8 br1 mb2"
+              className={"f9 db border-box w-100 ba b--gray3 pt3 ph3 pb8 br1 " +
+              "mb2 focus-b--black"}
               aria-describedby="comment-desc"
               onChange={this.commentChange}>
             </textarea>

--- a/pkg/interface/publish/src/js/components/lib/join.js
+++ b/pkg/interface/publish/src/js/components/lib/join.js
@@ -30,7 +30,7 @@ export class JoinScreen extends Component {
     if (keyPair[0] in notebookObj) {
       if (keyPair[1] in notebookObj[keyPair[0]]) {
         verdict = true;
-      } 
+      }
     }
     return verdict;
   }
@@ -93,8 +93,8 @@ export class JoinScreen extends Component {
     }
 
     return (
-      <div className={`h-100 w-100 pa3 pt2 overflow-x-hidden flex flex-column
-      bg-gray0-d white-d`}>
+      <div className={"h-100 w-100 pt2 overflow-x-hidden flex flex-column " +
+      "bg-gray0-d white-d pa3"}>
         <div
           className="w-100 dn-m dn-l dn-xl inter pt1 pb6 f8">
           <Link to="/~chat/">{"⟵ All Notebooks"}</Link>
@@ -105,7 +105,8 @@ export class JoinScreen extends Component {
           <p className="f9 gray2 mb4">Notebook names use lowercase, hyphens, and slashes.</p>
           <textarea
             ref={ e => { this.textarea = e; } }
-            className="f7 mono ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 mb2 db"
+            className={"f7 mono ba bg-gray0-d white-d pa3 mb2 db " +
+            "focus-b--black b--gray3 b--gray2-d "}
             placeholder="~zod/dream-journal"
             spellCheck="false"
             rows={1}

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -151,7 +151,8 @@ export class NewScreen extends Component {
             Provide a name for your notebook
           </p>
           <textarea
-            className="f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100"
+            className={"f7 ba bg-gray0-d white-d pa3 db w-100 " +
+            "focus-b--black b--gray3 b--gray2-d"}
             placeholder="eg. My Journal"
             rows={1}
             style={{
@@ -167,7 +168,8 @@ export class NewScreen extends Component {
           </p>
           <p className="f9 gray2 db mb2 pt1">What's your notebook about?</p>
           <textarea
-            className="f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100"
+            className={"f7 ba bg-gray0-d white-d pa3 db w-100 " +
+            "focus-b--black b--gray3 b--gray2-d"}
             placeholder="Notebook description"
             rows={1}
             style={{


### PR DESCRIPTION
Part of the Indigo spec. Text boxes, when focused, get a black border.

I threw it into Links' multi-line input too, but that one's more blurry as to whether it matches the specification (cc @urcades):
![Feb-21-2020 20-46-01](https://user-images.githubusercontent.com/20846414/75084034-534fae00-54eb-11ea-8017-db6d8f1ae682.gif)
