### PR TITLE
launch: dark mode

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -454,6 +454,23 @@
                left: 50%;
                transform: translate(-50%, -50%);
              }
+             @media all and (prefers-color-scheme: dark) {
+               html, body {
+                 background-color: #333;
+                 color: #fff;
+               }
+               a, a:visited {
+                 color: #fff;
+               }
+               input {
+                 background: #333;
+                 color: #fff;
+                 border: 1px solid #7f7f7f;
+               }
+               input:focus {
+                 border: 1px solid #fff;
+               }
+             }
              @media all and (min-width: 34.375rem) {
                .tc-ns {
                  text-align: center;

--- a/pkg/interface/chat/tile/tile.js
+++ b/pkg/interface/chat/tile/tile.js
@@ -25,7 +25,7 @@ export default class ChatTile extends Component {
     let numNotificationsElem =
       notificationsNum > 0 ? (
         <p
-          className="absolute green2"
+          className="absolute green2 white-d"
           style={{
             bottom: 6,
             fontWeight: 400,
@@ -39,11 +39,12 @@ export default class ChatTile extends Component {
       );
 
     return (
-      <div className="w-100 h-100 relative bg-white ba b--black">
+      <div className={"w-100 h-100 relative bg-white bg-gray0-d ba " +
+      "b--black b--gray1-d"}>
         <a className="w-100 h-100 db pa2 no-underline" href="/~chat">
-          <p className="black gray absolute f9" style={{left: 8, top: 8}}>Messaging</p>
+          <p className="black white-d absolute f9" style={{left: 8, top: 8}}>Messaging</p>
            <img
-             className="absolute"
+             className="absolute invert-d"
              style={{ left: 39, top: 39 }}
              src="/~chat/img/Tile.png"
              width={48}

--- a/pkg/interface/clock/tile/tile.js
+++ b/pkg/interface/clock/tile/tile.js
@@ -14,6 +14,26 @@ const innerSize = 124; //clock size
 //   }
 // }
 
+let text = "#000000", background = "#ffffff";
+
+let dark = window.matchMedia('(prefers-color-scheme: dark)');
+
+if (dark.matches) {
+  text = "#7f7f7f";
+  background = "#333";
+}
+
+dark.addEventListener("change", (e) => {
+  if (e.matches) {
+    text = "#7f7f7f";
+    background = "#333";
+  } else {
+    text = "#000000";
+    background = "#ffffff"
+  }
+})
+
+
 const toRelativeTime = (date, referenceTime, unit) => moment(date)
   .diff(referenceTime, unit)
 
@@ -182,7 +202,7 @@ class Clock extends Component {
       ctr,
       -1,
       2 * Math.PI,
-      '#FFFFFF'
+      'rgba(0,0,0,0)'
     )
 
     // Day
@@ -309,7 +329,7 @@ class Clock extends Component {
       ctr-1,
       -1,
       2 * Math.PI,
-      '#000000',
+      text,
       1
     );
 
@@ -321,7 +341,7 @@ class Clock extends Component {
       ctr,
       -1,
       2 * Math.PI,
-      '#FFFFFF',
+      background,
       1
     );
 
@@ -333,7 +353,7 @@ class Clock extends Component {
       ctr/1.85,
       -1,
       2 * Math.PI,
-      '#FFFFFF'
+      background
     )
 
     // Center white circle border
@@ -344,7 +364,7 @@ class Clock extends Component {
       ctr/1.85,
       -1,
       2 * Math.PI,
-      '#000000',
+      text,
       1
     );
 
@@ -354,10 +374,10 @@ class Clock extends Component {
       : moment().format('h:mm A')
     const dateText = moment().format('MMM Do')
     ctx.textAlign = 'center'
-    ctx.fillStyle = '#000000'
+    ctx.fillStyle = text
     ctx.font = '12px Inter'
     ctx.fillText(timeText, ctr, ctr + 6 - 7)
-    ctx.fillStyle = '#B1B1B1'
+    ctx.fillStyle = text
     ctx.font = '12px Inter'
     ctx.fillText(dateText, ctr, ctr + 6 + 7)
 
@@ -381,10 +401,9 @@ export default class ClockTile extends Component {
 
   renderWrapper(child) {
     return (
-      <div className="" style={{
+      <div className="bg-white bg-gray0-d" style={{
         width: outerSize,
         height: outerSize,
-        background: '#fff'
       }}>
         {child}
       </div>

--- a/pkg/interface/contacts/tile/tile.js
+++ b/pkg/interface/contacts/tile/tile.js
@@ -9,15 +9,16 @@ export default class ContactTile extends Component {
     const { props } = this;
 
     return (
-      <div className="w-100 h-100 relative bg-white b--black ba">
+      <div className={"w-100 h-100 relative bg-white bg-gray0-d " +
+      "b--black b--gray1-d ba"}>
         <a className="w-100 h-100 db pa2 bn" href="/~contacts">
           <p
-            className="black absolute f9"
+            className="black white-d absolute f9"
             style={{ left: 8, top: 8 }}>
             Contacts
           </p>
           <img
-            className="absolute"
+            className="absolute invert-d"
             style={{ left: 39, top: 39 }}
             src="/~contacts/img/Tile.png"
             width={48}

--- a/pkg/interface/launch/src/css/custom.css
+++ b/pkg/interface/launch/src/css/custom.css
@@ -26,3 +26,22 @@ textarea, select, input, button { outline: none; }
 .mix-blend-diff {
   mix-blend-mode: difference;
 }
+
+/* dark */
+@media all and (prefers-color-scheme: dark) {
+  body {
+    background-color: #333;
+  }
+  .bg-gray0-d {
+    background-color: #333;
+  }
+  .b--gray1-d {
+    border-color: #4d4d4d;
+  }
+  .white-d {
+    color: #fff;
+  }
+  .invert-d {
+    filter: invert(1);
+  }
+}

--- a/pkg/interface/launch/src/js/components/home.js
+++ b/pkg/interface/launch/src/js/components/home.js
@@ -23,7 +23,7 @@ export default class Home extends Component {
     });
 
     return (
-      <div className="fl w-100 h-100 bg-white center">
+      <div className="fl w-100 h-100 bg-white bg-gray0-d center">
         <Header />
         <div className={"v-mid pa2 dtc-m dtc-l dtc-xl " +
         "flex justify-between flex-wrap"}

--- a/pkg/interface/launch/src/js/components/tile.js
+++ b/pkg/interface/launch/src/js/components/tile.js
@@ -13,7 +13,7 @@ export default class Tile extends Component {
     let SpecificTile = window[this.props.type + 'Tile'];
 
     return (
-      <div className="fl ma2 bg-white overflow-hidden"
+      <div className="fl ma2 bg-white bg-gray0-d overflow-hidden"
            style={{ height: '126px', width: '126px' }}>
         { !!SpecificTile ?
           <SpecificTile data={this.props.data} />

--- a/pkg/interface/link/tile/tile.js
+++ b/pkg/interface/link/tile/tile.js
@@ -11,7 +11,7 @@ export default class LinkTile extends Component {
     let displayUnseen = unseenCount <= 0
       ? null
       : <p
-          className="absolute green2"
+          className="absolute green2 white-d"
           style={{
             bottom: 6,
             fontWeight: 400,
@@ -22,15 +22,16 @@ export default class LinkTile extends Component {
         </p>;
 
     return (
-      <div className="w-100 h-100 relative ba b--black bg-white">
+      <div className={"w-100 h-100 relative ba b--black b--gray1-d " +
+      "bg-white bg-gray0-d"}>
         <a className="w-100 h-100 db pa2 bn" href="/~link">
           <p
-            className="f9 black absolute"
+            className="f9 black white-d absolute"
             style={{ left: 8, top: 8 }}>
             Links
           </p>
           <img
-            className="absolute"
+            className="absolute invert-d"
             style={{ left: 39, top: 39 }}
             src="/~link/img/Tile.png"
             width={48}

--- a/pkg/interface/publish/tile/tile.js
+++ b/pkg/interface/publish/tile/tile.js
@@ -24,13 +24,14 @@ export default class PublishTile extends Component {
     }
 
     return (
-      <div className="w-100 h-100 relative bg-white ba b--black">
+      <div className={"w-100 h-100 relative bg-white bg-gray0-d " +
+      "ba b--black b--gray1-d"}>
         <a className="w-100 h-100 db no-underline" href="/~publish">
-          <p className="black f9 absolute" style={{ left: 8, top: 8 }}>
+          <p className="black white-d f9 absolute" style={{ left: 8, top: 8 }}>
             Publishing
           </p>
           <img
-            className="absolute"
+            className="absolute invert-d"
             style={{ left: 39, top: 39 }}
             src="/~publish/tile.png"
             width={48}
@@ -39,7 +40,7 @@ export default class PublishTile extends Component {
           <div
             className="absolute w-100 flex-col f9"
             style={{ verticalAlign: "bottom", bottom: 8, left: 8 }}>
-            <span className="green2">{notificationsNum}</span>
+            <span className="green2 white-d">{notificationsNum}</span>
           </div>
         </a>
       </div>

--- a/pkg/interface/soto/tile/tile.js
+++ b/pkg/interface/soto/tile/tile.js
@@ -7,7 +7,8 @@ export default class sotoTile extends Component {
 
   render() {
     return (
-      <div className="w-100 h-100 relative bg-black">
+      <div className={"w-100 h-100 relative bg-black bg-gray0-d " +
+      "ba b--black b--gray1-d"}>
         <a className="w-100 h-100 db bn" href="/~dojo">
           <p className="white f9 absolute"
            style={{ left: 8, top: 8 }}>

--- a/pkg/interface/weather/tile/tile.js
+++ b/pkg/interface/weather/tile/tile.js
@@ -138,14 +138,15 @@ export default class WeatherTile extends Component {
     }
     if (location.protocol === "https:") {
       secureCheck = <a
-        className="black f9 absolute pointer"
+        className="black white-d f9 absolute pointer"
         style={{right: 8, top: 8}}
         onClick={() => this.locationSubmit()}>Detect -></a>
     }
     return this.renderWrapper(
-      <div className="pa2 w-100 h-100 bg-white black b--black ba">
+      <div className={"pa2 w-100 h-100 bg-white bg-gray0-d black white-d " +
+      "b--black b--gray1-d ba"}>
         <a
-          className="f9 black pointer"
+          className="f9 black white-d pointer"
           onClick={() =>
             this.setState({ manualEntry: !this.state.manualEntry })
           }>
@@ -155,7 +156,7 @@ export default class WeatherTile extends Component {
         <p className="f9 pt2">
           Please enter your{" "}
           <a
-            className="black"
+            className="black white-d"
             href="https://latitudeandlongitude.org/"
             target="_blank">
             latitude and longitude
@@ -167,7 +168,7 @@ export default class WeatherTile extends Component {
           <form className="flex" style={{marginBlockEnd: 0 }}>
             <input
               id="gps"
-              className="w-100 black bg-transparent bn f9"
+              className="w-100 black white-d bg-transparent bn f9"
               type="text"
               placeholder="29.558107, -95.089023"
               onKeyDown={(e) => {
@@ -177,7 +178,8 @@ export default class WeatherTile extends Component {
                 }}
               }/>
             <input
-              className="bg-transparent black bn pointer f9 flex-shrink-0"
+              className={"bg-transparent black white-d bn pointer " +
+              "f9 flex-shrink-0"}
               type="submit"
               onClick={() => this.manualLocationSubmit()}
               value="->"/>
@@ -190,13 +192,17 @@ export default class WeatherTile extends Component {
   renderNoData() {
     return this.renderWrapper((
       <div
-        className="pa2 w-100 h-100 b--black ba bg-white black"
+        className={"pa2 w-100 h-100 b--black b--gray1-d ba " +
+        "bg-white bg-gray0-d black white-d"}
       onClick={() => this.setState({manualEntry: !this.state.manualEntry})}>
           <p className="f9 absolute"
             style={{left: 8, top: 8}}>
             Weather
           </p>
-        <p className="absolute w-100 flex-col f9" style={{verticalAlign: "bottom", bottom: 8, left: 8, cursor: "pointer"}}>-> Set location</p>
+        <p className="absolute w-100 flex-col f9"
+        style={{verticalAlign: "bottom", bottom: 8, left: 8, cursor: "pointer"}}>
+        -> Set location
+        </p>
       </div>
     ));
   }
@@ -208,7 +214,7 @@ export default class WeatherTile extends Component {
     let da = moment.unix(d.sunsetTime).format('h:mm a') || '';
 
     return this.renderWrapper(
-      <div className="w-100 h-100 b--black ba"
+      <div className="w-100 h-100 b--black b--gray1-d ba"
       style={{backdropFilter: "blur(80px)"}}>
         <p className="f9 absolute" style={{ left: 8, top: 8 }}>
           Weather


### PR DESCRIPTION
- Add dark mode class declarations to launch 
- Add dark mode classes to all tiles.
- Add a dark mode event listener to clock, swapping out a few hex colors for background and text. @g-a-v-i-n 
- Add dark mode styles to sign in screen.

<img width="500" alt="Screen Shot 2020-02-21 at 9 55 46 PM" src="https://user-images.githubusercontent.com/20846414/75085347-44222d80-54f6-11ea-86b8-6049f6ccce5a.png">

<img width="660" alt="Screen Shot 2020-02-21 at 9 38 55 PM" src="https://user-images.githubusercontent.com/20846414/75085350-45535a80-54f6-11ea-9cf2-6f50b25437fc.png">
