### PR TITLE
dbug: default to %state

### DIFF
--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -26,7 +26,7 @@
     ==
 :-  %dbug
 ?-  args
-  ~        [%bowl *about]
+  ~        [%state *about]
   [@ ~]    [what.args *about]
   [@ * ~]  [what about]:args
 ==


### PR DESCRIPTION
I find myself asking for `%state` way more often than `%bowl`, so seems fair to make that the default when no arguments are supplied to `+dbug`.