### PR TITLE
publish: add publish invite path

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -70,11 +70,18 @@
         :*  %pass  /launch/publish  %agent  [our.bol %launch]  %poke
             %launch-action  !>([%publish /publishtile '/~publish/tile.js'])
         ==
+        :*  %pass  /  %agent  [our.bol %invite-store]  %poke  %invite-action
+            !>([%create /publish])
+        ==
     ==
   ++  on-save  !>(state)
   ++  on-load
     |=  old=vase
-    `this(state !<(state-zero old))
+    :_  this(state !<(state-zero old))
+    :_  ~
+    :*  %pass  /  %agent  [our.bol %invite-store]  %poke  %invite-action
+        !>([%create /publish])
+    ==
   ::
   ++  on-poke
     |=  [=mark =vase]


### PR DESCRIPTION
In the OS1 OTA transition for publish it recreates notebooks, and sends invites to people that were previously subscribed. However since old publish did not have its publish invite store path initialized, people who receive that invite before they get the update will just crash and never see it even when they upgrade.

So this PR just adds that invite store path, just to avoid this messiness in this particular case. This change should go on the network ASAP.