### PR TITLE
publish: add 'edit note' functionality

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1225,7 +1225,7 @@
       (~(get by subs) who.act book.act)
     ?~  book
       ~|("nonexistent notebook: {<book.act>}" !!)
-    =/  not=(unit note)  (~(get by notes.u.book) note.act) 
+    =/  not=(unit note)  (~(get by notes.u.book) note.act)
     ?~  not
       ~|("nonexistent note: {<note.act>}" !!)
     =?  tile-num  !read.u.not
@@ -1613,7 +1613,7 @@
     (manx-response:gen (index u.book-json))
   ::
   ::  single note, with initial 50 comments, wrapped in html
-      [[~ [%'~publish' %note @ @ @ ~]] ~]
+      [[~ [%'~publish' %note @ @ @ *]] ~]
     =/  host=(unit @p)  (slaw %p i.t.t.site.url)
     ?~  host
       not-found:gen
@@ -1625,7 +1625,7 @@
     (manx-response:gen (index u.note-json))
   ::
   ::  single note, with initial 50 comments, wrapped in html
-      [[~ [%'~publish' %popout %note @ @ @ ~]] ~]
+      [[~ [%'~publish' %popout %note @ @ @ *]] ~]
     =/  host=(unit @p)  (slaw %p i.t.t.t.site.url)
     ?~  host
       not-found:gen

--- a/pkg/interface/publish/src/js/api.js
+++ b/pkg/interface/publish/src/js/api.js
@@ -131,7 +131,6 @@ class UrbitApi {
   }
 
   setSpinner(boolean) {
-    console.log("setspinner " + boolean)
     store.handleEvent({
       type: "local",
       data: {

--- a/pkg/interface/publish/src/js/components/lib/edit-post.js
+++ b/pkg/interface/publish/src/js/components/lib/edit-post.js
@@ -55,7 +55,6 @@ export class EditPost extends Component {
       window.api.setSpinner(false);
       props.history.push(noteHref);
     });
-
   }
 
   bodyChange(editor, data, value) {

--- a/pkg/interface/publish/src/js/components/lib/edit-post.js
+++ b/pkg/interface/publish/src/js/components/lib/edit-post.js
@@ -1,0 +1,136 @@
+import React, { Component } from 'react';
+import { SidebarSwitcher } from './icons/icon-sidebar-switch';
+import { Route, Link } from 'react-router-dom';
+import { Controlled as CodeMirror } from 'react-codemirror2';
+import { dateToDa } from '/lib/util';
+
+import 'codemirror/mode/markdown/markdown';
+
+export class EditPost extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      body: '',
+      submit: false
+    }
+    this.postSubmit = this.postSubmit.bind(this);
+    this.bodyChange = this.bodyChange.bind(this);
+  }
+
+  componentDidMount() {
+    const { props } = this;
+    if (!(props.notebooks[props.ship]) ||
+      !(props.notebooks[props.ship][props.book]) ||
+      !(props.notebooks[props.ship][props.book].notes[props.note]) ||
+      !(props.notebooks[props.ship][props.book].notes[props.note].file)) {
+      window.api.fetchNote(props.ship, props.book, props.note);
+    }
+    else {
+      let notebook = props.notebooks[props.ship][props.book];
+      let note = notebook.notes[props.note];
+      let file = note.file;
+      let body = file.slice(file.indexOf(';>') + 2);
+      this.setState({body: body});
+    }
+  }
+
+  postSubmit() {
+    let { props, state } = this;
+    let notebook = props.notebooks[props.ship][props.book];
+    let note = notebook.notes[props.note];
+    let title = note.title;
+    let editNote = {
+      "edit-note": {
+        who: props.ship.slice(1),
+        book: props.book,
+        note: props.note,
+        title: title,
+        body: state.body
+      }
+    }
+    window.api.setSpinner(true);
+    window.api.action("publish", "publish-action", editNote).then(() => {
+      let editIndex = props.location.pathname.indexOf("/edit");
+      let noteHref = props.location.pathname.slice(0, editIndex);
+      window.api.setSpinner(false);
+      props.history.push(noteHref);
+    });
+
+  }
+
+  bodyChange(editor, data, value) {
+    let submit = !(value === '');
+    this.setState({ body: value, submit: submit });
+  }
+
+  render() {
+    const { props, state } = this;
+    let notebook = props.notebooks[props.ship][props.book];
+    let note = notebook.notes[props.note];
+    let title = note.title;
+    let date = dateToDa(new Date(note["date-created"]));
+    date = date.slice(1, -10);
+
+    let submitStyle = (state.submit)
+      ? { color: '#2AA779', cursor: "pointer" }
+      : { color: '#B1B2B3', cursor: "auto" };
+
+    let hrefIndex = props.location.pathname.indexOf("/note/");
+    let publishsubStr = props.location.pathname.substr(hrefIndex)
+    let popoutHref = `/~publish/popout${publishsubStr}`;
+
+    let hiddenOnPopout = (props.popout)
+      ? "" : "dib-m dib-l dib-xl";
+
+    const options = {
+      mode: 'markdown',
+      theme: 'tlon',
+      lineNumbers: false,
+      lineWrapping: true,
+      scrollbarStyle: null,
+      cursorHeight: 0.85
+    };
+
+    return (
+      <div className="f9 h-100 relative">
+        <div className="w-100 tl pv4 flex justify-center">
+          <SidebarSwitcher
+            sidebarShown={props.sidebarShown}
+            popout={props.popout}
+          />
+          <button
+            className="v-mid w-100 mw6 tl h1 pl4"
+            disabled={!state.submit}
+            style={submitStyle}
+            onClick={this.postSubmit}>
+            Save "{title}"
+          </button>
+        <Link
+          className={"dn absolute right-1 top-1 " + hiddenOnPopout}
+          to={popoutHref}
+          target="_blank">
+          <img src="/~publish/popout.png"
+            height={16}
+            width={16}
+          />
+        </Link>
+        </div>
+        <div className="overflow-container mw6 center">
+        <div className="pl4">
+          <div className="gray2">{date}</div>
+        </div>
+        <div className="NewPost">
+          <CodeMirror
+            value={state.body}
+            options={options}
+            onBeforeChange={(e, d, v) => this.bodyChange(e, d, v)}
+            onChange={(editor, data, value) => {}}
+          />
+        </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default EditPost;

--- a/pkg/interface/publish/src/js/components/lib/new-post.js
+++ b/pkg/interface/publish/src/js/components/lib/new-post.js
@@ -117,17 +117,16 @@ export class NewPost extends Component {
           </Link>
         </div>
         <div className="overflow-container mw6 center">
-          <div style={{ padding: 16 }}>
+          <div className="pa4">
             <input
               autoFocus
               type="text"
-              style={{ paddingBottom: 8 }}
-              className="w-100"
+              className="w-100 pb2"
               onChange={this.titleChange}
               placeholder="New Post"
             />
 
-            <div style={{ color: "#7F7F7F" }}>{date}</div>
+            <div className="gray2">{date}</div>
           </div>
 
           <div className="NewPost">

--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -136,6 +136,16 @@ export class Note extends Component {
           date: moment(notebook.notes[nextId]["date-created"]).fromNow()
         }
 
+    let editPost = null;
+    let editUrl = props.location.pathname + "/edit";
+    if (notebook["writers-group-path"] in props.groups) {
+      let writers = notebook["writers-group-path"];
+      if (props.groups[writers].has(window.ship)) {
+        editPost =
+        <Link className="green2 f9" to={editUrl}>Edit</Link>
+      }
+    }
+
     let popout = (props.popout) ? "popout/" : "";
 
     let hrefIndex = props.location.pathname.indexOf("/note/");
@@ -182,7 +192,8 @@ export class Note extends Component {
                   }>
                   {name}
                 </div>
-                <div className="di f9 gray2">{date}</div>
+                <div className="di">
+                  <span className="f9 gray2">{date}</span><span className="ml2">{editPost}</span></div>
               </div>
             </div>
             <div className="md"

--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -138,12 +138,9 @@ export class Note extends Component {
 
     let editPost = null;
     let editUrl = props.location.pathname + "/edit";
-    if (notebook["writers-group-path"] in props.groups) {
-      let writers = notebook["writers-group-path"];
-      if (props.groups[writers].has(window.ship)) {
+    if (`~${window.ship}` === author) {
         editPost =
         <Link className="green2 f9" to={editUrl}>Edit</Link>
-      }
     }
 
     let popout = (props.popout) ? "popout/" : "";

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -8,6 +8,7 @@ import { JoinScreen } from '/components/lib/join';
 import { Notebook } from '/components/lib/notebook';
 import { Note } from '/components/lib/note';
 import { NewPost } from '/components/lib/new-post';
+import { EditPost } from '/components/lib/edit-post';
 
 
 export class Root extends Component {
@@ -155,7 +156,7 @@ export class Root extends Component {
             );
           }
         }}/>
-      <Route exact path="/~publish/:popout?/note/:ship/:notebook/:note"
+      <Route exact path="/~publish/:popout?/note/:ship/:notebook/:note/:edit?"
         render={ (props) => {
           let ship = props.match.params.ship || "";
           let notebook = props.match.params.notebook || "";
@@ -169,8 +170,11 @@ export class Root extends Component {
           let notebookContacts = (bookGroupPath in state.contacts)
             ? contacts[bookGroupPath] : {};
 
-          return (
-            <Skeleton
+          let edit = !!props.match.params.edit || false;
+
+          if (edit) {
+            return (
+              <Skeleton
               popout={popout}
               active={"rightPanel"}
               rightPanelHide={false}
@@ -180,18 +184,42 @@ export class Root extends Component {
               notebooks={state.notebooks}
               contacts={contacts}
               path={path}>
-              <Note
+              <EditPost
                 notebooks={state.notebooks}
                 book={notebook}
-                contacts={notebookContacts}
-                ship={ship}
                 note={note}
+                ship={ship}
                 sidebarShown={state.sidebarShown}
                 popout={popout}
-                {...props}
-              />
-            </Skeleton>
-          );
+                {...props}/>
+              </Skeleton>
+            )
+          }
+          else {
+            return (
+              <Skeleton
+                popout={popout}
+                active={"rightPanel"}
+                rightPanelHide={false}
+                sidebarShown={state.sidebarShown}
+                spinner={state.spinner}
+                invites={state.invites}
+                notebooks={state.notebooks}
+                contacts={contacts}
+                path={path}>
+                <Note
+                  notebooks={state.notebooks}
+                  book={notebook}
+                  contacts={notebookContacts}
+                  ship={ship}
+                  note={note}
+                  sidebarShown={state.sidebarShown}
+                  popout={popout}
+                  {...props}
+                />
+              </Skeleton>
+            );
+          }
         }}/>
       </BrowserRouter>
     )

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -210,6 +210,7 @@ export class Root extends Component {
                 <Note
                   notebooks={state.notebooks}
                   book={notebook}
+                  groups={state.groups}
                   contacts={notebookContacts}
                   ship={ship}
                   note={note}


### PR DESCRIPTION
- Add a wildcard to the endpoint mount for notes so we can handle params
- Removes an errant console.log
- Create an "Edit Post" component with a similar presentation as New Post
- Routes it into Note view and conditionally checks if the user is in the write group before presenting the 'edit' link

There were some inline styles that duplicated indigo-static classes in new-post, I believe, so I swapped in those classes too.

## Additional notes
Editing a note and then viewing the note returns the note but with a new line appended to the start and end. I can't see why this would originate in front-end: the state and value changes don't have this new line. 

I can only think this happens as part of the processing of the note after the API submission. Do you know why this does this?