### PR TITLE
publish: catch, amend, resubmit when creating notes with duplicate titles

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/new-post.js
+++ b/pkg/interface/publish/src/js/components/lib/new-post.js
@@ -32,12 +32,17 @@ export class NewPost extends Component {
       }
     }
 
-    this.setState({
-      awaiting: newNote["new-note"].note
-    }, () => {
       window.api.setSpinner(true);
-      window.api.action("publish", "publish-action", newNote);
-    });
+      window.api.action("publish", "publish-action", newNote).then(() =>{
+        this.setState({ awaiting: newNote["new-note"].note });
+      }).catch((err) => {
+        if (err.includes("note already exists")) {
+          let timestamp = Math.floor(Date.now() / 1000);
+          newNote["new-note"].note += "-" + timestamp;
+          this.setState({awaiting: newNote["new-note"].note});
+          window.api.action("publish", "publish-action", newNote);
+        }
+      });
   }
 
   componentWillMount() {


### PR DESCRIPTION
Before, if you wrote a note with a duplicate title, the promise would be rejected, but the front end would silently fail, hung on the spinner.

This commit adds a catch: if we get "note already exists" back from the promise, we revise the `new-note` object to append a timestamp to the `@tas` and send it back to the API.

(Why a timestamp? Because we don't have the full list of notes in state, just the most recent 50, so we can't reliably, proactively, see in front-end if we're about to duplicate a title.)

I also re-order the `awaiting` state change to happen *after* the API call, because otherwise it would:
- set the `awaiting` state, 
- see that it had the duplicate note already as the original note's title before the promise returned,
- push the route to the original note while we're waiting on the promise, and then 
- the duplicate note would submit successfully anyway.