### PR TITLE
publish: join notebook polish, join from URL

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1225,7 +1225,7 @@
       (~(get by subs) who.act book.act)
     ?~  book
       ~|("nonexistent notebook: {<book.act>}" !!)
-    =/  not=(unit note)  (~(get by notes.u.book) note.act) 
+    =/  not=(unit note)  (~(get by notes.u.book) note.act)
     ?~  not
       ~|("nonexistent note: {<note.act>}" !!)
     =?  tile-num  !read.u.not
@@ -1585,7 +1585,7 @@
   ::  presentation endpoints
   ::
   ::  all notebooks, short form, wrapped in html
-      [[~ [%'~publish' ?(~ [%join ~] [%new ~])]] ~]
+      [[~ [%'~publish' ?(~ [%join *] [%new ~])]] ~]
     =,  enjs:format
     =/  jon=json  (pairs notebooks+(notebooks-map-json our.bol books subs) ~)
     (manx-response:gen (index jon))

--- a/pkg/interface/publish/src/js/components/lib/join.js
+++ b/pkg/interface/publish/src/js/components/lib/join.js
@@ -16,7 +16,18 @@ export class JoinScreen extends Component {
     this.bookChange = this.bookChange.bind(this);
   }
 
+  componentDidMount() {
+    // direct join from incoming URL
+    if ((this.props.ship) && (this.props.notebook)) {
+      let incomingBook = `${this.props.ship}/${this.props.notebook}`;
+      this.setState({book: incomingBook}, () => {
+        this.onClickJoin();
+      })
+    }
+  }
+
   componentDidUpdate() {
+    // redirect to notebook when we have it
     if (this.props.notebooks) {
       if (this.state.awaiting) {
         let book = this.state.awaiting.split("/");
@@ -53,7 +64,6 @@ export class JoinScreen extends Component {
     const { props, state } = this;
 
     let text = state.book;
-    // an error condition to prevent double joins?
 
     let book = text.split('/');
     let ship = book[0];

--- a/pkg/interface/publish/src/js/components/lib/join.js
+++ b/pkg/interface/publish/src/js/components/lib/join.js
@@ -76,15 +76,15 @@ export class JoinScreen extends Component {
   }
 
   render() {
-    const { props } = this;
+    const { props, state } = this;
 
     let joinClasses = "db f9 green2 ba pa2 b--green2 bg-gray0-d pointer";
-    if ((!this.state.book) || (this.state.book === "/")) {
-      joinClasses = 'db f9 gray2 ba pa2 b--gray3 bg-gray0-d pointer';
+    if ((!state.book) || (state.book === "/")) {
+      joinClasses = 'db f9 gray2 ba pa2 b--gray3 bg-gray0-d';
     }
 
     let errElem = (<span />);
-    if (this.state.error) {
+    if (state.error) {
       errElem = (
         <span className="f9 inter red2 db">
           Notebook must have a valid name.
@@ -93,11 +93,11 @@ export class JoinScreen extends Component {
     }
 
     return (
-      <div className={"h-100 w-100 pt2 overflow-x-hidden flex flex-column " +
+      <div className={"h-100 w-100 pt4 overflow-x-hidden flex flex-column " +
       "bg-gray0-d white-d pa3"}>
         <div
           className="w-100 dn-m dn-l dn-xl inter pt1 pb6 f8">
-          <Link to="/~chat/">{"⟵ All Notebooks"}</Link>
+          <Link to="/~publish/">{"⟵ All Notebooks"}</Link>
         </div>
         <h2 className="mb3 f8">Subscribe to an Existing Notebook</h2>
         <div className="w-100">
@@ -106,7 +106,7 @@ export class JoinScreen extends Component {
           <textarea
             ref={ e => { this.textarea = e; } }
             className={"f7 mono ba bg-gray0-d white-d pa3 mb2 db " +
-            "focus-b--black b--gray3 b--gray2-d "}
+            "focus-b--black b--gray3 b--gray2-d nowrap "}
             placeholder="~zod/dream-journal"
             spellCheck="false"
             rows={1}
@@ -123,6 +123,7 @@ export class JoinScreen extends Component {
           {errElem}
           <br />
           <button
+            disabled={(!state.book) || (state.book === "/")}
             onClick={this.onClickJoin.bind(this)}
             className={joinClasses}
           >Join Chat</button>

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -70,8 +70,10 @@ export class Root extends Component {
             </Skeleton>
           )
         }}/>
-      <Route exact path="/~publish/join"
+      <Route exact path="/~publish/join/:ship?/:notebook?"
               render={ (props) => {
+                let ship = props.match.params.ship || "";
+                let notebook = props.match.params.notebook || "";
                 return (
                   <Skeleton
                   popout={false}
@@ -82,7 +84,11 @@ export class Root extends Component {
                   invites={state.invites}
                   notebooks={state.notebooks}
                   contacts={contacts}>
-                    <JoinScreen notebooks={state.notebooks} {...props} />
+                    <JoinScreen
+                    notebooks={state.notebooks}
+                    ship={ship}
+                    notebook={notebook}
+                    {...props} />
                   </Skeleton>
                 )
               }}/>


### PR DESCRIPTION
- Disabling the join button entirely if we don't have anything to send, so it doesn't have to handle that catch in `onClickJoin`
- Text input scrolls horizontally if the input is too long instead of the awkward multi-line thing it had
- Adding UI transitions to properly forward us to the notebook once we've joined it, and catching it when we join a notebook that doesn't exist (and the spinner behaviour, which I forgot to add earlier)
- If we tried to join our own, pre-existing notebook it would spin `<<http>>` forever, I think even persisting on reboots and requiring a fresh fakezod? I added a `return` before the auto-redirect transition so we don't make the API request and it has, seemingly, fixed it. It wasn't ... joining itself forever, was it?
- I also added the ability to automatically join a notebook from a URL, eg. `/~publish/join/~haddef-sigwen/a-third-notebook` will fulfil the API request to join the notebook and forward us when it's done.