### PR TITLE
links, publish: blend member sigils

### DIFF
--- a/pkg/interface/link/src/js/components/lib/comment-item.js
+++ b/pkg/interface/link/src/js/components/lib/comment-item.js
@@ -31,13 +31,17 @@ export class CommentItem extends Component {
 
   render() {
     let props = this.props;
+
+    let member = this.props.member || false;
+
     return (
       <div className="w-100 pv3">
-        <div className="flex">
+        <div className="flex bg-white bg-gray0-d">
           <Sigil
           ship={"~" + props.ship}
           size={36}
           color={"#" + props.color}
+          classes={(member ? "mix-blend-diff" : "")}
           />
           <p className="gray2 f9 flex items-center ml2">
             <span className={"black white-d " + props.nameClass}>

--- a/pkg/interface/link/src/js/components/lib/comments.js
+++ b/pkg/interface/link/src/js/components/lib/comments.js
@@ -52,7 +52,7 @@ export class Comments extends Component {
         ? props.contacts
         : {};
 
-      const {nickname, color} = getContactDetails(contacts[ship]);
+      const {nickname, color, member} = getContactDetails(contacts[ship]);
 
       let nameClass = nickname ? "inter" : "mono";
 
@@ -65,6 +65,7 @@ export class Comments extends Component {
           nickname={nickname}
           nameClass={nameClass}
           color={color}
+          member={member}
         />
       )
     })

--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -101,7 +101,7 @@ export class LinkPreview extends Component {
         </div>
         <div className="flex flex-column ml2 pt6 flex-auto">
           <a href={props.url} className="w-100 flex" target="_blank">
-            <p className="f8 truncate flex-auto">
+            <p className="f8 truncate">
               {props.title}
             </p>
             <span className="gray2 ml2 f8 dib v-btm flex-shrink-0">{hostname} ↗</span>

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -62,12 +62,14 @@ export class LinkItem extends Component {
 
     let comments = props.comments + " comment" + ((props.comments === 1) ? "" : "s");
 
+    let member = this.props.member || false;
     return (
-      <div className="w-100 pv3 flex">
+      <div className="w-100 pv3 flex bg-white bg-gray0-d">
         <Sigil
           ship={"~" + props.ship}
           size={36}
           color={"#" + props.color}
+          classes={(member ? "mix-blend-diff" : "")}
             />
         <div className="flex flex-column ml2 flex-auto">
           <a href={props.url}

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -74,7 +74,7 @@ export class LinkItem extends Component {
           className="w-100 flex"
           target="_blank"
           onClick={this.markPostAsSeen}>
-            <p className="f8 truncate flex-auto">{props.title}
+            <p className="f8 truncate">{props.title}
             </p>
             <span className="gray2 dib v-btm ml2 f8 flex-shrink-0">{hostname} ↗</span>
           </a>

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -61,7 +61,7 @@ export class Links extends Component {
         ? props.comments[url].totalItems
         : linksObj[linkIndex].commentCount || 0;
 
-      const {nickname, color} = getContactDetails(props.contacts[ship]);
+      const {nickname, color, member} = getContactDetails(props.contacts[ship]);
 
       return (
         <LinkItem
@@ -75,6 +75,7 @@ export class Links extends Component {
         nickname={nickname}
         ship={ship}
         color={color}
+        member={member}
         comments={commentCount}
         groupPath={props.groupPath}
         popout={popout}

--- a/pkg/interface/link/src/js/lib/util.js
+++ b/pkg/interface/link/src/js/lib/util.js
@@ -15,6 +15,7 @@ export function uuid() {
 }
 
 export function getContactDetails(contact) {
+  const member = !contact;
   contact = contact || {
     'nickname': '',
     'avatar': 'TODO',
@@ -22,7 +23,7 @@ export function getContactDetails(contact) {
   };
   const nickname = contact.nickname || '';
   const color = uxToHex(contact.color || '0x0');
-  return {nickname, color};
+  return {nickname, color, member};
 }
 
 // encodes string into base64url,

--- a/pkg/interface/publish/src/js/components/lib/comment-item.js
+++ b/pkg/interface/publish/src/js/components/lib/comment-item.js
@@ -42,20 +42,23 @@ export class CommentItem extends Component {
 
     let name = commentData.author;
     let color = "#000000";
+    let classes = "mix-blend-diff";
     if (contact) {
       name = (contact.nickname.length > 0)
         ? contact.nickname : commentData.author;
       color = `#${uxToHex(contact.color)}`;
+      classes = "";
     }
 
 
     return (
       <div>
-        <div className="flex mv3">
+        <div className="flex mv3 bg-white">
         <Sigil
           ship={commentData.author}
           size={24}
           color={color}
+          classes={classes}
         />
           <div className={"f9 mh2 pt1" +
           ((name === commentData.author) ? " mono" : "")}>


### PR DESCRIPTION
- If a user is a member, but not a contact (no metadata shared), their sigil is unstyled and blended as in Chat and Contacts. This is now incorporated into Publish and Links.
- Links had one too many `flex-auto`s and thus while long titles were truncated properly, short titles pushed their hostname too far to the edge. This is amended and it all seems to work properly now for both cases.