### PR TITLE
Visual QA: Publish comments-component, vertical padding fix

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -58,7 +58,7 @@ export class Comments extends Component {
 
     return (
       <div>
-        <div className="mt8">
+        <div className="mv8">
           <div>
             <textarea style={{resize:'vertical'}}
               ref={(el) => {this.textArea = el}}


### PR DESCRIPTION
Previously our comments component was spaced `mt9` from the post body, and was situated too close to the bottom of the viewport and the comments themselves, when populated.

This value has been edited to `mv9`, to give it some breathing room.