### PR TITLE
invite search: fuzzy search ships by nicknames, show ship nicknames

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -93,7 +93,6 @@ export class InviteSearch extends Component {
           return e.toLowerCase().includes(searchTerm);
         });
         if (match.length > 0) {
-          console.log("found")
           if (!(contact in shipMatches)) {
             shipMatches.push(contact);
           }
@@ -249,7 +248,7 @@ export class InviteSearch extends Component {
               classes="mix-blend-diff v-mid"
             />
             <span className="v-mid ml2 mw5 truncate dib">{"~" + ship}</span>
-            <span class="absolute right-1 di truncate mw4 inter f9 pt1">{nicknames}</span>
+            <span className="absolute right-1 di truncate mw4 inter f9 pt1">{nicknames}</span>
           </li>
         );
       });

--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -152,7 +152,9 @@ export class InviteSearch extends Component {
       searchValue: "",
       searchResults: { groups: [], ships: [] }
     });
-    ships.push(ship);
+    if (!ships.includes(ship)) {
+      ships.push(ship);
+    }
     if (groups.length > 0) {
       return false;
     }

--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -8,6 +8,7 @@ export class InviteSearch extends Component {
     this.state = {
       groups: [],
       peers: [],
+      contacts: new Map,
       searchValue: "",
       searchResults: {
         groups: [],
@@ -33,7 +34,8 @@ export class InviteSearch extends Component {
     groups = groups.filter(e => !e.startsWith("/~/"));
 
     let peers = [],
-      peerSet = new Set();
+      peerSet = new Set(),
+      contacts = new Map;
     Object.keys(this.props.groups).map(group => {
       if (this.props.groups[group].size > 0) {
         let groupEntries = this.props.groups[group].values();
@@ -41,10 +43,23 @@ export class InviteSearch extends Component {
           peerSet.add(member);
         }
       }
+      if (this.props.contacts[group]) {
+        let groupEntries = this.props.groups[group].values();
+        for (let member of groupEntries) {
+          if (this.props.contacts[group][member]) {
+            if (contacts.has(member)) {
+              contacts.get(member).push(this.props.contacts[group][member].nickname);
+            }
+            else {
+              contacts.set(member, [this.props.contacts[group][member].nickname]);
+            }
+          }
+        }
+      }
     });
     peers = Array.from(peerSet);
 
-    this.setState({ groups: groups, peers: peers });
+    this.setState({ groups: groups, peers: peers, contacts: contacts });
   }
 
   search(event) {
@@ -71,6 +86,19 @@ export class InviteSearch extends Component {
       let shipMatches = this.state.peers.filter(e => {
         return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
       });
+
+      for (let contact of this.state.contacts.keys()) {
+        let thisContact = this.state.contacts.get(contact);
+        let match = thisContact.filter(e => {
+          return e.toLowerCase().includes(searchTerm);
+        });
+        if (match.length > 0) {
+          console.log("found")
+          if (!(contact in shipMatches)) {
+            shipMatches.push(contact);
+          }
+        }
+      }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
@@ -203,12 +231,15 @@ export class InviteSearch extends Component {
       });
 
       let shipResults = state.searchResults.ships.map(ship => {
+        let nicknames = (this.state.contacts.has(ship))
+          ? this.state.contacts.get(ship).join(", ")
+          : "";
         return (
           <li
             key={ship}
             className={
               "list mono white-d f8 pv1 ph3 pointer" +
-              " hover-bg-gray4 hover-black-d"
+              " hover-bg-gray4 hover-black-d relative"
             }
             onClick={e => this.addShip(ship)}>
             <Sigil
@@ -217,7 +248,8 @@ export class InviteSearch extends Component {
               color="#000000"
               classes="mix-blend-diff v-mid"
             />
-            <span className="v-mid ml2">{"~" + ship}</span>
+            <span className="v-mid ml2 mw5 truncate dib">{"~" + ship}</span>
+            <span class="absolute right-1 di truncate mw4 inter f9 pt1">{nicknames}</span>
           </li>
         );
       });
@@ -306,7 +338,7 @@ export class InviteSearch extends Component {
           }}
           className={
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
-            " db focus-b--black focus-b--white-d mono placeholder-inter"
+            " db focus-b--black focus-b--white-d"
           }
           placeholder="Search for ships or existing groups"
           disabled={searchDisabled}

--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -250,6 +250,7 @@ export class NewScreen extends Component {
           </p>
           <InviteSearch
             groups={props.groups}
+            contacts={props.contacts}
             groupResults={true}
             invites={{
               groups: state.groups,

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -96,6 +96,7 @@ export class Root extends Component {
                     api={api}
                     inbox={state.inbox || {}}
                     groups={state.groups || {}}
+                    contacts={state.contacts || {}}
                     {...props}
                   />
                 </Skeleton>

--- a/pkg/interface/contacts/src/js/components/lib/add-contact.js
+++ b/pkg/interface/contacts/src/js/components/lib/add-contact.js
@@ -71,6 +71,7 @@ export class AddScreen extends Component {
           <div className="relative pl4 mt2 pb6">
           <InviteSearch
             groups={props.groups}
+            contacts={props.contacts}
             groupResults={false}
             invites={this.state.invites}
             setInvite={this.invChange}

--- a/pkg/interface/contacts/src/js/components/lib/invite-search.js
+++ b/pkg/interface/contacts/src/js/components/lib/invite-search.js
@@ -152,7 +152,9 @@ export class InviteSearch extends Component {
       searchValue: "",
       searchResults: { groups: [], ships: [] }
     });
-    ships.push(ship);
+    if (!ships.includes(ship)) {
+      ships.push(ship);
+    }
     if (groups.length > 0) {
       return false;
     }

--- a/pkg/interface/contacts/src/js/components/new.js
+++ b/pkg/interface/contacts/src/js/components/new.js
@@ -118,6 +118,7 @@ export class NewScreen extends Component {
           <div className="relative pl3 pb6 mt2">
             <InviteSearch
               groups={this.props.groups}
+              contacts={this.props.contacts}
               groupResults={false}
               invites={this.state.invites}
               setInvite={this.invChange}

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -72,6 +72,7 @@ export class Root extends Component {
                   <NewScreen
                     history={props.history}
                     groups={groups}
+                    contacts={contacts}
                     api={api} />
                 </Skeleton>
               );
@@ -133,6 +134,7 @@ export class Root extends Component {
                     groups={groups}
                     path={groupPath}
                     history={props.history}
+                    contacts={contacts}
                   />
                 </Skeleton>
               );

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -152,8 +152,10 @@ export class InviteSearch extends Component {
       searchValue: "",
       searchResults: { groups: [], ships: [] }
     });
-    ships.push(ship);
-    if (groups.length > 0) {
+    if (!ships.includes(ship)) {
+      ships.push(ship);
+    }
+    if ((groups.length > 0)) {
       return false;
     }
     this.props.setInvite({ groups: groups, ships: ships });

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -8,6 +8,7 @@ export class InviteSearch extends Component {
     this.state = {
       groups: [],
       peers: [],
+      contacts: new Map,
       searchValue: "",
       searchResults: {
         groups: [],
@@ -33,7 +34,8 @@ export class InviteSearch extends Component {
     groups = groups.filter(e => !e.startsWith("/~/"));
 
     let peers = [],
-      peerSet = new Set();
+      peerSet = new Set(),
+      contacts = new Map;
     Object.keys(this.props.groups).map(group => {
       if (this.props.groups[group].size > 0) {
         let groupEntries = this.props.groups[group].values();
@@ -41,10 +43,23 @@ export class InviteSearch extends Component {
           peerSet.add(member);
         }
       }
+      if (this.props.contacts[group]) {
+        let groupEntries = this.props.groups[group].values();
+        for (let member of groupEntries) {
+          if (this.props.contacts[group][member]) {
+            if (contacts.has(member)) {
+              contacts.get(member).push(this.props.contacts[group][member].nickname);
+            }
+            else {
+              contacts.set(member, [this.props.contacts[group][member].nickname]);
+            }
+          }
+        }
+      }
     });
     peers = Array.from(peerSet);
 
-    this.setState({ groups: groups, peers: peers });
+    this.setState({ groups: groups, peers: peers, contacts: contacts });
   }
 
   search(event) {
@@ -71,6 +86,18 @@ export class InviteSearch extends Component {
       let shipMatches = this.state.peers.filter(e => {
         return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
       });
+
+      for (let contact of this.state.contacts.keys()) {
+        let thisContact = this.state.contacts.get(contact);
+        let match = thisContact.filter(e => {
+          return e.toLowerCase().includes(searchTerm);
+        });
+        if (match.length > 0) {
+          if (!(contact in shipMatches)) {
+            shipMatches.push(contact);
+          }
+        }
+      }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
@@ -178,15 +205,15 @@ export class InviteSearch extends Component {
         state.searchResults.groups.length > 0 ? (
           <p className="f9 gray2 ph3">Groups</p>
         ) : (
-          ""
-        );
+            ""
+          );
 
       let shipHeader =
         state.searchResults.ships.length > 0 ? (
           <p className="f9 gray2 pv2 ph3">Ships</p>
         ) : (
-          ""
-        );
+            ""
+          );
 
       let groupResults = state.searchResults.groups.map(group => {
         return (
@@ -203,12 +230,15 @@ export class InviteSearch extends Component {
       });
 
       let shipResults = state.searchResults.ships.map(ship => {
+        let nicknames = (this.state.contacts.has(ship))
+          ? this.state.contacts.get(ship).join(", ")
+          : "";
         return (
           <li
             key={ship}
             className={
               "list mono white-d f8 pv1 ph3 pointer" +
-              " hover-bg-gray4 hover-black-d"
+              " hover-bg-gray4 hover-black-d relative"
             }
             onClick={e => this.addShip(ship)}>
             <Sigil
@@ -217,7 +247,8 @@ export class InviteSearch extends Component {
               color="#000000"
               classes="mix-blend-diff v-mid"
             />
-            <span className="v-mid ml2">{"~" + ship}</span>
+            <span className="v-mid ml2 mw5 truncate dib">{"~" + ship}</span>
+            <span className="absolute right-1 di truncate mw4 inter f9 pt1">{nicknames}</span>
           </li>
         );
       });
@@ -306,7 +337,7 @@ export class InviteSearch extends Component {
           }}
           className={
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
-            " db focus-b--black focus-b--white-d mono placeholder-inter"
+            " db focus-b--black focus-b--white-d"
           }
           placeholder="Search for ships or existing groups"
           disabled={searchDisabled}

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -188,6 +188,7 @@ export class NewScreen extends Component {
           <InviteSearch
             groupResults={true}
             groups={this.props.groups}
+            contacts={this.props.contacts}
             invites={this.state.invites}
             setInvite={this.setInvite}
           />

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -65,6 +65,7 @@ export class Root extends Component {
               <NewScreen
                 notebooks={state.notebooks}
                 groups={state.groups}
+                contacts={contacts}
                 api={api}
                 {...props}
               />


### PR DESCRIPTION
Submitting this PR for feedback and then I'll port the changes to all apps, so don't merge immediately.

This is an implementation that creates a map of all our contacts and every nickname we have for them; on search, we filter the array of nicknames and if we have any partial match, throw their ship into the search results.

<img width="507" alt="Screen Shot 2020-02-26 at 5 31 30 PM" src="https://user-images.githubusercontent.com/20846414/75394593-71882600-58be-11ea-879f-89af5e22a581.png">

Separately, in the render side we append all nicknames we know of. Both nicknames and long ship names get truncated.

<img width="507" alt="Screen Shot 2020-02-26 at 5 31 50 PM" src="https://user-images.githubusercontent.com/20846414/75394598-76e57080-58be-11ea-8eea-0d05ce26bb63.png">

In this implementation the performance will worsen the more contacts we have. At that point, we will probably want to debounce the search input.