### PR TITLE
ci: skip cachix push if env is not set and in a pr build

### DIFF
--- a/sh/cachix
+++ b/sh/cachix
@@ -2,7 +2,10 @@
 
 fail () {
   echo "$@"
-  exit 1
+  if [ "$TRAVIS_PULL_REQUEST" = false ]
+  then exit 1
+  else exit 0
+  fi
 }
 
 if [ -z "$CACHIX_SIGNING_KEY" ]


### PR DESCRIPTION
This has been an issue in recent PRs from forked repos.