### PR TITLE
contacts: add group details page, metadata-store reducer

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -1,4 +1,4 @@
-::  metadata-store: data store for application metadata and mappings 
+::  metadata-store: data store for application metadata and mappings
 ::  between groups and resources within applications
 ::
 ::  group-paths are expected to be an existing group path
@@ -73,7 +73,7 @@
     |^
     =/  cards=(list card)
       ?+  path  (on-watch:def path)
-          [%all ~]      (give %metadata-update !>([%associatons associations]))
+          [%all ~]      (give %metadata-update !>([%associations associations]))
           [%updates ~]  ~
           [%app-name @ ~]
         =/  =app-name  i.t.path

--- a/pkg/interface/contacts/src/js/components/lib/contact-card.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-card.js
@@ -521,7 +521,7 @@ export class ContactCard extends Component {
           </div>
           <button
             className={
-              `pl4 mt4 mb4 f9 red2 pointer ` + adminOpt
+              `pl4 mt4 mb4 mh4 f9 red2 pointer ` + adminOpt
             }
             onClick={this.removeFromGroup}>
             {(

--- a/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
@@ -66,6 +66,8 @@ export class ContactSidebar extends Component {
         );
       });
 
+    let detailHref = `/~contacts/detail${props.path}`
+
     return (
       <div className={`bn br-m br-l br-xl b--gray3 lh-copy h-100 flex-shrink-0
       flex-basis-100-s flex-basis-30-ns mw5-m mw5-l mw5-xl relative
@@ -81,7 +83,7 @@ export class ContactSidebar extends Component {
               : "dn")}>
             <p className="f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Invite</p>
           </Link>
-          <Link to={props.location.pathname + "/detail"}
+          <Link to={detailHref}
             className="dib dn-m dn-l dn-xl f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Channels</Link>
           {shareSheet}
           <h2 className="f9 pt4 pr4 pb2 pl4 gray2 c-default">Members</h2>

--- a/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
@@ -70,17 +70,19 @@ export class ContactSidebar extends Component {
       <div className={`bn br-m br-l br-xl b--gray3 lh-copy h-100 flex-shrink-0
       flex-basis-100-s flex-basis-30-ns mw5-m mw5-l mw5-xl relative
       overflow-hidden ` + responsiveClasses}>
-        <div className="pt3 pb6 pl3 f8 db dn-m dn-l dn-xl">
+        <div className="pt3 pb5 pl3 f8 db dn-m dn-l dn-xl">
           <Link to="/~contacts/">{"⟵ All Groups"}</Link>
         </div>
         <div className="overflow-auto h-100">
           <Link
             to={"/~contacts/add" + props.path}
-            className={((this.props.path.includes(window.ship))
+            className={((props.path.includes(window.ship))
               ? "dib"
               : "dn")}>
-            <p className="f9 pl4 pt4 gray2 bn">Invite</p>
+            <p className="f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Invite</p>
           </Link>
+          <Link to={props.location.pathname + "/detail"}
+            className="dib dn-m dn-l dn-xl f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Channels</Link>
           {shareSheet}
           <h2 className="f9 pt4 pr4 pb2 pl4 gray2 c-default">Members</h2>
           {contactItems}

--- a/pkg/interface/contacts/src/js/components/lib/group-detail.js
+++ b/pkg/interface/contacts/src/js/components/lib/group-detail.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import { uxToHex } from '/lib/util.js';
+
+export class GroupDetail extends Component {
+  render() {
+    const { props } = this;
+
+    let responsiveClass =
+      props.activeDrawer === "details" ? "db" : "dn db-ns";
+
+    let groupPath = props.path || "";
+
+    let groupChannels = props.channels.get(groupPath) || {};
+
+
+    let channelList = <div/>
+
+    channelList = Object.keys(groupChannels).map((channel) => {
+      let channelObj = groupChannels[channel];
+      if (!channelObj) {
+        return false;
+      }
+      let title = channelObj.metadata.title || channelObj["app-path"] || "";
+      let color = uxToHex(channelObj.metadata.color) || "000000";
+      let app = channelObj["app-name"] || "Unknown";
+      let channelPath = channelObj["app-path"];
+      let link = `/~${app}/join${channelPath}`
+      app = app.charAt(0).toUpperCase() + app.slice(1)
+      return(
+        <li
+        key={channel}
+        className="f9 list flex pv2 w-100">
+        <div className="dib"
+          style={{backgroundColor: `#${color}`, height: 32, width: 32}}
+        ></div>
+        <div className="flex flex-column flex-auto">
+          <p className="f9 inter ml2 w-100">{title}</p>
+          <p className="f9 inter ml2 w-100"
+          style={{marginTop: "0.35rem"}}>
+            <span className="f9 di mr2 inter">{app}</span>
+            <a className="f9 di green2" href={link}>Open</a>
+          </p>
+          </div>
+        </li>
+      )
+    })
+    return (
+      <div className={"h-100 w-100 overflow-x-hidden bg-white pa4 "
+      + responsiveClass}>
+      <p className="gray2 f9 mb2">Group Channels</p>
+      {channelList}
+      </div>
+    )
+  }
+}
+
+export default GroupDetail

--- a/pkg/interface/contacts/src/js/components/lib/group-detail.js
+++ b/pkg/interface/contacts/src/js/components/lib/group-detail.js
@@ -11,8 +11,10 @@ export class GroupDetail extends Component {
 
     let groupPath = props.path || "";
 
-    let groupChannels = props.channels.get(groupPath) || {};
+    let groupChannels = props.associations.get(groupPath) || {};
 
+    let isEmpty = Object.entries(groupChannels).length === 0 &&
+      groupChannels.constructor === Object;
 
     let channelList = <div/>
 
@@ -47,14 +49,20 @@ export class GroupDetail extends Component {
     })
 
     let backLink = props.location.pathname;
-    backLink = backLink.slice(0, props.location.pathname.indexOf("/detail"))
+    backLink = backLink.slice(0, props.location.pathname.indexOf("/detail"));
+
+    let emptyGroup = <div className={isEmpty ? "dt w-100 h-100" : "dn"}>
+      <p className="gray2 f9 tc v-mid dtc">This group has no channels. To add a channel, invite this group using any application.</p>
+    </div>
+
     return (
       <div className={"h-100 w-100 overflow-x-hidden bg-white pa4 "
       + responsiveClass}>
         <div className="pb5 f8 db dn-m dn-l dn-xl">
           <Link to={backLink}>⟵ Contacts</Link>
       </div>
-      <p className="gray2 f9 mb2 pt2 pt0-m pt0-l pt0-xl">Group Channels</p>
+        <p className={"gray2 f9 mb2 pt2 pt0-m pt0-l pt0-xl " + (isEmpty ? "dn" : "")}>Group Channels</p>
+      {emptyGroup}
       {channelList}
       </div>
     )

--- a/pkg/interface/contacts/src/js/components/lib/group-detail.js
+++ b/pkg/interface/contacts/src/js/components/lib/group-detail.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Route, Link } from 'react-router-dom';
 import { uxToHex } from '/lib/util.js';
 
 export class GroupDetail extends Component {
@@ -6,7 +7,7 @@ export class GroupDetail extends Component {
     const { props } = this;
 
     let responsiveClass =
-      props.activeDrawer === "details" ? "db" : "dn db-ns";
+      props.activeDrawer === "detail" ? "db" : "dn db-ns";
 
     let groupPath = props.path || "";
 
@@ -44,10 +45,16 @@ export class GroupDetail extends Component {
         </li>
       )
     })
+
+    let backLink = props.location.pathname;
+    backLink = backLink.slice(0, props.location.pathname.indexOf("/detail"))
     return (
       <div className={"h-100 w-100 overflow-x-hidden bg-white pa4 "
       + responsiveClass}>
-      <p className="gray2 f9 mb2">Group Channels</p>
+        <div className="pb5 f8 db dn-m dn-l dn-xl">
+          <Link to={backLink}>⟵ Contacts</Link>
+      </div>
+      <p className="gray2 f9 mb2 pt2 pt0-m pt0-l pt0-xl">Group Channels</p>
       {channelList}
       </div>
     )

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -103,10 +103,13 @@ export class Root extends Component {
                       defaultContacts={defaultContacts}
                       group={group}
                       activeDrawer={detail ? "detail" : "contacts"}
-                      path={groupPath} />
+                      path={groupPath}
+                      {...props} />
                       <GroupDetail
                         channels={channels}
                         path={groupPath}
+                        activeDrawer={detail ? "detail" : "contacts"}
+                        {...props}
                       />
                   </Skeleton>
               );

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -11,6 +11,7 @@ import { NewScreen } from '/components/new';
 import { ContactSidebar } from '/components/lib/contact-sidebar';
 import { ContactCard } from '/components/lib/contact-card';
 import { AddScreen } from '/components/lib/add-contact';
+import GroupDetail from './lib/group-detail';
 
 
 export class Root extends Component {
@@ -33,6 +34,7 @@ export class Root extends Component {
     let invites =
       (!!state.invites && '/contacts' in state.invites) ?
       state.invites['/contacts'] : {};
+    let channels = !! state.channels ? state.channels : new Map;
 
     return (
       <BrowserRouter>
@@ -77,12 +79,13 @@ export class Root extends Component {
                 </Skeleton>
               );
           }} />
-          <Route exact path="/~contacts/:ship/:group"
+          <Route exact path="/~contacts/:ship/:group/:detail?"
             render={ (props) => {
               let groupPath =
                 `/${props.match.params.ship}/${props.match.params.group}`;
               let groupContacts = contacts[groupPath] || {};
               let group = groups[groupPath] || new Set([]);
+              let detail = !!props.match.params.detail || false;
 
 
               return (
@@ -93,15 +96,18 @@ export class Root extends Component {
                   contacts={contacts}
                   invites={invites}
                   groups={groups}
-                  activeDrawer="contacts"
+                  activeDrawer={detail ? "detail" : "contacts"}
                   selected={groupPath}>
                     <ContactSidebar
                       contacts={groupContacts}
                       defaultContacts={defaultContacts}
                       group={group}
-                      activeDrawer="contacts"
+                      activeDrawer={detail ? "detail" : "contacts"}
                       path={groupPath} />
-                    <div className="h-100 w-100 overflow-x-hidden bg-white dn db-ns"></div>
+                      <GroupDetail
+                        channels={channels}
+                        path={groupPath}
+                      />
                   </Skeleton>
               );
             }}

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -79,13 +79,13 @@ export class Root extends Component {
                 </Skeleton>
               );
           }} />
-          <Route exact path="/~contacts/:ship/:group/:detail?"
+          <Route exact path="/~contacts/(detail)?/:ship/:group/"
             render={ (props) => {
               let groupPath =
                 `/${props.match.params.ship}/${props.match.params.group}`;
               let groupContacts = contacts[groupPath] || {};
               let group = groups[groupPath] || new Set([]);
-              let detail = !!props.match.params.detail || false;
+              let detail = !!props.match.url.includes("/detail");
 
 
               return (
@@ -137,7 +137,8 @@ export class Root extends Component {
                     defaultContacts={defaultContacts}
                     group={group}
                     activeDrawer="rightPanel"
-                    path={groupPath} />
+                    path={groupPath}
+                    {...props} />
                   <AddScreen
                     api={api}
                     groups={groups}
@@ -177,7 +178,8 @@ export class Root extends Component {
                     defaultContacts={defaultContacts}
                     group={group}
                     path={groupPath}
-                    selectedContact={shipPath} />
+                    selectedContact={shipPath}
+                    {...props} />
                   <ContactCard
                     history={props.history}
                     contact={contact}
@@ -221,7 +223,8 @@ export class Root extends Component {
                     defaultContacts={defaultContacts}
                     group={group}
                     path={groupPath}
-                    selectedContact={shipPath} />
+                    selectedContact={shipPath}
+                    {...props} />
                   <ContactCard
                     history={props.history}
                     contact={contact}

--- a/pkg/interface/contacts/src/js/components/root.js
+++ b/pkg/interface/contacts/src/js/components/root.js
@@ -34,7 +34,7 @@ export class Root extends Component {
     let invites =
       (!!state.invites && '/contacts' in state.invites) ?
       state.invites['/contacts'] : {};
-    let channels = !! state.channels ? state.channels : new Map;
+    let associations = !! state.associations ? state.associations : new Map;
 
     return (
       <BrowserRouter>
@@ -106,7 +106,7 @@ export class Root extends Component {
                       path={groupPath}
                       {...props} />
                       <GroupDetail
-                        channels={channels}
+                        associations={associations}
                         path={groupPath}
                         activeDrawer={detail ? "detail" : "contacts"}
                         {...props}

--- a/pkg/interface/contacts/src/js/reducers/metadata-update.js
+++ b/pkg/interface/contacts/src/js/reducers/metadata-update.js
@@ -23,20 +23,21 @@ export class MetadataReducer {
           metadata.set(channelObj["group-path"], {[channel]: channelObj});
         }
       })
-      state.channels = metadata;
+      state.associations = metadata;
     }
   }
 
   add(json, state) {
     let data = _.get(json, 'add', false);
     if (data) {
-      let metadata = state.channels;
+      let metadata = state.associations;
       if (metadata.has(data["group-path"])) {
         let groupMetadata = metadata.get(data["group-path"]);
         groupMetadata[`${data["group-path"]}/${data["app-name"]}${data["app-path"]}`] = data;
       } else {
         metadata.set(data["group-path"], data);
       }
+      state.associations = metadata;
     }
   }
 }

--- a/pkg/interface/contacts/src/js/reducers/metadata-update.js
+++ b/pkg/interface/contacts/src/js/reducers/metadata-update.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+
+export class MetadataReducer {
+  reduce(json, state) {
+    let data = _.get(json, 'metadata-update', false);
+    if (data) {
+      this.associations(data, state);
+      this.add(data, state);
+    }
+  }
+
+  associations(json, state) {
+    let data = _.get(json, 'associations', false);
+    if (data) {
+      let metadata = new Map;
+      Object.keys(data).map((channel) => {
+        let channelObj = data[channel];
+        if (metadata.has(channelObj["group-path"])) {
+          let groupMetadata = metadata.get(channelObj["group-path"]);
+          groupMetadata[channel] = channelObj;
+          metadata.set(channelObj["group-path"], groupMetadata);
+        } else {
+          metadata.set(channelObj["group-path"], {[channel]: channelObj});
+        }
+      })
+      state.channels = metadata;
+    }
+  }
+
+  add(json, state) {
+    let data = _.get(json, 'add', false);
+    if (data) {
+      let metadata = state.channels;
+      if (metadata.has(data["group-path"])) {
+        let groupMetadata = metadata.get(data["group-path"]);
+        groupMetadata[`${data["group-path"]}/${data["app-name"]}${data["app-path"]}`] = data;
+      } else {
+        metadata.set(data["group-path"], data);
+      }
+    }
+  }
+}

--- a/pkg/interface/contacts/src/js/store.js
+++ b/pkg/interface/contacts/src/js/store.js
@@ -12,7 +12,7 @@ class Store {
     this.state = {
       contacts: {},
       groups: {},
-      channels: new Map,
+      associations: new Map,
       permissions: {},
       invites: {},
       spinner: false

--- a/pkg/interface/contacts/src/js/store.js
+++ b/pkg/interface/contacts/src/js/store.js
@@ -3,6 +3,7 @@ import { ContactUpdateReducer } from '/reducers/contact-update';
 import { GroupUpdateReducer } from '/reducers/group-update';
 import { InviteUpdateReducer } from '/reducers/invite-update';
 import { PermissionUpdateReducer } from '/reducers/permission-update';
+import { MetadataReducer } from '/reducers/metadata-update.js';
 import { LocalReducer } from '/reducers/local.js';
 
 
@@ -11,6 +12,7 @@ class Store {
     this.state = {
       contacts: {},
       groups: {},
+      channels: new Map,
       permissions: {},
       invites: {},
       spinner: false
@@ -21,6 +23,7 @@ class Store {
     this.permissionUpdateReducer = new PermissionUpdateReducer();
     this.contactUpdateReducer = new ContactUpdateReducer();
     this.inviteUpdateReducer = new InviteUpdateReducer();
+    this.metadataReducer = new MetadataReducer();
     this.localReducer = new LocalReducer();
     this.setState = () => {};
   }
@@ -38,6 +41,7 @@ class Store {
     this.permissionUpdateReducer.reduce(json, this.state);
     this.contactUpdateReducer.reduce(json, this.state);
     this.inviteUpdateReducer.reduce(json, this.state);
+    this.metadataReducer.reduce(json, this.state);
     this.localReducer.reduce(json, this.state);
 
     this.setState(this.state);

--- a/pkg/interface/contacts/src/js/subscription.js
+++ b/pkg/interface/contacts/src/js/subscription.js
@@ -26,6 +26,10 @@ export class Subscription {
       this.handleEvent.bind(this),
       this.handleError.bind(this),
       this.handleQuitAndResubscribe.bind(this));
+    api.bind('/all', 'PUT', api.authTokens.ship, 'metadata-store',
+    this.handleEvent.bind(this),
+    this.handleError.bind(this),
+    this.handleQuitAndResubscribe.bind(this));
   }
 
   handleEvent(diff) {

--- a/pkg/interface/contacts/src/js/subscription.js
+++ b/pkg/interface/contacts/src/js/subscription.js
@@ -27,9 +27,9 @@ export class Subscription {
       this.handleError.bind(this),
       this.handleQuitAndResubscribe.bind(this));
     api.bind('/all', 'PUT', api.authTokens.ship, 'metadata-store',
-    this.handleEvent.bind(this),
-    this.handleError.bind(this),
-    this.handleQuitAndResubscribe.bind(this));
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this));
   }
 
   handleEvent(diff) {


### PR DESCRIPTION
To re-target `master` once #2365 is merged. Until then, this is just for review!

<img width="600" alt="image" src="https://user-images.githubusercontent.com/20846414/75414840-d6ac3d80-58f7-11ea-8024-9a2497bb990a.png">

- Quick display fix on the 'delete' button which was too close to the edge.
- Quick typo fix in metadata-store that led to `/all` subscriptions failing.
- Wrote a metadata reducer for the initial load and for `add` events; there are likely delete and change events but I cannot produce one!

The metadata data structure I wrote for the front-end is a map, keyed by group path, whose value is an object with keys of the channel name and a value of the full object. Like so:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/20846414/75414958-2a1e8b80-58f8-11ea-9c49-a5aba88d4266.png">

This makes it simple to display and programmatically link to.

## Additional notes

We pass all these "Open" links to the `/join` path of the respective application, because each application has a handler that redirects to a channel if we're already subscribed, or initiates a subscription to the channel in question if not, all seamlessly. (Links doesn't have this because it doesn't have a join flow yet, **but it will**...)

The metadata store will thus (theoretically) show you every channel the group has, even ones you're not in yet, and you can join them seamlessly. Pretty cool!

@loganallenc warned me that if we haven't started a chat, the subscription will fail. I cannot replicate this: I get an empty `associations` object. Maybe he ran into the typo bug too. It all runs smoothly.

The reason that the titles in the screenshot are the paths of the channels is that we fall back to the app-path name if we don't have a title for the channel.