### PR TITLE
metadata-store: never crash fetching app metadata

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -172,7 +172,7 @@
 ++  metadata-for-app
   |=  =app-name
   %-  ~(gas by *^associations)
-  %+  turn  ~(tap in (~(got by app-indices) app-name))
+  %+  turn  ~(tap in (~(gut by app-indices) app-name ~))
   |=  [=group-path =app-path]
   :-  [group-path [app-name app-path]]
   (~(got by associations) [group-path [app-name app-path]])


### PR DESCRIPTION
In order to track & respond to all app-related metadata, hooks may want to
subscribe to the metadata-store as the first thing they do on-init. In that case
it is exceedingly likely that there are no entries for the `app-name` in
`app-indices` yet.

This makes us fall back to the empty set in case `app-indices` has no entry for
the `app-name` yet.