### PR TITLE
hoon: +side and +sill vase splitters

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12083,6 +12083,21 @@
   ^-  vase
   [[%cell p.hed p.tal] [q.hed q.tal]]
 ::
+++  side                                                ::  split vase to cell
+  |=  vax=vase
+  ^-  [hed=vase tal=vase]
+  ?@  q.vax  !!
+  =.  p.vax  (~(fuse ut p.vax) [%cell %noun %noun])
+  [(slot 2 vax) (slot 3 vax)]
+::
+++  sill                                                ::  split vase to list
+  |=  vax=vase
+  ^-  (list vase)
+  ?~  q.vax
+    ~
+  =/  [hed=vase tal=vase]  (side vax)
+  [hed $(vax tal)]
+::
 ++  slot                                                ::  got axis in vase
   |=  {axe/@ vax/vase}  ^-  vase
   [(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]

--- a/pkg/arvo/tests/sys/hoon/vases.hoon
+++ b/pkg/arvo/tests/sys/hoon/vases.hoon
@@ -34,4 +34,28 @@
       !>  worm1
       !>  worm2
   ==
+::
+++  test-side-ok  ^-  tang
+  =/  vax=vase  !>([%foo 17])
+  %+  expect-eq
+    !>  (side vax)
+    !>  [hed=!>(%foo) tal=!>(17)]
+::
+++  test-side-crash  ^-  tang
+  =/  vax=vase  !>(17)
+  %+  expect-eq
+    !>  ?=([%| *] (mule |.((side vax))))
+    !>  `?`%.y
+::
+++  test-sill-ok  ^-  tang
+  =/  vax=vase  !>(`(list @ud)`~[1 2 3])
+  %+  expect-eq
+    !>  `(list @ud)`(turn (sill vax) |=(vase !<(@ud +<)))
+    !>  `(list @ud)`~[1 2 3]
+::
+++  test-sill-crash  ^-  tang
+  =/  vax=vase  !>([1 2])
+  %+  expect-eq
+    !>  ?=([%| *] (mule |.((sill vax))))
+    !>  `?`%.y
 --


### PR DESCRIPTION
`+side` is the inverse of `+slop`, and `+sill` splits a vase of a list-shaped noun into a list of vases, which I suspect Arvo might want to use for decoding moves and Clay might want to use for destructuring Ford build results.

Both arms preserve type information and specialize for the shape that was discovered.  If the shape doesn't match, they crash.