### PR TITLE
chat: display chat titles in sidebar

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/sidebar-item.js
+++ b/pkg/interface/chat/src/js/components/lib/sidebar-item.js
@@ -42,6 +42,8 @@ export class SidebarItem extends Component {
       return lett.url;
     } else if ('code' in lett) {
       return lett.code.expression;
+    } else if ('me' in lett) {
+      return lett.me;
     } else {
       return '';
     }
@@ -51,35 +53,41 @@ export class SidebarItem extends Component {
     const { props, state } = this;
 
     let unreadElem = !!props.unread
-                     ? "fw7 green2"
+                     ? "green2"
                      : "";
 
-    let title = props.title.substr(1);
+    let title = props.title;
 
-    let description = this.getLetter(props.description);
+    let box = props.box.substr(1);
+
+    let latest = this.getLetter(props.latest);
 
     let selectedCss = !!props.selected ? 'bg-gray5 bg-gray1-d gray3-d' : 'bg-white bg-gray0-d gray3-d pointer';
 
+    let authorCss = (props.nickname === props.ship)
+      ? "mono" : "";
+
+    let author = (props.nickname === props.ship)
+      ? `~${props.ship}` : props.nickname;
+
     return (
       <div
-        className={"z1 pa3 pt4 pb4 bb b--gray4 b--gray1-d " + selectedCss}
+        className={"z1 pa3 pt2 pb2 bb b--gray4 b--gray1-d " + selectedCss}
         onClick={this.onClick.bind(this)}>
         <div className="w-100 v-mid">
-          <p className={"dib mono f8 " + unreadElem }>
-            <span className={(unreadElem === "") ? "gray3 gray2-d" : ""}>
-              {title.substr(0, title.indexOf("/"))}/
-            </span>
-            {title.substr(title.indexOf("/") + 1)}
+          <p className="dib f8">
+              {title}
           </p>
+          <p className="f8 db mono gray3 gray2-d pt1">{box}</p>
         </div>
-        <div className="w-100 pt1">
-          <p className="dib mono f9 mr3">
-            {props.ship === "" ? "" : "~"}
-            {props.ship}
+        <div className="w-100 pt3">
+          <p className={((unreadElem === "") ? "black white-d" : "") +
+          unreadElem + " dib f9 mr3 mw4 truncate v-mid " + authorCss}>
+            {(author === "~") ? "" : author}
           </p>
-          <p className="dib mono f9 gray3">{state.timeSinceNewestMessage}</p>
+          <p className="dib mono f9 gray3 v-mid">{state.timeSinceNewestMessage}</p>
         </div>
-        <p className="f8 clamp-3 pt2">{description}</p>
+        <p className="f8 clamp-3 pt1">{latest}</p>
       </div>
     );
   }

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -46,13 +46,16 @@ export class Root extends Component {
 
     let contacts = !!state.contacts ? state.contacts : {};
 
-    const renderChannelSidebar = (props) => (
+    const renderChannelSidebar = (props, station) => (
       <Sidebar
         inbox={state.inbox}
         messagePreviews={messagePreviews}
+        associations={state.associations || new Map}
+        contacts={contacts}
         invites={invites}
         unreads={unreads}
         api={api}
+        station={station}
         {...props}
       />
     );
@@ -161,7 +164,7 @@ export class Root extends Component {
                   spinner={state.spinner}
                   popout={popout}
                   sidebarShown={state.sidebarShown}
-                  sidebar={renderChannelSidebar(props)}
+                  sidebar={renderChannelSidebar(props, station)}
                 >
                   <ChatScreen
                     station={station}

--- a/pkg/interface/chat/src/js/components/sidebar.js
+++ b/pkg/interface/chat/src/js/components/sidebar.js
@@ -19,7 +19,6 @@ export class Sidebar extends Component {
 
   render() {
     const { props, state } = this;
-    let station = `/${props.match.params.ship}/${props.match.params.station}`;
 
     let sidebarInvites = Object.keys(props.invites)
       .map((uid) => {
@@ -39,14 +38,28 @@ export class Sidebar extends Component {
           : {text: 'No messages yet'};
         let author = !!msg ? msg.author : '';
         let when = !!msg ? msg.when : 0;
+
+        let title = box;
+        if ((props.associations.has(box)) && (props.associations.get(box).metadata)) {
+        title = (props.associations.get(box).metadata.title)
+          ? props.associations.get(box).metadata.title : box;
+        }
+
+        let nickname = author;
+        if ((props.contacts[box]) && (author in props.contacts[box])) {
+          nickname = (props.contacts[box][author].nickname)
+            ? props.contacts[box][author].nickname : author;
+        }
+
         return {
           msg,
           when,
           author,
+          nickname,
           letter,
           box,
-          title: box,
-          selected: station === box
+          title: title,
+          selected: props.station === box
         };
       })
       .sort((a, b) => {
@@ -58,10 +71,11 @@ export class Sidebar extends Component {
           <SidebarItem
             key={obj.box + '/' + obj.when}
             title={obj.title}
-            description={obj.letter}
+            latest={obj.letter}
             box={obj.box}
             when={obj.when}
             ship={obj.author}
+            nickname={obj.nickname}
             selected={obj.selected}
             unread={unread}
             history={props.history}

--- a/pkg/interface/chat/src/js/reducers/metadata-update.js
+++ b/pkg/interface/chat/src/js/reducers/metadata-update.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+
+export class MetadataReducer {
+  reduce(json, state) {
+    let data = _.get(json, 'metadata-update', false);
+    if (data) {
+      this.associations(data, state);
+      this.add(data, state);
+    }
+  }
+
+  associations(json, state) {
+    let data = _.get(json, 'associations', false);
+    if (data) {
+      let metadata = new Map;
+      Object.keys(data).map((channel) => {
+        let channelObj = data[channel];
+        metadata.set(channelObj["app-path"], channelObj);
+      })
+      state.associations = metadata;
+    }
+  }
+
+  add(json, state) {
+    let data = _.get(json, 'add', false);
+    if (data) {
+      let metadata = state.associations;
+      metadata.set(data["app-path"], data);
+      state.associations = metadata;
+    }
+  }
+}

--- a/pkg/interface/chat/src/js/store.js
+++ b/pkg/interface/chat/src/js/store.js
@@ -4,6 +4,7 @@ import { ContactUpdateReducer } from '/reducers/contact-update';
 import { ChatUpdateReducer } from '/reducers/chat-update';
 import { InviteUpdateReducer } from '/reducers/invite-update';
 import { PermissionUpdateReducer } from '/reducers/permission-update';
+import { MetadataReducer } from '/reducers/metadata-update.js';
 import { LocalReducer } from '/reducers/local.js';
 
 
@@ -15,6 +16,7 @@ class Store {
       contacts: {},
       permissions: {},
       invites: {},
+      associations: new Map,
       spinner: false,
       sidebarShown: true,
       pendingMessages: new Map([]),
@@ -27,6 +29,7 @@ class Store {
     this.contactUpdateReducer = new ContactUpdateReducer();
     this.chatUpdateReducer = new ChatUpdateReducer();
     this.inviteUpdateReducer = new InviteUpdateReducer();
+    this.metadataReducer = new MetadataReducer();
     this.localReducer = new LocalReducer();
     this.setState = () => {};
   }
@@ -45,6 +48,7 @@ class Store {
     this.contactUpdateReducer.reduce(json, this.state);
     this.chatUpdateReducer.reduce(json, this.state);
     this.inviteUpdateReducer.reduce(json, this.state);
+    this.metadataReducer.reduce(json, this.state);
     this.localReducer.reduce(json, this.state);
 
     this.setState(this.state);


### PR DESCRIPTION
- Adds a basic metadata-update reducer that is keyed by `app-path`
- Displays the title of the chat in sidebar
- Integrates contact metadata in the sidebar while we're at it
- Fixes a bug where unmanaged chats weren't showing 'selected' CSS by propping the `station` call from router to the sidebar
- Fixes a bug where 'me' messages showed as blank in the sidebar

<img src="https://user-images.githubusercontent.com/20846414/75600800-de97e900-5a81-11ea-85cb-e506de1de156.png" width="300"/>