### PR TITLE
link: metadata integration

### DIFF
--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -1,21 +1,33 @@
 ::  link-listen-hook: get your friends' bookmarks
 ::
-::    on-init, subscribes to all groups on this ship. for every ship in a group,
-::    we subscribe to their link's local-pages and annotations
-::    at the group path (through link-proxy-hook),
-::    and forwards all entries into our link as submissions and comments.
+::    subscribes to all %link resources in the metadata-store.
+::    for all all ships in groups associated with those resources, we subscribe
+::    to their link's local-pages and annotations at the resource path (through
+::    link-proxy-hook), and forward all entries into our link-store as
+::    submissions and comments.
 ::
-::    if a subscription to a group member fails, we assume it's because their
-::    group definition hasn't been updated to include us yet.
+::    if a subscription to a target fails, we assume it's because their
+::    metadata+groups definition hasn't been updated to include us yet.
 ::    we retry with exponential backoff, maxing out at one hour timeouts.
+::    to expede this process, we prod other potential listeners when we add
+::    them to our metadata+groups definition.
 ::
-/-  *link, group-store
-/+  default-agent, verb, dbug
+/-  *metadata-store, *link, group-store
+/+  metadata, default-agent, verb, dbug
 ::
 |%
 +$  state-0
   $:  %0
       retry-timers=(map target @dr)
+      ::  reasoning: the resources we're subscribed to,
+      ::             and the groups that cause that.
+      ::
+      ::    we don't strictly need to track this in state, but doing so heavily
+      ::    simplifies logic and reduces the amount of big scries we do.
+      ::    this also gives us the option to check & restore subscriptions,
+      ::    should we ever need that.
+      ::
+      reasoning=(jug [ship app-path] group-path)
   ==
 ::
 +$  what-target  ?(%local-pages %annotations)
@@ -52,7 +64,7 @@
   ++  on-init
     ^-  (quip card _this)
     :_  this
-    [watch-groups:do]~
+    ~[watch-metadata:do watch-groups:do]
   ::
   ++  on-save  !>(state)
   ++  on-load
@@ -63,26 +75,27 @@
   ++  on-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
-    ?:  ?=([%groups ~] wire)
-      =^  cards  state
+    =^  cards  state
+      ?+  wire  ~|([dap.bowl %weird-agent-wire wire] !!)
+          [%metadata ~]
+        (take-metadata-sign:do sign)
+      ::
+          [%groups ~]
         (take-groups-sign:do sign)
-      [cards this]
-    ?:  ?=([%links ?(%local-pages %annotations) @ ^] wire)
-      =^  cards  state
+      ::
+          [%links ?(%local-pages %annotations) @ ^]
         (take-link-sign:do (wire-to-target t.wire) sign)
-      [cards this]
-    ?:  ?=([%forward ^] wire)
-      =^  cards  state
+      ::
+          [%forward ^]
         (take-forward-sign:do t.wire sign)
-      [cards this]
-    ?:  ?=([%prod *] wire)
-      ~|  [%weird-sign -.sign]
-      ?>  ?=(%poke-ack -.sign)
-      ?~  p.sign  [~ this]
-      %-  (slog [leaf+"failed to prod" u.p.sign])
-      [~ this]
-    ~|  [dap.bowl %weird-wire wire]
-    !!
+      ::
+          [%prod *]
+        ?>  ?=(%poke-ack -.sign)
+        ?~  p.sign  [~ state]
+        %-  (slog leaf+"prod failed" u.p.sign)
+        [~ state]
+      ==
+    [cards this]
   ::
   ++  on-poke
     |=  [=mark =vase]
@@ -122,8 +135,65 @@
 ::
 ::
 |_  =bowl:gall
++*  md  ~(. metadata bowl)
 ::
-::  groups subscription
+::  metadata subscription
+::
+++  watch-metadata
+  ^-  card
+  [%pass /metadata %agent [our.bowl %metadata-store] %watch /app-name/link]
+::
+++  take-metadata-sign
+  |=  =sign:agent:gall
+  ^-  (quip card _state)
+  ?-  -.sign
+    %poke-ack     ~|([dap.bowl %unexpected-poke-ack /metadata] !!)
+    %kick         [[watch-metadata]~ state]
+  ::
+      %watch-ack
+    ?~  p.sign  [~ state]
+    =/  =tank
+      :-  %leaf
+      "{(trip dap.bowl)} failed subscribe to metadata store. very wrong!"
+    %-  (slog tank u.p.sign)
+    [~ state]
+  ::
+      %fact
+    =*  mark  p.cage.sign
+    =*  vase  q.cage.sign
+    ?.  ?=(%metadata-update mark)
+      ~|  [dap.bowl %unexpected-mark mark]
+      !!
+    %-  handle-metadata-update
+    !<(metadata-update vase)
+  ==
+::
+++  handle-metadata-update
+  |=  upd=metadata-update
+  ^-  (quip card _state)
+  ?+  -.upd  [~ state]
+      %associations
+    =/  socs=(list [=group-path resource])
+      ~(tap in ~(key by associations.upd))
+    =|  cards=(list card)
+    |-  ::TODO  try for +roll maybe?
+    ?~  socs  [cards state]
+    =^  caz  state
+      =,  i.socs
+      ?.  =(%link app-name)  [~ state]
+      (listen-to-group app-path group-path)
+    $(socs t.socs, cards (weld cards caz))
+  ::
+      %add
+    ?>  =(%link app-name.resource.upd)
+    (listen-to-group app-path.resource.upd group-path.upd)
+  ::
+      %remove
+    ?>  =(%link app-name.resource.upd)
+    (leave-from-group app-path.resource.upd group-path.upd)
+  ==
+::
+::  groups subscriptions
 ::
 ++  watch-groups
   ^-  card
@@ -148,48 +218,97 @@
     =*  mark  p.cage.sign
     =*  vase  q.cage.sign
     ?+  mark  ~|([dap.bowl %unexpected-mark mark] !!)
-      %group-initial  (handle-group-initial !<(groups:group-store vase))
+      %group-initial  [~ state]  ::NOTE  initial handled using metadata
       %group-update   (handle-group-update !<(group-update:group-store vase))
     ==
   ==
 ::
-++  handle-group-initial
-  |=  =groups:group-store
-  ^-  (quip card _state)
-  =|  cards=(list card)
-  =/  groups=(list [=path =group:group-store])
-    ~(tap by groups)
-  |-
-  ?~  groups  [cards state]
-  =^  caz  state
-    %-  handle-group-update
-    [%add [group path]:i.groups]
-  $(cards (weld cards caz), groups t.groups)
-::
 ++  handle-group-update
   |=  upd=group-update:group-store
   ^-  (quip card _state)
-  :_  state
-  ?+  -.upd  ~
-      ?(%path %add %remove)
-    =/  whos=(list ship)  ~(tap in members.upd)
-    |-  ^-  (list card)
-    ?~  whos  ~
-    ::  no need to subscribe to ourselves
-    ::
-    ?:  =(our.bowl i.whos)
-      $(whos t.whos)
+  ?.  ?=(?(%path %add %remove) -.upd)
+    [~ state]
+  =/  socs=(list app-path)
+    (app-paths-from-group:md %link pax.upd)
+  =/  whos=(list ship)
+    ~(tap in members.upd)
+  =|  cards=(list card)
+  |-
+  =*  loop-socs  $
+  ?~  socs  [cards state]
+  |-
+  =*  loop-whos  $
+  ?~  whos  loop-socs(socs t.socs)
+  =^  caz  state
     ?:  ?=(%remove -.upd)
-      %+  weld
-        $(whos t.whos)
-      (end-link-subscriptions i.whos pax.upd)
-    :^    (start-link-subscription %local-pages i.whos pax.upd)
-        (start-link-subscription %annotations i.whos pax.upd)
-      (prod-other-listener i.whos pax.upd)
-    $(whos t.whos)
-  ==
+      (leave-from-peer i.socs pax.upd i.whos)
+    (listen-to-peer i.socs pax.upd i.whos)
+  loop-whos(whos t.whos, cards (weld cards caz))
 ::
 ::  link subscriptions
+::
+++  listen-to-group
+  |=  [=app-path =group-path]
+  ^-  (quip card _state)
+  =/  peers=(list ship)
+    ~|  group-path
+    %~  tap  in
+    =-  (fall - *group:group-store)
+    %^  scry-for  (unit group:group-store)
+      %group-store
+    group-path
+  =|  cards=(list card)
+  |-
+  ?~  peers  [cards state]
+  =^  caz  state
+    (listen-to-peer app-path group-path i.peers)
+  $(peers t.peers, cards (weld cards caz))
+::
+++  leave-from-group
+  |=  [=app-path =group-path]
+  ^-  (quip card _state)
+  =/  peers=(list ship)
+    %~  tap  in
+    =-  (fall - *group:group-store)
+    %^  scry-for  (unit group:group-store)
+      %group-store
+    group-path
+  =|  cards=(list card)
+  |-
+  ?~  peers  [cards state]
+  =^  caz  state
+    (leave-from-peer app-path group-path i.peers)
+  $(peers t.peers, cards (weld cards caz))
+::
+++  listen-to-peer
+  |=  [=app-path =group-path who=ship]
+  ^-  (quip card _state)
+  ?:  =(our.bowl who)
+    [~ state]
+  :_  =-  state(reasoning -)
+      (~(put ju reasoning) [who app-path] group-path)
+  :-  (prod-other-listener who app-path)
+  ?^  (~(get ju reasoning) [who app-path])
+    ~
+  (start-link-subscriptions who app-path)
+::
+++  leave-from-peer
+  |=  [=app-path =group-path who=ship]
+  ^-  (quip card _state)
+  ?:  =(our.bowl who)
+    [~ state]
+  :_  =-  state(reasoning -)
+      (~(del ju reasoning) [who app-path] group-path)
+  ?.  (~(has ju reasoning) [who app-path] group-path)
+    ~
+  (end-link-subscriptions who app-path)
+::
+++  start-link-subscriptions
+  |=  [=ship =app-path]
+  ^-  (list card)
+  :~  (start-link-subscription %local-pages ship app-path)
+      (start-link-subscription %annotations ship app-path)
+  ==
 ::
 ++  start-link-subscription
   |=  =target
@@ -283,7 +402,7 @@
 ++  take-retry
   |=  =target
   ^-  (list card)
-  ::  relevant: whether :who is still in group :where
+  ::  relevant: whether :who is still associated with resource :where
   ::
   =;  relevant=?
     ?.  relevant  ~
@@ -291,16 +410,13 @@
   ?:  %-  ~(has by wex.bowl)
       [[%links (target-to-wire target)] who.target %link-proxy-hook]
     |
-  %.  who.target
-  %~  has  in
-  =-  (fall - *group:group-store)
-  .^  (unit group:group-store)
-    %gx
-    (scot %p our.bowl)
+  %+  lien  (groups-from-resource:md %link where.target)
+  |=  =group-path
+  ^-  ?
+  =-  (~(has in (fall - *group:group-store)) who.target)
+  %^  scry-for  (unit group:group-store)
     %group-store
-    (scot %da now.bowl)
-    (snoc where.target %noun)
-  ==
+  group-path
 ::
 ++  do-link-action
   |=  [=wire =action]
@@ -373,4 +489,14 @@
     ==
   %-  (slog tank u.p.sign)
   [~ state]
+::
+++  scry-for
+  |*  [=mold =app-name =path]
+  .^  mold
+    %gx
+    (scot %p our.bowl)
+    app-name
+    (scot %da now.bowl)
+    (snoc `^path`path %noun)
+  ==
 --

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -4,12 +4,11 @@
 ::    stores if permission conditions are met.
 ::    the patterns herein should one day be generalized into a proxy-hook lib.
 ::
-::    this adopts a very primitive view of groups-store as containing only
-::    groups of interesting (rather than uninteresting) ships. it sets the
-::    permission condition to be that ship must be in group matching the path
-::    it's subscribing to.
-::    we check this on-watch, but also subscribe to groups so that we can kick
-::    subscriptions if needed (eg ship removed from group).
+::    this uses metadata-store to discover resources and their associated
+::    groups. it sets the permission condition to be that a ship must be in a
+::    group associated with the resource it's subscribing to.
+::    we check this on-watch, but also subscribe to metadata & groups so that
+::    we can kick subscriptions if needed (eg ship removed from group).
 ::
 ::    we deduplicate incoming subscriptions on the same path, ensuring we have
 ::    exactly one local subscription per unique incoming subscription path.
@@ -18,10 +17,10 @@
 ::    become part of the stores standard anyway.
 ::
 ::    when adding support for new paths, the only things you'll likely want
-::    to touch are +permitted, +initial-response, & maybe +handle-group-update.
+::    to touch are +permitted, +initial-response, & +kick-proxies.
 ::
-/-  group-store
-/+  *link, default-agent, verb, dbug
+/-  group-store, *metadata-store
+/+  *link, metadata, default-agent, verb, dbug
 |%
 +$  state-0
   $:  %0
@@ -48,7 +47,7 @@
   ++  on-init
     ^-  (quip card _this)
     :_  this
-    [watch-groups:do]~
+    ~[watch-groups:do watch-metadata:do]
   ::
   ++  on-save  !>(state)
   ++  on-load
@@ -96,11 +95,15 @@
   --
 ::
 |_  =bowl:gall
++*  md  ~(. metadata bowl)
+::
+::  permissions
+::
 ++  permitted
   |=  [who=ship =path]
   ^-  ?
-  ::  we only expose group-specific /local-pages and /annotations,
-  ::  and only to ships in the relevant group.
+  ::  we only expose /local-pages and /annotations,
+  ::  to ships in the groups associated with the resource.
   ::  (no url-specific annotations subscriptions, either.)
   ::
   =/  target=(unit ^path)
@@ -110,12 +113,75 @@
       `t.t.path
     ~
   ?~  target  |
-  =;  group
-    ?&  ?=(^ group)
-        (~(has in u.group) who)
-    ==
-  %+  scry-for  (unit group:group-store)
-  [%group-store u.target]
+  ~?  !.^(? %gu (scot %p our.bowl) %metadata-store (scot %da now.bowl) ~)
+    %woah-md-s-not-booted  ::TODO  fallback if needed
+  %+  lien  (groups-from-resource:md %link u.target)
+  |=  =group-path
+  ^-  ?
+  =-  (~(has in (fall - *group:group-store)) who)
+  %^  scry-for  (unit group:group-store)
+    %group-store
+  group-path
+::
+++  kick-revoked-permissions
+  |=  [=path who=(list ship)]
+  ^-  (list card)
+  %+  murn  who
+  |=  =ship
+  ^-  (unit card)
+  ::  no need to remove to ourselves
+  ::
+  ?:  =(our.bowl ship)  ~
+  ?:  (permitted ship path)  ~
+  `(kick-proxies ship path)
+::
+::  metadata subscription
+::
+++  watch-metadata
+  ^-  card
+  [%pass /metadata %agent [our.bowl %metadata-store] %watch /app-name/link]
+::
+++  take-metadata-sign
+  |=  =sign:agent:gall
+  ^-  (quip card _state)
+  ?-  -.sign
+    %poke-ack     ~|([dap.bowl %unexpected-poke-ack /metadata] !!)
+    %kick         [[watch-metadata]~ state]
+  ::
+      %watch-ack
+    ?~  p.sign  [~ state]
+    =/  =tank
+      :-  %leaf
+      "{(trip dap.bowl)} failed subscribe to metadata store. very wrong!"
+    %-  (slog tank u.p.sign)
+    [~ state]
+  ::
+      %fact
+    =*  mark  p.cage.sign
+    =*  vase  q.cage.sign
+    ?.  ?=(%metadata-update mark)
+      ~|  [dap.bowl %unexpected-mark mark]
+      !!
+    %-  handle-metadata-update
+    !<(metadata-update vase)
+  ==
+::
+++  handle-metadata-update
+  |=  upd=metadata-update
+  ^-  (quip card _state)
+  :_  state
+  ?.  ?=(%remove -.upd)  ~
+  ?>  =(%link app-name.resource.upd)
+  ::  if a group is no longer associated with a resource,
+  ::  we need to re-check permissions for everyone in that group.
+  ::
+  %+  kick-revoked-permissions
+    app-path.resource.upd
+  %~  tap  in
+  =-  (fall - *group:group-store)
+  %^  scry-for  (unit group:group-store)
+    %group-store
+  group-path.upd
 ::
 ::  groups subscription
 ::TODO  largely copied from link-listen-hook. maybe make a store-listener lib?
@@ -153,29 +219,26 @@
   ^-  (quip card _state)
   :_  state
   ?.  ?=(%remove -.upd)  ~
-  =/  whos=(list ship)  ~(tap in members.upd)
-  |-  ^-  (list card)
-  ?~  whos  ~
-  ::  no need to remove to ourselves
+  ::  if someone was removed from a group, find all link resources associated
+  ::  with that group, then kick their subscriptions if they're no longer
   ::
-  ?:  =(our.bowl i.whos)
-    $(whos t.whos)
-  :_  $(whos t.whos)
-  ::NOTE  this depends kind of unfortunately on the fact that we only accept
-  ::      subscriptions to /local-pages//* paths. it'd be more correct if we
-  ::      "just" looked at all paths in the map, and found the matching ones.
-  ::TODO  what exactly did i mean by this?
-  %+  kick-proxies  i.whos
-  :~  [%local-pages pax.upd]
-      [%annotations '' pax.upd]
-  ==
+  %-  zing
+  %+  turn  (app-paths-from-group:md %link pax.upd)
+  |=  =app-path
+  ^-  (list card)
+  %+  kick-revoked-permissions
+    app-path
+  ~(tap in members.upd)
 ::
 ::  proxy subscriptions
 ::
 ++  kick-proxies
-  |=  [who=ship paths=(list path)]
+  |=  [who=ship =path]
   ^-  card
-  [%give %kick paths `who]
+  =-  [%give %kick - `who]
+  :~  [%local-pages path]
+      [%annotations %$ path]
+  ==
 ::
 ++  handle-proxy-sign
   |=  [=wire =sign:agent:gall]
@@ -211,14 +274,10 @@
     [%give %fact ~ %link-initial !>(initial)]
   ?+  path  !!
       [%local-pages ^]
-    :-  %local-pages
-    %+  scry-for  (map ^path pages)
-    [%link-store path]
+    [%local-pages .^((map ^path pages) %gx path)]
   ::
       [%annotations %$ ^]
-    :-  %annotations
-    %+  scry-for  (per-path-url notes)
-    [%link-store path]
+    [%annotations .^((per-path-url notes) %gx %$ t.t.path)]
   ==
 ::
 ++  start-proxy
@@ -249,12 +308,14 @@
   ::
   [(proxy-pass-link-store path %leave ~)]~
 ::
+::  helpers
+::
 ++  scry-for
-  |*  [=mold app=term =path]
+  |*  [=mold =app-name =path]
   .^  mold
     %gx
     (scot %p our.bowl)
-    app
+    app-name
     (scot %da now.bowl)
     (snoc `^path`path %noun)
   ==

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -182,7 +182,7 @@
   |=  =group-path
   ^-  ^associations
   %-  ~(gas by *^associations)
-  %+  turn  ~(tap in (~(got by group-indices) group-path))
+  %+  turn  ~(tap in (~(gut by group-indices) group-path ~))
   |=  =resource
   :-  [group-path resource]
   (~(got by associations) [group-path resource])

--- a/pkg/arvo/lib/metadata.hoon
+++ b/pkg/arvo/lib/metadata.hoon
@@ -1,0 +1,54 @@
+::  metadata: helpers for getting data from the metadata-store
+::
+/-  *metadata-store
+::
+|_  =bowl:gall
+++  app-paths-from-group
+  |=  [=app-name =group-path]
+  ^-  (list app-path)
+  %+  murn
+    %~  tap  in
+    =-  (~(gut by -) group-path ~)
+    .^  (jug ^group-path resource)
+      %gy
+      (scot %p our.bowl)
+      %metadata-store
+      (scot %da now.bowl)
+      /group-indices
+    ==
+  |=  =resource
+  ^-  (unit app-path)
+  ?.  =(app-name.resource app-name)  ~
+  `app-path.resource
+::
+++  groups-from-resource
+  |=  =resource
+  ^-  (list group-path)
+  =;  resources
+    %~  tap  in
+    %+  ~(gut by resources)
+      resource
+    *(set group-path)
+  .^  (jug ^resource group-path)
+    %gy
+    (scot %p our.bowl)
+    %metadata-store
+    (scot %da now.bowl)
+    /resource-indices
+  ==
+::
+++  check-resource-permissions
+  |=  [=ship =resource]
+  ^-  ?
+  %+  lien  (groups-from-resource resource)
+  |=  =group-path
+  .^  ?
+    %gx
+    (scot %p our.bowl)
+    %permission-store
+    (scot %da now.bowl)
+    %permitted
+    (scot %p ship)
+    (snoc group-path %noun)
+  ==
+--

--- a/pkg/arvo/mar/link/view-action.hoon
+++ b/pkg/arvo/mar/link/view-action.hoon
@@ -1,0 +1,24 @@
+/-  *link-view
+=,  dejs:format
+|_  act=view-action
+++  grab
+  |%
+  ++  noun  view-action
+  ++  json
+    |^  %-  of
+        :~  %create^(ot 'path'^pa 'title'^so 'description'^so 'members'^mems ~)
+        ==
+    ::
+    ++  mems
+      %-  of
+      :~  %group^pa
+          %ships^(cu sy (ar (su ;~(pfix sig fed:ag))))
+      ==
+    --
+  --
+::
+++  grow
+  |%
+  ++  noun  act
+  --
+--

--- a/pkg/arvo/sur/link-view.hoon
+++ b/pkg/arvo/sur/link-view.hoon
@@ -1,0 +1,12 @@
+::  link-view: encapsulating link management
+::
+|%
+++  view-action
+  $%  $:  %create
+          =path
+          title=@t
+          description=@t
+          members=$%([%group =path] [%ships ships=(set ship)])
+      ==
+  ==
+--

--- a/pkg/interface/link/src/js/api.js
+++ b/pkg/interface/link/src/js/api.js
@@ -86,7 +86,7 @@ class UrbitApi {
   inviteAccept(uid) {
     this.inviteAction({
       accept: {
-        path: '/chat',
+        path: '/link',
         uid
       }
     });
@@ -95,7 +95,7 @@ class UrbitApi {
   inviteDecline(uid) {
     this.inviteAction({
       decline: {
-        path: '/chat',
+        path: '/link',
         uid
       }
     });
@@ -142,6 +142,13 @@ class UrbitApi {
       console.error,
       ()=>{} // no-op on quit
     );
+  }
+
+  createCollection(path, title, description, members) {
+    // members is either {group:'/group-path'} or {'ships':[~zod]}
+    return this.action("link-view", "link-view-action", {
+      create: {path, title, description, members}
+    })
   }
 
   linkAction(data) {

--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import { Route, Link } from 'react-router-dom';
 import { ChannelsItem } from '/components/lib/channels-item';
+import { SidebarInvite } from '/components/lib/sidebar-invite';
 
 export class ChannelsSidebar extends Component {
   // drawer to the left
@@ -9,42 +10,21 @@ export class ChannelsSidebar extends Component {
   render() {
     const { props, state } = this;
 
-    let privateChannel =
-      Object.keys(props.groups)
-      .filter((path) => {
-        return (path === "/~/default")
-      })
-      .map((path) => {
-        let name = "Private"
-        let selected = (props.selected === path);
-        let linkCount = !!props.links[path] ? props.links[path].totalItems : 0;
-        const unseenCount = !!props.links[path]
-          ? props.links[path].unseenCount
-          : linkCount
+    let sidebarInvites = Object.keys(props.invites)
+      .map((uid) => {
         return (
-          <ChannelsItem
-            key={path}
-            link={path}
-            memberList={props.groups[path]}
-            selected={selected}
-            linkCount={linkCount}
-            unseenCount={unseenCount}
-            name={name}/>
-        )
-      })
+          <SidebarInvite
+            uid={uid}
+            invite={props.invites[uid]}
+            api={props.api} />
+        );
+      });
 
-    let channelItems =
-      Object.keys(props.groups)
-      .filter((path) => {
-        return (!path.startsWith("/~/"))
-      })
-      .map((path) => {
-        let name = path.substr(1);
-        let nameSeparator = name.indexOf("/");
-        name = name.substr(nameSeparator + 1);
-
-        let selected = (props.selected === path);
-        let linkCount = !!props.links[path] ? props.links[path].totalItems : 0;
+    const channelItems =
+      Object.keys(props.resources).map((path) => {
+        const meta = props.resources[path];
+        const selected = (props.selected === path);
+        const linkCount = !!props.links[path] ? props.links[path].totalItems : 0;
         const unseenCount = !!props.links[path]
           ? props.links[path].unseenCount
           : linkCount
@@ -53,12 +33,12 @@ export class ChannelsSidebar extends Component {
           <ChannelsItem
             key={path}
             link={path}
-            memberList={props.groups[path]}
+            memberList={props.groups[meta.group]}
             selected={selected}
             linkCount={linkCount}
             unseenCount={unseenCount}
-            name={name}/>
-        )
+            name={meta.title}/>
+        );
       });
 
     let activeClasses = (this.props.active === "channels") ? " " : "dn-s ";
@@ -70,7 +50,7 @@ export class ChannelsSidebar extends Component {
     if (this.props.popout) {
       hiddenClasses = false;
     } else {
-    hiddenClasses = this.props.sidebarShown;
+      hiddenClasses = this.props.sidebarShown;
     }
 
     return (
@@ -81,15 +61,15 @@ export class ChannelsSidebar extends Component {
         : "dn")}>
         <a className="db dn-m dn-l dn-xl f8 pb3 pl3" href="/">⟵ Landscape</a>
         <div className="overflow-y-scroll h-100">
-          <h2 className={`f8 f9-m f9-l f9-xl
-           pt1 pt4-m pt4-l pt4-xl
-           pr4 pb3 pb3-m pb3-l pb3-xl
-           pl3 pl4-m pl4-l pl4-xl
-           black-s gray2 white-d c-default
-           bb b--gray4 mb2 mb0-m mb0-l mb0-xl`}>
-             Your Collections
-             </h2>
-          {privateChannel}
+          <div className="w-100 bg-transparent pa4 bb b--gray4 b--gray1-d"
+            style={{paddingBottom: 13}}>
+            <Link
+              className="dib f9 pointer green2 gray4-d mr4"
+              to={"/~link/new"}>
+              New Collection
+            </Link>
+          </div>
+          {sidebarInvites}
           {channelItems}
         </div>
       </div>

--- a/pkg/interface/link/src/js/components/lib/channels-item.js
+++ b/pkg/interface/link/src/js/components/lib/channels-item.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
 
-import { Route, Link } from 'react-router-dom'; 
+import { Route, Link } from 'react-router-dom';
 
 export class ChannelsItem extends Component {
   render() {
     const { props } = this;
 
-    let selectedClass = (props.selected) 
-    ? "bg-gray5 bg-gray1-d b--gray4 b--gray2-d" 
+    let selectedClass = (props.selected)
+    ? "bg-gray5 bg-gray1-d b--gray4 b--gray2-d"
     : "b--gray4 b--gray2-d";
 
     let memberCount = props.memberList
@@ -18,7 +18,7 @@ export class ChannelsItem extends Component {
       : null;
 
     return (
-      <Link to={"/~link" + props.link}>
+      <Link to={"/~link/list/0" + props.link}>
         <div className={"w-100 v-mid f9 pl4 bb z1 pa3 pt4 pb4 b--gray4 b--gray1-d gray3-d pointer " + selectedClass}>
           <p className="f9 pt1">{props.name}</p>
           <p className="f9 gray2">

--- a/pkg/interface/link/src/js/components/lib/comments-pagination.js
+++ b/pkg/interface/link/src/js/components/lib/comments-pagination.js
@@ -6,8 +6,8 @@ export class CommentsPagination extends Component {
   render() {
     let props = this.props;
 
-    let prevPage = "/" + (Number(props.commentPage) - 1);
-    let nextPage = "/" + (Number(props.commentPage) + 1);
+    let prevPage = (Number(props.commentPage) - 1);
+    let nextPage = (Number(props.commentPage) + 1);
 
     let prevDisplay = ((Number(props.commentPage) > 0))
     ? "dib"
@@ -26,22 +26,24 @@ export class CommentsPagination extends Component {
         className={"pb6 absolute inter f8 left-0 " + prevDisplay}
         to={"/~link"
         + popout
-        + props.groupPath
+        + "/item"
         + "/" + props.linkPage
         + "/" + props.linkIndex
+        + "/" + prevPage
         + "/" + encodedUrl
-        + "/comments" + prevPage}>
+        + props.resourcePath}>
           &#60;- Previous Page
         </Link>
         <Link
         className={"pb6 absolute inter f8 right-0 " + nextDisplay}
-        to={"/~link" 
+        to={"/~link"
         + popout
-        + props.groupPath
-        + "/" + props.linkPage 
-        + "/" + props.linkIndex 
+        + "/item"
+        + "/" + props.linkPage
+        + "/" + props.linkIndex
+        + "/" + nextPage
         + "/" + encodedUrl
-        + "/comments" + nextPage}>
+        + props.resourcePath}>
           Next Page ->
         </Link>
       </div>

--- a/pkg/interface/link/src/js/components/lib/comments.js
+++ b/pkg/interface/link/src/js/components/lib/comments.js
@@ -19,7 +19,7 @@ export class Comments extends Component {
     ) {
       this.setState({requested: this.props.commentPage});
       api.getCommentsPage(
-        this.props.groupPath,
+        this.props.resourcePath,
         this.props.url,
         this.props.commentPage);
     }
@@ -73,8 +73,8 @@ export class Comments extends Component {
       <div>
         {commentsList}
         <CommentsPagination
-        key={props.groupPath + props.commentPage}
-        groupPath={props.groupPath}
+        key={props.resourcePath + props.commentPage}
+        resourcePath={props.resourcePath}
         popout={props.popout}
         linkPage={props.linkPage}
         linkIndex={props.linkIndex}

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -1,0 +1,369 @@
+import React, { Component } from "react";
+import urbitOb from "urbit-ob";
+import { Sigil } from "../lib/icons/sigil";
+
+export class InviteSearch extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      groups: [],
+      peers: [],
+      contacts: new Map,
+      searchValue: "",
+      searchResults: {
+        groups: [],
+        ships: []
+      },
+      inviteError: false
+    };
+    this.search = this.search.bind(this);
+  }
+
+  componentDidMount() {
+    this.peerUpdate();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps !== this.props) {
+      this.peerUpdate();
+    }
+  }
+
+  peerUpdate() {
+    let groups = Array.from(Object.keys(this.props.groups));
+    groups = groups.filter(e => !e.startsWith("/~/"));
+
+    let peers = [],
+      peerSet = new Set(),
+      contacts = new Map;
+    Object.keys(this.props.groups).map(group => {
+      if (this.props.groups[group].size > 0) {
+        let groupEntries = this.props.groups[group].values();
+        for (let member of groupEntries) {
+          peerSet.add(member);
+        }
+      }
+      if (this.props.contacts[group]) {
+        let groupEntries = this.props.groups[group].values();
+        for (let member of groupEntries) {
+          if (this.props.contacts[group][member]) {
+            if (contacts.has(member)) {
+              contacts.get(member).push(this.props.contacts[group][member].nickname);
+            }
+            else {
+              contacts.set(member, [this.props.contacts[group][member].nickname]);
+            }
+          }
+        }
+      }
+    });
+    peers = Array.from(peerSet);
+
+    this.setState({ groups: groups, peers: peers, contacts: contacts });
+  }
+
+  search(event) {
+    let searchTerm = event.target.value.toLowerCase().replace("~", "");
+
+    this.setState({ searchValue: event.target.value });
+
+    if (searchTerm.length < 2) {
+      this.setState({ searchResults: { groups: [], ships: [] } });
+    }
+
+    if (searchTerm.length > 2) {
+      if (this.state.inviteError === true) {
+        this.setState({ inviteError: false });
+      }
+
+      let groupMatches = [];
+      if (this.props.groupResults) {
+        groupMatches = this.state.groups.filter(e => {
+          return e.includes(searchTerm);
+        });
+      }
+
+      let shipMatches = this.state.peers.filter(e => {
+        return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
+      });
+
+      for (let contact of this.state.contacts.keys()) {
+        let thisContact = this.state.contacts.get(contact);
+        let match = thisContact.filter(e => {
+          return e.toLowerCase().includes(searchTerm);
+        });
+        if (match.length > 0) {
+          if (!(contact in shipMatches)) {
+            shipMatches.push(contact);
+          }
+        }
+      }
+
+      this.setState({
+        searchResults: { groups: groupMatches, ships: shipMatches }
+      });
+
+      let isValid = true;
+      if (!urbitOb.isValidPatp("~" + searchTerm)) {
+        isValid = false;
+      }
+
+      if (shipMatches.length === 0 && isValid) {
+        shipMatches.push(searchTerm);
+        this.setState({
+          searchResults: { groups: groupMatches, ships: shipMatches }
+        });
+      }
+    }
+  }
+
+  deleteGroup() {
+    let { ships } = this.props.invites;
+    this.setState({
+      searchValue: "",
+      searchResults: { groups: [], ships: [] }
+    });
+    this.props.setInvite({ groups: [], ships: ships });
+  }
+
+  deleteShip(ship) {
+    let { groups, ships } = this.props.invites;
+    this.setState({
+      searchValue: "",
+      searchResults: { groups: [], ships: [] }
+    });
+    ships = ships.filter(e => {
+      return e !== ship;
+    });
+    this.props.setInvite({ groups: groups, ships: ships });
+  }
+
+  addGroup(group) {
+    this.setState({
+      searchValue: "",
+      searchResults: { groups: [], ships: [] }
+    });
+    this.props.setInvite({ groups: [group], ships: [] });
+  }
+
+  addShip(ship) {
+    let { groups, ships } = this.props.invites;
+    this.setState({
+      searchValue: "",
+      searchResults: { groups: [], ships: [] }
+    });
+    if (!ships.includes(ship)) {
+      ships.push(ship);
+    }
+    if (groups.length > 0) {
+      return false;
+    }
+    this.props.setInvite({ groups: groups, ships: ships });
+  }
+
+  submitShipToAdd(ship) {
+    let searchTerm = ship
+      .toLowerCase()
+      .replace("~", "")
+      .trim();
+    let isValid = true;
+    if (!urbitOb.isValidPatp("~" + searchTerm)) {
+      isValid = false;
+    }
+    if (!isValid) {
+      this.setState({ inviteError: true, searchValue: "" });
+    } else if (isValid) {
+      this.addShip(searchTerm);
+      this.setState({ searchValue: "" });
+    }
+  }
+
+  render() {
+    const { props, state } = this;
+    let searchDisabled = false;
+    if (props.invites.groups) {
+      if (props.invites.groups.length > 0) {
+        searchDisabled = true;
+      }
+    }
+
+    let participants = <div />;
+    let searchResults = <div />;
+
+    let invErrElem = <span />;
+    if (state.inviteError) {
+      invErrElem = (
+        <span className="f9 inter red2 db pt2">
+          Invited ships must be validly formatted ship names.
+        </span>
+      );
+    }
+
+    if (
+      state.searchResults.groups.length > 0 ||
+      state.searchResults.ships.length > 0
+    ) {
+      let groupHeader =
+        state.searchResults.groups.length > 0 ? (
+          <p className="f9 gray2 ph3">Groups</p>
+        ) : (
+          ""
+        );
+
+      let shipHeader =
+        state.searchResults.ships.length > 0 ? (
+          <p className="f9 gray2 pv2 ph3">Ships</p>
+        ) : (
+          ""
+        );
+
+      let groupResults = state.searchResults.groups.map(group => {
+        return (
+          <li
+            key={group}
+            className={
+              "list mono white-d f8 pv2 ph3 pointer" +
+              " hover-bg-gray4 hover-black-d"
+            }
+            onClick={e => this.addGroup(group)}>
+            {group}
+          </li>
+        );
+      });
+
+      let shipResults = state.searchResults.ships.map(ship => {
+        let nicknames = (this.state.contacts.has(ship))
+          ? this.state.contacts.get(ship).join(", ")
+          : "";
+        return (
+          <li
+            key={ship}
+            className={
+              "list mono white-d f8 pv1 ph3 pointer" +
+              " hover-bg-gray4 hover-black-d relative"
+            }
+            onClick={e => this.addShip(ship)}>
+            <Sigil
+              ship={"~" + ship}
+              size={24}
+              color="#000000"
+              classes="mix-blend-diff v-mid"
+            />
+            <span className="v-mid ml2 mw5 truncate dib">{"~" + ship}</span>
+            <span className="absolute right-1 di truncate mw4 inter f9 pt1">{nicknames}</span>
+          </li>
+        );
+      });
+
+      searchResults = (
+        <div
+          className={
+            "absolute bg-white bg-gray0-d white-d" +
+            " pv3 z-1 w-100 mt1 ba b--white-d overflow-y-scroll mh-16"
+          }>
+          {groupHeader}
+          {groupResults}
+          {shipHeader}
+          {shipResults}
+        </div>
+      );
+    }
+
+    let groupInvites = props.invites.groups || [];
+    let shipInvites = props.invites.ships || [];
+
+    if (groupInvites.length > 0 || shipInvites.length > 0) {
+      let groups = groupInvites.map(group => {
+        return (
+          <span
+            key={group}
+            className={
+              "f9 mono black pa2 bg-gray5 bg-gray1-d" +
+              " ba b--gray4 b--gray2-d white-d dib mr2 mt2 c-default"
+            }>
+            {group}
+            <span
+              className="white-d ml3 mono pointer"
+              onClick={e => this.deleteGroup(group)}>
+              x
+            </span>
+          </span>
+        );
+      });
+
+      let ships = shipInvites.map(ship => {
+        return (
+          <span
+            key={ship}
+            className={
+              "f9 mono black pa2 bg-gray5 bg-gray1-d" +
+              " ba b--gray4 b--gray2-d white-d dib mr2 mt2 c-default"
+            }>
+            {"~" + ship}
+            <span
+              className="white-d ml3 mono pointer"
+              onClick={e => this.deleteShip(ship)}>
+              x
+            </span>
+          </span>
+        );
+      });
+
+      participants = (
+        <div
+          className={
+            "f9 gray2 bb bl br b--gray3 b--gray2-d bg-gray0-d " +
+            "white-d pa3 db w-100 inter"
+          }>
+          <span className="db gray2">Participants</span>
+          {groups} {ships}
+        </div>
+      );
+    }
+
+    return (
+      <div className="relative">
+        <img
+          src="/~chat/img/search.png"
+          className="absolute invert-d"
+          style={{
+            height: 16,
+            width: 16,
+            top: 14,
+            left: 12
+          }}
+        />
+        <textarea
+          ref={e => {
+            this.textarea = e;
+          }}
+          className={
+            "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
+            " db focus-b--black focus-b--white-d"
+          }
+          placeholder="Search for ships or existing groups"
+          disabled={searchDisabled}
+          rows={1}
+          spellCheck={false}
+          style={{
+            resize: "none",
+            paddingLeft: 36
+          }}
+          onKeyPress={e => {
+            if (e.key === "Enter" || e.key === ",") {
+              e.preventDefault();
+              this.submitShipToAdd(this.state.searchValue);
+            }
+          }}
+          onChange={this.search}
+          value={state.searchValue}
+        />
+        {searchResults}
+        {participants}
+        {invErrElem}
+      </div>
+    );
+  }
+}
+
+export default InviteSearch;

--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -115,14 +115,13 @@ export class LinkPreview extends Component {
             </span>
             <Link
               to={
-                "/~link" +
-                props.groupPath +
-                "/" +
+                "/~link/item/" +
                 props.page +
                 "/" +
                 props.linkIndex +
-                "/" +
-                base64urlEncode(props.url)
+                "/0/" +
+                base64urlEncode(props.url) +
+                props.resourcePath
               }
               className="v-top">
               <span className="f9 inter gray2">{props.comments}</span>

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -34,7 +34,7 @@ export class LinkItem extends Component {
   }
 
   markPostAsSeen() {
-    api.seenLink(this.props.groupPath, this.props.url);
+    api.seenLink(this.props.resourcePath, this.props.url);
   }
 
   render() {
@@ -90,7 +90,7 @@ export class LinkItem extends Component {
             {this.state.timeSinceLinkPost}
           </span>
           <Link to=
-          {"/~link" + props.popout + props.groupPath + "/" + props.page + "/" + props.linkIndex + "/" + encodedUrl}
+          {"/~link" + props.popout + "/item/" + props.page + "/" + props.linkIndex + "/0/" + encodedUrl + props.resourcePath}
           className="v-top"
           onClick={this.markPostAsSeen}>
             <span className="f9 inter gray2">

--- a/pkg/interface/link/src/js/components/lib/link-submit.js
+++ b/pkg/interface/link/src/js/components/lib/link-submit.js
@@ -20,7 +20,7 @@ export class LinkSubmit extends Component {
       ? this.state.linkTitle
       : this.state.linkValue;
       api.setSpinner(true);
-    api.postLink(this.props.groupPath, link, title).then(r => {
+    api.postLink(this.props.resourcePath, link, title).then(r => {
       api.setSpinner(false);
       this.setState({ linkValue: "", linkTitle: "" });
     });

--- a/pkg/interface/link/src/js/components/lib/links-tabbar.js
+++ b/pkg/interface/link/src/js/components/lib/links-tabbar.js
@@ -28,14 +28,14 @@ export class LinksTabBar extends Component {
           <div className={"dib f8 pl6"}>
             <Link
               className={"no-underline " + memColor}
-              to={`/~link/` + popout + `members` + props.groupPath}>
+              to={`/~link/` + popout + `members` + props.resourcePath}>
               Members
             </Link>
           </div>
         ) : (
           <div className="dib" style={{ width: 0 }}></div>
         )}
-        <a href={`/~link/popout` + props.groupPath} target="_blank"
+        <a href={`/~link/popout/list/${props.page}${props.resourcePath}`} target="_blank"
         className="dib fr">
           <img
             className={`flex-shrink-0 pr4 dn` + hidePopoutIcon}

--- a/pkg/interface/link/src/js/components/lib/pagination.js
+++ b/pkg/interface/link/src/js/components/lib/pagination.js
@@ -5,26 +5,26 @@ export class Pagination extends Component {
   render() {
     let props = this.props;
 
-    let prevPage = "/" + (Number(props.page) - 1);
-    let nextPage = "/" + (Number(props.page) + 1);
+    let prevPage = (Number(props.page) - 1);
+    let nextPage = (Number(props.page) + 1);
 
     let prevDisplay = ((props.currentPage > 0))
     ? "dib absolute left-0"
     : "dn";
 
-    let nextDisplay = ((props.currentPage + 1) < props.totalPages) 
-    ? "dib absolute right-0" 
+    let nextDisplay = ((props.currentPage + 1) < props.totalPages)
+    ? "dib absolute right-0"
     : "dn";
 
     return (
       <div className="w-100 inter relative pv6">
         <div className={prevDisplay + " inter f8"}>
-          <Link to={"/~link" + props.popout + props.groupPath + prevPage}>
+          <Link to={"/~link" + props.popout + "/list/" + prevPage + props.resourcePath}>
             &#60;- Previous Page
           </Link>
         </div>
         <div className={nextDisplay + " inter f8"}>
-          <Link to={"/~link" + props.popout + props.groupPath + nextPage}>
+          <Link to={"/~link" + props.popout + "/list/" + nextPage + props.resourcePath}>
             Next Page ->
           </Link>
         </div>

--- a/pkg/interface/link/src/js/components/lib/sidebar-invite.js
+++ b/pkg/interface/link/src/js/components/lib/sidebar-invite.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import _ from 'lodash';
+
+export class SidebarInvite extends Component {
+
+  onAccept() {
+    api.invite.accept(this.props.uid);
+  }
+
+  onDecline() {
+    api.invite.decline(this.props.uid);
+  }
+
+  render() {
+    const { props } = this;
+
+    return (
+      <div className='w-100 bg-transparent pa4 bb b--gray4 b--gray1-d'>
+        <div className='w-100 v-mid'>
+          <p className="dib f8 mono gray4-d">
+            {props.invite.text}
+          </p>
+        </div>
+        <a
+          className="dib pointer pa2 f9 bg-green2 white mt4"
+          onClick={this.onAccept.bind(this)}>
+          Accept Invite
+        </a>
+        <a
+          className="dib pointer ml4 pa2 f9 bg-black bg-gray0-d white mt4"
+          onClick={this.onDecline.bind(this)}>
+          Decline
+        </a>
+      </div>
+    )
+  }
+}
+

--- a/pkg/interface/link/src/js/components/link.js
+++ b/pkg/interface/link/src/js/components/link.js
@@ -29,7 +29,7 @@ export class LinkDetail extends Component {
     // if we have no preloaded data, and we aren't expecting it, get it
     if (!this.state.data.title) {
       api.getSubmission(
-        this.props.groupPath, this.props.url, this.updateData.bind(this)
+        this.props.resourcePath, this.props.url, this.updateData.bind(this)
       );
     }
   }
@@ -46,7 +46,7 @@ export class LinkDetail extends Component {
     api.setSpinner(true);
 
     api.postComment(
-      this.props.groupPath,
+      this.props.resourcePath,
       url,
       this.state.comment
     ).then(() => {
@@ -98,10 +98,10 @@ export class LinkDetail extends Component {
           />
           <Link
             className="dib f9 fw4 pt2 gray2 lh-solid"
-            to={"/~link" + popout + props.groupPath + "/" + props.page}>
+            to={"/~link" + popout + "/list/" + props.page + props.resourcePath}>
             {"<- Collection index"}
           </Link>
-          <LinksTabBar {...props} popout={popout} groupPath={props.groupPath} />
+          <LinksTabBar {...props} popout={popout} resourcePath={props.resourcePath} />
         </div>
         <div className="w-100 mt2 flex justify-center overflow-y-scroll ph4 pb4">
           <div className="w-100 mw7">
@@ -111,7 +111,7 @@ export class LinkDetail extends Component {
               comments={comments}
               nickname={nickname}
               ship={ship}
-              groupPath={props.groupPath}
+              resourcePath={props.resourcePath}
               page={props.page}
               linkIndex={props.linkIndex}
               time={this.state.data.time}
@@ -143,8 +143,8 @@ export class LinkDetail extends Component {
               </button>
             </div>
             <Comments
-              groupPath={props.groupPath}
-              key={props.groupPath + props.commentPage}
+              resourcePath={props.resourcePath}
+              key={props.resourcePath + props.commentPage}
               comments={props.comments}
               commentPage={props.commentPage}
               contacts={props.contacts}

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -25,16 +25,29 @@ export class Links extends Component {
          (!this.props.links[linkPage] ||
           this.props.links.local[linkPage])
     ) {
-      api.getPage(this.props.groupPath, this.props.page);
+      api.getPage(this.props.resourcePath, this.props.page);
     }
   }
 
   markAllAsSeen() {
-    api.seenLink(this.props.groupPath);
+    api.seenLink(this.props.resourcePath);
   }
 
   render() {
     let props = this.props;
+
+    if (!props.resource.title) {
+      return (
+        <div className="h-100 w-100 overflow-x-hidden flex flex-column bg-white bg-gray0-d dn db-ns">
+          <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
+            <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
+              Loading...
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     let popout = (props.popout) ? "/popout" : "";
     let linkPage = props.page;
 
@@ -77,7 +90,7 @@ export class Links extends Component {
         color={color}
         member={member}
         comments={commentCount}
-        groupPath={props.groupPath}
+        resourcePath={props.resourcePath}
         popout={popout}
         />
       )
@@ -99,26 +112,30 @@ export class Links extends Component {
           <SidebarSwitcher
            sidebarShown={props.sidebarShown}
            popout={props.popout}/>
-         <Link to={`/~link` + popout + props.groupPath} className="pt2">
+         <Link to={`/~link${popout}/list/${props.page}${props.resourcePath}`} className="pt2">
            <h2
              className={`dib f9 fw4 v-top lh-solid` +
-             (props.groupPath.includes("/~/")
+             (props.resource.group.includes("/~/")
              ? ""
              : " mono")}>
-              {(props.groupPath.includes("/~/"))
-              ? "Private"
-              : props.groupPath.substr(1)}
+               { props.resource.title +
+                 ( props.resource.description
+                   ? ": " + props.resource.description
+                   : ""
+                 )
+               }
            </h2>
          </Link>
           <LinksTabBar
           {...props}
           popout={popout}
-          groupPath={props.groupPath + "/" + props.page}/>
+          page={props.page}
+          resourcePath={props.resourcePath}/>
         </div>
         <div className="w-100 mt2 flex justify-center overflow-y-scroll ph4 pb4">
           <div className="w-100 mw7">
             <div className="flex">
-              <LinkSubmit groupPath={props.groupPath}/>
+              <LinkSubmit resourcePath={props.resourcePath}/>
             </div>
             <div className="pb4">
             <span
@@ -129,9 +146,9 @@ export class Links extends Component {
             {LinkList}
             <Pagination
             {...props}
-            key={props.groupPath + props.page}
+            key={props.resourcePath + props.page}
             popout={popout}
-            groupPath={props.groupPath}
+            resourcePath={props.resourcePath}
             currentPage={currentPage}
             totalPages={totalPages}
             />

--- a/pkg/interface/link/src/js/components/new.js
+++ b/pkg/interface/link/src/js/components/new.js
@@ -1,0 +1,252 @@
+import React, { Component } from 'react';
+import { InviteSearch } from './lib/invite-search';
+import { Route, Link } from 'react-router-dom';
+import { uuid, isPatTa, deSig } from '/lib/util';
+import urbitOb from 'urbit-ob';
+
+export class NewScreen extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: '',
+      description: '',
+      idName: '',
+      groups: [],
+      ships: [],
+      idError: false,
+      inviteError: false,
+      createGroup: true
+    };
+
+    this.titleChange = this.titleChange.bind(this);
+    this.descriptionChange = this.descriptionChange.bind(this);
+    this.setInvite = this.setInvite.bind(this);
+    this.createGroupChange = this.createGroupChange.bind(this);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { props, state } = this;
+
+    if (prevProps !== props) {
+      let station = `/~${window.ship}/${state.idName}`;
+      if (station in props.resources) {
+        console.log('TODO nav', '/~chat/room' + station);
+      }
+    }
+  }
+
+  titleChange(event) {
+    let asciiSafe = event.target.value.toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-");
+    this.setState({
+      idName: asciiSafe + '-' + Math.floor(Math.random()*10000), // uniqueness
+      title: event.target.value
+    });
+  }
+
+  descriptionChange(event) {
+    this.setState({
+      description: event.target.value
+    });
+  }
+
+  setInvite(value) {
+    this.setState({
+      groups: value.groups,
+      ships: value.ships
+    });
+  }
+
+  createGroupChange(event) {
+    if (event.target.checked) {
+      this.setState({
+        createGroup: !!event.target.checked,
+        security: 'village'
+      });
+    } else {
+      this.setState({
+        createGroup: !!event.target.checked,
+      });
+    }
+  }
+
+  onClickCreate() {
+    const { props, state } = this;
+
+    if (!state.title) {
+      this.setState({
+        idError: true,
+        inviteError: false
+      });
+      return;
+    }
+
+    let appPath = `/${state.idName}`;
+
+    if (appPath in props.resources) {
+      this.setState({
+        inviteError: false,
+        idError: true,
+        success: false
+      });
+      return;
+    }
+
+    let isValid = true;
+    let aud = state.ships.map(mem => `~${deSig(mem.trim())}`);
+    aud.forEach((mem) => {
+      if (!urbitOb.isValidPatp(mem)) {
+        isValid = false;
+      }
+    });
+
+    if (!isValid) {
+      this.setState({
+        inviteError: true,
+        idError: false,
+        success: false
+      });
+      return;
+    }
+
+    const target = aud.length === 0
+      ? {group: state.groups[0]}
+      : {ships: aud};
+
+    if (this.textarea) {
+      this.textarea.value = '';
+    }
+
+    this.setState({
+      error: false,
+      success: true,
+      group: [],
+      ships: []
+    }, () => {
+      api.setSpinner(true);
+      //TODO account for state.createGroup
+      let submit = api.createCollection(
+        appPath,
+        state.title,
+        state.description,
+        target
+      );
+      submit.then(() => {
+        api.setSpinner(false);
+        console.log('TODO nav', `/~link/list/0${appPath}`);
+      })
+    });
+  }
+
+  render() {
+    const { props, state } = this;
+    let inviteSwitchClasses = (state.security === "village")
+      ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
+      : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
+    if (state.createGroup) {
+      inviteSwitchClasses = inviteSwitchClasses + " o-50";
+    }
+
+    let createGroupClasses = state.createGroup
+      ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
+      : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
+
+    let createClasses = !!state.idName
+      ? "pointer db f9 mt7 green2 bg-gray0-d ba pv3 ph4 b--green2"
+      : "pointer db f9 mt7 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3";
+
+    let idClasses =
+      "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 " +
+      "focus-b--black focus-b--white-d ";
+
+    let idErrElem = (<span />);
+    if (state.idError) {
+      idErrElem = (
+        <span className="f9 inter red2 db pt2">
+          Chat must have a valid name.
+        </span>
+      );
+    }
+
+    let createGroupToggle = <div/>
+    if (state.groups.length === 0) {
+      createGroupToggle = (
+        <div className="mt7">
+          <input
+            type="checkbox"
+            style={{ WebkitAppearance: "none", width: 28 }}
+            className={createGroupClasses}
+            onChange={this.createGroupChange}
+          />
+          <span className="dib f9 white-d inter ml3">Create Group</span>
+          <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
+            Participants will share this group across applications
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={
+          "h-100 w-100 mw6 pa3 pt4 overflow-x-hidden " +
+          "bg-gray0-d white-d flex flex-column"
+        }>
+        <div className="w-100 dn-m dn-l dn-xl inter pt1 pb6 f8">
+          <Link to="/~link/">{"⟵ All Collections"}</Link>
+        </div>
+        <h2 className="mb3 f8">New Chat</h2>
+        <div className="w-100">
+          <p className="f8 mt3 lh-copy db">Name</p>
+          <textarea
+            className={idClasses}
+            placeholder="Cool Collection"
+            rows={1}
+            style={{
+              resize: "none"
+            }}
+            onChange={this.titleChange}
+          />
+              {idErrElem}
+          <p className="f8 mt3 lh-copy db">
+            Description
+            <span className="gray3"> (Optional)</span>
+          </p>
+          <textarea
+            className={idClasses}
+            placeholder="The hippest links"
+            rows={1}
+            style={{
+              resize: "none"
+            }}
+            onChange={this.descriptionChange}
+          />
+          <p className="f8 mt4 lh-copy db">
+            Invite
+            <span className="gray3"> (Optional)</span>
+          </p>
+          <p className="f9 gray2 db mb2 pt1">
+            Selected entities will be able to post to chat
+          </p>
+          <InviteSearch
+            groups={props.groups}
+            contacts={props.contacts}
+            groupResults={true}
+            invites={{
+              groups: state.groups,
+              ships: state.ships
+            }}
+            setInvite={this.setInvite}
+          />
+          {createGroupToggle}
+          <button
+            onClick={this.onClickCreate.bind(this)}
+            className={createClasses}>
+            Create Collection
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/pkg/interface/link/src/js/components/skeleton.js
+++ b/pkg/interface/link/src/js/components/skeleton.js
@@ -25,6 +25,8 @@ export class Skeleton extends Component {
         <div className={`cf w-100 h-100 flex ` + popoutBorder}>
         <ChannelsSidebar
             popout={popout}
+            resources={this.props.resources}
+            invites={this.props.invites}
             groups={this.props.groups}
             active={this.props.active}
             selected={this.props.selected}

--- a/pkg/interface/link/src/js/reducers/invite-update.js
+++ b/pkg/interface/link/src/js/reducers/invite-update.js
@@ -11,6 +11,10 @@ export class InviteUpdateReducer {
       this.accepted(data, state);
       this.decline(data, state);
     }
+    data = _.get(json, 'invite-initial', false);
+    if (data) {
+      state.invites = data;
+    }
   }
 
   create(json, state) {
@@ -37,7 +41,6 @@ export class InviteUpdateReducer {
   accepted(json, state) {
     let data = _.get(json, 'accepted', false);
     if (data) {
-      console.log(data);
       delete state.invites[data.path][data.uid];
     }
   }

--- a/pkg/interface/link/src/js/reducers/link-update.js
+++ b/pkg/interface/link/src/js/reducers/link-update.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 // page size as expected from link-view.
 // must change in parallel with the +page-size in /app/link-view to
 // ensure sane behavior.
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 3;
 
 export class LinkUpdateReducer {
   reduce(json, state) {

--- a/pkg/interface/link/src/js/reducers/metadata-update.js
+++ b/pkg/interface/link/src/js/reducers/metadata-update.js
@@ -1,0 +1,47 @@
+import _ from 'lodash';
+
+export class MetadataReducer {
+  reduce(json, state) {
+    let data = _.get(json, 'metadata-update', false);
+    if (data) {
+      this.associations(data, state);
+      this.add(data, state);
+    }
+  }
+
+  associations(json, state) {
+    let data = _.get(json, 'associations', false);
+    if (data) {
+      let metadata = new Map;
+      Object.keys(data).map((key) => {
+        let assoc = data[key];
+        if (assoc['app-name'] !== 'link') {
+          return;
+        }
+        if (state.resources[assoc['app-path']]) {
+          console.error('beware! overwriting previous data', data['app-path']);
+        }
+        state.resources[assoc['app-path']] = {
+          group: assoc['group-path'],
+          ...assoc.metadata
+        };
+      });
+    }
+  }
+
+  add(json, state) {
+    let data = _.get(json, 'add', false);
+    if (data) {
+      if (data['app-name'] !== 'link') {
+        return;
+      }
+      if (state.resources[data['app-path']]) {
+        console.error('beware! overwriting previous data', data['app-path']);
+      }
+      state.resources[data['app-path']] = {
+        group: data['group-path'],
+        ...data.metadata
+      };
+    }
+  }
+}

--- a/pkg/interface/link/src/js/store.js
+++ b/pkg/interface/link/src/js/store.js
@@ -1,6 +1,8 @@
 import { InitialReducer } from '/reducers/initial';
 import { ContactUpdateReducer } from '/reducers/contact-update.js';
 import { PermissionUpdateReducer } from '/reducers/permission-update';
+import { MetadataReducer } from '/reducers/metadata-update.js';
+import { InviteUpdateReducer } from '/reducers/invite-update';
 import { LinkUpdateReducer } from '/reducers/link-update';
 import { LocalReducer } from '/reducers/local.js';
 import _ from 'lodash';
@@ -11,6 +13,8 @@ class Store {
     this.state = {
       contacts: {},
       groups: {},
+      resources: {},
+      invites: {},
       links: {},
       comments: {},
       seen: {},
@@ -22,6 +26,8 @@ class Store {
     this.initialReducer = new InitialReducer();
     this.contactUpdateReducer = new ContactUpdateReducer();
     this.permissionUpdateReducer = new PermissionUpdateReducer();
+    this.metadataReducer = new MetadataReducer();
+    this.inviteUpdateReducer = new InviteUpdateReducer();
     this.localReducer = new LocalReducer();
     this.linkUpdateReducer = new LinkUpdateReducer();
     this.setState = () => {};
@@ -43,6 +49,8 @@ class Store {
     this.initialReducer.reduce(json, this.state);
     this.contactUpdateReducer.reduce(json, this.state);
     this.permissionUpdateReducer.reduce(json, this.state);
+    this.metadataReducer.reduce(json, this.state);
+    this.inviteUpdateReducer.reduce(json, this.state);
     this.localReducer.reduce(json, this.state);
     this.linkUpdateReducer.reduce(json, this.state);
 

--- a/pkg/interface/link/src/js/subscription.js
+++ b/pkg/interface/link/src/js/subscription.js
@@ -11,16 +11,25 @@ export class Subscription {
   }
 
   initializeLinks() {
-    // add invite, permissions flows once link stores are more than
-    // group-specific
     api.bind('/all', 'PUT', api.authTokens.ship, 'group-store',
-    this.handleEvent.bind(this),
-    this.handleError.bind(this),
-    this.handleQuitAndResubscribe.bind(this));
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this)
+    );
     api.bind('/primary', 'PUT', api.authTokens.ship, 'contact-view',
       this.handleEvent.bind(this),
       this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this)
+    );
+    api.bind('/primary', 'PUT', api.authTokens.ship, 'invite-view',
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
       this.handleQuitAndResubscribe.bind(this));
+    api.bind('/app-name/link', 'PUT', api.authTokens.ship, 'metadata-store',
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this)
+    );
 
     // open a subscription for all submissions
     api.getPage('', 0);


### PR DESCRIPTION
Chunky commits this time, because of big, intertwining changes. In brief:
- make link hooks use metadata-store for resource discovery & syncing
- add aggregate action to link-view for creating new collection, with maybe a new (unmanaged) group + invites
- update frontend to use metadata for resource discovery and detail rendering, invites

6c19b05 is more or less the same thing as #2368, except for groups instead of apps.

Depends on whatever @loganallenc's implementation of #2377 ends up being. Doesn't sync links properly without that.

Putting this out here for preliminary review. Remaining work:
- [ ] Support creating real groups from the new collection screen. Checkbox currently looks weird and does nothing, "unmanaged" only.
- [ ] Member management screen for collections?
- [ ] Minor UI fixes
- [ ] Support `/~link/join/resource` route as linked to be contacts frontend
- [ ] Currently always syncs in all of a group's collections. Maybe we want explicit opt-in, even if you're already in the group?