### PR TITLE
contacts: changed color + copy of "add to group" button

### DIFF
--- a/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/contacts/src/js/components/lib/contact-sidebar.js
@@ -81,7 +81,7 @@ export class ContactSidebar extends Component {
             className={((props.path.includes(window.ship))
               ? "dib"
               : "dn")}>
-            <p className="f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Invite</p>
+            <p className="f9 pl4 pt0 pt4-m pt4-l pt4-xl green2 bn">Add to Group</p>
           </Link>
           <Link to={detailHref}
             className="dib dn-m dn-l dn-xl f9 pl4 pt0 pt4-m pt4-l pt4-xl gray2 bn">Channels</Link>

--- a/pkg/interface/contacts/src/js/components/lib/share-sheet.js
+++ b/pkg/interface/contacts/src/js/components/lib/share-sheet.js
@@ -13,7 +13,7 @@ export class ShareSheet extends Component {
 
     return (
       <div>
-        <p className="pt4 pb2 pl4 pr4 f8 gray2 f9">Share Your Profile</p>
+        <p className="pt4 pb2 pl4 pr4 f8 gray2 f9">Group Identity</p>
         <ContactItem
           key={props.ship}
           ship={props.ship}


### PR DESCRIPTION
I changed the copy and appearance (color only) of the "Invite" button previously located in Contacts, as it looked like a non-interactive label.

I actually have a related Asana task to this issue regarding copy-checking in general throughout OS1, so the copy of this button edit may change in the near term, depending on how this other task goes.