### PR TITLE
ford: restores pit-shortcircuit, but only during boot

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f887b67ad8c784c7d56c724207e4beb6940bf2b18b70a2af39f10f2739d2a388
-size 9702258
+oid sha256:9211b21328ab202e35ade5e1c94d74b45d06a5a05d5814bd1c9d88200e5c7987
+size 9694669

--- a/pkg/arvo/lib/test/ford.hoon
+++ b/pkg/arvo/lib/test/ford.hoon
@@ -14,43 +14,7 @@
 ::
 =/  test-pit=vase  !>(..zuse)
 =/  ford-gate  (ford-vane test-pit)
-::  prime %reef cache in .ford-gate so we don't have to rebuild the kernel
 ::
-=<  ~&  %test-reef-priming
-    =/  co  (by-clock:contain compiler-cache-key:ford-gate build-result)
-    ::
-    =.  compiler-cache.state.ax.ford-gate
-      %+  ~(put co compiler-cache.state.ax.ford-gate)
-        [%ride (rain /~nul/home/hoon/hoon/sys hoon-scry) !>(~)]
-      [%success %ride !>(ride)]
-    ::  we'd have to build arvo, so don't bother trying to cache it
-    ::
-    =.  compiler-cache.state.ax.ford-gate
-      %+  ~(put co compiler-cache.state.ax.ford-gate)
-        [%ride (rain /~nul/home/hoon/zuse/sys zuse-scry) !>(..is)]
-      [%success %ride !>(..zuse)]
-    ::  run %reef now that we've cached the hard parts
-    ::
-    ~&  %test-reef-loading
-    =.  ford-gate
-      =-  ?>(?=(~ -<) ->)
-      %:  ford-call-with-comparator
-        ford-gate
-        ~1234.5.6
-        scry=(scry-with-results (with-reef ~1234.5.6 ~))
-        call-args=[*duct *type %build %.n %reef ~nul %home]
-        ^=  comparator
-        |=  moves=(list move:ford-gate)
-        ?>  =(1 (lent moves))
-        ?>  ?=(^ moves)
-        ?>  ?=([* %give %made @da %complete *] i.moves)
-        =/  result  result.p.card.i.moves
-        ?>  ?=([%success %reef *] build-result.result)
-        ~
-      ==
-    ~&  %test-reef-loaded
-    ~!  +6.ford-gate
-    .
 |%
 ++  verify-post-made
   |=  $:  move=move:ford-gate
@@ -217,7 +181,7 @@
       [%hoon !>(zuse-scry)]
   ::
       :-  [%cw [[~nul %home %da date] /hoon/hoon/sys]]
-      [%cass !>([ud=0 da=date])]
+      [%cass !>([ud=1 da=date])]
   ==
 ::
 ++  with-reef-unit
@@ -232,7 +196,7 @@
       `[%noun !>(~)]
   ::
       :-  [%cw [[~nul %home %da date] /hoon/hoon/sys]]
-      `[%cass !>([ud=0 da=date])]
+      `[%cass !>([ud=1 da=date])]
   ==
 ::
 ++  ford-call

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -4658,6 +4658,23 @@
       ::
       ?.  ?=([~ %success %scry *] zuse-scry-result)
         (wrap-error zuse-scry-result)
+      ::
+      ::  short-circuit to .pit during boot
+      ::
+      ::    This avoids needing to recompile the kernel if we're asked
+      ::    to build %hoon one the home desk, at revision 1 or 2.
+      ::
+      ?:  ?&  =(our ship.disc)
+              ?=(?(%base %home) desk.disc)
+          ::
+              =/  =beam
+                [[ship.disc desk.disc [%da date.build]] /hoon/hoon/sys]
+              =/  cass
+                (scry [%141 %noun] [~ %cw beam])
+              ?=([~ ~ %cass * ?(%1 %2) *] cass)
+          ==
+        ::
+        (return-result %success %reef pit)
       ::  omit case from path to prevent cache misses
       ::
       =/  hoon-path=path


### PR DESCRIPTION
This PR is a rethink of #2322 -- slightly less principled, but much more performant. It restores %ford's "pit" short-circuit for kernel builds, but only during the boot process. Bugs caused by faulty "pit" short-circuit during normal operation will still be fixed as they were in #2322, but boot and `+test` are both much faster. These changes are necessary to restore well-functioning CI, and keep our kernel cycle-times somewhat reasonable.

These changes were made on #2366, but should go in separately (and maybe first). I'll update that PR once this is complete and merged.