### PR TITLE
metadata-hook: support group members other than host creating/editing shared resources

### DIFF
--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -224,7 +224,7 @@
     ?>  ?=(^ app-path.act)
     %-  zing
     :~  :~  (chat-hook-poke [%remove app-path.act])
-            (metadata-store-poke [%remove group-path [%chat app-path.act]])
+            (metadata-poke [%remove group-path [%chat app-path.act]])
             (chat-poke [%delete app-path.act])
         ==
       ::
@@ -300,7 +300,7 @@
         ?:  (is-managed app-path)  (snag 0 app-path)
         (snag 1 app-path)
       ==
-    :~  (metadata-store-poke [%add group-path [%chat app-path] metadata])
+    :~  (metadata-poke [%add group-path [%chat app-path] metadata])
         (metadata-hook-poke [%add-owned group-path])
     ==
   ::
@@ -309,10 +309,10 @@
     ^-  card
     [%pass / %agent [our.bol %contact-view] %poke %contact-view-action !>(act)]
   ::
-  ++  metadata-store-poke
+  ++  metadata-poke
     |=  act=metadata-action
     ^-  card
-    [%pass / %agent [our.bol %metadata-store] %poke %metadata-action !>(act)]
+    [%pass / %agent [our.bol %metadata-hook] %poke %metadata-action !>(act)]
   ::
   ++  metadata-hook-poke
     |=  act=metadata-hook-action

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -42,6 +42,9 @@
       =^  cards  state
         (poke-hook-action:hc !<(metadata-hook-action vase))
       [cards this]
+    ::
+        %metadata-action
+      [(poke-action:hc !<(metadata-action vase)) this]
     == 
   ::
   ++  on-watch
@@ -106,6 +109,43 @@
     [%pass path %agent [ship %metadata-hook] %leave ~]~
   --
 ::
+++  poke-action
+  |=  act=metadata-action
+  ^-  (list card)
+  |^
+  ?:  (team:title our.bowl src.bowl)
+    ?-  -.act
+        %add     (send group-path.act)
+        %remove  (send group-path.act)
+    ==
+  ?>  (is-permitted src.bowl group-path.act)
+  ?-  -.act
+      %add     (metadata-poke our.bowl %metadata-store)
+      %remove  (metadata-poke our.bowl %metadata-store)
+  ==
+  ::
+  ++  send
+    |=  =group-path
+    ^-  (list card)
+    =/  =ship
+      %+  slav  %p
+      ?:  (is-managed group-path)  (snag 0 group-path)
+      (snag 1 group-path)
+    =/  app  ?:(=(ship our.bowl) %metadata-store %metadata-hook)
+    (metadata-poke ship app)
+  ::
+  ++  metadata-poke
+    |=  [=ship app=@tas]
+    ^-  (list card)
+    [%pass / %agent [ship app] %poke %metadata-action !>(act)]~
+  ::
+  ++  is-managed
+    |=  =path
+    ^-  ?
+    ?>  ?=(^ path)
+    !=(i.path '~')
+  --
+::
 ++  watch-group
   |=  =path
   ^-  (list card)
@@ -116,17 +156,6 @@
   |=  [[=group-path =resource] =metadata]
   ^-  card
   [%give %fact ~ %metadata-update !>([%add group-path resource metadata])]
-  ::
-  ++  is-permitted
-    |=  [=ship pax=^path]
-    ^-  ?
-    =.  pax
-      ;:  weld
-          /=permission-store/(scot %da now.bowl)/permitted
-          [(scot %p ship) pax]
-          /noun
-      ==
-    .^(? %gx pax)
   ::
   ++  metadata-scry
     |=  pax=^path
@@ -203,4 +232,15 @@
   ^-  (quip card _state)
   ?>  ?=(^ wir)
   [~ ?~(saw state state(synced (~(del by synced) t.wir)))]
+::
+++  is-permitted
+  |=  [=ship pax=path]
+  ^-  ?
+  =.  pax
+    ;:  weld
+        /=permission-store/(scot %da now.bowl)/permitted
+        [(scot %p ship) pax]
+        /noun
+    ==
+  .^(? %gx pax)
 --

--- a/pkg/arvo/mar/metadata/action.hoon
+++ b/pkg/arvo/mar/metadata/action.hoon
@@ -1,0 +1,7 @@
+/-  *metadata-store
+|_  act=metadata-action
+++  grab
+  |%
+  ++  noun  metadata-action
+  --
+--


### PR DESCRIPTION
Pretty small change, but nice quality of life improvement.

NOTE: this is good to keep in mind for links and publish, because the preference is now to send all metadata actions through %metadata-hook so that we have automatic support for foreign chatrooms / publish blogs / links collections being shown in the group's available channels. (not just the host's channels)