### PR TITLE
chat: settings — edit channel metadata, shortcode copying

### DIFF
--- a/pkg/arvo/lib/metadata-json.hoon
+++ b/pkg/arvo/lib/metadata-json.hoon
@@ -8,7 +8,7 @@
   %+  turn  ~(tap by associations)
   |=  [[=group-path =resource] =metadata]
   ^-  [cord json]
-  :-  
+  :-
   %-  crip
   ;:  weld
       (trip (spat group-path))
@@ -21,6 +21,50 @@
       [%app-path (path app-path.resource)]
       [%metadata (metadata-to-json metadata)]
   ==
+::
+++  json-to-action
+  |=  jon=json
+  ^-  metadata-action
+  =,  dejs:format
+  =<  (parse-json jon)
+  |%
+  ++  parse-json
+    %-  of
+    :~  [%add add]
+        [%remove remove]
+    ==
+  ::
+  ++  add
+    %-  ot
+    :~  [%group-path pa]
+        [%resource resource]
+        [%metadata metadata]
+    ==
+  ++  remove
+    %-  ot
+    :~  [%group-path pa]
+        [%resource resource]
+    ==
+  ::
+  ++  nu
+    |=  jon=json
+    ?>  ?=({$s *} jon)
+    (rash p.jon hex)
+  ::
+  ++  metadata
+    %-  ot
+    :~  [%title so]
+        [%description so]
+        [%color nu]
+        [%date-created (se %da)]
+        [%creator (su ;~(pfix sig fed:ag))]
+    ==
+  ++  resource
+    %-  ot
+    :~  [%app-name so]
+        [%app-path pa]
+    ==
+  --
 ::
 ++  metadata-to-json
   |=  met=metadata

--- a/pkg/arvo/mar/metadata/action.hoon
+++ b/pkg/arvo/mar/metadata/action.hoon
@@ -1,0 +1,11 @@
+/+  *metadata-json
+=,  dejs:format
+|_  act=metadata-action
+++  grab
+  |%
+  ++  noun  metadata-action
+  ++  json
+    |=  jon=^json
+    (json-to-action jon)
+  --
+--

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -183,7 +183,7 @@ class UrbitApi {
 
   metadataAction(data) {
     console.log(data)
-    return this.action("metadata-store", "metadata-action", data);
+    return this.action("metadata-hook", "metadata-action", data);
   }
 
   metadataAdd(appPath, groupPath, title, description, dateCreated, color) {
@@ -196,11 +196,11 @@ class UrbitApi {
           "app-name": "chat"
         },
         metadata: {
-          title: title,
-          description: description,
-          color: color,
+          title,
+          description,
+          color,
           'date-created': dateCreated,
-          creator: creator
+          creator
         }
       }
     })

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -182,7 +182,6 @@ class UrbitApi {
   }
 
   metadataAction(data) {
-    console.log(data)
     return this.action("metadata-hook", "metadata-action", data);
   }
 

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -181,6 +181,28 @@ class UrbitApi {
     });
   }
 
+  metadataAction(data) {
+    return this.action("metadata-store", "metadata-action", data);
+  }
+
+  metadataAdd(appPath, groupPath, title, description, dateCreated, color) {
+    let creator = `~${window.ship}`
+    return this.metadataAction({
+      add: {
+        "app-name": "chat",
+        "app-path": appPath,
+        "group-path": groupPath,
+        metadata: {
+          title: title,
+          description: description,
+          color: color,
+          'date-created': dateCreated,
+          creator: creator
+        }
+      }
+    })
+  }
+
   sidebarToggle() {
     let sidebarBoolean = true;
     if (store.state.sidebarShown === true) {

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -182,6 +182,7 @@ class UrbitApi {
   }
 
   metadataAction(data) {
+    console.log(data)
     return this.action("metadata-store", "metadata-action", data);
   }
 
@@ -189,9 +190,11 @@ class UrbitApi {
     let creator = `~${window.ship}`
     return this.metadataAction({
       add: {
-        "app-name": "chat",
-        "app-path": appPath,
         "group-path": groupPath,
+        resource: {
+          "app-path": appPath,
+          "app-name": "chat"
+        },
         metadata: {
           title: title,
           description: description,

--- a/pkg/interface/chat/src/js/components/lib/message.js
+++ b/pkg/interface/chat/src/js/components/lib/message.js
@@ -125,11 +125,11 @@ export class Message extends Component {
       );
     } else {
       let chatroom = letter.text.match(
-        /(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z])+([/-])?)+/
+        /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z])+([/-])?)+/
         );
       if ((chatroom !== null) // matched possible chatroom
-        && (chatroom[1].length > 2) // possible ship?
-        && (urbitOb.isValidPatp(chatroom[1]) // valid patp?
+        && (chatroom[2].length > 2) // possible ship?
+        && (urbitOb.isValidPatp(chatroom[2]) // valid patp?
         && (chatroom[0] === letter.text))) { // entire message is room name?
           return (
             <Link

--- a/pkg/interface/chat/src/js/components/lib/message.js
+++ b/pkg/interface/chat/src/js/components/lib/message.js
@@ -133,7 +133,7 @@ export class Message extends Component {
         && (chatroom[0] === letter.text))) { // entire message is room name?
           return (
             <Link
-            className="bb b--black f7 mono lh-copy v-top"
+            className="bb b--black b--white-d f7 mono lh-copy v-top"
             to={"/~chat/join/" + chatroom.input}>
               {letter.text}
             </Link>

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -210,7 +210,7 @@ export class Root extends Component {
                   spinner={state.spinner}
                   sidebarShown={state.sidebarShown}
                   popout={popout}
-                  sidebar={renderChannelSidebar(props)}
+                  sidebar={renderChannelSidebar(props, station)}
                 >
                   <MemberScreen
                     {...props}
@@ -240,17 +240,22 @@ export class Root extends Component {
 
               let popout = props.match.url.includes("/popout/");
 
+              let association = ((state.associations) &&
+              (state.associations.has(station)))
+                ? state.associations.get(station) : {};
+
               return (
                 <Skeleton
                   sidebarHideOnMobile={true}
                   spinner={state.spinner}
                   popout={popout}
                   sidebarShown={state.sidebarShown}
-                  sidebar={renderChannelSidebar(props)}
+                  sidebar={renderChannelSidebar(props, station)}
                 >
                   <SettingsScreen
                     {...props}
                     station={station}
+                    association={association}
                     api={api}
                     station={station}
                     group={group}

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -148,6 +148,27 @@ export class SettingsScreen extends Component {
         </div>
         <div className="w-100 pl3 mt4 cf">
           <h2 className="f8 pb2">Chat Settings</h2>
+          <div className="w-100 mt3">
+            <p className="f8 mt3 lh-copy">Share</p>
+            <p className="f9 gray2 mb4">Share a shortcode to join this chat</p>
+            <div className="relative w-100 flex"
+              style={{ maxWidth: "29rem" }}>
+              <input
+                className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+                disabled={true}
+                value={props.station.substr(1)}
+              />
+              <span className="f8 pointer green2 absolute pa3 inter"
+                style={{right: 12, top: 1}}
+                ref="copy"
+                onClick={() => {
+                  navigator.clipboard.writeText(props.station.substr(1));
+                  this.refs.copy.innerText = "Copied";
+                }}>
+                Copy
+              </span>
+            </div>
+          </div>
           {this.renderDelete()}
         </div>
       </div>

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { deSig } from '/lib/util';
+import { deSig, uxToHex } from '/lib/util';
 import { Route, Link } from "react-router-dom";
-import { store } from "/store";
 
 
 import { ChatTabBar } from '/components/lib/chat-tabbar';
@@ -19,6 +18,7 @@ export class SettingsScreen extends Component {
     };
 
     this.renderDelete = this.renderDelete.bind(this);
+    this.changeTitle = this.changeTitle.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -30,6 +30,11 @@ export class SettingsScreen extends Component {
         props.api.setSpinner(false);
         props.history.push('/~chat');
       });
+    }
+
+    if ((this.state.title === "") && (prevProps !== this.props)) {
+      if ((props.association) && (props.association.metadata))
+      this.setState({title: props.association.metadata.title});
     }
   }
 
@@ -79,29 +84,42 @@ export class SettingsScreen extends Component {
 
     let chatOwner = (deSig(props.match.params.ship) === window.ship);
 
-    let title = ((props.association) && (props.association.metadata))
-      ? props.association.metadata.title : "";
+    let association = ((props.association) && (props.association.metadata))
+      ? props.association : {};
 
     return(
       <div>
-        <div className={"w-100 fl mt3 " + ((chatOwner) ? 'o-30' : '')}
-        style={{maxWidth: "29rem"}}>
+        <div className={"w-100 fl mt3 " + ((chatOwner) ? '' : 'o-30')}>
         <p className="f8 mt3 lh-copy">Rename</p>
         <p className="f9 gray2 db mb4">Change the name of this chat</p>
+        <div className="relative w-100 flex"
+        style={{maxWidth: "29rem"}}>
           <input
             className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
-            value={title}
+            value={this.state.title}
+            disabled={!chatOwner}
             onChange={this.changeTitle}
           />
-          <span className="f8 pointer absolute pa3 inter"
+          <span className={"f8 absolute pa3 inter " +
+          ((chatOwner) ? "pointer" : "")}
             style={{ right: 12, top: 1 }}
             ref="rename"
             onClick={() => {
-              this.refs.rename.innerText = "Saved";
-              props.api. //TODO
+              if (chatOwner) {
+                this.refs.rename.innerText = "Saved";
+                props.api.metadataAdd(
+                  association['app-path'],
+                  association['group-path'],
+                  this.state.title,
+                  association.metadata.description,
+                  association.metadata['date-created'],
+                  uxToHex(association.metadata.color)
+                )
+              }
             }}>
             Save
-              </span>
+            </span>
+          </div>
         </div>
       </div>
     )
@@ -208,6 +226,7 @@ export class SettingsScreen extends Component {
             </div>
           </div>
           {this.renderDelete()}
+          {this.renderMetadataSettings()}
         </div>
       </div>
     );

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -14,11 +14,25 @@ export class SettingsScreen extends Component {
 
     this.state = {
       isLoading: false,
-      title: ""
+      title: "",
+      description: "",
+      color: ""
     };
 
     this.renderDelete = this.renderDelete.bind(this);
     this.changeTitle = this.changeTitle.bind(this);
+    this.changeDescription = this.changeDescription.bind(this);
+    this.changeColor = this.changeColor.bind(this);
+  }
+
+  componentDidMount() {
+    if ((this.props.association) && (this.props.association.metadata)) {
+      this.setState({
+        title: this.props.association.metadata.title,
+        description: this.props.association.metadata.description,
+        color: uxToHex(this.props.association.metadata.color)
+      });
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -34,12 +48,23 @@ export class SettingsScreen extends Component {
 
     if ((this.state.title === "") && (prevProps !== this.props)) {
       if ((props.association) && (props.association.metadata))
-      this.setState({title: props.association.metadata.title});
+      this.setState({
+        title: props.association.metadata.title,
+        description: props.association.metadata.description,
+        color: uxToHex(props.association.metadata.color)});
     }
   }
 
   changeTitle() {
     this.setState({title: event.target.value})
+  }
+
+  changeDescription() {
+    this.setState({description: event.target.value});
+  }
+
+  changeColor() {
+    this.setState({color: event.target.value});
   }
 
   deleteChat() {
@@ -118,6 +143,66 @@ export class SettingsScreen extends Component {
               }
             }}>
             Save
+            </span>
+          </div>
+          <p className="f8 mt3 lh-copy">Change description</p>
+          <p className="f9 gray2 db mb4">Change the description of this chat</p>
+          <div className="relative w-100 flex"
+            style={{ maxWidth: "29rem" }}>
+            <input
+              className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+              value={this.state.description}
+              disabled={!chatOwner}
+              onChange={this.changeDescription}
+            />
+            <span className={"f8 absolute pa3 inter " +
+              ((chatOwner) ? "pointer" : "")}
+              style={{ right: 12, top: 1 }}
+              ref="description"
+              onClick={() => {
+                if (chatOwner) {
+                  this.refs.description.innerText = "Saved";
+                  props.api.metadataAdd(
+                    association['app-path'],
+                    association['group-path'],
+                    association.metadata.title,
+                    this.state.description,
+                    association.metadata['date-created'],
+                    uxToHex(association.metadata.color)
+                  )
+                }
+              }}>
+              Save
+            </span>
+          </div>
+          <p className="f8 mt3 lh-copy">Change color</p>
+          <p className="f9 gray2 db mb4">Give this chat a color when viewing group channels</p>
+          <div className="relative w-100 flex"
+            style={{ maxWidth: "20rem" }}>
+            <input
+              className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+              value={this.state.color}
+              disabled={!chatOwner}
+              onChange={this.changeColor}
+            />
+            <span className={"f8 absolute pa3 inter " +
+              ((chatOwner) ? "pointer" : "")}
+              style={{ right: 12, top: 1 }}
+              ref="color"
+              onClick={() => {
+                if ((chatOwner) && (this.state.color.match(/[0-9A-F]{6}/i))) {
+                  this.refs.color.innerText = "Saved";
+                  props.api.metadataAdd(
+                    association['app-path'],
+                    association['group-path'],
+                    association.metadata.title,
+                    association.metadata.description,
+                    association.metadata['date-created'],
+                    this.state.color
+                  )
+                }
+              }}>
+              Save
             </span>
           </div>
         </div>

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -14,7 +14,8 @@ export class SettingsScreen extends Component {
     super(props);
 
     this.state = {
-      isLoading: false
+      isLoading: false,
+      title: ""
     };
 
     this.renderDelete = this.renderDelete.bind(this);
@@ -30,6 +31,10 @@ export class SettingsScreen extends Component {
         props.history.push('/~chat');
       });
     }
+  }
+
+  changeTitle() {
+    this.setState({title: event.target.value})
   }
 
   deleteChat() {
@@ -67,6 +72,39 @@ export class SettingsScreen extends Component {
       </div>
       </div>
     );
+  }
+
+  renderMetadataSettings() {
+    const { props, state } = this;
+
+    let chatOwner = (deSig(props.match.params.ship) === window.ship);
+
+    let title = ((props.association) && (props.association.metadata))
+      ? props.association.metadata.title : "";
+
+    return(
+      <div>
+        <div className={"w-100 fl mt3 " + ((chatOwner) ? 'o-30' : '')}
+        style={{maxWidth: "29rem"}}>
+        <p className="f8 mt3 lh-copy">Rename</p>
+        <p className="f9 gray2 db mb4">Change the name of this chat</p>
+          <input
+            className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+            value={title}
+            onChange={this.changeTitle}
+          />
+          <span className="f8 pointer absolute pa3 inter"
+            style={{ right: 12, top: 1 }}
+            ref="rename"
+            onClick={() => {
+              this.refs.rename.innerText = "Saved";
+              props.api. //TODO
+            }}>
+            Save
+              </span>
+        </div>
+      </div>
+    )
   }
 
   render() {
@@ -154,11 +192,11 @@ export class SettingsScreen extends Component {
             <div className="relative w-100 flex"
               style={{ maxWidth: "29rem" }}>
               <input
-                className="f8 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+                className="f8 mono ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
                 disabled={true}
                 value={props.station.substr(1)}
               />
-              <span className="f8 pointer green2 absolute pa3 inter"
+              <span className="f8 pointer absolute pa3 inter"
                 style={{right: 12, top: 1}}
                 ref="copy"
                 onClick={() => {

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -131,7 +131,7 @@ export class SettingsScreen extends Component {
             ref="rename"
             onClick={() => {
               if (chatOwner) {
-                this.refs.rename.innerText = "Saved";
+                props.api.setSpinner(true);
                 props.api.metadataAdd(
                   association['app-path'],
                   association['group-path'],
@@ -139,7 +139,10 @@ export class SettingsScreen extends Component {
                   association.metadata.description,
                   association.metadata['date-created'],
                   uxToHex(association.metadata.color)
-                )
+                ).then(() => {
+                  this.refs.rename.innerText = "Saved";
+                  props.api.setSpinner(false);
+                })
               }
             }}>
             Save
@@ -161,7 +164,7 @@ export class SettingsScreen extends Component {
               ref="description"
               onClick={() => {
                 if (chatOwner) {
-                  this.refs.description.innerText = "Saved";
+                  props.api.setSpinner(true);
                   props.api.metadataAdd(
                     association['app-path'],
                     association['group-path'],
@@ -169,7 +172,10 @@ export class SettingsScreen extends Component {
                     this.state.description,
                     association.metadata['date-created'],
                     uxToHex(association.metadata.color)
-                  )
+                  ).then(() => {
+                    this.refs.description.innerText = "Saved";
+                    props.api.setSpinner(false);
+                  })
                 }
               }}>
               Save
@@ -191,7 +197,7 @@ export class SettingsScreen extends Component {
               ref="color"
               onClick={() => {
                 if ((chatOwner) && (this.state.color.match(/[0-9A-F]{6}/i))) {
-                  this.refs.color.innerText = "Saved";
+                  props.api.setSpinner(true);
                   props.api.metadataAdd(
                     association['app-path'],
                     association['group-path'],
@@ -199,7 +205,10 @@ export class SettingsScreen extends Component {
                     association.metadata.description,
                     association.metadata['date-created'],
                     this.state.color
-                  )
+                  ).then(() => {
+                    this.refs.color.innerText = "Saved";
+                    props.api.setSpinner(false);
+                  })
                 }
               }}>
               Save

--- a/pkg/interface/chat/src/js/reducers/metadata-update.js
+++ b/pkg/interface/chat/src/js/reducers/metadata-update.js
@@ -6,6 +6,7 @@ export class MetadataReducer {
     if (data) {
       this.associations(data, state);
       this.add(data, state);
+      this.update(data, state);
     }
   }
 
@@ -23,6 +24,15 @@ export class MetadataReducer {
 
   add(json, state) {
     let data = _.get(json, 'add', false);
+    if (data) {
+      let metadata = state.associations;
+      metadata.set(data["app-path"], data);
+      state.associations = metadata;
+    }
+  }
+
+  update(json, state) {
+    let data = _.get(json, 'update-metadata', false);
     if (data) {
       let metadata = state.associations;
       metadata.set(data["app-path"], data);


### PR DESCRIPTION
- Adds sig-prepended, unmanaged chats to the regex that linkifies channels when mentioned in chat
- Adds a "copy shortcode" section to settings with the channel name for easy copying
- Dark mode linkified chats had a black border underneath them instead of white. No longer.
- Took a detour in ~hell~ lib/metadata-json.hoon and wrote JSON to metadata action parsers for add and remove actions, because I can do that now
- Constructed the API calls in the front-end for revising metadata
- Added 'update-metadata' responses to the metadata reducer (it just overwrites the entry in the map)
- Added edit fields for title, description, and color; the color field is regex validated for 6 hexadecimal characters; all fields pre-fill with current metadata and are disabled and faded if you aren't the owner of the chat; would appreciate a further test for people who can easily do multi-ship testing, but it shouldn't be errant

<img src="https://user-images.githubusercontent.com/20846414/75740430-a0930300-5cd5-11ea-86de-5632308b3175.png" width="500"/>


