### PR TITLE
vere: disables gc on |mass in the daemon process

### DIFF
--- a/pkg/urbit/vere/reck.c
+++ b/pkg/urbit/vere/reck.c
@@ -135,7 +135,9 @@ _reck_kick_term(u3_pier* pir_u, u3_noun pox, c3_l tid_l, u3_noun fav)
 
       //  gc the daemon area
       //
-      uv_timer_start(&u3K.tim_u, (uv_timer_cb)u3_daemon_grab, 0, 0);
+      //    XX disabled due to known leaks; uncomment for dev
+      //
+      // uv_timer_start(&u3K.tim_u, (uv_timer_cb)u3_daemon_grab, 0, 0);
       return c3y;
     } break;
 


### PR DESCRIPTION
... due to periodic minor leaks. This was enabled in #1323. It'd be nice for it to run in CI, but running it on user ships is not worth the risk of crashing on (ephemeral) leaks.

#2177 may be a good place to re-enable in CI.