### PR TITLE
Rename Vere release tarballs

### DIFF
--- a/sh/release
+++ b/sh/release
@@ -23,11 +23,11 @@ do
   sh/cross urbit "$plat"
 
   tmp=$(mktemp -d)
-  mkdir -p $tmp/urbit-$plat-$ver
-  traced cp -r cross/$plat/* $tmp/urbit-$plat-$ver
+  mkdir -p $tmp/$ver-$plat
+  traced cp -r cross/$plat/* $tmp/$ver-$plat
 
-  echo "packaging release/urbit-$plat-$ver.tgz"
-  (cd $tmp; tar cz urbit-$plat-$ver) > release/urbit-$plat-$ver.tgz
+  echo "packaging release/$ver-$plat.tgz"
+  (cd $tmp; tar cz $ver-$plat) > release/$ver-$plat.tgz
 
   rm -rf $tmp
 done


### PR DESCRIPTION
Historically Vere has used a simple 'vx.y.z' versioning scheme that predates the monorepo structure introduced in 7ce50ad.  Going forward it's expected that our blessed runtime king/serf binaries will follow the scheme 'urbit-vx.y.z', i.e. with an `urbit-` prefix, to disambiguate them from other repository subprojects.

This renames Vere release tarballs as their version followed by their target platform.  So with the updated tag scheme, instead of e.g. 'urbit-linux64-vx.y.z.tgz' these will appear along the lines of 'urbit-vx.y.z-linux64.tgz'.

(**Note**: currently these release binaries are generated for every commit, but it seems it would be sufficient to just generate them for tags starting with `urbit-v`.  This would catch all releases and release candidates.  Does anyone feel strongly about preserving the per-commit release builds?)

cc @benjamin-tlon @brendanhay