### PR TITLE
invite search: proper padding, blending of group name

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -205,7 +205,7 @@ export class InviteSearch extends Component {
     ) {
       let groupHeader =
         state.searchResults.groups.length > 0 ? (
-          <p className="f9 gray2 ph3">Groups</p>
+          <p className="f9 gray2 ph3 pb2">Groups</p>
         ) : (
           ""
         );
@@ -222,11 +222,11 @@ export class InviteSearch extends Component {
           <li
             key={group}
             className={
-              "list mono mix-blend-diff white f8 pv2 ph3 pointer" +
+              "list mono white-d f8 pv2 ph3 pointer" +
               " hover-bg-gray4 hover-bg-gray1-d"
             }
-            onClick={e => this.addGroup(group)}>
-            {group}
+            onClick={() => this.addGroup(group)}>
+            <span className="mix-blend-diff white">{group}</span>
           </li>
         );
       });

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -205,7 +205,7 @@ export class InviteSearch extends Component {
     ) {
       let groupHeader =
         state.searchResults.groups.length > 0 ? (
-          <p className="f9 gray2 ph3">Groups</p>
+          <p className="f9 gray2 ph3 pb2">Groups</p>
         ) : (
             ""
           );
@@ -222,11 +222,11 @@ export class InviteSearch extends Component {
           <li
             key={group}
             className={
-              "list mono mix-blend-diff white f8 pv2 ph3 pointer" +
+              "list mono white-d f8 pv2 ph3 pointer" +
               " hover-bg-gray4 hover-bg-gray1-d"
             }
-            onClick={e => this.addGroup(group)}>
-            {group}
+            onClick={() => this.addGroup(group)}>
+            <span className="mix-blend-diff white">{group}</span>
           </li>
         );
       });

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -205,7 +205,7 @@ export class InviteSearch extends Component {
     ) {
       let groupHeader =
         state.searchResults.groups.length > 0 ? (
-          <p className="f9 gray2 ph3">Groups</p>
+          <p className="f9 gray2 ph3 pb2">Groups</p>
         ) : (
             ""
           );
@@ -222,11 +222,11 @@ export class InviteSearch extends Component {
           <li
             key={group}
             className={
-              "list mono mix-blend-diff white f8 pv2 ph3 pointer" +
+              "list mono white-d f8 pv2 ph3 pointer" +
               " hover-bg-gray4 hover-bg-gray1-d"
             }
-            onClick={e => this.addGroup(group)}>
-            {group}
+            onClick={() => this.addGroup(group)}>
+            <span className="mix-blend-diff white">{group}</span>
           </li>
         );
       });


### PR DESCRIPTION
Was starting work on incorporating the group names into the search and started with this — the blending of results was padded inconsistently and all black on dark mode. This should be solid now.

Outside this PR, I wanted to inquire about two issues with incorporating group names and slate it for later work:
1. We don't get group metadata from our subscriptions and we would have to add another subscription and reducer set to get them
2. Reducers are done a bit inconsistently at the moment anyway (Chat + Notebooks + hopefully the others using a Map, Contacts using an object), and throwing associations to the invite search component would basically expect a Map. Hopefully since Contacts' invite search usage disables group searching it wouldn't even come up (we could just throw a `new Map` in as a prop), but it's something that may come up once other apps have their own implementation of the metadata store.