### PR TITLE
chat, groups: metadata reducer additions

### DIFF
--- a/pkg/interface/chat/src/js/reducers/metadata-update.js
+++ b/pkg/interface/chat/src/js/reducers/metadata-update.js
@@ -7,6 +7,7 @@ export class MetadataReducer {
       this.associations(data, state);
       this.add(data, state);
       this.update(data, state);
+      this.remove(data, state);
     }
   }
 
@@ -36,6 +37,15 @@ export class MetadataReducer {
     if (data) {
       let metadata = state.associations;
       metadata.set(data["app-path"], data);
+      state.associations = metadata;
+    }
+  }
+
+  remove(json, state) {
+    let data = _.get(json, 'remove', false);
+    if (data) {
+      let metadata = state.associations;
+      metadata.delete(data["app-path"]);
       state.associations = metadata;
     }
   }

--- a/pkg/interface/groups/src/js/reducers/metadata-update.js
+++ b/pkg/interface/groups/src/js/reducers/metadata-update.js
@@ -6,6 +6,8 @@ export class MetadataReducer {
     if (data) {
       this.associations(data, state);
       this.add(data, state);
+      this.update(data, state);
+      this.remove(data, state);
     }
   }
 
@@ -34,8 +36,35 @@ export class MetadataReducer {
       }
       metadata[data['group-path']]
         [`${data["group-path"]}/${data["app-name"]}${data["app-path"]}`] = data;
- 
+
       state.associations = metadata;
+    }
+  }
+  update(json, state) {
+    let data = _.get(json, 'update-metadata', false);
+    if (data) {
+      let metadata = state.associations;
+      if (!(data["group-path"] in metadata)) {
+        metadata[data["group-path"]] = {};
+      }
+      metadata[data["group-path"]][
+        `${data["group-path"]}/${data["app-name"]}${data["app-path"]}`
+      ] = data;
+
+      state.associations = metadata;
+    }
+  }
+
+  remove(json, state) {
+    let data = _.get(json, 'remove', false);
+    if (data) {
+      let metadata = state.associations;
+      if (data['group-path'] in metadata) {
+        let path =
+        `${data['group-path']}/${data['app-name']}${data['app-path']}`
+        delete metadata[data["group-path"]][path];
+        state.associations = metadata;
+      }
     }
   }
 }


### PR DESCRIPTION
- Chat handles metadata `remove` updates
- Groups handles metadata `update-metadata`, `remove` updates

Creating a chat that creates a group and deleting the chat removes the chat from the channel list, but the group persists ... I wonder if there's something we should handle there or just leave it be. 

I suppose I understand the case where you would want to make a new channel for a group that started in Chat and then have no channels — you could pick up elsewhere.