### PR TITLE
groups: tweak contact card navigation

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -495,6 +495,9 @@ export class ContactCard extends Component {
         !(props.path.includes('/~/default'))
       ) ? "dib" : "dn";
 
+    let hiddenonMe = (props.path === "/~/default")
+      ? "dn" : "";
+
     let card = state.edit ? this.renderEditCard() : this.renderCard();
     return (
       <div className="w-100 h-100 overflow-hidden">
@@ -504,7 +507,9 @@ export class ContactCard extends Component {
             "bb b--gray4 b--gray2-d "
           }>
           <div className="f9 mv4 mh3 pt1 dib w-100">
-            <Link to={"/~groups/detail" + props.path}>{"⟵ Channels"}</Link>
+            <Link className={hiddenonMe} to={"/~groups/detail" + props.path}>
+              {"⟵ Channels"}
+            </Link>
           </div>
           <div className="flex">
             <button
@@ -524,8 +529,7 @@ export class ContactCard extends Component {
           </div>
           <button
             className={
-              `bg-gray0-d mv4 mh3 pa1 f9 red2 pointer flex-shrink-0 ` +
-              adminOpt
+              `bg-gray0-d mv4 mh3 pa1 f9 red2 pointer flex-shrink-0 ` + adminOpt
             }
             onClick={this.removeFromGroup}>
             {props.ship === window.ship && props.path.includes(window.ship)

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -482,7 +482,7 @@ export class ContactCard extends Component {
     let editInfoText =
       state.edit ? "Finish" : "Edit";
     if (props.share && state.edit) {
-      editInfoText = "Share with Group";
+      editInfoText = "Share";
     }
 
     let ourOpt = (props.ship === window.ship) ? "dib" : "dn";
@@ -498,9 +498,12 @@ export class ContactCard extends Component {
     let card = state.edit ? this.renderEditCard() : this.renderCard();
     return (
       <div className="w-100 h-100 overflow-hidden">
-        <div className={"flex justify-between w-100 bg-white bg-gray0-d "  +
-        "bb b--gray4 b--gray2-d "}>
-          <div className="ml3 f9 pt4 w-100">
+        <div
+          className={
+            "flex justify-between w-100 bg-white bg-gray0-d " +
+            "bb b--gray4 b--gray2-d "
+          }>
+          <div className="f9 mv4 mh3 pt1 dib w-100">
             <Link to={"/~groups/detail" + props.path}>{"⟵ Channels"}</Link>
           </div>
           <div className="flex">
@@ -512,19 +515,22 @@ export class ContactCard extends Component {
                   this.editToggle();
                 }
               }}
-              className={`white-d bg-gray0-d ml3 mt2 mb2 f9 pa1 pointer flex-shrink-0 ` + ourOpt}>
+              className={
+                `white-d bg-gray0-d mv4 mh3 f9 pa1 pointer flex-shrink-0 ` +
+                ourOpt
+              }>
               {editInfoText}
             </button>
           </div>
           <button
             className={
-              `bg-gray0-d ph4 mt4 mb4 f9 red2 pointer flex-shrink-0 ` + adminOpt
+              `bg-gray0-d mv4 mh3 pa1 f9 red2 pointer flex-shrink-0 ` +
+              adminOpt
             }
             onClick={this.removeFromGroup}>
-            {(
-              props.ship === window.ship && props.path.includes(window.ship)
-                ? "Leave Group" : "Remove from Group"
-            )}
+            {props.ship === window.ship && props.path.includes(window.ship)
+              ? "Leave Group"
+              : "Remove from Group"}
           </button>
         </div>
         <div className="h-100 w-100 overflow-x-hidden pb8 white-d">{card}</div>


### PR DESCRIPTION
Contact card header had some weird behaviours.

- "Share with Group" got overlapped by the other buttons in different viewports.
- The "me" view had a different header height size than the contact card view — I think because one of the buttons had a different margin setting than the other, and when absent, it created an askew look to the header.
- `<— Channels` shouldn't link back to `/~/default` on the "me" view. Now it does not.