### PR TITLE
invite search: surface group metadata in results

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -31,7 +31,20 @@ export class InviteSearch extends Component {
 
   peerUpdate() {
     let groups = Array.from(Object.keys(this.props.groups));
-    groups = groups.filter(e => !e.startsWith("/~/"));
+    groups = groups.filter(e => !e.startsWith("/~/"))
+    .map(e => {
+      let eachGroup = new Set();
+      eachGroup.add(e);
+      if (this.props.associations) {
+        let name = e;
+        if (e in this.props.associations) {
+          name = (this.props.associations[e].metadata.title !== "")
+            ? this.props.associations[e].metadata.title : e;
+        }
+        eachGroup.add(name);
+      }
+      return Array.from(eachGroup);
+    });
 
     let peers = [],
       peerSet = new Set(),
@@ -79,7 +92,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return e.includes(searchTerm);
+          return (e[0].includes(searchTerm) || e[1].includes(searchTerm));
         });
       }
 
@@ -220,13 +233,14 @@ export class InviteSearch extends Component {
       let groupResults = state.searchResults.groups.map(group => {
         return (
           <li
-            key={group}
+            key={group[0]}
             className={
-              "list mono white-d f8 pv2 ph3 pointer" +
-              " hover-bg-gray4 hover-bg-gray1-d"
+              "list white-d f8 pv2 ph3 pointer" +
+              " hover-bg-gray4 hover-bg-gray1-d " +
+              ((group[1]) ? "inter" : "mono")
             }
-            onClick={() => this.addGroup(group)}>
-            <span className="mix-blend-diff white">{group}</span>
+            onClick={() => this.addGroup(group[0])}>
+            <span className="mix-blend-diff white">{(group[1]) ? group[1] : group[0]}</span>
           </li>
         );
       });

--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -256,7 +256,7 @@ export class NewScreen extends Component {
             <span className="gray3"> (Optional)</span>
           </p>
           <p className="f9 gray2 db mb2 pt1">
-            Selected entities will be able to post to chat
+            Selected groups or ships will be able to post to chat
           </p>
           <InviteSearch
             groups={props.groups}

--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -261,6 +261,7 @@ export class NewScreen extends Component {
           <InviteSearch
             groups={props.groups}
             contacts={props.contacts}
+            associations={props.associations}
             groupResults={true}
             invites={{
               groups: state.groups,

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -101,6 +101,7 @@ export class Root extends Component {
                     inbox={state.inbox || {}}
                     groups={state.groups || {}}
                     contacts={state.contacts || {}}
+                    associations={associations.contacts}
                     {...props}
                   />
                 </Skeleton>

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -8,7 +8,7 @@ export class InviteSearch extends Component {
     this.state = {
       groups: [],
       peers: [],
-      contacts: new Map,
+      contacts: new Map(),
       searchValue: "",
       searchResults: {
         groups: [],
@@ -31,11 +31,27 @@ export class InviteSearch extends Component {
 
   peerUpdate() {
     let groups = Array.from(Object.keys(this.props.groups));
-    groups = groups.filter(e => !e.startsWith("/~/"));
+    groups = groups
+      .filter(e => !e.startsWith("/~/"))
+      .map(e => {
+        let eachGroup = new Set();
+        eachGroup.add(e);
+        if (this.props.associations) {
+          let name = e;
+          if (e in this.props.associations) {
+            name =
+              this.props.associations[e].metadata.title !== ""
+                ? this.props.associations[e].metadata.title
+                : e;
+          }
+          eachGroup.add(name);
+        }
+        return Array.from(eachGroup);
+      });
 
     let peers = [],
       peerSet = new Set(),
-      contacts = new Map;
+      contacts = new Map();
     Object.keys(this.props.groups).map(group => {
       if (this.props.groups[group].size > 0) {
         let groupEntries = this.props.groups[group].values();
@@ -48,10 +64,13 @@ export class InviteSearch extends Component {
         for (let member of groupEntries) {
           if (this.props.contacts[group][member]) {
             if (contacts.has(member)) {
-              contacts.get(member).push(this.props.contacts[group][member].nickname);
-            }
-            else {
-              contacts.set(member, [this.props.contacts[group][member].nickname]);
+              contacts
+                .get(member)
+                .push(this.props.contacts[group][member].nickname);
+            } else {
+              contacts.set(member, [
+                this.props.contacts[group][member].nickname
+              ]);
             }
           }
         }
@@ -79,7 +98,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return e.includes(searchTerm);
+          return e[0].includes(searchTerm) || e[1].includes(searchTerm);
         });
       }
 
@@ -207,35 +226,41 @@ export class InviteSearch extends Component {
         state.searchResults.groups.length > 0 ? (
           <p className="f9 gray2 ph3 pb2">Groups</p>
         ) : (
-            ""
-          );
+          ""
+        );
 
       let shipHeader =
         state.searchResults.ships.length > 0 ? (
           <p className="f9 gray2 pv2 ph3">Ships</p>
         ) : (
-            ""
-          );
+          ""
+        );
 
       let groupResults = state.searchResults.groups.map(group => {
         return (
           <li
-            key={group}
+            key={group[0]}
             className={
-              "list mono white-d f8 pv2 ph3 pointer" +
-              " hover-bg-gray4 hover-bg-gray1-d"
+              "list white-d f8 pv2 ph3 pointer" +
+              " hover-bg-gray4 hover-bg-gray1-d " +
+              (group[1] ? "inter" : "mono")
             }
-            onClick={() => this.addGroup(group)}>
-            <span className="mix-blend-diff white">{group}</span>
+            onClick={() => this.addGroup(group[0])}>
+            <span className="mix-blend-diff white">
+              {group[1] ? group[1] : group[0]}
+            </span>
           </li>
         );
       });
 
       let shipResults = state.searchResults.ships.map(ship => {
-        let nicknames = (this.state.contacts.has(ship))
-          ? this.state.contacts.get(ship)
-            .filter(e => {return !(e === "")})
-            .join(", ")
+        let nicknames = this.state.contacts.has(ship)
+          ? this.state.contacts
+              .get(ship)
+              .filter(e => {
+                return !(e === "");
+              })
+              .join(", ")
           : "";
         return (
           <li
@@ -251,8 +276,12 @@ export class InviteSearch extends Component {
               color="#000000"
               classes="mix-blend-diff v-mid"
             />
-            <span className="v-mid ml2 mw5 truncate dib mix-blend-diff white">{"~" + ship}</span>
-            <span className="absolute right-1 di truncate mw4 inter f9 pt1 mix-blend-diff white">{nicknames}</span>
+            <span className="v-mid ml2 mw5 truncate dib mix-blend-diff white">
+              {"~" + ship}
+            </span>
+            <span className="absolute right-1 di truncate mw4 inter f9 pt1 mix-blend-diff white">
+              {nicknames}
+            </span>
           </li>
         );
       });

--- a/pkg/interface/groups/src/js/components/lib/sidebar-invite.js
+++ b/pkg/interface/groups/src/js/components/lib/sidebar-invite.js
@@ -20,7 +20,7 @@ export class SidebarInvite extends Component {
     return (
       <div className='pa3'>
         <div className='w-100 v-mid'>
-          <p className="dib f8 mono">
+          <p className="dib f8 mono white-d">
             You have been invited to join {props.invite.path}
           </p>
         </div>

--- a/pkg/interface/groups/src/js/components/new.js
+++ b/pkg/interface/groups/src/js/components/new.js
@@ -127,8 +127,8 @@ export class NewScreen extends Component {
             }}
             onChange={this.descriptionChange}
           />
-          <h2 className="f8 pt6">Add Group Members</h2>
-          <p className="f9 gray2 lh-copy">Invite ships to your group</p>
+          <h2 className="f8 pt6">Invite <span className="gray2">(Optional)</span></h2>
+          <p className="f9 gray2 lh-copy">Selected ships will be invited to your group</p>
           <div className="relative pb6 mt2">
             <InviteSearch
               groups={this.props.groups}

--- a/pkg/interface/link/src/js/components/new.js
+++ b/pkg/interface/link/src/js/components/new.js
@@ -217,6 +217,7 @@ export class NewScreen extends Component {
             Selected entities will be able to post to the collection
           </p>
           <InviteSearch
+            associations={props.associations.contacts}
             groups={props.groups}
             contacts={props.contacts}
             groupResults={true}

--- a/pkg/interface/link/src/js/components/new.js
+++ b/pkg/interface/link/src/js/components/new.js
@@ -214,7 +214,7 @@ export class NewScreen extends Component {
             <span className="gray3"> (Optional)</span>
           </p>
           <p className="f9 gray2 db mb2 pt1">
-            Selected entities will be able to post to the collection
+            Selected groups or ships will be able to post to collection
           </p>
           <InviteSearch
             associations={props.associations.contacts}

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -186,6 +186,7 @@ export class NewScreen extends Component {
           </p>
           <p className="f9 gray2 db mb2 pt1">Select an initial read-only audience for your notebook</p>
           <InviteSearch
+            associations={this.props.associations}
             groupResults={true}
             groups={this.props.groups}
             contacts={this.props.contacts}

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -184,7 +184,7 @@ export class NewScreen extends Component {
             (Optional)
           </span>
           </p>
-          <p className="f9 gray2 db mb2 pt1">Select an initial read-only audience for your notebook</p>
+          <p className="f9 gray2 db mb2 pt1">Selected ships will be invited to read your notebook. Selected groups will be invited to read and write notes.</p>
           <InviteSearch
             associations={this.props.associations}
             groupResults={true}

--- a/pkg/interface/publish/src/js/components/root.js
+++ b/pkg/interface/publish/src/js/components/root.js
@@ -23,6 +23,7 @@ export class Root extends Component {
     const { props, state } = this;
 
     let contacts = !!state.contacts ? state.contacts : {};
+    let associations = !!state.associations ? state.associations : {contacts: {}}
 
     return (
       <BrowserRouter>
@@ -63,6 +64,7 @@ export class Root extends Component {
             notebooks={state.notebooks}
             contacts={contacts}>
               <NewScreen
+                associations={associations.contacts}
                 notebooks={state.notebooks}
                 groups={state.groups}
                 contacts={contacts}


### PR DESCRIPTION
- If we have group metadata, organise our initialised index of groups as an array of `["endpoint", "title"]`
- When searching, filter against both indexes of the array with `||` so partial matches against either return the group as a result
- Show the title if we have it, otherwise show the endpoint
- If group results are disabled then group metadata can be exempted as a prop without a resulting crash. 

<img width="521" alt="Screen Shot 2020-03-06 at 11 01 39 PM" src="https://user-images.githubusercontent.com/20846414/76136462-c71bab80-5fff-11ea-8ed8-44e3baf36103.png">

If I can flex for a second: I wrote this entire thing in one go, cold, and it just worked. I felt really powerful.

## Additional notes

I don't know if calling `.includes()` on a string that isn't allocated in an array causes a crash (see L101 of invite-search.js in these commits) — but thus far we don't pass groups without the associated group metadata so ... 

I think maybe if we skip the dedupe we do by making an array from the set, and just passed the endpoint twice in those cases, it might fix that edge case. What do you think?