### PR TITLE
groups: sidebar, additional check for safety

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/group-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/group-sidebar.js
@@ -62,6 +62,7 @@ export class GroupSidebar extends Component {
         let groupChannel = `${path}/contacts${path}`
         if (
           props.associations[path] &&
+          props.associations[path][groupChannel] &&
           props.associations[path][groupChannel].metadata
         ) {
           name =


### PR DESCRIPTION
When accepting an invite, the sidebar would crash the application
because we were accessing 'metadata' of undefined -- accessing
too many nested property levels without enough safety.

This commit just adds a check for the intermediate property.