### PR TITLE
arvo: removes looping crash printf

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -624,7 +624,6 @@
     ::
     ++  loop
       ^+  this
-      ~>  %mean.'arvo: loop crashed'
       ?~  run
         this
       ?:  =(~ q.i.run)    :: XX TMI


### PR DESCRIPTION
Does what it says ... This printf is unnecessary, and repeats unpleasantly in stack traces. It was an ill-advised last-minute addition in #2366. Mea culpa.

@jtobin, I'm happy to push one or more pills into this PR if that'd be useful.