### PR TITLE
groups: add max-width for group titles

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/group-detail.js
+++ b/pkg/interface/groups/src/js/components/lib/group-detail.js
@@ -125,7 +125,7 @@ export class GroupDetail extends Component {
           <Link
             className="absolute right-1 f9"
             to={"/~groups/settings" + props.path}>Group Settings</Link>
-          <p className="f9">{title}</p>
+          <p className="f9 mw5 mw3-m mw4-l">{title}</p>
           <p className="f9 gray2">{description}</p>
           <p className="f9">
             {props.group.size + " participant" +


### PR DESCRIPTION
- Really long group titles can overlap with "settings" on smaller viewports, so this is a a bandaid fix to shrink its max-width based on the viewport size.
![image](https://user-images.githubusercontent.com/20846414/76255407-80f36180-6224-11ea-8222-49eeab6c6b22.png)
