### PR TITLE
eyre: upon login redirect parameter being empty, redirect to /

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1101,11 +1101,12 @@
             complete=%.y
         ==
       ::
+      =/  actual-redirect  ?:(=(u.redirect '') '/' u.redirect)
       %-  handle-response
       :*  %start
           :-  status-code=307
           ^=  headers
-            :~  ['location' u.redirect]
+            :~  ['location' actual-redirect]
                 ['set-cookie' cookie-line]
             ==
           data=~


### PR DESCRIPTION
Resolves a long-standing issue where going to the naked /~/login path after already being logged in would return a blank page and not properly redirect.