### PR TITLE
publish: naive visual fix for publish body scrollbar-overlap

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/comment-item.js
+++ b/pkg/interface/publish/src/js/components/lib/comment-item.js
@@ -53,7 +53,7 @@ export class CommentItem extends Component {
 
     return (
       <div>
-        <div className="flex mv3 bg-white bg-gray0-d">
+        <div className="flex mv3 bg-white bg-gray0-d w-50 w-100-m center">
         <Sigil
           ship={commentData.author}
           size={24}
@@ -66,7 +66,7 @@ export class CommentItem extends Component {
           </div>
           <div className="f9 gray3 pt1">{date}</div>
         </div>
-        <div className="f8 lh-solid mb8 mb2">
+        <div className="f8 lh-solid mb8 mb2 w-50 w-100-m w-100-s center">
           {content}
         </div>
       </div>

--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -58,7 +58,7 @@ export class Comments extends Component {
 
     return (
       <div>
-        <div className="mv8">
+        <div className="mv8 w-50 w-100-m w-100-s center">
           <div>
             <textarea style={{resize:'vertical'}}
               ref={(el) => {this.textArea = el}}

--- a/pkg/interface/publish/src/js/components/lib/note-navigation.js
+++ b/pkg/interface/publish/src/js/components/lib/note-navigation.js
@@ -22,14 +22,14 @@ export class NoteNavigation extends Component {
       nextComponent =
       <Link to={nextUrl} className="di flex-column flex-auto tr w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Next</div>
-        <div className="f9 mb1 truncate">{this.props.next.title}</div>
+        <div className="f9 mb1 ml3 truncate">{this.props.next.title}</div>
         <div className="f9 gray2">{this.props.next.date}</div>
       </Link>
 
       prevComponent =
       <Link to={prevUrl} className="di flex-column flex-auto w-100 pv6 bt br bb b--gray3">
         <div className="f9 gray2 mb2">Previous</div>
-        <div className="f9 mb1 truncate">{this.props.prev.title}</div>
+        <div className="f9 mb1 mr3 truncate">{this.props.prev.title}</div>
         <div className="f9 gray2">{this.props.prev.date}</div>
       </Link>
 
@@ -38,7 +38,7 @@ export class NoteNavigation extends Component {
       prevComponent =
       <Link to={prevUrl} className="di flex-column flex-auto w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Previous</div>
-        <div className="f9 mb1 truncate">{this.props.prev.title}</div>
+        <div className="f9 mb1 mr3 truncate">{this.props.prev.title}</div>
         <div className="f9 gray2">{this.props.prev.date}</div>
       </Link>
     } else if (this.props.next) {
@@ -46,14 +46,14 @@ export class NoteNavigation extends Component {
       nextComponent =
       <Link to={nextUrl} className="di flex-column flex-auto tr w-100 pv6 bt bb b--gray3">
         <div className="f9 gray2 mb2">Next</div>
-        <div className="f9 mb1 truncate">{this.props.next.title}</div>
+        <div className="f9 mb1 ml3 truncate">{this.props.next.title}</div>
         <div className="f9 gray2">{this.props.next.date}</div>
       </Link>
 
     }
 
     return (
-        <div className="flex pt4">
+        <div className="flex pt4 w-50 w-100-m w-100-s center">
           {prevComponent}
           {nextComponent}
         </div>

--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -165,7 +165,7 @@ export class Note extends Component {
               popout={props.popout}
               sidebarShown={props.sidebarShown}
             />
-            <Link className="f9 w-100 w-90-m w-90-l mw6 tl" to={baseUrl}>
+            <Link className="f9 w-50 w-100-m w-100-s center tl" to={baseUrl}>
               {"<- Notebook index"}
             </Link>
             <Link
@@ -178,8 +178,8 @@ export class Note extends Component {
               />
             </Link>
           </div>
-          <div className="w-100 mw6 overflow-container">
-            <div className="flex flex-column">
+          <div className="w-100 center overflow-container">
+            <div className="w-50 w-100-m w-100-s center flex flex-column">
               <div className="f9 mb1"
               style={{overflowWrap: "break-word"}}>{title}</div>
               <div className="flex mb6">
@@ -193,7 +193,7 @@ export class Note extends Component {
                   <span className="f9 gray2">{date}</span><span className="ml2">{editPost}</span></div>
               </div>
             </div>
-            <div className="md"
+            <div className="md w-50 w-100-m w-100-s center"
             style={{overflowWrap: "break-word"}}>
               <ReactMarkdown source={newfile} />
             </div>


### PR DESCRIPTION
As mentioned in the commit title, please keep in mind this is a "very naive" fix to the mentioned issue of "scrollbar overlap" over the publish body content.

This definitely needs more work in order to make the interface properly responsive and legible on larger/smaller screens, but it serves as a proof of itent for laptop-sized screens.

Will discuss more in PR comments.