### PR TITLE
eth-watcher: reduce required number of confirmations

### DIFF
--- a/pkg/arvo/ted/eth-watcher.hoon
+++ b/pkg/arvo/ted/eth-watcher.hoon
@@ -80,7 +80,7 @@
   |=  [pup=watchpup =latest=number:block]
   =/  m  (strand:strandio ,watchpup)
   ^-  form:m
-  =/  zoom-margin=number:block  100
+  =/  zoom-margin=number:block  30
   =/  zoom-step=number:block  100.000
   ?:  (lth latest-number (add number.pup zoom-margin))
     (pure:m pup)


### PR DESCRIPTION
To 30 blocks + 30 blocks + 0-5 minutes == about 15 minutes total.
Further reduction should be possible, but requires changing the
algorithm a bit.  We don't want to reduce the number of confirmations
below about 30, though, since we don't handle reorganizations well.

See #2414.