### PR TITLE
publish: make 'edit post' button transparent

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/edit-post.js
+++ b/pkg/interface/publish/src/js/components/lib/edit-post.js
@@ -98,7 +98,7 @@ export class EditPost extends Component {
             popout={props.popout}
           />
           <button
-            className="v-mid w-100 mw6 tl h1 pl4"
+            className="v-mid bg-transparent w-100 mw6 tl h1 pl4"
             disabled={!state.submit}
             style={submitStyle}
             onClick={this.postSubmit}>


### PR DESCRIPTION
Previously, the button was filled in white — looking icky in dark mode.

<img width="446" alt="image" src="https://user-images.githubusercontent.com/20846414/76373652-6b129900-6317-11ea-8f2d-43add7430df9.png">
