### PR TITLE
chat: splice, URL test and send mixed content messages

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/message.js
+++ b/pkg/interface/chat/src/js/components/lib/message.js
@@ -100,7 +100,7 @@ export class Message extends Component {
           rel="noopener noreferrer">
             {letter.url}
         </a>
-        <a className="f7 pointer lh-copy v-top"
+        <a className="ml2 f7 pointer lh-copy v-top"
         onClick={e => this.unFoldEmbed()}>
           [embed]
           </a>


### PR DESCRIPTION
Cuts up a message by gaps in the message, removes the URLs and reattaches the message content with the gaps intact; sends the URLs as separate messages after it.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/20846414/76376648-30acfa00-631f-11ea-9e87-743d4d768bf5.png">