### PR TITLE
chat: revert #2295, #2371 — restores previous scroll implementation

### DIFF
--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -33,7 +33,6 @@ export class ChatScreen extends Component {
 
  componentDidMount() {
    this.updateReadNumber();
-   this.scrollToBottom("auto");
  }
 
  componentWillUnmount() {

--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -23,7 +23,6 @@ export class ChatScreen extends Component {
 
    this.hasAskedForMessages = false;
    this.onScroll = this.onScroll.bind(this);
-   this.messages = this.messagesWithPending.bind(this);
 
    this.updateReadInterval = setInterval(
      this.updateReadNumber.bind(this),
@@ -50,7 +49,6 @@ export class ChatScreen extends Component {
      `/${props.match.params.ship}/${props.match.params.station}` :
      `/${props.match.params[1]}/${props.match.params.ship}/${props.match.params.station}`;
 
-   // Switched chats
    if (
      prevProps.match.params.station !== props.match.params.station ||
      prevProps.match.params.ship !== props.match.params.ship
@@ -65,7 +63,7 @@ export class ChatScreen extends Component {
          scrollLocked: false
        },
        () => {
-         this.scrollToBottom("auto");
+         this.scrollToBottom();
          this.updateReadInterval = setInterval(
            this.updateReadNumber.bind(this),
            1000
@@ -73,18 +71,13 @@ export class ChatScreen extends Component {
          this.updateReadNumber();
        }
      );
-   // Switched to chat
    } else if (props.chatInitialized && !(station in props.inbox)) {
      props.history.push("/~chat");
-   // A new message came in, other cases
-   } else {
-    this.scrollToBottom("auto");
-    if (
+   } else if (
      props.envelopes.length - prevProps.envelopes.length >=
      200
-    ) {
+   ) {
      this.hasAskedForMessages = false;
-    }
    }
  }
 
@@ -121,9 +114,9 @@ export class ChatScreen extends Component {
    }
  }
 
- scrollToBottom(behavior = 'smooth') {
+ scrollToBottom() {
    if (!this.state.scrollLocked && this.scrollElement) {
-     this.scrollElement.scrollIntoView({ behavior });
+     this.scrollElement.scrollIntoView({ behavior: "smooth" });
    }
  }
 
@@ -178,9 +171,12 @@ export class ChatScreen extends Component {
    }
  }
 
- messagesWithPending() {
+ render() {
    const { props, state } = this;
+
    let messages = props.envelopes.slice(0);
+
+   let lastMsgNum = messages.length > 0 ? messages.length : 0;
 
    if (messages.length > 100 * state.numPages) {
      messages = messages.slice(
@@ -197,24 +193,18 @@ export class ChatScreen extends Component {
      return (value.pending = true);
    });
 
-   return messages.concat(pendingMessages);
- }
+   let reversedMessages = messages.concat(pendingMessages);
+   reversedMessages = reversedMessages.reverse();
 
- render() {
-   const { props } = this;
-
-   const lastMsgNum = props.envelopes.slice(0) > 0 ? props.envelopes.slice(0) : 0
-   const messages = this.messagesWithPending();
-
-   const messagesFragment = messages.map((msg, i) => {
+   reversedMessages = reversedMessages.map((msg, i) => {
      // Render sigil if previous message is not by the same sender
      let aut = ["author"];
      let renderSigil =
-       _.get(messages[i - 1], aut) !==
+       _.get(reversedMessages[i + 1], aut) !==
        _.get(msg, aut, msg.author);
      let paddingTop = renderSigil;
      let paddingBot =
-       _.get(messages[i - 1], aut) !==
+       _.get(reversedMessages[i - 1], aut) !==
        _.get(msg, aut, msg.author);
 
      return (
@@ -230,7 +220,7 @@ export class ChatScreen extends Component {
      );
    });
 
-   const group = Array.from(props.group.values());
+   let group = Array.from(props.group.values());
 
    const isinPopout = props.popout ? "popout/" : "";
 
@@ -281,14 +271,14 @@ export class ChatScreen extends Component {
          />
        </div>
        <div
-         className="overflow-y-scroll bg-white bg-gray0-d pt3 pb2 flex flex-column"
+         className="overflow-y-scroll bg-white bg-gray0-d pt3 pb2 flex flex-column-reverse"
          style={{ height: "100%", resize: "vertical" }}
          onScroll={this.onScroll}>
-         {messagesFragment}
          <div
            ref={el => {
              this.scrollElement = el;
            }}></div>
+         {reversedMessages}
        </div>
        <ChatInput
          api={props.api}


### PR DESCRIPTION
Closes #2421. Reopens #2024, #2331. With apologies to @litpub.

The tradeoff costs of the implementation in #2295 were judged too high for being used in production right now — as we head into OS1 launch we decided as a team that the best solution for the moment is to go back to the previous experience, working on everything but FF's scroll; rather than having scrollback jumping to the bottom on new messages.

Additionally, @loganallenc said he already investigated the intersectionObserver API discussed in #2421 about a year or so ago and this implementation was the best tradeoff he had. Thus, we are in the position to have to just revert this for now.

## Additional notes for observers
This weird flexbox issue is at least making a bit of progress at Mozilla — they've marked it [on their shortlist of bugs to fix this year](https://bugzilla.mozilla.org/show_bug.cgi?id=1042151#c49), and at least took it out of `wont-fix`.