### PR TITLE
publish: add -m, -l widths for edit post button

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/edit-post.js
+++ b/pkg/interface/publish/src/js/components/lib/edit-post.js
@@ -98,7 +98,7 @@ export class EditPost extends Component {
             popout={props.popout}
           />
           <button
-            className="v-mid bg-transparent w-100 mw6 tl h1 pl4"
+            className="v-mid bg-transparent w-100 w-80-m w-90-l mw6 tl h1 pl4"
             disabled={!state.submit}
             style={submitStyle}
             onClick={this.postSubmit}>


### PR DESCRIPTION
On smaller screens the "Save post" button would overlap with the sidebar switch — this just does the same thing as [45af92c](https://github.com/urbit/urbit/pull/2317/commits/45af92c173e3de0de443a121d24e3b44eee87c24#diff-937cf0ac21da74e0283462b4bf02930bR161) to get it out of the way...

<img width="288" alt="image" src="https://user-images.githubusercontent.com/20846414/76379831-99987000-6327-11ea-8b52-eecc1a2cf9dd.png">
