### PR TITLE
link-proxy-hook: correctly scry initial response

### DIFF
--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -274,10 +274,10 @@
     [%give %fact ~ %link-initial !>(initial)]
   ?+  path  !!
       [%local-pages ^]
-    [%local-pages .^((map ^path pages) %gx path)]
+    [%local-pages (scry-for (map ^path pages) %link-store path)]
   ::
       [%annotations %$ ^]
-    [%annotations .^((per-path-url notes) %gx %$ t.t.path)]
+    [%annotations (scry-for (per-path-url notes) %link-store path)]
   ==
 ::
 ++  start-proxy


### PR DESCRIPTION
Was using "manual" scries, and incorrect ones at that. Would crash, causing
subscriptions to not go through. Now uses the helper function and correct paths.