### PR TITLE
apps: augment with /lib/dbug

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -6,7 +6,7 @@
     *invite-store,
     *metadata-hook,
     *metadata-store
-/+  *contact-json, default-agent
+/+  *contact-json, default-agent, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -22,6 +22,7 @@
 --
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  bol=bowl:gall

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -1,6 +1,6 @@
 :: contact-store: data store that holds group-based contact data
 ::
-/+  *contact-json, default-agent
+/+  *contact-json, default-agent, dbug
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -18,6 +18,7 @@
 ::
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -9,7 +9,7 @@
     *metadata-hook,
     *permission-group-hook,
     *permission-hook
-/+  *server, *contact-json, default-agent
+/+  *server, *contact-json, default-agent, dbug
 /=  index
   /^  octs
   /;  as-octs:mimes:html
@@ -46,6 +46,7 @@
 +$  card  card:agent:gall
 --
 ::
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -1,7 +1,7 @@
 ::  eth-watcher: ethereum event log collector
 ::
 /-  *eth-watcher, spider
-/+  default-agent, verb
+/+  default-agent, verb, dbug
 =,  ethereum-types
 =,  able:jael
 ::
@@ -57,6 +57,7 @@
 ::
 ::  Main
 ::
+%-  agent:dbug
 ^-  agent:gall
 =|  state=app-state
 %+  verb  |

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -4,7 +4,7 @@
 ::    can be poked by the host team to send an invite out to someone.
 ::    can be poked by foreign ships to send an invite to us.
 ::
-/+  *invite-json, default-agent, verb
+/+  *invite-json, default-agent, verb, dbug
 ::
 |%
 +$  state-0  [%0 ~]
@@ -16,6 +16,7 @@
 =*  state  -
 ::
 %+  verb  |
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -1,4 +1,4 @@
-/+  *invite-json, default-agent
+/+  *invite-json, default-agent, dbug
 |%
 +$  card  card:agent:gall
 ::
@@ -14,6 +14,7 @@
 ::
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  bol=bowl:gall

--- a/pkg/arvo/app/invite-view.hoon
+++ b/pkg/arvo/app/invite-view.hoon
@@ -6,7 +6,7 @@
 ::
 ::TODO  could maybe use /lib/proxy-hook, be renamed invite-proxy-hook
 ::
-/+  *invite-json, default-agent
+/+  *invite-json, default-agent, dbug
 ::
 |%
 +$  card  card:agent:gall
@@ -19,6 +19,8 @@
     ^-  card
     [%pass /store %agent [our %invite-store] %watch /updates]
   --
+::
+%-  agent:dbug
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .

--- a/pkg/arvo/app/launch.hoon
+++ b/pkg/arvo/app/launch.hoon
@@ -1,5 +1,5 @@
 /-  launch
-/+  *server, default-agent
+/+  *server, default-agent, dbug
 ::
 /=  index
   /^  $-(marl manx)
@@ -38,6 +38,7 @@
 ::
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 |_  bol=bowl:gall
 +*  this  .

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -8,7 +8,7 @@
     *invite-store,
     *metadata-store,
     *metadata-hook
-/+  *server, *publish, cram, default-agent
+/+  *server, *publish, cram, default-agent, dbug
 ::
 /=  index
   /^  $-(json manx)
@@ -75,6 +75,7 @@
 ::
 =|  versioned-state
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  bol=bowl:gall

--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -1,4 +1,4 @@
-/+  *server, *server, default-agent
+/+  *server, *server, default-agent, dbug
 /=  tile-js
   /^  octs
   /;  as-octs:mimes:html
@@ -21,6 +21,7 @@
 --
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  bol=bowl:gall


### PR DESCRIPTION
This has proven very valuable for surface-level debugging so far. Looking at state, subscriptions etc. With OS1 support rush in mind, adds /lib/dbug to a handful of apps that didn't have it yet.