### PR TITLE
dbug: allow complex, hoon-based state queries

### DIFF
--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -1,8 +1,12 @@
 ::  +dbug: tell /lib/dbug app to print some generic state
 ::
 ::    :app +dbug
+::      the entire state
+::    :app +dbug %bowl
 ::      the entire bowl
-::    :app +dbug [direction] [specifics]
+::    :app +dbug [%state 'thing']
+::      data at thing.state. allows for complex hoon, like '(lent thing)'
+::    :app +dbug [direction specifics]
 ::      all in subs matching the parameters
 ::      direction: %incoming or %outgoing
 ::      specifics:
@@ -19,14 +23,14 @@
         *
         ::  inline arguments
         ::
-        args=?(~ [what=?(%bowl %state) ~] [=what =about ~])
+        args=?(~ [what=?(%bowl %state) ~] [=poke ~])
         ::  named arguments
         ::
         ~
     ==
 :-  %dbug
 ?-  args
-  ~        [%state *about]
-  [@ ~]    [what.args *about]
-  [@ * ~]  [what about]:args
+  ~          [%state '']
+  [@ ~]      ?-(what.args %bowl [%bowl ~], %state [%state ''])
+  [[@ *] ~]  poke.args
 ==

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -3,11 +3,11 @@
 ::    usage: %-(agent:dbug your-agent)
 ::
 |%
-+$  what
-  $?  %bowl
-      %state
-      %incoming
-      %outgoing
++$  poke
+  $%  [%bowl ~]
+      [%state grab=cord]
+      [%incoming =about]
+      [%outgoing =about]
   ==
 ::
 +$  about
@@ -31,12 +31,17 @@
       =^  cards  agent  (on-poke:ag mark vase)
       [cards this]
     =/  dbug
-      !<([=what =about] vase)
+      !<(poke vase)
     =;  out=^vase
       ((slog (sell out) ~) [~ this])
-    ?-  what.dbug
+    ?-  -.dbug
       %bowl   !>(bowl)
-      %state  on-save:ag
+    ::
+        %state
+      =?  grab.dbug  =('' grab.dbug)  '-'
+      %+  slap
+        (slop on-save:ag !>([bowl=bowl ..zuse]))
+      (ream grab.dbug)
     ::
         %incoming
       !>


### PR DESCRIPTION
`+dbug [%state 'some-hoon']` now allows you to run `some-hoon` against the
application's state. That hoon has access to the bowl and stdlib for
more dbugging convenience.

Behold:

```hoon
> :chat-store +dbug [%state '~(key by inbox)']
{[i=~.~ t=/~dev/hello]}
```

Some applications, like chat-store, accrue enormous amounts of state. Being able to poke at that more granularly will likely prove useful in debugging issues with those applications.