### PR TITLE
behn: drop drip failures

### DIFF
--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -101,7 +101,10 @@
         [duct card]
       =/  =tang
         (weld u.error `tang`[leaf/"drip failed" ~])
-      [duct %hurl fail/tang card]
+      ::  XX should be
+      ::  [duct %hurl fail/tang card]
+      ::
+      [duct %pass /drip-slog %d %flog %crud %drip-fail tang]
     event-core(moves [move moves])
   ::  +trim: in response to memory pressue
   ::


### PR DESCRIPTION
Restores previous behavior.  This is wrong, but without it we fail when
vanes (specifically Ford) crash on goof.

Confirmed this works on a localhost version of ~pem.  To access +repn from the dojo, I then had to run `|wipe-ford 100`.  I assume os1 does this kind of thing programmatically.  Regardless, os1 should be tested as an OTA directly on top of this.