### PR TITLE
chat: split and send mixed messages sequentially

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -150,33 +150,43 @@ export class ChatInput extends Component {
       return;
     }
 
-    let URLs = [];
-    let letter = state.message.split(" ").map((each) => {
+    let message = [];
+    state.message.split(" ").map((each) => {
       if (this.isUrl(each)) {
+        if (message.length > 0) {
+          message = message.join(" ");
+          message = this.getLetterType(message);
+          props.api.chat.message(
+            props.station,
+            `~${window.ship}`,
+            Date.now(),
+            message
+          );
+          message = [];
+        }
         let URL = this.getLetterType(each);
-        URLs.push(URL);
+        props.api.chat.message(
+          props.station,
+          `~${window.ship}`,
+          Date.now(),
+          URL
+        );
       }
       else {
-        return each;
+        return message.push(each);
       }
-    }).join(" ");
+    })
 
-    letter = this.getLetterType(letter);
-
-    props.api.chat.message(
-      props.station,
-      `~${window.ship}`,
-      Date.now(),
-      letter
-    );
-
-    for (let each of URLs) {
+    if (message.length > 0) {
+      message = message.join(" ");
+      message = this.getLetterType(message);
       props.api.chat.message(
         props.station,
         `~${window.ship}`,
         Date.now(),
-        each
+        message
       );
+      message = [];
     }
 
     // perf: setTimeout(this.closure, 2000);


### PR DESCRIPTION
Hot and cold in that order. This amends the behaviour of messages
with text and URLs to submit them in order of found URL,
instead of batching the URLs at the end.

Same message, before and after:

<img width="299" alt="Screen Shot 2020-03-12 at 9 44 41 PM" src="https://user-images.githubusercontent.com/20846414/76581780-f3757300-64aa-11ea-8d16-26ba030ef068.png">
