### PR TITLE
launch: stop passing 'invite' prop to tiles

### DIFF
--- a/pkg/interface/launch/src/js/components/home.js
+++ b/pkg/interface/launch/src/js/components/home.js
@@ -22,8 +22,8 @@ export default class Home extends Component {
         tileData = this.props.data[tile] !== null
           ? this.props.data[tile] : {};
 
-        tileData["invites"] = ("invites" in this.props.data)
-        ? this.props.data["invites"] : {};
+        // tileData["invites"] = ("invites" in this.props.data)
+        // ? this.props.data["invites"] : {};
       }
       return <Tile key={tile} type={tile} data={tileData} />;
     });


### PR DESCRIPTION
Closes #2472.

If you set the weather it currently crashes the launch screen because it tries to set an invites property on a string. 

Since the invite append behaviour was intended for the groups tile, I'm just commenting it out here to prevent the crash, and to go later at integrating invite numbers across all tiles at once (if we even want to do that — we've been discussing the flows a lot lately). 