### PR TITLE
weather: redirect after autodetect submission

### DIFF
--- a/pkg/interface/weather/tile/tile.js
+++ b/pkg/interface/weather/tile/tile.js
@@ -23,6 +23,7 @@ export default class WeatherTile extends Component {
       }, { maximumAge: Infinity, timeout: 10000 });
       api.action("clock", "json", latlng);
       api.action('weather', 'json', latlng);
+      this.setState({ manualEntry: !this.state.manualEntry });
     });
   }
 


### PR DESCRIPTION
Closes #2473.

Autodetect doesn't redirect after it's done. 

It submits fine, but people can be confused. (The clock doesn't update to be colourful either but that's patched in #2471 — it's also possible that 2471 fixes some wonky weather behaviours too.) 

With both of these patches, though, weather should be restored to normal.