### PR TITLE
chat: groupify

### DIFF
--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -440,16 +440,24 @@
 ++  envelope-scry
   |=  pax=path
   ^-  (list envelope)
-  =.  pax  ;:(weld /=chat-store/(scot %da now.bol)/envelopes pax /noun)
-  .^((list envelope) %gx pax)
+  (scry-for (list envelope) %chat-store [%envelopes pax])
 ::
 ++  configs-scry
   ^-  chat-configs
-  .^(chat-configs %gx /=chat-store/(scot %da now.bol)/configs/noun)
+  (scry-for chat-configs %chat-store /configs)
 ::
 ++  group-scry
   |=  pax=path
   ^-  (unit group)
-  .^((unit group) %gx ;:(weld /=group-store/(scot %da now.bol) pax /noun))
+  (scry-for (unit group) %group-store pax)
 ::
+++  scry-for
+  |*  [=mold app=term =path]
+  .^  mold
+    %gx
+    (scot %p our.bol)
+    app
+    (scot %da now.bol)
+    (snoc `^path`path %noun)
+  ==
 --

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -245,6 +245,46 @@
         (permission-hook-poke [%add-synced ship.act group-path])
         (metadata-hook-poke [%add-synced ship.act group-path])
     ==
+  ::
+      %groupify
+    ?>  ?=([%'~' ^] app-path.act)
+    =/  data=(unit mailbox)
+      (scry-for (unit mailbox) %chat-store [%mailbox app-path.act])
+    ?~  data
+      ~&  [%cannot-groupify-nonexistent app-path.act]
+      ~
+    =/  permission=(unit permission)
+      (scry-for (unit permission) %permission-store [%permission app-path.act])
+    ?:  |(?=(~ permission) ?=(%black kind.u.permission))
+      ~&  [%cannot-groupify-blacklist app-path.act]
+      ~
+    =/  =metadata
+      =-  (fall - *metadata)
+      %^  scry-for  (unit metadata)
+        %metadata-store
+      =/  encoded-path=@ta
+        (scot %t (spat app-path.act))
+      /metadata/[encoded-path]/chat/[encoded-path]
+    =/  new-path=^path  (slag 1 `path`app-path.act)
+    =/  members=(set ship)
+      %+  fall
+        (group-scry app-path.act)
+      *(set ship)
+    =/  cards-1=(list card)
+        (poke-chat-view-action %delete app-path.act)
+    =/  cards-2=(list card)
+      %-  poke-chat-view-action
+      :*  %create
+          title.metadata
+          description.metadata
+          new-path
+          new-path
+          %village
+          members
+          &
+      ==
+    %+  snoc  (weld cards-1 cards-2)
+    (chat-poke %messages new-path envelopes.u.data)
   ==
   ::
   ++  create-chat

--- a/pkg/arvo/lib/chat-json.hoon
+++ b/pkg/arvo/lib/chat-json.hoon
@@ -258,6 +258,7 @@
     :~  [%create create]
         [%delete delete]
         [%join join]
+        [%groupify groupify]
     ==
   ::
   ++  create
@@ -280,6 +281,9 @@
         [%app-path pa]
         [%ask-history bo]
     ==
+  ::
+  ++  groupify
+    (ot [%app-path pa] ~)
   ::
   ++  sec
     =,  dejs:format

--- a/pkg/arvo/sur/chat-view.hoon
+++ b/pkg/arvo/sur/chat-view.hoon
@@ -12,5 +12,12 @@
       ==
       [%delete app-path=path]
       [%join =ship app-path=path ask-history=?]
+      ::  %groupify: for unmanaged %village chats: recreate as group-based chat
+      ::
+      ::    will delete the old chat, recreate it based on a proper group,
+      ::    and invite the current whitelist to that group.
+      ::    existing messages get moved over.
+      ::
+      [%groupify app-path=path]
   ==
 --

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -24,6 +24,7 @@ class UrbitApi {
       create: this.chatViewCreate.bind(this),
       delete: this.chatViewDelete.bind(this),
       join: this.chatViewJoin.bind(this),
+      groupify: this.chatViewGroupify.bind(this)
     };
 
     this.chatHook = {
@@ -172,6 +173,10 @@ class UrbitApi {
         'ask-history': askHistory
       }
     });
+  }
+
+  chatViewGroupify(path) {
+    return this.chatViewAction({ groupify: { 'app-path': path } });
   }
 
   inviteAction(data) {

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -259,6 +259,11 @@ export class Root extends Component {
 
               let popout = props.match.url.includes("/popout/");
 
+              let permission = state.permissions[station] || {
+                kind: "",
+                who: new Set([])
+              };
+              
               let association =
                 station in associations["chat"] ? associations.chat[station] : {};
 
@@ -274,6 +279,7 @@ export class Root extends Component {
                     {...props}
                     station={station}
                     association={association}
+                    permission={permission}
                     api={api}
                     station={station}
                     group={group}

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -76,7 +76,22 @@ export class SettingsScreen extends Component {
     props.api.setSpinner(true);
 
     this.setState({
-      isLoading: true
+      isLoading: true,
+      loadingText: (deSig(props.match.params.ship) === window.ship)
+        ? 'Deleting...'
+        : 'Leaving...'
+    });
+  }
+
+  groupifyChat() {
+    const { props, state } = this;
+
+    props.api.chatView.groupify(props.station);
+    props.api.setSpinner(true);
+
+    this.setState({
+      isLoading: true,
+      loadingText: 'Converting...'
     });
   }
 
@@ -104,6 +119,33 @@ export class SettingsScreen extends Component {
       </div>
       </div>
     );
+  }
+
+  renderGroupify() {
+    const { props, state } = this;
+
+    const chatOwner = (deSig(props.match.params.ship) === window.ship);
+    console.log(chatOwner, props.match.params.ship, window.ship);
+
+    const ownedUnmanagedVillage =
+      chatOwner &&
+      props.station.slice(0, 3) === '/~/' &&
+      props.permission.kind === 'white';
+
+    if (!ownedUnmanagedVillage) {
+      return null;
+    } else {
+      return (
+        <div>
+          <div className={"w-100 fl mt3 "}>
+            <p className="f8 mt3 lh-copy db">Convert Chat</p>
+            <p className="f9 gray2 db mb4">Convert this chat into a group + associated chat.</p>
+            <a onClick={this.groupifyChat.bind(this)}
+               className={"dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer"}>Convert to group</a>
+          </div>
+        </div>
+      );
+    }
   }
 
   renderMetadataSettings() {
@@ -210,10 +252,7 @@ export class SettingsScreen extends Component {
     let writeGroup = Array.from(props.group.values());
 
     if (!!state.isLoading) {
-      let text = "Deleting...";
-      if (deSig(props.match.params.ship) !== window.ship) {
-        text = "Leaving...";
-      }
+      let text = state.loadingText || 'Working...';
 
       let title = props.station.substr(1);
 
@@ -321,6 +360,7 @@ export class SettingsScreen extends Component {
               </span>
             </div>
           </div>
+          {this.renderGroupify()}
           {this.renderDelete()}
           {this.renderMetadataSettings()}
         </div>

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -139,7 +139,9 @@ export class SettingsScreen extends Component {
         <div>
           <div className={"w-100 fl mt3 "}>
             <p className="f8 mt3 lh-copy db">Convert Chat</p>
-            <p className="f9 gray2 db mb4">Convert this chat into a group + associated chat.</p>
+            <p className="f9 gray2 db mb4">
+              Convert this chat into a group with associated chat.
+            </p>
             <a onClick={this.groupifyChat.bind(this)}
                className={"dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer"}>Convert to group</a>
           </div>


### PR DESCRIPTION
Allows users to upgrade invite-only chats into full-fledged groups (with an associated chat). Relies on largely on existing chat-view logic to move things around (delete the old chat, create the new one, copy messages & metadata over).

Frontend copy might need another pass, but shouldn't be awful as-is.