### PR TITLE
contact-hook: re-establish connection to group-store if subscription …

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -12,15 +12,17 @@
 ::
 +$  versioned-state
   $%  state-zero
+      state-one
   ==
 ::
-+$  state-zero
-  $:  %0
-      synced=(map path ship)
++$  state-zero  [%0 state-base]
++$  state-one   [%1 state-base]
++$  state-base
+  $:  synced=(map path ship)
       invite-created=_|
   ==
 --
-=|  state-zero
+=|  state-one
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
@@ -40,8 +42,18 @@
     ==
   ++  on-save   !>(state)
   ++  on-load
-    |=  old=vase
-    `this(state !<(state-zero old))
+    |=  old-vase=vase
+    ^-  (quip card _this)
+    =/  old  !<(versioned-state old-vase)
+    ?:  ?=(%1 -.old)
+      [~ this(state old)]
+    =/  upgraded-state
+      %*  .  *state-one
+          synced  synced
+          invite-created  invite-created
+      ==
+    :_  this(state upgraded-state)
+    [%pass /group %agent [our.bol %group-store] %watch /updates]~
   ::
   ++  on-poke
     |=  [=mark =vase]


### PR DESCRIPTION
…failed during ota

This fixes the issue where members added to a group would occasionally not be sent an invite.