### PR TITLE
ames: noop on spurious %done from gall

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3229,6 +3229,8 @@
     ::  no-op on spurious response from vane due to gall breach bug
     ::
     ?:  =(~ pending-vane-ack.state)
+      =/  dat  ok^her.channel^her-life.channel
+      ~>  %slog.0^leaf/"ames: ignoring spurious %done {<dat>}"
       message-sink
     ::
     =^  pending  pending-vane-ack.state  ~(get to pending-vane-ack.state)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3226,6 +3226,10 @@
   ++  on-done
     |=  ok=?
     ^+  message-sink
+    ::  no-op on spurious response from vane due to gall breach bug
+    ::
+    ?:  =(~ pending-vane-ack.state)
+      message-sink
     ::
     =^  pending  pending-vane-ack.state  ~(get to pending-vane-ack.state)
     =/  =message-num  message-num.p.pending


### PR DESCRIPTION
This is a temporary workaround to get some of our galaxies and stars unstuck.  Each of these stuck ships is currently blocked on processing an input queue to an agent that got started after a peer that has since breached sent moves to it.  Since Ames no longer remembers any state about the peer, when the agent processes the move, Gall gives a %done to Ames that Ames doesn't understand.

To work around this, Ames should no-op when it receives this spurious %done, so that the rest of the agent's input queue can be drained without crashing.

I'm in the process of testing this now.