### PR TITLE
chat-cli: ensure bound map is sorted

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -185,7 +185,7 @@
   ::
   ^-  state-1
   ?-  -.u.old
-    %1  u.old(width 80)
+    %1  u.old(bound (~(gas by *(map target glyph)) ~(tap by bound.u.old)))
   ::
       ?(~ ^)
     :-  %1
@@ -200,7 +200,7 @@
     ::
         bound
       ^-  (map target glyph)
-      %-  ~(gas in *(map target glyph))
+      %-  ~(gas by *(map target glyph))
       %+  turn  ~(tap by bound.u.old)
       |=  [t=[ship path] g=glyph]
       [`target`[| t] g]


### PR DESCRIPTION
During upgrade, we gassed _in_ a map, instead of _by_, causing it to use
set-style sorting, leading to incorrect lookups.

This fixes that upgrade logic, and re-builds the map for existing instances.

(idk what the width configuration was doing there for the previous upgrade-to-same case.)

Fixes #2478.