### PR TITLE
soto: allow paste functionality on right-click

### DIFF
--- a/pkg/interface/soto/src/js/components/input.js
+++ b/pkg/interface/soto/src/js/components/input.js
@@ -79,7 +79,16 @@ render() {
         cursor={this.props.cursor}
         onClick={e => store.setState({ cursor: e.target.selectionEnd })}
         onKeyDown={this.keyPress}
-        onPaste={e => {e.preventDefault()}}
+        onPaste={e => {
+          let clipboardData = e.clipboardData || window.clipboardData;
+          let paste = Array.from(clipboardData.getData('Text'));
+          paste.reduce(async (previous, next) => {
+            await previous;
+            this.setState({cursor: this.props.cursor + 1});
+            return store.doEdit({ ins: { cha: next, at: this.props.cursor } });
+          }, Promise.resolve());
+          e.preventDefault();
+          }}
         ref={this.inputRef}
         defaultValue={this.props.input}
       />


### PR DESCRIPTION
When we make a Dojo session, we use Sole to communicate between Dojo and whatever interface we have, transmitting each keystroke as you type and dynamically correcting as you go. This makes things a bit difficult for pasting, because you need to input each keystroke in series without losing track of the state on either side.

This commit sequentially resolves keystroke transmission promises, waiting for each to be confirmed before continuing. Seems to work in all browsers, had a hiccup that only happened one time in Firefox where later ones came first? But then it worked fine the time after that.

This is right click only for now, but I can figure out how to programmatically grab ctrl+v / cmd+v later...