### PR TITLE
launch: don't render blank invites tile

### DIFF
--- a/pkg/interface/launch/src/js/components/home.js
+++ b/pkg/interface/launch/src/js/components/home.js
@@ -25,7 +25,9 @@ export default class Home extends Component {
         // tileData["invites"] = ("invites" in this.props.data)
         // ? this.props.data["invites"] : {};
       }
-      return <Tile key={tile} type={tile} data={tileData} />;
+      if (tile !== "invites") {
+        return <Tile key={tile} type={tile} data={tileData} />;
+      }
     });
 
     let headerData = {};


### PR DESCRIPTION
You see this gap in the top left?

![image](https://user-images.githubusercontent.com/20846414/76670948-dd7ab780-6569-11ea-9f79-4a3d4df529dd.png)

It's a blank tile for invites, now that we subscribe to them. I thought I was filtering it out — since it's kind of infrequent that you see this gap — but now it specifically doesn't return a tile for it.