### PR TITLE
chat: use more precise regex for splitting messages

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -134,8 +134,7 @@ export class ChatInput extends Component {
   isUrl(string) {
     try {
       let websiteTest = new RegExp(''
-        + /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}/.source
-        + /\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.source
+      + /((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)/.source
       );
       return websiteTest.test(string);
     } catch (e) {


### PR DESCRIPTION
See some chatter in #2454.

Current URL regex is getting too many false positives, cutting up debug conversations. Replacing with one that only matches positive if there's a schema in front:

- www.google.com doesn't match. img.jpg doesn't match. a base hash won't match.
- https://google.com will match.
- dat://wogjerpgorejgiuohg3oigh3g03ihtq3.onion will match.

cc @ixv 
