### PR TITLE
chat: remove "#" from fallback sigil color in chat input

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -200,7 +200,7 @@ export class ChatInput extends Component {
   readOnlyRender() {
     const { props } = this;
     let color = !!props.ownerContact
-      ? uxToHex(props.ownerContact.color) : '#000000';
+      ? uxToHex(props.ownerContact.color) : '000000';
 
     let sigilClass = !!props.ownerContact
       ? "" : "mix-blend-diff";
@@ -230,7 +230,7 @@ export class ChatInput extends Component {
     const { props, state } = this;
 
     let color = !!props.ownerContact
-      ? uxToHex(props.ownerContact.color) : '#000000';
+      ? uxToHex(props.ownerContact.color) : '000000';
 
     let sigilClass = !!props.ownerContact
       ? "" : "mix-blend-diff";


### PR DESCRIPTION
Closes #2499.

In the chat input we fall back to `#000000` and blend it; but we also
prefix any colour we send to the sigil component with a `#` for
`uxToHex` values, so we end up passing `##000000`. This results
in simplified sigils -- when in doubt, ensure the hex formatting
is correct...