### PR TITLE
arvo: add web app manifest to launch app

### DIFF
--- a/pkg/arvo/app/launch/index.hoon
+++ b/pkg/arvo/app/launch/index.hoon
@@ -3,11 +3,13 @@
   ;head
     ;title: Home
     ;meta(charset "utf-8");
-    ;meta
-      =name     "viewport"
-      =content  "width=device-width, initial-scale=1, shrink-to-fit=no";
-      ;link(rel "stylesheet", href "/~launch/css/index.css");
-      ;link(rel "icon", type "image/png", href "/~launch/img/Favicon.png");
+    ;meta(name "viewport", content "width=device-width, initial-scale=1, shrink-to-fit=no");
+    ;meta(name "apple-mobile-web-app-capable", content "yes");
+    ;meta(name "apple-mobile-web-app-status-bar-style", content "default");
+    ;meta(name "apple-touch-fullscreen", content "yes");
+    ;link(rel "stylesheet", href "/~launch/css/index.css");
+    ;link(rel "icon", type "image/png", href "/~launch/img/Favicon.png");
+    ;link(rel "manifest", href "/~launch/manifest.json");
   ==
   ;body
     ;div#root;

--- a/pkg/arvo/app/launch/manifest.json
+++ b/pkg/arvo/app/launch/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Landscape",
+  "short_name": "Landscape",
+  "description": "A graphical web interface for your Urbit ship.",
+  "display": "standalone",
+  "background_color": "#FFFFFF",
+  "theme_color": "#000000",
+  "icons": [{
+    "src": "/~launch/img/Favicon.png",
+    "sizes": "128x128",
+    "type": "image/png"
+  }]
+}


### PR DESCRIPTION
This commit adds a web app manifest to the launch app so that Landscape can be added to the smartphone home screen and be used standalone (i.e. seperate from the browser) …