### PR TITLE
chat-hook: clear all subscriptions on watch-nack

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -609,10 +609,7 @@
   ::
       [%backlog @ @ @ *]
     =/  pax  `path`(oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
-    =.  synced  (~(del by synced) pax)
-    :_  state
-    :-  [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]
-    %.  ~
+    %.  (poke-chat-hook-action %remove pax)
     %-  slog
     :*  leaf+"chat-hook failed subscribe on {(spud pax)}"
         leaf+"stack trace:"

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -605,7 +605,7 @@
   ?~  saw  [~ state]
   ?+  wir  [~ state]
       [%store @ *]
-    [~ state(synced (~(del by synced) t.wir))]
+    (poke-chat-hook-action %remove t.wir)
   ::
       [%backlog @ @ @ *]
     =/  pax  `path`(oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)


### PR DESCRIPTION
We would remove the entry from state, but not clean up its subscriptions.

Found this trying to join a chat I was in that got deleted, then re-created. It yelled `subscribe wire not unique` at me for `/mailbox/~/~host/chat`.

@loganallenc Perhaps this change should also be made for the `%store` case? But that doesn't do any subscription cleaning rn so I'm less sure. Please confirm sanity on this in general.