### PR TITLE
groups: enable sigil foreground color customization

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -5,10 +5,15 @@
 +$  card  card:agent:gall
 +$  versioned-state
   $%  state-zero
+      state-one
   ==
 ::
 +$  state-zero
   $:  %0
+      rolodex=rolodex-old
+  ==
++$  state-one
+  $:  %1
       =rolodex
   ==
 +$  diff
@@ -16,7 +21,7 @@
   ==
 --
 ::
-=|  state-zero
+=|  state-one
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
@@ -31,8 +36,7 @@
   ++  on-save   !>(state)
   ++  on-load
     |=  old=vase
-    `this(state !<(state-zero old))
-  ::
+    `this(state (upgrade-state !<(versioned-state old)))
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
@@ -161,13 +165,14 @@
   |=  [con=contact edit=edit-field]
   ^-  contact
   ?-  -.edit
-      %nickname  con(nickname nickname.edit)
-      %email     con(email email.edit)
-      %phone     con(phone phone.edit)
-      %website   con(website website.edit)
-      %notes     con(notes notes.edit)
-      %color     con(color color.edit)
-      %avatar    con(avatar avatar.edit)
+      %nickname          con(nickname nickname.edit)
+      %email             con(email email.edit)
+      %phone             con(phone phone.edit)
+      %website           con(website website.edit)
+      %notes             con(notes notes.edit)
+      %background-color  con(background-color background-color.edit)
+      %foreground-color  con(foreground-color foreground-color.edit)
+      %avatar            con(avatar avatar.edit)
   ==
 ::
 ++  send-diff
@@ -178,4 +183,28 @@
     ~[/all /updates [%contacts pax]]
     %contact-update  !>(upd)
   ==  ==
+++  upgrade-state
+  |=  old=versioned-state
+  =?  old  ?=(%0 -.old)
+    (state-0-to-1 old)
+  ?>  ?=(%1 -.old)
+  old
+++  state-0-to-1
+  |=  s=state-zero
+  ^-  state-one
+  :-  %1
+  %-  ~(run by rolodex.s)
+  |=  c=contacts-old
+  %-  ~(run by c)
+  |=  old=contact-old
+  ^-  contact
+  :*  nickname.old
+      email.old
+      phone.old
+      website.old
+      notes.old
+      0xff.ffff
+      color.old
+      avatar.old
+  ==
 --

--- a/pkg/arvo/lib/contact-json.hoon
+++ b/pkg/arvo/lib/contact-json.hoon
@@ -38,7 +38,8 @@
       [%phone s+phone.con]
       [%website s+website.con]
       [%notes s+notes.con]
-      [%color s+(scot %ux color.con)]
+      [%'foregroundColor' s+(scot %ux foreground-color.con)]
+      [%'backgroundColor' s+(scot %ux background-color.con)]
       [%avatar s+'TODO']
   ==
 ::
@@ -46,15 +47,15 @@
   |=  edit=edit-field
   ^-  json
   =,  enjs:format
-  %+  frond  -.edit
   ?-  -.edit
-    %nickname  s+nickname.edit
-    %email     s+email.edit
-    %phone     s+phone.edit
-    %website   s+website.edit
-    %notes     s+notes.edit
-    %color     s+(scot %ux color.edit)
-    %avatar    s+'TODO'
+    %nickname          (frond %nickname s+nickname.edit)
+    %email             (frond %email s+email.edit)
+    %phone             (frond %phone s+phone.edit)
+    %website           (frond %website s+website.edit)
+    %notes             (frond %notes s+notes.edit)
+    %foreground-color  (frond 'foregroundColor' s+(scot %ux foreground-color.edit))
+    %background-color  (frond 'backgroundColor' s+(scot %ux background-color.edit))
+    %avatar            (frond %avatar s+'TODO')
   ==
 ::
 ++  update-to-json
@@ -191,7 +192,8 @@
       [%phone so:dejs:format]
       [%website so:dejs:format]
       [%notes so:dejs:format]
-      [%color nu]
+      [%foreground-color nu]
+      [%background-color nu]
       [%avatar (mu:dejs:format avat)]
   ==
 ::
@@ -202,7 +204,8 @@
       [%phone so:dejs:format]
       [%website so:dejs:format]
       [%notes so:dejs:format]
-      [%color nu]
+      [%foreground-color nu]
+      [%background-color nu]
       [%avatar (mu:dejs:format avat)]
   ==
 --

--- a/pkg/arvo/sur/contact-store.hoon
+++ b/pkg/arvo/sur/contact-store.hoon
@@ -1,5 +1,18 @@
 /-  *identity
 |%
++$  rolodex-old  (map path contacts-old)
+::
++$  contacts-old  (map ship contact-old)
+::
++$  contact-old
+  $:  nickname=@t
+      email=@t
+      phone=@t
+      website=@t
+      notes=@t
+      color=@ux
+      avatar=(unit avatar)
+  ==
 +$  rolodex  (map path contacts)
 ::
 +$  contacts  (map ship contact)
@@ -12,7 +25,8 @@
       phone=@t
       website=@t
       notes=@t
-      color=@ux
+      foreground-color=$~(0xff.ffff @ux)
+      background-color=@ux
       avatar=(unit avatar)
   ==
 ::
@@ -22,7 +36,8 @@
       [%phone phone=@t]
       [%website website=@t]
       [%notes notes=@t]
-      [%color color=@ux]
+      [%foreground-color foreground-color=@ux]
+      [%background-color background-color=@ux]
       [%avatar avatar=(unit avatar)]
   ==
 ::

--- a/pkg/interface/groups/src/js/api.js
+++ b/pkg/interface/groups/src/js/api.js
@@ -116,7 +116,8 @@ class UrbitApi {
     {phone: ''}
     {website: ''}
     {notes: ''}
-    {color: 'fff'}  // with no 0x prefix
+    {background-color: 'fff'}  // with no 0x prefix
+    {foreground-color: 'fff'}  // with no 0x prefix
     {avatar: null}
     {avatar: {p: length, q: bytestream}}
     */

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -11,7 +11,8 @@ export class ContactCard extends Component {
     super(props);
     this.state = {
       edit: props.share,
-      colorToSet: null,
+      foregroundColorToSet: null,
+      backgroundColorToSet: null,
       nickNameToSet: null,
       emailToSet: null,
       phoneToSet: null,
@@ -19,7 +20,8 @@ export class ContactCard extends Component {
       notesToSet: null
     };
     this.editToggle = this.editToggle.bind(this);
-    this.sigilColorSet = this.sigilColorSet.bind(this);
+    this.sigilForegroundColorSet = this.sigilForegroundColorSet.bind(this);
+    this.sigilBackgroundColorSet = this.sigilBackgroundColorSet.bind(this);
     this.nickNameToSet = this.nickNameToSet.bind(this);
     this.emailToSet = this.emailToSet.bind(this);
     this.phoneToSet = this.phoneToSet.bind(this);
@@ -35,7 +37,8 @@ export class ContactCard extends Component {
     if (props.ship !== prevProps.ship) {
       this.setState({
         edit: props.share,
-        colorToSet: null,
+        foregroundColorToSet: null,
+        backgroundColorToSet: null,
         nickNameToSet: null,
         emailToSet: null,
         phoneToSet: null,
@@ -46,13 +49,22 @@ export class ContactCard extends Component {
     }
     // sigil color updates are done by keystroke parsing on update
     // other field edits are exclusively handled by setField()
-    let currentColor = (props.contact.color) ? props.contact.color : "000000";
-    currentColor = uxToHex(currentColor);
+    let currentBackgroundColor = (props.contact.backgroundColor) ?
+      props.contact.backgroundColor : "FFFFFF";
+    currentBackgroundColor = uxToHex(currentBackgroundColor);
     let hexExp = /([0-9A-Fa-f]{6})/
-    let hexTest = hexExp.exec(this.state.colorToSet);
+    let backgroundHexTest = hexExp.exec(this.state.backgroundColorToSet);
 
-    if (hexTest && (hexTest[1] !== currentColor) && !props.share) {
-      api.contactEdit(props.path, `~${props.ship}`, {color: hexTest[1]});
+    let currentForegroundColor = (props.contact.foregroundColor) ?
+      props.contact.foregroundColor : "000000";
+    currentForegroundColor = uxToHex(currentForegroundColor);
+    let foregroundHexTest = hexExp.exec(this.state.foregroundColorToSet);
+
+    if (backgroundHexTest && (backgroundHexTest[1] !== currentBackgroundColor) && !props.share) {
+      api.contactEdit(props.path, `~${props.ship}`, {"background-color": backgroundHexTest[1]});
+    }
+    if (foregroundHexTest && (foregroundHexTest[1] !== currentForegroundColor) && !props.share) {
+      api.contactEdit(props.path, `~${props.ship}`, {"foreground-color": foregroundHexTest[1]});
     }
   }
 
@@ -83,8 +95,12 @@ export class ContactCard extends Component {
     this.setState({ websiteToSet: value });
   }
 
-  sigilColorSet(event) {
-    this.setState({ colorToSet: event.target.value });
+  sigilForegroundColorSet(event) {
+    this.setState({ foregroundColorToSet: event.target.value.toLowerCase() });
+  }
+
+  sigilBackgroundColorSet(event) {
+    this.setState({ backgroundColorToSet: event.target.value.toLowerCase() });
   }
 
   shipParser(ship) {
@@ -222,14 +238,16 @@ export class ContactCard extends Component {
       phone: props.rootIdentity.phone,
       website: props.rootIdentity.website,
       notes: props.rootIdentity.notes,
-      color: uxToHex(props.rootIdentity.color)
+      foregroundColor: uxToHex(props.rootIdentity.foregroundColor),
+      backgroundColor: uxToHex(props.rootIdentity.backgroundColor)
     } : {
       nickname: props.contact.nickname,
       email: props.contact.email,
       phone: props.contact.phone,
       website: props.contact.website,
       notes: props.contact.notes,
-      color: props.contact.color
+      foregroundColor: props.contact.foregroundColor,
+      backgroundColor: props.contact.backgroundColor
     };
 
     let contact = {
@@ -238,7 +256,8 @@ export class ContactCard extends Component {
       phone: this.pickFunction(state.phoneToSet, defaultVal.phone),
       website: this.pickFunction(state.websiteToSet, defaultVal.website),
       notes: this.pickFunction(state.notesToSet, defaultVal.notes),
-      color: this.pickFunction(state.colorToSet, defaultVal.color),
+      "foreground-color": this.pickFunction(state.foregroundColorToSet, defaultVal.foregroundColor),
+      "background-color": this.pickFunction(state.backgroundColorToSet, defaultVal.backgroundColor),
       avatar: null
     };
     api.setSpinner(true);
@@ -260,7 +279,8 @@ export class ContactCard extends Component {
       phone: "",
       website: "",
       notes: "",
-      color: "000000",
+      "foreground-color": "FFFFFF",
+      "background-color": "000000",
       avatar: null
     };
 
@@ -286,22 +306,33 @@ export class ContactCard extends Component {
       phone: props.rootIdentity.phone,
       website: props.rootIdentity.website,
       notes: props.rootIdentity.notes,
-      color: props.rootIdentity.color
+      foregroundColor: props.rootIdentity.foregroundColor,
+      backgroundColor: props.rootIdentity.backgroundColor
     } : {
       nickname: props.contact.nickname,
       email: props.contact.email,
       phone: props.contact.phone,
       website: props.contact.website,
       notes: props.contact.notes,
-      color: props.contact.color
+      foregroundColor: props.contact.foregroundColor,
+      backgroundColor: props.contact.backgroundColor
     };
 
     let shipType = this.shipParser(props.ship);
 
-    let defaultColor = !!defaultValue.color ? defaultValue.color : "000000";
-    defaultColor = uxToHex(defaultColor);
-    let currentColor = !!state.colorToSet ? state.colorToSet : defaultColor;
-    currentColor = uxToHex(currentColor);
+    let defaultForegroundColor = !!defaultValue.foregroundColor ?
+      defaultValue.foregroundColor : "000000";
+    defaultForegroundColor = uxToHex(defaultForegroundColor);
+    let currentForegroundColor = !!state.foregroundColorToSet ?
+      state.foregroundColorToSet : defaultForegroundColor;
+    currentForegroundColor = uxToHex(currentForegroundColor);
+
+    let defaultBackgroundColor = !!defaultValue.backgroundColor ?
+      defaultValue.backgroundColor : "FFFFFF";
+    defaultBackgroundColor = uxToHex(defaultBackgroundColor);
+    let currentBackgroundColor = !!state.backgroundColorToSet ?
+      state.backgroundColorToSet : defaultBackgroundColor;
+    currentBackgroundColor = uxToHex(currentBackgroundColor);
 
     let sigilColor = "";
     let hasAvatar =
@@ -311,13 +342,27 @@ export class ContactCard extends Component {
       sigilColor = (
         <div className="tl mt4 mb4 w-auto ml-auto mr-auto"
           style={{ width: "fit-content" }}>
-          <p className="f9 gray2 lh-copy">Sigil Color</p>
+          <p className="f9 gray2 lh-copy">Sigil Foreground Color</p>
+          <textarea
+            className={"b--gray4 b--gray2-d black white-d bg-gray0-d f7 ba db pl2 " +
+                       "focus-b--black focus-b--white-d"}
+            onChange={this.sigilForegroundColorSet}
+            defaultValue={defaultForegroundColor}
+            key={"fg" + defaultForegroundColor}
+            style={{
+              resize: "none",
+              height: 40,
+              paddingTop: 10,
+              width: 114
+            }}>
+          </textarea>
+          <p className="f9 gray2 lh-copy">Sigil Background Color</p>
           <textarea
             className={"b--gray4 b--gray2-d black white-d bg-gray0-d f7 ba db pl2 " +
             "focus-b--black focus-b--white-d"}
-            onChange={this.sigilColorSet}
-            defaultValue={defaultColor}
-            key={"default" + defaultColor}
+            onChange={this.sigilBackgroundColorSet}
+            defaultValue={defaultBackgroundColor}
+            key={"bg" + defaultBackgroundColor}
             style={{
               resize: "none",
               height: 40,
@@ -343,8 +388,9 @@ export class ContactCard extends Component {
       : <Sigil
           ship={props.ship}
           size={128}
-          color={"#" + currentColor}
-          key={"avatar" + currentColor} />;
+          foregroundColor={"#" + currentForegroundColor}
+          backgroundColor={"#" + currentBackgroundColor}
+          key={"avatar" + currentBackgroundColor} />;
 
     return (
       <div className="w-100 mt8 flex justify-center pa4 pt8 pt0-l pa0-xl pt4-xl pb8">
@@ -403,8 +449,14 @@ export class ContactCard extends Component {
   renderCard() {
     const { props } = this;
     let shipType = this.shipParser(props.ship);
-    let currentColor = props.contact.color ? props.contact.color : "0x0";
-    let hexColor = uxToHex(currentColor);
+
+    let currentForegroundColor = props.contact.foregroundColor ?
+      props.contact.foregroundColor : "0xff.ffff";
+    let hexForegroundColor = uxToHex(currentForegroundColor);
+
+    let currentBackgroundColor = props.contact.backgroundColor ?
+      props.contact.backgroundColor : "0x0";
+    let hexBackgroundColor = uxToHex(currentBackgroundColor);
 
     let avatar =
       ('avatar' in props.contact && props.contact.avatar !== "TODO") ?
@@ -412,8 +464,9 @@ export class ContactCard extends Component {
       <Sigil
         ship={props.ship}
         size={128}
-        color={"#" + hexColor}
-        key={hexColor} />;
+        foregroundColor={"#" + hexForegroundColor}
+        backgroundColor={"#" + hexBackgroundColor}
+        key={hexBackgroundColor} />;
 
     let websiteHref =
       (props.contact.website && props.contact.website.includes("://")) ?

--- a/pkg/interface/groups/src/js/components/lib/contact-item.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-item.js
@@ -9,7 +9,8 @@ export class ContactItem extends Component {
     const { props } = this;
 
     let selectedClass = (props.selected) ? "bg-gray4 bg-gray1-d" : "";
-    let hexColor = uxToHex(props.color);
+    let hexBackgroundColor = uxToHex(props.backgroundColor);
+    let hexForegroundColor = uxToHex(props.foregroundColor);
     let name = (props.nickname) ? props.nickname : cite(props.ship);
 
     let prefix = props.share ? 'share' : 'view';
@@ -21,9 +22,10 @@ export class ContactItem extends Component {
         >
           <Sigil
             ship={props.ship}
-            color={"#" + hexColor}
+            backgroundColor={"#" + hexBackgroundColor}
+            foregroundColor={"#" + hexForegroundColor}
             size={32}
-            key={`${props.ship}.sidebar.${hexColor}`} />
+            key={`${props.ship}.sidebar.${hexBackgroundColor}`} />
           <p
             className={
               "f9 w-70 dib v-mid ml2 nowrap " +

--- a/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
@@ -14,14 +14,16 @@ export class ContactSidebar extends Component {
       props.activeDrawer === "contacts" ? "db" : "dn db-ns";
 
     let me = (window.ship in props.defaultContacts) ?
-      props.defaultContacts[window.ship] : { color: '0x0', nickname: null};
+      props.defaultContacts[window.ship] :
+      {foregroundColor: '0xff.ffff', backgroundColor: '0x0', nickname: null};
 
     let shareSheet =
       !(window.ship in props.contacts) ?
       ( <ShareSheet
           ship={window.ship}
           nickname={me.nickname}
-          color={me.color}
+          foregroundColor={me.foregroundColor}
+          backgroundColor={me.backgroundColor}
           path={props.path}
           selected={props.path + "/" + window.ship === props.selectedContact}
         />
@@ -39,7 +41,8 @@ export class ContactSidebar extends Component {
             key={contact}
             ship={contact}
             nickname={obj.nickname}
-            color={obj.color}
+            foregroundColor={obj.foregroundColor}
+            backgroundColor={obj.backgroundColor}
             path={props.path}
             selected={path === props.selectedContact}
             share={false}
@@ -56,7 +59,8 @@ export class ContactSidebar extends Component {
             "bg-white bg-gray0-d"}>
             <Sigil
               ship={member}
-              color="#000000"
+              foregroundColor="#FFFFFF"
+              backgroundColor="#000000"
               size={32}
               classes="mix-blend-diff"
               />

--- a/pkg/interface/groups/src/js/components/lib/group-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/group-sidebar.js
@@ -23,7 +23,8 @@ export class GroupSidebar extends Component {
                 selectedClass}>
               <Sigil
               ship={window.ship}
-              color="#000000"
+              foregroundColor="#FFFFFF"
+              backgroundColor="#000000"
               classes="mix-blend-diff"
               size={32}/>
               <p

--- a/pkg/interface/groups/src/js/components/lib/icons/sigil.js
+++ b/pkg/interface/groups/src/js/components/lib/icons/sigil.js
@@ -17,12 +17,12 @@ export class Sigil extends Component {
       return (
         <div
           className={"dib " + classes}
-          style={{ flexBasis: 32, backgroundColor: props.color }}>
+          style={{ flexBasis: 32, backgroundColor: props.backgroundColor }}>
           {sigil({
             patp: props.ship,
             renderer: reactRenderer,
             size: props.size,
-            colors: [props.color, "white"]
+            colors: [props.backgroundColor, props.foregroundColor]
           })}
         </div>
       );

--- a/pkg/interface/groups/src/js/components/lib/share-sheet.js
+++ b/pkg/interface/groups/src/js/components/lib/share-sheet.js
@@ -9,7 +9,6 @@ export class ShareSheet extends Component {
   render() {
     const { props } = this;
     let selectedClass = (props.selected) ? "bg-gray4" : "";
-    let hexColor = uxToHex(props.color);
 
     return (
       <div>
@@ -18,7 +17,8 @@ export class ShareSheet extends Component {
           key={props.ship}
           ship={props.ship}
           nickname={props.nickname}
-          color={props.color}
+          backgroundColor={props.backgroundColor}
+          foregroundColor={props.foregroundColor}
           path={props.path}
           selected={props.selected}
           share={true} />


### PR DESCRIPTION
Bridge had spoiled me on this.

Also fixes a bug where if you type an uppercase letter A-F to the sigil color box you enter an annoying infinite request loop until you refresh.

<img src="https://user-images.githubusercontent.com/14286382/76709082-79d8c180-6704-11ea-80b5-fde2cd1c87f3.png" width="250">