### PR TITLE
chat-cli: absolute parity wrt "shortcodes"

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -185,7 +185,9 @@
   ::
   ^-  state-1
   ?-  -.u.old
-    %1  u.old(bound (~(gas by *(map target glyph)) ~(tap by bound.u.old)))
+      %1
+    =?  width.u.old  =(0 width.u.old)  80
+    u.old(bound (~(gas by *(map target glyph)) ~(tap by bound.u.old)))
   ::
       ?(~ ^)
     :-  %1

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -634,12 +634,19 @@
     ++  tag   |*(a=@tas (cold a (jest a)))  ::TODO  into stdlib
     ++  ship  ;~(pfix sig fed:ag)
     ++  path  ;~(pfix net ;~(plug urs:ab (easy ~)))  ::NOTE  short only, tmp
+    ::  +mang: un/managed indicator prefix
+    ::
+    ++  mang
+      ;~  pose
+        (cold %| (jest '~/'))
+        (cold %& (easy ~))
+      ==
     ::  +tarl: local target, as /path
     ::
     ++  tarl  (stag our-self path)
-    ::  +tarx: local target, maybe group
+    ::  +tarx: local target, maybe managed
     ::
-    ++  tarx  ;~(plug (fuss 'group ' '') path)
+    ++  tarx  ;~(plug mang path)
     ::  +tarp: sponsor target, as ^/path
     ::
     ++  tarp
@@ -650,7 +657,8 @@
     ++  targ
       ;~  pose
         ;~  plug
-          (fuss 'group ' '')
+          mang
+        ::
           ;~  pose
             tarl
             tarp
@@ -1265,7 +1273,7 @@
   ++  full
     ^-  tape
     ;:  weld
-      ?:(in-group.one "g " "")
+      ?:(in-group.one "" "~/")
       (scow %p ship.one)
       (spud path.one)
     ==
@@ -1278,7 +1286,7 @@
   ++  phat
     ^-  tape
     %+  weld
-      ?:(in-group.one "g " "")
+      ?:(in-group.one "" "~/")
     %+  weld
       ?:  =(our-self ship.one)  ~
       ?:  =((sein:title our.bowl now.bowl our-self) ship.one)  "^"


### PR DESCRIPTION
Downgrades unmanaged chat paths to their uglified versions, as used by
web chat. Removes "group-based" indicators and makes them implicit in
shorter paths instead. Fixes #2503.

Includes a just-in-case addition of fixing configured `width` if it's not sane. Observed it being 0 on development ships a small amount of times. Couldn't reproduce, but want to add this as a precaution: should patch up anyone left in insane state.