### PR TITLE
links: add soundcloud embeds

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -7,7 +7,8 @@ export class LinkPreview extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      timeSinceLinkPost: this.getTimeSinceLinkPost()
+      timeSinceLinkPost: this.getTimeSinceLinkPost(),
+      embed: ""
     };
   }
 
@@ -67,6 +68,12 @@ export class LinkPreview extends Component {
         /(?:(?:(?:(?:watch\?)?(?:time_continue=(?:[0-9]+))?.+v=)?([a-zA-Z0-9_-]+))(?:\?t\=(?:[0-9a-zA-Z]+))?)/.source // id
     );
 
+    let soundcloudRegex = new RegExp('' +
+      /(https?:\/\/(?:www.)?soundcloud.com\/[\w-]+\/?(?:sets\/)?[\w-]+)/.source
+    );
+
+    let isSoundcloud = soundcloudRegex.exec(props.url);
+
     let ytMatch = youTubeRegex.exec(props.url);
 
     let embed = "";
@@ -91,13 +98,26 @@ export class LinkPreview extends Component {
       );
     }
 
+    if (isSoundcloud && this.state.embed === "") {
+      fetch(
+        'https://soundcloud.com/oembed?format=json&url=' +
+        encodeURIComponent(props.url))
+      .then((response) => {
+        return response.json();
+      })
+      .then((json) => {
+        console.log(json)
+        this.setState({embed: json.html})
+      })
+    }
+
     let nameClass = props.nickname ? "inter" : "mono";
 
     return (
       <div className="pb6 w-100">
         <div
           className={"w-100 tc " + (ytMatch ? "embed-container" : "")}>
-          {embed}
+          {embed || <div dangerouslySetInnerHTML={{__html: this.state.embed}}/>}
         </div>
         <div className="flex flex-column ml2 pt6 flex-auto">
           <a href={props.url} className="w-100 flex" target="_blank">

--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -28,6 +28,27 @@ export class LinkPreview extends Component {
         timeSinceLinkPost: this.getTimeSinceLinkPost()
       });
     }, 60000);
+
+    // check for soundcloud for fetching embed
+    let soundcloudRegex = new RegExp('' +
+      /(https?:\/\/(?:www.)?soundcloud.com\/[\w-]+\/?(?:sets\/)?[\w-]+)/.source
+    );
+
+    let isSoundcloud = soundcloudRegex.exec(this.props.url);
+
+    if (isSoundcloud && this.state.embed === "") {
+      fetch(
+        'https://soundcloud.com/oembed?format=json&url=' +
+        encodeURIComponent(this.props.url))
+        .then((response) => {
+          return response.json();
+        })
+        .then((json) => {
+          this.setState({ embed: json.html })
+        });
+    } else if (!isSoundcloud) {
+      this.setState({ embed: "" });
+    }
   }
 
   componentWillUnmount() {
@@ -68,12 +89,6 @@ export class LinkPreview extends Component {
         /(?:(?:(?:(?:watch\?)?(?:time_continue=(?:[0-9]+))?.+v=)?([a-zA-Z0-9_-]+))(?:\?t\=(?:[0-9a-zA-Z]+))?)/.source // id
     );
 
-    let soundcloudRegex = new RegExp('' +
-      /(https?:\/\/(?:www.)?soundcloud.com\/[\w-]+\/?(?:sets\/)?[\w-]+)/.source
-    );
-
-    let isSoundcloud = soundcloudRegex.exec(props.url);
-
     let ytMatch = youTubeRegex.exec(props.url);
 
     let embed = "";
@@ -96,19 +111,6 @@ export class LinkPreview extends Component {
           frameBorder="0"
           allow="picture-in-picture, fullscreen"></iframe>
       );
-    }
-
-    if (isSoundcloud && this.state.embed === "") {
-      fetch(
-        'https://soundcloud.com/oembed?format=json&url=' +
-        encodeURIComponent(props.url))
-      .then((response) => {
-        return response.json();
-      })
-      .then((json) => {
-        console.log(json)
-        this.setState({embed: json.html})
-      })
     }
 
     let nameClass = props.nickname ? "inter" : "mono";


### PR DESCRIPTION
- Gets the embed HTML from the Soundcloud [oembed API](https://developers.soundcloud.com/docs/oembed). 
- Sets the HTML in our state once we get it since we're waiting on a promise; passes it into the DOM as HTML directly as a fallback from the local `embed` variable (theoretically unsafe if we assume Soundcloud's oembed API gets attacked?).

In general I think what we really want is to stop manually regexing for these embeds and to get the Links back-end to get the metadata for us — so we can support anything and everything that returns an embed as part of OpenGraph.

For now this is ok. I think @vvisigoth just wants it in.

<img width="954" alt="Screen Shot 2020-03-16 at 9 23 02 PM" src="https://user-images.githubusercontent.com/20846414/76812878-ad7f1e80-67cc-11ea-8a7f-a94673ce0326.png">
