### PR TITLE
soto: cmd/ctrl+v pasting, whitelist keys

### DIFF
--- a/pkg/interface/soto/src/js/components/input.js
+++ b/pkg/interface/soto/src/js/components/input.js
@@ -15,6 +15,11 @@ export class Input extends Component {
     }
 
   keyPress = (e) => {
+    if ((e.getModifierState("Control") || event.getModifierState("Meta"))
+       && e.key === "v") {
+      return;
+    }
+
     e.preventDefault();
 
     let ignoredKeys = ["Meta", "Alt", "Control", "Escape", "Shift",

--- a/pkg/interface/soto/src/js/components/input.js
+++ b/pkg/interface/soto/src/js/components/input.js
@@ -22,12 +22,13 @@ export class Input extends Component {
 
     e.preventDefault();
 
-    let ignoredKeys = ["Meta", "Alt", "Control", "Escape", "Shift",
-                       "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8",
-                       "F9", "F10", "F11", "F12", "Backspace", "Unidentified",
-                       "Delete", "Insert", "Home", "PageUp", "PageDown", "End",
-                       "Dead", "CapsLock"
-                      ];
+    let allowedKeys = [
+      "Enter", "Backspace", "ArrowLeft", "ArrowRight", "Tab"
+    ];
+
+    if ((e.key.length > 1) && (!(allowedKeys.includes(e.key)))) {
+      return;
+    }
 
   // submit on enter
   if (e.key === "Enter") {
@@ -63,7 +64,7 @@ export class Input extends Component {
   }
 
   // capture and transmit most characters
-  else if (ignoredKeys.indexOf(e.key) === -1) {
+  else {
     store.doEdit({ ins: { cha: e.key, at: this.props.cursor } });
     store.setState({ cursor: this.props.cursor + 1 });
   }


### PR DESCRIPTION
- Allows pasting from the keyboard to pass through the keypress handler and use `onPaste`'s sequential promises
- On @ohAitch's suggestion invert the `ignoredKeys` approach and use the four longer keys as a whitelist