### PR TITLE
chat-cli: skip catch-up if chat-store not booted

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -226,6 +226,8 @@
 ::
 ++  catch-up
   ^-  (quip card _state)
+  ?.  .^(? %gu /(scot %p our.bowl)/chat-store/(scot %da now.bowl))
+    [~ state]
   =/  =inbox
     (scry-for inbox %chat-store /all)
   |-  ^-  (quip card _state)


### PR DESCRIPTION
This way we don't just crash on the scry that follows.

Seen this occur on first boot occasionally. The resulting crash seems harmless, but this should clean it up regardless.