### PR TITLE
ames: print num-fragments in packet verbage

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3141,7 +3141,7 @@
         message-sink
       ::  ack all other packets
       ::
-      %-  (trace rcv.veb |.("send ack {<seq^fragment-num>}"))
+      %-  (trace rcv.veb |.("send ack-1 {<seq^fragment-num^num-fragments>}"))
       (give %send seq %& fragment-num)
     ::  last-heard<seq<10+last-heard; this is a packet in a live message
     ::
@@ -3182,7 +3182,7 @@
     ::  ack any packet other than the last one, and continue either way
     ::
     =?  message-sink  !is-last-fragment
-      %-  (trace rcv.veb |.("send ack {<seq^fragment-num>}"))
+      %-  (trace rcv.veb |.("send ack-2 {<seq^fragment-num^num-fragments>}"))
       (give %send seq %& fragment-num)
     ::  enqueue all completed messages starting at +(last-heard.state)
     ::


### PR DESCRIPTION
Gives you a poor man's progress bar.  For example, to determine how much
of an OTA you've downloaded from your sponsor, run:

|ames-sift (sein:title our now our)
|ames-verb %rcv

and then to turn it off:

|ames-verb