### PR TITLE
publish: fix onScroll fetching bug

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -171,7 +171,7 @@ export class Note extends Component {
     let baseUrl = `/~publish/${popout}notebook/${props.ship}/${props.book}`;
     return (
       <div
-        className="h-100 no-scrollbar"
+        className="h-100 overflow-y-scroll"
         onScroll={this.onScroll}
         ref={el => {
           this.scrollElement = el;

--- a/pkg/interface/publish/src/js/components/lib/notebook.js
+++ b/pkg/interface/publish/src/js/components/lib/notebook.js
@@ -177,65 +177,67 @@ export class Notebook extends Component {
 
     return (
       <div
-        className="center mw6 f9 h-100"
-        style={{ paddingLeft: 16, paddingRight: 16 }}>
-        <SidebarSwitcher
-          popout={props.popout}
-          sidebarShown={props.sidebarShown}
-        />
-        <div className="w-100 dn-m dn-l dn-xl inter pt4 pb6 f9">
-          <Link to="/~publish">{"<- All Notebooks"}</Link>
-        </div>
-        <Link
-        className={"dn absolute right-1 top-1 " + hiddenOnPopout}
-        to={popoutHref}
-        target="_blank"
-        >
-          <img src="/~publish/popout.png"
-            height={16}
-            width={16}
+        className="overflow-y-scroll"
+        style={{ paddingLeft: 16, paddingRight: 16 }}
+        onScroll={this.onScroll}
+        ref={el => {
+          this.scrollElement = el;
+        }}>
+        <div className="center mw6 f9 h-100"
+          style={{ paddingLeft: 16, paddingRight: 16 }}>
+          <SidebarSwitcher
+            popout={props.popout}
+            sidebarShown={props.sidebarShown}
           />
-        </Link>
-        <div
-          className="h-100 pt0 pt8-m pt8-l pt8-xl no-scrollbar"
-          onScroll={this.onScroll}
-          ref={el => {
-            this.scrollElement = el;
-          }}>
-          <div
-            className="flex justify-between"
-            style={{ marginBottom: 32 }}>
-            <div className="flex-col">
-              <div className="mb1">{notebook.title}</div>
-              <span>
-                <span className="gray3 mr1">by</span>
-                <span className={contact.nickname ? null : "mono"}
-                title={props.ship}>
-                  {name}
+          <div className="w-100 dn-m dn-l dn-xl inter pt4 pb6 f9">
+            <Link to="/~publish">{"<- All Notebooks"}</Link>
+          </div>
+          <Link
+          className={"dn absolute right-1 top-1 " + hiddenOnPopout}
+          to={popoutHref}
+          target="_blank"
+          >
+            <img src="/~publish/popout.png"
+              height={16}
+              width={16}
+            />
+          </Link>
+          <div className="h-100 pt0 pt8-m pt8-l pt8-xl no-scrollbar">
+            <div
+              className="flex justify-between"
+              style={{ marginBottom: 32 }}>
+              <div className="flex-col">
+                <div className="mb1">{notebook.title}</div>
+                <span>
+                  <span className="gray3 mr1">by</span>
+                  <span className={contact.nickname ? null : "mono"}
+                  title={props.ship}>
+                    {name}
+                  </span>
                 </span>
-              </span>
+              </div>
+              <div className="flex">
+                {newPost}
+                {unsub}
+              </div>
             </div>
-            <div className="flex">
-              {newPost}
-              {unsub}
+
+            <div className="flex" style={{ marginBottom: 24 }}>
+              <Link to={base} className={tabStyles.posts}>
+                All Posts
+              </Link>
+              <Link to={about} className={tabStyles.about}>
+                About
+              </Link>
+              {subsComponent}
+              {settingsComponent}
+              <div className="bb b--gray4 b--gray2-d gray2 pv4 ph2"
+                style={{ flexGrow: 1 }}></div>
             </div>
-          </div>
 
-          <div className="flex" style={{ marginBottom: 24 }}>
-            <Link to={base} className={tabStyles.posts}>
-              All Posts
-            </Link>
-            <Link to={about} className={tabStyles.about}>
-              About
-            </Link>
-            {subsComponent}
-            {settingsComponent}
-            <div className="bb b--gray4 b--gray2-d gray2 pv4 ph2"
-              style={{ flexGrow: 1 }}></div>
-          </div>
-
-          <div style={{ height: "calc(100% - 188px)" }} className="f9 lh-solid">
-            {inner}
+            <div style={{ height: "calc(100% - 188px)" }} className="f9 lh-solid">
+              {inner}
+            </div>
           </div>
         </div>
       </div>

--- a/pkg/interface/publish/src/js/components/skeleton.js
+++ b/pkg/interface/publish/src/js/components/skeleton.js
@@ -31,7 +31,7 @@ export class Skeleton extends Component {
             path={props.path}
             invites={props.invites}
             />
-          <div className={"h-100 w-100 relative white-d overflow-y-scroll " + rightPanelHide} style={{
+          <div className={"h-100 w-100 relative white-d " + rightPanelHide} style={{
             flexGrow: 1,
           }}>
             {props.children}


### PR DESCRIPTION
Fixes this issue (https://github.com/urbit/urbit/issues/2479) which was introduced by this commit (https://github.com/urbit/urbit/pull/2446/commits/1b4b3274893c50e0038a2555b4e65808e456ebc8) which moved the scrolling behavior to the skeleton component, causing the onScroll event to fail to fire.

I was told this was to fix a visual bug, which I think was primarily about the scrollbar showing up on the inner div, rather than at the right side of the screen. This PR doesn't re-introduce the scrollbar visual bug, the only visual difference between this and whats on the network now is the sidebar toggle and popout buttons now stay in place as you scroll.

![image](https://user-images.githubusercontent.com/4741759/76907481-8c1d4180-6863-11ea-883c-3b4fe06d9a2b.png)
