### PR TITLE
arvo: Multi-stack drifting

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5db7d1d0e52104330b14217d101b041d512c512adaf657fa913fe1b80e4f7945
-size 13075373
+oid sha256:72e661b80b800809e73e50adbb504edbd1a9f66084d9c60e4ddc905c53a6232c
+size 13075845

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -21,7 +21,6 @@
 ::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =>
 |%
-::
 +|  %global
 ::
 ::  $arch: fundamental node
@@ -531,10 +530,10 @@
   ::
   ++  le
     =>  |%
-        ::  $germ: worklist source and stack depth
+        ::  $germ: worklist source and bar stack
         ::  $plan: worklist
         ::
-        +$  germ  [vane=term depth=@ud]
+        +$  germ  [vane=term bars=(list duct)]
         +$  plan  (pair germ (list move))
         --
     ::
@@ -569,9 +568,8 @@
     ::  +emit: enqueue a worklist with source
     ::
     ++  emit
-      |=  [src=term moz=(list move)]
-      =/  =plan  [[src +(depth.gem)] moz]
-      this(run [plan run])
+      |=  pan=plan
+      this(run [pan run])
     ::  +poke: prepare a worklist-of-one from outside
     ::
     ++  poke
@@ -586,7 +584,7 @@
         ~|  [%bad-wire wire.ovum]
         ?>  ?=([%$ *] wire.ovum)
         [duct=~ %pass t.wire.ovum vane maze]
-      (emit %$ move ~)
+      (emit [%$ ~] move ~)
     ::  +crud: prepare a worklist-of-one with error report from outside
     ::
     ++  crud
@@ -601,7 +599,7 @@
         ~|  [%bad-wire wire.ovum]
         ?>  ?=([%$ *] wire.ovum)
         [duct=~ %hurl goof %pass t.wire.ovum vane maze]
-      (emit %$ move ~)
+      (emit [%$ ~] move ~)
     ::  +spam: prepare a worklist for all targets
     ::
     ++  spam
@@ -651,7 +649,7 @@
         =*  task  task.note.ball.move
         ::
         ~?  &(!lac !=(%$ vane.gem))
-          :-  (runt [(dec depth.gem) '|'] "")
+          :-  (runt [(lent bars.gem) '|'] "")
           :^  %pass  [vane.gem vane]
             ?:  ?=(?(%deal %deal-gall) +>-.task)
               :-  :-  +>-.task
@@ -672,7 +670,7 @@
         =*  task  task.note.ball.move
         ::
         ~?  !lac
-          :-  (runt [(dec depth.gem) '|'] "")
+          :-  (runt [(lent bars.gem) '|'] "")
           [%slip vane.gem (symp +>-.task) duct]
         ::
         (call duct vane task)
@@ -702,7 +700,7 @@
           ?>(?=(^ wire) wire)
         ::
         ~?  &(!lac |(!=(%blit +>-.gift) !=(%d vane.gem)))
-          :-  (runt [(dec depth.gem) '|'] "")
+          :-  (runt [(lent bars.gem) '|'] "")
           :^  %give  vane.gem
             ?:  ?=(%unto +>-.gift)
               [+>-.gift (symp +>+<.gift)]
@@ -748,7 +746,8 @@
     ++  call
       |=  [=duct way=term task=maze]
       ^+  this
-      %+  push  way
+      %+  push  [way duct bars.gem]
+      ~|  bar-stack=`(list ^duct)`[duct bars.gem]
       %.  task
       call:(spin:(plow way) duct eny dud)
     ::  +take: retreat along call-stack
@@ -756,21 +755,23 @@
     ++  take
       |=  [=duct =wire way=term gift=maze]
       ^+  this
-      %+  push  way
+      %+  push  [way duct bars.gem]
       ::
       ::  cons source onto .gift to make a $sign
       ::
+      ~|  wire=wire
+      ~|  bar-stack=`(list ^duct)`[duct bars.gem]
       %.  [wire [vane.gem gift]]
       take:(spin:(plow way) duct eny dud)
     ::  +push: finalize an individual step
     ::
     ++  push
-      |=  [way=term [zom=vase vax=vase] sac=worm]
+      |=  [gum=germ [zom=vase vax=vase] sac=worm]
       ^+  this
       =^  moz  sac
         (~(refine-moves me sac vil) zom)
-      =.  van  (~(put by van) way [vax sac])
-      (emit way moz)
+      =.  van  (~(put by van) vane.gum [vax sac])
+      (emit `plan`[`germ`gum `(list move)`moz])
     ::  +plow: operate on a vane, in time and space
     ::
     ++  plow


### PR DESCRIPTION
We have three stacks: the hoon stack, bar stack, and duct stack.  This
turns the bar stack to a list of ducts and adds it to the hoon stack.
This tells you the ducts of the moves that caused the move where you
crashed.

See:

```
recover: dig: intr
crud: %belt event failed
bail: intr
  bar-stack
~[
  ~[/g/use/spider/~zod/find/~.dojo_0v5ogno.5anji.vn3f6.4gs7t.6r2ft /d //term/1]
  ~[/g/use/dojo/~zod/out/~zod/spider/drum/wool /d //term/1]
  ~[/d //term/1]
  ~[/g/use/dojo/~zod/drum/hand /d //term/1]
  ~[/g/use/hood/~zod/out/~zod/dojo/drum/phat/~zod/dojo /d //term/1]
  ~[/d //term/1]
  ~[//term/1]
]
call: failed
/~zod/home/~2020.3.17..23.14.11..50e0/sys/vane/ford:<[6.128 3].[6.220 5]>
/~zod/home/~2020.3.17..23.14.11..50e0/sys/vane/ford:<[6.129 3].[6.220 5]>
/~zod/home/~2020.3.17..23.14.11..50e0/sys/vane/ford:<[6.132 3].[6.220 5]>
...
```