### PR TITLE
goad: run with %force on kernel change

### DIFF
--- a/pkg/arvo/app/goad.hoon
+++ b/pkg/arvo/app/goad.hoon
@@ -59,7 +59,7 @@
       :_  this  :_  ~
       [%pass /dill %arvo %d %flog %crud %goad-fail u.error.sign-arvo]
     %-  (slog leaf+"goad: recompiling all apps" ~)
-    [(goad |) this]
+    [(goad &) this]
   ==
 ::
 ++  on-fail   on-fail:def


### PR DESCRIPTION
In many cases running without %force is insufficient because ford
crashes while unsubscribing.  This should fix some cases of OTAs being
received but not processed.