### PR TITLE
link: restore contributor counts in sidebar

### DIFF
--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -33,7 +33,7 @@ export class ChannelsSidebar extends Component {
           <ChannelsItem
             key={path}
             link={path}
-            memberList={props.groups[meta.group]}
+            memberList={props.groups[meta["group-path"]]}
             selected={selected}
             linkCount={linkCount}
             unseenCount={unseenCount}


### PR DESCRIPTION
Closes #2502.

During the metadata restructure I didn't adjust this property pass, and it passed through an empty "group" prop and processed it as 0. This commit fixes that.