### PR TITLE
publish: stop post input area from overflowing parent container in firefox

### DIFF
--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -93,7 +93,14 @@ a {
 
 .NewPost {
   width: 100%;
-  height: calc(100% - 115px);
+  height: calc(100vh - 174px);
+  display: flex;
+  padding-top: 8px;
+}
+
+.EditPost {
+  width: 100%;
+  height: calc(100vh - 120px);
   display: flex;
   padding-top: 8px;
 }

--- a/pkg/interface/publish/src/js/components/lib/edit-post.js
+++ b/pkg/interface/publish/src/js/components/lib/edit-post.js
@@ -118,7 +118,7 @@ export class EditPost extends Component {
         <div className="pl4">
           <div className="gray2">{date}</div>
         </div>
-        <div className="NewPost">
+        <div className="EditPost">
           <CodeMirror
             value={state.body}
             options={options}


### PR DESCRIPTION
Fixes https://github.com/urbit/urbit/issues/2542

For some reason calc behaves differently on firefox, so I stopped using it. Tested on Firefox, Chrome, Safari and Brave.