### PR TITLE
Chat: move chat to existing group

### DIFF
--- a/pkg/arvo/lib/chat-json.hoon
+++ b/pkg/arvo/lib/chat-json.hoon
@@ -283,7 +283,8 @@
     ==
   ::
   ++  groupify
-    (ot [%app-path pa] ~)
+    =-  (ot [%app-path pa] [%existing -] ~)
+    (mu (ot [%group-path pa] [%inclusive bo] ~))
   ::
   ++  sec
     =,  dejs:format

--- a/pkg/arvo/sur/chat-view.hoon
+++ b/pkg/arvo/sur/chat-view.hoon
@@ -1,7 +1,14 @@
 /-  *rw-security
 |%
 +$  chat-view-action
-  $%  $:  %create
+  $%  ::  %create: create a new chat
+      ::
+      ::    if :app-path and :group-path are different, :members must be empty,
+      ::    as the :group-path is assumed to exist.
+      ::    if :app-path and :group-path are identical, and the :group-path
+      ::    doesn't yet exist, will create a new group with :members.
+      ::
+      $:  %create
           title=@t
           description=@t
           app-path=path

--- a/pkg/arvo/sur/chat-view.hoon
+++ b/pkg/arvo/sur/chat-view.hoon
@@ -25,6 +25,10 @@
       ::    and invite the current whitelist to that group.
       ::    existing messages get moved over.
       ::
-      [%groupify app-path=path]
+      ::    if :existing is provided, associates chat with that group instead
+      ::    of creating a new one. :inclusive indicates whether or not to add
+      ::    chat members to the group, if they aren't there already.
+      ::
+      [%groupify app-path=path existing=(unit [group-path=path inclusive=?])]
   ==
 --

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -175,8 +175,15 @@ class UrbitApi {
     });
   }
 
-  chatViewGroupify(path) {
-    return this.chatViewAction({ groupify: { 'app-path': path } });
+  chatViewGroupify(path, group = null, inclusive = false) {
+    let action = { groupify: { 'app-path': path, existing: null } };
+    if (group) {
+      action.groupify.existing = {
+        'group-path': group,
+        inclusive: inclusive
+      }
+    }
+    return this.chatViewAction(action);
   }
 
   inviteAction(data) {

--- a/pkg/interface/chat/src/js/components/lib/invite-element.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-element.js
@@ -65,6 +65,7 @@ export class InviteElement extends Component {
         groups={{}}
         contacts={props.contacts}
         groupResults={false}
+        shipResults={true}
         invites={{
           groups: [],
           ships: this.state.members

--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -96,37 +96,37 @@ export class InviteSearch extends Component {
         });
       }
 
-      let shipMatches = this.state.peers.filter(e => {
-        return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
-      });
-
-      for (let contact of this.state.contacts.keys()) {
-        let thisContact = this.state.contacts.get(contact);
-        let match = thisContact.filter(e => {
-          return e.toLowerCase().includes(searchTerm);
+      let shipMatches = [];
+      if (this.props.shipResults) {
+        shipMatches = this.state.peers.filter(e => {
+          return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
         });
-        if (match.length > 0) {
-          if (!(contact in shipMatches)) {
-            shipMatches.push(contact);
+
+        for (let contact of this.state.contacts.keys()) {
+          let thisContact = this.state.contacts.get(contact);
+          let match = thisContact.filter(e => {
+            return e.toLowerCase().includes(searchTerm);
+          });
+          if (match.length > 0) {
+            if (!(contact in shipMatches)) {
+              shipMatches.push(contact);
+            }
           }
+        }
+
+        let isValid = true;
+        if (!urbitOb.isValidPatp("~" + searchTerm)) {
+          isValid = false;
+        }
+
+        if (shipMatches.length === 0 && isValid) {
+          shipMatches.push(searchTerm);
         }
       }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
-
-      let isValid = true;
-      if (!urbitOb.isValidPatp("~" + searchTerm)) {
-        isValid = false;
-      }
-
-      if (shipMatches.length === 0 && isValid) {
-        shipMatches.push(searchTerm);
-        this.setState({
-          searchResults: { groups: groupMatches, ships: shipMatches }
-        });
-      }
     }
   }
 
@@ -202,6 +202,18 @@ export class InviteSearch extends Component {
 
     let participants = <div />;
     let searchResults = <div />;
+
+    let placeholder = '';
+    if (props.shipResults) {
+      placeholder = 'ships';
+    }
+    if (props.groupResults) {
+      if (placeholder.length > 0) {
+        placeholder = placeholder + ' or ';
+      }
+      placeholder = placeholder + 'existing groups';
+    }
+    placeholder = 'Search for ' + placeholder;
 
     let invErrElem = <span />;
     if (state.inviteError) {
@@ -357,7 +369,7 @@ export class InviteSearch extends Component {
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
             " db focus-b--black focus-b--white-d"
           }
-          placeholder="Search for ships or existing groups"
+          placeholder={placeholder}
           disabled={searchDisabled}
           rows={1}
           spellCheck={false}

--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -263,6 +263,7 @@ export class NewScreen extends Component {
             contacts={props.contacts}
             associations={props.associations}
             groupResults={true}
+            shipResults={true}
             invites={{
               groups: state.groups,
               ships: state.ships

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -280,6 +280,9 @@ export class Root extends Component {
                     station={station}
                     association={association}
                     permission={permission}
+                    groups={state.groups || {}}
+                    contacts={state.contacts || {}}
+                    associations={associations.contacts}
                     api={api}
                     station={station}
                     group={group}

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -181,7 +181,6 @@ export class SettingsScreen extends Component {
     const { props, state } = this;
 
     const chatOwner = (deSig(props.match.params.ship) === window.ship);
-    console.log(chatOwner, props.match.params.ship, window.ship);
 
     const ownedUnmanagedVillage =
       chatOwner &&
@@ -192,9 +191,8 @@ export class SettingsScreen extends Component {
       return null;
     } else {
       let inclusiveToggle = <div/>
-      console.log('tg', state.targetGroup);
       if (state.targetGroup) {
-        //TODO toggle component
+        //TODO toggle component into /lib
         let inclusiveClasses = state.inclusive
           ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
           : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
@@ -207,7 +205,7 @@ export class SettingsScreen extends Component {
               onChange={this.changeInclusive}
             />
             <span className="dib f9 white-d inter ml3">
-              Inclusive
+              Add all members to group
             </span>
             <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
               Add chat members to the group if they aren't in it yet

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -5,6 +5,7 @@ import { Route, Link } from "react-router-dom";
 
 
 import { ChatTabBar } from '/components/lib/chat-tabbar';
+import { InviteSearch } from '/components/lib/invite-search';
 import SidebarSwitcher from './lib/icons/icon-sidebar-switch';
 
 
@@ -16,10 +17,15 @@ export class SettingsScreen extends Component {
       isLoading: false,
       title: "",
       description: "",
-      color: ""
+      color: "",
+      // groupify settings
+      targetGroup: null,
+      inclusive: false
     };
 
     this.renderDelete = this.renderDelete.bind(this);
+    this.changeTargetGroup = this.changeTargetGroup.bind(this);
+    this.changeInclusive = this.changeInclusive.bind(this);
     this.changeTitle = this.changeTitle.bind(this);
     this.changeDescription = this.changeDescription.bind(this);
     this.changeColor = this.changeColor.bind(this);
@@ -56,6 +62,18 @@ export class SettingsScreen extends Component {
           color: `#${uxToHex(props.association.metadata.color)}`
         });
     }
+  }
+
+  changeTargetGroup(target) {
+    if (target.groups.length === 1) {
+      this.setState({ targetGroup: target.groups[0] });
+    } else {
+      this.setState({ targetGroup: null });
+    }
+  }
+
+  changeInclusive(event) {
+    this.setState({ inclusive: !!event.target.checked });
   }
 
   changeTitle() {
@@ -122,7 +140,9 @@ export class SettingsScreen extends Component {
   groupifyChat() {
     const { props, state } = this;
 
-    props.api.chatView.groupify(props.station);
+    props.api.chatView.groupify(
+      props.station, state.targetGroup, state.inclusive
+    );
     props.api.setSpinner(true);
 
     this.setState({
@@ -171,15 +191,56 @@ export class SettingsScreen extends Component {
     if (!ownedUnmanagedVillage) {
       return null;
     } else {
+      let inclusiveToggle = <div/>
+      console.log('tg', state.targetGroup);
+      if (state.targetGroup) {
+        //TODO toggle component
+        let inclusiveClasses = state.inclusive
+          ? "relative checked bg-green2 br3 h1 toggle v-mid z-0"
+          : "relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0";
+        inclusiveToggle = (
+          <div className="mt4">
+            <input
+              type="checkbox"
+              style={{ WebkitAppearance: "none", width: 28 }}
+              className={inclusiveClasses}
+              onChange={this.changeInclusive}
+            />
+            <span className="dib f9 white-d inter ml3">
+              Inclusive
+            </span>
+            <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
+              Add chat members to the group if they aren't in it yet
+            </p>
+          </div>
+        );
+      }
+
       return (
         <div>
-          <div className={"w-100 fl mt3 "}>
+          <div className={"w-100 fl mt3"} style={{maxWidth: "29rem"}}>
             <p className="f8 mt3 lh-copy db">Convert Chat</p>
             <p className="f9 gray2 db mb4">
-              Convert this chat into a group with associated chat.
+              Convert this chat into a group with associated chat, or select a
+              group to add this chat to.
             </p>
+            <InviteSearch
+              groups={props.groups}
+              contacts={props.contacts}
+              associations={props.associations}
+              groupResults={true}
+              shipResults={false}
+              invites={{
+                groups: state.targetGroup ? [state.targetGroup] : [],
+                ships: []
+              }}
+              setInvite={this.changeTargetGroup}
+            />
+            {inclusiveToggle}
             <a onClick={this.groupifyChat.bind(this)}
-               className={"dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer"}>Convert to group</a>
+               className={"dib f9 black gray4-d bg-gray0-d ba pa2 mt4 b--black b--gray1-d pointer"}>
+              Convert to group
+            </a>
           </div>
         </div>
       );

--- a/pkg/interface/groups/src/js/components/lib/add-contact.js
+++ b/pkg/interface/groups/src/js/components/lib/add-contact.js
@@ -73,6 +73,7 @@ export class AddScreen extends Component {
             groups={props.groups}
             contacts={props.contacts}
             groupResults={false}
+            shipResults={true}
             invites={this.state.invites}
             setInvite={this.invChange}
           />

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -102,37 +102,37 @@ export class InviteSearch extends Component {
         });
       }
 
-      let shipMatches = this.state.peers.filter(e => {
-        return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
-      });
-
-      for (let contact of this.state.contacts.keys()) {
-        let thisContact = this.state.contacts.get(contact);
-        let match = thisContact.filter(e => {
-          return e.toLowerCase().includes(searchTerm);
+      let shipMatches = [];
+      if (this.props.shipResults) {
+        shipMatches = this.state.peers.filter(e => {
+          return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
         });
-        if (match.length > 0) {
-          if (!(contact in shipMatches)) {
-            shipMatches.push(contact);
+
+        for (let contact of this.state.contacts.keys()) {
+          let thisContact = this.state.contacts.get(contact);
+          let match = thisContact.filter(e => {
+            return e.toLowerCase().includes(searchTerm);
+          });
+          if (match.length > 0) {
+            if (!(contact in shipMatches)) {
+              shipMatches.push(contact);
+            }
           }
+        }
+
+        let isValid = true;
+        if (!urbitOb.isValidPatp("~" + searchTerm)) {
+          isValid = false;
+        }
+
+        if (shipMatches.length === 0 && isValid) {
+          shipMatches.push(searchTerm);
         }
       }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
-
-      let isValid = true;
-      if (!urbitOb.isValidPatp("~" + searchTerm)) {
-        isValid = false;
-      }
-
-      if (shipMatches.length === 0 && isValid) {
-        shipMatches.push(searchTerm);
-        this.setState({
-          searchResults: { groups: groupMatches, ships: shipMatches }
-        });
-      }
     }
   }
 
@@ -208,6 +208,18 @@ export class InviteSearch extends Component {
 
     let participants = <div />;
     let searchResults = <div />;
+
+    let placeholder = '';
+    if (props.shipResults) {
+      placeholder = 'ships';
+    }
+    if (props.groupResults) {
+      if (placeholder.length > 0) {
+        placeholder = placeholder + ' or ';
+      }
+      placeholder = placeholder + 'existing groups';
+    }
+    placeholder = 'Search for ' + placeholder;
 
     let invErrElem = <span />;
     if (state.inviteError) {
@@ -372,7 +384,7 @@ export class InviteSearch extends Component {
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
             " db focus-b--black focus-b--white-d"
           }
-          placeholder="Search for ships or existing groups"
+          placeholder={placeholder}
           disabled={searchDisabled}
           rows={1}
           spellCheck={false}

--- a/pkg/interface/groups/src/js/components/new.js
+++ b/pkg/interface/groups/src/js/components/new.js
@@ -134,6 +134,7 @@ export class NewScreen extends Component {
               groups={this.props.groups}
               contacts={this.props.contacts}
               groupResults={false}
+              shipResults={true}
               invites={this.state.invites}
               setInvite={this.invChange}
             />

--- a/pkg/interface/link/src/js/components/lib/invite-element.js
+++ b/pkg/interface/link/src/js/components/lib/invite-element.js
@@ -57,6 +57,7 @@ export class InviteElement extends Component {
           groups={{}}
           contacts={props.contacts}
           groupResults={false}
+          shipResults={true}
           invites={{
             groups: [],
             ships: this.state.members

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -102,37 +102,37 @@ export class InviteSearch extends Component {
         });
       }
 
-      let shipMatches = this.state.peers.filter(e => {
-        return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
-      });
-
-      for (let contact of this.state.contacts.keys()) {
-        let thisContact = this.state.contacts.get(contact);
-        let match = thisContact.filter(e => {
-          return e.toLowerCase().includes(searchTerm);
+      let shipMatches = [];
+      if (this.props.shipResults) {
+        shipMatches = this.state.peers.filter(e => {
+          return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
         });
-        if (match.length > 0) {
-          if (!(contact in shipMatches)) {
-            shipMatches.push(contact);
+
+        for (let contact of this.state.contacts.keys()) {
+          let thisContact = this.state.contacts.get(contact);
+          let match = thisContact.filter(e => {
+            return e.toLowerCase().includes(searchTerm);
+          });
+          if (match.length > 0) {
+            if (!(contact in shipMatches)) {
+              shipMatches.push(contact);
+            }
           }
+        }
+
+        let isValid = true;
+        if (!urbitOb.isValidPatp("~" + searchTerm)) {
+          isValid = false;
+        }
+
+        if (shipMatches.length === 0 && isValid) {
+          shipMatches.push(searchTerm);
         }
       }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
-
-      let isValid = true;
-      if (!urbitOb.isValidPatp("~" + searchTerm)) {
-        isValid = false;
-      }
-
-      if (shipMatches.length === 0 && isValid) {
-        shipMatches.push(searchTerm);
-        this.setState({
-          searchResults: { groups: groupMatches, ships: shipMatches }
-        });
-      }
     }
   }
 
@@ -208,6 +208,18 @@ export class InviteSearch extends Component {
 
     let participants = <div />;
     let searchResults = <div />;
+
+    let placeholder = '';
+    if (props.shipResults) {
+      placeholder = 'ships';
+    }
+    if (props.groupResults) {
+      if (placeholder.length > 0) {
+        placeholder = placeholder + ' or ';
+      }
+      placeholder = placeholder + 'existing groups';
+    }
+    placeholder = 'Search for ' + placeholder;
 
     let invErrElem = <span />;
     if (state.inviteError) {
@@ -372,7 +384,7 @@ export class InviteSearch extends Component {
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
             " db focus-b--black focus-b--white-d"
           }
-          placeholder="Search for ships or existing groups"
+          placeholder={placeholder}
           disabled={searchDisabled}
           rows={1}
           spellCheck={false}

--- a/pkg/interface/link/src/js/components/new.js
+++ b/pkg/interface/link/src/js/components/new.js
@@ -221,6 +221,7 @@ export class NewScreen extends Component {
             groups={props.groups}
             contacts={props.contacts}
             groupResults={true}
+            shipResults={true}
             invites={{
               groups: state.groups,
               ships: state.ships

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -102,37 +102,37 @@ export class InviteSearch extends Component {
         });
       }
 
-      let shipMatches = this.state.peers.filter(e => {
-        return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
-      });
-
-      for (let contact of this.state.contacts.keys()) {
-        let thisContact = this.state.contacts.get(contact);
-        let match = thisContact.filter(e => {
-          return e.toLowerCase().includes(searchTerm);
+      let shipMatches = [];
+      if (this.props.shipResults) {
+        shipMatches = this.state.peers.filter(e => {
+          return e.includes(searchTerm) && !this.props.invites.ships.includes(e);
         });
-        if (match.length > 0) {
-          if (!(contact in shipMatches)) {
-            shipMatches.push(contact);
+
+        for (let contact of this.state.contacts.keys()) {
+          let thisContact = this.state.contacts.get(contact);
+          let match = thisContact.filter(e => {
+            return e.toLowerCase().includes(searchTerm);
+          });
+          if (match.length > 0) {
+            if (!(contact in shipMatches)) {
+              shipMatches.push(contact);
+            }
           }
+        }
+
+        let isValid = true;
+        if (!urbitOb.isValidPatp("~" + searchTerm)) {
+          isValid = false;
+        }
+
+        if (shipMatches.length === 0 && isValid) {
+          shipMatches.push(searchTerm);
         }
       }
 
       this.setState({
         searchResults: { groups: groupMatches, ships: shipMatches }
       });
-
-      let isValid = true;
-      if (!urbitOb.isValidPatp("~" + searchTerm)) {
-        isValid = false;
-      }
-
-      if (shipMatches.length === 0 && isValid) {
-        shipMatches.push(searchTerm);
-        this.setState({
-          searchResults: { groups: groupMatches, ships: shipMatches }
-        });
-      }
     }
   }
 
@@ -208,6 +208,18 @@ export class InviteSearch extends Component {
 
     let participants = <div />;
     let searchResults = <div />;
+
+    let placeholder = '';
+    if (props.shipResults) {
+      placeholder = 'ships';
+    }
+    if (props.groupResults) {
+      if (placeholder.length > 0) {
+        placeholder = placeholder + ' or ';
+      }
+      placeholder = placeholder + 'existing groups';
+    }
+    placeholder = 'Search for ' + placeholder;
 
     let invErrElem = <span />;
     if (state.inviteError) {
@@ -372,7 +384,7 @@ export class InviteSearch extends Component {
             "f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 w-100" +
             " db focus-b--black focus-b--white-d"
           }
-          placeholder="Search for ships or existing groups"
+          placeholder={placeholder}
           disabled={searchDisabled}
           rows={1}
           spellCheck={false}

--- a/pkg/interface/publish/src/js/components/lib/new.js
+++ b/pkg/interface/publish/src/js/components/lib/new.js
@@ -189,6 +189,7 @@ export class NewScreen extends Component {
           <InviteSearch
             associations={this.props.associations}
             groupResults={true}
+            shipResults={true}
             groups={this.props.groups}
             contacts={this.props.contacts}
             invites={this.state.invites}


### PR DESCRIPTION
Expands on the "groupify" functionality added in #2480 by allowing you to merge invite-only chats into an existing group.

UI/copy here might need some light touching up. Currently just display the group search, lets you continue without selecting a group (old behavior, creates a new group based on the chat), or shows you the "inclusive" toggle if you do select a target group (new behavior, merges chat into existing group).

![convert](https://user-images.githubusercontent.com/3829764/77008240-1352de00-6966-11ea-9d4f-5869a4174c17.gif)
