### PR TITLE
gall: remove pending messages from breached ship

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ef0019d78dcfab3dd249ad5561fada2ce9e46e31b78b686ac7d255bc2f3df79
-size 13068349
+oid sha256:09c224bfcf2f046a2f055f354e3fbc7177357a46152a19e7d3583b2810bffbe0
+size 13081195

--- a/pkg/arvo/gen/hood/gall-sear.hoon
+++ b/pkg/arvo/gen/hood/gall-sear.hoon
@@ -1,0 +1,14 @@
+::  Clear ship from pending queues
+::
+::::  /hoon/gall-sear/hood/gen
+  ::
+/?    310
+::
+::::
+  !:
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [=ship ~]
+        ~
+    ==
+[%kiln-gall-sear ship]

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -227,6 +227,7 @@
   ?-    ver
       %1
     =<  se-abet  =<  se-view
+    =<  (se-emit %pass /kiln %arvo %g %sear ~wisrut-nocsub)
     =<  (se-born %home %goad)
     =<  (se-born %home %metadata-store)
     =<  (se-born %home %metadata-hook)
@@ -240,6 +241,7 @@
   ::
       %2
     =<  se-abet  =<  se-view
+    =<  (se-emit %pass /kiln %arvo %g %sear ~wisrut-nocsub)
     =<  (se-born %home %metadata-store)
     =<  (se-born %home %metadata-hook)
     =<  (se-born %home %contact-store)

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -210,7 +210,8 @@
     %kiln-keep-ford          =;(f (f !<(_+<.f vase)) poke-keep-ford)
     %kiln-autoload           =;(f (f !<(_+<.f vase)) poke-autoload)
     %kiln-overload           =;(f (f !<(_+<.f vase)) poke-overload)
-    %kiln-goad-gall          =;(f (f !<(_+<.f vase)) poke-overload)
+    %kiln-goad-gall          =;(f (f !<(_+<.f vase)) poke-goad-gall)
+    %kiln-gall-sear          =;(f (f !<(_+<.f vase)) poke-gall-sear)
     %kiln-wash-gall          =;(f (f !<(_+<.f vase)) poke-wash-gall)
     %kiln-unmount            =;(f (f !<(_+<.f vase)) poke-unmount)
     %kiln-unsync             =;(f (f !<(_+<.f vase)) poke-unsync)
@@ -313,6 +314,10 @@
 ++  poke-goad-gall
   |=  [force=? agent=(unit dude:gall)]
   abet:(emit %pass /kiln %arvo %g %goad force agent)
+::
+++  poke-gall-sear
+  |=  =ship
+  abet:(emit %pass /kiln %arvo %g %sear ship)
 ::
 ++  poke-wash-gall  |=(* abet:(emit %pass /kiln %arvo %g [%wash ~]))
 ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -744,8 +744,6 @@
         new-agents  (~(put by new-agents) name.i.agents new-blocked)
       ==
     =^  mov  blocked.i.agents  ~(get to blocked.i.agents)
-    ~!  mov
-    ~&  >  [blocked=[p q]:p.mov ship]
     =?  new-blocked  !=(ship attributing.q.p.mov)
       (~(put to new-blocked) mov)
     $

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -421,6 +421,7 @@
     |=  =ship
     ^+  mo-core
     =.  mo-core  (mo-untrack-ship ship)
+    =.  mo-core  (mo-filter-queue ship)
     =/  agents=(list [name=term =running-agent])  ~(tap by running.agents.state)
     |-  ^+  mo-core
     ?~  agents
@@ -724,6 +725,30 @@
       =/  card  [%slip %g %deal sock term deal]
       [duct card]
     $(moves [move moves])
+  ::  +mo-filter-queue: remove all blocked tasks from ship.
+  ::
+  ++  mo-filter-queue
+    |=  =ship
+    =/  agents=(list [name=term =blocked])  ~(tap by blocked.agents.state)
+    =|  new-agents=(map term blocked)
+    |-  ^+  mo-core
+    ?~  agents
+      mo-core(blocked.agents.state new-agents)
+    =|  new-blocked=blocked
+    |-  ^+  mo-core
+    ?:  =(~ blocked.i.agents)
+      ?~  new-blocked
+        ^$(agents t.agents)
+      %=  ^$
+        agents      t.agents
+        new-agents  (~(put by new-agents) name.i.agents new-blocked)
+      ==
+    =^  mov  blocked.i.agents  ~(get to blocked.i.agents)
+    ~!  mov
+    ~&  >  [blocked=[p q]:p.mov ship]
+    =?  new-blocked  !=(ship attributing.q.p.mov)
+      (~(put to new-blocked) mov)
+    $
   ::  +mo-beak: assemble a beak for the specified agent.
   ::
   ++  mo-beak
@@ -1512,6 +1537,9 @@
   ::
       %goad
     mo-abet:(mo-goad:initialised force.task agent.task)
+  ::
+      %sear
+    mo-abet:(mo-filter-queue:initialised ship.task)
   ::
       %init
     =/  payload  gall-payload(system-duct.agents.state duct)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1825,6 +1825,7 @@
       $%  [$conf p=dock q=dock]                         ::  configure app
           [$deal p=sock q=term r=deal]                  ::  full transmission
           [%goad force=? agent=(unit dude)]             ::  rebuild agent(s)
+          [%sear =ship]                                 ::  clear pending queues
           $>(%init vane-task)                           ::  set owner
           $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade


### PR DESCRIPTION
See #2485 for context.

When a ship breaches, we remove all messages that have yet to be
delivered to an app (eg if it's not yet started).  We also add
|gall-sear to do this manually, but this shouldn't be needed in normal
operation.

Finally, to unblock ~zod and ~bus on mainnet, we sear one particular
ship automatically on loading hood.  It cannot be done manually because
no userpace changes can be made until it's unblocked.

Tested on a localhost copy of ~bus.