### PR TITLE
chat: sidebar pulls nickname from associated group

### DIFF
--- a/pkg/interface/chat/src/js/components/sidebar.js
+++ b/pkg/interface/chat/src/js/components/sidebar.js
@@ -40,6 +40,7 @@ export class Sidebar extends Component {
         let when = !!msg ? msg.when : 0;
 
         let title = box.substr(1);
+        let associatedGroup = box;
         if (
           box in props.associations["chat"] &&
           props.associations.chat[box].metadata
@@ -47,13 +48,17 @@ export class Sidebar extends Component {
           title = props.associations.chat[box].metadata.title
             ? props.associations.chat[box].metadata.title
             : box.substr(1);
+          associatedGroup = props.associations.chat[box]["group-path"]
+            ? props.associations.chat[box]["group-path"]
+            : box;
         }
 
         let nickname = author;
-        if (box in props.contacts && author in props.contacts[box]) {
-          nickname = props.contacts[box][author].nickname
-            ? props.contacts[box][author].nickname
-            : author;
+        if (associatedGroup in props.contacts &&
+          author in props.contacts[associatedGroup]) {
+            nickname = props.contacts[associatedGroup][author].nickname
+              ? props.contacts[associatedGroup][author].nickname
+              : author;
         }
 
         return {


### PR DESCRIPTION
In the chat sidebar, we were looking for the box in our contacts object, 
not the associated group, so if you had a group and chat of the same name,
you'd see nicknames, but in no other situations. This commit rectifies
that by safely polling for the associated group of the chat.