### PR TITLE
chat: make autocomplete reflect both possible paths to chat channel

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -445,17 +445,17 @@
   ++  tab-list
     ^-  (list (option:auto tank))
     :~
-      [%join leaf+";join ~ship/chat-name (glyph)"]
-      [%leave leaf+";leave ~ship/chat-name"]
+      [%join leaf+";join (~/)~ship/chat-name (glyph)"]
+      [%leave leaf+";leave (~/)~ship/chat-name"]
       ::
       [%create leaf+";create [type] /chat-name (glyph)"]
       [%delete leaf+";delete /chat-name"]
-      [%invite leaf+";invite /chat-name ~ships"]
-      [%banish leaf+";banish /chat-name ~ships"]
+      [%invite leaf+";invite (~/)/chat-name ~ships"]
+      [%banish leaf+";banish (~/)/chat-name ~ships"]
     ::
-      [%bind leaf+";bind [glyph] ~ship/chat-name"]
+      [%bind leaf+";bind [glyph] (~/)~ship/chat-name"]
       [%unbind leaf+";unbind [glyph]"]
-      [%what leaf+";what (~ship/chat-name) (glyph)"]
+      [%what leaf+";what ((~/)~ship/chat-name) (glyph)"]
     ::
       [%settings leaf+";settings"]
       [%set leaf+";set key (value)"]


### PR DESCRIPTION
From what I've been told and experienced, the path to joining a chat channel must have a `~/` prefix. The current UI implies that it is optional rather than required. This PR fixes that as well as a similar problem with an autocomplete feature.