### PR TITLE
links: adjust sigil size to 38

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -65,7 +65,7 @@ export class LinkItem extends Component {
       <div className="w-100 pv3 flex bg-white bg-gray0-d">
         <Sigil
           ship={"~" + props.ship}
-          size={36}
+          size={38}
           color={"#" + props.color}
           classes={(member ? "mix-blend-diff" : "")}
             />


### PR DESCRIPTION
In links, the `pt1` used to separate the `LinkItem` matter — title and author/date/comments — stretches the sigil, being sized at 36, to 36x38. It results in this:

![image](https://user-images.githubusercontent.com/20846414/77118188-07205c80-6a0a-11ea-9b3c-638d44688647.png)

I decided to just size it up to 38px instead of futzing with the line-heights of the matter.

![image](https://user-images.githubusercontent.com/20846414/77118229-1dc6b380-6a0a-11ea-8ad1-e593c9e0db5a.png)
