### PR TITLE
groups: two contact card changes

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -486,9 +486,6 @@ export class ContactCard extends Component {
     }
 
     let ourOpt = (props.ship === window.ship) ? "dib" : "dn";
-    let localOpt =
-      ((props.ship === window.ship) && (props.path === "/~/default"))
-      ? "dib" : "dn";
 
     let adminOpt =
        ((props.path.includes(`~${window.ship}/`)) || ((props.ship === window.ship) &&
@@ -532,7 +529,7 @@ export class ContactCard extends Component {
               `bg-gray0-d mv4 mh3 pa1 f9 red2 pointer flex-shrink-0 ` + adminOpt
             }
             onClick={this.removeFromGroup}>
-            {props.ship === window.ship && props.path.includes(window.ship)
+            {props.ship === window.ship
               ? "Leave Group"
               : "Remove from Group"}
           </button>

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -491,9 +491,9 @@ export class ContactCard extends Component {
       ? "dib" : "dn";
 
     let adminOpt =
-      ( (props.path.includes(window.ship) || (props.ship === window.ship)) &&
-        !(props.path.includes('/~/default'))
-      ) ? "dib" : "dn";
+       ((props.path.includes(`~${window.ship}/`)) || ((props.ship === window.ship) &&
+        !(props.path.includes('/~/default'))))
+       ? "dib" : "dn";
 
     let meLink = (props.path === "/~/default")
       ? `/~groups` : `/~groups/detail${props.path}`;


### PR DESCRIPTION
- Before we saw if window.ship was in the path of the group. If you're a star or higher, you'll match many group paths that you don't own. This strengthens the check.
- When you were looking at your own card in another group, it would say "Remove from" group. This is from an arbitrarily strict ternary check that adminOpt catches for us, so we just check if the ship is us.