### PR TITLE
chat fe: disable advanced groupify

### DIFF
--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -219,8 +219,7 @@ export class SettingsScreen extends Component {
           <div className={"w-100 fl mt3"} style={{maxWidth: "29rem"}}>
             <p className="f8 mt3 lh-copy db">Convert Chat</p>
             <p className="f9 gray2 db mb4">
-              Convert this chat into a group with associated chat, or select a
-              group to add this chat to.
+              Convert this chat into a group with associated chat.
             </p>
             {/*
             <InviteSearch

--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -222,6 +222,7 @@ export class SettingsScreen extends Component {
               Convert this chat into a group with associated chat, or select a
               group to add this chat to.
             </p>
+            {/*
             <InviteSearch
               groups={props.groups}
               contacts={props.contacts}
@@ -235,8 +236,9 @@ export class SettingsScreen extends Component {
               setInvite={this.changeTargetGroup}
             />
             {inclusiveToggle}
+            */}
             <a onClick={this.groupifyChat.bind(this)}
-               className={"dib f9 black gray4-d bg-gray0-d ba pa2 mt4 b--black b--gray1-d pointer"}>
+               className={"dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer"}>
               Convert to group
             </a>
           </div>


### PR DESCRIPTION
Introduced in #2546, the new functionality seems able to induce weird
behavior causing messages to be processed twice. Disabling this
functionality on the frontend until that has been fixed.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/3829764/77123239-db1fce00-6a3f-11ea-8cfc-1d2fbabc0317.png">
