### PR TITLE
groups: permission remove button for group members

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
@@ -47,6 +47,9 @@ export class ContactSidebar extends Component {
         );
       });
 
+    let adminOpt = (props.path.includes(`~${window.ship}/`))
+      ? "dib" : "dn";
+
     let groupItems =
       Array.from(group).map((member) => {
         return (
@@ -65,7 +68,7 @@ export class ContactSidebar extends Component {
               title={member}>
               {cite(member)}
             </p>
-            <p className="dib v-mid f9 mh2 red2 pointer"
+            <p className={"v-mid f9 mh2 red2 pointer " + adminOpt}
               style={{paddingTop: 6}}
               onClick={() => {
                 props.api.setSpinner(true);

--- a/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
@@ -68,7 +68,7 @@ export class ContactSidebar extends Component {
               title={member}>
               {cite(member)}
             </p>
-            <p className={"v-mid f9 mh2 red2 pointer " + adminOpt}
+            <p className={"v-mid f9 mh3 red2 pointer " + adminOpt}
               style={{paddingTop: 6}}
               onClick={() => {
                 props.api.setSpinner(true);


### PR DESCRIPTION
Adds 'adminOpt' to the remove button for group members
who have not yet shared metadata.

(Otherwise "Remove" shows all the time beside those members, for all members' UIs, in every group.)