### PR TITLE
chat-hook: clean up pre-OS1 subscriptions

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -63,7 +63,13 @@
     |^
     =/  old  !<(versioned-state old-vase)
     ?:  ?=(%1 -.old)
-      [~ this(state old)]
+      :_  this(state old)
+      %+  murn  ~(tap by wex.bol)
+      |=  [[=wire =ship =term] *]
+      ^-  (unit card)
+      ?.  &(?=([%mailbox *] wire) =(our.bol ship) =(%chat-store term))
+        ~
+      `[%pass wire %agent [our.bol %chat-store] %leave ~]
     ::  path structure ugprade logic
     ::
     =/  keys=(set path)  (scry:cc (set path) %chat-store /keys)


### PR DESCRIPTION
As discussed per email:

If chats with identical resource paths were created, that would result
in chat-hook seeing updates twice.

These "/mailbox wire sub to local chat-store" subscriptions aren't
created by the current logic anymore, and as such any existing ones
should be eradicated.

You can do a dry-run of the check made here (or the entire logic, if you want, using `+dbug`. Output from my ship: all the chats (DMs) I'm hosting.

```hoon
> :chat-hook +dbug [%state '(skim ~(tap by wex.bowl) |=([[=wire =ship =term] *] &(?=([%mailbox *] wire) =(our.bowl ship) =(%chat-store term))))']
[   i
  [ p=[wire=/mailbox/~palfun-foslup/littel-ponnys ship=~palfun-foslup term=%chat-store]
    q=[acked=%.y path=/mailbox/~palfun-foslup/littel-ponnys]
  ]
    t
  ~[
    [ p=[wire=/mailbox/~palfun-foslup/novlud-padtyv ship=~palfun-foslup term=%chat-store]
      q=[acked=%.y path=/mailbox/~palfun-foslup/novlud-padtyv]
    ]
    [ p=[wire=/mailbox/~palfun-foslup/fabled-faster ship=~palfun-foslup term=%chat-store]
      q=[acked=%.y path=/mailbox/~palfun-foslup/fabled-faster]
    ]
    [ p=[wire=/mailbox/~palfun-foslup/haddef-sigwen ship=~palfun-foslup term=%chat-store]
      q=[acked=%.y path=/mailbox/~palfun-foslup/haddef-sigwen]
    ]
    [ p=[wire=/mailbox/~palfun-foslup/rovnys-ricfer ship=~palfun-foslup term=%chat-store]
      q=[acked=%.y path=/mailbox/~palfun-foslup/rovnys-ricfer]
    ]
  ]
]
```