### PR TITLE
publish: add pending state for comments

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/comment-item.js
+++ b/pkg/interface/publish/src/js/components/lib/comment-item.js
@@ -29,6 +29,7 @@ export class CommentItem extends Component {
     });
   }
   render() {
+    let pending = !!this.props.pending ? "o-60" : "";
     let commentData = this.props.comment[Object.keys(this.props.comment)[0]];
     let content = commentData.content.split("\n").map((line, i)=> {
       return (
@@ -55,7 +56,7 @@ export class CommentItem extends Component {
     }
 
     return (
-      <div>
+      <div className={pending}>
         <div className="flex mv3 bg-white bg-gray0-d">
         <Sigil
           ship={commentData.author}

--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -75,7 +75,7 @@ export class Comments extends Component {
         [da]: {
           author: this.props.ship,
           content: com["new-comment"].body,
-          "date-created": Math.round(new Date().getTime() / 1000)
+          "date-created": Math.round(new Date().getTime())
         }
       }
       return (

--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -15,13 +15,15 @@ export class Comments extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.comments && (
-      Object.keys(prevProps.comments[0]) !==
-      Object.keys(this.props.comments[0]))
-      ) {
+    let previousComments = prevProps.comments[0] || {};
+    let currentComments = this.props.comments[0] || {};
+    let previous = Object.keys(previousComments) || [];
+    let current = Object.keys(currentComments) || [];
+    if ((prevProps.comments && this.props.comments) &&
+      (previous !== current)) {
         let pendingSet = this.state.pending;
-        Object.keys(this.props.comments[0]).map((com) => {
-          let obj = this.props.comments[0][com];
+        Object.keys(currentComments).map((com) => {
+          let obj = currentComments[com];
           for (let each of pendingSet.values()) {
             if (obj.content === each["new-comment"].body) {
               pendingSet.delete(each);


### PR DESCRIPTION
- Much like the chat variant, shows your last pending comment in faded opacity below; and still allows you to type another one while waiting for it. Posting that second comment, however, will still be disabled while you're waiting.

Performance question: To get it to be a seamless update (not popping in and out), I handle it in `componentDidUpdate`, but I can't get it to only do this when the latest comment has changed; if I add another `[0]` to that `Object.keys()`, it never processes — even though the strings ostensibly are different between the previous latest comment and our current; if I just compare `Object.keys()`, it always processes, on every keystroke, because it's comparing arrays, and of course the arrays are different assignments.

Likewise, handling pending comments in our Comments component has the side effect of losing the currently pending comment when we navigate away (though ostensibly it will post and be shown within a few seconds anyway). I assumed from a UX standpoint that people, unlike chat, won't be juggling tons of pending comments — otherwise this has to be rewritten into the reducer as Chat does. I tried the simpler approach first.