### PR TITLE
os1: add startup content

### DIFF
--- a/pkg/arvo/app/launch.hoon
+++ b/pkg/arvo/app/launch.hoon
@@ -2,7 +2,7 @@
 /+  *server, default-agent, dbug
 ::
 /=  index
-  /^  $-(marl manx)
+  /^  $-([json marl] manx)
   /:  /===/app/launch/index  /!noun/
 /=  script
   /^  octs
@@ -25,6 +25,7 @@
 |%
 +$  versioned-state
   $%  state-zero
+      state-one
   ==
 +$  state-zero
   $:  %0
@@ -32,11 +33,18 @@
       data=tile-data:launch
       path-to-tile=(map path @tas)
   ==
++$  state-one
+  $:  %1
+      tiles=(set tile:launch)
+      data=tile-data:launch
+      path-to-tile=(map path @tas)
+      first-time=?
+  ==
 ::
 +$  card  card:agent:gall
 --
 ::
-=|  state-zero
+=|  state-one
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
@@ -45,19 +53,36 @@
     def   ~(. (default-agent this %|) bol)
 ++  on-init
   ^-  (quip card _this)
-  :_  this
+  :_  this(state *state-one)
   [%pass / %arvo %e %connect [~ /] %launch]~
 ::
 ++  on-save  !>(state)
 ::
 ++  on-load
   |=  old=vase
-  `this(state !<(state-zero old))
+  ^-  (quip card _this)
+  =/  old-state  !<(versioned-state old)
+  :-  ~
+  ?-    -.old-state
+      %0
+    %=  this
+      state  [%1 tiles.old-state data.old-state path-to-tile.old-state %.n]
+    ==
+  ::
+      %1  this(state old-state)
+  ==
 ::
 ++  on-poke
   |=  [mar=mark vas=vase]
   ^-  (quip card _this)
   ?+    mar  (on-poke:def mar vas)
+      %json
+    ?>  (team:title our.bol src.bol)
+    =/  jon  !<(json vas)
+    :-  ~
+    ?.  =(jon [%s 'disable welcome message'])
+      this
+    this(first-time %.n)
   ::
       %launch-action
     =/  act  !<(action:launch vas)
@@ -92,7 +117,8 @@
     ::
         ~
       =/  hym=manx
-        %-  index
+        %+  index
+          [%b first-time]
         ^-  marl
         %+  turn  ~(tap by data)
         |=  [key=@tas [jon=json url=@t]]

--- a/pkg/arvo/app/launch/index.hoon
+++ b/pkg/arvo/app/launch/index.hoon
@@ -1,4 +1,4 @@
-|=  scripts=marl
+|=  [startup=json scripts=marl]
 ;html
   ;head
     ;title: Home
@@ -15,5 +15,6 @@
     ;script@"/~modulo/session.js";
     ;*  scripts
     ;script@"/~launch/js/index.js";
+    ;script: window.startupMessage = {(en-json:html startup)}
   ==
 ==

--- a/pkg/interface/chat/src/css/custom.css
+++ b/pkg/interface/chat/src/css/custom.css
@@ -84,6 +84,10 @@ h2 {
   font-family: "Source Code Pro", monospace;
 }
 
+.bg-welcome-green {
+  background-color: #ECF6F2;
+}
+
 .list-ship {
   line-height: 2.2;
 }

--- a/pkg/interface/chat/src/js/components/lib/welcome.js
+++ b/pkg/interface/chat/src/js/components/lib/welcome.js
@@ -7,7 +7,14 @@ export class Welcome extends Component {
     this.state = {
       show: true
     }
+    this.disableWelcome = this.disableWelcome.bind(this);
   }
+
+  disableWelcome() {
+    this.setState({ show: false });
+    localStorage.setItem("urbit-chat:wasWelcomed", JSON.stringify(true));
+  }
+
   render() {
     let wasWelcomed = localStorage.getItem("urbit-chat:wasWelcomed");
     if (wasWelcomed === null) {
@@ -21,14 +28,11 @@ export class Welcome extends Component {
 
     return ((!wasWelcomed && this.state.show) && (inbox.length !== 0)) ? (
       <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
-      <p className="f9 lh-copy">Chats are basic, instant, linear modes of conversation. Many chats can be bundled under one group.</p>
-      <p className="f9 pt2 dib fw6 pointer"
-      onClick={(() => {
-        localStorage.setItem("urbit-chat:wasWelcomed", JSON.stringify(true));
-        this.setState({show: false})
-      })}>
-        Close this message
-      </p>
+        <p className="f9 lh-copy">Chats are instant, linear modes of conversation. Many chats can be bundled under one group.</p>
+        <p className="f9 pt2 dib fw6 pointer"
+          onClick={(() => this.disableWelcome())}>
+          Close this message
+        </p>
       </div>
     ) : <div/>
   }

--- a/pkg/interface/chat/src/js/components/lib/welcome.js
+++ b/pkg/interface/chat/src/js/components/lib/welcome.js
@@ -27,11 +27,11 @@ export class Welcome extends Component {
     let inbox = !!this.props.inbox ? this.props.inbox : {};
 
     return ((!wasWelcomed && this.state.show) && (inbox.length !== 0)) ? (
-      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
-        <p className="f9 lh-copy">Chats are instant, linear modes of conversation. Many chats can be bundled under one group.</p>
-        <p className="f9 pt2 dib fw6 pointer"
+      <div className="ma4 pa2 bg-welcome-green bg-gray1-d white-d">
+        <p className="f8 lh-copy">Chats are instant, linear modes of conversation. Many chats can be bundled under one group.</p>
+        <p className="f8 pt2 dib pointer bb"
           onClick={(() => this.disableWelcome())}>
-          Close this message
+          Close this
         </p>
       </div>
     ) : <div/>

--- a/pkg/interface/chat/src/js/components/lib/welcome.js
+++ b/pkg/interface/chat/src/js/components/lib/welcome.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+
+export class Welcome extends Component {
+  constructor() {
+    super();
+    this.state = {
+      show: true
+    }
+  }
+  render() {
+    let wasWelcomed = localStorage.getItem("urbit-chat:wasWelcomed");
+    if (wasWelcomed === null) {
+      localStorage.setItem("urbit-chat:wasWelcomed", JSON.stringify(false));
+      return wasWelcomed = false;
+    } else {
+      wasWelcomed = JSON.parse(wasWelcomed);
+    }
+
+    let inbox = !!this.props.inbox ? this.props.inbox : {};
+
+    return ((!wasWelcomed && this.state.show) && (inbox.length !== 0)) ? (
+      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
+      <p className="f9 lh-copy">Chats are basic, instant, linear modes of conversation. Many chats can be bundled under one group.</p>
+      <p className="f9 pt2 dib fw6 pointer"
+      onClick={(() => {
+        localStorage.setItem("urbit-chat:wasWelcomed", JSON.stringify(true));
+        this.setState({show: false})
+      })}>
+        Close this message
+      </p>
+      </div>
+    ) : <div/>
+  }
+}
+
+export default Welcome

--- a/pkg/interface/chat/src/js/components/sidebar.js
+++ b/pkg/interface/chat/src/js/components/sidebar.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import classnames from 'classnames';
 import _ from 'lodash';
 
+import Welcome from '/components/lib/welcome.js';
 import { SidebarInvite } from '/components/lib/sidebar-invite';
 import { SidebarItem } from '/components/lib/sidebar-item';
 
@@ -111,6 +112,7 @@ export class Sidebar extends Component {
           </a>
         </div>
         <div className="overflow-y-auto h-100">
+          <Welcome inbox={props.inbox}/>
           {sidebarInvites}
           {sidebarItems}
         </div>

--- a/pkg/interface/groups/src/css/custom.css
+++ b/pkg/interface/groups/src/css/custom.css
@@ -55,6 +55,10 @@ a {
   line-height: 16px;
 }
 
+.bg-welcome-green {
+  background-color: #ECF6F2;
+}
+
 .mono {
   font-family: "Source Code Pro", monospace;
 }

--- a/pkg/interface/groups/src/js/components/lib/group-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/group-sidebar.js
@@ -4,6 +4,7 @@ import { Route, Link } from 'react-router-dom';
 import { GroupItem } from '/components/lib/group-item';
 import { Sigil } from '/components/lib/icons/sigil';
 import { SidebarInvite } from '/components/lib/sidebar-invite';
+import { Welcome } from '/components/lib/welcome';
 import { cite } from '/lib/util';
 
 export class GroupSidebar extends Component {
@@ -93,6 +94,7 @@ export class GroupSidebar extends Component {
           <Link to="/~groups/new" className="dib">
             <p className="f9 pt4 pl4 green2 bn">Create Group</p>
           </Link>
+          <Welcome contacts={props.contacts}/>
           <h2 className="f9 pt4 pr4 pb2 pl4 gray2 c-default">Your Identity</h2>
           {rootIdentity}
           {inviteItems}

--- a/pkg/interface/groups/src/js/components/lib/welcome.js
+++ b/pkg/interface/groups/src/js/components/lib/welcome.js
@@ -27,11 +27,11 @@ export class Welcome extends Component {
     let contacts = !!this.props.contacts ? this.props.contacts : {};
 
     return ((!wasWelcomed && this.state.show) && (contacts.length !== 0)) ? (
-      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
-        <p className="f9 lh-copy">Each Group is a list of other Urbit IDs that share some set of modules: chats, links and notebooks.</p>
-        <p className="f9 pt2 dib fw6 pointer"
+      <div className="ma4 pa2 bg-welcome-green bg-gray1-d white-d">
+        <p className="f8 lh-copy">Each Group is a list of other Urbit IDs that share some set of modules: chats, links and notebooks.</p>
+        <p className="f8 pt2 dib pointer bb"
           onClick={(() => this.disableWelcome())}>
-          Close this message
+          Close this
       </p>
       </div>
     ) : <div />

--- a/pkg/interface/groups/src/js/components/lib/welcome.js
+++ b/pkg/interface/groups/src/js/components/lib/welcome.js
@@ -7,7 +7,14 @@ export class Welcome extends Component {
     this.state = {
       show: true
     }
+    this.disableWelcome = this.disableWelcome.bind(this);
   }
+
+  disableWelcome() {
+    this.setState({ show: false });
+    localStorage.setItem("urbit-groups:wasWelcomed", JSON.stringify(true));
+  }
+
   render() {
     let wasWelcomed = localStorage.getItem("urbit-groups:wasWelcomed");
     if (wasWelcomed === null) {
@@ -21,12 +28,9 @@ export class Welcome extends Component {
 
     return ((!wasWelcomed && this.state.show) && (contacts.length !== 0)) ? (
       <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
-        <p className="f9 lh-copy">Groups are private spaces you inhabit with other ships. Modules can be shared with members of a group.</p>
+        <p className="f9 lh-copy">Each Group is a list of other Urbit IDs that share some set of modules: chats, links and notebooks.</p>
         <p className="f9 pt2 dib fw6 pointer"
-          onClick={(() => {
-            localStorage.setItem("urbit-groups:wasWelcomed", JSON.stringify(true));
-            this.setState({ show: false })
-          })}>
+          onClick={(() => this.disableWelcome())}>
           Close this message
       </p>
       </div>

--- a/pkg/interface/groups/src/js/components/lib/welcome.js
+++ b/pkg/interface/groups/src/js/components/lib/welcome.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+
+export class Welcome extends Component {
+  constructor() {
+    super();
+    this.state = {
+      show: true
+    }
+  }
+  render() {
+    let wasWelcomed = localStorage.getItem("urbit-groups:wasWelcomed");
+    if (wasWelcomed === null) {
+      localStorage.setItem("urbit-groups:wasWelcomed", JSON.stringify(false));
+      return wasWelcomed = false;
+    } else {
+      wasWelcomed = JSON.parse(wasWelcomed);
+    }
+
+    let contacts = !!this.props.contacts ? this.props.contacts : {};
+
+    return ((!wasWelcomed && this.state.show) && (contacts.length !== 0)) ? (
+      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
+        <p className="f9 lh-copy">Groups are private spaces you inhabit with other ships. Modules can be shared with members of a group.</p>
+        <p className="f9 pt2 dib fw6 pointer"
+          onClick={(() => {
+            localStorage.setItem("urbit-groups:wasWelcomed", JSON.stringify(true));
+            this.setState({ show: false })
+          })}>
+          Close this message
+      </p>
+      </div>
+    ) : <div />
+  }
+}
+
+export default Welcome

--- a/pkg/interface/launch/src/js/components/home.js
+++ b/pkg/interface/launch/src/js/components/home.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 import Header from '/components/header';
 import Tile from '/components/tile';
-
+import Welcome from '/components/welcome';
 
 export default class Home extends Component {
 
@@ -42,6 +42,7 @@ export default class Home extends Component {
         "flex justify-between flex-wrap"}
         style={{maxWidth: "40rem"}}>
           {tileElems}
+          <Welcome/>
         </div>
       </div>
     );

--- a/pkg/interface/launch/src/js/components/home.js
+++ b/pkg/interface/launch/src/js/components/home.js
@@ -41,8 +41,8 @@ export default class Home extends Component {
         <div className={"v-mid pa2 dtc-m dtc-l dtc-xl " +
         "flex justify-between flex-wrap"}
         style={{maxWidth: "40rem"}}>
+          <Welcome />
           {tileElems}
-          <Welcome/>
         </div>
       </div>
     );

--- a/pkg/interface/launch/src/js/components/welcome.js
+++ b/pkg/interface/launch/src/js/components/welcome.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+
+export class Welcome extends Component {
+  constructor() {
+    super();
+    this.state = {
+      show: true
+    }
+  }
+
+  render() {
+    let firstTime = window.startupMessage;
+    return (firstTime && this.state.show)
+    ? (
+      <div className={"fl ma2 bg-white bg-gray0-d white-d overflow-hidden " +
+      "ba b--black b--gray1-d pa2 w-100 mw6 lh-copy"}>
+      <p className="f9">You've just come into possession of a virtual computer you own completely. You can run it on a laptop, you can run it on a server, but it doesn't really matter.</p>
+      <p className="f9 pt2">With the key you used to access this space, you can never lose this computer. You can never lose what's on this computer.</p>
+      <p className="f9 pt2">To begin, you should probably pop into a chat and verify there are signs of life in this new place. If you were invited by a friend, you probably already have access to a few.</p>
+      <p className="f9 pt2">If you don't, feel free to <a className="no-underline bb b--black b--gray1-d" href="/~chat/join/~/~dopzod/urbit-help">join our lobby.</a></p>
+      <p className="dib f9 pt2 bb b--black b--gray1-d pointer"
+      onClick={(() => {
+        window.api.action("launch", "json", "disable welcome message");
+        this.setState({show: false});
+      })}>Close this note</p>
+      </div>
+    )
+    : ( <div/>)
+  }
+}
+
+export default Welcome

--- a/pkg/interface/launch/src/js/components/welcome.js
+++ b/pkg/interface/launch/src/js/components/welcome.js
@@ -6,6 +6,12 @@ export class Welcome extends Component {
     this.state = {
       show: true
     }
+    this.disableWelcome = this.disableWelcome.bind(this);
+  }
+
+  disableWelcome() {
+    window.api.action("launch", "json", "disable welcome message");
+    this.setState({ show: false });
   }
 
   render() {
@@ -13,16 +19,18 @@ export class Welcome extends Component {
     return (firstTime && this.state.show)
     ? (
       <div className={"fl ma2 bg-white bg-gray0-d white-d overflow-hidden " +
-      "ba b--black b--gray1-d pa2 w-100 mw6 lh-copy"}>
-      <p className="f9">You've just come into possession of a virtual computer you own completely. You can run it on a laptop, you can run it on a server, but it doesn't really matter.</p>
-      <p className="f9 pt2">With the key you used to access this space, you can never lose this computer. You can never lose what's on this computer.</p>
-      <p className="f9 pt2">To begin, you should probably pop into a chat and verify there are signs of life in this new place. If you were invited by a friend, you probably already have access to a few.</p>
-      <p className="f9 pt2">If you don't, feel free to <a className="no-underline bb b--black b--gray1-d" href="/~chat/join/~/~dopzod/urbit-help">join our lobby.</a></p>
-      <p className="dib f9 pt2 bb b--black b--gray1-d pointer"
-      onClick={(() => {
-        window.api.action("launch", "json", "disable welcome message");
-        this.setState({show: false});
-      })}>Close this note</p>
+      "ba b--black b--gray1-d pa2 w-100 lh-copy"}>
+        <p className="f9">Welcome. This virtual computer belongs to you completely. The Urbit ID you used to boot it is yours as well.</p>
+        <p className="f9 pt2">Since your ID and OS belong to you, it’s up to you to keep them safe. Be sure your ID is somewhere you won’t lose it and you keep your OS on a machine you trust.</p>
+        <p className="f9 pt2">Urbit OS is designed to keep your data secure and hard to lose. But the system is still young — so don’t put anything critical in here just yet.</p>
+        <p className="f9 pt2">To begin exploring, you should probably pop into a chat and verify there are signs of life in this new place. If you were invited by a friend, you probably already have access to a few groups.</p>
+        <p className="f9 pt2">If you don't know where to go, feel free to <a className="no-underline bb b--black b--gray1-d dib" href="/~chat/join/~/~dopzod/urbit-help">join our lobby.</a>
+        </p>
+        <p className="f9 pt2">Have fun!</p>
+        <p className="dib f9 pt2 bb b--black b--gray1-d pointer"
+          onClick={(() => {this.disableWelcome()})}>
+          Close this note
+        </p>
       </div>
     )
     : ( <div/>)

--- a/pkg/interface/link/src/css/custom.css
+++ b/pkg/interface/link/src/css/custom.css
@@ -64,6 +64,10 @@ a {
   line-height: 2.2;
 }
 
+.bg-welcome-green {
+  background-color: #ECF6F2;
+}
+
 .c-default {
   cursor: default;
 }

--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { Route, Link } from 'react-router-dom';
 import { ChannelsItem } from '/components/lib/channels-item';
 import { SidebarInvite } from '/components/lib/sidebar-invite';
+import { Welcome } from '/components/lib/welcome';
 
 export class ChannelsSidebar extends Component {
   // drawer to the left
@@ -69,6 +70,7 @@ export class ChannelsSidebar extends Component {
               New Collection
             </Link>
           </div>
+          <Welcome associations={props.associations}/>
           {sidebarInvites}
           {channelItems}
         </div>

--- a/pkg/interface/link/src/js/components/lib/welcome.js
+++ b/pkg/interface/link/src/js/components/lib/welcome.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+
+export class Welcome extends Component {
+  constructor() {
+    super();
+    this.state = {
+      show: true
+    }
+  }
+  render() {
+    let wasWelcomed = localStorage.getItem("urbit-link:wasWelcomed");
+    if (wasWelcomed === null) {
+      localStorage.setItem("urbit-link:wasWelcomed", JSON.stringify(false));
+      return wasWelcomed = false;
+    } else {
+      wasWelcomed = JSON.parse(wasWelcomed);
+    }
+
+    let associations = !!this.props.associations ? this.props.associations : {};
+
+    return ((!wasWelcomed && this.state.show) && (associations.length !== 0)) ? (
+      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
+        <p className="f9 lh-copy">For now, collections only hold links. In the future, they'll be able to organize and display rich varieties of content.</p>
+        <p className="f9 pt2 dib fw6 pointer"
+          onClick={(() => {
+            localStorage.setItem("urbit-link:wasWelcomed", JSON.stringify(true));
+            this.setState({ show: false })
+          })}>
+          Close this message
+      </p>
+      </div>
+    ) : <div />
+  }
+}
+
+export default Welcome

--- a/pkg/interface/link/src/js/components/lib/welcome.js
+++ b/pkg/interface/link/src/js/components/lib/welcome.js
@@ -27,11 +27,11 @@ export class Welcome extends Component {
     let associations = !!this.props.associations ? this.props.associations : {};
 
     return ((!wasWelcomed && this.state.show) && (associations.length !== 0)) ? (
-      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
-        <p className="f9 lh-copy">Links are for collecting and discussing outside content. Each post is a URL and a comment thread.</p>
-        <p className="f9 pt2 dib fw6 pointer"
+      <div className="ma4 pa2 bg-welcome-green bg-gray1-d white-d">
+        <p className="f8 lh-copy">Links are for collecting and discussing outside content. Each post is a URL and a comment thread.</p>
+        <p className="f8 pt2 dib bb pointer"
           onClick={(() => this.disableWelcome())}>
-          Close this message
+          Close this
       </p>
       </div>
     ) : <div />

--- a/pkg/interface/link/src/js/components/lib/welcome.js
+++ b/pkg/interface/link/src/js/components/lib/welcome.js
@@ -7,7 +7,14 @@ export class Welcome extends Component {
     this.state = {
       show: true
     }
+    this.disableWelcome = this.disableWelcome.bind(this);
   }
+
+  disableWelcome() {
+    this.setState({ show: false });
+    localStorage.setItem("urbit-link:wasWelcomed", JSON.stringify(true));
+  }
+
   render() {
     let wasWelcomed = localStorage.getItem("urbit-link:wasWelcomed");
     if (wasWelcomed === null) {
@@ -21,12 +28,9 @@ export class Welcome extends Component {
 
     return ((!wasWelcomed && this.state.show) && (associations.length !== 0)) ? (
       <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray1-d white-d">
-        <p className="f9 lh-copy">For now, collections only hold links. In the future, they'll be able to organize and display rich varieties of content.</p>
+        <p className="f9 lh-copy">Links are for collecting and discussing outside content. Each post is a URL and a comment thread.</p>
         <p className="f9 pt2 dib fw6 pointer"
-          onClick={(() => {
-            localStorage.setItem("urbit-link:wasWelcomed", JSON.stringify(true));
-            this.setState({ show: false })
-          })}>
+          onClick={(() => this.disableWelcome())}>
           Close this message
       </p>
       </div>

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -46,6 +46,10 @@ a {
   font-family: 'Source Code Pro', monospace;
 }
 
+.bg-welcome-green {
+  background-color: #ECF6F2;
+}
+
 @media all and (max-width: 34.375em) {
   .dn-s {
     display: none;

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -3,6 +3,7 @@ import { Route, Link } from 'react-router-dom';
 import { Dropdown } from './dropdown';
 import { NotebookItem } from './notebook-item';
 import { SidebarInvite } from './sidebar-invite';
+import { Welcome } from './welcome';
 
 export class Sidebar extends Component {
   constructor(props) {
@@ -179,6 +180,7 @@ export class Sidebar extends Component {
         </div>
         <div className="overflow-y-auto pb1"
         style={{height: "calc(100% - 82px)"}}>
+          <Welcome notebooks={props.notebooks}/>
           {sidebarInvites}
           {notebookItems}
         </div>

--- a/pkg/interface/publish/src/js/components/lib/welcome.js
+++ b/pkg/interface/publish/src/js/components/lib/welcome.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+
+export class Welcome extends Component {
+  constructor() {
+    super();
+    this.state = {
+      show: true
+    }
+  }
+  render() {
+    let wasWelcomed = localStorage.getItem("urbit-publish:wasWelcomed");
+    if (wasWelcomed === null) {
+      localStorage.setItem("urbit-publish:wasWelcomed", JSON.stringify(false));
+      return wasWelcomed = false;
+    } else {
+      wasWelcomed = JSON.parse(wasWelcomed);
+    }
+
+    let notebooks = !!this.props.notebooks ? this.props.notebooks : {};
+
+    return ((!wasWelcomed && this.state.show) && (notebooks.length !== 0)) ? (
+      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
+        <p className="f9 lh-copy">Notebooks are best used for longer-form writing and text editing. Notes accept Markdown for formatting.</p>
+        <p className="f9 pt2 dib fw6 pointer"
+          onClick={(() => {
+            localStorage.setItem("urbit-publish:wasWelcomed", JSON.stringify(true));
+            this.setState({ show: false })
+          })}>
+          Close this message
+      </p>
+      </div>
+    ) : <div />
+  }
+}
+
+export default Welcome

--- a/pkg/interface/publish/src/js/components/lib/welcome.js
+++ b/pkg/interface/publish/src/js/components/lib/welcome.js
@@ -7,7 +7,14 @@ export class Welcome extends Component {
     this.state = {
       show: true
     }
+    this.disableWelcome = this.disableWelcome.bind(this);
   }
+
+  disableWelcome() {
+    this.setState({ show: false });
+    localStorage.setItem("urbit-publish:wasWelcomed", JSON.stringify(true));
+  }
+
   render() {
     let wasWelcomed = localStorage.getItem("urbit-publish:wasWelcomed");
     if (wasWelcomed === null) {
@@ -21,12 +28,9 @@ export class Welcome extends Component {
 
     return ((!wasWelcomed && this.state.show) && (notebooks.length !== 0)) ? (
       <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
-        <p className="f9 lh-copy">Notebooks are best used for longer-form writing and text editing. Notes accept Markdown for formatting.</p>
+        <p className="f9 lh-copy">Notebooks are for longer-form writing and discussion. Each Notebook is a collection of Markdown-formatted notes with optional comments.</p>
         <p className="f9 pt2 dib fw6 pointer"
-          onClick={(() => {
-            localStorage.setItem("urbit-publish:wasWelcomed", JSON.stringify(true));
-            this.setState({ show: false })
-          })}>
+          onClick={(() => this.disableWelcome())}>
           Close this message
       </p>
       </div>

--- a/pkg/interface/publish/src/js/components/lib/welcome.js
+++ b/pkg/interface/publish/src/js/components/lib/welcome.js
@@ -27,11 +27,11 @@ export class Welcome extends Component {
     let notebooks = !!this.props.notebooks ? this.props.notebooks : {};
 
     return ((!wasWelcomed && this.state.show) && (notebooks.length !== 0)) ? (
-      <div className="ma4 pa2 ba bg-gray5 b--gray4 bg-gray0-d b--gray2-d white-d">
-        <p className="f9 lh-copy">Notebooks are for longer-form writing and discussion. Each Notebook is a collection of Markdown-formatted notes with optional comments.</p>
-        <p className="f9 pt2 dib fw6 pointer"
+      <div className="ma4 pa2 white-d bg-welcome-green bg-gray1-d">
+        <p className="f8 lh-copy">Notebooks are for longer-form writing and discussion. Each Notebook is a collection of Markdown-formatted notes with optional comments.</p>
+        <p className="f8 pt2 dib pointer bb"
           onClick={(() => this.disableWelcome())}>
-          Close this message
+          Close this
       </p>
       </div>
     ) : <div />


### PR DESCRIPTION
- Add startup content with instructions and tips for new users. Does not proc on OTA, only for new ships. Dismisses each message with `localStorage`, and in each app auto-dismisses the message if you have any data anyway.
- The link in launch for the 'lobby' is presently a URL join for `~/~dopzod/urbit-help`, lmk if this is changing.

<img width="626" alt="Screen Shot 2020-03-20 at 4 13 13 PM" src="https://user-images.githubusercontent.com/20846414/77207037-c2122e00-6ace-11ea-92e7-b3df83685325.png">
<img width="366" alt="Screen Shot 2020-03-20 at 5 11 48 PM" src="https://user-images.githubusercontent.com/20846414/77207041-c2aac480-6ace-11ea-861b-428fb17da6da.png">
