### PR TITLE
dbug: subscription searching & printing improvements

### DIFF
--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -11,6 +11,7 @@
   ==
 ::
 +$  about
+  $@  ~
   $%  [%ship =ship]
       [%path =path]
       [%wire =wire]
@@ -54,6 +55,7 @@
       =;  relevant=?
         ?.  relevant  ~
         `>[path=path from=ship duct=duct]<
+      ?:  ?=(~ about.dbug)  &
       ?-  -.about.dbug
         %ship  =(ship ship.about.dbug)
         %path  ?=(^ (find path.about.dbug path))
@@ -72,6 +74,7 @@
       =;  relevant=?
         ?.  relevant  ~
         `>[wire=wire agnt=[ship term] path=path ackd=acked]<
+      ?:  ?=(~ about.dbug)  &
       ?-  -.about.dbug
         %ship  =(ship ship.about.dbug)
         %path  ?=(^ (find path.about.dbug path))

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -32,44 +32,51 @@
       [cards this]
     =/  dbug
       !<(poke vase)
-    =;  out=^vase
-      ((slog (sell out) ~) [~ this])
+    =;  =tang
+      ((slog tang) [~ this])
     ?-  -.dbug
-      %bowl   !>(bowl)
+      %bowl   [(sell !>(bowl))]~
     ::
         %state
       =?  grab.dbug  =('' grab.dbug)  '-'
+      =-  [(sell !>(-))]~
       %+  slap
         (slop on-save:ag !>([bowl=bowl ..zuse]))
       (ream grab.dbug)
     ::
         %incoming
-      !>
-      %+  murn  ~(tap by sup.bowl)
-      |=  sub=[=duct [=ship =path]]
-      ^-  (unit _sub)
+      %+  murn
+        %+  sort  ~(tap by sup.bowl)
+        |=  [[* a=[=ship =path]] [* b=[=ship =path]]]
+        (aor [path ship]:a [path ship]:b)
+      |=  [=duct [=ship =path]]
+      ^-  (unit tank)
       =;  relevant=?
-        ?:(relevant `sub ~)
+        ?.  relevant  ~
+        `>[path=path from=ship duct=duct]<
       ?-  -.about.dbug
-        %ship  =(ship.sub ship.about.dbug)
-        %path  ?=(^ (find path.about.dbug path.sub))
-        %wire  %+  lien  duct.sub
+        %ship  =(ship ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path))
+        %wire  %+  lien  duct
                |=(=wire ?=(^ (find wire.about.dbug wire)))
         %term  !!
       ==
     ::
         %outgoing
-      !>
-      %+  murn  ~(tap by wex.bowl)
-      |=  sub=[[=wire =ship =term] [acked=? =path]]
-      ^-  (unit _sub)
+      %+  murn
+        %+  sort  ~(tap by wex.bowl)
+        |=  [[[a=wire *] *] [[b=wire *] *]]
+        (aor a b)
+      |=  [[=wire =ship =term] [acked=? =path]]
+      ^-  (unit tank)
       =;  relevant=?
-        ?:(relevant `sub ~)
+        ?.  relevant  ~
+        `>[wire=wire agnt=[ship term] path=path ackd=acked]<
       ?-  -.about.dbug
-        %ship  =(ship.sub ship.about.dbug)
-        %path  ?=(^ (find path.about.dbug path.sub))
-        %wire  ?=(^ (find wire.about.dbug wire.sub))
-        %term  =(term.sub term.about.dbug)
+        %ship  =(ship ship.about.dbug)
+        %path  ?=(^ (find path.about.dbug path))
+        %wire  ?=(^ (find wire.about.dbug wire))
+        %term  =(term term.about.dbug)
       ==
     ==
   ::


### PR DESCRIPTION
This proved a little rough around the edges during recent investigation. Printing accounted for TMI type information, and didn't let you select all subscriptions.

Previously (truncated example):

```hoon
> :chat-hook +dbug [%outgoing %ship our]
[ i=[[wire=/store/~/~dev/bbb ship=~dev term=%chat-store] acked=%.y path=/mailbox/~/~dev/bbb]
    t
  [   i
    [[wire=/store/~/~dev/rrr ship=~dev term=%chat-store] acked=%.y path=/mailbox/~/~dev/rrr]
      t
    [   i
      [[wire=/store/~/~dev/cc ship=~dev term=%chat-store] acked=%.y path=/mailbox/~/~dev/cc]
        t
      ...
    ]
  ]
]
```

This PR prints subscription details in a cleaner way, and sorts them by wire or path for outgoing and incoming subscriptions respectively.

Now (also truncated, but to the same linecount as above):

```hoon
> :chat-hook +dbug [%outgoing ~]
[wire=/invites agnt=[~dev %invite-store] path=/invitatory/chat ackd=%.y]
[wire=/permissions agnt=[~dev %permission-store] path=/updates ackd=%.y]
[wire=/store/~/~dev/aa agnt=[~dev %chat-store] path=/mailbox/~/~dev/aa ackd=%.y]
[wire=/store/~/~dev/bb agnt=[~dev %chat-store] path=/mailbox/~/~dev/bb ackd=%.y]
[wire=/store/~/~dev/bbb agnt=[~dev %chat-store] path=/mailbox/~/~dev/bbb ackd=%.y]
[ wire=/store/~/~dev/initial-chat
  agnt=[~dev %chat-store]
  path=/mailbox/~/~dev/initial-chat
  ackd=%.y
]
[wire=/store/~/~dev/rrr agnt=[~dev %chat-store] path=/mailbox/~/~dev/rrr ackd=%.y]
...
```