### PR TITLE
zuse: allow com in de-purl query parsing

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6705,7 +6705,7 @@
       ;~(pose pcar net wut)
     ::                                                  ::  ++pquo:de-purl:html
     ++  pquo                                            ::  normal query char
-      ;~(pose pure pesc pold net wut col)
+      ;~(pose pure pesc pold net wut col com)
     ::                                                  ::  ++pure:de-purl:html
     ++  pure                                            ::  2396 unreserved
       ;~(pose aln hep dot cab sig)


### PR DESCRIPTION
Trying to use some http api, with a url of the following shape, and was getting a cttp error upon sending out the request.

```
https://example.com/?what=this,that
```

```
cttp: url parsing failed
cttp: strange request (unparsable url)
```

Looked it up, `cttp.c` just calls `de-purl:html`. Turns out that doesn't like commas in the query. Both [RFC 2396](https://tools.ietf.org/html/rfc2396#section-3.4) and [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.4) allow this though.

This makes the minimum viable change to get `,` to parse as part of a url's query.

I would've changed `+fque` and `+fquu` to use `+pque` instead, which seems to match RFC 3986, but that's a more drastic change: query parsing would no longer uses `+pold`.
`+pold`'s behavior (replace `+` with ` `  (ace)) seems questionable to me though, and isn't mirrored between `+de-purl` and `+en-purl`:

```hoon
> (en-purl:html (need (de-purl:html 'https://example.com/?test=this+thing')))
"https://example.com/?test=this%20thing"
```

These parsers in general feel a bit hard to get a hold of. `+pure`'s comment says "2396 unreserved", but uses 3986's unreserved character definition instead. Others, like `+pquo`, I can't seem to match to any definitions or rules specifics in the RFCs at all.  

It's also not immediately clear to me why this uses definitions from 2396 at all, when it's been superseded by 3986. Perhaps there's some backwards compatibility concerns I'm overlooking.

I might be down to rewrite these using names and definitions taken directly from RFC 3986, if others would be down to potentially approve and merge that.

(CI failure is, unfortunately, still unrelated.)