### PR TITLE
zuse: better ethereum abi data type

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -8171,15 +8171,18 @@
     =>  |%
         ::  solidity types. integer bitsizes ignored
         ++  etyp
+          $@  $?  ::  static
+                  %address  %bool
+                  %int      %uint
+                  %real     %ureal
+                  ::  dynamic
+                  %bytes    %string
+              ==
           $%  ::  static
-              %address  %bool
-              %int      %uint
-              %real     %ureal
               [%bytes-n n=@ud]
               ::  dynamic
               [%array-n t=etyp n=@ud]
               [%array t=etyp]
-              %bytes    %string
           ==
         ::
         ::  solidity-style typed data. integer bitsizes ignored


### PR DESCRIPTION
Considering some of the options here were atoms, not cells, `$%` wasn't
appropriate, and led to `*etyp:abi:ethereum` resulting in ford %ride execution
failure. Simply using `$?` instead would result in a `fish-loop`, so here we split
the atom cases from the tagged union ones with a `$@`.


Previously:

```hoon
> *etyp:abi:ethereum
ford: %ride failed to execute:
```

Now:

```hoon
> *etyp:abi:ethereum
%string
```