### PR TITLE
soto: ignore backspace at cursor position 0

### DIFF
--- a/pkg/interface/soto/src/js/components/input.js
+++ b/pkg/interface/soto/src/js/components/input.js
@@ -39,6 +39,8 @@ export class Input extends Component {
   else if ((e.key === "Backspace") && (this.props.cursor > 0)) {
     store.doEdit({ del: this.props.cursor - 1});
     return store.setState({ cursor: this.props.cursor - 1});
+  } else if (e.key === "Backspace") {
+    return;
   }
 
   else if (e.key.startsWith("Arrow")) {


### PR DESCRIPTION
Closes #2590.

If you entered the web dojo and hit Backspace immediately,
it would still process it as a valid key but pass the whole key forward.

This adds a conditional to ignore the key in those cases.