### PR TITLE
clay: add option to skip queue

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fb8003d603f01ed63813d04b0049fe145be0ee2509fbc8ac16bedf5fca8a335
-size 13073371
+oid sha256:ad8493489fa46102c2fe05a633b344c6d40cd98c5fc2c1f6af491902a75a2458
+size 13082944

--- a/pkg/arvo/gen/hood/cancel.hoon
+++ b/pkg/arvo/gen/hood/cancel.hoon
@@ -7,5 +7,5 @@
 ::::
   ::
 :-  %say
-|=  *
-[%kiln-cancel ~]
+|=  [* a=$@(~ [@tas ~]) *]
+[%kiln-cancel ?@(a %foo -.a)]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -154,8 +154,8 @@
   abet:abet:(merge:(work syd) ali sud cas gim)
 ::
 ++  poke-cancel
-  |=  ~
-  abet:(emit %pass /cancel %arvo %c [%drop %foo])
+  |=  a=@tas
+  abet:(emit %pass /cancel %arvo %c [%drop a])
 ::
 ++  poke-info
   |=  {mez/tape tor/(unit toro)}

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4175,7 +4175,11 @@
     ~?  ?=(^ act.ruf)
       [%clay-cancelling hen -.req -.eval-data]:u.act.ruf
     =.  act.ruf  ~
-    ?~  cue.ruf
+    ?:  =(~ cue.ruf)
+      [~ ..^$]
+    ?:  =(%force des.req)
+      =^  queued  cue.ruf  ~(get to cue.ruf)
+      ~&  [%dropping-hard [duct -.task]:p.queued cue-length=~(wyt in cue.ruf)]
       [~ ..^$]
     =/  =duct  duct:(need ~(top to cue.ruf))
     [[duct %pass /queued-request %b %wait now]~ ..^$]


### PR DESCRIPTION
Makes it so that |cancel %force skips the next thing in the queue if
you're not in the middle of something.  If you are in the middle of
something, it skips the thing you're in the middle of (just like naked
|cancel).

This should resolve issues where |cancel doesn't drain the queue.