### PR TITLE
publish: flexbox sizing in skeleton, links open in _blank

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/note.js
+++ b/pkg/interface/publish/src/js/components/lib/note.js
@@ -213,7 +213,7 @@ export class Note extends Component {
             </div>
             <div className="md"
             style={{overflowWrap: "break-word"}}>
-              <ReactMarkdown source={newfile} />
+              <ReactMarkdown source={newfile} linkTarget={"_blank"} />
             </div>
             <NoteNavigation
               popout={props.popout}

--- a/pkg/interface/publish/src/js/components/skeleton.js
+++ b/pkg/interface/publish/src/js/components/skeleton.js
@@ -31,7 +31,7 @@ export class Skeleton extends Component {
             path={props.path}
             invites={props.invites}
             />
-          <div className={"h-100 w-100 relative white-d " + rightPanelHide} style={{
+          <div className={"h-100 w-100 relative white-d flex-auto " + rightPanelHide} style={{
             flexGrow: 1,
           }}>
             {props.children}


### PR DESCRIPTION
I noticed the skeleton leads to overflow out of the parent container on very small sizes.
<img width="257" alt="Screen Shot 2020-03-23 at 9 08 11 PM" src="https://user-images.githubusercontent.com/20846414/77378710-217d7180-6d4d-11ea-8b8f-d0e881f8a09b.png">

I add `flex-auto` so that it stays within the container with horizontal scroll if it is indeed that small.

<img width="245" alt="Screen Shot 2020-03-23 at 9 10 10 PM" src="https://user-images.githubusercontent.com/20846414/77378721-2fcb8d80-6d4d-11ea-9579-130429ba9de7.png">

I also pass a prop to the react-markdown renderer so links in Publish'd notes target `_blank`, opening in new tabs, instead of leaving the app.