### PR TITLE
dbug: print %state's value, not whole vase

### DIFF
--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -40,7 +40,7 @@
     ::
         %state
       =?  grab.dbug  =('' grab.dbug)  '-'
-      =-  [(sell !>(-))]~
+      =-  [(sell -)]~
       %+  slap
         (slop on-save:ag !>([bowl=bowl ..zuse]))
       (ream grab.dbug)


### PR DESCRIPTION
I oopsied this in #2587. Made it pretty-print the vase of the state, instead of just the state. Tiny fix!