### PR TITLE
publish: pending comments use our ship, not owner

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/comments.js
+++ b/pkg/interface/publish/src/js/components/lib/comments.js
@@ -73,7 +73,7 @@ export class Comments extends Component {
       let da = dateToDa(new Date);
       let comment = {
         [da]: {
-          author: this.props.ship,
+          author: `~${window.ship}`,
           content: com["new-comment"].body,
           "date-created": Math.round(new Date().getTime())
         }


### PR DESCRIPTION
Noticed this when commenting in ~dopzod's notebooks — it shows ~dopzod as the author of the pending comment because we pass `this.props.ship` not `~${window.ship}`, so this commit fixes that.