### PR TITLE
server: add basic cache-control for faster load speeds

### DIFF
--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -57,15 +57,18 @@
 ++  gen
   |%
   ::
+  ++  max-1-da  ['cache-control' 'max-age=86400']
+  ++  max-1-wk  ['cache-control' 'max-age=604800']
+  ::
   ++  html-response
     |=  =octs
     ^-  simple-payload:http
-    [[200 ['content-type' 'text/html']~] `octs]
+    [[200 [['content-type' 'text/html'] max-1-wk ~]] `octs]
   ::
   ++  js-response
     |=  =octs
     ^-  simple-payload:http
-    [[200 ['content-type' 'text/javascript']~] `octs]
+    [[200 [['content-type' 'text/javascript'] max-1-da ~]] `octs]
   ::
   ++  json-response
     |=  =octs
@@ -75,7 +78,7 @@
   ++  css-response
     |=  =octs
     ^-  simple-payload:http
-    [[200 ['content-type' 'text/css']~] `octs]
+    [[200 [['content-type' 'text/css'] max-1-da ~]] `octs]
   ::
   ++  manx-response
     |=  man=manx
@@ -85,12 +88,12 @@
   ++  png-response
     |=  =octs
     ^-  simple-payload:http
-    [[200 ['content-type' 'image/png']~] `octs]
+    [[200 [['content-type' 'image/png'] max-1-wk ~]] `octs]
   ::
   ++  woff2-response
     |=  =octs
     ^-  simple-payload:http
-    [[200 ['content-type' 'font/woff2']~] `octs]
+    [[200 [['content-type' 'font/woff2'] max-1-wk ~]] `octs]
   ::
   ++  not-found
     ^-  simple-payload:http


### PR DESCRIPTION
We weren't doing basic server-side caching of our assets, which was significantly slowing down our pageload speed. Added a simple policy where assets we frequently change have a 1 day timeout and assets that don't frequently change have a 1 week timeout.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control