### PR TITLE
link: leave collections, retain metadata

### DIFF
--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -320,7 +320,10 @@
   ::  add link to group submissions
   ::
   =/  =links  (~(gut by by-group) path *links)
-  =.  submissions.links
+  =^  added  submissions.links
+    ?:  ?=(^ (find ~[submission] submissions.links))
+      [| submissions.links]
+    :-  &
     (submissions:merge submissions.links ~[submission])
   =.  by-group  (~(put by by-group) path links)
   ::  add submission to global sites
@@ -330,6 +333,7 @@
   ::  send updates to subscribers
   ::
   :_  state
+  ?.  added  ~
   :_  ~
   :+  %give  %fact
   :+  :~  /submissions
@@ -346,13 +350,17 @@
   ::
   =/  urls  (~(gut by discussions) path *(map ^url discussion))
   =/  =discussion  (~(gut by urls) url *discussion)
-  =.  comments.discussion
+  =^  added  comments.discussion
+    ?:  ?=(^ (find ~[comment] comments.discussion))
+      [| comments.discussion]
+    :-  &
     (comments:merge comments.discussion ~[comment])
   =.  urls  (~(put by urls) url discussion)
   =.  discussions  (~(put by discussions) path urls)
   ::  send updates to subscribers
   ::
   :_  state
+  ?.  added  ~
   :_  ~
   :+  %give  %fact
   :+  :~  /discussions

--- a/pkg/arvo/mar/link/listen-action.hoon
+++ b/pkg/arvo/mar/link/listen-action.hoon
@@ -1,0 +1,21 @@
+::  link-listen-action
+::
+/-  *link-listen-hook
+=,  dejs:format
+|_  act=action
+++  grab
+  |%
+  ++  noun  action
+  ++  json
+    =,  dejs:format
+    %-  of
+    :~  %watch^pa
+        %leave^pa
+    ==
+  --
+::
+++  grow
+  |%
+  ++  noun  act
+  --
+--

--- a/pkg/arvo/mar/link/listen-update.hoon
+++ b/pkg/arvo/mar/link/listen-update.hoon
@@ -1,0 +1,23 @@
+::  link-listen-update
+::
+/-  *link-listen-hook
+=,  dejs:format
+|_  upd=update
+++  grab
+  |%
+  ++  noun  update
+  --
+::
+++  grow
+  |%
+  ++  noun  upd
+  ++  json
+    =,  enjs:format
+    %+  frond  'link-listen-update'
+    %+  frond  -.upd
+    ?-  -.upd
+      %listening        a+(turn ~(tap in paths.upd) path)
+      ?(%watch %leave)  (path path.upd)
+    ==
+  --
+--

--- a/pkg/arvo/sur/link-listen-hook.hoon
+++ b/pkg/arvo/sur/link-listen-hook.hoon
@@ -1,0 +1,17 @@
+::  link-listen-hook: actions for getting your friends' bookmarks
+::
+::    Note that /app/link-listen-hook auto-joins any new collections in groups
+::    you're a part of. You only need the watch action here for leaving and
+::    re-joining.
+::
+|%
++$  action
+  $%  [%watch =path]
+      [%leave =path]
+  ==
+::
++$  update
+  $%  [%listening paths=(set path)]
+      action
+  ==
+--

--- a/pkg/interface/link/src/js/api.js
+++ b/pkg/interface/link/src/js/api.js
@@ -165,6 +165,18 @@ class UrbitApi {
     });
   }
 
+  linkListenAction(data) {
+    return this.action('link-listen-hook', 'link-listen-action', data);
+  }
+
+  joinCollection(path) {
+    return this.linkListenAction({ watch: path });
+  }
+
+  removeCollection(path) {
+    return this.linkListenAction({ leave: path });
+  }
+
   linkAction(data) {
     return this.action("link-store", "link-action", data);
   }

--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -21,8 +21,9 @@ export class ChannelsSidebar extends Component {
       });
 
     const channelItems =
-      Object.keys(props.associations).map((path) => {
+      [...props.listening].map((path) => {
         const meta = props.associations[path];
+        if (!meta) return null;
         const selected = (props.selected === path);
         const linkCount = !!props.links[path] ? props.links[path].totalItems : 0;
         const unseenCount = !!props.links[path]

--- a/pkg/interface/link/src/js/components/root.js
+++ b/pkg/interface/link/src/js/components/root.js
@@ -54,7 +54,8 @@ export class Root extends Component {
                 groups={groups}
                 rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
-                links={links}>
+                links={links}
+                listening={state.listening}>
                 <div className="h-100 w-100 overflow-x-hidden bg-white bg-gray0-d dn db-ns">
                 <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
                       <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
@@ -75,7 +76,8 @@ export class Root extends Component {
                 groups={groups}
                 rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
-                links={links}>
+                links={links}
+                listening={state.listening}>
                 <NewScreen
                   associations={associations}
                   groups={groups}
@@ -89,6 +91,7 @@ export class Root extends Component {
         <Route exact path="/~link/join/:resource"
           render={ (props) => {
             const resourcePath = '/' + props.match.params.resource;
+            api.joinCollection(resourcePath);
             props.history.push(makeRoutePath(resourcePath));
           }}
         />
@@ -111,7 +114,8 @@ export class Root extends Component {
                 selected={resourcePath}
                 rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
-                links={links}>
+                links={links}
+                listening={state.listening}>
                 <MemberScreen
                   sidebarShown={state.sidebarShown}
                   resource={resource}
@@ -148,7 +152,8 @@ export class Root extends Component {
                 rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
                 popout={popout}
-                links={links}>
+                links={links}
+                listening={state.listening}>
                 <SettingsScreen
                   sidebarShown={state.sidebarShown}
                   resource={resource}
@@ -200,7 +205,8 @@ export class Root extends Component {
                   sidebarShown={state.sidebarShown}
                   sidebarHideMobile={true}
                   popout={popout}
-                  links={links}>
+                  links={links}
+                  listening={state.listening}>
                   <Links
                   {...props}
                   contacts={contactDetails}
@@ -254,7 +260,8 @@ export class Root extends Component {
                   sidebarShown={state.sidebarShown}
                   sidebarHideMobile={true}
                   popout={popout}
-                  links={links}>
+                  links={links}
+                  listening={state.listening}>
                   <LinkDetail
                   {...props}
                   resource={resource}

--- a/pkg/interface/link/src/js/components/settings.js
+++ b/pkg/interface/link/src/js/components/settings.js
@@ -107,39 +107,74 @@ export class SettingsScreen extends Component {
     }
   }
 
-  deleteCollection() {
+  removeCollection() {
     const { props, state } = this;
 
-    api.deleteCollection(props.resourcePath);
     api.setSpinner(true);
-
     this.setState({
       isLoading: true
     });
+    api.removeCollection(props.resourcePath)
+    .then(() => {
+      this.setState({
+        isLoading: false
+      });
+      api.setSpinner(false);
+    });
+  }
+
+  deleteCollection() {
+    const { props, state } = this;
+
+    api.setSpinner(true);
+    this.setState({
+      isLoading: true
+    });
+    api.deleteCollection(props.resourcePath)
+    .then(() => {
+      this.setState({
+        isLoading: false
+      });
+      api.setSpinner(false);
+    });
+  }
+
+  renderRemove() {
+    const { props, state } = this;
+
+    return (
+      <div className="w-100 fl mt3">
+        <p className="f8 mt3 lh-copy db">Remove Collection</p>
+        <p className="f9 gray2 db mb4">
+          Remove this collection from your collection list.
+        </p>
+        <a onClick={this.removeCollection.bind(this)}
+           className="dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer">
+          Remove collection
+        </a>
+      </div>
+    );
   }
 
   renderDelete() {
     const { props, state } = this;
 
-    const isManaged = ('/~/' !== props.groupPath.slice(0,3));
-
-    let deleteClasses = 'dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d pointer';
-    let deleteText = 'Remove this collection from your collection list.';
-    let deleteAction = 'Remove';
-    if (props.amOwner && isManaged) {
-      deleteText = 'Delete this collection. (All group members will no longer see this chat.)';
-      deleteAction = 'Delete';
-      deleteClasses = 'dib f9 ba pa2 b--red2 red2 pointer bg-gray0-d';
+    if (!props.amOwner) {
+      return null;
+    } else {
+      return (
+        <div className="w-100 fl mt3">
+          <p className="f8 mt3 lh-copy db">Delete Collection</p>
+          <p className="f9 gray2 db mb4">
+            Delete this collection, for you and all group members.
+          </p>
+          <a onClick={this.deleteCollection.bind(this)}
+             className="dib f9 ba pa2 b--red2 red2 pointer bg-gray0-d">
+            Delete collection
+          </a>
+        </div>
+      );
     }
-
-    return (
-      <div className="w-100 fl mt3">
-        <p className="f8 mt3 lh-copy db">Delete Collection</p>
-        <p className="f9 gray2 db mb4">{deleteText}</p>
-        <a onClick={this.deleteCollection.bind(this)}
-           className={deleteClasses}>{deleteAction + ' collection'}</a>
-      </div>
-    );
   }
 
   renderMetadataSettings() {
@@ -303,6 +338,7 @@ export class SettingsScreen extends Component {
         </div>
         <div className="w-100 pl3 mt4 cf">
           <h2 className="f8 pb2">Collection Settings</h2>
+          {this.renderRemove()}
           {this.renderDelete()}
           {this.renderMetadataSettings()}
         </div>

--- a/pkg/interface/link/src/js/components/skeleton.js
+++ b/pkg/interface/link/src/js/components/skeleton.js
@@ -31,7 +31,8 @@ export class Skeleton extends Component {
             groups={this.props.groups}
             selected={this.props.selected}
             sidebarShown={this.props.sidebarShown}
-            links={this.props.links}/>
+            links={this.props.links}
+            listening={this.props.listening}/>
           <div className={"h-100 w-100 flex-auto" + rightPanelHide} style={{
             flexGrow: 1,
           }}>

--- a/pkg/interface/link/src/js/reducers/listen-update.js
+++ b/pkg/interface/link/src/js/reducers/listen-update.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+export class ListenUpdateReducer {
+  reduce(json, state) {
+    let data = _.get(json, 'link-listen-update', false);
+    if (data) {
+      this.listening(data, state);
+      this.watch(data, state);
+      this.leave(data, state);
+    }
+  }
+
+  listening(json, state) {
+    let data = _.get(json, 'listening', false);
+    if (data) {
+      state.listening = new Set(data);
+    }
+  }
+
+  watch(json, state) {
+    let data = _.get(json, 'watch', false);
+    if (data) {
+      state.listening.add(data);
+    }
+  }
+
+  leave(json, state) {
+    let data = _.get(json, 'leave', false);
+    if (data) {
+      state.listening.delete(data);
+    }
+  }
+}
+

--- a/pkg/interface/link/src/js/store.js
+++ b/pkg/interface/link/src/js/store.js
@@ -5,6 +5,7 @@ import { PermissionUpdateReducer } from '/reducers/permission-update';
 import { MetadataReducer } from '/reducers/metadata-update.js';
 import { InviteUpdateReducer } from '/reducers/invite-update';
 import { LinkUpdateReducer } from '/reducers/link-update';
+import { ListenUpdateReducer } from '/reducers/listen-update';
 import { LocalReducer } from '/reducers/local.js';
 import _ from 'lodash';
 
@@ -20,6 +21,7 @@ class Store {
       },
       invites: {},
       links: {},
+      listening: new Set(),
       comments: {},
       seen: {},
       permissions: {},
@@ -35,6 +37,7 @@ class Store {
     this.inviteUpdateReducer = new InviteUpdateReducer();
     this.localReducer = new LocalReducer();
     this.linkUpdateReducer = new LinkUpdateReducer();
+    this.listenUpdateReducer = new ListenUpdateReducer();
     this.setState = () => {};
   }
 
@@ -59,6 +62,7 @@ class Store {
     this.inviteUpdateReducer.reduce(json, this.state);
     this.localReducer.reduce(json, this.state);
     this.linkUpdateReducer.reduce(json, this.state);
+    this.listenUpdateReducer.reduce(json, this.state);
 
     this.setState(this.state);
   }

--- a/pkg/interface/link/src/js/subscription.js
+++ b/pkg/interface/link/src/js/subscription.js
@@ -36,6 +36,13 @@ export class Subscription {
       this.handleQuitAndResubscribe.bind(this)
     );
 
+    // open a subscription for what collections we're listening to
+    api.bind('/listening', 'PUT', api.authTokens.ship, 'link-listen-hook',
+      this.handleEvent.bind(this),
+      this.handleError.bind(this),
+      this.handleQuitAndResubscribe.bind(this)
+    );
+
     // open a subscription for all submissions
     api.getPage('', 0);
 


### PR DESCRIPTION
Previously, we were mangling the group associations when "removing" link collections. But precisely because we were removing the collection's metadata, there was no way to rejoin them. 

This PR updates link-listen-hook to explicitly track the resources we're listening to in state, and provides actions for removing from (and adding back to) that list.
To match that, on the frontend, we fill the sidebar based on this list from link-listen-hook, instead of looking at all the associations stored in metadata. We also always show the "remove" action to everyone, but still only show "delete" to group owners.

Fixes #2576. Also fixes a bug where link-store was sending out updates for content it had already heard before.