### PR TITLE
arvo: add wire to %give verb message

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -705,7 +705,7 @@
             ?:  ?=(%unto +>-.gift)
               [+>-.gift (symp +>+<.gift)]
             (symp +>-.gift)
-          duct
+          duct.move
         ::
         (take duct wire vane gift)
       ::


### PR DESCRIPTION
This must have been removed on accident recently.