### PR TITLE
group-hook: fix resubscribe bug

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -273,13 +273,38 @@
         %contacts
       =/  owner  (~(got by synced) path.fact)
       ?>  =(owner src.bol)
-      %+  weld
-      :~  (contact-poke [%delete path.fact])
-          (contact-poke [%create path.fact])
+      =/  have-contacts=(unit contacts)
+        (contacts-scry path.fact)
+      ?~  have-contacts
+        ::  if we don't have any contacts yet,
+        ::  create the entry, and %add every contact
+        ::
+        :-  (contact-poke [%create path.fact])
+        %+  turn  ~(tap by contacts.fact)
+        |=  [=ship =contact]
+        (contact-poke [%add path.fact ship contact])
+      ::  if we already have some, decide between %add, %remove and recreate
+      ::  on a per-contact basis
+      ::
+      %-  zing
+      %+  turn
+        %~  tap  in
+        %-  ~(uni in ~(key by contacts.fact))
+        ~(key by u.have-contacts)
+      |=  =ship
+      ^-  (list card)
+      =/  have=(unit contact)  (~(get by u.have-contacts) ship)
+      =/  want=(unit contact)  (~(get by contacts.fact) ship)
+      ?~  have
+        [(contact-poke %add path.fact ship (need want))]~
+      ?~  want
+        [(contact-poke %remove path.fact ship)]~
+      ?:  =(u.want u.have)  ~
+      ::TODO  probably want an %all edit-field that resolves to more granular
+      ::      updates within the contact-store?
+      :~  (contact-poke %remove path.fact ship)
+          (contact-poke %add path.fact ship u.want)
       ==
-      %+  turn  ~(tap by contacts.fact)
-      |=  [=ship =contact]
-      (contact-poke [%add path.fact ship contact])
     ::
         %add
       =/  owner  (~(got by synced) path.fact)

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -74,20 +74,26 @@
       ?~  p.sign
         [~ this]
       %-  (slog u.p.sign)
-      ?>  ?=([@ @ *] wire)
-      =/  =ship   (slav %p i.wire)
-      =.  synced.state  (~(del by synced.state) t.t.wire)
+      ?>  ?=([@ %group ^] wire)
+      =/  =ship  (slav %p i.wire)
+      =*  group  t.t.wire
+      ::  only remove from synced if this watch-nack came from the ship we
+      ::  thought we were actively syncing from
+      ::
+      =?  synced.state
+          =(ship (~(gut by synced.state) group ship))
+        (~(del by synced.state) group)
       [~ this]
     ::
         %kick
-      ?>  ?=([@ @ *] wire)
+      ?>  ?=([@ %group ^] wire)
       =/  =ship  (slav %p i.wire)
-      ?.  (~(has by synced.state) t.t.wire)
+      =*  group  t.t.wire
+      ?.  (~(has by synced.state) group)
         [~ this]
-      =/  group-path  [%group t.t.wire]
-      =/  group-wire  [i.wire group-path]
+      =*  group-path  t.wire
       :_  this
-      [%pass group-wire %agent [ship %group-hook] %watch group-path]~
+      [%pass wire %agent [ship %group-hook] %watch group-path]~
     ::
         %fact
       ?.  ?=(%group-update p.cage.sign)

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -34,7 +34,22 @@
   ++  on-save  !>(state)
   ++  on-load
     |=  old=vase
-    `this(state !<(state-zero old))
+    ^-  (quip card _this)
+    :_  this(state !<(state-zero old))
+    %+  murn
+      ~(tap by synced)
+    |=  [=path =ship]
+    ^-  (unit card)
+    =/  =wire
+      [(scot %p ship) %group path]
+    =/  =term
+      ?:  =(our.bowl ship)
+        %group-store
+      %group-hook
+    ?:  (~(has by wex.bowl) [wire ship term])
+      ~
+    `[%pass wire %agent [ship term] %watch [%group path]]
+  ::
   ++  on-leave  on-leave:def
   ++  on-peek   on-peek:def
   ++  on-arvo   on-arvo:def

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -82,9 +82,9 @@
         %kick
       ?>  ?=([@ @ *] wire)
       =/  =ship  (slav %p i.wire)
-      ?.  (~(has by synced.state) wire)
+      ?.  (~(has by synced.state) t.t.wire)
         [~ this]
-      =/  group-path  [%group wire]
+      =/  group-path  [%group t.t.wire]
       =/  group-wire  [i.wire group-path]
       :_  this
       [%pass group-wire %agent [ship %group-hook] %watch group-path]~

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -191,10 +191,23 @@
     =/  ship  (~(get by synced.state) pax.diff)
     ?~  ship  ~
     ?.  =(src.bol u.ship)  ~
-    :~  (group-poke pax.diff [%unbundle pax.diff])
-        (group-poke pax.diff [%bundle pax.diff])
-        (group-poke pax.diff [%add members.diff pax.diff])
-    ==
+    =/  have-group=(unit group)
+      (group-scry pax.diff)
+    ?~  have-group
+      ::  if we don't have the group yet, create it
+      ::
+      :~  (group-poke pax.diff [%bundle pax.diff])
+          (group-poke pax.diff [%add members.diff pax.diff])
+      ==
+    ::  if we already have the group, calculate and apply the diff
+    ::
+    =/  added=group    (~(dif in members.diff) u.have-group)
+    =/  removed=group  (~(dif in u.have-group) members.diff)
+    %+  weld
+      ?~  added  ~
+      [(group-poke pax.diff [%add added pax.diff])]~
+    ?~  removed  ~
+    [(group-poke pax.diff [%remove removed pax.diff])]~
   ::
       %add
     :_  state

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -33,11 +33,12 @@
   ++  on-init  on-init:def
   ++  on-save  !>(state)
   ++  on-load
-    |=  old=vase
+    |=  =vase
     ^-  (quip card _this)
-    :_  this(state !<(state-zero old))
+    =/  old  !<(state-zero vase)
+    :_  this(state old)
     %+  murn
-      ~(tap by synced)
+      ~(tap by synced.old)
     |=  [=path =ship]
     ^-  (unit card)
     =/  =wire


### PR DESCRIPTION
This fixes a bug where group-hook wouldn't resubscribe correctly upon getting kicked. Now uses the correct group path for that resubscribe, instead of the whole wire.

Also adds on-load logic that checks to see if we have a subscription in place for every `synced` entry, and starts a new subscription if we don't.

Couldn't help myself and touched up the kick and watch-nack logic a bit to be more clear and correct. `=*` for pointing to specific parts of the wire that we care about, and the watch-nack case now makes sure it's actually relevant to the current configuration before we delete the entry. (The `=/  =ship` was sitting unused, pretty sure this is what it was intended for.)

I would test this on ~palfun but it's still spinning behn from today's OTA. Happy to wait that out and give it a shot before we merge, but logic seems fine from testing on a fake ship.

Fixes #2578's root cause.