### PR TITLE
metadata-hook: use dbug agent wrapper

### DIFF
--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -4,7 +4,7 @@
 ::  /group/%group-path                      all updates related to this group
 ::
 /-  *metadata-store, *metadata-hook
-/+  default-agent
+/+  default-agent, dbug
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -18,6 +18,7 @@
 --
 =|  state-zero
 =*  state  -
+%-  agent:dbug
 ^-  agent:gall
 =<
   |_  =bowl:gall


### PR DESCRIPTION
Not sure why this was still missing, I thought I got all of 'em in #2448. Apparently I missed a spot!