### PR TITLE
lib: !. on dbug and verb wrapper agent cores

### DIFF
--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -21,6 +21,7 @@
 ++  agent
   |=  =agent:gall
   ^-  agent:gall
+  !.
   |_  =bowl:gall
   +*  this  .
       ag    ~(. agent bowl)

--- a/pkg/arvo/lib/verb.hoon
+++ b/pkg/arvo/lib/verb.hoon
@@ -3,7 +3,7 @@
 |=  [loud=? =agent:gall]
 =|  bowl-print=_|
 ^-  agent:gall
-|^
+|^  !.
 |_  =bowl:gall
 +*  this  .
     ag    ~(. agent bowl)


### PR DESCRIPTION
Events always pass through these, adding to the stack trace on-crash.
This information is practically never useful, however. Adding !. leaves
these cores out of the traces.

Before:

```
> :link-store %something-dumb
/~dev/home/~2020.3.26..19.03.58..29bd/sys/vane/gall:<[1.191 9].[1.191 37]>
/~dev/home/0/lib/dbug/hoon:<[30 5].[84 7]>
/~dev/home/0/lib/dbug/hoon:<[31 5].[84 7]>
/~dev/home/0/lib/dbug/hoon:<[32 7].[33 19]>
/~dev/home/0/lib/dbug/hoon:<[32 25].[32 47]>
/~dev/home/0/lib/verb/hoon:<[31 3].[39 15]>
/~dev/home/0/lib/verb/hoon:<[32 3].[39 15]>
/~dev/home/0/lib/verb/hoon:<[33 3].[39 15]>
/~dev/home/0/lib/verb/hoon:<[38 3].[39 15]>
/~dev/home/0/lib/verb/hoon:<[38 21].[38 43]>
/~dev/home/0/app/link-store/hoon:<[99 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[100 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[101 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[102 7].[106 9]>
/~dev/home/0/app/link-store/hoon:<[102 17].[102 40]>
/~dev/home/0/lib/default-agent/hoon:<[19 3].[20 5]>
"unexpected poke to %link-store with mark %noun"
/~dev/home/0/lib/default-agent/hoon:<[20 3].[20 5]>
```

After:

```
> :link-store %something-dumb
/~dev/home/~2020.3.26..19.03.58..29bd/sys/vane/gall:<[1.191 9].[1.191 37]>
/~dev/home/0/app/link-store/hoon:<[99 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[100 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[101 5].[107 17]>
/~dev/home/0/app/link-store/hoon:<[102 7].[106 9]>
/~dev/home/0/app/link-store/hoon:<[102 17].[102 40]>
/~dev/home/0/lib/default-agent/hoon:<[19 3].[20 5]>
"unexpected poke to %link-store with mark %noun"
/~dev/home/0/lib/default-agent/hoon:<[20 3].[20 5]>
```