### PR TITLE
chat: settings pass 'groups' prop from permissions

### DIFF
--- a/pkg/interface/chat/src/js/components/settings.js
+++ b/pkg/interface/chat/src/js/components/settings.js
@@ -214,6 +214,11 @@ export class SettingsScreen extends Component {
         );
       }
 
+      let groups = {};
+      Object.keys(props.permissions).forEach((pem) => {
+        groups[pem] = props.permissions[pem].who;
+      });
+
       return (
         <div>
           <div className={"w-100 fl mt3"} style={{maxWidth: "29rem"}}>
@@ -223,7 +228,7 @@ export class SettingsScreen extends Component {
               group to add this chat to.
             </p>
             <InviteSearch
-              permissions={props.permissions}
+              groups={groups}
               contacts={props.contacts}
               associations={props.associations}
               groupResults={true}


### PR DESCRIPTION
Fixes #2629. When invite search in #2616 was patched in review to not break parity with the other applications, a 'groups' prop needed to be created and passed to it from our permissions; in settings this wasn't created and passed, thus the page crashes for unmanaged group owners. This PR remedies that.