### PR TITLE
clay: don't underflow when patch produces empty file

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b317cdb5fccee9afbebd16a3f5ff14a0138af893e9ca03da4af6effb34ea2bd
-size 13101105
+oid sha256:c9609b017c0fb9e4797e6a5f6e1052ae70725b4178f8ba18e7cef3c6ed1489c5
+size 13109549

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2563,6 +2563,8 @@
       =+  dif=;;((urge cord) q.r.bol)
       =,  format
       =+  pac=(of-wain (lurk:differ (to-wain (cat 3 txt '\0a')) dif))
+      ?~  pac
+        ''
       (end 3 (dec (met 3 pac)) pac)
     ::
     ::  Traverse an ankh.


### PR DESCRIPTION
Fixes #2602

I haven't been able to reproduce this bug, but I can see how it could
happen in theory.  This should resolve the issue.