### PR TITLE
dojo: add autocomplete for various dojo syntaxes

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1226,7 +1226,7 @@
       ^-  (unit [term tank])
       ?.  =(variable (end 3 (met 3 variable) name))
         ~
-      `[name (xsell q.cage)]
+      `[name (sell q.cage)]
     ::
     ++  complete-gen-poke-to-app
       |=  [app=term gen=term]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1230,12 +1230,12 @@
     ::
     ++  complete-gen-poke-to-app
       |=  [app=term gen=term]
+      =.  app
+        ?:(?=(%$ app) %hood app)
       %+  complete
         ?:  =(%hood app)
           (cat 3 '|' gen)
         :((cury cat 3) ':' app '|' gen)
-      =.  app
-        ?:(?=(%$ app) %hood app)
       =/  pfix=path
         /(scot %p our.hid)/[q.byk.hid]/(scot %da now.hid)/gen/[app]
       ::

--- a/pkg/arvo/lib/language-server/complete.hoon
+++ b/pkg/arvo/lib/language-server/complete.hoon
@@ -345,4 +345,32 @@
   :-  %&
   ~?  >  debug  %parsed-good
   ((cury tab-list-hoon sut) tssg+sources.p.res)
+::
+:: Generators
+++  tab-generators
+  |=  [pfix=path app=(unit term) gens=(list term)]
+  ^-  (list (option tank))
+  %+  turn  gens
+  |=  gen=term
+  ^-  (option tank)
+  =/  pax=path
+    (weld pfix ~[gen %hoon])
+  =/  file
+    .^(@t %cx pax)
+  :_  (render-help file)
+  ?~  app
+    (cat 3 '+' gen)
+  ?:  =(%hood u.app)
+    (cat 3 '|' gen)
+  :((cury cat 3) ':' u.app '|' gen)
+::  Stolen from +help
+++  render-help
+  |=  a=@t
+  ^-  tank
+  :-  %leaf
+  =/  c  (to-wain:format a)
+  ?~  c  "~"
+  ?.  =('::  ' (end 3 4 i.c))
+    "<undocumented>"
+  (trip i.c)
 --


### PR DESCRIPTION
Adds autocomplete for
- :app poke syntax
- :app|gen poke generator syntax
- +gen naked generator syntax
- =var variable syntax

Mines generators for their `+help` strings

Demo:
![Screen Shot 2020-04-01 at 11 26 37 am](https://user-images.githubusercontent.com/46801558/78089779-b5190700-740b-11ea-92b3-fe9e25486b0b.png)
![Screen Shot 2020-04-01 at 11 26 02 am](https://user-images.githubusercontent.com/46801558/78089783-b64a3400-740b-11ea-8916-d0f0399d3250.png)
![Screen Shot 2020-04-01 at 11 25 40 am](https://user-images.githubusercontent.com/46801558/78089784-b6e2ca80-740b-11ea-811d-904e20cd5767.png)
![Screen Shot 2020-04-01 at 11 25 25 am](https://user-images.githubusercontent.com/46801558/78089786-b813f780-740b-11ea-85b6-7dd395f03717.png)
