### PR TITLE
os1: add dark mode style for app name in headers

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/header-bar.js
+++ b/pkg/interface/chat/src/js/components/lib/header-bar.js
@@ -41,7 +41,7 @@ export class HeaderBar extends Component {
             className="dib f9 v-mid inter ml2"
             href="/"
             style={{ top: 14 }}>
-            ⟵</a> <p className="dib f9 v-mid inter ml2">Messaging</p>
+            ⟵</a> <p className="dib f9 v-mid inter ml2 white-d">Messaging</p>
         </div>
       </div>
     );

--- a/pkg/interface/groups/src/js/components/lib/header-bar.js
+++ b/pkg/interface/groups/src/js/components/lib/header-bar.js
@@ -41,7 +41,7 @@ export class HeaderBar extends Component {
             className="dib f9 v-mid inter ml2"
             href="/"
             style={{ top: 14 }}>
-            ⟵</a> <p className="dib f9 v-mid inter ml2">Manage Groups</p>
+            ⟵</a> <p className="dib f9 v-mid inter ml2 white-d">Manage Groups</p>
         </div>
       </div>
     );

--- a/pkg/interface/link/src/js/components/lib/header-bar.js
+++ b/pkg/interface/link/src/js/components/lib/header-bar.js
@@ -41,7 +41,7 @@ export class HeaderBar extends Component {
             className="dib f9 v-mid inter ml2"
             href="/"
             style={{ top: 14 }}>
-            ⟵</a> <p className="dib f9 v-mid inter ml2">Links</p>
+            ⟵</a> <p className="dib f9 v-mid inter ml2 white-d">Links</p>
         </div>
       </div>
     );

--- a/pkg/interface/publish/src/js/components/lib/header-bar.js
+++ b/pkg/interface/publish/src/js/components/lib/header-bar.js
@@ -41,7 +41,7 @@ export class HeaderBar extends Component {
             className="dib f9 v-mid inter ml2"
             href="/"
             style={{ top: 14 }}>
-            ⟵</a> <p className="dib f9 v-mid inter ml2">Publishing</p>
+            ⟵</a> <p className="dib f9 v-mid inter ml2 white-d">Publishing</p>
         </div>
       </div>
     );

--- a/pkg/interface/soto/src/js/components/lib/header-bar.js
+++ b/pkg/interface/soto/src/js/components/lib/header-bar.js
@@ -38,7 +38,7 @@ export class HeaderBar extends Component {
             className="dib f9 v-mid inter ml2"
             href="/"
             style={{ top: 14 }}>
-            ⟵</a> <p className="dib f9 v-mid inter ml2">Dojo</p>
+            ⟵</a> <p className="dib f9 v-mid inter ml2 white-d">Dojo</p>
         </div>
       </div>
     );


### PR DESCRIPTION
Style tweaking in #2615 lacked `white-d` for text in the header, so text in the header shows as black in dark mode. This PR remedies that.