### PR TITLE
link, publish: fix sidebar for multi-item groups

### DIFF
--- a/pkg/interface/link/src/js/components/lib/channel-sidebar.js
+++ b/pkg/interface/link/src/js/components/lib/channel-sidebar.js
@@ -41,7 +41,7 @@ export class ChannelsSidebar extends Component {
       if (groupPath in associations) {
         if (groupedChannels[groupPath]) {
           let array = groupedChannels[groupPath];
-          array.push[path];
+          array.push(path);
           groupedChannels[groupPath] = array;
         } else {
           groupedChannels[groupPath] = [path];

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -53,7 +53,7 @@ export class Sidebar extends Component {
       if (path in associations) {
         if (groupedNotebooks[path]) {
           let array = groupedNotebooks[path];
-          array.push[book];
+          array.push(book);
           groupedNotebooks[path] = array;
         } else {
           groupedNotebooks[path] = [book];


### PR DESCRIPTION
A syntax typo led the array for grouped notebooks to not have paths
pushed into it. Only the last item in the group would be pushed into the
array. This commit fixes that typo.

-_-;;

Untested, but pretty, pretty sure this is the issue in question. Fixes #2638.