### PR TITLE
chat: DMs repositioned below grouped chats

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/group-item.js
+++ b/pkg/interface/chat/src/js/components/lib/group-item.js
@@ -17,7 +17,30 @@ export class GroupItem extends Component {
     let first = (props.index === 0) ? "pt1" : "pt4"
 
 
-    let channelItems = channels.map((each, i) => {
+    let channelItems = channels.sort((a, b) => {
+      if (props.index === "/~/") {
+        let aPreview = props.messagePreviews[a];
+        let bPreview = props.messagePreviews[b];
+        let aWhen = !!aPreview ? aPreview.when : 0;
+        let bWhen = !!bPreview ? bPreview.when : 0;
+
+        return bWhen - aWhen;
+      } else {
+      let aAssociation = a in props.chatMetadata ? props.chatMetadata[a] : {};
+      let bAssociation = b in props.chatMetadata ? props.chatMetadata[b] : {};
+      let aTitle = a;
+      let bTitle = b;
+      if (aAssociation.metadata && aAssociation.metadata.title) {
+        aTitle = (aAssociation.metadata.title !== "")
+          ? aAssociation.metadata.title : a;
+        }
+      if (bAssociation.metadata && bAssociation.metadata.title) {
+        bTitle =
+          bAssociation.metadata.title !== "" ? bAssociation.metadata.title : b;
+        }
+      return aTitle.toLowerCase().localeCompare(bTitle.toLowerCase());
+      }
+    }).map((each, i) => {
       let unread = props.unreads[each];
       let title = each.substr(1);
       if (

--- a/pkg/interface/chat/src/js/components/sidebar.js
+++ b/pkg/interface/chat/src/js/components/sidebar.js
@@ -68,9 +68,6 @@ export class Sidebar extends Component {
       .map((each, i) => {
         let channels = groupedChannels[each] || [];
         if (channels.length === 0) return;
-        if (groupedChannels["/~/"] && groupedChannels["/~/"].length !== 0) {
-          i = i + 1;
-        }
         return(
           <GroupItem
             key={i}
@@ -86,7 +83,7 @@ export class Sidebar extends Component {
         )
       });
       if (groupedChannels["/~/"] && groupedChannels["/~/"].length !== 0) {
-        groupedItems.unshift(
+        groupedItems.push(
           <GroupItem
             association={"/~/"}
             chatMetadata={props.associations["chat"]}
@@ -94,7 +91,7 @@ export class Sidebar extends Component {
             inbox={props.inbox}
             station={props.station}
             unreads={props.unreads}
-            index={0}
+            index={"/~/"}
             key={"/~/"}
             {...props}
           />


### PR DESCRIPTION
I'm in so many direct messages that my grouped chats are buried, regardless of filtering down to seeing just them. Realising the error of my ways, this PR repositions the DMs *below* our (potentially filtered down) set of grouped chats.

cc @urcades 