### PR TITLE
eth-watcher: separate timeout from refresh-rate

### DIFF
--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -87,8 +87,9 @@
   |=  [state=app-state our=ship dap=term]
   ^-  card:agent:gall
   =/  args=vase  !>
-    :*  %watch  /[dap]
-        url.state  =(%czar (clan:title our))  ~m5
+    :+  %watch  /[dap]
+    ^-  config:eth-watcher
+    :*  url.state  =(%czar (clan:title our))  ~m5  ~m30
         launch:contracts:azimuth
         ~[azimuth:contracts:azimuth]
         (topics whos.state)

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -51,6 +51,7 @@
     ::
     ++  node-url  'http://eth-mainnet.urbit.org:8545'
     ++  refresh-rate  ~h1
+    ++  timeout-time  ~h2
     --
 ::
 =|  state-0
@@ -207,6 +208,7 @@
   :*  node-url
       |
       refresh-rate
+      timeout-time
       public:mainnet-contracts
       ~[azimuth delegated-sending]:mainnet-contracts
       ~

--- a/pkg/arvo/sur/eth-watcher.hoon
+++ b/pkg/arvo/sur/eth-watcher.hoon
@@ -3,9 +3,18 @@
 =,  able:jael
 |%
 +$  config
-  $:  url=@ta
+  $:  ::  url: ethereum node rpc endpoint
+      ::  eager: if true, give logs asap, send disavows in case of reorg
+      ::  refresh-rate: rate at which to check for updates
+      ::  timeout-time: time an update check is allowed to take
+      ::  from: oldest block number to look at
+      ::  contracts: contract addresses to look at
+      ::  topics: event descriptions to look for
+      ::
+      url=@ta
       eager=?
       refresh-rate=@dr
+      timeout-time=@dr
       from=number:block
       contracts=(list address:ethereum)
       =topics


### PR DESCRIPTION
Previously, when the refresh-rate timer activated, and the thread from
the previous activation was still running, we would kill it and start
a new one. For low refresh rates, on slower machines, nodes, or network
connections, this could cause the update to never conclude.

Here we add a timeout-time to eth-watcher's `config`. If the refresh-rate
timer activates, and a thread exists, but hasn't been running for at
least the specified timeout-time yet, we simply take no action, and wait
for the next refresh timer.

Note that we opted for "at least timeout-time", instead of killing &
restarting directly after the specified timeout-time has passed, to
avoid having to handle an extra timer flow.

In the `+on-load` logic, we configure the timeout-time for existing
watchdogs as six times the refresh-rate. We want to set
azimuth-tracker's timeout-time to `~m30`, and don't care much about other,
less-likely-to-be-active use cases of eth-watcher.

Fixes #2570.