### PR TITLE
os1: skeleton uses b--gray4, not b--gray2

### DIFF
--- a/pkg/interface/chat/src/js/components/skeleton.js
+++ b/pkg/interface/chat/src/js/components/skeleton.js
@@ -27,7 +27,7 @@ export class Skeleton extends Component {
       ? "" : "ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl";
 
     let popoutBorder = this.props.popout
-      ? "" : "ba-m ba-l ba-xl b--gray2 br1 ";
+      ? "" : "ba-m ba-l ba-xl b--gray4 b--gray1-d br1 ";
 
     return (
       // app outer skeleton

--- a/pkg/interface/groups/src/js/components/skeleton.js
+++ b/pkg/interface/groups/src/js/components/skeleton.js
@@ -13,7 +13,7 @@ export class Skeleton extends Component {
     return (
       <div className="h-100 w-100 ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl">
         <HeaderBar spinner={props.spinner} invites={props.invites} associations={props.associations} />
-        <div className="cf w-100 h-100 h-100-m-40-ns flex ba-m ba-l ba-xl b--gray2 br1">
+        <div className="cf w-100 h-100 h-100-m-40-ns flex ba-m ba-l ba-xl b--gray4 b--gray1-d br1">
           <GroupSidebar
             contacts={props.contacts}
             groups={props.groups}

--- a/pkg/interface/link/src/js/components/skeleton.js
+++ b/pkg/interface/link/src/js/components/skeleton.js
@@ -17,7 +17,7 @@ export class Skeleton extends Component {
       ? "" : "h-100-m-40-ns ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl"
 
     let popoutBorder = (popout)
-      ? "" : "ba-m ba-l ba-xl b--gray2 br1"
+      ? "" : "ba-m ba-l ba-xl b--gray4 b--gray1-d br1"
 
       let linkInvites = ('/link' in this.props.invites)
       ? this.props.invites['/link'] : {};

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -328,6 +328,9 @@ md img {
   .b--gray0-d {
     border-color: #333;
   }
+  .b--gray1-d {
+    border-color: #4d4d4d;
+  }
   .b--gray2-d {
     border-color: #7f7f7f;
   }

--- a/pkg/interface/publish/src/js/components/lib/sidebar-invite.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar-invite.js
@@ -28,7 +28,7 @@ export class SidebarInvite extends Component {
     const { props } = this;
 
     return (
-      <div className='pa3 bb b--gray4 b--gray2-d'>
+      <div className='pa3 bb b--gray4 b--gray1-d'>
         <div className='w-100 v-mid'>
           <p className="dib f9 mono gray4-d">
             {props.invite.text}

--- a/pkg/interface/publish/src/js/components/lib/sidebar.js
+++ b/pkg/interface/publish/src/js/components/lib/sidebar.js
@@ -107,7 +107,7 @@ export class Sidebar extends Component {
     return (
       <div
         className={
-          "bn br-m br-l br-xl b--gray4 b--gray2-d lh-copy h-100 " +
+          "bn br-m br-l br-xl b--gray4 b--gray1-d lh-copy h-100 " +
           "flex-shrink-0 pt3 pt0-m pt0-l pt0-xl relative " +
           "overflow-y-hidden " + activeClasses +
           (hiddenClasses ? "flex-basis-100-s flex-basis-250-ns" : "dn")

--- a/pkg/interface/publish/src/js/components/skeleton.js
+++ b/pkg/interface/publish/src/js/components/skeleton.js
@@ -16,7 +16,7 @@ export class Skeleton extends Component {
       ? "" : "h-100-m-40-ns ph4-m ph4-l ph4-xl pb4-m pb4-l pb4-xl"
 
     let popoutBorder = (popout)
-      ? "": "ba-m ba-l ba-xl b--gray2 br1"
+      ? "": "ba-m ba-l ba-xl b--gray4 b--gray1-d br1"
 
     return (
       <div className={"absolute h-100 w-100 " + popoutWindow}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20846414/78159976-4f2f7e00-7411-11ea-8c46-ab42c474d924.png)

The outer borders of OS1 applications were all using `gray2`, a step up from the internal borders of `gray4`, which was distracting and inconsistent. This brings them to a light gray (and `gray1` in dark mode) to match the internal borders.