### PR TITLE
clock: ensure launch is listening correctly

### DIFF
--- a/pkg/arvo/app/clock.hoon
+++ b/pkg/arvo/app/clock.hoon
@@ -1,4 +1,4 @@
-/+  *server, default-agent, verb
+/+  *server, default-agent, verb, dbug
 /=  tile-js
   /^  octs
   /;  as-octs:mimes:html
@@ -17,6 +17,7 @@
 +$  state-zero  [%0 data=json]
 --
 %+  verb  |
+%-  agent:dbug
 =|  state-zero
 =*  state  -
 ^-  agent:gall

--- a/pkg/arvo/app/clock.hoon
+++ b/pkg/arvo/app/clock.hoon
@@ -35,13 +35,21 @@
   ==
 ::  bootstrapping to get %goad started OTA
 ::
-++  on-save   !>(%2)
+++  on-save   !>(%3)
 ++  on-load
   |=  old-state=vase
-  =/  old  !<(?(~ %1 %2) old-state)
+  ^-  (quip card _this)
+  =/  old  !<(?(~ %1 %2 %3) old-state)
   =^  cards  this
-    ?:  ?=(%2 old)
+    ?:  ?=(%3 old)
       `this
+    ?:  ?=(%2 old)
+      ::  ensure launch is set up to listen to us correctly
+      ::
+      =/  launcha
+        [%launch-action !>([%add %clock /clocktile '/~clock/js/tile.js'])]
+      :_  this
+      [%pass /clock %agent [our.bowl %launch] %poke launcha]~
     :_  this  :_  ~
     [%pass /behn %arvo %b %wait +(now.bowl)]
   ::

--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -1,4 +1,4 @@
-/+  *server, *server, default-agent, dbug
+/+  *server, *server, default-agent, verb, dbug
 /=  tile-js
   /^  octs
   /;  as-octs:mimes:html
@@ -21,6 +21,7 @@
 --
 =|  state-zero
 =*  state  -
+%+  verb  |
 %-  agent:dbug
 ^-  agent:gall
 =<


### PR DESCRIPTION
In the wild, ships that were live pre-OS1 still had launch subscriptions
open to the clock on the `/tile` path, instead of the currently-used
`/clocktile` path. Additionally, launch state for the clock tile seemed
incomplete.

Here, we simply re-`%add` the clock to launch, during `+on-load`.

Note that launch [currently](https://github.com/urbit/urbit/blob/069ec72f8ad4c834ea5a04aa2749f3d787b87632/pkg/arvo/app/launch.hoon#L110) does not clean up old subscriptions on
path change. For the pre-OS1 case, the old path is no longer in use,
rendering the subscription harmless. For cases where the correct
subscription was already in place, it'll print a %watch-wire-not-unique,
but doesn't do any harm besides that.

I thought I'd just go and fix that launch logic real quick, but it's a bit more involved. To look up path from tile name, you kind of want [this](https://github.com/urbit/urbit/blob/069ec72f8ad4c834ea5a04aa2749f3d787b87632/pkg/arvo/app/launch.hoon#L39) to be a map instead of a set. Could write state transition logic, or maybe just do a search through the set instead, but don't want to let myself go on this. Happy to make some change there if requested, though.

Tested as working for the problem case on ~palfun-foslup. Tested as working for the "already works" case on a fakeship.

Closes #2585.