### PR TITLE
invite search: avoid crashing with no associations

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -33,15 +33,15 @@ export class InviteSearch extends Component {
     let groups = Array.from(Object.keys(this.props.groups));
     groups = groups.filter(e => !e.startsWith("/~/"))
     .map(e => {
-      let eachGroup = new Set();
-      eachGroup.add(e);
+      let eachGroup = [];
+      eachGroup.push(e);
       if (this.props.associations) {
         let name = e;
         if (e in this.props.associations) {
           name = (this.props.associations[e].metadata.title !== "")
             ? this.props.associations[e].metadata.title : e;
         }
-        eachGroup.add(name);
+        eachGroup.push(name);
       }
       return Array.from(eachGroup);
     });

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -31,20 +31,17 @@ export class InviteSearch extends Component {
 
   peerUpdate() {
     let groups = Array.from(Object.keys(this.props.groups));
-    groups = groups
-      .filter(e => !e.startsWith("/~/"))
+    groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
-        let eachGroup = new Set();
-        eachGroup.add(e);
+        let eachGroup = [];
+        eachGroup.push(e);
         if (this.props.associations) {
           let name = e;
           if (e in this.props.associations) {
-            name =
-              this.props.associations[e].metadata.title !== ""
-                ? this.props.associations[e].metadata.title
-                : e;
+            name = (this.props.associations[e].metadata.title !== "")
+              ? this.props.associations[e].metadata.title : e;
           }
-          eachGroup.add(name);
+          eachGroup.push(name);
         }
         return Array.from(eachGroup);
       });

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -31,20 +31,17 @@ export class InviteSearch extends Component {
 
   peerUpdate() {
     let groups = Array.from(Object.keys(this.props.groups));
-    groups = groups
-      .filter(e => !e.startsWith("/~/"))
+    groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
-        let eachGroup = new Set();
-        eachGroup.add(e);
+        let eachGroup = [];
+        eachGroup.push(e);
         if (this.props.associations) {
           let name = e;
           if (e in this.props.associations) {
-            name =
-              this.props.associations[e].metadata.title !== ""
-                ? this.props.associations[e].metadata.title
-                : e;
+            name = (this.props.associations[e].metadata.title !== "")
+              ? this.props.associations[e].metadata.title : e;
           }
-          eachGroup.add(name);
+          eachGroup.push(name);
         }
         return Array.from(eachGroup);
       });

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -31,20 +31,17 @@ export class InviteSearch extends Component {
 
   peerUpdate() {
     let groups = Array.from(Object.keys(this.props.groups));
-    groups = groups
-      .filter(e => !e.startsWith("/~/"))
+    groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
-        let eachGroup = new Set();
-        eachGroup.add(e);
+        let eachGroup = [];
+        eachGroup.push(e);
         if (this.props.associations) {
           let name = e;
           if (e in this.props.associations) {
-            name =
-              this.props.associations[e].metadata.title !== ""
-                ? this.props.associations[e].metadata.title
-                : e;
+            name = (this.props.associations[e].metadata.title !== "")
+              ? this.props.associations[e].metadata.title : e;
           }
-          eachGroup.add(name);
+          eachGroup.push(name);
         }
         return Array.from(eachGroup);
       });


### PR DESCRIPTION
Fixes #2657. 
 
By using an array, not a set, we stop deduplicating our group index,
pushing redundant information instead. When searching, this prevents a
component fail state where it cannot search a non-existent index for
matches.