### PR TITLE
apps: added hints to the top of many networked apps

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -5,6 +5,7 @@
 /-  *permission-store, *chat-hook, *invite-store, *metadata-store,
     *permission-hook, *group-store, *permission-group-hook  ::TMP  for upgrade
 /+  *chat-json, *chat-eval, default-agent, verb, dbug
+~%  %chat-hook-top  ..is  ~
 |%
 +$  card  card:agent:gall
 ::
@@ -39,10 +40,11 @@
 =|  state-1
 =*  state  -
 ::
-%+  verb  |
 %-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 =<
+  ~%  %chat-hook-agent-core  ..poke-json  ~
   |_  bol=bowl:gall
   +*  this       .
       chat-core  +>
@@ -222,6 +224,7 @@
     --
   ::
   ++  on-poke
+    ~/  %chat-hook-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
     =^  cards  state
@@ -239,6 +242,7 @@
     [cards this]
   ::
   ++  on-watch
+    ~/  %chat-hook-watch
     |=  =path
     ^-  (quip card _this)
     ?+  path          (on-watch:def path)
@@ -248,6 +252,7 @@
     ==
   ::
   ++  on-agent
+    ~/  %chat-hook-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
     ?+  -.sign  (on-agent:def wire sign)
@@ -287,6 +292,7 @@
   --
 ::
 ::
+~%  %chat-hook-library  ..card  ~
 |_  bol=bowl:gall
 ::
 ++  poke-json

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -1,6 +1,7 @@
 :: chat-store: data store that holds linear sequences of chat messages
 ::
 /+  *chat-json, *chat-eval, default-agent, verb, dbug
+~%  %chat-store-top  ..is  ~
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -25,6 +26,7 @@
 %+  verb  |
 ^-  agent:gall
 =<
+  ~%  %chat-store-agent-core  ..peek-x-envelopes  ~
   |_  =bowl:gall
   +*  this       .
       chat-core  +>
@@ -42,6 +44,7 @@
     [%pass /lo-chst %agent [our.bowl %chat-hook] %poke %noun !>(%store-load)]~
   ::
   ++  on-poke
+    ~/  %chat-store-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
     ?>  (team:title our.bowl src.bowl)
@@ -53,6 +56,7 @@
     [cards this]
   ::
   ++  on-watch
+    ~/  %chat-store-watch
     |=  =path
     ^-  (quip card _this)
     |^
@@ -77,6 +81,7 @@
   ::
   ++  on-leave  on-leave:def
   ++  on-peek
+    ~/  %chat-store-peek
     |=  =path
     ^-  (unit (unit cage))
     ?+  path  (on-peek:def path)
@@ -104,6 +109,7 @@
   --
 ::
 ::
+~%  %chat-store-library  ..card  ~
 |_  bol=bowl:gall
 ::
 ++  peek-x-envelopes

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -42,6 +42,7 @@
   /^  (map knot @)
   /:  /===/app/chat/img  /_  /png/
 ::
+~%  %chat-view-top  ..is  ~
 |%
 +$  card  card:agent:gall
 ::
@@ -58,6 +59,7 @@
 %-  agent:dbug
 ^-  agent:gall
 =<
+  ~%  %chat-view-agent-core  ..poke-handle-http-request  ~
   |_  bol=bowl:gall
   +*  this       .
       chat-core  +>
@@ -73,6 +75,7 @@
         [%pass /chat-view %agent [our.bol %launch] %poke launcha]
     ==
   ++  on-poke
+    ~/  %chat-view-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
     ?>  (team:title our.bol src.bol)
@@ -94,6 +97,7 @@
     ==
   ::
   ++  on-watch
+    ~/  %chat-view-watch
     |=  =path
     ^-  (quip card _this)
     ?>  (team:title our.bol src.bol)
@@ -129,6 +133,7 @@
     --
   ::
   ++  on-agent
+    ~/  %chat-view-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
     ?+    -.sign  (on-agent:def wire sign)
@@ -145,6 +150,7 @@
     ==
   ::
   ++  on-arvo
+    ~/  %chat-view-arvo
     |=  [=wire =sign-arvo]
     ^-  (quip card _this)
     ?.  ?=(%bound +<.sign-arvo)
@@ -159,6 +165,7 @@
   --
 ::
 ::
+~%  %chat-view-library  ..card  ~
 |_  bol=bowl:gall
 ::
 ++  poke-handle-http-request

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -7,6 +7,7 @@
     *metadata-hook,
     *metadata-store
 /+  *contact-json, default-agent, dbug
+~%  %contact-hook-top  ..is  ~
 |%
 +$  card  card:agent:gall
 ::

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -2,6 +2,7 @@
 ::
 /-  *group-store, *group-hook
 /+  default-agent, verb, dbug
+~%  %group-hook-top  ..is  ~
 |%
 +$  card  card:agent:gall
 ::

--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -18,6 +18,7 @@
 /-  link-listen-hook, *metadata-store, *link, group-store
 /+  mdl=metadata, default-agent, verb, dbug
 ::
+~%  %link-listen-hook-top  ..is  ~
 |%
 +$  versioned-state
   $%  [%0 state-0]

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -21,6 +21,7 @@
 ::
 /-  group-store, *metadata-store
 /+  *link, metadata, default-agent, verb, dbug
+~%  %link-proxy-hook-top  ..is  ~
 |%
 +$  state-0
   $:  %0

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -5,6 +5,7 @@
 ::
 /-  *metadata-store, *metadata-hook
 /+  default-agent, dbug
+~%  %metadata-hook-top  ..is  ~
 |%
 +$  card  card:agent:gall
 +$  versioned-state

--- a/pkg/arvo/app/permission-hook.hoon
+++ b/pkg/arvo/app/permission-hook.hoon
@@ -7,6 +7,7 @@
 /-  *permission-hook
 /+  *permission-json, default-agent, verb, dbug
 ::
+~%  %permission-hook-top  ..is  ~
 |%
 +$  state
   $%  [%0 state-0]

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -39,6 +39,7 @@
   /^  (map knot @)
   /:  /===/app/publish/img  /_  /png/
 ::
+~%  %publish  ..is  ~
 |%
 +$  card  card:agent:gall
 ::


### PR DESCRIPTION
For the purposes of more detailed flame graphs when doing Chrome tracing, we added jet hints to most of the networked apps, and to the chat apps. More to come in the next few days.