### PR TITLE
chat-js: transition to new chat upon chatSynced changing in join or new chat screen

### DIFF
--- a/pkg/interface/chat/src/js/components/join.js
+++ b/pkg/interface/chat/src/js/components/join.js
@@ -46,7 +46,8 @@ export class JoinScreen extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { props, state } = this;
-    if (state.station in props.inbox) {
+    if (state.station in props.inbox ||
+        props.chatSynced !== prevProps.chatSynced) {
       props.history.push(`/~chat/room${state.station}`);
     }
   }

--- a/pkg/interface/chat/src/js/components/root.js
+++ b/pkg/interface/chat/src/js/components/root.js
@@ -110,6 +110,7 @@ export class Root extends Component {
                     permissions={state.permissions || {}}
                     contacts={state.contacts || {}}
                     associations={associations.contacts}
+                    chatSynced={state.chatSynced || {}}
                     {...props}
                   />
                 </Skeleton>
@@ -139,6 +140,7 @@ export class Root extends Component {
                     api={api}
                     inbox={state.inbox}
                     autoJoin={station}
+                    chatSynced={state.chatSynced || {}}
                     {...props} />
                 </Skeleton>
               );


### PR DESCRIPTION
Small change, improves perceived performance of join and new chat screen moving to chatroom as soon as chatSynced (%chat-hook property) changes.