### PR TITLE
link: line up link info on same line height

### DIFF
--- a/pkg/interface/link/src/js/components/lib/link-detail-preview.js
+++ b/pkg/interface/link/src/js/components/lib/link-detail-preview.js
@@ -129,18 +129,14 @@ export class LinkPreview extends Component {
             <span className="gray2 ml2 f8 dib v-btm flex-shrink-0">{hostname} ↗</span>
           </a>
           <div className="w-100 pt1">
-            <span className={"f9 pr2 white-d v-mid " + nameClass}
+            <span className={"f9 pr2 white-d dib " + nameClass}
             title={props.ship}>
               {props.nickname ? props.nickname : cite(props.ship)}
             </span>
-            <span className="f9 inter gray2 pr3 v-mid">
+            <span className="f9 inter gray2 pr3 dib">
               {this.state.timeSinceLinkPost}
             </span>
-            <Link
-              to={makeRoutePath(props.resourcePath, props.popout, props.page, props.url, props.linkIndex)}
-              className="v-top">
-              <span className="f9 inter gray2">{props.comments}</span>
-            </Link>
+              <span className="f9 inter gray2 dib">{props.comments}</span>
           </div>
         </div>
       </div>

--- a/pkg/interface/link/src/js/components/lib/link-item.js
+++ b/pkg/interface/link/src/js/components/lib/link-item.js
@@ -79,22 +79,21 @@ export class LinkItem extends Component {
             <span className="gray2 dib v-btm ml2 f8 flex-shrink-0">{hostname} ↗</span>
           </a>
           <div className="w-100 pt1">
-            <span className={"f9 pr2 v-mid " + mono}
+            <span className={"f9 pr2 dib " + mono}
             title={props.ship}>
             {(props.nickname)
               ? props.nickname
               : cite(props.ship)}
             </span>
           <span
-            className={seenState + " f9 inter pr3 v-mid"}
+            className={seenState + " f9 inter pr3 dib"}
             onClick={this.markPostAsSeen}>
             {this.state.timeSinceLinkPost}
           </span>
           <Link to=
             {makeRoutePath(props.resourcePath, props.popout, props.page, props.url, props.linkIndex)}
-          className="v-top"
           onClick={this.markPostAsSeen}>
-            <span className="f9 inter gray2">
+            <span className="f9 inter gray2 dib">
                 {comments}
               </span>
             </Link>


### PR DESCRIPTION
Juggling `display: inline-block` and `vertical-align` classes to get the Link info to line up correctly.

Compare before / after: 

<img width="403" alt="image" src="https://user-images.githubusercontent.com/20846414/78320324-30c3a280-7537-11ea-94b9-d677bc366854.png">
<img width="282" alt="Screen Shot 2020-04-02 at 11 09 17 PM" src="https://user-images.githubusercontent.com/20846414/78320337-34efc000-7537-11ea-9434-63eaa4dc4b68.png">
