### PR TITLE
invite search: populate group index from contacts

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -30,7 +30,7 @@ export class InviteSearch extends Component {
   }
 
   peerUpdate() {
-    let groups = Array.from(Object.keys(this.props.groups));
+    let groups = Array.from(Object.keys(this.props.contacts));
     groups = groups.filter(e => !e.startsWith("/~/"))
     .map(e => {
       let eachGroup = [];

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -30,7 +30,7 @@ export class InviteSearch extends Component {
   }
 
   peerUpdate() {
-    let groups = Array.from(Object.keys(this.props.groups));
+    let groups = Array.from(Object.keys(this.props.contacts));
     groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
         let eachGroup = [];

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -30,7 +30,7 @@ export class InviteSearch extends Component {
   }
 
   peerUpdate() {
-    let groups = Array.from(Object.keys(this.props.groups));
+    let groups = Array.from(Object.keys(this.props.contacts));
     groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
         let eachGroup = [];

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -30,7 +30,7 @@ export class InviteSearch extends Component {
   }
 
   peerUpdate() {
-    let groups = Array.from(Object.keys(this.props.groups));
+    let groups = Array.from(Object.keys(this.props.contacts));
     groups = groups.filter(e => !e.startsWith("/~/"))
       .map(e => {
         let eachGroup = [];


### PR DESCRIPTION
After #2616, an edge case was introduced: 

- After migrating from subscribing to group-store, and passing its groups to invite search, we instead passed the permissions;
- by default, permission-store doesn't retain permissions for groups unless already associated with a channel and subscribed to a channel;
- Occasionally, circumstances require that ships that aren't in any managed channels, create a channel and associate it with a group;

Thus, if you were on a ship that was predominantly infrastructural — that is, not in any channels, but used to just host chats, notebooks, or collections, that belong to a group — the group wouldn't be passed to invite search; thus you couldn't see the groups in invite search; thus could never create those channels.

By instead iterating through `props.contacts` when populating the group index in invite search, we can see all the groups we belong to, regardless of whether we are already in any channels associated with the group.