### PR TITLE
gall: added hack to reduce processing time for chat messages by 30%

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -773,6 +773,60 @@
   ++  mo-apply
     |=  [agent=term =routes =deal]
     ^+  mo-core
+    ::  TODO: Remove this horrific hack when ford pinto comes!
+    =>  |%
+        +$  serial  @uvH
+        ::
+        +$  letter
+          $%  [%text text=cord]
+              [%url url=cord]
+              [%code expression=cord output=(list tank)]
+              [%me narrative=cord]
+          ==
+        ::
+        +$  envelope
+          $:  uid=serial
+              number=@
+              author=ship
+              when=time
+              =letter
+          ==
+        ::
+        +$  config
+          $:  length=@
+              read=@
+          ==
+        ::
+        +$  mailbox
+          $:  =config
+              envelopes=(list envelope)
+          ==
+        ::
+        +$  inbox  (map path mailbox)
+        ::
+        +$  chat-configs  (map path config)
+        ::
+        +$  chat-base
+          $%  [%create =path]
+              [%delete =path]
+              [%message =path =envelope]
+              [%read =path]
+          ==
+        ::
+        +$  chat-action
+          $%  ::  %messages: append a list of messages to mailbox
+              ::
+              [%messages =path envelopes=(list envelope)]
+              chat-base
+          ==
+        ::
+        +$  chat-update
+          $%  [%keys keys=(set path)]
+              [%config =path =config]
+              [%messages =path start=@ud end=@ud envelopes=(list envelope)]
+              chat-base
+          ==
+        --
     ::
     =/  =path
       =/  ship  (scot %p attributing.routes)
@@ -783,9 +837,19 @@
       [p q]:beak
     ::
     ?:  ?=(%raw-poke -.deal)
-      =/  =schematic:ford  [%vale ship-desk +.deal]
-      =/  =note-arvo  [%f %build live=%.n schematic]
-      (mo-pass path note-arvo)
+      ::  TODO: Remove this horrific hack when ford pinto comes!
+      ?+  mark.deal
+        =/  =schematic:ford  [%vale ship-desk +.deal]
+        =/  =note-arvo  [%f %build live=%.n schematic]
+        (mo-pass path note-arvo)
+      ::
+          %chat-action
+        =/  =cage  [%chat-action !>(;;(chat-action noun.deal))]
+        =/  new-deal=^deal  [%poke cage]
+        =/  app  (ap-abed:ap agent routes)
+        =.  app  (ap-apply:app new-deal)
+        ap-abet:app
+      ==
     ::
     ?:  ?=(%poke-as -.deal)
       =/  =schematic:ford  [%cast ship-desk mark.deal [%$ cage.deal]]
@@ -845,6 +909,60 @@
   ++  mo-handle-ames-response
     |=  =ames-response
     ^+  mo-core
+    ::  TODO: Remove this horrific hack when ford pinto comes!
+    =>  |%
+        +$  serial  @uvH
+        ::
+        +$  letter
+          $%  [%text text=cord]
+              [%url url=cord]
+              [%code expression=cord output=(list tank)]
+              [%me narrative=cord]
+          ==
+        ::
+        +$  envelope
+          $:  uid=serial
+              number=@
+              author=ship
+              when=time
+              =letter
+          ==
+        ::
+        +$  config
+          $:  length=@
+              read=@
+          ==
+        ::
+        +$  mailbox
+          $:  =config
+              envelopes=(list envelope)
+          ==
+        ::
+        +$  inbox  (map path mailbox)
+        ::
+        +$  chat-configs  (map path config)
+        ::
+        +$  chat-base
+          $%  [%create =path]
+              [%delete =path]
+              [%message =path =envelope]
+              [%read =path]
+          ==
+        ::
+        +$  chat-action
+          $%  ::  %messages: append a list of messages to mailbox
+              ::
+              [%messages =path envelopes=(list envelope)]
+              chat-base
+          ==
+        ::
+        +$  chat-update
+          $%  [%keys keys=(set path)]
+              [%config =path =config]
+              [%messages =path start=@ud end=@ud envelopes=(list envelope)]
+              chat-base
+          ==
+        --
     ::
     ?-    -.ames-response
         ::  %d: diff; ask ford to validate .noun as .mark
@@ -853,11 +971,18 @@
       =/  =wire  /sys/rep
       ::  agents load their code from the %home desk, including marks
       ::
-      =/  =note-arvo
-        =/  =disc:ford  [our %home]
-        [%f %build live=%.n %vale disc [mark noun]:ames-response]
       ::
-      (mo-pass wire note-arvo)
+      ::  TODO: Remove this hack when we get Ford pinto!!!
+      ?+  mark.ames-response
+        =/  =note-arvo
+          =/  =disc:ford  [our %home]
+          [%f %build live=%.n %vale disc [mark noun]:ames-response]
+        (mo-pass wire note-arvo)
+      ::
+          %chat-update
+        =/  =cage  [%chat-update !>(;;(chat-update noun:ames-response))]
+        (mo-give %unto %fact cage)
+      ==
     ::
         ::  %x: kick; tell agent the publisher canceled the subscription
         ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -844,10 +844,9 @@
         (mo-pass path note-arvo)
       ::
           %chat-action
-        =/  chat-act=(unit chat-action)
-          ((soft chat-action) ;;(chat-action noun.deal))
+        =/  chat-act=(unit chat-action)  ((soft chat-action) noun.deal)
         ?~  chat-act
-          ~&  %gall-raw-poke-chat-action-failed
+          ~&  gall-raw-chat-poke-failed+[agent attributing.routes]
           mo-core
         =/  =cage  [%chat-action !>(u.chat-act)]
         =/  new-deal=^deal  [%poke cage]
@@ -920,7 +919,6 @@
         %d
       =/  =wire  /sys/rep
       ::  agents load their code from the %home desk, including marks
-      ::
       ::
       =/  =note-arvo
         =/  =disc:ford  [our %home]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -844,7 +844,12 @@
         (mo-pass path note-arvo)
       ::
           %chat-action
-        =/  =cage  [%chat-action !>(;;(chat-action noun.deal))]
+        =/  chat-act=(unit chat-action)
+          ((soft chat-action) ;;(chat-action noun.deal))
+        ?~  chat-act
+          ~&  %gall-raw-poke-chat-action-failed
+          mo-core
+        =/  =cage  [%chat-action !>(u.chat-act)]
         =/  new-deal=^deal  [%poke cage]
         =/  app  (ap-abed:ap agent routes)
         =.  app  (ap-apply:app new-deal)
@@ -909,61 +914,6 @@
   ++  mo-handle-ames-response
     |=  =ames-response
     ^+  mo-core
-    ::  TODO: Remove this horrific hack when ford pinto comes!
-    =>  |%
-        +$  serial  @uvH
-        ::
-        +$  letter
-          $%  [%text text=cord]
-              [%url url=cord]
-              [%code expression=cord output=(list tank)]
-              [%me narrative=cord]
-          ==
-        ::
-        +$  envelope
-          $:  uid=serial
-              number=@
-              author=ship
-              when=time
-              =letter
-          ==
-        ::
-        +$  config
-          $:  length=@
-              read=@
-          ==
-        ::
-        +$  mailbox
-          $:  =config
-              envelopes=(list envelope)
-          ==
-        ::
-        +$  inbox  (map path mailbox)
-        ::
-        +$  chat-configs  (map path config)
-        ::
-        +$  chat-base
-          $%  [%create =path]
-              [%delete =path]
-              [%message =path =envelope]
-              [%read =path]
-          ==
-        ::
-        +$  chat-action
-          $%  ::  %messages: append a list of messages to mailbox
-              ::
-              [%messages =path envelopes=(list envelope)]
-              chat-base
-          ==
-        ::
-        +$  chat-update
-          $%  [%keys keys=(set path)]
-              [%config =path =config]
-              [%messages =path start=@ud end=@ud envelopes=(list envelope)]
-              chat-base
-          ==
-        --
-    ::
     ?-    -.ames-response
         ::  %d: diff; ask ford to validate .noun as .mark
         ::
@@ -972,17 +922,10 @@
       ::  agents load their code from the %home desk, including marks
       ::
       ::
-      ::  TODO: Remove this hack when we get Ford pinto!!!
-      ?+  mark.ames-response
-        =/  =note-arvo
-          =/  =disc:ford  [our %home]
-          [%f %build live=%.n %vale disc [mark noun]:ames-response]
-        (mo-pass wire note-arvo)
-      ::
-          %chat-update
-        =/  =cage  [%chat-update !>(;;(chat-update noun:ames-response))]
-        (mo-give %unto %fact cage)
-      ==
+      =/  =note-arvo
+        =/  =disc:ford  [our %home]
+        [%f %build live=%.n %vale disc [mark noun]:ames-response]
+      (mo-pass wire note-arvo)
     ::
         ::  %x: kick; tell agent the publisher canceled the subscription
         ::


### PR DESCRIPTION
After a discussion with Ted, I decided to try to remove Ford entirely from the hot-path of chat message sending / receiving to improve performance. Received about a 50% speed improvement for receiving a chat poke, and about a 15% improvement to receiving a chat subscription update from my tests.

Here for review!

Note: This is a hack meant to improve performance until the point at which Ford pinto is ready.