### PR TITLE
dbug: document "all subscriptions" option in gen

### DIFF
--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -10,6 +10,7 @@
 ::      all in subs matching the parameters
 ::      direction: %incoming or %outgoing
 ::      specifics:
+::        ~              all subscriptions
 ::        [%ship ~ship]  subscriptions to/from this ship
 ::        [%path /path]  subscriptions on path containing /path
 ::        [%wire /wire]  subscriptions on wire containing /wire


### PR DESCRIPTION
This should've been added in #2587.