### PR TITLE
various: alphabetise associations accesses the object

### DIFF
--- a/pkg/interface/chat/src/js/lib/util.js
+++ b/pkg/interface/chat/src/js/lib/util.js
@@ -138,14 +138,14 @@ export function alphabetiseAssociations(associations) {
   Object.keys(associations).sort((a, b) => {
     let aName = a.substr(1);
     let bName = b.substr(1);
-    if (a.metadata && a.metadata.title) {
-      aName = a.metadata.title !== ""
-        ? a.metadata.title
+    if (associations[a].metadata && associations[a].metadata.title) {
+      aName = associations[a].metadata.title !== ""
+        ? associations[a].metadata.title
         : a.substr(1);
     }
-    if (b.metadata && b.metadata.title) {
-      bName = b.metadata.title !== ""
-        ? b.metadata.title
+    if (associations[b].metadata && associations[b].metadata.title) {
+      bName = associations[b].metadata.title !== ""
+        ? associations[b].metadata.title
         : b.substr(1);
     }
     return aName.toLowerCase().localeCompare(bName.toLowerCase());

--- a/pkg/interface/link/src/js/lib/util.js
+++ b/pkg/interface/link/src/js/lib/util.js
@@ -171,14 +171,14 @@ export function alphabetiseAssociations(associations) {
   Object.keys(associations).sort((a, b) => {
     let aName = a.substr(1);
     let bName = b.substr(1);
-    if (a.metadata && a.metadata.title) {
-      aName = a.metadata.title !== ""
-        ? a.metadata.title
+    if (associations[a].metadata && associations[a].metadata.title) {
+      aName = associations[a].metadata.title !== ""
+        ? associations[a].metadata.title
         : a.substr(1);
     }
-    if (b.metadata && b.metadata.title) {
-      bName = b.metadata.title !== ""
-        ? b.metadata.title
+    if (associations[b].metadata && associations[b].metadata.title) {
+      bName = associations[b].metadata.title !== ""
+        ? associations[b].metadata.title
         : b.substr(1);
     }
     return aName.toLowerCase().localeCompare(bName.toLowerCase());

--- a/pkg/interface/publish/src/js/lib/util.js
+++ b/pkg/interface/publish/src/js/lib/util.js
@@ -97,14 +97,14 @@ export function alphabetiseAssociations(associations) {
   Object.keys(associations).sort((a, b) => {
     let aName = a.substr(1);
     let bName = b.substr(1);
-    if (a.metadata && a.metadata.title) {
-      aName = a.metadata.title !== ""
-        ? a.metadata.title
+    if (associations[a].metadata && associations[a].metadata.title) {
+      aName = associations[a].metadata.title !== ""
+        ? associations[a].metadata.title
         : a.substr(1);
     }
-    if (b.metadata && b.metadata.title) {
-      bName = b.metadata.title !== ""
-        ? b.metadata.title
+    if (associations[b].metadata && associations[b].metadata.title) {
+      bName = associations[b].metadata.title !== ""
+        ? associations[b].metadata.title
         : b.substr(1);
     }
     return aName.toLowerCase().localeCompare(bName.toLowerCase());


### PR DESCRIPTION
Previously we were checking for a title for the association by accessing
a non-existent property of the key we were using to iterate through
the object. What we want to do is access the iterated object to find
that title, and so this commit does that.

Because of this issue, group titles weren't being used to sort groups in all sidebars except Groups (which has a bespoke sort) — it was silently defaulting to the paths, sorting by `@p`.

Fixes #2672.