### PR TITLE
publish: sanitise markdown snippets in preview

### DIFF
--- a/pkg/interface/publish/src/js/components/lib/notebook-posts.js
+++ b/pkg/interface/publish/src/js/components/lib/notebook-posts.js
@@ -71,7 +71,10 @@ export class NotebookPosts extends Component {
             </div>
             <p className="mb1"
             style={{overflowWrap: "break-word"}}>
-              {note.snippet}
+              <ReactMarkdown
+                unwrapDisallowed
+                allowedTypes={['text', 'root', 'break', 'paragraph']}
+                source={note.snippet} />
             </p>
             <div className="flex">
               <div className={(contact.nickname ? null : "mono") +


### PR DESCRIPTION
Runs the snippet through ReactMarkdown instead of rendering it as text.
We restrict the allowed nodes in the render to pure text, so the snippet is not
overly visually heavy. At the moment, any links will be rendered as pure text instead of excluding them. Demo:
![Screen Shot 2020-04-08 at 6 08 36 pm](https://user-images.githubusercontent.com/46801558/78760116-06a13300-79c4-11ea-957e-821c6e7f25b0.png)
![Screen Shot 2020-04-08 at 6 08 48 pm](https://user-images.githubusercontent.com/46801558/78760120-09038d00-79c4-11ea-9965-35c11bfb5d0b.png)

cc: @matildepark 
