### PR TITLE
invite-search: handle suggestions for short searches

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -127,8 +127,8 @@ export class InviteSearch extends Component {
           isValid = false;
         }
 
-        if (shipMatches.length === 0 && isValid) {
-          shipMatches.push(searchTerm);
+        if (isValid && shipMatches.findIndex(s => s === searchTerm) < 0) {
+          shipMatches.unshift(searchTerm);
         }
       }
 

--- a/pkg/interface/chat/src/js/components/lib/invite-search.js
+++ b/pkg/interface/chat/src/js/components/lib/invite-search.js
@@ -88,11 +88,11 @@ export class InviteSearch extends Component {
 
     this.setState({ searchValue: event.target.value });
 
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < 1) {
       this.setState({ searchResults: { groups: [], ships: [] } });
     }
 
-    if (searchTerm.length > 2) {
+    if (searchTerm.length > 0) {
       if (this.state.inviteError === true) {
         this.setState({ inviteError: false });
       }
@@ -100,7 +100,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return (e[0].includes(searchTerm) || e[1].includes(searchTerm));
+          return (e[0].includes(searchTerm) || e[1].toLowerCase().includes(searchTerm));
         });
       }
 
@@ -139,6 +139,15 @@ export class InviteSearch extends Component {
       if(!selected || staleSelection) {
         const newSelection = _.get(groupMatches, '[0][0]') || shipMatches[0];
         this.setState({ selected: newSelection })
+      }
+
+
+      if(searchTerm.length < 3) {
+        groupMatches = groupMatches.filter(([, name]) =>
+          name.toLowerCase().split(' ').some(s => s.startsWith(searchTerm))
+        ).sort((a,b) => a[1].length - b[1].length);
+
+        shipMatches = shipMatches.slice(0,3);
       }
 
       this.setState({

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -128,8 +128,8 @@ export class InviteSearch extends Component {
           isValid = false;
         }
 
-        if (shipMatches.length === 0 && isValid) {
-          shipMatches.push(searchTerm);
+        if (isValid && shipMatches.findIndex(s => s === searchTerm) < 0) {
+          shipMatches.unshift(searchTerm);
         }
       }
 

--- a/pkg/interface/groups/src/js/components/lib/invite-search.js
+++ b/pkg/interface/groups/src/js/components/lib/invite-search.js
@@ -89,11 +89,11 @@ export class InviteSearch extends Component {
 
     this.setState({ searchValue: event.target.value });
 
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < 1) {
       this.setState({ searchResults: { groups: [], ships: [] } });
     }
 
-    if (searchTerm.length > 2) {
+    if (searchTerm.length > 0) {
       if (this.state.inviteError === true) {
         this.setState({ inviteError: false });
       }
@@ -101,7 +101,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return e[0].includes(searchTerm) || e[1].includes(searchTerm);
+          return e[0].includes(searchTerm) || e[1].toLowerCase().includes(searchTerm);
         });
       }
 
@@ -140,6 +140,15 @@ export class InviteSearch extends Component {
       if(!selected || staleSelection) {
         const newSelection = _.get(groupMatches, '[0][0]') || shipMatches[0];
         this.setState({ selected: newSelection })
+      }
+
+           
+      if(searchTerm.length < 3) {
+        groupMatches = groupMatches.filter(([, name]) =>
+          name.toLowerCase().split(' ').some(s => s.startsWith(searchTerm))
+        ).sort((a,b) => a[1].length - b[1].length);
+
+        shipMatches = shipMatches.slice(0,3);
       }
 
       this.setState({

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -89,11 +89,11 @@ export class InviteSearch extends Component {
 
     this.setState({ searchValue: event.target.value });
 
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < 1) {
       this.setState({ searchResults: { groups: [], ships: [] } });
     }
 
-    if (searchTerm.length > 2) {
+    if (searchTerm.length > 0) {
       if (this.state.inviteError === true) {
         this.setState({ inviteError: false });
       }
@@ -101,7 +101,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return e[0].includes(searchTerm) || e[1].includes(searchTerm);
+          return e[0].includes(searchTerm) || e[1].toLowerCase().includes(searchTerm);
         });
       }
 
@@ -140,6 +140,14 @@ export class InviteSearch extends Component {
       if(!selected || staleSelection) {
         const newSelection = _.get(groupMatches, '[0][0]') || shipMatches[0];
         this.setState({ selected: newSelection })
+      }
+
+      if(searchTerm.length < 3) {
+        groupMatches = groupMatches.filter(([, name]) =>
+          name.toLowerCase().split(' ').some(s => s.startsWith(searchTerm))
+        ).sort((a,b) => a[1].length - b[1].length);
+
+        shipMatches = shipMatches.slice(0,3);
       }
 
       this.setState({

--- a/pkg/interface/link/src/js/components/lib/invite-search.js
+++ b/pkg/interface/link/src/js/components/lib/invite-search.js
@@ -128,8 +128,8 @@ export class InviteSearch extends Component {
           isValid = false;
         }
 
-        if (shipMatches.length === 0 && isValid) {
-          shipMatches.push(searchTerm);
+        if (isValid && shipMatches.findIndex(s => s === searchTerm) < 0) {
+          shipMatches.unshift(searchTerm);
         }
       }
 

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -89,11 +89,11 @@ export class InviteSearch extends Component {
 
     this.setState({ searchValue: event.target.value });
 
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < 1) {
       this.setState({ searchResults: { groups: [], ships: [] } });
     }
 
-    if (searchTerm.length > 2) {
+    if (searchTerm.length > 0) {
       if (this.state.inviteError === true) {
         this.setState({ inviteError: false });
       }
@@ -101,7 +101,7 @@ export class InviteSearch extends Component {
       let groupMatches = [];
       if (this.props.groupResults) {
         groupMatches = this.state.groups.filter(e => {
-          return e[0].includes(searchTerm) || e[1].includes(searchTerm);
+          return e[0].includes(searchTerm) || e[1].toLowerCase().includes(searchTerm);
         });
       }
 
@@ -140,6 +140,14 @@ export class InviteSearch extends Component {
       if(!selected || staleSelection) {
         const newSelection = _.get(groupMatches, '[0][0]') || shipMatches[0];
         this.setState({ selected: newSelection })
+      }
+
+      if(searchTerm.length < 3) {
+        groupMatches = groupMatches.filter(([, name]) =>
+          name.toLowerCase().split(' ').some(s => s.startsWith(searchTerm))
+        ).sort((a,b) => a[1].length - b[1].length);
+
+        shipMatches = shipMatches.slice(0,3);
       }
 
       this.setState({

--- a/pkg/interface/publish/src/js/components/lib/invite-search.js
+++ b/pkg/interface/publish/src/js/components/lib/invite-search.js
@@ -128,8 +128,8 @@ export class InviteSearch extends Component {
           isValid = false;
         }
 
-        if (shipMatches.length === 0 && isValid) {
-          shipMatches.push(searchTerm);
+        if (isValid && shipMatches.findIndex(s => s === searchTerm) < 0) {
+          shipMatches.unshift(searchTerm);
         }
       }
 


### PR DESCRIPTION
Triggers invitee suggestions after one character of input. To
compensate for the potential explosion of suggestions, we
tighten our group searching criteria and truncate the
ship suggestions on short searches. Also addresses a bug where names of
groups were not being downcased before search.

Fixes #2635

cc: @matildepark 