### PR TITLE
ford: print source line on syntax error

### DIFF
--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -3165,10 +3165,12 @@
       ?~  q.parsed
         =/  =path  (rail-to-path source-rail)
         %-  return-error
-        :-  :-  %leaf
-            %+  weld  "ford: %hood: syntax error at "
-            "[{<p.p.parsed>} {<q.p.parsed>}] in {<path>}"
-        ~
+        =/  lyn  p.p.parsed
+        =/  col  q.p.parsed
+        :~  leaf+(runt [(dec col) '-'] "^")
+            leaf+(trip (snag (dec lyn) (to-wain:format q.q.as-cage)))
+            leaf+"ford: %hood: syntax error at [{<lyn>} {<col>}] in {<path>}"
+        ==
       ::
       (return-result %success %hood p.u.q.parsed)
     ::


### PR DESCRIPTION
Thanks to @belisarius222 for walking me through this. :)

Previous behavior:
```
> +hello 'world'
ford: %hood: syntax error at [12 13] in /~zod/home/0/gen/hello/hoon
ford: %core on /~zod/home/0/gen/hello/hoon failed:
~zod:dojo>
```

New behavior:
```
> +hello 'world'
ford: %hood: syntax error at [12 13] in /~zod/home/0/gen/hello/hoon
(crip (weld \ "hello, " (trip txt)))
------------^
ford: %core on /~zod/home/0/gen/hello/hoon failed:
~zod:dojo> 
```

The last line still reads "backwards" to me; I think it would make more sense at the top. But it wasn't obvious to me how to achieve that, since that line is produced in a separate build step.