### PR TITLE
chat-fe: filter empty groups in sidebar

### DIFF
--- a/pkg/interface/chat/src/js/components/sidebar.js
+++ b/pkg/interface/chat/src/js/components/sidebar.js
@@ -58,6 +58,7 @@ export class Sidebar extends Component {
       });
 
     let groupedItems = Object.keys(associations)
+      .filter((each) => (groupedChannels[each] || []).length !== 0)
       .filter((each) => {
         if (selectedGroups.length === 0) {
           return true;
@@ -67,7 +68,6 @@ export class Sidebar extends Component {
       })
       .map((each, i) => {
         let channels = groupedChannels[each] || [];
-        if (channels.length === 0) return;
         return(
           <GroupItem
             key={i}


### PR DESCRIPTION
Empty groups caused the padding on the first group to be too large.
Filter the groups before we map over them so that we can set padding
properly.

Fixes #2674

cc: @matildepark 