### PR TITLE
publish: eagerly store your own changes

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -119,17 +119,52 @@
   ++  on-load
     |=  old=vase
     ^-  (quip card _this)
-    =/  old-state=versioned-state  !<(versioned-state old)
+    =/  old-state=(each versioned-state tang)
+      (mule |.(!<(versioned-state old)))
     =|  cards=(list card)
     |^
-    ?-  -.old-state
+    ?:  ?=(%| -.old-state)
+      =/  zero  !<(state-zero old)
+      =/  rav  [%next %t [%da now.bol] /app/publish/notebooks]
+      =/  tile-json
+        (frond:enjs:format %notifications (numb:enjs:format 0))
+      =/  init-cards=(list card)
+        :~  [%pass /read/paths %arvo %c %warp our.bol q.byk.bol `rav]
+            :*  %pass  /permissions  %agent  [our.bol %permission-store]  %watch
+                /updates
+            ==
+            (invite-poke:main [%create /publish])
+            :*  %pass  /invites  %agent  [our.bol %invite-store]  %watch
+                /invitatory/publish
+            ==
+            [%give %fact [/publishtile]~ %json !>(tile-json)]
+        ==
+      =+  ^-  [kick-cards=(list card) old-subs=(jug @tas @p)]  kick-subs
+      =/  inv-scry-pax
+        /(scot %p our.bol)/invite-store/(scot %da now.bol)/invitatory/publish/noun
+      =/  inv=(unit invitatory)  .^((unit invitatory) %gx inv-scry-pax)
+      =|  new-state=state-two
+      =?  tile-num.new-state  ?=(^ inv)
+        ~(wyt by u.inv)
+      %=  $
+          old-state  [%& %2 new-state]
+      ::
+          cards
+        ;:  weld
+          (kill-builds pubs.zero)
+          kick-cards
+          init-cards
+          (move-files old-subs)
+        ==
+      ==
+    ?-  -.p.old-state
         %1
       %=  $
-          -.old-state  %2
+          -.p.old-state  %2
       ::
           cards
         %-  zing
-        %+  turn  ~(tap by books.old-state)
+        %+  turn  ~(tap by books.p.old-state)
         |=  [name=@tas book=notebook-2]
         ^-  (list card)
         =/  group-host=(unit @p)
@@ -146,25 +181,25 @@
     ::
         %2
       %=  $
-          old-state
+          p.old-state
         =/  new-books=(map [@p @tas] notebook)
           %-  %~  uni  by
-            %-  ~(run by subs.old-state)
+            %-  ~(run by subs.p.old-state)
             |=  old-notebook=notebook-2
             ^-  notebook-3
             (convert-notebook-2-3 old-notebook)
           ^-  (map [@p @tas] notebook)
-          %-  ~(rep by books.old-state)
+          %-  ~(rep by books.p.old-state)
           |=  [[key=@tas val=notebook-2] out=(map [@p @tas] notebook)]
           ^-  (map [@p @tas] notebook)
           %+  ~(put by out)
             [our.bol key]
           (convert-notebook-2-3 val)
-        [%3 our-paths.old-state new-books tile-num.old-state [~ ~]]
+        [%3 our-paths.p.old-state new-books tile-num.p.old-state [~ ~]]
       ==
     ::
         %3
-      [cards this(state old-state)]
+      [cards this(state p.old-state)]
     ==
     ::
     ++  convert-comment-2-3
@@ -191,6 +226,103 @@
         |=  =note-2
         (convert-note-2-3 note-2)
       ==
+    ::
+    ++  kick-subs
+      ^-  [(list card) (jug @tas @p)]
+      =+  ^-  [paths=(list path) subs=(jug @tas @p)]
+        %+  roll  ~(tap by sup.bol)
+        |=  [[duct [who=@p pax=path]] paths=(list path) subs=(jug @tas @p)]
+        ^-  [(list path) (jug @tas @p)]
+        ?.  ?=([%collection @ ~] pax)
+          [paths subs]
+        =/  book-name  i.t.pax
+        :-  [pax paths]
+        (~(put ju subs) book-name who)
+      ?~  paths
+        [~ subs]
+      [[%give %kick paths ~]~ subs]
+    ::
+    ++  kill-builds
+      |=  pubs=(map @tas collection-zero)
+      ^-  (list card)
+      %-  zing
+      %+  turn  ~(tap by pubs)
+      |=  [col-name=@tas col-data=collection-zero]
+      ^-  (list card)
+      :-  [%pass /collection/[col-name] %arvo %f %kill ~]
+      %-  zing
+      %+  turn  ~(tap by pos.col-data)
+      |=  [pos-name=@tas *]
+      :~  [%pass /post/[col-name]/[pos-name] %arvo %f %kill ~]
+          [%pass /comments/[col-name]/[pos-name] %arvo %f %kill ~]
+      ==
+    ::
+    ++  send-invites
+      |=  [book=@tas subscribers=(set @p)]
+      ^-  (list card)
+      %+  turn  ~(tap in subscribers)
+      |=  who=@p
+      ^-  card
+      =/  uid  (sham %publish who book eny.bol)
+      =/  inv=invite
+        :*  our.bol  %publish  /notebook/[book]  who
+            (crip "invite for notebook {<our.bol>}/{(trip book)}")
+        ==
+      =/  act=invite-action  [%invite /publish uid inv]
+      [%pass /invite %agent [who %invite-hook] %poke %invite-action !>(act)]
+    ::
+    ++  move-files
+      |=  old-subs=(jug @tas @p)
+      ^-  (list card)
+      =+  ^-  [cards=(list card) sob=soba:clay]
+        %+  roll  .^((list path) %ct (weld our-beak:main /web/publish))
+        |=  [pax=path car=(list card) sob=soba:clay]
+        ^-  [(list card) soba:clay]
+        ?+    pax
+            [car sob]
+        ::
+            [%web %publish @ %publish-info ~]
+          =/  book-name  i.t.t.pax
+          =/  old=old-info  .^(old-info %cx (welp our-beak:main pax))
+          =/  group-pax  /~/(scot %p our.bol)/[book-name]
+          =/  book=notebook-info
+            [title.old '' =(%open comments.old) / /]
+          =+  ^-  [grp-car=(list card) write-pax=path read-pax=path]
+            (make-groups:main book-name [group-pax ~ %.n %.n] title.old '')
+          =.  writers.book      write-pax
+          =.  subscribers.book  read-pax
+          =/  inv-car  (send-invites book-name (~(get ju old-subs) book-name))
+          :-  :(weld car grp-car inv-car)
+          ^-  soba:clay
+          :+  [pax %del ~]
+            :-  /app/publish/notebooks/[book-name]/publish-info
+            [%ins %publish-info !>(book)]
+          sob
+        ::
+            [%web %publish @ @ %udon ~]
+          =/  book  i.t.t.pax
+          =/  note  i.t.t.t.pax
+          :-  car
+          :+  [pax %del ~]
+            :-  /app/publish/notebooks/[book]/[note]/udon
+            [%ins %udon !>(.^(@t %cx (welp our-beak:main pax)))]
+          sob
+        ::
+            [%web %publish @ @ @ %publish-comment ~]
+          =/  book  i.t.t.pax
+          =/  note  i.t.t.t.pax
+          =/  comm  i.t.t.t.t.pax
+          =/  old-com  .^(old-comment %cx (welp our-beak:main pax))
+          =/  new=comment-2
+            [creator.old-com date-created.old-com content.old-com]
+          :-  car
+
+          :+  [pax %del ~]
+            :-  /app/publish/notebooks/[book]/[note]/[comm]/publish-comment
+            [%ins %publish-comment !>(new)]
+          sob
+        ==
+      [[%pass /move-files %arvo %c %info q.byk.bol %& sob] cards]
     --
   ::
   ++  on-poke

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1913,6 +1913,8 @@
     =/  old-note  (~(get by notes.u.book) note.del)
     ?~  old-note
       [~ sty]
+    ?:  =(our.bol author.u.old-note)
+      [~ sty]
     =/  new-note=note
       %=  data.del
         date-created  date-created.u.old-note
@@ -1932,6 +1934,11 @@
       [~ sty]
     =/  note  (~(get by notes.u.book) note.del)
     ?~  note
+      [~ sty]
+    =/  old-comment  (~(get by comments.u.note) comment-date.del)
+    ?~  old-comment
+      [~ sty]
+    ?:  =(our.bol author.u.old-comment)
       [~ sty]
     =.  comments.u.note  (~(put by comments.u.note) comment-date.del data.del)
     =.  notes.u.book  (~(put by notes.u.book) note.del u.note)

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -330,6 +330,11 @@
     ^-  (quip card _this)
     ?+  mar  (on-poke:def mar vas)
     ::
+        %noun
+      ?:  =(q.vas %flush-limbo)
+        [~ this(limbo [~ ~])]
+      [~ this]
+    ::
         %handle-http-request
       =+  !<([id=@ta req=inbound-request:eyre] vas)
       :_  this
@@ -364,7 +369,45 @@
     ==
   ::
   ++  on-leave  on-leave:def
-  ++  on-peek   on-peek:def
+  ++  on-peek
+    |=  pax=path
+    ^-  (unit (unit cage))
+    ?+  pax  (on-peek:def pax)
+    ::
+        [%t %limbo ~]
+      :^  ~  ~  %noun
+      !>  ^-  (list path)
+      %+  weld
+        %+  turn  ~(tap by notes.limbo)
+        |=  [[who=@p book=@tas note=@tas] *]
+        ^-  path
+        /(scot %p who)/[book]/[note]
+      %+  turn  ~(tap by comments.limbo)
+      |=  [[who=@p book=@tas note=@tas comment=@da] *]
+      ^-  path
+      /(scot %p who)/[book]/[note]/(scot %ds comment)
+    ::
+        [%x %limbo @ @ @ ~]
+      =/  host=(unit @p)  (slaw %p i.t.t.pax)
+      ?~  host  [~ ~]
+      =/  book-name  i.t.t.t.pax
+      =/  note-name  i.t.t.t.t.pax
+      =/  note  (~(get by notes.limbo) u.host book-name note-name)
+      ?~  note  ~
+      ``noun+!>(u.note)
+    ::
+        [%x %limbo @ @ @ @ ~]
+      =/  host=(unit @p)           (slaw %p i.t.t.pax)
+      =/  comment-date=(unit @da)  (slaw %da i.t.t.t.t.t.pax)
+      ?~  host          [~ ~]
+      ?~  comment-date  [~ ~]
+      =/  book-name  i.t.t.t.pax
+      =/  note-name  i.t.t.t.t.pax
+      =/  comment
+        (~(get by comments.limbo) u.host book-name note-name u.comment-date)
+      ?~  comment  ~
+      ``noun+!>(u.comment)
+    ==
   ::
   ++  on-agent
     |=  [wir=wire sin=sign:agent:gall]

--- a/pkg/arvo/lib/publish.hoon
+++ b/pkg/arvo/lib/publish.hoon
@@ -60,11 +60,11 @@
   (notebook-short-json book)
 ::
 ++  notebooks-map-json
-  |=  [our=@p books=(map @tas notebook) subs=(map [@p @tas] notebook)]
+  |=  [our=@p books=(map [@p @tas] notebook)]
   ^-  json
   =,  enjs:format
-  =/  subs-notebooks-map=json
-    %-  ~(rep by subs)
+  =/  notebooks-map=json
+    %-  ~(rep by books)
     |=  [[[host=@p book-name=@tas] book=notebook] out=json]
     ^-  json
     =/  host-ta  (scot %p host)
@@ -79,22 +79,9 @@
     =.  p.u.books  (~(put by p.u.books) book-name (notebook-short-json book))
     :-  %o
     (~(put by p.out) host-ta u.books)
-  =?  subs-notebooks-map  ?=(~ subs-notebooks-map)
+  =?  notebooks-map  ?=(~ notebooks-map)
     [%o ~]
-  =/  our-notebooks-map=json
-    %-  ~(rep by books)
-    |=  [[book-name=@tas book=notebook] out=json]
-    ^-  json
-    ?~  out
-      (frond book-name (notebook-short-json book))
-    ?>  ?=(%o -.out)
-    :-  %o
-    (~(put by p.out) book-name (notebook-short-json book))
-  ?~  our-notebooks-map
-    subs-notebooks-map
-  ?>  ?=(%o -.subs-notebooks-map)
-  :-  %o
-  (~(put by p.subs-notebooks-map) (scot %p our) our-notebooks-map)
+  notebooks-map
 ::
 ++  notebook-short-json
   |=  book=notebook
@@ -170,6 +157,7 @@
       num-comments+(numb ~(wyt by comments.note))
       comments+(comments-page comments.note 0 50)
       read+b+read.note
+      pending+b+pending.note
   ==
 ::
 ++  notes-by-date
@@ -197,6 +185,7 @@
       num-comments+(numb ~(wyt by comments.note))
       read+b+read.note
       snippet+s+snippet.note
+      pending+b+pending.note
   ==
 ::
 ++  notes-page
@@ -246,5 +235,6 @@
   :~  author+s+(scot %p author.com)
       date-created+(time date-created.com)
       content+s+content.com
+      pending+b+pending.com
   ==
 --

--- a/pkg/arvo/mar/publish/comment.hoon
+++ b/pkg/arvo/mar/publish/comment.hoon
@@ -44,7 +44,7 @@
         %+  cook
           |=  [author=@ @ @ date-created=@da @ content=@t]
           ^-  comment
-          [author date-created content]
+          [author date-created content %.n]
         old-parser
       ==
     --

--- a/pkg/arvo/sur/publish.hoon
+++ b/pkg/arvo/sur/publish.hoon
@@ -27,13 +27,24 @@
       [%read who=@p book=@tas note=@tas]
   ==
 ::
-+$  comment
++$  comment  comment-3
+::
++$  comment-2
   $:  author=@p
       date-created=@da
       content=@t
   ==
 ::
-+$  note
++$  comment-3
+  $:  author=@p
+      date-created=@da
+      content=@t
+      pending=?
+  ==
+::
++$  note  note-3
+::
++$  note-2
   $:  author=@p
       title=@t
       filename=@tas
@@ -42,11 +53,37 @@
       read=?
       file=@t
       snippet=@t
-::      build=(each manx tang)
-      comments=(map @da comment)
+      comments=(map @da comment-2)
   ==
 ::
-+$  notebook
++$  note-3
+  $:  author=@p
+      title=@t
+      filename=@tas
+      date-created=@da
+      last-edit=@da
+      read=?
+      file=@t
+      snippet=@t
+      comments=(map @da comment)
+      pending=?
+  ==
+::
++$  notebook  notebook-3
+::
++$  notebook-2
+  $:  title=@t
+      description=@t
+      comments=?
+      writers=path
+      subscribers=path
+      date-created=@da
+      notes=(map @tas note-2)
+      order=(list @tas)
+      unread=(set @tas)
+  ==
+::
++$  notebook-3
   $:  title=@t
       description=@t
       comments=?

--- a/pkg/interface/publish/src/js/reducers/primary.js
+++ b/pkg/interface/publish/src/js/reducers/primary.js
@@ -60,18 +60,22 @@ export class PrimaryReducer {
     let book   = Object.keys(json[host])[0];
     let noteId = json[host][book]["note-id"];
     if (state.notebooks[host] && state.notebooks[host][book]) {
-      if (state.notebooks[host][book]["notes-by-date"]) {
-        state.notebooks[host][book]["notes-by-date"].unshift(noteId);
-      } else {
-        state.notebooks[host][book]["notes-by-date"] = [noteId];
-      }
-
       if (state.notebooks[host][book].notes) {
+        if (state.notebooks[host][book].notes[noteId] &&
+            state.notebooks[host][book].notes[noteId].pending)
+        {
+          state.notebooks[host][book].notes[noteId].pending = false;
+          return;
+        }
+        if (state.notebooks[host][book]["notes-by-date"]) {
+          state.notebooks[host][book]["notes-by-date"].unshift(noteId);
+        } else {
+          state.notebooks[host][book]["notes-by-date"] = [noteId];
+        }
         state.notebooks[host][book].notes[noteId] = json[host][book];
       } else {
         state.notebooks[host][book].notes = {[noteId]: json[host][book]};
       }
-
       state.notebooks[host][book]["num-notes"] += 1;
       if (!json[host][book].read) {
         state.notebooks[host][book]["num-unread"] += 1;
@@ -79,7 +83,6 @@ export class PrimaryReducer {
       let prevNoteId = state.notebooks[host][book]["notes-by-date"][1] || null;
       state.notebooks[host][book].notes[noteId]["prev-note"] = prevNoteId
       state.notebooks[host][book].notes[noteId]["next-note"] = null;
-
       if (state.notebooks[host][book].notes[prevNoteId]) {
         state.notebooks[host][book].notes[prevNoteId]["next-note"] = noteId;
       }
@@ -96,10 +99,26 @@ export class PrimaryReducer {
         state.notebooks[host][book].notes &&
         state.notebooks[host][book].notes[note])
     {
-      state.notebooks[host][book].notes[note]["num-comments"] += 1;
+
       if (state.notebooks[host][book].notes[note].comments) {
-        state.notebooks[host][book].notes[note].comments.unshift(comment);
+        let limboCommentIdx =
+          _.findIndex(state.notebooks[host][book].notes[note].comments, (o) => {
+          let oldVal = o[Object.keys(o)[0]];
+          let newVal = comment[Object.keys(comment)[0]];
+          return (oldVal.pending &&
+            (oldVal.author ===  newVal.author) &&
+            (oldVal.content === newVal.content)
+          );
+        });
+        if (limboCommentIdx === -1) {
+          state.notebooks[host][book].notes[note]["num-comments"] += 1;
+          state.notebooks[host][book].notes[note].comments.unshift(comment);
+        } else {
+          state.notebooks[host][book].notes[note].comments[limboCommentIdx] =
+            comment;
+        }
       } else if (state.notebooks[host][book].notes[note]["num-comments"] === 1) {
+        state.notebooks[host][book].notes[note]["num-comments"] += 1;
         state.notebooks[host][book].notes[note].comments = [comment];
       }
     }


### PR DESCRIPTION
This PR changes publish so that when we make changes, whether its adding, editing, or deleting a post or comment, it will immediately store that upon receiving the poke, even if we are not the host of the notebook, and immediately send that update to the frontend.

If we aren't the host, and our poke to the host crashes, we handle that by either deleting the post/comment in the case of an add, or restoring the old one, in the case of an edit or delete. We also then send the opposite update to the frontend, eg: a delete if it was a failed add, etc.

The frontend reducers for adding notes and comments have been updated to be able to deduplicate updates, since in the normal case the frontend will now receive 2 updates, one pre- and one post-confirmation.

Additionally, this PR contains some cleanup to make it easier to write. One was the merging of books and subs, into a single field called books. The other was to eliminate the OS1 +onload stuff as its basically dead code now, I expect I'll get some pushback on that though.