### PR TITLE
chat: add unique ID to grouped chat paths

### DIFF
--- a/pkg/interface/chat/src/js/components/new.js
+++ b/pkg/interface/chat/src/js/components/new.js
@@ -95,6 +95,7 @@ export class NewScreen extends Component {
 
   onClickCreate() {
     const { props, state } = this;
+    let grouped = (this.state.createGroup || (this.state.groups.length > 0));
 
     if (!state.title) {
       this.setState({
@@ -104,7 +105,7 @@ export class NewScreen extends Component {
       return;
     }
 
-    let station = `/${state.idName}`;
+    let station = `/${state.idName}` + (grouped ? `-${Math.floor(Math.random() * 10000)}` : "");
 
     if (station in props.inbox) {
       this.setState({


### PR DESCRIPTION
Fixes #2706. Fixes #2697.

Namespace issues! A common case in our post-groups chat world is the same name for Chats in several groups, eg. "general"; because that gets converted to the same, ASCII-safe path and then redirected if it exists, users couldn't make chats with the same name.

Additionally this meant that if a group owner breached and remade the chat, the two chats with the same path would clobber each other in the sidebar's filter, showing only one.

This PR follows Links' lead for managed chats, adding a few random digits to the path/shortcode for those cases. Because the join flow for managed chats is different from unmanaged chats, we don't really rely on the path to join the group — it's relatively invisible to the user. I may put a PR in to hide the "copy shortcode" prompt for managed chats shortly to make this more evident ...