### PR TITLE
channel.js: added way to handle event source errors more smoothly, and implemented in chat

### DIFF
--- a/pkg/arvo/app/launch/js/channel.js
+++ b/pkg/arvo/app/launch/js/channel.js
@@ -1,5 +1,17 @@
 class Channel {
   constructor() {
+    this.init();
+    this.deleteOnUnload();
+
+    //  a way to handle channel errors
+    //
+    //
+    this.onChannelError = (err) => {
+      console.error('event source error: ', err);
+    };
+  }
+
+  init() {
     //  unique identifier: current time and random number
     //
     this.uid =
@@ -40,8 +52,10 @@ class Channel {
     //    disconnect function may be called exactly once.
     //
     this.outstandingSubscriptions = new Map();
+  }
 
-    this.deleteOnUnload();
+  setOnChannelError(onError = (err) => {}) {
+    this.onChannelError = onError;
   }
 
   deleteOnUnload() {
@@ -196,8 +210,9 @@ class Channel {
     }
 
     this.eventSource.onerror = e => {
-      console.error("eventSource error:", e);
       this.delete();
+      this.init();
+      this.onChannelError(e);
     }
   }
 

--- a/pkg/interface/chat/src/js/store.js
+++ b/pkg/interface/chat/src/js/store.js
@@ -9,7 +9,20 @@ import { LocalReducer } from '/reducers/local.js';
 
 class Store {
   constructor() {
-    this.state = {
+    this.state = this.initialState();
+
+    this.initialReducer = new InitialReducer();
+    this.permissionUpdateReducer = new PermissionUpdateReducer();
+    this.contactUpdateReducer = new ContactUpdateReducer();
+    this.chatUpdateReducer = new ChatUpdateReducer();
+    this.inviteUpdateReducer = new InviteUpdateReducer();
+    this.metadataReducer = new MetadataReducer();
+    this.localReducer = new LocalReducer();
+    this.setState = () => {};
+  }
+
+  initialState() {
+    return {
       inbox: {},
       chatSynced: {},
       contacts: {},
@@ -24,15 +37,6 @@ class Store {
       pendingMessages: new Map([]),
       chatInitialized: false
     };
-
-    this.initialReducer = new InitialReducer();
-    this.permissionUpdateReducer = new PermissionUpdateReducer();
-    this.contactUpdateReducer = new ContactUpdateReducer();
-    this.chatUpdateReducer = new ChatUpdateReducer();
-    this.inviteUpdateReducer = new InviteUpdateReducer();
-    this.metadataReducer = new MetadataReducer();
-    this.localReducer = new LocalReducer();
-    this.setState = () => {};
   }
 
   setStateHandler(setState) {
@@ -41,6 +45,11 @@ class Store {
 
   handleEvent(data) {
     let json = data.data;
+
+    if ('clear' in json && json.clear) {
+      this.setState(this.initialState());
+      return;
+    }
 
     console.log(json);
     this.initialReducer.reduce(json, this.state);

--- a/pkg/interface/chat/src/js/subscription.js
+++ b/pkg/interface/chat/src/js/subscription.js
@@ -13,9 +13,22 @@ export class Subscription {
   start() {
     if (api.authTokens) {
       this.firstRoundSubscription();
+      window.urb.setOnChannelError(this.onChannelError.bind(this));
     } else {
       console.error("~~~ ERROR: Must set api.authTokens before operation ~~~");
     }
+  }
+
+  onChannelError(err) {
+    console.error('event source error: ', err);
+    console.log('initiating new channel');
+    this.firstRoundSubscriptionComplete = false;
+    setTimeout(2000, () => {
+      store.handleEvent({
+        data: { clear : true}
+      });
+      this.start();
+    });
   }
 
   subscribe(path, app) {


### PR DESCRIPTION
Figured out that there was an unhandled error condition in Channel.js. Handled it. Tested an implementation within chat where chat can reset itself and re-establish subscriptions in no-connectivity scenarios. It works.