### PR TITLE
publish: install mousetrap before we use it....

### DIFF
--- a/pkg/interface/publish/package-lock.json
+++ b/pkg/interface/publish/package-lock.json
@@ -3764,6 +3764,11 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/pkg/interface/publish/package.json
+++ b/pkg/interface/publish/package.json
@@ -32,6 +32,7 @@
     "del": "^5.1.0",
     "lodash": "^4.17.11",
     "moment": "^2.20.1",
+    "mousetrap": "^1.6.5",
     "react": "^16.5.2",
     "react-codemirror2": "^6.0.0",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
This PR https://github.com/urbit/urbit/pull/2694 introduced mousetrap to publish without adding it to the package.json, resulting in this issue: https://github.com/urbit/urbit/issues/2671#issuecomment-612756244