### PR TITLE
link: improve page load performance

### DIFF
--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -288,12 +288,30 @@
 ++  handle-metadata-update
   |=  upd=metadata-update
   ^-  (quip card _state)
-  ?.  ?=(%remove -.upd)  [~ state]
-  ?>  =(%link app-name.resource.upd)
-  =?  listening
-      ?=(~ (groups-from-resource:md %link app-path.resource.upd))
-    (~(del in listening) app-path.resource.upd)
-  (leave-from-group app-path.resource.upd group-path.upd)
+  ?+  -.upd  [~ state]
+      %add
+    ?>  =(%link app-name.resource.upd)
+    ::  auto-listen to collections in unmanaged groups only
+    ::
+    ?.  ?=([%'~' ^] group-path.upd)  [~ state]
+    =,  resource.upd
+    =^  update  listening
+      ^-  (quip card _listening)
+      ?:  (~(has in listening) app-path)
+        [~ listening]
+      :-  [(send-update %watch app-path)]~
+      (~(put in listening) app-path)
+    =^  cards  state
+      (listen-to-group app-path group-path.upd)
+    [(weld update cards) state]
+  ::
+      %remove
+    ?>  =(%link app-name.resource.upd)
+    =?  listening
+        ?=(~ (groups-from-resource:md %link app-path.resource.upd))
+      (~(del in listening) app-path.resource.upd)
+    (leave-from-group app-path.resource.upd group-path.upd)
+  ==
 ::
 ::  groups subscriptions
 ::

--- a/pkg/arvo/app/link-view.hoon
+++ b/pkg/arvo/app/link-view.hoon
@@ -16,6 +16,7 @@
     group-hook, permission-hook, permission-group-hook,
     metadata-hook, contact-view
 /+  *link, metadata, *server, default-agent, verb, dbug
+~%  %link-view-top  ..is  ~
 ::
 |%
 +$  state-0
@@ -154,6 +155,7 @@
   ++  on-fail   on-fail:def
   --
 ::
+~%  %link-view-logic  ..card  ~
 |_  =bowl:gall
 +*  md  ~(. metadata bowl)
 ::
@@ -488,6 +490,7 @@
 ::    }
 ::
 ++  give-initial-submissions
+  ~/  %link-view-initial-submissions
   |=  [p=@ud =path]
   ^-  (list card)
   :_  ?:  =(0 p)  ~

--- a/pkg/arvo/app/link-view.hoon
+++ b/pkg/arvo/app/link-view.hoon
@@ -1,13 +1,13 @@
 ::  link-view: frontend endpoints
 ::
 ::  endpoints, mapping onto link-store's paths. p is for page as in pagination.
-::  updates only work for page 0.
+::  only the /0/submissions endpoint provides updates.
 ::  as with link-store, urls are expected to use +wood encoding.
 ::
-::    /json/[p]/submissions                           pages for all groups
-::    /json/[p]/submissions/[some-group]              page for one group
-::    /json/[p]/discussions/[wood-url]/[some-group]   page for url in group
-::    /json/[n]/submission/[wood-url]/[some-group]    nth matching submission
+::    /json/0/submissions                             initial + updates for all
+::    /json/[p]/submissions/[collection]              page for one collection
+::    /json/[p]/discussions/[wood-url]/[collection]   page for url in collection
+::    /json/[n]/submission/[wood-url]/[collection]    nth matching submission
 ::    /json/seen                                      mark-as-read updates
 ::
 /-  *link-view,
@@ -491,9 +491,11 @@
 ::
 ++  give-initial-submissions
   ~/  %link-view-initial-submissions
-  |=  [p=@ud =path]
+  |=  [p=@ud =requested=path]
   ^-  (list card)
-  :_  ?:  =(0 p)  ~
+  :_  ::  only keep the base case alive (for updates), kick all others
+      ::
+      ?:  &(=(0 p) ?=(~ requested-path))  ~
       [%give %kick ~ ~]~
   =;  =json
     [%give %fact ~ %json !>(json)]
@@ -501,9 +503,9 @@
   %-  pairs:enjs:format
   %+  turn
     %~  tap  by
-    %+  scry-for  (map ^path submissions)
-    [%submissions path]
-  |=  [=^path =submissions]
+    %+  scry-for  (map path submissions)
+    [%submissions requested-path]
+  |=  [=path =submissions]
   ^-  [@t json]
   :-  (spat path)
   =;  =json
@@ -516,6 +518,15 @@
     %~  wyt  in
     %+  scry-for  (set url)
     [%unseen path]
+  ?:  &(=(0 p) ?=(~ requested-path))
+    ::  for a broad-scope initial result, only give total counts
+    ::
+    =,  enjs:format
+    %-  pairs
+    =+  l=(lent submissions)
+    :~  'totalItems'^(numb l)
+        'totalPages'^(numb (div l page-size))
+    ==
   %^  page-to-json  p
     %+  get-paginated  `p
     submissions

--- a/pkg/arvo/app/link-view.hoon
+++ b/pkg/arvo/app/link-view.hoon
@@ -161,15 +161,16 @@
 ::
 ++  page-size  25
 ++  get-paginated
-  |*  [p=(unit @ud) l=(list)]
-  ^-  [total=@ud pages=@ud page=_l]
-  :+  (lent l)
-    %+  add  (div (lent l) page-size)
-    (min 1 (mod (lent l) page-size))
-  ?~  p  l
-  %+  scag  page-size
-  %+  slag  (mul u.p page-size)
-  l
+  |*  [page=(unit @ud) list=(list)]
+  ^-  [total=@ud pages=@ud page=_list]
+  =/  l=@ud  (lent list)
+  :+  l
+    %+  add  (div l page-size)
+    (min 1 (mod l page-size))
+  ?~  page  list
+  %+  swag
+    [(mul u.page page-size) page-size]
+  list
 ::
 ++  page-to-json
   =,  enjs:format

--- a/pkg/interface/link/src/js/components/lib/message-screen.js
+++ b/pkg/interface/link/src/js/components/lib/message-screen.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+export class MessageScreen extends Component {
+  render() {
+    return (
+      <div className="h-100 w-100 overflow-x-hidden flex flex-column bg-white bg-gray0-d dn db-ns">
+        <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
+          <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
+            {this.props.text}
+          </p>
+        </div>
+      </div>
+    );
+  }
+}

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -19,11 +19,18 @@ export class Links extends Component {
     this.componentDidUpdate();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const linkPage = this.props.page;
-    if ( (this.props.page != 0) &&
-         (!this.props.links[linkPage] ||
-          this.props.links.local[linkPage])
+    // if we just navigated to this particular page,
+    // and don't have links for it yet,
+    // or the links we have might not be complete,
+    // request the links for that page.
+    if ( (!prevProps ||
+          linkPage !== prevProps.page ||
+          this.props.resourcePath !== prevProps.resourcePath
+         ) &&
+         !this.props.links[linkPage] ||
+         this.props.links.local[linkPage]
     ) {
       api.getPage(this.props.resourcePath, this.props.page);
     }

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { LoadingScreen } from './loading';
+import { MessageScreen } from '/components/lib/message-screen';
 import { LinksTabBar } from './lib/links-tabbar';
 import { SidebarSwitcher } from '/components/lib/icons/icon-sidebar-switch.js';
 import { Route, Link } from "react-router-dom";
@@ -59,15 +60,8 @@ export class Links extends Component {
 
     let LinkList = (<LoadingScreen/>);
     if (props.links && props.links.totalItems === 0) {
-      //TODO the below re-used from landing screen. refactor into MessageScreen?
       LinkList = (
-        <div className="h-100 w-100 overflow-x-hidden bg-white bg-gray0-d dn db-ns">
-          <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
-            <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
-              Start by posting a link to this collection.
-            </p>
-          </div>
-        </div>
+        <MessageScreen text="Start by posting a link to this collection."/>
       );
     } else if (Object.keys(links).length > 0) {
       LinkList = Object.keys(links)

--- a/pkg/interface/link/src/js/components/links-list.js
+++ b/pkg/interface/link/src/js/components/links-list.js
@@ -57,38 +57,52 @@ export class Links extends Component {
     ? Number(props.links.totalPages)
     : 1;
 
-    let LinkList = Object.keys(links)
-    .map((linkIndex) => {
-      let linksObj = props.links[linkPage];
-      let { title, url, time, ship } = linksObj[linkIndex];
-      const seen = props.seen[url];
-      let members = {};
+    let LinkList = (<LoadingScreen/>);
+    if (props.links && props.links.totalItems === 0) {
+      //TODO the below re-used from landing screen. refactor into MessageScreen?
+      LinkList = (
+        <div className="h-100 w-100 overflow-x-hidden bg-white bg-gray0-d dn db-ns">
+          <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
+            <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
+              Start by posting a link to this collection.
+            </p>
+          </div>
+        </div>
+      );
+    } else if (Object.keys(links).length > 0) {
+      LinkList = Object.keys(links)
+      .map((linkIndex) => {
+        let linksObj = props.links[linkPage];
+        let { title, url, time, ship } = linksObj[linkIndex];
+        const seen = props.seen[url];
+        let members = {};
 
-      const commentCount = props.comments[url]
-        ? props.comments[url].totalItems
-        : linksObj[linkIndex].commentCount || 0;
+        const commentCount = props.comments[url]
+          ? props.comments[url].totalItems
+          : linksObj[linkIndex].commentCount || 0;
 
-      const {nickname, color, member} = getContactDetails(props.contacts[ship]);
+        const {nickname, color, member} = getContactDetails(props.contacts[ship]);
 
-      return (
-        <LinkItem
-        key={time}
-        title={title}
-        page={props.page}
-        linkIndex={linkIndex}
-        url={url}
-        timestamp={time}
-        seen={seen}
-        nickname={nickname}
-        ship={ship}
-        color={color}
-        member={member}
-        comments={commentCount}
-        resourcePath={props.resourcePath}
-        popout={props.popout}
-        />
-      )
-    })
+        return (
+          <LinkItem
+          key={time}
+          title={title}
+          page={props.page}
+          linkIndex={linkIndex}
+          url={url}
+          timestamp={time}
+          seen={seen}
+          nickname={nickname}
+          ship={ship}
+          color={color}
+          member={member}
+          comments={commentCount}
+          resourcePath={props.resourcePath}
+          popout={props.popout}
+          />
+        )
+      });
+    }
 
     return (
       <div

--- a/pkg/interface/link/src/js/components/loading.js
+++ b/pkg/interface/link/src/js/components/loading.js
@@ -1,15 +1,8 @@
 import React, { Component } from 'react';
+import { MessageScreen } from '/components/lib/message-screen';
 
 export class LoadingScreen extends Component {
   render() {
-    return (
-      <div className="h-100 w-100 overflow-x-hidden flex flex-column bg-white bg-gray0-d dn db-ns">
-        <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
-          <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
-            Loading...
-          </p>
-        </div>
-      </div>
-    );
+    return (<MessageScreen text="Loading..."/>);
   }
 }

--- a/pkg/interface/link/src/js/components/root.js
+++ b/pkg/interface/link/src/js/components/root.js
@@ -10,6 +10,7 @@ import { Skeleton } from '/components/skeleton';
 import { NewScreen } from '/components/new';
 import { MemberScreen } from '/components/member';
 import { SettingsScreen } from '/components/settings';
+import { MessageScreen } from '/components/lib/message-screen';
 import { Links } from '/components/links-list';
 import { LinkDetail } from '/components/link';
 import { makeRoutePath, amOwnerOfGroup, base64urlDecode } from '../lib/util';
@@ -63,13 +64,7 @@ export class Root extends Component {
                 selectedGroups={selectedGroups}
                 links={links}
                 listening={state.listening}>
-                <div className="h-100 w-100 overflow-x-hidden bg-white bg-gray0-d dn db-ns">
-                <div className="pl3 pr3 pt2 dt pb3 w-100 h-100">
-                      <p className="f8 pt3 gray2 w-100 h-100 dtc v-mid tc">
-                        Select or create a collection to begin.
-                      </p>
-                    </div>
-                </div>
+                <MessageScreen text="Select or create a collection to begin."/>
               </Skeleton>
             );
           }} />

--- a/pkg/interface/link/src/js/reducers/link-update.js
+++ b/pkg/interface/link/src/js/reducers/link-update.js
@@ -37,8 +37,10 @@ export class LinkUpdateReducer {
 
         // since data contains an up-to-date full version of the page,
         // we can safely overwrite the one in state.
-        state.links[path][page] = here.page;
-        state.links[path].local[page] = false;
+        if (typeof page === 'number' && here.page) {
+          state.links[path][page] = here.page;
+          state.links[path].local[page] = false;
+        }
         state.links[path].totalPages = here.totalPages;
         state.links[path].totalItems = here.totalItems;
         state.links[path].unseenCount = here.unseenCount;
@@ -48,7 +50,7 @@ export class LinkUpdateReducer {
         if (!state.seen[path]) {
           state.seen[path] = {};
         }
-        here.page.map(submission => {
+        (here.page || []).map(submission => {
           state.seen[path][submission.url] = submission.seen;
         });
       }


### PR DESCRIPTION
By doing more or less the same thing that chat does, where it doesn't load in big backlog on page-load, but instead only does so when you actually go to view the resource.

Also does some smaller refactoring things. Cleans up the pagination logic in link-view a little bit, and refactors "message display" as used for the link fe landing page and "loading" messages into its own component.