### PR TITLE
chat-fe: resubscribe message iff chatSynced is populated

### DIFF
--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -274,6 +274,7 @@ export class ChatScreen extends Component {
               this.scrollElement = el;
             }}></div>
             { (
+                props.chatSynced &&
                 !(props.station in props.chatSynced) &&
                 (messages.length > 0)
               ) ? (

--- a/pkg/interface/chat/src/js/store.js
+++ b/pkg/interface/chat/src/js/store.js
@@ -11,7 +11,7 @@ class Store {
   constructor() {
     this.state = {
       inbox: {},
-      chatSynced: {},
+      chatSynced: null,
       contacts: {},
       permissions: {},
       invites: {},


### PR DESCRIPTION
Previously, if a room was navigated to directly, the resubscribe message
would show before the chatSynced state was loaded. Initialises
chatSynced as null and checks it is not null before showing the
resubscribe message.

cc: @matildepark 