### PR TITLE
Contacts quality of life fixes

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -77,6 +77,7 @@
     ^-  (quip card _this)
     ?+  path          (on-watch:def path)
         [%contacts *]  [(watch-contacts:cc t.path) this]
+        [%synced *]    [(watch-synced:cc t.path) this]
     ==
   ::
   ++  on-agent
@@ -201,6 +202,12 @@
     %give  %fact  ~  %contact-update
     !>([%contacts pax contacts])
   ==  ==
+::
+++  watch-synced
+  |=  pax=path
+  ^-  (list card)
+  ?>  (team:title our.bol src.bol)
+  [%give %fact ~ %contact-hook-update !>([%initial synced])]~
 ::
 ++  watch-ack
   |=  [wir=wire saw=(unit tang)]
@@ -353,7 +360,8 @@
     |=  =path
     ^-  (quip card _state)
     ?.  (~(has by synced) path)
-      [~ state]
+      :_  state
+      [(contact-poke [%delete path])]~
     :_  state(synced (~(del by synced) path))
     :~  [%pass [%contacts path] %agent [our.bol %contact-store] %leave ~]
         [(contact-poke [%delete path])]

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -19,7 +19,7 @@
 +$  state-zero  [%0 state-base]
 +$  state-one   [%1 state-base]
 +$  state-base
-  $:  synced=(map path ship)
+  $:  =synced
       invite-created=_|
   ==
 --
@@ -125,31 +125,29 @@
 ++  poke-contact-action
   |=  act=contact-action
   ^-  (quip card _state)
-  |^  
   :_  state
   ?+  -.act  !!
     %edit    (handle-contact-action path.act ship.act act)
     %add     (handle-contact-action path.act ship.act act)
     %remove  (handle-contact-action path.act ship.act act)
   ==
-  ::
-  ++  handle-contact-action
-    |=  [=path =ship act=contact-action]
-    ^-  (list card)
-    ::  local
-    ?:  (team:title our.bol src.bol)
-      ?.  (~(has by synced) path)  ~
-      =/  shp  ?:(=(path /~/default) our.bol (~(got by synced) path))
-      =/  appl  ?:(=(shp our.bol) %contact-store %contact-hook)
-      [%pass / %agent [shp appl] %poke %contact-action !>(act)]~
-    ::  foreign
-    =/  shp  (~(got by synced) path)
-    ?.  |(=(shp our.bol) =(src.bol ship))  ~
-    ::  scry group to check if ship is a member
-    =/  =group  (need (group-scry path))
-    ?.  (~(has in group) shp)  ~
-    [%pass / %agent [our.bol %contact-store] %poke %contact-action !>(act)]~
-  --
+::
+++  handle-contact-action
+  |=  [=path =ship act=contact-action]
+  ^-  (list card)
+  ::  local
+  ?:  (team:title our.bol src.bol)
+    ?.  (~(has by synced) path)  ~
+    =/  shp  ?:(=(path /~/default) our.bol (~(got by synced) path))
+    =/  appl  ?:(=(shp our.bol) %contact-store %contact-hook)
+    [%pass / %agent [shp appl] %poke %contact-action !>(act)]~
+  ::  foreign
+  =/  shp  (~(got by synced) path)
+  ?.  |(=(shp our.bol) =(src.bol ship))  ~
+  ::  scry group to check if ship is a member
+  =/  =group  (need (group-scry path))
+  ?.  (~(has in group) shp)  ~
+  [%pass / %agent [our.bol %contact-store] %poke %contact-action !>(act)]~
 ::
 ++  poke-hook-action
   |=  act=contact-hook-action
@@ -163,7 +161,7 @@
     =.  synced  (~(put by synced) path.act our.bol)
     :_  state
     :~  [%pass contact-path %agent [our.bol %contact-store] %watch contact-path]
-        [%give %fact ~ %contact-hook-update !>([%initial synced])]
+        [%give %fact [/synced]~ %contact-hook-update !>([%initial synced])]
     ==
   ::
       %add-synced
@@ -173,7 +171,7 @@
     =/  contact-path  [%contacts path.act]
     :_  state
     :~  [%pass contact-path %agent [ship.act %contact-hook] %watch contact-path]
-        [%give %fact ~ %contact-hook-update !>([%initial synced])]
+        [%give %fact [/synced]~ %contact-hook-update !>([%initial synced])]
     ==
   ::
       %remove
@@ -185,16 +183,19 @@
       %-  zing
       :~  (pull-wire [%contacts path.act])
           [%give %kick ~[[%contacts path.act]] ~]~
-          [%give %fact ~ %contact-hook-update !>([%initial synced])]~
+          [%give %fact [/synced]~ %contact-hook-update !>([%initial synced])]~
       ==
     ?.  |(=(u.ship src.bol) (team:title our.bol src.bol))
       ::  if neither ship = source or source = us, do nothing
       [~ state]
     ::  delete a foreign ship's path
+    =/  cards
+      (handle-contact-action path.act our.bol [%remove path.act our.bol])
     :_  state(synced (~(del by synced) path.act))
     %-  zing
     :~  (pull-wire [%contacts path.act])
-        [%give %fact ~ %contact-hook-update !>([%initial synced])]~
+        [%give %fact [/synced]~ %contact-hook-update !>([%initial synced])]~
+        cards
     ==
   ==
 ::
@@ -207,10 +208,7 @@
   =/  =group  (need (group-scry pax))
   ?>  (~(has in group) src.bol)
   =/  contacts  (need (contacts-scry pax))
-  :~  :*
-    %give  %fact  ~  %contact-update
-    !>([%contacts pax contacts])
-  ==  ==
+  [%give %fact ~ %contact-update !>([%contacts pax contacts])]~
 ::
 ++  watch-synced
   |=  pax=path
@@ -324,13 +322,15 @@
       ==
     ::
         %add
-      =/  owner  (~(got by synced) path.fact)
-      ?>  |(=(owner src.bol) =(src.bol ship.fact))
+      =/  owner  (~(get by synced) path.fact)
+      ?~  owner  ~
+      ?>  |(=(u.owner src.bol) =(src.bol ship.fact))
       ~[(contact-poke [%add path.fact ship.fact contact.fact])]
     ::
         %remove
-      =/  owner  (~(got by synced) path.fact)
-      ?>  |(=(owner src.bol) =(src.bol ship.fact))
+      =/  owner  (~(get by synced) path.fact)
+      ?~  owner  ~
+      ?>  |(=(u.owner src.bol) =(src.bol ship.fact))
       %+  welp
         :~  (group-poke [%remove [ship.fact ~ ~] path.fact])
             (contact-poke [%remove path.fact ship.fact])

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -138,6 +138,7 @@
     ^-  (list card)
     ::  local
     ?:  (team:title our.bol src.bol)
+      ?.  (~(has by synced) path)  ~
       =/  shp  ?:(=(path /~/default) our.bol (~(got by synced) path))
       =/  appl  ?:(=(shp our.bol) %contact-store %contact-hook)
       [%pass / %agent [shp appl] %poke %contact-action !>(act)]~
@@ -161,7 +162,9 @@
       [~ state]
     =.  synced  (~(put by synced) path.act our.bol)
     :_  state
-    [%pass contact-path %agent [our.bol %contact-store] %watch contact-path]~
+    :~  [%pass contact-path %agent [our.bol %contact-store] %watch contact-path]
+        [%give %fact ~ %contact-hook-update !>([%initial synced])]
+    ==
   ::
       %add-synced
     ?>  (team:title our.bol src.bol)
@@ -169,7 +172,9 @@
     =.  synced  (~(put by synced) path.act ship.act)
     =/  contact-path  [%contacts path.act]
     :_  state
-    [%pass contact-path %agent [ship.act %contact-hook] %watch contact-path]~
+    :~  [%pass contact-path %agent [ship.act %contact-hook] %watch contact-path]
+        [%give %fact ~ %contact-hook-update !>([%initial synced])]
+    ==
   ::
       %remove
     =/  ship  (~(get by synced) path.act)
@@ -180,13 +185,17 @@
       %-  zing
       :~  (pull-wire [%contacts path.act])
           [%give %kick ~[[%contacts path.act]] ~]~
+          [%give %fact ~ %contact-hook-update !>([%initial synced])]~
       ==
     ?.  |(=(u.ship src.bol) (team:title our.bol src.bol))
       ::  if neither ship = source or source = us, do nothing
       [~ state]
     ::  delete a foreign ship's path
-    :-  (pull-wire [%contacts path.act])
-    state(synced (~(del by synced) path.act))
+    :_  state(synced (~(del by synced) path.act))
+    %-  zing
+    :~  (pull-wire [%contacts path.act])
+        [%give %fact ~ %contact-hook-update !>([%initial synced])]~
+    ==
   ==
 ::
 ++  watch-contacts

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -142,7 +142,7 @@
   |=  [=path =ship]
   ^-  (quip card _state)
   =/  contacts  (~(got by rolodex) path)
-  ?>  (~(has by contacts) ship)
+  ?.  (~(has by contacts) ship)  [~ state]
   =.  contacts  (~(del by contacts) ship)
   :-  (send-diff path [%remove path ship])
   state(rolodex (~(put by rolodex) path contacts))

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -147,9 +147,9 @@
   ::
       %delete
     %+  weld
-    :~  (group-poke [%unbundle path.act])
+    :~  (contact-hook-poke [%remove path.act])
+        (group-poke [%unbundle path.act])
         (contact-poke [%delete path.act])
-        (contact-hook-poke [%remove path.act])
     ==
     (delete-metadata path.act)
   ::

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -38,18 +38,12 @@
     ^-  (quip card _this)
     =/  old  !<(state-zero vase)
     :_  this(state old)
-    %+  murn
-      ~(tap by synced.old)
+    %+  murn  ~(tap by synced.old)
     |=  [=path =ship]
     ^-  (unit card)
-    =/  =wire
-      [(scot %p ship) %group path]
-    =/  =term
-      ?:  =(our.bowl ship)
-        %group-store
-      %group-hook
-    ?:  (~(has by wex.bowl) [wire ship term])
-      ~
+    =/  =wire  [(scot %p ship) %group path]
+    =/  =term  ?:(=(our.bowl ship) %group-store %group-hook)
+    ?:  (~(has by wex.bowl) [wire ship term])  ~
     `[%pass wire %agent [ship term] %watch [%group path]]
   ::
   ++  on-leave  on-leave:def
@@ -173,10 +167,9 @@
       %remove  [(update-subscribers [%group pax.diff] diff) state]
   ::
       %unbundle
-    :_  state(synced (~(del by synced.state) pax.diff))
-    %+  snoc
-      (update-subscribers [%group pax.diff] diff)
-    [%give %kick [%group pax.diff]~ ~]
+    =/  ship  (~(get by synced.state) pax.diff)
+    ?~  ship  [~ state]
+    (poke-group-hook-action [%remove pax.diff])
   ==
 ::
 ++  handle-foreign
@@ -185,7 +178,6 @@
   ?-  -.diff
       %keys    [~ state]
       %bundle  [~ state]
-  ::
       %path
     :_  state
     ?~  pax.diff  ~
@@ -219,23 +211,24 @@
     [(group-poke pax.diff diff)]~
   ::
       %remove
-    :_  state
-    ?~  pax.diff  ~
+    ?~  pax.diff  [~ state]
     =/  ship  (~(get by synced.state) pax.diff)
-    ?~  ship  ~
-    ?.  =(src.bol u.ship)  ~
-    [(group-poke pax.diff diff)]~
+    ?~  ship  [~ state]
+    ?.  =(src.bol u.ship)  [~ state]
+    ?.  (~(has in members.diff) our.bol)  [~ state]
+    =/  changes  (poke-group-hook-action [%remove pax.diff])
+    :_  +.changes
+    %+  welp  -.changes
+    :~  (group-poke pax.diff diff)
+        (group-poke pax.diff [%unbundle pax.diff])
+    ==
   ::
       %unbundle
-    ?~  pax.diff
-      [~ state]
+    ?~  pax.diff  [~ state]
     =/  ship  (~(get by synced.state) pax.diff)
-    ?~  ship
-      [~ state]
-    ?.  =(src.bol u.ship)
-      [~ state]
-    :_  state(synced (~(del by synced.state) pax.diff))
-    [(group-poke pax.diff diff)]~
+    ?~  ship  [~ state]
+    ?.  =(src.bol u.ship)  [~ state]
+    (poke-group-hook-action [%remove pax.diff])
   ==
 ::
 ++  group-poke
@@ -262,5 +255,4 @@
   ?:  =(u.shp our.bol)
     [%pass wir %agent [our.bol %group-store] %leave ~]~
   [%pass wir %agent [u.shp %group-hook] %leave ~]~
-::
 --

--- a/pkg/arvo/lib/contact-json.hoon
+++ b/pkg/arvo/lib/contact-json.hoon
@@ -1,9 +1,20 @@
-/-  *contact-view
+/-  *contact-view, *contact-hook
 |%
 ++  nu                                              ::  parse number as hex
   |=  jon/json
   ?>  ?=({$s *} jon)
   (rash p.jon hex)
+::
+++  hook-update-to-json
+  |=  upd=contact-hook-update
+  =,  enjs:format
+  ^-  json
+  %+  frond  %contact-hook-update
+  %-  pairs
+  %+  turn  ~(tap by synced.upd)
+  |=  [pax=^path shp=^ship]
+  ^-  [cord json]
+  [(spat pax) s+(scot %p shp)]
 ::
 ++  rolodex-to-json
   |=  rolo=rolodex

--- a/pkg/arvo/mar/contact/hook-update.hoon
+++ b/pkg/arvo/mar/contact/hook-update.hoon
@@ -1,0 +1,13 @@
+/+  *contact-json
+|_  upd=contact-hook-update
+++  grow
+  |%
+  ++  json  (hook-update-to-json upd)
+  --
+::
+++  grab
+  |%
+  ++  noun  contact-hook-update
+  --
+::
+--

--- a/pkg/arvo/sur/contact-hook.hoon
+++ b/pkg/arvo/sur/contact-hook.hoon
@@ -12,4 +12,7 @@
       ::
       [%remove =path]
   ==
+::
++$  synced  (map path ship)
++$  contact-hook-update  [%initial =synced]
 --

--- a/pkg/interface/groups/src/js/api.js
+++ b/pkg/interface/groups/src/js/api.js
@@ -11,8 +11,7 @@ class UrbitApi {
     this.bindPaths = [];
 
     this.contactHook = {
-      edit: this.contactEdit.bind(this),
-      remove: this.contactRemove.bind(this)
+      edit: this.contactEdit.bind(this)
     };
 
     this.contactView = {
@@ -106,14 +105,6 @@ class UrbitApi {
 
   contactHookAction(data) {
     return this.action("contact-hook", "contact-action", data);
-  }
-
-  contactRemove(path, ship) {
-    return this.contactHookAction({
-      remove: {
-        path, ship
-      }
-    });
   }
 
   contactEdit(path, ship, editField) {

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -323,6 +323,7 @@ export class ContactCard extends Component {
         this.setState({awaiting: false});
         props.history.push(`/~groups${destination}`);
       });
+      api.contactView.delete(props.path);
     }))
   }
 

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -317,13 +317,12 @@ export class ContactCard extends Component {
     );
 
     this.setState({awaiting: true, type: "Removing from group"}, (() => {
-      api.contactHook.remove(props.path, `~${props.ship}`).then(() => {
+      api.contactView.delete(props.path).then(() => {
         let destination = (props.ship === window.ship)
           ? "" : props.path;
         this.setState({awaiting: false});
         props.history.push(`/~groups${destination}`);
       });
-      api.contactView.delete(props.path);
     }))
   }
 

--- a/pkg/interface/groups/src/js/store.js
+++ b/pkg/interface/groups/src/js/store.js
@@ -9,14 +9,7 @@ import { LocalReducer } from '/reducers/local.js';
 
 class Store {
   constructor() {
-    this.state = {
-      contacts: {},
-      groups: {},
-      associations: {},
-      permissions: {},
-      invites: {},
-      selectedGroups: []
-    };
+    this.state = this.initialState();
 
     this.initialReducer = new InitialReducer();
     this.groupUpdateReducer = new GroupUpdateReducer();
@@ -28,12 +21,28 @@ class Store {
     this.setState = () => {};
   }
 
+  initialState() {
+    return {
+      contacts: {},
+      groups: {},
+      associations: {},
+      permissions: {},
+      invites: {},
+      selectedGroups: []
+    };
+  }
+
   setStateHandler(setState) {
     this.setState = setState;
   }
 
   handleEvent(data) {
     let json = data.data;
+
+    if ('clear' in json && json.clear) {
+      this.setState(this.initialState());
+      return;
+    }
 
     console.log(json);
     this.initialReducer.reduce(json, this.state);

--- a/pkg/interface/groups/src/js/subscription.js
+++ b/pkg/interface/groups/src/js/subscription.js
@@ -49,9 +49,6 @@ export class Subscription {
     store.handleEvent(diff);
   }
 
-  handleEvent(diff) {
-    store.handleEvent(diff);
-  }
 }
 
 export let subscription = new Subscription();

--- a/pkg/interface/groups/src/js/subscription.js
+++ b/pkg/interface/groups/src/js/subscription.js
@@ -13,9 +13,22 @@ export class Subscription {
   start() {
     if (api.authTokens) {
       this.firstRoundSubscription();
+      window.urb.setOnChannelError(this.onChannelError.bind(this));
     } else {
       console.error("~~~ ERROR: Must set api.authTokens before operation ~~~");
     }
+  }
+
+  onChannelError(err) {
+    console.error('event source error: ', err);
+    console.log('initiating new channel');
+    this.firstRoundSubscriptionComplete = false;
+    setTimeout(2000, () => {
+      store.handleEvent({
+        data: { clear : true}
+      });
+      this.start();
+    });
   }
 
   subscribe(path, app) {


### PR DESCRIPTION
- Fixes #2488, Fixes #2696
- Updates subscription.js to do subscriptions in two rounds for performance
- Updates subscription.js to initiate new channel upon event source error.
- Adds a synced path to contact-hook so that we can make a "you lost connection, resubscribe UI element" as a preliminary "workaround" for rejoining a group from a breached ship (need to discuss with @urcades for next steps?)
- Suppresses printing of an error printf that isn't useful but that should happen