### PR TITLE
chat: leave chats associated with group on group leave

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -571,9 +571,6 @@
       [%mailbox @ *]
     ~&  mailbox-kick+wir
     ?.  (~(has by synced) t.wir)  [~ state]
-    ?.  (is-permitted our.bol t.wir)
-      :_  state
-      ~[(chat-view-poke %delete t.wir)]
     ~&  %chat-hook-resubscribe
     =/  =ship  (~(got by synced) t.wir)
     =/  mailbox=(unit mailbox)  (chat-scry t.wir)
@@ -605,7 +602,8 @@
   ::
       [%backlog @ @ @ *]
     =/  chat=path  (oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
-    %.  (poke-chat-hook-action %remove chat)
+    :_  state
+    %.  ~[(chat-view-poke %delete pax)]
     %-  slog
     :*  leaf+"chat-hook failed subscribe on {(spud chat)}"
         leaf+"stack trace:"

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -571,6 +571,9 @@
       [%mailbox @ *]
     ~&  mailbox-kick+wir
     ?.  (~(has by synced) t.wir)  [~ state]
+    ?.  (is-permitted our.bol t.wir)
+      :_  state
+      ~[(chat-view-poke %delete t.wir)]
     ~&  %chat-hook-resubscribe
     =/  =ship  (~(got by synced) t.wir)
     =/  mailbox=(unit mailbox)  (chat-scry t.wir)


### PR DESCRIPTION
When a group is left, the permissions no longer exist and the mailbox
subscription is kicked. Before attempting to resubscribe, we simply
check if we still have permissions and if not, leave the chat.

cc: @matildepark 