### PR TITLE
publish: increase legibility for code in dark mode

### DIFF
--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -167,7 +167,7 @@ a {
 .cm-s-tlon span.cm-variable-3, .cm-s-tlon span.cm-type { color: black; }
 .cm-s-tlon span.cm-property { color: black; }
 .cm-s-tlon span.cm-operator { color: black; }
-.cm-s-tlon span.cm-comment { color: black; background-color: var(--light-gray); padding:2px; border-radius: 2px;}
+.cm-s-tlon span.cm-comment { color: black; background-color: var(--light-gray); display: inline-block; border-radius: 2px;}
 .cm-s-tlon span.cm-string { color: var(--dark-gray); }
 .cm-s-tlon span.cm-string-2 { color: var(--gray); }
 .cm-s-tlon span.cm-qualifier { color: #555; }
@@ -362,10 +362,6 @@ md img {
     background: #333;
     color: #fff;
   }
-  .CodeMirror-selected {
-    background: #4d4d4d !important;
-    color: white;
-  }
 
   .cm-s-tlon span.cm-def {
     color: white;
@@ -392,12 +388,7 @@ md img {
     color: white;
   }
 
-  .cm-s-tlon span.cm-comment {
-    color: black;
-    background-color: var(--gray);
-    padding: 2px;
-    border-radius: 2px;
-  }
+
   .cm-s-tlon span.cm-string {
     color: var(--gray);
   }
@@ -416,5 +407,19 @@ md img {
 
   .cm-s-tlon span.cm-link {
     color: var(--gray);
+  }
+
+  /* set rules w/ both color & bg-color last to preserve legibility */
+  .CodeMirror-selected {
+    background: var(--medium-gray) !important;
+    color: white;
+  }
+
+  .cm-s-tlon span.cm-comment {
+    color: black;
+    display: inline-block;
+    padding: 0;
+    background-color: rgba(255,255,255, 0.3);
+    border-radius: 2px;
   }
 }


### PR DESCRIPTION
Makes the rules that set both a background and foreground color come
last in the CSS, increasing their specificity. Changes the highlight to a
lighter grey, to better stand out. Correctly aligns highlights with code
block backgrounds.

Demo:
![Screen Shot 2020-04-15 at 1 48 01 pm](https://user-images.githubusercontent.com/46801558/79296820-da376a80-7f1f-11ea-9383-f3af038b888b.png)
![Screen Shot 2020-04-15 at 1 51 02 pm](https://user-images.githubusercontent.com/46801558/79296955-2aaec800-7f20-11ea-82ec-9acee2dde413.png)


alignment on light mode:
![Screen Shot 2020-04-15 at 1 46 56 pm](https://user-images.githubusercontent.com/46801558/79296876-f9ce9300-7f1f-11ea-89a8-6cbfaee79fd0.png)
light mode after:
![Screen Shot 2020-04-15 at 1 46 37 pm](https://user-images.githubusercontent.com/46801558/79296893-05ba5500-7f20-11ea-920c-bb4d9a14f10f.png)

cc: @matildepark 

Fixes #2684