### PR TITLE
link-js: fix pages disappearing on small screens

### DIFF
--- a/pkg/interface/link/src/js/components/root.js
+++ b/pkg/interface/link/src/js/components/root.js
@@ -80,7 +80,6 @@ export class Root extends Component {
                 associations={associations}
                 invites={invites}
                 groups={groups}
-                rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
                 selectedGroups={selectedGroups}
                 links={links}
@@ -118,7 +117,6 @@ export class Root extends Component {
                 invites={invites}
                 groups={groups}
                 selected={resourcePath}
-                rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
                 selectedGroups={selectedGroups}
                 links={links}
@@ -155,7 +153,6 @@ export class Root extends Component {
                 invites={invites}
                 groups={groups}
                 selected={resourcePath}
-                rightPanelHide={true}
                 sidebarShown={state.sidebarShown}
                 selectedGroups={selectedGroups}
                 popout={popout}


### PR DESCRIPTION
The rightPanelHide prop was being improperly set on the home, settings
and members screens, causing them to be blank on small screen sizes

Fixes #2727

cc: @matildepark 