### PR TITLE
chat-hook: on %remove, try our best to pull subs

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -358,8 +358,6 @@
       %+  weld  path.act
       ?~(mailbox /0 /(scot %ud (lent envelopes.u.mailbox)))
     :_  state
-    ::TODO  we shouldn't include the trailing /0 or similar in the wire,
-    ::      we never use it anywhere, and it complicates other logic. see #2746
     :~  [%pass chat-history %agent [ship.act %chat-hook] %watch chat-history]
         [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]
     ==

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -583,15 +583,15 @@
     [%pass chat-history %agent [ship %chat-hook] %watch chat-history]~
   ::
       [%backlog @ @ *]
-    =/  pax  `path`(oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
-    ?.  (~(has by synced) pax)  [~ state]
+    =/  chat=path  (oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
+    ?.  (~(has by synced) chat)  [~ state]
     =/  =ship
       ?:  =('~' i.t.wir)
         (slav %p i.t.t.wir)
       (slav %p i.t.wir)
-    =.  pax  ?~((chat-scry pax) wir [%mailbox pax])
+    =/  =path  ?~((chat-scry chat) wir [%mailbox chat])
     :_  state
-    [%pass pax %agent [ship %chat-hook] %watch pax]~
+    [%pass path %agent [ship %chat-hook] %watch path]~
   ==
 ::
 ++  watch-ack
@@ -603,10 +603,10 @@
     (poke-chat-hook-action %remove t.wir)
   ::
       [%backlog @ @ @ *]
-    =/  pax  `path`(oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
-    %.  (poke-chat-hook-action %remove pax)
+    =/  chat=path  (oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
+    %.  (poke-chat-hook-action %remove chat)
     %-  slog
-    :*  leaf+"chat-hook failed subscribe on {(spud pax)}"
+    :*  leaf+"chat-hook failed subscribe on {(spud chat)}"
         leaf+"stack trace:"
         u.saw
     ==

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -363,15 +363,22 @@
     ==
   ::
       %remove
-    =/  ship  (~(get by synced) path.act)
-    ?~  ship  [~ state]
+    =/  ship=(unit ship)
+      =/  ship  (~(get by synced) path.act)
+      ?^  ship  ship
+      =?  path.act  ?=([%'~' *] path.act)  t.path.act
+      ?~  path.act  ~
+      (slaw %p i.path.act)
+    ?~  ship
+      ~&  [dap.bol %unknown-host-cannot-leave path.act]
+      [~ state]
     ?:  &(!=(u.ship src.bol) ?!((team:title our.bol src.bol)))
       [~ state]
     =.  synced  (~(del by synced) path.act)
     :_  state
     %-  zing
-    :~  (pull-wire [%backlog (weld path.act /0)])
-        (pull-wire [%mailbox path.act])
+    :~  (pull-wire u.ship [%backlog (weld path.act /0)])
+        (pull-wire u.ship [%mailbox path.act])
         [%give %kick ~[[%mailbox path.act]] ~]~
         [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]~
     ==
@@ -709,12 +716,9 @@
   ==
 ::
 ++  pull-wire
-  |=  pax=path
+  |=  [=ship =wire]
   ^-  (list card)
-  ?>  ?=(^ pax)
-  =/  shp  (~(get by synced) t.pax)
-  ?~  shp  ~
-  ?:  =(u.shp our.bol)
-    [%pass pax %agent [our.bol %chat-store] %leave ~]~
-  [%pass pax %agent [u.shp %chat-hook] %leave ~]~
+  ?:  =(ship our.bol)
+    [%pass wire %agent [our.bol %chat-store] %leave ~]~
+  [%pass wire %agent [ship %chat-hook] %leave ~]~
 --


### PR DESCRIPTION
Previously, we were removing the relevant entry from the `synced` map
before calling `+pull-wire`, which requires an entry to still be there.
This lead to subscriptions not actually being pulled, commonly leading
to "subscribe wire not unique" errors on re-join.

In addition to fixing that, `%remove` actions now try to pull the
subscription regardless of whether they have an entry in the `synced`
map or not. `%leave` is always safe, and we might want to clean up
subscriptions that shouldn't be there anymore in the first place.