### PR TITLE
dbug: avoid printing nothing at all

### DIFF
--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -47,6 +47,9 @@
       (ream grab.dbug)
     ::
         %incoming
+      =;  =tang
+        ?^  tang  tang
+        [%leaf "no matching subscriptions"]~
       %+  murn
         %+  sort  ~(tap by sup.bowl)
         |=  [[* a=[=ship =path]] [* b=[=ship =path]]]
@@ -66,6 +69,9 @@
       ==
     ::
         %outgoing
+      =;  =tang
+        ?^  tang  tang
+        [%leaf "no matching subscriptions"]~
       %+  murn
         %+  sort  ~(tap by wex.bowl)
         |=  [[[a=wire *] *] [[b=wire *] *]]

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -35,7 +35,7 @@
     =/  dbug
       !<(poke vase)
     =;  =tang
-      ((slog tang) [~ this])
+      ((%*(. slog pri 1) tang) [~ this])
     ?-  -.dbug
       %bowl   [(sell !>(bowl))]~
     ::


### PR DESCRIPTION
Previously, if filtering subscriptions turned up no results, nothing was
printed. With this change, we explicitly print "no matching subscriptions"
instead.

Wondering if we should do something to make the result stand out more, too. Since it gets printed _above_ the command in dojo scrollback, people seem to sometimes just miss it.