### PR TITLE
fix +sloe for %hint'ed cores

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12073,6 +12073,7 @@
   ^-  (list term)
   ?+    typ  ~
       {$hold *}  $(typ ~(repo ut typ))
+      {$hint *}  $(typ ~(repo ut typ))
       {$core *}
     %-  zing
     %+  turn  ~(tap by q.r.q.typ)


### PR DESCRIPTION
`+sloe`, which lists the arms of a core type, was broken for core types wrapped in a `%hint` tag, producing `~` as though the core had no arms.  This fix unwraps the `%hint` using `+repo:ut`, like everything else.

I think this bug arose because `%hint` was added later, and there was no type error because it was wildcard-matched with a `?+`.  I hope this is the only such case!