### PR TITLE
chat-fe: add backlog loading indicator

### DIFF
--- a/pkg/interface/chat/src/js/components/chat.js
+++ b/pkg/interface/chat/src/js/components/chat.js
@@ -7,6 +7,7 @@ import { Route, Link } from "react-router-dom";
 import { store } from "/store";
 
 import { ResubscribeElement } from '/components/lib/resubscribe-element';
+import { BacklogElement } from '/components/lib/backlog-element';
 import { Message } from '/components/lib/message';
 import { SidebarSwitcher } from '/components/lib/icons/icon-sidebar-switch.js';
 import { ChatTabBar } from '/components/lib/chat-tabbar';
@@ -335,6 +336,10 @@ export class ChatScreen extends Component {
               ref={el => {
                 this.scrollElement = el;
               }}></div>
+            {(props.chatInitialized &&
+              !(props.station in props.inbox)) && (
+                  <BacklogElement />
+            )}
             {(
               props.chatSynced &&
               !(props.station in props.chatSynced) &&
@@ -361,6 +366,10 @@ export class ChatScreen extends Component {
             ref={el => {
               this.scrollElement = el;
             }}></div>
+          {(props.chatInitialized &&
+            !(props.station in props.inbox)) && (
+                <BacklogElement />
+          )}
           {(
             props.chatSynced &&
             !(props.station in props.chatSynced) &&

--- a/pkg/interface/chat/src/js/components/lib/backlog-element.js
+++ b/pkg/interface/chat/src/js/components/lib/backlog-element.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+
+
+export class BacklogElement extends Component {
+
+
+  render() {
+    let props = this.props;
+
+    return (
+      <div className="center mw6">
+        <div className="db pa3 ma3 ba b--gray4 bg-gray5 b--gray2-d bg-gray1-d white-d flex items-center">
+            <img className="invert-d spin-active v-mid"
+              src="/~chat/img/Spinner.png"
+              width={16}
+              height={16}
+            />
+            <p className="lh-copy db ml3">
+            Past messages are being restored
+            </p>
+        </div>
+      </div>
+
+    );
+  }
+}


### PR DESCRIPTION
Adds a backlog loading indicator that displays when we have not yet
received the backlog from the host.

Demo:
![Screen Shot 2020-04-18 at 5 17 40 pm](https://user-images.githubusercontent.com/46801558/79630967-0c073600-8199-11ea-8f74-dafaf9c16818.png) 

![Screen Shot 2020-04-18 at 5 18 02 pm](https://user-images.githubusercontent.com/46801558/79630964-0a3d7280-8199-11ea-8fd8-7fb9c1b4b35d.png)
