### PR TITLE
chat-fe: add unread and day indicators

### DIFF
--- a/pkg/interface/chat/src/css/custom.css
+++ b/pkg/interface/chat/src/css/custom.css
@@ -173,6 +173,10 @@ h2 {
   color: #7ea899;
 }
 
+.unread-notice {
+  top: 48px;
+}
+
 /* responsive */
 
 @media all and (max-width: 34.375em) {
@@ -190,6 +194,9 @@ h2 {
   }
   .embed-container {
     padding-bottom: 56.25%;
+  }
+  .unread-notice {
+    top: 96px;
   }
 }
 

--- a/pkg/interface/chat/src/css/custom.css
+++ b/pkg/interface/chat/src/css/custom.css
@@ -169,6 +169,10 @@ h2 {
   border-radius: 100%;
 }
 
+.green3 {
+  color: #7ea899;
+}
+
 /* responsive */
 
 @media all and (max-width: 34.375em) {

--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -120,7 +120,9 @@ class UrbitApi {
       }
     };
 
-    this.action("chat-hook", "json", data);
+    this.action("chat-hook", "json", data).then(() => {
+      this.chatRead(path);
+    })
     data.message.envelope.author = data.message.envelope.author.substr(1);
     this.addPendingMessage(data.message);
   }

--- a/pkg/interface/chat/src/js/components/lib/unread-notice.js
+++ b/pkg/interface/chat/src/js/components/lib/unread-notice.js
@@ -17,8 +17,8 @@ export class UnreadNotice extends Component {
 
     return (
       <div
-        style={{ left: "0px", top: "48px" }}
-        className="pa4 w-100 absolute z-1"
+        style={{ left: "0px" }}
+        className="pa4 w-100 absolute z-1 unread-notice"
       >
         <div className="ba b--green2 green2 bg-white bg-gray0-d flex items-center pa2 f9 justify-between br1">
           <p className="lh-copy db">
@@ -30,7 +30,7 @@ export class UnreadNotice extends Component {
             )}
             <span className="green3">{timestamp}</span>
           </p>
-          <div onClick={onRead} className="inter b--green2 pointer">
+          <div onClick={onRead} className="ml4 inter b--green2 pointer tr lh-copy">
             Mark as Read
           </div>
         </div>

--- a/pkg/interface/chat/src/js/components/lib/unread-notice.js
+++ b/pkg/interface/chat/src/js/components/lib/unread-notice.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import classnames from "classnames";
+import moment from "moment";
+
+export class UnreadNotice extends Component {
+  render() {
+    let { unread, unreadMsg, onRead } = this.props;
+
+    let when = moment.unix(unreadMsg.when / 10000);
+
+    let datestamp = moment.unix(unreadMsg.when / 1000).format("YYYY.M.D");
+    let timestamp = moment.unix(unreadMsg.when / 1000).format("HH:mm");
+
+    if (datestamp === moment().format("YYYY.M.D")) {
+      datestamp = null;
+    }
+
+    return (
+      <div
+        style={{ left: "0px", top: "48px" }}
+        className="pa4 w-100 absolute z-1"
+      >
+        <div className="ba b--green2 green2 bg-white bg-gray0-d flex items-center pa2 f9 justify-between br1">
+          <p className="lh-copy db">
+            {unread} new messages since{" "}
+            {datestamp && (
+              <>
+                <span className="green3">~{datestamp}</span> at{" "}
+              </>
+            )}
+            <span className="green3">{timestamp}</span>
+          </p>
+          <div onClick={onRead} className="inter b--green2 pointer">
+            Mark as Read
+          </div>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Adds unread and day indicators. Also changes sending of read receipts to occur when the unread indicator passes the halfway mark of the screen.

cc: @urcades 


Demo:
![Screen Shot 2020-04-19 at 2 12 53 am](https://user-images.githubusercontent.com/46801558/79643272-8fe70f80-81e5-11ea-9ef8-dc5c31e111e1.png)

![Screen Shot 2020-04-19 at 2 11 43 am](https://user-images.githubusercontent.com/46801558/79643246-6d54f680-81e5-11ea-95b7-7294aae84e93.png)
![Screen Shot 2020-04-19 at 2 11 20 am](https://user-images.githubusercontent.com/46801558/79643251-71811400-81e5-11ea-9a7a-9b8cd901e99b.png)
