### PR TITLE
meta: add note re: announcing default pill

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -119,6 +119,9 @@ this:
 ```
 urbit-vx.y.z
 
+Note that this Vere release will by default boot fresh ships using an Urbit OS
+va.b.c pill.
+
 Release binaries:
 
 (linux64)
@@ -138,9 +141,11 @@ Contributions:
 
 The same schpeel re: release candidates applies here.
 
-Do not include implicit Urbit OS changes in Vere releases.  This used to be
-done, historically, but shouldn't be any longer.  If there are Urbit OS and
-Vere changes to be released, make two releases.
+Note that the release notes indicate which version of Urbit OS the Vere release
+will use by default when booting fresh ships.  Do not include implicit Urbit OS
+changes in Vere releases; this used to be done, historically, but shouldn't be
+any longer.  If there are Urbit OS and Vere changes to be released, make two
+separate releases.
 
 ### Deploy the update
 


### PR DESCRIPTION
Resolves #2735.

/cc @philipcmonk @ixv @joemfb @Fang- 

(A note: in general I don't think that we should change the pill corresponding to a Vere release after making it available, but this does happen from time to time.  In such cases we should just post the appropriate update to urbit-dev.)