### PR TITLE
publish: change line-height on numbered lists

### DIFF
--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -265,7 +265,7 @@ a {
 .md code, .md pre {
   font-family: "Source Code Pro", mono;
 }
-.md ul>li {
+.md ul>li, .md ol>li {
   line-height: 1.5;
 }
 .md a {

--- a/pkg/interface/publish/src/css/custom.css
+++ b/pkg/interface/publish/src/css/custom.css
@@ -242,7 +242,7 @@ a {
   display: none;
 }
 
-.md h1, .md h2, .md h3, .md h4, .md h5, .md p, .md a, .md ul, .md blockquote,.md code,.md pre {
+.md h1, .md h2, .md h3, .md h4, .md h5, .md p, .md a, .md ul, .md ol, .md blockquote,.md code,.md pre {
   font-size: 14px;
   margin-bottom: 16px;
 }


### PR DESCRIPTION
Fixes #2773, makes Galen happy.

We set line-height for `ul > li`, but not `ol > li`, so ordered lists had inconsistent line-height.