### PR TITLE
chat-hook: fix variable name

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -603,7 +603,7 @@
       [%backlog @ @ @ *]
     =/  chat=path  (oust [(dec (lent t.wir)) 1] `(list @ta)`t.wir)
     :_  state
-    %.  ~[(chat-view-poke %delete pax)]
+    %.  ~[(chat-view-poke %delete chat)]
     %-  slog
     :*  leaf+"chat-hook failed subscribe on {(spud chat)}"
         leaf+"stack trace:"


### PR DESCRIPTION
Fixes variable name mixup causing crash in master. Sorry about this one, I've learnt my lesson with rebasing