### PR TITLE
groups: add avatar prop to share sheet

### DIFF
--- a/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-sidebar.js
@@ -31,6 +31,7 @@ export class ContactSidebar extends Component {
       ( <ShareSheet
           ship={window.ship}
           nickname={me.nickname}
+          avatar={me.avatar}
           color={me.color}
           path={props.path}
           selected={props.path + '/' + window.ship === props.selectedContact}

--- a/pkg/interface/groups/src/js/components/lib/share-sheet.js
+++ b/pkg/interface/groups/src/js/components/lib/share-sheet.js
@@ -16,6 +16,7 @@ export class ShareSheet extends Component {
         <p className="pt4 pb2 pl4 pr4 f8 gray2 f9">Group Identity</p>
         <ContactItem
           key={props.ship}
+          avatar={props.avatar}
           ship={props.ship}
           nickname={props.nickname}
           color={props.color}


### PR DESCRIPTION
I dropped one case: a lack of avatar prop in the share sheet, which passes to `ContactItem`, resulting in a blank share sheet icon.