### PR TITLE
chat: toggle code at start of input

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import moment from 'moment';
 import { UnControlled as CodeEditor } from 'react-codemirror2';
+import CodeMirror from 'codemirror';
 
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/addon/display/placeholder';
@@ -306,7 +307,9 @@ export class ChatInput extends Component {
         'Enter': cm =>
             this.messageSubmit(),
         'Shift-3': cm =>
-          this.toggleCode()
+          cm.getValue().length === 0
+            ? this.toggleCode()
+            : CodeMirror.Pass
       }
     };
 
@@ -340,8 +343,8 @@ export class ChatInput extends Component {
           <CodeEditor
             options={options}
             editorDidMount={(editor) => {
- this.editor = editor;
-}}
+            this.editor = editor;
+            }}
             onChange={(e, d, v) => this.messageChange(e, d, v)}
           />
         </div>


### PR DESCRIPTION
Closes #2795. Replays #2774.

Liam, there seems to have been a regression in chat-input. Compare the extraKeys when I [made this the first time](https://github.com/urbit/urbit/blob/de077ffb4759d31a9eab33d50bba97b046a6ad78/pkg/interface/chat/src/js/components/lib/chat-input.js#L432-L461); somewhere in here there was a patpautocomplete migration out of these extrakeys and into a shipsearch component, and I assume resolving a merge conflict regressed these changes.