### PR TITLE
drum: sane boot order

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -226,8 +226,6 @@
 ::
 ++  catch-up
   ^-  (quip card _state)
-  ?.  .^(? %gu /(scot %p our.bowl)/chat-store/(scot %da now.bowl))
-    [~ state]
   =/  =inbox
     (scry-for inbox %chat-store /all)
   |-  ^-  (quip card _state)

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -114,8 +114,6 @@
       `t.t.path
     ~
   ?~  target  |
-  ~?  !.^(? %gu (scot %p our.bowl) %metadata-store (scot %da now.bowl) ~)
-    %woah-md-s-not-booted  ::TODO  fallback if needed
   %+  lien  (groups-from-resource:md %link u.target)
   |=  =group-path
   ^-  ?

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -356,7 +356,7 @@
   ++  priorities
     ^-  (list (set @))
     :~
-      (sy ~[%dojo])  ::  ensure dojo connects first
+      :: set up stores with priority: depended on, but never depending
       %-  sy
       :~  %permission-store
           %chat-store
@@ -366,7 +366,8 @@
           %invite-store
           %metadata-store
       ==
-      (sy ~[%chat-hook])  :: ensure chat-cli can sub to invites
+      :: ensure chat-cli can sub to invites
+      (sy ~[%chat-hook])
     ==
   ++  sort-by-priorities
     =/  priorities  priorities
@@ -389,7 +390,10 @@
   %+  roll
     %+  sort
       ~(tap in eel)
-    |=([[@ a=term] [@ b=term]] (aor a b))
+    |=  [[@ a=term] [@ b=term]]
+    ?:  =(a %dojo)  %.n
+    ?:  =(b %dojo)  %.y
+    (aor a b)
   =<  .(con +>)
   |:  $:{gil/gill:gall con/_.}  ^+  con
   =.  +>.$  con

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -332,26 +332,31 @@
 ++  se-adit                                           ::  update servers
   ^+  this
   |^
-  %+  reel
+  =/  servers=(list well:gall)
     (sort ~(tap in ray) sort-by-priorities)
-  |=  [=well:gall that=_this]
-  ^+  that
-  =/  =wire  [%drum p.well q.well ~]
+  |-
+  ?~  servers
+    this
+  =/  wel=well:gall
+    i.servers
+  =/  =wire  [%drum p.wel q.wel ~]
   =/  hig=(unit (unit server))
-    (~(get by fur) q.well)
-  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.well syd.u.u.hig)))
-    that
+    (~(get by fur) q.wel)
+  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.wel syd.u.u.hig)))
+    this
   =.  fur
-    (~(put by fur) q.well ~)
-  =.  that
-    (se-text "activated app {(trip p.well)}/{(trip q.well)}")
-  %-  se-emit
-  [%pass wire %arvo %g %conf [our.hid q.well] our.hid p.well]
+    (~(put by fur) q.wel ~)
+  =.  this
+    (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
+  =.  this
+    %-  se-emit
+    [%pass wire %arvo %g %conf [our.hid q.wel] our.hid p.wel]
+  $(servers t.servers)
   ::
   ++  priorities
     ^-  (list (set @))
     :~
-      ::  Setup stores first: depended on, but never depending
+      (sy ~[%dojo])  ::  ensure dojo connects first
       %-  sy
       :~  %permission-store
           %chat-store
@@ -361,8 +366,7 @@
           %invite-store
           %metadata-store
       ==
-      :: ensure chat-cli can sub to invites
-      (sy ~[%chat-hook])
+      (sy ~[%chat-hook])  :: ensure chat-cli can sub to invites
     ==
   ++  sort-by-priorities
     =/  priorities  priorities
@@ -385,10 +389,7 @@
   %+  roll
     %+  sort
       ~(tap in eel)
-    |=  [[@ a=term] [@ b=term]]
-    ?:  =(a %dojo)  %.y
-    ?:  =(b %dojo)  %.n
-    (aor a b)
+    |=([[@ a=term] [@ b=term]] (aor a b))
   =<  .(con +>)
   |:  $:{gil/gill:gall con/_.}  ^+  con
   =.  +>.$  con

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -386,7 +386,10 @@
 ::
 ++  se-adze                                           ::  update connections
   ^+  .
-  %+  roll  ~(tap in eel)
+  %+  roll
+    %+  sort
+      ~(tap in eel)
+    |=([[@ a=term] [@ b=term]] (aor a b))
   =<  .(con +>)
   |:  $:{gil/gill:gall con/_.}  ^+  con
   =.  +>.$  con

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -155,6 +155,7 @@
 =+  (~(gut by bin) ost *source)
 =*  dev  -
 |_  {moz/(list card:agent:gall) biz/(list dill-blit:dill)}
++*  this  .
 ++  diff-sole-effect-phat                             ::  app event
   |=  {way/wire fec/sole-effect}
   =<  se-abet  =<  se-view
@@ -329,19 +330,59 @@
   [%give %fact ~[/drum] %dill-blit !>(dill-blit)]
 ::
 ++  se-adit                                           ::  update servers
-  ^+  .
-  ::  ensure dojo connects after talk
-  =*  dojo-on-top  |=([a=* b=*] |(=(%dojo a) &(!=(%dojo b) (aor a b))))
-  %+  roll  (sort ~(tap in ray) dojo-on-top)
-  =<  .(con +>)
-  |:  $:{wel/well:gall con/_..se-adit}  ^+  con
-  =.  +>.$  con
-  =+  hig=(~(get by fur) q.wel)
-  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.wel syd.u.u.hig)))  +>.$
-  =.  +>.$  (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
-  %-  se-emit(fur (~(put by fur) q.wel ~))
+  ^+  this
+  |^
+  =/  servers=(list well:gall)
+    (sort ~(tap in ray) sort-by-priorities)
+  |-
+  ?~  servers
+    this
+  =/  wel=well:gall
+    i.servers
   =/  =wire  [%drum p.wel q.wel ~]
-  [%pass wire %arvo %g %conf [our.hid q.wel] our.hid p.wel]
+  =/  hig=(unit (unit server))
+    (~(get by fur) q.wel)
+  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.wel syd.u.u.hig)))
+    this
+  =.  fur
+    (~(put by fur) q.wel ~)
+  =.  this
+    (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
+  =.  this
+    %-  se-emit
+    [%pass wire %arvo %g %conf [our.hid q.wel] our.hid p.wel]
+  $(servers t.servers)
+  ::
+  ++  priorities
+    ^-  (list (set @))
+    :~
+      (sy ~[%dojo])  ::  ensure dojo connects first
+      %-  sy
+      :~  %permission-store
+          %chat-store
+          %contact-store
+          %group-store
+          %link-store
+          %invite-store
+          %metadata-store
+      ==
+      (sy ~[%chat-hook])  :: ensure chat-cli can sub to invites
+    ==
+  ++  sort-by-priorities
+    =/  priorities  priorities
+    |=  [[desk a=term] [desk b=term]]
+    ^-  ?
+    ?~  priorities
+      (aor a b)
+    =*  priority  i.priorities
+    ?:  &((~(has in priority) a) (~(has in priority) b))
+      (aor a b)
+    ?:  (~(has in priority) a)
+      %.y
+    ?:  (~(has in priority) b)
+      %.n
+    $(priorities t.priorities)
+  --
 ::
 ++  se-adze                                           ::  update connections
   ^+  .

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -332,31 +332,26 @@
 ++  se-adit                                           ::  update servers
   ^+  this
   |^
-  =/  servers=(list well:gall)
+  %+  reel
     (sort ~(tap in ray) sort-by-priorities)
-  |-
-  ?~  servers
-    this
-  =/  wel=well:gall
-    i.servers
-  =/  =wire  [%drum p.wel q.wel ~]
+  |=  [=well:gall that=_this]
+  ^+  that
+  =/  =wire  [%drum p.well q.well ~]
   =/  hig=(unit (unit server))
-    (~(get by fur) q.wel)
-  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.wel syd.u.u.hig)))
-    this
+    (~(get by fur) q.well)
+  ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.well syd.u.u.hig)))
+    that
   =.  fur
-    (~(put by fur) q.wel ~)
-  =.  this
-    (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
-  =.  this
-    %-  se-emit
-    [%pass wire %arvo %g %conf [our.hid q.wel] our.hid p.wel]
-  $(servers t.servers)
+    (~(put by fur) q.well ~)
+  =.  that
+    (se-text "activated app {(trip p.well)}/{(trip q.well)}")
+  %-  se-emit
+  [%pass wire %arvo %g %conf [our.hid q.well] our.hid p.well]
   ::
   ++  priorities
     ^-  (list (set @))
     :~
-      (sy ~[%dojo])  ::  ensure dojo connects first
+      ::  Setup stores first: depended on, but never depending
       %-  sy
       :~  %permission-store
           %chat-store
@@ -366,7 +361,8 @@
           %invite-store
           %metadata-store
       ==
-      (sy ~[%chat-hook])  :: ensure chat-cli can sub to invites
+      :: ensure chat-cli can sub to invites
+      (sy ~[%chat-hook])
     ==
   ++  sort-by-priorities
     =/  priorities  priorities
@@ -389,7 +385,10 @@
   %+  roll
     %+  sort
       ~(tap in eel)
-    |=([[@ a=term] [@ b=term]] (aor a b))
+    |=  [[@ a=term] [@ b=term]]
+    ?:  =(a %dojo)  %.y
+    ?:  =(b %dojo)  %.n
+    (aor a b)
   =<  .(con +>)
   |:  $:{gil/gill:gall con/_.}  ^+  con
   =.  +>.$  con


### PR DESCRIPTION
Fixes issues related to drum boot ordering
- Changes drum's boot order to be deterministic regardless of the ship
you're on.
- Sorts cli connections so that the user always boots into %dojo
regardless of their @p

Fixes: #2248 #2681