### PR TITLE
chat: strictly match URLs in outgoing strings

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -173,7 +173,7 @@ export class ChatInput extends Component {
 
   isUrl(string) {
     try {
-      const websiteTest = new RegExp(String(/((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)/.source)
+      const websiteTest = new RegExp(String(/^((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)/.source)
       );
       return websiteTest.test(string);
     } catch (e) {


### PR DESCRIPTION
Our regex processes true, and sends a message as a URL, if any part of
the string is a URL starting with a URI schema.
We pass this function strings cut up by spaces. If a link was enclosed
in quotes, or in brackets, this would still process as true.

This adds ^ to the regex to only process strings that START with
a schema.

What's the difference? Before, all these have a match somewhere in them, so they get send as URL letters:
![image](https://user-images.githubusercontent.com/20846414/80436154-783a1600-88cc-11ea-9010-099ca62fb166.png)

After, only the first matches:
![image](https://user-images.githubusercontent.com/20846414/80436164-82f4ab00-88cc-11ea-8a51-6bd34c6be942.png)

Now it gets positives only when it's quite clearly a pasted link.

![image](https://user-images.githubusercontent.com/20846414/80436197-9c95f280-88cc-11ea-8c0f-f9614131cc1a.png)
