### PR TITLE
chat-js: only show scrollbars if overflow

### DIFF
--- a/pkg/interface/chat/src/css/custom.css
+++ b/pkg/interface/chat/src/css/custom.css
@@ -71,7 +71,7 @@ h2 {
 }
 
 .clamp-attachment {
-  overflow: scroll;
+  overflow: auto;
   max-height: 10em;
   max-width: 100%;
 }

--- a/pkg/interface/chat/src/js/components/lib/message.js
+++ b/pkg/interface/chat/src/js/components/lib/message.js
@@ -65,17 +65,17 @@ export class Message extends Component {
         (!!letter.code.output &&
          letter.code.output.length && letter.code.output.length > 0) ?
         (
-          <pre className="f7 clamp-attachment pa1 mt0 mb0">
+          <pre className="f7 clamp-attachment pa1 mt0 mb0 b--gray4 b--gray1-d bl br bb">
             {letter.code.output[0].join('\n')}
           </pre>
         ) : null;
       return (
-        <span>
-          <pre className="f7 clamp-attachment pa1 mt0 mb0 bg-light-gray">
+        <div className="mv2">
+          <pre className="f7 clamp-attachment pa1 mt0 mb0 bg-light-gray b--gray4 b--gray1-d ba">
             {letter.code.expression}
           </pre>
           {outputElement}
-        </span>
+        </div>
       );
     } else if ('url' in letter) {
       let imgMatch =


### PR DESCRIPTION
Uses overflow: auto on the code attachments so that scrollbars only
appear if the content overflows the container. Adds borders on sent Hoon
code to improve visual separation. 
Demo:
![Screen Shot 2020-04-28 at 12 53 44 pm](https://user-images.githubusercontent.com/46801558/80442154-b75d7b00-894f-11ea-9f2f-47356d03f78d.png)


![Screen Shot 2020-04-28 at 12 56 12 pm](https://user-images.githubusercontent.com/46801558/80442149-b593b780-894f-11ea-9161-b4d4c7d29606.png)

cc: @urcades 
