### PR TITLE
chat: autofocus input on desktop

### DIFF
--- a/pkg/interface/chat/src/js/components/lib/chat-input.js
+++ b/pkg/interface/chat/src/js/components/lib/chat-input.js
@@ -340,8 +340,13 @@ export class ChatInput extends Component {
           <CodeEditor
             options={options}
             editorDidMount={(editor) => {
- this.editor = editor;
-}}
+            this.editor = editor;
+            if (!/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(
+                navigator.userAgent
+              )) {
+              editor.focus();
+              }
+            }}
             onChange={(e, d, v) => this.messageChange(e, d, v)}
           />
         </div>


### PR DESCRIPTION
Closes #2821.

With our new chat input, we faced a regression in that we don't autofocus the input; this reinstates the old logic, so that mobile devices don't constantly jump to the bottom of the screen, while desktop devices get autofocus.