### PR TITLE
chat: prepend new pending messages, not append

### DIFF
--- a/pkg/interface/chat/src/js/api.js
+++ b/pkg/interface/chat/src/js/api.js
@@ -72,7 +72,7 @@ class UrbitApi {
 
   addPendingMessage(msg) {
     if (store.state.pendingMessages.has(msg.path)) {
-      store.state.pendingMessages.get(msg.path).push(msg.envelope);
+      store.state.pendingMessages.get(msg.path).unshift(msg.envelope);
     } else {
       store.state.pendingMessages.set(msg.path, [msg.envelope]);
     }


### PR DESCRIPTION
Closes #2802.

After 1b90328f3950a07882de4141fd274c87cd8b6d58, we fixed the graphic quirk with pending messages rearranging owners of chat messages, by concatenating the message array to the pending array and letting flexbox flop the whole thing. However, since we still `push` pending messages, not `unshift` them, this would reverse them as new ones were added.

This just replaces that one method and restores pending messages being displayed in the right order.

<img width="228" alt="Screen Shot 2020-04-28 at 8 13 22 PM" src="https://user-images.githubusercontent.com/20846414/80550219-67050e00-898d-11ea-8d0d-784a35217e77.png">
