### PR TITLE
king: add --ames-latency option

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -31,6 +31,7 @@ data Opts = Opts
     , oHttpPort     :: Maybe Word16
     , oHttpsPort    :: Maybe Word16
     , oLoopbackPort :: Maybe Word16
+    , oAmesLatency  :: Maybe Int
     }
   deriving (Show)
 
@@ -220,6 +221,13 @@ opts = do
       <> long "ames"
       <> help "Ames port"
       <> hidden
+
+    oAmesLatency <-
+      optional
+      $  option (map (*1000) auto)
+      $  metavar "DELAY"
+      <> long "ames-latency"
+      <> help "Milliseconds before sending ames event"
 
     oHttpPort <-
       optional

--- a/pkg/hs/urbit-king/lib/Urbit/King/Config.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Config.hs
@@ -39,6 +39,7 @@ data NetworkConfig = NetworkConfig
   , _ncHttpPort   :: Maybe Word16
   , _ncHttpsPort  :: Maybe Word16
   , _ncLocalPort  :: Maybe Word16
+  , _ncAmesLatency :: Maybe Int
   } deriving (Show)
 
 makeLenses ''NetworkConfig

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -138,11 +138,12 @@ toNetworkConfig CLI.Opts {..} = NetworkConfig { .. }
     (_   , _   , True) -> NMLocalhost
     (_   , _   , _   ) -> NMNormal
 
-  _ncNetMode   = mode
-  _ncAmesPort  = oAmesPort
-  _ncHttpPort  = oHttpPort
-  _ncHttpsPort = oHttpsPort
-  _ncLocalPort = oLoopbackPort
+  _ncNetMode     = mode
+  _ncAmesPort    = oAmesPort
+  _ncHttpPort    = oHttpPort
+  _ncHttpsPort   = oHttpsPort
+  _ncLocalPort   = oLoopbackPort
+  _ncAmesLatency = oAmesLatency
 
 tryBootFromPill :: ( HasLogFunc e, HasNetworkConfig e, HasPierConfig e
                    , HasConfigDir e, HasStderrLogFunc e

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -174,6 +174,10 @@ ames inst who isFake enqueueEv stderr =
                 bindSock socketVar
               Right (bs, addr) -> do
                 logTrace $ displayShow ("(ames) Received packet from ", addr)
+                mLatency <- view (networkConfigL . ncAmesLatency)
+                case mLatency of
+                  Nothing -> pure ()
+                  Just latency -> threadDelay $ latency
                 case addr of
                     SockAddrInet p a -> atomically (enqueueEv $ hearEv p a bs)
                     _                -> pure ()

--- a/pkg/hs/urbit-king/test/AmesTests.hs
+++ b/pkg/hs/urbit-king/test/AmesTests.hs
@@ -51,7 +51,7 @@ instance HasNetworkConfig NetworkTestApp where
 runNetworkApp :: RIO NetworkTestApp a -> IO a
 runNetworkApp = runRIO NetworkTestApp
   { _ntaLogFunc = mkLogFunc l
-  , _ntaNetworkConfig = NetworkConfig NMNormal Nothing Nothing Nothing Nothing
+  , _ntaNetworkConfig = NetworkConfig NMNormal Nothing Nothing Nothing Nothing Nothing
   }
   where
     l _ _ _ _ = pure ()


### PR DESCRIPTION
Adds --ames-latency option, which specifies a time in milliseconds that
the king should wait before sending an ames event to the serf. 

Motivation:
In practice, one often wants to mimic unreliable network conditions 
between fake ships on their own machine. This allows developers to 
do that. 

(Please be hard on style, I'm a haskell neophyte) 