### PR TITLE
gall: smaller %watch-not-unique print

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1555,7 +1555,9 @@
         =.  ap-core
           =/  =tang
             ~[leaf+"subscribe wire not unique" >agent-name< >short-wire< >dock<]
-          %-  (slog >out=outgoing.subscribers.current-agent< tang)
+          =/  have
+            (~(got by outgoing.subscribers.current-agent) short-wire dock)
+          %-  (slog >out=have< tang)
           (ap-error %watch-not-unique tang)
         $(moves t.moves)
       =.  outgoing.subscribers.current-agent


### PR DESCRIPTION
Instead of printing all outgoing subscriptions for the app, only print the
subscription whose wire we're trying to re-use.

In the case of wire re-use, I usually don't care about all those other subscriptions...

(Given this is a kernel PR, and our current OTA strategy around those, this might need to be retargeted at something other than master...)