### PR TITLE
groups: fix self destruct on kick

### DIFF
--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -215,7 +215,9 @@
     =/  ship  (~(get by synced.state) pax.diff)
     ?~  ship  [~ state]
     ?.  =(src.bol u.ship)  [~ state]
-    ?.  (~(has in members.diff) our.bol)  [~ state]
+    ?.  (~(has in members.diff) our.bol)
+      :_  state
+      [(group-poke pax.diff diff)]~
     =/  changes  (poke-group-hook-action [%remove pax.diff])
     :_  +.changes
     %+  welp  -.changes

--- a/pkg/interface/groups/src/js/api.js
+++ b/pkg/interface/groups/src/js/api.js
@@ -17,6 +17,7 @@ class UrbitApi {
     this.contactView = {
       create: this.contactCreate.bind(this),
       delete: this.contactDelete.bind(this),
+      remove: this.contactRemove.bind(this),
       share: this.contactShare.bind(this)
     };
 
@@ -101,6 +102,10 @@ class UrbitApi {
 
   contactDelete(path) {
     return this.contactViewAction({ delete: { path }});
+  }
+
+  contactRemove(path, ship) {
+    return this.contactViewAction({ remove: { path, ship } });
   }
 
   contactHookAction(data) {

--- a/pkg/interface/groups/src/js/components/lib/contact-card.js
+++ b/pkg/interface/groups/src/js/components/lib/contact-card.js
@@ -32,7 +32,8 @@ export class ContactCard extends Component {
     this.notesToSet = this.notesToSet.bind(this);
     this.setField = this.setField.bind(this);
     this.shareWithGroup = this.shareWithGroup.bind(this);
-    this.removeFromGroup = this.removeFromGroup.bind(this);
+    this.removeSelfFromGroup = this.removeSelfFromGroup.bind(this);
+    this.removeOtherFromGroup = this.removeOtherFromGroup.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -335,7 +336,7 @@ export class ContactCard extends Component {
     }));
   }
 
-  removeFromGroup() {
+  removeSelfFromGroup() {
     const { props } = this;
     // share empty contact so that we can remove ourselves from group
     // if we haven't shared yet
@@ -355,10 +356,19 @@ export class ContactCard extends Component {
 
     this.setState({ awaiting: true, type: 'Removing from group' }, (() => {
       api.contactView.delete(props.path).then(() => {
-        const destination = (props.ship === window.ship)
-          ? '' : props.path;
         this.setState({ awaiting: false });
-        props.history.push(`/~groups${destination}`);
+        props.history.push(`/~groups`);
+      });
+    }));
+  }
+
+  removeOtherFromGroup() {
+    const { props } = this;
+
+    this.setState({ awaiting: true, type: 'Removing from group' }, (() => {
+      api.contactView.remove(props.path, `~${props.ship}`).then(() => {
+        this.setState({ awaiting: false });
+        props.history.push(`/~groups${props.path}`);
       });
     }));
   }
@@ -638,7 +648,7 @@ export class ContactCard extends Component {
             className={
               'bg-gray0-d mv4 mh3 pa1 f9 red2 pointer flex-shrink-0 ' + adminOpt
             }
-            onClick={this.removeFromGroup}
+            onClick={props.ship === window.ship ? this.removeSelfFromGroup : this.removeOtherFromGroup}
           >
             {props.ship === window.ship
               ? 'Leave Group'


### PR DESCRIPTION
Fixes a bug where kicking a member with contact info set would delete the group. Also fixes a bug where a group member leaving would not be propagated to the rest of the group

fixes #2816
