### PR TITLE
u3: fixes bug in +rub jet (unsafe coercion from c3_w to noun)

### DIFF
--- a/pkg/urbit/jets/e/rub.c
+++ b/pkg/urbit/jets/e/rub.c
@@ -14,7 +14,13 @@
     u3_atom w, x, y, z;
     u3_atom p, q;
 
-    u3_atom m = u3qa_add(a, u3r_met(0, b));
+    u3_atom m;
+    {
+      c3_w  bit_w = u3r_met(0, b);
+      u3_noun bit = u3i_words(1, &bit_w);
+      m = u3qa_add(a, bit);
+      u3z(bit);
+    }
 
     //  Compute c and d.
     {


### PR DESCRIPTION
This is a very long-standing bug (introduced in ae2f94b01848dd760bb5c912e3010689f4a86d61, which github hilariously attributes to @vvisigoth)  in the jet for `+rub`, which is length-based atom decoding for `+cue` and the inverse of `+mat`.

The implicit coercion from `c3_w` (uint32_t) to `u3_noun` (uint32_t, but ... different) would result in reading random data from the loom, but only when decoding atoms at a position greater than 128MB into a jam buffer. We only recently started jam-ing/cue-ing buffers that big (with the introduction of `|pack`), so this bug was latent until now.