### PR TITLE
publish: allow crash case to no-op instead

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1857,8 +1857,9 @@
   ::
       %remove
     =/  app-path  [(scot %p author.del) /[book.del]]
-    =/  group-path  (group-from-book app-path)
-    [(metadata-poke [%remove group-path [%publish app-path]])]~
+    =/  group-path=(unit path)  (group-from-book app-path)
+    ?~  group-path  ~
+    [(metadata-poke [%remove u.group-path [%publish app-path]])]~
   ==
   ::
   ++  add
@@ -1884,11 +1885,11 @@
   ::
   ++  group-from-book
     |=  app-path=path
-    ^-  path
+    ^-  (unit path)
     ?.  .^(? %gu (scot %p our.bol) %metadata-store (scot %da now.bol) ~)
       ?:  ?=([@ ^] app-path)
         ~&  [%assuming-ported-legacy-publish app-path]
-        [%'~' app-path]
+        `[%'~' app-path]
       ~|  [%weird-publish app-path]
       !!
     =/  resource-indices
@@ -1899,8 +1900,10 @@
         (scot %da now.bol)
         /resource-indices
       ==
-    =/  groups=(set path)  (~(got by resource-indices) [%publish app-path])
-    (snag 0 ~(tap in groups))
+    =/  groups=(unit (set path))
+      (~(get by resource-indices) [%publish app-path])
+    ?~  groups  ~
+    `(snag 0 ~(tap in u.groups))
   --
 ::
 ++  metadata-hook-poke

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -331,9 +331,16 @@
     ?+  mar  (on-poke:def mar vas)
     ::
         %noun
-      ?:  =(q.vas %flush-limbo)
-        [~ this(limbo [~ ~])]
-      [~ this]
+      ?+  q.vas
+        [~ this]
+      ::
+          %flush-limbo  [~ this(limbo [~ ~])]
+      ::
+          %reset-warp
+        =/  rav  [%sing %t [%da now.bol] /app/publish/notebooks]
+        :_  this
+        [%pass /read/paths %arvo %c %warp our.bol q.byk.bol `rav]~
+      ==
     ::
         %handle-http-request
       =+  !<([id=@ta req=inbound-request:eyre] vas)

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1890,8 +1890,7 @@
       ?:  ?=([@ ^] app-path)
         ~&  [%assuming-ported-legacy-publish app-path]
         `[%'~' app-path]
-      ~|  [%weird-publish app-path]
-      !!
+      ~&([%weird-publish app-path] ~)
     =/  resource-indices
       .^  (jug resource group-path)
         %gy
@@ -1903,7 +1902,9 @@
     =/  groups=(unit (set path))
       (~(get by resource-indices) [%publish app-path])
     ?~  groups  ~
-    `(snag 0 ~(tap in u.groups))
+    =/  group-paths  ~(tap in u.groups)
+    ?~  group-paths  ~
+    `i.group-paths
   --
 ::
 ++  metadata-hook-poke


### PR DESCRIPTION
When we remove metadata for a notebook, if the metadata does not exists, we previously crashed. Now we just no-op. This isn't directly related to any issues seen on the network, but prevented certain recovery tactics I tried to use when fixing ~bitpyx.

In general the publish %warp loop is fragile to these crashes, if you receive an update from clay and crash before you can set the next read, publish will not recover from that. This should be fixed more rigorously at some point. I'm unsure if the answer is to remove all such possible crashes, or to stop using clay entirely, which is why I have only fixed this one case for now.