### PR TITLE
drum: fix broken app start

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -360,7 +360,7 @@
   =/  hig=(unit (unit server))
     (~(get by fur) q.wel)
   ?:  &(?=(^ hig) |(?=(~ u.hig) =(p.wel syd.u.u.hig)))
-    this
+    $(servers t.servers)
   =.  fur
     (~(put by fur) q.wel ~)
   =.  this


### PR DESCRIPTION
If we find an agent that has already been launched then we continue
iterating through the list of apps instead of stopping

Fixes: #2858