### PR TITLE
Add ContentType to uploaded s3 images.

### DIFF
--- a/pkg/interface/chat/src/js/lib/s3.js
+++ b/pkg/interface/chat/src/js/lib/s3.js
@@ -33,7 +33,8 @@ export default class S3Client {
       Bucket: bucket,
       Key:  filename,
       Body: buffer,
-      ACL: 'public-read'
+      ACL: 'public-read',
+      ContentType: buffer.type
     };
     return new Promise((resolve, reject) => {
       if (!this.s3) {

--- a/pkg/interface/groups/src/js/lib/s3.js
+++ b/pkg/interface/groups/src/js/lib/s3.js
@@ -33,7 +33,8 @@ export default class S3Client {
       Bucket: bucket,
       Key:  filename,
       Body: buffer,
-      ACL: 'public-read'
+      ACL: 'public-read',
+      ContentType: buffer.type
     };
     return new Promise((resolve, reject) => {
       if (!this.s3) {


### PR DESCRIPTION
Fixes #2865 

When uploading files to S3, the `ContentType` is not set as per the docs [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property).

This results in the S3 object not having the proper header set (instead it is application/octet-stream) so the images when clicked are downloaded instead of viewed natively.

Fortunately, the buffer object passed to the upload function contains the mime type as one of its properties.

Therefore, extracting this and passing it to S3 sets the ContentType properly and fixes the issue.