### PR TITLE
chat: virtualize message-to-json conversion

### DIFF
--- a/pkg/arvo/lib/chat-json.hoon
+++ b/pkg/arvo/lib/chat-json.hoon
@@ -41,9 +41,16 @@
   (fall ((ot output+(ar dank) ~) a) ~)
 ::
 ++  lett
+  =,  enjs:format
   |=  =letter
   ^-  json
-  =,  enjs:format
+  =;  result=(each json tang)
+    ?-  -.result
+      %&  p.result
+      %|  (frond %text s+'[[json rendering error]]')
+    ==
+  %-  mule
+  |.
   ?-  -.letter
       %text
     (frond %text s+text.letter)


### PR DESCRIPTION
Bad `@t` text might crash and fully halt the json conversion, preventing any
data from being delivered to the frontend.

Straight-up virtualizing the entire thing feels a bit aggressive, but seems like the safest bet here. Maybe the issue is just in the `%code` `%output` rendering, which calls `+wash`, but this way we don't need to know anything about how _any_ of the `enjs` functions convert to strings.

Targeting master directly, as a proposal to push this out with some priority. The estimated amount of people affected by #2878 (which this fixes) is 20-50, but that number could grow at any time, and the issue's pretty big-impact.