### PR TITLE
publish: abide by namespacing conventions

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -7,7 +7,8 @@
     *permission-store,
     *invite-store,
     *metadata-store,
-    *metadata-hook
+    *metadata-hook,
+    *rw-security
 /+  *server, *publish, cram, default-agent, dbug
 ::
 /=  index
@@ -2126,13 +2127,13 @@
   =/  book=(unit notebook)  (~(get by books) host book-name)
   ?~  book
     ~
-  =/  notebook-json  (notebook-full-json host book-name u.book)
+  =/  notebook-json  (notebook-full:enjs host book-name u.book)
   ?>  ?=(%o -.notebook-json)
   =.  p.notebook-json
-    (~(uni by p.notebook-json) (notes-page notes.u.book 0 50))
+    (~(uni by p.notebook-json) (notes-page:enjs notes.u.book 0 50))
   =.  p.notebook-json
     (~(put by p.notebook-json) %subscribers (get-subscribers-json book-name))
-  =/  notebooks-json  (notebooks-map-json our.bol books)
+  =/  notebooks-json  (notebooks-map:enjs our.bol books)
   ?>  ?=(%o -.notebooks-json)
   =/  host-books-json  (~(got by p.notebooks-json) (scot %p host))
   ?>  ?=(%o -.host-books-json)
@@ -2151,11 +2152,11 @@
   =/  note=(unit note)  (~(get by notes.u.book) note-name)
   ?~  note
     ~
-  =/  notebook-json  (notebook-full-json host book-name u.book)
+  =/  notebook-json  (notebook-full:enjs host book-name u.book)
   ?>  ?=(%o -.notebook-json)
-  =/  note-json  (note-presentation-json u.book note-name u.note)
+  =/  note-json  (note-presentation:enjs u.book note-name u.note)
   =.  p.notebook-json  (~(uni by p.notebook-json) note-json)
-  =/  notebooks-json  (notebooks-map-json our.bol books)
+  =/  notebooks-json  (notebooks-map:enjs our.bol books)
   ?>  ?=(%o -.notebooks-json)
   =/  host-books-json  (~(got by p.notebooks-json) (scot %p host))
   ?>  ?=(%o -.host-books-json)
@@ -2199,7 +2200,7 @@
       [[[~ %json] [%'~publish' %notebooks ~]] ~]
     %-  json-response:gen
     %-  json-to-octs
-    (notebooks-map-json our.bol books)
+    (notebooks-map:enjs our.bol books)
   ::
   ::  notes pagination
       [[[~ %json] [%'~publish' %notes @ @ @ @ ~]] ~]
@@ -2219,7 +2220,7 @@
     %-  json-response:gen
     %-  json-to-octs
     :-  %o
-    (notes-page notes.u.book u.start u.length)
+    (notes-page:enjs notes.u.book u.start u.length)
   ::
   ::  comments pagination
       [[[~ %json] [%'~publish' %comments @ @ @ @ @ ~]] ~]
@@ -2242,7 +2243,7 @@
       not-found:gen
     %-  json-response:gen
     %-  json-to-octs
-    (comments-page comments.u.note u.start u.length)
+    (comments-page:enjs comments.u.note u.start u.length)
   ::
   ::  single notebook with initial 50 notes in short form, as json
       [[[~ %json] [%'~publish' @ @ ~]] ~]
@@ -2254,10 +2255,10 @@
     =/  book=(unit notebook)  (~(get by books) u.host book-name)
     ?~  book
       not-found:gen
-    =/  notebook-json  (notebook-full-json u.host book-name u.book)
+    =/  notebook-json  (notebook-full:enjs u.host book-name u.book)
     ?>  ?=(%o -.notebook-json)
     =.  p.notebook-json
-      (~(uni by p.notebook-json) (notes-page notes.u.book 0 50))
+      (~(uni by p.notebook-json) (notes-page:enjs notes.u.book 0 50))
     =.  p.notebook-json
       (~(put by p.notebook-json) %subscribers (get-subscribers-json book-name))
     =/  jon=json  (pairs notebook+notebook-json ~)
@@ -2277,7 +2278,7 @@
     =/  note=(unit note)  (~(get by notes.u.book) note-name)
     ?~  note
       not-found:gen
-    =/  jon=json  o+(note-presentation-json u.book note-name u.note)
+    =/  jon=json  o+(note-presentation:enjs u.book note-name u.note)
     (json-response:gen (json-to-octs jon))
   ::
   ::  presentation endpoints
@@ -2285,7 +2286,7 @@
   ::  all notebooks, short form, wrapped in html
       [[~ [%'~publish' ?(~ [%join *] [%new ~])]] ~]
     =,  enjs:format
-    =/  jon=json  (pairs notebooks+(notebooks-map-json our.bol books) ~)
+    =/  jon=json  (pairs notebooks+(notebooks-map:enjs our.bol books) ~)
     (manx-response:gen (index jon))
   ::
   ::  single notebook, with initial 50 notes in short form, wrapped in html

--- a/pkg/arvo/lib/publish.hoon
+++ b/pkg/arvo/lib/publish.hoon
@@ -1,14 +1,218 @@
-/-  *publish
+/-  sur=publish
 /+  elem-to-react-json
+^?
+=<  [. sur]
+=,  sur
 |%
 ::
-++  tang-to-json
-  |=  tan=tang
-  %-  wall:enjs:format
-  %-  zing
-  %+  turn  tan
-  |=  a=tank
-  (wash [0 80] a)
+++  enjs
+  =,  enjs:format
+  |%
+  ::
+  ++  tang
+    |=  tan=^tang
+    %-  wall
+    %-  zing
+    %+  turn  tan
+    |=  a=^tank
+    (wash [0 80] a)
+  ::
+  ++  note-build
+    |=  build=(each manx ^tang)
+    ^-  json
+    ?:  ?=(%.y -.build)
+      %-  pairs
+      :~  success+b+%.y
+          result+(elem-to-react-json p.build)
+      ==
+    %-  pairs
+    :~  success+b+%.n
+        result+(tang p.build)
+    ==
+  ::
+  ++  notebooks-list
+    |=  [our=@p books=(map @tas notebook) subs=(map [@p @tas] notebook)]
+    ^-  json
+    :-  %a
+    %+  weld
+      %+  turn  ~(tap by books)
+      |=  [name=@tas book=notebook]
+      (notebook-short book)
+    %+  turn  ~(tap by subs)
+    |=  [[host=@p name=@tas] book=notebook]
+    (notebook-short book)
+  ::
+  ++  notebooks-map
+    |=  [our=@p books=(map [@p @tas] notebook)]
+    ^-  json
+    =/  notebooks-map=json
+      %-  ~(rep by books)
+      |=  [[[host=@p book-name=@tas] book=notebook] out=json]
+      ^-  json
+      =/  host-ta  (scot %p host)
+      ?~  out
+        (frond host-ta (frond book-name (notebook-short book)))
+      ?>  ?=(%o -.out)
+      =/  books  (~(get by p.out) host-ta)
+      ?~  books
+        :-  %o
+        (~(put by p.out) host-ta (frond book-name (notebook-short book)))
+      ?>  ?=(%o -.u.books)
+      =.  p.u.books  (~(put by p.u.books) book-name (notebook-short book))
+      :-  %o
+      (~(put by p.out) host-ta u.books)
+    =?  notebooks-map  ?=(~ notebooks-map)
+      [%o ~]
+    notebooks-map
+  ::
+  ++  notebook-short
+    |=  book=notebook
+    ^-  json
+    %-  pairs
+    :~  title+s+title.book
+        date-created+(time date-created.book)
+        about+s+description.book
+        num-notes+(numb ~(wyt by notes.book))
+        num-unread+(numb (count-unread notes.book))
+        comments+b+comments.book
+        writers-group-path+s+(spat writers.book)
+        subscribers-group-path+s+(spat subscribers.book)
+    ==
+  ::
+  ++  notebook-full
+    |=  [host=@p book-name=@tas book=notebook]
+    ^-  json
+    %-  pairs
+    :~  title+s+title.book
+        about+s+description.book
+        date-created+(time date-created.book)
+        num-notes+(numb ~(wyt by notes.book))
+        num-unread+(numb (count-unread notes.book))
+        notes-by-date+(notes-by-date notes.book)
+        comments+b+comments.book
+        writers-group-path+s+(spat writers.book)
+        subscribers-group-path+s+(spat subscribers.book)
+    ==
+  ::
+  ++  note-presentation
+    |=  [book=notebook note-name=@tas not=note]
+    ^-  (map @t json)
+    =/  notes-list=(list [@tas note])
+      %+  sort  ~(tap by notes.book)
+      |=  [[@tas n1=note] [@tas n2=note]]
+      (gte date-created.n1 date-created.n2)
+    =/  idx=@  (need (find [note-name not]~ notes-list))
+    =/  next=(unit [name=@tas not=note])
+      ?:  =(idx 0)  ~
+      `(snag (dec idx) notes-list)
+    =/  prev=(unit [name=@tas not=note])
+      ?:  =(+(idx) (lent notes-list))  ~
+      `(snag +(idx) notes-list)
+    =/  current=json  (note-full note-name not)
+    ?>  ?=(%o -.current)
+    =.  p.current  (~(put by p.current) %prev-note ?~(prev ~ s+name.u.prev))
+    =.  p.current  (~(put by p.current) %next-note ?~(next ~ s+name.u.next))
+    =/  notes=(list [@t json])  [note-name current]~
+    =?  notes  ?=(^ prev)
+      [[name.u.prev (note-short name.u.prev not.u.prev)] notes]
+    =?  notes  ?=(^ next)
+      [[name.u.next (note-short name.u.next not.u.next)] notes]
+    %-  my
+    :~  notes+(pairs notes)
+        notes-by-date+a+(turn notes-list |=([name=@tas *] s+name))
+    ==
+  ::
+  ++  note-full
+    |=  [note-name=@tas =note]
+    ^-  json
+    %-  pairs
+    :~  note-id+s+note-name
+        author+s+(scot %p author.note)
+        title+s+title.note
+        date-created+(time date-created.note)
+        snippet+s+snippet.note
+        file+s+file.note
+        num-comments+(numb ~(wyt by comments.note))
+        comments+(comments-page comments.note 0 50)
+        read+b+read.note
+        pending+b+pending.note
+    ==
+  ::
+  ++  notes-by-date
+    |=  notes=(map @tas note)
+    ^-  json
+    =/  notes-list=(list [@tas note])
+      %+  sort  ~(tap by notes)
+      |=  [[@tas n1=note] [@tas n2=note]]
+      (gte date-created.n1 date-created.n2)
+    :-  %a
+    %+  turn  notes-list
+    |=  [name=@tas note]
+    ^-  json
+    [%s name]
+  ::
+  ++  note-short
+    |=  [note-name=@tas =note]
+    ^-  json
+    %-  pairs
+    :~  note-id+s+note-name
+        author+s+(scot %p author.note)
+        title+s+title.note
+        date-created+(time date-created.note)
+        num-comments+(numb ~(wyt by comments.note))
+        read+b+read.note
+        snippet+s+snippet.note
+        pending+b+pending.note
+    ==
+  ::
+  ++  notes-page
+    |=  [notes=(map @tas note) start=@ud length=@ud]
+    ^-  (map @t json)
+    =/  notes-list=(list [@tas note])
+      %+  sort  ~(tap by notes)
+      |=  [[@tas n1=note] [@tas n2=note]]
+      (gte date-created.n1 date-created.n2)
+    %-  my
+    :~  notes-by-date+a+(turn notes-list |=([name=@tas *] s+name))
+        notes+o+(^notes-list (scag length (slag start notes-list)))
+    ==
+  ::
+  ++  notes-list
+    |=  notes=(list [@tas note])
+    ^-  (map @t json)
+    %+  roll  notes
+    |=  [[name=@tas not=note] out-map=(map @t json)]
+    ^-  (map @t json)
+    (~(put by out-map) name (note-short name not))
+  ::
+  ++  comments-page
+    |=  [comments=(map @da ^comment) start=@ud end=@ud]
+    ^-  json
+    =/  coms=(list [@da ^comment])
+      %+  sort  ~(tap by comments)
+      |=  [[d1=@da ^comment] [d2=@da ^comment]]
+      (gte d1 d2)
+    %-  comments-list
+    (scag end (slag start coms))
+  ::
+  ++  comments-list
+    |=  comments=(list [@da ^comment])
+    ^-  json
+    :-  %a
+    (turn comments comment)
+  ::
+  ++  comment
+    |=  [date=@da com=^comment]
+    ^-  json
+    %+  frond
+      (scot %da date)
+    %-  pairs
+    :~  author+s+(scot %p author.com)
+        date-created+(time date-created.com)
+        content+s+content.com
+        pending+b+pending.com
+    ==
+  --
 ::
 ++  string-to-symbol
   |=  tap=tape
@@ -24,19 +228,6 @@
     (add 32 a)
   '-'
 ::
-++  note-build-to-json
-  |=  build=(each manx tang)
-  ^-  json
-  ?:  ?=(%.y -.build)
-    %-  pairs:enjs:format
-    :~  success+b+%.y
-        result+(elem-to-react-json p.build)
-    ==
-  %-  pairs:enjs:format
-  :~  success+b+%.n
-      result+(tang-to-json p.build)
-  ==
-::
 ++  count-unread
   |=  notes=(map @tas note)
   ^-  @ud
@@ -46,195 +237,4 @@
     count
   +(count)
 ::
-++  notebooks-list-json
-  |=  [our=@p books=(map @tas notebook) subs=(map [@p @tas] notebook)]
-  ^-  json
-  =,  enjs:format
-  :-  %a
-  %+  weld
-    %+  turn  ~(tap by books)
-    |=  [name=@tas book=notebook]
-    (notebook-short-json book)
-  %+  turn  ~(tap by subs)
-  |=  [[host=@p name=@tas] book=notebook]
-  (notebook-short-json book)
-::
-++  notebooks-map-json
-  |=  [our=@p books=(map [@p @tas] notebook)]
-  ^-  json
-  =,  enjs:format
-  =/  notebooks-map=json
-    %-  ~(rep by books)
-    |=  [[[host=@p book-name=@tas] book=notebook] out=json]
-    ^-  json
-    =/  host-ta  (scot %p host)
-    ?~  out
-      (frond host-ta (frond book-name (notebook-short-json book)))
-    ?>  ?=(%o -.out)
-    =/  books  (~(get by p.out) host-ta)
-    ?~  books
-      :-  %o
-      (~(put by p.out) host-ta (frond book-name (notebook-short-json book)))
-    ?>  ?=(%o -.u.books)
-    =.  p.u.books  (~(put by p.u.books) book-name (notebook-short-json book))
-    :-  %o
-    (~(put by p.out) host-ta u.books)
-  =?  notebooks-map  ?=(~ notebooks-map)
-    [%o ~]
-  notebooks-map
-::
-++  notebook-short-json
-  |=  book=notebook
-  ^-  json
-  =,  enjs:format
-  %-  pairs
-  :~  title+s+title.book
-      date-created+(time date-created.book)
-      about+s+description.book
-      num-notes+(numb ~(wyt by notes.book))
-      num-unread+(numb (count-unread notes.book))
-      comments+b+comments.book
-      writers-group-path+s+(spat writers.book)
-      subscribers-group-path+s+(spat subscribers.book)
-  ==
-::
-++  notebook-full-json
-  |=  [host=@p book-name=@tas book=notebook]
-  ^-  json
-  =,  enjs:format
-  %-  pairs
-  :~  title+s+title.book
-      about+s+description.book
-      date-created+(time date-created.book)
-      num-notes+(numb ~(wyt by notes.book))
-      num-unread+(numb (count-unread notes.book))
-      notes-by-date+(notes-by-date notes.book)
-      comments+b+comments.book
-      writers-group-path+s+(spat writers.book)
-      subscribers-group-path+s+(spat subscribers.book)
-  ==
-::
-++  note-presentation-json
-  |=  [book=notebook note-name=@tas not=note]
-  ^-  (map @t json)
-  =,  enjs:format
-  =/  notes-list=(list [@tas note])
-    %+  sort  ~(tap by notes.book)
-    |=  [[@tas n1=note] [@tas n2=note]]
-    (gte date-created.n1 date-created.n2)
-  =/  idx=@  (need (find [note-name not]~ notes-list))
-  =/  next=(unit [name=@tas not=note])
-    ?:  =(idx 0)  ~
-    `(snag (dec idx) notes-list)
-  =/  prev=(unit [name=@tas not=note])
-    ?:  =(+(idx) (lent notes-list))  ~
-    `(snag +(idx) notes-list)
-  =/  current=json  (note-full-json note-name not)
-  ?>  ?=(%o -.current)
-  =.  p.current  (~(put by p.current) %prev-note ?~(prev ~ s+name.u.prev))
-  =.  p.current  (~(put by p.current) %next-note ?~(next ~ s+name.u.next))
-  =/  notes=(list [@t json])  [note-name current]~
-  =?  notes  ?=(^ prev)
-    [[name.u.prev (note-short-json name.u.prev not.u.prev)] notes]
-  =?  notes  ?=(^ next)
-    [[name.u.next (note-short-json name.u.next not.u.next)] notes]
-  %-  my
-  :~  notes+(pairs notes)
-      notes-by-date+a+(turn notes-list |=([name=@tas *] s+name))
-  ==
-::
-++  note-full-json
-  |=  [note-name=@tas =note]
-  ^-  json
-  =,  enjs:format
-  %-  pairs
-  :~  note-id+s+note-name
-      author+s+(scot %p author.note)
-      title+s+title.note
-      date-created+(time date-created.note)
-      snippet+s+snippet.note
-      file+s+file.note
-      num-comments+(numb ~(wyt by comments.note))
-      comments+(comments-page comments.note 0 50)
-      read+b+read.note
-      pending+b+pending.note
-  ==
-::
-++  notes-by-date
-  |=  notes=(map @tas note)
-  ^-  json
-  =/  notes-list=(list [@tas note])
-    %+  sort  ~(tap by notes)
-    |=  [[@tas n1=note] [@tas n2=note]]
-    (gte date-created.n1 date-created.n2)
-  :-  %a
-  %+  turn  notes-list
-  |=  [name=@tas note]
-  ^-  json
-  [%s name]
-::
-++  note-short-json
-  |=  [note-name=@tas =note]
-  ^-  json
-  =,  enjs:format
-  %-  pairs
-  :~  note-id+s+note-name
-      author+s+(scot %p author.note)
-      title+s+title.note
-      date-created+(time date-created.note)
-      num-comments+(numb ~(wyt by comments.note))
-      read+b+read.note
-      snippet+s+snippet.note
-      pending+b+pending.note
-  ==
-::
-++  notes-page
-  |=  [notes=(map @tas note) start=@ud length=@ud]
-  ^-  (map @t json)
-  =/  notes-list=(list [@tas note])
-    %+  sort  ~(tap by notes)
-    |=  [[@tas n1=note] [@tas n2=note]]
-    (gte date-created.n1 date-created.n2)
-  %-  my
-  :~  notes-by-date+a+(turn notes-list |=([name=@tas *] s+name))
-      notes+o+(notes-list-json (scag length (slag start notes-list)))
-  ==
-::
-++  notes-list-json
-  |=  notes=(list [@tas note])
-  ^-  (map @t json)
-  %+  roll  notes
-  |=  [[name=@tas not=note] out-map=(map @t json)]
-  ^-  (map @t json)
-  (~(put by out-map) name (note-short-json name not))
-::
-++  comments-page
-  |=  [comments=(map @da comment) start=@ud end=@ud]
-  ^-  json
-  =/  coms=(list [@da comment])
-    %+  sort  ~(tap by comments)
-    |=  [[d1=@da comment] [d2=@da comment]]
-    (gte d1 d2)
-  %-  comments-list-json
-  (scag end (slag start coms))
-::
-++  comments-list-json
-  |=  comments=(list [@da comment])
-  ^-  json
-  =,  enjs:format
-  :-  %a
-  (turn comments comment-json)
-::
-++  comment-json
-  |=  [date=@da com=comment]
-  ^-  json
-  =,  enjs:format
-  %+  frond:enjs:format
-    (scot %da date)
-  %-  pairs
-  :~  author+s+(scot %p author.com)
-      date-created+(time date-created.com)
-      content+s+content.com
-      pending+b+pending.com
-  ==
 --

--- a/pkg/arvo/mar/publish/primary-delta.hoon
+++ b/pkg/arvo/mar/publish/primary-delta.hoon
@@ -1,7 +1,6 @@
 ::
 ::::  /hoon/action/publish/mar
   ::
-/-  *publish
 /+  *publish
 ::
 |_  del=primary-delta
@@ -18,37 +17,37 @@
         %add-book
       %+  frond:enjs:format  (scot %p host.del)
       %+  frond:enjs:format  book.del
-      (notebook-short-json data.del)
+      (notebook-short:enjs data.del)
     ::
         %add-note
       %+  frond:enjs:format  (scot %p host.del)
       %+  frond:enjs:format  book.del
-      (note-full-json note.del data.del)
+      (note-full:enjs note.del data.del)
     ::
         %add-comment
       %-  pairs:enjs:format
       :~  host+s+(scot %p host.del)
           book+s+book.del
           note+s+note.del
-          comment+(comment-json comment-date.del data.del)
+          comment+(comment:enjs comment-date.del data.del)
       ==
     ::
         %edit-book
       %+  frond:enjs:format  (scot %p host.del)
       %+  frond:enjs:format  book.del
-      (notebook-short-json data.del)
+      (notebook-short:enjs data.del)
     ::
         %edit-note
       %+  frond:enjs:format  (scot %p host.del)
       %+  frond:enjs:format  book.del
-      (note-full-json note.del data.del)
+      (note-full:enjs note.del data.del)
     ::
         %edit-comment
       %-  pairs:enjs:format
       :~  host+s+(scot %p host.del)
           book+s+book.del
           note+s+note.del
-          comment+(comment-json comment-date.del data.del)
+          comment+(comment:enjs comment-date.del data.del)
       ==
     ::
         %del-book

--- a/pkg/arvo/sur/publish.hoon
+++ b/pkg/arvo/sur/publish.hoon
@@ -1,4 +1,5 @@
 /-  *rw-security
+^?
 |%
 ::
 +$  group-info


### PR DESCRIPTION
Makes publish abide by namespacing conventions. Some liberties were taken with the structure because publish is not split into the typical triumvirate. 