### PR TITLE
zuse: allow whitespace around = in attr:de-xml:html

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8da3208fcb4424da285159aa3d923bba941ad25a026b30ab0e58e54f4ecac80b
-size 12885759
+oid sha256:66c71e256923835bf9aee19f6bf7ea301f187230fe9cb4d7c695a98cb612019b
+size 12884154

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6469,8 +6469,16 @@
       ;~  plug
         ;~(pfix (plus whit) name)
         ;~  pose
-          (ifix [;~(plug tis yel) yel] (star ;~(less yel escp)))
-          (ifix [;~(plug tis say) say] (star ;~(less say escp)))
+          %+  ifix
+            :_  yel
+            ;~(plug (ifix [. .]:(star whit) tis) yel)
+          (star ;~(less yel escp))
+        ::
+          %+  ifix
+            :_  say
+            ;~(plug (ifix [. .]:(star whit) tis) say)
+          (star ;~(less say escp))
+        ::
           (easy ~)
         ==
       ==


### PR DESCRIPTION
Allow zero or one whitespace character before and/or after the equals sign in name attribute pairs, such as `<hello a = "yo" />` or `<hello a= "yo" />`. Following the spec at https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Eq.

Needed this for my hackathon thing.