### PR TITLE
zuse: allow yel in chrd:de-xml:html

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66c71e256923835bf9aee19f6bf7ea301f187230fe9cb4d7c695a98cb612019b
-size 12884154
+oid sha256:749dbf182ef35fd4324538966b0afeb89a22d0477e39e626df440fc49fd7fdda
+size 12884083

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6493,7 +6493,7 @@
     ::                                                  ::  ++chrd:de-xml:html
     ++  chrd                                            ::  character data
       %+  cook  |=(a/tape ^-(mars ;/(a)))
-      (plus ;~(less yel ;~(pose (just `@`10) escp)))
+      (plus ;~(pose (just `@`10) escp))
     ::                                                  ::  ++comt:de-xml:html
     ++  comt                                            ::  comments
       =-  (ifix [(jest '<!--') (jest '-->')] (star -))


### PR DESCRIPTION
Allow the literal " (double-quote) character to appear in character data sections of xml, for example `<a>"hello"</a>`. Following the spec at https://www.w3.org/TR/2006/REC-xml11-20060816/#dt-chardata.

The xml parsing adventure continues.

Ping @Fang-.