### PR TITLE
chat-cli: multi-sole, un-special-case moons

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -1538,6 +1538,8 @@
   ^-  (list tape)
   ?~  txt  ~
   =/  [end=@ud nex=?]
+    =+  ret=(find "\0a" (scag +(wid) `tape`txt))
+    ?^  ret  [u.ret &]
     ?:  (lte (lent txt) wid)  [(lent txt) &]
     =+  ace=(find " " (flop (scag +(wid) `tape`txt)))
     ?~  ace  [wid |]

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -457,11 +457,12 @@
 ::  +sh-in: handle user input
 ::
 ++  sh-in
-  |=  act=sole-action:sole-sur
+  =,  sole-sur
+  |=  act=sole-action
   ^-  (quip card _state)
   =*  sole-id=@ta  id.act
-  =/  cli-state=sole-share:sole-sur
-    (~(gut by soles) sole-id *sole-share:sole-sur)
+  =/  cli-state=sole-share
+    (~(gut by soles) sole-id *sole-share)
   |^  =^  [=_cli-state cards=(list card)]  state
         ?-  -.dat.act
           %det  (edit +.dat.act)
@@ -524,7 +525,7 @@
     =|  moves=(list card)
     =?  moves  ?=(^ options)
       [(tab:sh-out options) moves]
-    =|  fxs=(list sole-effect:sole-sur)
+    =|  fxs=(list sole-effect)
     |-  ^-  outward
     ?~  to-send
       [[cli-state (flop moves)] state]
@@ -541,7 +542,7 @@
   ::    applies the change and does sanitizing.
   ::
   ++  edit
-    |=  cal=sole-change:sole-sur
+    |=  cal=sole-change
     ^-  outward
     =^  inv  cli-state  (~(transceive sole-lib cli-state) cal)
     =+  fix=(sanity inv buf.cli-state)
@@ -560,20 +561,20 @@
   ::    if invalid, produces error correction description, for use with +slug.
   ::
   ++  sanity
-    |=  [inv=sole-edit:sole-sur buf=(list @c)]
-    ^-  [lit=(list sole-edit:sole-sur) err=(unit @u)]
+    |=  [inv=sole-edit buf=(list @c)]
+    ^-  [lit=(list sole-edit) err=(unit @u)]
     =+  res=(rose (tufa buf) read)
     ?:  ?=(%& -.res)  [~ ~]
     [[inv]~ `p.res]
   ::  +slug: apply error correction to prompt input
   ::
   ++  slug
-    |=  [lit=(list sole-edit:sole-sur) err=(unit @u)]
+    |=  [lit=(list sole-edit) err=(unit @u)]
     ^-  outward
     ?~  lit  [[cli-state ~] state]
     =^  lic  cli-state
       %-  ~(transmit sole-lib cli-state)
-      ^-  sole-edit:sole-sur
+      ^-  sole-edit
       ?~(t.lit i.lit [%mor lit])
     :_  state
     :-  cli-state
@@ -1353,13 +1354,14 @@
 ::  +mr: render messages
 ::
 ++  mr
+  =,  sole-sur
   |_  $:  source=target
           envelope
       ==
   ::  +activate: produce sole-effect for printing message details
   ::
   ++  render-activate
-    ^-  sole-effect:sole-sur
+    ^-  sole-effect
     ~[%mor [%tan meta] body]
   ::  +meta: render message metadata (serial, timestamp, author, target)
   ::
@@ -1372,7 +1374,7 @@
   ::  +body: long-form render of message contents
   ::
   ++  body
-    |-  ^-  sole-effect:sole-sur
+    |-  ^-  sole-effect
     ?-  -.letter
         ?(%text %me)
       =/  pre=tape  ?:(?=(%me -.letter) "@ " "")
@@ -1384,7 +1386,7 @@
         %code
       =/  texp=tape  ['>' ' ' (trip expression.letter)]
       :-  %mor
-      |-  ^-  (list sole-effect:sole-sur)
+      |-  ^-  (list sole-effect)
       ?:  =("" texp)  [tan+output.letter ~]
       =/  newl  (find "\0a" texp)
       ?~  newl  [txt+texp $(texp "")]

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -280,7 +280,8 @@
   ^-  card
   [%pass /invites %agent [our.bowl %invite-store] %watch /invitatory/chat]
 ::
-++  our-self  (name:title our.bowl)
+::TODO  better moon support. (name:title our.bowl)
+++  our-self  our.bowl
 ::  +target-to-path: prepend ship to the path
 ::
 ++  target-to-path

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -36,7 +36,6 @@
       width=@ud                                     ::  display width
       timez=(pair ? @ud)                            ::  timezone adjustment
       soles=(map @ta sole-share:sole-sur)           ::  console state
-      eny=@uvJ
   ==
 ::
 +$  state-1
@@ -117,7 +116,7 @@
   |_  =bowl:gall
   +*  this       .
       talk-core  +>
-      tc         ~(. talk-core(eny eny.bowl) bowl)
+      tc         ~(. talk-core bowl)
       def        ~(. (default-agent this %|) bowl)
   ::
   ++  on-init
@@ -252,8 +251,6 @@
       %+  ~(put by *(map @t sole-share:sole-sur))
         (cat 3 'drum_' (scot %p our.bowl))
       state.cli.u.old
-    ::
-      eny
     ==
   ::
   ?>  ?=(%2 -.u.old)
@@ -1005,7 +1002,7 @@
       ^-  (quip card _state)
       ~!  bowl
       =/  =serial  (shaf %msg-uid eny.bowl)
-      :_  state(eny (shax eny.bowl))
+      :_  state
       ^-  (list card)
       %+  turn  ~(tap in audience)
       |=  =target

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -770,7 +770,7 @@
     ::
     ++  text
       %+  cook  crip
-      (plus ;~(less (jest '•') next))
+      (plus next)
     ::  +expr: parse expression into [cord hoon]
     ::
     ++  expr

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -531,7 +531,7 @@
     =^  char  cli-state
       (~(transmit sole-lib cli-state) [%ins send-pos `@c`i.to-send])
     %_  $
-      moves  [(effect:sh-out %det char) moves]
+      moves  [(effect-to:sh-out sole-id %det char) moves]
       send-pos  +(send-pos)
       to-send  t.to-send
     ==
@@ -805,7 +805,8 @@
       ?.  =(`0 (find ";" buf))  ~
       [(note:sh-out (tufa `(list @)`buf)) ~]
     :_  cards
-    %+  effect:sh-out  %mor
+    %+  effect-to:sh-out  sole-id
+    :-  %mor
     :~  [%nex ~]
         [%det cal]
     ==
@@ -1164,13 +1165,17 @@
 ::
 ++  sh-out
   |%
+  ::  +effect-to: console effect card to a single listener
+  ::
+  ++  effect-to
+    |=  [sole-id=@ta fec=sole-effect:sole-sur]
+    ^-  card
+    [%give %fact [/sole/[sole-id]]~ %sole-effect !>(fec)]
   ::  +effect: console effect card for all listeners
   ::
   ++  effect
     |=  fec=sole-effect:sole-sur
-    =/  =path  /sole/(cat 3 'drum_' (scot %p our.bowl))
     ^-  card
-    ::TODO  don't hard-code session id 'drum' here
     =-  [%give %fact - %sole-effect !>(fec)]
     %+  turn  ~(tap in ~(key by soles))
     |=  sole-id=@ta

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -1452,8 +1452,13 @@
         ~(glyph tr source)
       =/  lis=(list tape)
         %+  simple-wrap
-          ~|  [%weird-text `@`+.letter]
-          `tape``(list @)`(tuba (trip +.letter))
+          =/  result=(each tape tang)
+            %-  mule  |.
+            `(list @)`(tuba (trip +.letter))
+          ?-  -.result
+            %&  p.result
+            %|  "[[msg rendering error]]"
+          ==
         (sub wyd (min (div wyd 2) (lent pef)))
       =+  lef=(lent pef)
       =+  ?:((gth (lent lis) 0) (snag 0 lis) "")

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -254,7 +254,6 @@
     ==
   ::
   ?>  ?=(%2 -.u.old)
-  =.  width.u.old  (max 40 width.u.old)
   u.old
 ::  +catch-up: process all chat-store state
 ::
@@ -1081,7 +1080,7 @@
     ::
     ++  set-width
       |=  w=@ud
-      [~ state(width w)]
+      [~ state(width (max 40 w))]
     ::  +set-timezone: configure timestamp printing adjustment
     ::
     ++  set-timezone


### PR DESCRIPTION
Allows chat-cli to be `|link`ed to between moons and planets.

The multi-soling here is pretty minimal in that they all share the same configuration (mention `%bel`s, display width, timezone config etc), but that shouldn't make it any less usable. Supporting those properly would be more invasive work that's probably not worth the time right now.

Sorta-but-not-really fixes #2870, by making moons' chat-cli inherit exactly nothing from their planets, making for parity with the web ui.  
Also indirectly closes #1870 and closes #2154 and closes #2167 I guess.

Also makes some smaller improvements:
- No longer hard-crashes on `%bad-text` errors, instead printing a failure message. (fixes #2125)
- Now prints newlines in messages properly.
- Remove entropy from state.
- Allow sending the `•` character in messages.

(Note that this depends on and targets the `release/link-dojo` branch.)