### PR TITLE
publish: fix bug in publish comment mark

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -614,7 +614,11 @@
     [~ state]
   =/  book-name      i.t.t.t.pax
   =/  note-name      i.t.t.t.t.pax
-  =/  new-comment    !<(comment q.r.u.rot)
+  =/  com-2-3    !<(?(comment-2 comment-3) q.r.u.rot)
+  =/  new-comment=comment-3
+    ?:  ?=(comment-2 com-2-3)
+      [author.com-2-3 date-created.com-2-3 content.com-2-3 %.n]
+    com-2-3
   =/  rif=riff:clay  [q.byk.bol `[%next %x [%da now.bol] pax]]
   =/  delta=notebook-delta
     [%edit-comment our.bol book-name note-name u.comment-date new-comment]
@@ -749,7 +753,11 @@
     =/  comment-name  (slaw %da i.t.t.t.t.t.pax)
     ?~  comment-name
       [~ sty]
-    =/  new-com  .^(comment %cx (welp our-beak pax))
+    =/  com-2-3  .^(?(comment-2 comment-3) %cx (welp our-beak pax))
+    =/  new-com=comment-3
+      ?:  ?=(comment-2 com-2-3)
+        [author.com-2-3 date-created.com-2-3 content.com-2-3 %.n]
+      com-2-3
     =/  rif=riff:clay  [q.byk.bol `[%next %x [%da now.bol] pax]]
     ::
     =/  delta=notebook-delta

--- a/pkg/arvo/mar/publish/comment.hoon
+++ b/pkg/arvo/mar/publish/comment.hoon
@@ -1,5 +1,5 @@
 /-  *publish
-|_  com=comment
+|_  com=?(comment-2 comment-3)
 ::
 ::
 ++  grow
@@ -9,6 +9,13 @@
     (as-octs:mimes:html (of-wain:format txt))
   ++  txt
     ^-  wain
+    ?:  ?=(comment-2 com)
+      :*  (cat 3 'author: ' (scot %p author.com))
+          (cat 3 'date-created: ' (scot %da date-created.com))
+          '-----'
+          (to-wain:format content.com)
+      ==
+    ?>  ?=(comment-3 com)
     :*  (cat 3 'author: ' (scot %p author.com))
         (cat 3 'date-created: ' (scot %da date-created.com))
         '-----'


### PR DESCRIPTION
Introduced by a stupid mistake I made in this PR: https://github.com/urbit/urbit/pull/2707 where I forgot that changes to a mark type definition need to include the old mark type. This should fix this issue: https://github.com/urbit/urbit/issues/2731

I've tested this fix by booting a ship from before #2707, making a notebook with comments, adding the code from #2707 and confirming the reproduction, then copying these changes in.

Apologies to everyone this issue has plagued.