### PR TITLE
jets: fix broken jets so ~marzod can boot.

### DIFF
--- a/pkg/urbit/jets/d/by_apt.c
+++ b/pkg/urbit/jets/d/by_apt.c
@@ -3,6 +3,7 @@
 */
 #include "all.h"
 
+// l and r are keys, p.n.a-s.
 static
 c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
 {
@@ -18,7 +19,7 @@ c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != l ) {
     u3_noun u_l;
     u3x_cell(l, 0, &u_l);
-    if (!_(u3qc_gor(p_n_a, u_l))) {
+    if (c3n == u3qc_gor(p_n_a, u_l)) {
       return c3n;
     }
     if (c3y == u3r_sing(p_n_a, u_l)) {
@@ -29,7 +30,7 @@ c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != r ) {
     u3_noun u_r;
     u3x_cell(r, 0, &u_r);
-    if (!_(u3qc_gor(u_r, p_n_a))) {
+    if (c3n == u3qc_gor(u_r, p_n_a)) {
       return c3n;
     }
     if (c3y == u3r_sing(u_r, p_n_a)) {
@@ -43,14 +44,14 @@ c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
     u3x_trel(l_a, &n_l_a, &l_l_a, &r_l_a);
     u3x_cell(n_l_a, &p_n_l_a, 0);
 
-    if (!_(u3qc_mor(p_n_a, p_n_l_a))) {
+    if (c3n == u3qc_mor(p_n_a, p_n_l_a)) {
       return c3n;
     }
     if (c3y == u3r_sing(p_n_a, p_n_l_a)) {
       return c3n;
     }
     u3_noun nu_l = u3nc(0, p_n_a);
-    if (!_(_by_apt(l_a, nu_l, 0))) {
+    if (c3n == _by_apt(l_a, nu_l, r)) {
       u3z(nu_l);
       return c3n;
     }
@@ -63,14 +64,14 @@ c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
     u3x_trel(r_a, &n_r_a, &l_r_a, &r_r_a);
     u3x_cell(n_r_a, &p_n_r_a, 0);
 
-    if (!_(u3qc_mor(p_n_a, p_n_r_a))) {
+    if (c3n == u3qc_mor(p_n_a, p_n_r_a)) {
       return c3n;
     }
     if (c3y == u3r_sing(p_n_a, p_n_r_a)) {
       return c3n;
     }
     u3_noun nu_r = u3nc(0, p_n_a);
-    if (!_(_by_apt(r_a, 0, nu_r))) {
+    if (c3n == _by_apt(r_a, l, nu_r)) {
       u3z(nu_r);
       return c3n;
     }
@@ -80,7 +81,7 @@ c3_o _by_apt(u3_noun a, u3_noun l, u3_noun r)
   return c3y;
 }
 
-
+// TODO: +apt:in and +apt:by are disabled since it breaks ames in some way?
 u3_noun
 u3wdb_apt(u3_noun cor)
 {

--- a/pkg/urbit/jets/d/in_apt.c
+++ b/pkg/urbit/jets/d/in_apt.c
@@ -16,7 +16,7 @@ c3_o _in_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != l ) {
     u3_noun u_l;
     u3x_cell(l, 0, &u_l);
-    if (!_(u3qc_gor(n_a, u_l))) {
+    if (c3n == u3qc_gor(n_a, u_l)) {
       return c3n;
     }
   }
@@ -24,7 +24,7 @@ c3_o _in_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != r ) {
     u3_noun u_r;
     u3r_cell(r, 0, &u_r);
-    if (!_(u3qc_gor(u_r, n_a))) {
+    if (c3n == u3qc_gor(u_r, n_a)) {
       return c3n;
     }
   }
@@ -32,11 +32,11 @@ c3_o _in_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != l_a ) {
     u3_noun n_l_a, l_l_a, r_l_a;
     u3x_trel(l_a, &n_l_a, &l_l_a, &r_l_a);
-    if (!_(u3qc_mor(n_a, n_l_a))) {
+    if (c3n == u3qc_mor(n_a, n_l_a)) {
       return c3n;
     }
     u3_noun nu_l = u3nc(0, n_a);
-    if (!_(_in_apt(l_a, nu_l, 0))) {
+    if (c3n == _in_apt(l_a, nu_l, r)) {
       u3z(nu_l);
       return c3n;
     }
@@ -46,11 +46,11 @@ c3_o _in_apt(u3_noun a, u3_noun l, u3_noun r)
   if ( u3_nul != r_a ) {
     u3_noun n_r_a, l_r_a, r_r_a;
     u3x_trel(r_a, &n_r_a, &l_r_a, &r_r_a);
-    if (!_(u3qc_mor(n_a, n_r_a))) {
+    if (c3n == u3qc_mor(n_a, n_r_a)) {
       return c3n;
     }
     u3_noun nu_r = u3nc(0, n_a);
-    if (!_(_in_apt(r_a, 0, nu_r))) {
+    if (c3n == _in_apt(r_a, l, nu_r)) {
       u3z(nu_r);
       return c3n;
     }
@@ -60,6 +60,7 @@ c3_o _in_apt(u3_noun a, u3_noun l, u3_noun r)
   return c3y;
 }
 
+// TODO: +apt:in and +apt:by are disabled since it breaks ames in some way?
 u3_noun
 u3wdi_apt(u3_noun cor)
 {

--- a/pkg/urbit/jets/e/scow.c
+++ b/pkg/urbit/jets/e/scow.c
@@ -190,7 +190,7 @@ _print_p(u3_atom cor, u3_atom p)
   u3_atom sxz = u3n_slam_on(hok, u3k(p));
 
   // Simple galaxy case
-  if (c3y == u3qa_lte(sxz, 256)) {
+  if (c3y == u3qa_lth(sxz, 256)) {
     c3_y a, b, c;
     u3_po_to_suffix(sxz, &a, &b, &c);
     u3z(sxz);

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -1619,7 +1619,7 @@ static c3_c* _141_two_xeb_ha[] = {
   };
 
 static u3j_core _141_two__in_d[] =
-  { { "apt", 7, _141_two__in_apt_a, 0, _141_two__in_apt_ha },
+  { // { "apt", 7, _141_two__in_apt_a, 0, _141_two__in_apt_ha },
     { "bif", 7, _141_two__in_bif_a, 0, _141_two__in_bif_ha },
     { "del", 7, _141_two__in_del_a, 0, _141_two__in_del_ha },
     { "dif", 7, _141_two__in_dif_a, 0, _141_two__in_dif_ha },
@@ -1728,7 +1728,7 @@ static c3_c* _141_two__in_ha[] = {
 static u3j_core _141_two__by_d[] =
   { { "all", 7, _141_two__by_all_a, 0, _141_two__by_all_ha },
     { "any", 7, _141_two__by_any_a, 0, _141_two__by_any_ha },
-    { "apt", 7, _141_two__by_apt_a, 0, _141_two__by_apt_ha },
+    // { "apt", 7, _141_two__by_apt_a, 0, _141_two__by_apt_ha },
     { "bif", 7, _141_two__by_bif_a, 0, _141_two__by_bif_ha },
     { "del", 7, _141_two__by_del_a, 0, _141_two__by_del_ha },
     { "dif", 7, _141_two__by_dif_a, 0, _141_two__by_dif_ha },


### PR DESCRIPTION
This fixes an off by one error in ship name printing, and disables
the +apt:{by,in} jets. I've tried debugging the +apt jets and am
making no progress other than finding a bug in the recursion; this
isn't enough to get ~marzod to boot, though.