### PR TITLE
vere: improves jammed state reloading in |pack

### DIFF
--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1742,7 +1742,7 @@ u3m_rock_load(c3_c* dir_c, c3_d evt_d)
       //  XX u3m_file bails, but we'd prefer to return errors
       //
       u3_noun fil = u3m_file(nam_c);
-      u3a_print_memory(stderr, "rock: load", u3r_met(3, fil));
+      u3a_print_memory(stderr, "rock: load", u3r_met(5, fil));
 
       u3_noun pro = u3m_soft(0, u3ke_cue, fil);
 

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1092,10 +1092,14 @@ u3r_mp(mpz_t   a_mp,
     u3a_atom* b_u = u3a_to_ptr(b);
     c3_w    len_w = b_u->len_w;
 
-    //  slight deficiency in the GMP API.
+    //  avoid reallocation on import, if possible
     //
-    c3_assert(!(len_w >> 27));
-    mpz_init2(a_mp, len_w << 5);
+    if ( (len_w >> 27) ) {
+      mpz_init(a_mp);
+    }
+    else {
+      mpz_init2(a_mp, len_w << 5);
+    }
 
     mpz_import(a_mp, len_w, -1, sizeof(c3_w), 0, 0, b_u->buf_w);
   }


### PR DESCRIPTION
Much like #2919, these are some small fixes I had on a long-running branch. PR'ing them now as their individually useful, and I'd like to cut a patch release soon.