### PR TITLE
fe: center tile image of chat, groups, link, publish, and soto

### DIFF
--- a/pkg/interface/chat/tile/tile.js
+++ b/pkg/interface/chat/tile/tile.js
@@ -45,7 +45,7 @@ export default class ChatTile extends Component {
           <p className="black white-d absolute f9" style={{left: 8, top: 8}}>Messaging</p>
            <img
              className="absolute invert-d"
-             style={{ left: 39, top: 39 }}
+             style={{ left: 38, top: 38 }}
              src="/~chat/img/Tile.png"
              width={48}
              height={48} />

--- a/pkg/interface/groups/tile/tile.js
+++ b/pkg/interface/groups/tile/tile.js
@@ -42,7 +42,7 @@ export default class ContactTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~groups/img/Tile.png"
             width={48}
             height={48}

--- a/pkg/interface/link/tile/tile.js
+++ b/pkg/interface/link/tile/tile.js
@@ -32,7 +32,7 @@ export default class LinkTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~link/img/Tile.png"
             width={48}
             height={48}

--- a/pkg/interface/publish/tile/tile.js
+++ b/pkg/interface/publish/tile/tile.js
@@ -32,7 +32,7 @@ export default class PublishTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~publish/tile.png"
             width={48}
             height={48}

--- a/pkg/interface/soto/tile/tile.js
+++ b/pkg/interface/soto/tile/tile.js
@@ -17,8 +17,8 @@ export default class sotoTile extends Component {
           <img src="~dojo/img/Tile.png"
             className="absolute"
             style={{
-              left: 39,
-              top: 39,
+              left: 38,
+              top: 38,
               height: 48,
               width: 48
               }}

--- a/pkg/interface/weather/tile/tile.js
+++ b/pkg/interface/weather/tile/tile.js
@@ -201,7 +201,7 @@ export default class WeatherTile extends Component {
             Weather
           </p>
         <p className="absolute w-100 flex-col f9"
-        style={{verticalAlign: "bottom", bottom: 8, left: 8, cursor: "pointer"}}>
+        style={{bottom: 8, left: 8, cursor: "pointer"}}>
         -> Set location
         </p>
       </div>


### PR DESCRIPTION
The enclosing `<div>` of a tile has a `height` and `width` of `126px` but the inner `<div>` has `height` and `width` of `100%` and a border of `1px` resulting in a 124x124 tile area.  This PR centers the tile image in this area: `(124-48)/2 = 38`.

It also removes `verticalAlign:"bottom"` from the \"-> Set location\" `<p>` in the Weather tile; `vertical-align` has no effect on `<p>` since it's not an `inline` or `table-cell` element.

Not sure if this is the right branch for this.