### PR TITLE
fe: center tile image of chat, groups, link, publish, and soto

### DIFF
--- a/pkg/interface/src/apps/launch/components/tiles/basic.js
+++ b/pkg/interface/src/apps/launch/components/tiles/basic.js
@@ -19,7 +19,7 @@ export default class BasicTile extends React.PureComponent {
                style={{left: 8, top: 8}}>{props.title}</p>
              <img
                className="absolute invert-d"
-               style={{ left: 39, top: 39 }}
+               style={{ left: 38, top: 38 }}
                src={props.iconUrl}
                width={48}
                height={48} />

--- a/pkg/interface/src/apps/launch/components/tiles/custom.js
+++ b/pkg/interface/src/apps/launch/components/tiles/custom.js
@@ -14,7 +14,7 @@ export default class CustomTile extends React.PureComponent {
                         "b--black b--gray1-d"}>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src={'/~launch/img/UnknownCustomTile.png'}
             width={48}
             height={48} />

--- a/pkg/interface/src/apps/launch/components/tiles/weather.js
+++ b/pkg/interface/src/apps/launch/components/tiles/weather.js
@@ -206,7 +206,7 @@ export default class WeatherTile extends React.Component {
             Weather
           </p>
         <p className="absolute w-100 flex-col f9"
-        style={{verticalAlign: "bottom", bottom: 8, left: 8, cursor: "pointer"}}>
+        style={{bottom: 8, left: 8, cursor: "pointer"}}>
         -> Set location
         </p>
       </div>

--- a/pkg/interface/src/oldApps/chat/tile/tile.js
+++ b/pkg/interface/src/oldApps/chat/tile/tile.js
@@ -45,7 +45,7 @@ export default class ChatTile extends Component {
           <p className="black white-d absolute f9" style={{left: 8, top: 8}}>Messaging</p>
            <img
              className="absolute invert-d"
-             style={{ left: 39, top: 39 }}
+             style={{ left: 38, top: 38 }}
              src="/~chat/img/Tile.png"
              width={48}
              height={48} />

--- a/pkg/interface/src/oldApps/groups/tile/tile.js
+++ b/pkg/interface/src/oldApps/groups/tile/tile.js
@@ -42,7 +42,7 @@ export default class ContactTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~groups/img/Tile.png"
             width={48}
             height={48}

--- a/pkg/interface/src/oldApps/link/tile/tile.js
+++ b/pkg/interface/src/oldApps/link/tile/tile.js
@@ -32,7 +32,7 @@ export default class LinkTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~link/img/Tile.png"
             width={48}
             height={48}

--- a/pkg/interface/src/oldApps/publish/tile/tile.js
+++ b/pkg/interface/src/oldApps/publish/tile/tile.js
@@ -32,7 +32,7 @@ export default class PublishTile extends Component {
           </p>
           <img
             className="absolute invert-d"
-            style={{ left: 39, top: 39 }}
+            style={{ left: 38, top: 38 }}
             src="/~publish/tile.png"
             width={48}
             height={48}

--- a/pkg/interface/src/oldApps/soto/tile/tile.js
+++ b/pkg/interface/src/oldApps/soto/tile/tile.js
@@ -17,8 +17,8 @@ export default class sotoTile extends Component {
           <img src="~dojo/img/Tile.png"
             className="absolute"
             style={{
-              left: 39,
-              top: 39,
+              left: 38,
+              top: 38,
               height: 48,
               width: 48
               }}


### PR DESCRIPTION
Was https://github.com/urbit/urbit/pull/2925.

The enclosing `<div>` of a tile has a `height` and `width` of `126px` but the inner `<div>` has `height` and `width` of `100%` and a border of `1px` resulting in a 124x124 tile area.  This PR centers the tile image in this area: `(124-48)/2 = 38`.

It also removes `verticalAlign:"bottom"` from the \"-> Set location\" `<p>` in the Weather tile; `vertical-align` has no effect on `<p>` since it's not an `inline` or `table-cell` element.

I tested this on `master` but not on this branch because I don't know how.  I tried:
```
git clone -b feat/spa https://github.com/urbit/urbit.git
cd urbit/pkg/interface
npm install
npm install -g gulp

# not clear what to do, so try all:
cp config/urbitrc-sample config/urbitrc
cp config/urbitrc-sample config/.urbitrc
cp config/urbitrc-sample .urbitrc

# setup zod, edit config/urbitrc, config/.urbitrc, .urbitrc

# now what?
npm run build
npm ERR! missing script: build
```
`urbit/pkg/interface/CONTRIBUTING.md` refers to `urbit/pkg/interface/urbitrc-sample` instead of `urbit/pkg/interface/config/urbitrc-sample`, and `urbit/pkg/interface/contacts` which doesn't exist, so it seems out-of-date.

I tried `npm run start` and `npm run build:dev`, which seems to do something, but `|commit %home` only changes `/~zod/home/4/app/landscape/js/index/js` and I don't see any changes in the browser.


