### PR TITLE
&publish-info parser cleanup

### DIFF
--- a/pkg/arvo/mar/publish/comment.hoon
+++ b/pkg/arvo/mar/publish/comment.hoon
@@ -26,34 +26,37 @@
   |%
   ++  mime
     |=  [mite:eyre p=octs:eyre]
-    |^  (rash q.p both-parser)
+    |^  (rash q.p ;~(sfix both-parser (punt gaq)))
     ++  key-val
-      |*  [key=rule val=rule]
-      ;~(sfix ;~(pfix key val) gaq)
+      |*  [key=@tas val=rule]
+      ;~(pfix (jest key) col ace val)
     ++  old-parser
-      ;~  plug
-        (key-val (jest 'creator: ~') fed:ag)
-        (key-val (jest 'collection: ') sym)
-        (key-val (jest 'post: ') sym)
-        (key-val (jest 'date-created: ~') (cook year when:so))
-        (key-val (jest 'last-modified: ~') (cook year when:so))
-        ;~(pfix (jest (cat 3 '-----' 10)) (cook crip (star next)))
+      ;~  (glue gaq)
+        (key-val %creator ;~(pfix sig fed:ag))
+        (key-val %collection sym)
+        (key-val %post sym)
+        (key-val %title (cook crip (star prn)))
+        (key-val %date-created ;~(pfix sig (cook year when:so)))
+        (key-val %last-modified ;~(pfix sig (cook year when:so))
+        (cold ~ (jest '-----'))
+        (cook crip (star next)))
       ==
     ++  new-parser
-      ;~  plug
-        (key-val (jest 'author: ~') fed:ag)
-        (key-val (jest 'date-created: ~') (cook year when:so))
-        ;~(pfix (jest (cat 3 '-----' 10)) (cook crip (star next)))
+      ;~  (glue gaq)
+        (key-val %author ;~(pfix sig fed:ag))
+        (key-val %date-created ;~(pfix sig (cook year when:so)))
+        (cold ~ (jest '-----'))
+        (cook crip (star next)))
       ==
     ++  both-parser
       ;~  pose
         %+  cook
-          |=  [author=@ date-created=@da content=@t]
+          |=  [author=@ date-created=@da ~ content=@t]
           ^-  comment
           [author date-created content %.n]
         new-parser
         %+  cook
-          |=  [author=@ @ @ date-created=@da @ content=@t]
+          |=  [author=@ @ @ date-created=@da @ ~ content=@t]
           ^-  comment
           [author date-created content %.n]
         old-parser

--- a/pkg/arvo/mar/publish/comment.hoon
+++ b/pkg/arvo/mar/publish/comment.hoon
@@ -37,16 +37,16 @@
         (key-val %post sym)
         (key-val %title (cook crip (star prn)))
         (key-val %date-created ;~(pfix sig (cook year when:so)))
-        (key-val %last-modified ;~(pfix sig (cook year when:so))
+        (key-val %last-modified ;~(pfix sig (cook year when:so)))
         (cold ~ (jest '-----'))
-        (cook crip (star next)))
+        (cook crip (star next))
       ==
     ++  new-parser
       ;~  (glue gaq)
         (key-val %author ;~(pfix sig fed:ag))
         (key-val %date-created ;~(pfix sig (cook year when:so)))
         (cold ~ (jest '-----'))
-        (cook crip (star next)))
+        (cook crip (star next))
       ==
     ++  both-parser
       ;~  pose

--- a/pkg/arvo/mar/publish/comment.hoon
+++ b/pkg/arvo/mar/publish/comment.hoon
@@ -35,7 +35,6 @@
         (key-val %creator ;~(pfix sig fed:ag))
         (key-val %collection sym)
         (key-val %post sym)
-        (key-val %title (cook crip (star prn)))
         (key-val %date-created ;~(pfix sig (cook year when:so)))
         (key-val %last-modified ;~(pfix sig (cook year when:so)))
         (cold ~ (jest '-----'))

--- a/pkg/arvo/mar/publish/info.hoon
+++ b/pkg/arvo/mar/publish/info.hoon
@@ -42,7 +42,7 @@
       ;~  (glue gaq)
         (key-val %title (cook crip (star prn)))
         (key-val %description (cook crip (star prn)))
-        (key-val %comments (fuss %on %off)))
+        (key-val %comments (fuss %on %off))
         (key-val %writers fel:stab)
         (key-val %subscribers fel:stab)
       ==

--- a/pkg/arvo/mar/publish/info.hoon
+++ b/pkg/arvo/mar/publish/info.hoon
@@ -24,36 +24,27 @@
   |%
   ++  mime
     |=  [mite:eyre p=octs:eyre]
-    |^  (rash q.p both-parser)
+    |^  (rash q.p ;~(sfix both-parser (punt gaq)))
     ++  key-val
-      |*  [key=rule val=rule]
-      ;~(sfix ;~(pfix key val) gaq)
+      |*  [key=@tas val=rule]
+      ;~(pfix (jest key) col ace val)
     ++  old-parser
-      ;~  plug
-        (key-val (jest 'owner: ~') fed:ag)
-        (key-val (jest 'title: ') (cook crip (star prn)))
-        (key-val (jest 'filename: ') sym)
-        %+  key-val  (jest 'comments: ')
-          ;~(pose (jest %open) (jest %closed) (jest %none))
-        %+  key-val  (jest 'allow-edit: ')
-          ;~(pose (jest %post) (jest %comment) (jest %all) (jest %none))
-        (key-val (jest 'date-created: ~') (cook year when:so))
-        ;~  pose
-          (key-val (jest 'last-modified: ~') (cook year when:so))
-          ;~(pfix (jest 'last-modified: ~') (cook year when:so))
-        ==
+      ;~  (glue gaq)
+        (key-val %owner ;~(pfix sig fed:ag))
+        (key-val %title (cook crip (star prn)))
+        (key-val %filename sym)
+        (key-val %comments (perk %open %closed %none ~))
+        (key-val %allow-edit (perk %post %comment %all %none ~))
+        (key-val %date-created ;~(pfix sig (cook year when:so)))
+        (key-val %last-modified ;~(pfix sig (cook year when:so)))
       ==
     ++  new-parser
-      ;~  plug
-        (key-val (jest 'title: ') (cook crip (star prn)))
-        (key-val (jest 'description: ') (cook crip (star prn)))
-        %+  key-val  (jest 'comments: ')
-          (cook |=(a=@ =(%on a)) ;~(pose (jest %on) (jest %off)))
-        (key-val (jest 'writers: ') ;~(pfix net (more net urs:ab)))
-        ;~  pose
-          (key-val (jest 'subscribers: ') ;~(pfix net (more net urs:ab)))
-          ;~(pfix (jest 'subscribers: ') ;~(pfix net (more net urs:ab)))
-        ==
+      ;~  (glue gaq)
+        (key-val %title (cook crip (star prn)))
+        (key-val %description (cook crip (star prn)))
+        (key-val %comments (fuss %on %off)))
+        (key-val %writers fel:stab)
+        (key-val %subscribers fel:stab)
       ==
     ++  both-parser
       ;~  pose


### PR DESCRIPTION
On review, getting rid of all the `last-modified: ~` is not necessarily a pure improvement; going the other way, here's a sketch of a less idiomatic approach:

```
=,  userlib
=+  [t=(cook crip (star prn)) p=;~(pfix sig fed:ag) da=;~(pfix sig (cook year when:so))]
%-  parsf:scanf
[;"""
  owner: {p}
  title: {t}
  filename: {sym}
  comments: {(perk %open %closed %none ~)}
  allow-edit: {(perk %post %comment %all %none ~)}
  date-created: {da}
  """]
```

**Note:** submitting as a draft because this has not been tested including for syntax errors, the device I was running urbit on got water-damaged QQ 
(Also I don't know where to get copies of the files this is supposed to be parsing, at any rate)