### PR TITLE
shoe: console application library

### DIFF
--- a/pkg/arvo/app/shoe.hoon
+++ b/pkg/arvo/app/shoe.hoon
@@ -1,5 +1,8 @@
 ::  shoe: example usage of /lib/shoe
 ::
+::    the app supports one command: "demo".
+::    running this command renders some text on all sole clients.
+::
 /+  shoe, verb, dbug, default-agent
 |%
 +$  state-0  [%0 ~]
@@ -49,8 +52,11 @@
 ++  on-command
   |=  [sole-id=@ta =command]
   ^-  (quip card _this)
-  :_  this
-  [%shoe ~ %sole %txt "{(scow %p src.bowl)} ran the command"]~
+  =-  [[%shoe ~ %sole -]~ this]
+  =/  =tape  "{(scow %p src.bowl)} ran the command"
+  ?.  =(src our):bowl
+    [%txt tape]
+  [%klr [[`%br ~ `%g] [(crip tape)]~]~]
 ::
 ++  can-connect
   |=  sole-id=@ta

--- a/pkg/arvo/app/shoe.hoon
+++ b/pkg/arvo/app/shoe.hoon
@@ -1,0 +1,64 @@
+::  shoe: example usage of /lib/shoe
+::
+/+  shoe, verb, dbug, default-agent
+|%
++$  state-0  [%0 ~]
++$  command  ~
+::
++$  card  card:shoe
+--
+=|  state-0
+=*  state  -
+::
+%+  verb  |
+%-  agent:dbug
+^-  agent:gall
+%-  (agent:shoe command)
+^-  (shoe:shoe command)
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+    des   ~(. (default:shoe this command) bowl)
+::
+++  on-init   on-init:def
+++  on-save   !>(state)
+++  on-load
+  |=  old=vase
+  ^-  (quip card _this)
+  [~ this]
+::
+++  on-poke   on-poke:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+::
+++  command-parser
+  |=  sole-id=@ta
+  ^+  |~(nail *(like command))
+  (cold ~ (jest 'demo'))
+::
+++  tab-list
+  |=  sole-id=@ta
+  ^-  (list [@t tank])
+  :~  ['demo' leaf+"run example command"]
+  ==
+::
+++  on-command
+  |=  [sole-id=@ta =command]
+  ^-  (quip card _this)
+  :_  this
+  [%shoe ~ %sole %txt "{(scow %p src.bowl)} ran the command"]~
+::
+++  can-connect
+  |=  sole-id=@ta
+  ^-  ?
+  ?|  =(~zod src.bowl)
+      (team:title [our src]:bowl)
+  ==
+::
+++  on-connect      on-connect:des
+++  on-disconnect   on-disconnect:des
+--

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -165,7 +165,7 @@
     =^  cards  shoe  on-init:og
     [(deal cards) this]
   ::
-  ++  on-save   !>([shoe-inner=on-save:og shoe-self=state])
+  ++  on-save   !>([%shoe-app on-save:og state])
   ::
   ++  on-load
     |=  old-state=vase
@@ -173,22 +173,14 @@
     ::  we could be upgrading from a shoe-less app, in which case the vase
     ::  contains inner application state instead of our +on-save.
     ::  to distinguish between the two, we check for the presence of our own
-    ::  +on-save faces in the vase.
+    ::  +on-save tag in the vase.
     ::
-    |^  ?.  worn
-          =^  cards  shoe  (on-load:og old-state)
-          [(deal cards) this]
-        =^  old-inner  state  !<([vase state-0] old-state)
-        =^  cards      shoe   (on-load:og old-inner)
-        [(deal cards) this]
-    ::
-    ++  worn
-      &((have %shoe-inner) (have %shoe-self))
-    ::
-    ++  have
-      |=  =term
-      (head (mule |.((slab term -:old-state))))
-    --
+    ?.  ?=([%shoe-app ^] q.old-state)
+      =^  cards  shoe  (on-load:og old-state)
+      [(deal cards) this]
+    =^  old-inner  state  +:!<([%shoe-app vase state-0] old-state)
+    =^  cards      shoe   (on-load:og old-inner)
+    [(deal cards) this]
   ::
   ++  on-poke
     |=  [=mark =vase]

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -117,9 +117,7 @@
   ::
   ++  can-connect
     |=  sole-id=@ta
-    ?|  =(~zod src.bowl)
-        (team:title [our src]:bowl)
-    ==
+    (team:title [our src]:bowl)
   ::
   ++  on-connect
     |=  sole-id=@ta

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -1,0 +1,341 @@
+::  shoe: console application library
+::
+::    /lib/sole: draw some characters
+::    /lib/shoe: draw the rest of the fscking app
+::
+::    call +agent with a type, then call the resulting function with a core
+::    of the shape described in +shoe.
+::    you may produce classic gall cards and "shoe-effects", shorthands for
+::    sending cli events to connected clients.
+::    default implementations for the shoe-specific arms are in +default.
+::    for a simple usage example, see /app/shoe.
+::
+/-  *sole
+/+  sole, auto=language-server-complete
+|%
++$  state-0
+  $:  %0
+      soles=(map @ta sole-share)
+  ==
+::  $card: standard gall cards plus shoe effects
+::
++$  card
+  $%  card:agent:gall
+      [%shoe sole-ids=(list @ta) effect=shoe-effect]  ::  ~ sends to all soles
+  ==
+::  $shoe-effect: easier sole-effects
+::
++$  shoe-effect
+  $%  [%sole effect=sole-effect]
+      ::TODO  complex screen-draw effects
+  ==
+::  +shoe: gall agent core with extra arms
+::
+++  shoe
+  |*  command-type=mold
+  $_  ^|
+  |_  bowl:gall
+  ++  command-parser
+    |~  sole-id=@ta
+    |~(nail *(like command-type))
+  ::
+  ++  tab-list
+    |~  sole-id=@ta
+    ::  (list [@t tank])
+    *(list (option:auto tank))
+  ::
+  ++  on-command
+    |~  [sole-id=@ta command=command-type]
+    *(quip card _^|(..on-init))
+  ::
+  ++  can-connect
+    |~  sole-id=@ta
+    *?
+  ::
+  ++  on-connect
+    |~  sole-id=@ta
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-disconnect
+    |~  sole-id=@ta
+    *(quip card _^|(..on-init))
+  ::
+  ::NOTE  standard gall agent arms below, though they may produce %shoe cards
+  ::
+  ++  on-init
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-save
+    *vase
+  ::
+  ++  on-load
+    |~  vase
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-poke
+    |~  [mark vase]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-watch
+    |~  path
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-leave
+    |~  path
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-peek
+    |~  path
+    *(unit (unit cage))
+  ::
+  ++  on-agent
+    |~  [wire sign:agent:gall]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-arvo
+    |~  [wire sign-arvo]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-fail
+    |~  [term tang]
+    *(quip card _^|(..on-init))
+  --
+::  +default: bare-minimum implementations of shoe arms
+::
+++  default
+  |*  [shoe=* command-type=mold]
+  |_  =bowl:gall
+  ++  command-parser
+    (easy *command-type)
+  ::
+  ++  tab-list
+    ~
+  ::
+  ++  on-command
+    |=  [sole-id=@ta command=command-type]
+    [~ shoe]
+  ::
+  ++  can-connect
+    |=  sole-id=@ta
+    ?|  =(~zod src.bowl)
+        (team:title [our src]:bowl)
+    ==
+  ::
+  ++  on-connect
+    |=  sole-id=@ta
+    [~ shoe]
+  ::
+  ++  on-disconnect
+    |=  sole-id=@ta
+    [~ shoe]
+  --
+::  +agent: creates wrapper core that handles sole events and calls shoe arms
+::
+++  agent
+  |*  command-type=mold
+  |=  =(shoe command-type)
+  =|  state-0
+  =*  state  -
+  ^-  agent:gall
+  =>
+    |%
+    ++  deal
+      |=  cards=(list card)
+      %+  turn  cards
+      |=  =card
+      ^-  card:agent:gall
+      ?.  ?=(%shoe -.card)  card
+      ?-  -.effect.card
+          %sole
+        =-  [%give %fact - %sole-effect !>(effect.effect.card)]
+        %+  turn
+          ?^  sole-ids.card  sole-ids.card
+          ~(tap in ~(key by soles))
+        |=  sole-id=@ta
+        /sole/[sole-id]
+      ==
+    --
+  ::
+  |_  =bowl:gall
+  +*  this  .
+      og    ~(. shoe bowl)
+  ::
+  ++  on-init
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  on-init:og
+    [(deal cards) this]
+  ::
+  ++  on-save   !>([shoe-inner=on-save:og shoe-self=state])
+  ::
+  ++  on-load
+    |=  old-state=vase
+    ^-  (quip card:agent:gall agent:gall)
+    ::  we could be upgrading from a shoe-less app, in which case the vase
+    ::  contains inner application state instead of our +on-save.
+    ::  to distinguish between the two, we check for the presence of our own
+    ::  +on-save faces in the vase.
+    ::
+    |^  ?.  worn
+          =^  cards  shoe  (on-load:og old-state)
+          [(deal cards) this]
+        =^  old-inner  state  !<([vase state-0] old-state)
+        =^  cards      shoe   (on-load:og old-inner)
+        [(deal cards) this]
+    ::
+    ++  worn
+      &((have %shoe-inner) (have %shoe-self))
+    ::
+    ++  have
+      |=  =term
+      (head (mule |.((slab term -:old-state))))
+    --
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card:agent:gall agent:gall)
+    ?.  ?=(%sole-action mark)
+      =^  cards  shoe  (on-poke:og mark vase)
+      [(deal cards) this]
+    ::
+    =/  act  !<(sole-action vase)
+    =*  sole-id  id.act
+    =/  cli-state=sole-share
+      (~(gut by soles) sole-id *sole-share)
+    |^  =^  [cards=(list card) =_cli-state]  shoe
+          ?-  -.dat.act
+            %det  [(apply-edit +.dat.act) shoe]
+            %clr  [[~ cli-state] shoe]
+            %ret  run-command
+            %tab  [(tab +.dat.act) shoe]
+          ==
+        :-  (deal cards)
+        this(soles (~(put by soles) sole-id cli-state))
+    ::
+    ++  effect
+      |=  =sole-effect
+      ^-  card
+      [%shoe [sole-id]~ %sole sole-effect]
+    ::
+    ++  apply-edit
+      |=  =sole-change
+      ^-  (quip card _cli-state)
+      =^  inverse  cli-state
+        (~(transceive sole cli-state) sole-change)
+      ::  res: & for fully parsed, | for parsing failure at location
+      ::
+      =/  res=(each (unit) @ud)
+        %+  rose  (tufa buf.cli-state)
+        (command-parser:og sole-id)
+      ?:  ?=(%& -.res)  [~ cli-state]
+      ::  parsing failed
+      ::
+      ?.  &(?=(%del -.inverse) =(+(p.inverse) (lent buf.cli-state)))
+        ::  if edit was somewhere in the middle, let it happen anyway
+        ::
+        [~ cli-state]
+      ::  if edit was insertion at buffer tail, revert it
+      ::
+      =^  undo  cli-state
+        (~(transmit sole cli-state) inverse)
+      :_  cli-state
+      :_  ~
+      %+  effect  %mor
+      :~  [%det undo]   ::  undo edit
+          [%err p.res]  ::  cursor to error location
+      ==
+    ::
+    ++  run-command
+      ^+  [[*(list card) cli-state] shoe]
+      =/  cmd=(unit command-type)
+        %+  rust  (tufa buf.cli-state)
+        (command-parser:og sole-id)
+      ?~  cmd
+        [[[(effect %bel ~)]~ cli-state] shoe]
+      =^  cards  shoe  (on-command:og sole-id u.cmd)
+      ::  clear buffer
+      ::
+      =^  clear  cli-state  (~(transmit sole cli-state) [%set ~])
+      =-  [[[- cards] cli-state] shoe]
+      %+  effect  %mor
+      :~  [%nex ~]
+          [%det clear]
+      ==
+    ::
+    ::NOTE  cargo-culted
+    ++  tab
+      |=  pos=@ud
+      ^-  (quip card _cli-state)
+      =+  (get-id:auto pos (tufa buf.cli-state))
+      =/  needle=term
+        (fall id %$)
+      ::  autocomplete empty command iff user at start of command
+      ::
+      =/  options=(list (option:auto tank))
+        (search-prefix:auto needle (tab-list:og sole-id))
+      =/  advance=term
+        (longest-match:auto options)
+      =/  to-send=tape
+        %-  trip
+        (rsh 3 (met 3 needle) advance)
+      =/  send-pos=@ud
+        %+  add  pos
+        (met 3 (fall forward ''))
+      =|  cards=(list card)
+      =?  cards  ?=(^ options)
+        [(effect %tab options) cards]
+      |-  ^-  (quip card _cli-state)
+      ?~  to-send
+        [(flop cards) cli-state]
+      =^  char  cli-state
+        (~(transmit sole cli-state) [%ins send-pos `@c`i.to-send])
+      %_  $
+        cards     [(effect %det char) cards]
+        send-pos  +(send-pos)
+        to-send   t.to-send
+      ==
+    --
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    ?.  ?=([%sole @ ~] path)
+      =^  cards  shoe
+        (on-watch:og path)
+      [(deal cards) this]
+    =*  sole-id  i.t.path
+    ?>  (can-connect:og sole-id)
+    =.  soles  (~(put by soles) sole-id *sole-share)
+    =^  cards  shoe
+      (on-connect:og sole-id)
+    :_  this
+    %-  deal
+    :_  cards
+    [%shoe [sole-id]~ %sole %pro & dap.bowl "> "]
+  ::
+  ++  on-leave
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-leave:og path)
+    [(deal cards) this]
+  ::
+  ++  on-peek  on-peek:og
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-agent:og wire sign)
+    [(deal cards) this]
+  ::
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-arvo:og wire sign-arvo)
+    [(deal cards) this]
+  ::
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-fail:og term tang)
+    [(deal cards) this]
+  --
+--

--- a/pkg/arvo/lib/sole.hoon
+++ b/pkg/arvo/lib/sole.hoon
@@ -99,7 +99,7 @@
   |=  sole-change
   ^-  {sole-edit sole-share}
   ?.  &(=(his.ler his.ven) (lte own.ler own.ven))
-    ~&  [%receive-sync his+[his.ler his.ven] own+[own.ler own.ven]]
+    ~|  [%receive-sync his+[his.ler his.ven] own+[own.ler own.ven]]
     !!
   ?>  &(=(his.ler his.ven) (lte own.ler own.ven))
   ?>  |(!=(own.ler own.ven) =(`@`0 haw) =(haw (sham buf)))


### PR DESCRIPTION
In which we invent footwear that's actually comfortable to walk in.

Sole expects applications to do non-trivial logic, but applications often just want to implement some text commands. `/lib/shoe` can take care of that lower-level work.

Wrap as `((shoe command-type) your-agent)`, where `command-type` is the type of CLI commands for your app, and `your-agent` is a standard gall agent, with five extra arms: `+command-parser`, `+tab-list`, `+on-command`, `+on-connect`, and `+on-disconnect`. The extra arms will be called by `/lib/shoe` whenever it needs to deal with sole events.

Further documentation is in the lib itself, and the example `/app/shoe`.

This PR includes a commit for making chat-cli use sole. Modifies existing version upgrade logic instead of creating a new version, since `%2` hasn't gone out onto the network yet. Would be nice to get this in alongside that if possible, we need the re-link here too.

Going forward, we should try adding `shoe-effect`s along the lines of "draw table row with this data" or similar, allowing parts of output rendering to be taken up by `/lib/shoe`.

(Took the liberty of merging master into `release/next-sys` prior to these commits, to avoid a merge conflict in chat-cli.)