### PR TITLE
zuse: improve json to rn parsing

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5a70c8ce5e2f28d5bcfc17fe3e94955c18716cb534922682b62ee964668992e
-size 12885823
+oid sha256:de3b622f4ce90a9c2ce73fa233ba356e239a64d8aa4820ea7f48663110aa3fdd
+size 18821765

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5538,9 +5538,9 @@
         ==
         ;~  pose
           ;~  pfix
-            (just 'e')
+            (mask "eE")
             ;~  plug
-              ;~(pose (cold | hep) (easy &))
+              ;~(pose (cold | hep) (cold & lus) (easy &))
               ;~  pose
                 ;~(pfix (plus (just '0')) dim:ag)
                 dim:ag


### PR DESCRIPTION
Allow the exponent token to be 'e' or 'E', allow the explicit sign of '+'.
Following the spec at https://json.org.

Fixes the bug Jose discovered in https://github.com/urbit/urbit/pull/1892#issuecomment-633428939.

Closes #2935.