### PR TITLE
behn: fix bug with timers at same date

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2416f1b963cfa2c76d5f18f7164ad1bd4c42080879ee0ec0c9ec6052e60a4c01
-size 13802426
+oid sha256:869783fa440d654aae5354d950edd527067691a34947645cba2cffea2737ab89
+size 13813188


### PR DESCRIPTION
Changes Behn's `.timers` data structure to maintain a queue for each date at which we have timers, preserving insertion order.