### PR TITLE
hoon: add doq, kel, ker, pal, pam, par, pat, sel, ser, soq, tic

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5591,46 +5591,58 @@
 ::::  4h: parsing (ascii glyphs)
   ::
 ++  ace  (just ' ')
-++  ban  (just '>')
 ++  bar  (just '|')
-++  bas  (just '\\')  ::  XX deprecated
-++  bat  (just '\\')
-++  buc  (just '$')   ::  XX deprecated
-++  bus  (just '$')
+++  bas  (just '\\')
+++  buc  (just '$')
 ++  cab  (just '_')
 ++  cen  (just '%')
 ++  col  (just ':')
 ++  com  (just ',')
+++  doq  (just '"')
 ++  dot  (just '.')
-++  fas  (just '/')  ::  XX deprecated?
-++  gal  (just '<')   ::  XX deprecated
-++  gar  (just '>')   ::  XX deprecated
-++  vat  (just '@')   ::  pronounced "at"
+++  fas  (just '/')
+++  gal  (just '<')
+++  gar  (just '>')
 ++  hax  (just '#')
 ++  hep  (just '-')   ::  pronounced "ep"
+++  kel  (just '{')
+++  ker  (just '}')
 ++  ket  (just '^')
-++  leb  (just '{')
-++  led  (just '<')
-++  lob  (just '{')
-++  lit  (just '(')
-++  lac  (just '[')
 ++  lus  (just '+')
 ++  mic  (just ';')   ::  pronounced "mick"
-++  net  (just '/')
-++  pad  (just '&')
-++  rac  (just ']')
-++  reb  (just '}')
-++  rob  (just '}')
-++  rit  (just ')')
-++  say  (just '\'')
+++  pal  (just '(')
+++  pam  (just '&')
+++  par  (just ')')
+++  pat  (just '@')
+++  sel  (just '[')
+++  ser  (just ']')
 ++  sig  (just '~')
+++  soq  (just '\'')
 ++  tar  (just '*')
-++  tec  (just '`')
+++  tic  (just '`')
 ++  tis  (just '=')   ::  pronounced "is"
-++  toc  (just '"')   ::  XX deprecated
-++  yel  (just '"')
 ++  wut  (just '?')
 ++  zap  (just '!')
+::
+++  ban  (just '>')   ::  XX deprecated, use gar
+++  bat  (just '\\')  ::  XX deprecated, use bas
+++  bus  (just '$')   ::  XX deprecated, use buc
+++  lac  (just '[')   ::  XX deprecated, use sel
+++  leb  (just '{')   ::  XX deprecated, use kel
+++  led  (just '<')   ::  XX deprecated, use gal
+++  lit  (just '(')   ::  XX deprecated, use pal
+++  lob  (just '{')   ::  XX deprecated, use kel
+++  net  (just '/')   ::  XX deprecated, use fas
+++  pad  (just '&')   ::  XX deprecated, use pam
+++  rac  (just ']')   ::  XX deprecated, use ser
+++  reb  (just '}')   ::  XX deprecated, use ker
+++  rit  (just ')')   ::  XX deprecated, use par
+++  rob  (just '}')   ::  XX deprecated, use ker
+++  say  (just '\'')  ::  XX deprecated, use soq
+++  tec  (just '`')   ::  XX deprecated, use tic
+++  toc  (just '"')   ::  XX deprecated, use doq
+++  vat  (just '@')   ::  XX deprecated, use pat   ::  pronounced "at"
+++  yel  (just '"')   ::  XX deprecated, use doq
 ::
 ::::  4i: parsing (useful idioms)
   ::


### PR DESCRIPTION
      update "XX deprecated" comments to match:
      https://urbit.org/docs/tutorials/hoon/hoon-syntax/#reading-hoon-aloud

WIP: do not merge.

Replaces https://github.com/urbit/urbit/pull/2930.

I'll start by replacing calls to the deprecated parsers.
I'll do this as a series of commits.
Then I'll replace `%bscb` with `%bccb`, etc, in another
series of commits.

Work diary (I will update this with each commit):

```
git clone -b na-release/next-vere https://github.com/urbit/urbit.git urbit-na-release-next-vere
cd urbit-na-release-next-vere
```
Add `doq`, `kel`, `ker`, `pal`, `pam`, `par`, `pat`, `sel`, `ser`, `soq`, `tic`
to `pkg/arvo/sys/hoon/hoon` and create a fakezod:
```
urbit -A pkg/arvo -B bin/solid.pill -F zod
```
Create new pill with added parsers:
```
.parse-add/pill +solid
^d
```
Move `zod` out of the way:
```
mv zod zod-orig
```

Check work so far:
```
urbit -B zod-orig/.urb/put/parse-add.pill -F zod
```
```
doq
<1.iot {tub/{p/{p/@ud q/@ud} q/""} <1.rff {daf/@t <259.zbf 51.qgd 129.iya 41.mac 1.ane $141>}>}>
```
Delete check `zod`:
```
rm -Rf zod
```
Next up: `bus` to `buc`.
