### PR TITLE
ames: don't set new timer if we woke up too early

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1669,6 +1669,11 @@
           peer-core
         ?~  next-wake.packet-pump-state.u.message-pump-state
           peer-core
+        ::  If we crashed because we woke up too early, assume another
+        ::  timer is already set.
+        ::
+        ?:  (lth now.channel u.next-wake.packet-pump-state.u.message-pump-state)
+          peer-core
         ::
         =/  =wire  (make-pump-timer-wire her.channel bone)
         (emit duct %pass wire %b %wait (add now.channel ~s30))


### PR DESCRIPTION
Otherwise if we end up having multple outstanding timers, they never
coalesce to a single timer.