### PR TITLE
hoon: update on-save

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -140,7 +140,7 @@
   `..on-init
 ::
 ++  on-save
-  !>([%4 lac])
+  !>([%5 lac])
 ::
 ++  on-load
   |=  =old-state=vase


### PR DESCRIPTION
Whoops, all updates are relinking dojo/chat-cli.  Not an urgent problem.