### PR TITLE
hoon: add doq, kel, ker, pal, pam, par, pat, sel, ser, soq, tic

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2416f1b963cfa2c76d5f18f7164ad1bd4c42080879ee0ec0c9ec6052e60a4c01
-size 13802426
+oid sha256:947be4fb752c2fb232b141c9ea1a8c80eff38325764010ea78c8755271a65f63
+size 13796458

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -534,7 +534,7 @@
     ::
     ++  tag   |*(a=@tas (cold a (jest a)))  ::TODO  into stdlib
     ++  ship  ;~(pfix sig fed:ag)
-    ++  path  ;~(pfix net ;~(plug urs:ab (easy ~)))  ::NOTE  short only, tmp
+    ++  path  ;~(pfix fas ;~(plug urs:ab (easy ~)))  ::NOTE  short only, tmp
     ::  +mang: un/managed indicator prefix
     ::
     ++  mang

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -618,7 +618,7 @@
     ++  letter
       ;~  pose
         (stag %url turl)
-        (stag %me ;~(pfix vat text))
+        (stag %me ;~(pfix pat text))
         (stag %text ;~(less mic hax text))
       ==
     ::  +turl: url parser

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -154,7 +154,7 @@
         ==
       ==
     ::
-      ;~  pfix  net
+      ;~  pfix  fas
         ;~  pose
           (parse-variable (cold %sur hep) ;~(pfix gap parse-cables))
           (parse-variable (cold %lib lus) ;~(pfix gap parse-cables))
@@ -168,8 +168,8 @@
   ++  parse-sink
     ;~  pose
       ;~(plug (cold %file tar) parse-beam)
-      ;~(plug (cold %flat pat) (most net sym))
-      ;~(plug (cold %pill dot) (most net sym))
+      ;~(plug (cold %flat pat) (most fas sym))
+      ;~(plug (cold %pill dot) (most fas sym))
       ;~(plug (cold %http lus) (stag %post parse-url))
       ;~(plug (cold %http hep) (stag %put parse-url))
       (stag %show (cook $?($1 $2 $3 $4 $5) (cook lent (stun [1 5] wut))))
@@ -217,7 +217,7 @@
     ;~  pose
       ;~  plug
         ;~(pfix sig fed:ag)
-        ;~(pose ;~(pfix net sym) (easy default-app))
+        ;~(pose ;~(pfix fas sym) (easy default-app))
       ==
       %+  stag  our
       ;~(pose sym (easy default-app))
@@ -252,7 +252,7 @@
     auri:de-purl:html
   ::
   ++  parse-model   ;~(plug parse-server parse-config)
-  ++  parse-server  (stag 0 (most net sym))
+  ++  parse-server  (stag 0 (most fas sym))
   ++  parse-hoon    tall:hoon-parser
   ::
   ++  parse-rood

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -207,7 +207,7 @@
         ;~(plug (cold %ur lus) parse-url)
         ;~(plug (cold %ge lus) parse-model)
         ;~(plug (cold %te hep) sym (star ;~(pfix ace parse-source)))
-        ;~(plug (cold %as pad) sym ;~(pfix ace parse-source))
+        ;~(plug (cold %as pam) sym ;~(pfix ace parse-source))
         ;~(plug (cold %do cab) parse-hoon ;~(pfix ace parse-source))
         parse-value
       ==
@@ -273,7 +273,7 @@
     ==
   ++  parse-value
     ;~  pose
-      (stag %sa ;~(pfix tar pad sym))
+      (stag %sa ;~(pfix tar pam sym))
       (stag %ex parse-hoon)
       (stag %tu (ifix [lac rac] (most ace parse-source)))
     ==

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -168,7 +168,7 @@
   ++  parse-sink
     ;~  pose
       ;~(plug (cold %file tar) parse-beam)
-      ;~(plug (cold %flat vat) (most net sym))
+      ;~(plug (cold %flat pat) (most net sym))
       ;~(plug (cold %pill dot) (most net sym))
       ;~(plug (cold %http lus) (stag %post parse-url))
       ;~(plug (cold %http hep) (stag %put parse-url))

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -275,7 +275,7 @@
     ;~  pose
       (stag %sa ;~(pfix tar pam sym))
       (stag %ex parse-hoon)
-      (stag %tu (ifix [lac rac] (most ace parse-source)))
+      (stag %tu (ifix [sel ser] (most ace parse-source)))
     ==
   ::
   ++  parse-config

--- a/pkg/arvo/gen/hood/static.hoon
+++ b/pkg/arvo/gen/hood/static.hoon
@@ -24,8 +24,8 @@
   =/  parsed=(unit (list coin))
   %+  rust  link
   ;~  pose
-    ;~(pfix net (more net nuck:so))
-    (more net nuck:so)
+    ;~(pfix fas (more fas nuck:so))
+    (more fas nuck:so)
   ==
   ?~  parsed
     link

--- a/pkg/arvo/lib/bip32.hoon
+++ b/pkg/arvo/lib/bip32.hoon
@@ -81,7 +81,7 @@
 ++  derivation-path
   ;~  pfix
     ;~(pose (jest 'm/') (easy ~))
-  %+  most  net
+  %+  most  fas
   ;~  pose
     %+  cook
       |=(i=@ (add i (bex 31)))

--- a/pkg/arvo/lib/bip32.hoon
+++ b/pkg/arvo/lib/bip32.hoon
@@ -85,7 +85,7 @@
   ;~  pose
     %+  cook
       |=(i=@ (add i (bex 31)))
-    ;~(sfix dem say)
+    ;~(sfix dem soq)
   ::
     dem
   ==  ==

--- a/pkg/arvo/lib/language-server/build.hoon
+++ b/pkg/arvo/lib/language-server/build.hoon
@@ -11,7 +11,7 @@
   =/  parse-path
     %+  cook
       |=(p=path (slag 3 p))
-    (ifix [net (jest '::')] (more net urs:ab))
+    (ifix [fas (jest '::')] (more fas urs:ab))
   =/  parse-full
     ;~(plug parse-path ;~(sfix ;~((glue dot) parse-pair parse-pair) gar))
   (rust tape parse-full)

--- a/pkg/arvo/lib/language-server/build.hoon
+++ b/pkg/arvo/lib/language-server/build.hoon
@@ -13,7 +13,7 @@
       |=(p=path (slag 3 p))
     (ifix [net (jest '::')] (more net urs:ab))
   =/  parse-full
-    ;~(plug parse-path ;~(sfix ;~((glue dot) parse-pair parse-pair) ban))
+    ;~(plug parse-path ;~(sfix ;~((glue dot) parse-pair parse-pair) gar))
   (rust tape parse-full)
 ::
 ++  get-errors-from-tang

--- a/pkg/arvo/lib/language-server/build.hoon
+++ b/pkg/arvo/lib/language-server/build.hoon
@@ -7,7 +7,7 @@
   =/  parse-pair
     %+  cook
       |=([row=@ud col=@ud] [(dec row) col])
-    (ifix [lac rac] ;~((glue ace) dem dem))
+    (ifix [sel ser] ;~((glue ace) dem dem))
   =/  parse-path
     %+  cook
       |=(p=path (slag 3 p))

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -120,7 +120,7 @@
     ::
     ++  parse-alts
       %+  wide-or-tall
-        (ifix [lit rit] (most ace subcrane))
+        (ifix [pal par] (most ace subcrane))
       ;~(sfix (star subcrane) gap duz)
     ::  +parse-face: parse a face around a subcrane
     ::

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -77,7 +77,7 @@
           (stag %fssg ;~(pfix sig hoon))
           ::  `/$`  process query string
           ::
-          (stag %fsbc ;~(pfix bus hoon))
+          (stag %fsbc ;~(pfix buc hoon))
           ::  `/|`  first of many options that succeeds
           ::
           (stag %fsbr ;~(pfix bar parse-alts))

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -17,19 +17,19 @@
       ::  parses the zuse version, eg "/?  309"
       ::
         ;~  pose
-          (ifix [;~(plug net wut gap) gap] dem)
+          (ifix [;~(plug fas wut gap) gap] dem)
           (easy zuse)
         ==
       ::  pareses the structures, eg "/-  types"
       ::
         ;~  pose
-          (ifix [;~(plug net hep gap) gap] (most ;~(plug com gaw) cable))
+          (ifix [;~(plug fas hep gap) gap] (most ;~(plug com gaw) cable))
           (easy ~)
         ==
       ::  parses the libraries, eg "/+  lib1, lib2"
       ::
         ;~  pose
-          (ifix [;~(plug net lus gap) gap] (most ;~(plug com gaw) cable))
+          (ifix [;~(plug fas lus gap) gap] (most ;~(plug com gaw) cable))
           (easy ~)
         ==
       ::
@@ -42,7 +42,7 @@
   ++  beam
     %+  sear  de-beam:format
     ;~  pfix
-      net
+      fas
       (sear plex (stag %clsg poor)):hoon-parser
     ==
   ::  +cable: parses a +^cable, a reference to something on the filesystem
@@ -70,7 +70,7 @@
     |%
     ++  apex
       %+  knee  *^crane  |.  ~+
-      ;~  pfix  net
+      ;~  pfix  fas
         ;~  pose
           ::  `/~`  hoon literal
           ::
@@ -110,10 +110,10 @@
           (stag %fstr ;~(pfix tar subcrane))
           ::  `/!mark/ evaluate as hoon, then pass through mark
           ::
-          (stag %fszp ;~(pfix zap ;~(sfix sym net)))
+          (stag %fszp ;~(pfix zap ;~(sfix sym fas)))
           ::  `/mark/` passes current path through :mark
           ::
-          (stag %fszy ;~(sfix sym net))
+          (stag %fszy ;~(sfix sym fas))
         ==
       ==
     ::  +parse-alts: parse a set of alternatives
@@ -140,7 +140,7 @@
       %+  wide-or-tall
         fail
       =-  ;~(sfix (star -) gap duz)
-      ;~(pfix gap net ;~(plug static-path subcrane))
+      ;~(pfix gap fas ;~(plug static-path subcrane))
     ::  +parse-pipe: parses a pipe of mark conversions
     ::
     ++  parse-pipe
@@ -188,11 +188,11 @@
   ::  +static-path: parses a path
   ::
   ++  static-path
-    (sear plex (stag %clsg (more net hasp))):hoon-parser
+    (sear plex (stag %clsg (more fas hasp))):hoon-parser
   ::  +late-bound-path: a path whose time varies
   ::
   ++  late-bound-path
-    ;~  pfix  net
+    ;~  pfix  fas
       %+  cook  |=(a=truss a)
       =>  hoon-parser
       ;~  plug

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -182,7 +182,7 @@
     ::
     ++  hoon
       %+  wide-or-tall
-        (ifix [lac rac] (stag %cltr (most ace wide:hoon-parser)))
+        (ifix [sel ser] (stag %cltr (most ace wide:hoon-parser)))
       ;~(pfix gap tall:hoon-parser)
     --
   ::  +static-path: parses a path

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -92,7 +92,7 @@
           (stag %fscm ;~(pfix com parse-switch))
           ::  `/&`  pass through a series of mark
           ::
-          (stag %fspm ;~(pfix pad parse-pipe))
+          (stag %fspm ;~(pfix pam parse-pipe))
           ::  `/_`  run a crane on each file in the current directory
           ::
           (stag %fscb ;~(pfix cab subcrane))
@@ -145,7 +145,7 @@
     ::
     ++  parse-pipe
       %+  wide-or-tall
-        ;~(plug (plus ;~(sfix sym pad)) subcrane)
+        ;~(plug (plus ;~(sfix sym pam)) subcrane)
       =+  (cook |=(a=term [a ~]) sym)
       ;~(pfix gap ;~(plug - subcrane))
     ::  +parse-gate: parses a gate applied to a crane

--- a/pkg/arvo/mar/lens/command.hoon
+++ b/pkg/arvo/mar/lens/command.hoon
@@ -32,7 +32,7 @@
         %-  su
         ;~  plug
             sym
-            ;~(pfix col (more net (cook crip (star ;~(less net prn)))))
+            ;~(pfix col (more fas (cook crip (star ;~(less fas prn)))))
         ==
         listen-api+(su ;~(plug sym ;~(pfix col sym)))
         export+so
@@ -54,7 +54,7 @@
         %-  su
         ;~  plug
             sym
-            ;~(pfix col (more net (cook crip (star ;~(less net prn)))))
+            ;~(pfix col (more fas (cook crip (star ;~(less fas prn)))))
         ==
         command+so
         app+(su sym)

--- a/pkg/arvo/mar/publish/info.hoon
+++ b/pkg/arvo/mar/publish/info.hoon
@@ -49,10 +49,10 @@
         (key-val (jest 'description: ') (cook crip (star qit)))
         %+  key-val  (jest 'comments: ')
           (cook |=(a=@ =(%on a)) ;~(pose (jest %on) (jest %off)))
-        (key-val (jest 'writers: ') ;~(pfix net (more net urs:ab)))
+        (key-val (jest 'writers: ') ;~(pfix fas (more fas urs:ab)))
         ;~  pose
-          (key-val (jest 'subscribers: ') ;~(pfix net (more net urs:ab)))
-          ;~(pfix (jest 'subscribers: ') ;~(pfix net (more net urs:ab)))
+          (key-val (jest 'subscribers: ') ;~(pfix fas (more fas urs:ab)))
+          ;~(pfix (jest 'subscribers: ') ;~(pfix fas (more fas urs:ab)))
         ==
       ==
     ++  both-parser

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5683,13 +5683,13 @@
              ;~(less ;~(plug (just `@`10) soz) (just `@`10))
          ==
 ++  qit  ;~  pose                                       ::  chars in a cord
-             ;~(less bat say prn)
-             ;~(pfix bat ;~(pose bat say mes))          ::  escape chars
+             ;~(less bat soq prn)
+             ;~(pfix bat ;~(pose bat soq mes))          ::  escape chars
          ==
-++  qut  ;~  simu  say                                  ::  cord
+++  qut  ;~  simu  soq                                  ::  cord
            ;~  pose
              ;~  less  soz
-               (ifix [say say] (boss 256 (more gon qit)))
+               (ifix [soq soq] (boss 256 (more gon qit)))
              ==
              =+  hed=;~(pose ;~(plug (plus ace) vul) (just '\0a'))
              %-  iny  %+  ifix
@@ -5698,7 +5698,7 @@
              (boss 256 (star qat))
            ==
          ==
-++  soz  ;~(plug say say say)                           ::  delimiting '''
+++  soz  ;~(plug soq soq soq)                           ::  delimiting '''
 ++  sym                                                 ::  symbol
   %+  cook
     |=(a/tape (rap 3 ^-((list @) a)))
@@ -5799,7 +5799,7 @@
              (cook tuft (ifix [sig dot] hex))
              ;~(pfix sig ;~(pose sig dot))
            ==
-  ++  voy  ;~(pfix bat ;~(pose bat say bix))
+  ++  voy  ;~(pfix bat ;~(pose bat soq bix))
   --
 ++  ag
   |%

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12144,7 +12144,7 @@
             ==
   ++  glam  ~+((glue ace))
   ++  hasp  ;~  pose                                    ::  path element
-              (ifix [lac rac] wide)
+              (ifix [sel ser] wide)
               (stag %cncl (ifix [pal par] (most ace wide)))
               (stag %sand (stag %tas (cold %$ buc)))
               (stag %sand (stag %t qut))
@@ -13160,7 +13160,7 @@
         ::
           %+  stag  %link
           ;~  (glue (punt whit))
-            (ifix [lac rac] (cool (cash rac) werk))
+            (ifix [sel ser] (cool (cash ser) werk))
             (ifix [pal par] (cash par))
           ==
         ::
@@ -13169,7 +13169,7 @@
           %+  stag  %mage
           ;~  pfix  zap
             ;~  (glue (punt whit))
-              (ifix [lac rac] (cash rac))
+              (ifix [sel ser] (cash ser))
               (ifix [pal par] (cash par))
             ==
           ==
@@ -13387,7 +13387,7 @@
         ::
         (stag %bscl (ifix [lob rob] (most ace wyde)))
       :-  '['
-        (stag %bscl (ifix [lac rac] (most ace wyde)))
+        (stag %bscl (ifix [sel ser] (most ace wyde)))
       :-  '*'
         (cold [%base %noun] tar)
       :-  '/'
@@ -13596,7 +13596,7 @@
         ::
           ;~  pfix  sig
             ;~  pose
-              (stag %clsg (ifix [lac rac] (most ace wide)))
+              (stag %clsg (ifix [sel ser] (most ace wide)))
             ::
               %+  stag  %cnsg
               %+  ifix
@@ -13920,14 +13920,14 @@
         ;~  pfix  (jest '+*')
           ;~  plug
             ;~(pfix gap sym)
-            ;~(pfix gap (ifix [lac rac] (most ace sym)))
+            ;~(pfix gap (ifix [sel ser] (most ace sym)))
             ;~(pfix gap loan)
           ==
         ==
       ==
    ::  parses a or [a b c] or a  b  c  ==
    ++  lynx
-      =/  wid  (ifix [lac rac] (most ace sym))
+      =/  wid  (ifix [sel ser] (most ace sym))
       =/  tal
         ;~  sfix
           (most gap sym)
@@ -14179,7 +14179,7 @@
         ;~  gunk
           ;~  pose
             dem
-            (ifix [lac rac] ;~(plug dem ;~(pfix ace dem)))
+            (ifix [sel ser] ;~(plug dem ;~(pfix ace dem)))
           ==
           loaf
         ==
@@ -14242,7 +14242,7 @@
     %+  cook  |=(hoon +<)
     %+  stag  %cltr
     %+  ifix
-      [;~(plug lac gap) ;~(plug gap rac)]
+      [;~(plug sel gap) ;~(plug gap ser)]
     (most gap tall)
   ::
   ++  ropa  (most col rope)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12470,7 +12470,7 @@
       %+  cook  |=(a/marl:hoot a)
       ;~  pose
         ;~  less  (jest '"""')
-          (ifix [yel yel] (cook collapse-chars quote-innards))
+          (ifix [doq doq] (cook collapse-chars quote-innards))
         ==
       ::
         %-  inde
@@ -12482,7 +12482,7 @@
       %+  cook  |=(a/(list $@(@ tuna:hoot)) a)
       %-  star
       ;~  pose
-        ;~(pfix bas ;~(pose (mask "-+*%;\{") bas yel bix:ab))
+        ;~(pfix bas ;~(pose (mask "-+*%;\{") bas doq bix:ab))
         inline-embed
         ;~(less bas lob ?:(in-tall-form fail doq) prn)
         ?:(lin fail ;~(less (jest '\0a"""') (just '\0a')))
@@ -13142,7 +13142,7 @@
         ::
         ::  "quoted text"
         ::
-          (stag %quod (ifix [yel yel] (cool (cash yel) werk)))
+          (stag %quod (ifix [doq doq] (cool (cash doq) werk)))
         ::
         ::  `classic markdown quote`
         ::
@@ -13619,11 +13619,11 @@
   ++  soil
     ;~  pose
       ;~  less  (jest '"""')
-        %+  ifix  [yel yel]
+        %+  ifix  [doq doq]
         %-  star
         ;~  pose
-          ;~(pfix bas ;~(pose bas yel lob bix:ab))
-          ;~(less yel bas lob prn)
+          ;~(pfix bas ;~(pose bas doq lob bix:ab))
+          ;~(less doq bas lob prn)
           (stag ~ sump)
         ==
       ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12484,7 +12484,7 @@
       ;~  pose
         ;~(pfix bas ;~(pose (mask "-+*%;\{") bas yel bix:ab))
         inline-embed
-        ;~(less bas lob ?:(in-tall-form fail toc) prn)
+        ;~(less bas lob ?:(in-tall-form fail doq) prn)
         ?:(lin fail ;~(less (jest '\0a"""') (just '\0a')))
       ==
     ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12484,12 +12484,12 @@
       ;~  pose
         ;~(pfix bas ;~(pose (mask "-+*%;\{") bas doq bix:ab))
         inline-embed
-        ;~(less bas lob ?:(in-tall-form fail doq) prn)
+        ;~(less bas kel ?:(in-tall-form fail doq) prn)
         ?:(lin fail ;~(less (jest '\0a"""') (just '\0a')))
       ==
     ::
     ++  bracketed-elem                                  ::  bracketed element
-      %+  ifix  [lob rob]
+      %+  ifix  [kel ker]
       ;~(plug tag-head wide-elems)
     ::
     ++  wrapped-elems                                   ::  wrapped tuna
@@ -13385,7 +13385,7 @@
       :-  '{'
         ::  XX deprecated
         ::
-        (stag %bscl (ifix [lob rob] (most ace wyde)))
+        (stag %bscl (ifix [kel ker] (most ace wyde)))
       :-  '['
         (stag %bscl (ifix [sel ser] (most ace wyde)))
       :-  '*'
@@ -13485,7 +13485,7 @@
       :-  '('
         (stag %cncl (ifix [pal par] (most ace wide)))
       :-  '{'
-        (stag %ktcl (stag %bscl (ifix [lob rob] (most ace wyde))))
+        (stag %ktcl (stag %bscl (ifix [kel ker] (most ace wyde))))
       :-  '*'
         ;~  pose
           (stag %kttr ;~(pfix tar wyde))
@@ -13622,8 +13622,8 @@
         %+  ifix  [doq doq]
         %-  star
         ;~  pose
-          ;~(pfix bas ;~(pose bas doq lob bix:ab))
-          ;~(less doq bas lob prn)
+          ;~(pfix bas ;~(pose bas doq kel bix:ab))
+          ;~(less doq bas kel prn)
           (stag ~ sump)
         ==
       ==
@@ -13632,13 +13632,13 @@
         [(jest '"""\0a') (jest '\0a"""')]
       %-  star
       ;~  pose
-        ;~(pfix bas ;~(pose bas lob bix:ab))
-        ;~(less bas lob prn)
+        ;~(pfix bas ;~(pose bas kel bix:ab))
+        ;~(less bas kel prn)
         ;~(less (jest '\0a"""') (just `@`10))
         (stag ~ sump)
       ==
     ==
-  ++  sump  (ifix [lob rob] (stag %cltr (most ace wide)))
+  ++  sump  (ifix [kel ker] (stag %cltr (most ace wide)))
   ++  norm                                              ::  rune regular form
     |=  tol/?
     |%

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12146,7 +12146,7 @@
   ++  hasp  ;~  pose                                    ::  path element
               (ifix [lac rac] wide)
               (stag %cncl (ifix [lit rit] (most ace wide)))
-              (stag %sand (stag %tas (cold %$ bus)))
+              (stag %sand (stag %tas (cold %$ buc)))
               (stag %sand (stag %t qut))
               %+  cook
                 |=(a/coin [%sand ?:(?=({~ $tas *} a) %tas %ta) ~(rent co a)])
@@ -13152,7 +13152,7 @@
         ::
           %+  stag  %code
           ;~  plug
-            lus  ;~(pose lus hep bus tar)
+            lus  ;~(pose lus hep buc tar)
             low  (star ;~(pose nud low hep col))
           ==
         ::
@@ -13198,7 +13198,7 @@
               tash:so
               ;~(pfix dot perd:so)
               ;~(pfix sig ;~(pose twid:so (easy [%$ %n 0])))
-              ;~(pfix cen ;~(pose sym bus pad bar qut nuck:so))
+              ;~(pfix cen ;~(pose sym buc pad bar qut nuck:so))
             ==
           ::
             ;~(simu whit (easy ~))
@@ -13351,11 +13351,11 @@
         ;~(pfix com (stag %bsmc wide))
       :-  '$'
         ;~  pose
-          ;~  pfix  bus
+          ;~  pfix  buc
             ;~  pose
             ::  XX all three deprecated
             ::
-              (stag %leaf (stag %tas (cold %$ bus)))
+              (stag %leaf (stag %tas (cold %$ buc)))
               (stag %leaf (stag %t qut))
               (stag %leaf (sear |=(a/coin ?:(?=($$ -.a) (some +.a) ~)) nuck:so))
             ==
@@ -13366,7 +13366,7 @@
         ;~  pose
           ;~  pfix  cen
             ;~  pose
-              (stag %leaf (stag %tas (cold %$ bus)))
+              (stag %leaf (stag %tas (cold %$ buc)))
               (stag %leaf (stag %f (cold & pad)))
               (stag %leaf (stag %f (cold | bar)))
               (stag %leaf (stag %t qut))
@@ -13391,7 +13391,7 @@
       :-  '*'
         (cold [%base %noun] tar)
       :-  '/'
-        ;~(pfix net (stag %loop ;~(pose (cold %$ bus) sym)))
+        ;~(pfix net (stag %loop ;~(pose (cold %$ buc) sym)))
       :-  '@'
         ;~(pfix vat (stag %base (stag %atom mota)))
       :-  '?'
@@ -13450,11 +13450,11 @@
         ;~(pfix cab (stag %ktcl (stag %bscb wide)))
       :-  '$'
         ;~  pose
-          ;~  pfix  bus
+          ;~  pfix  buc
             ;~  pose
               ::  XX: these are all obsolete in hoon 142
               ::
-              (stag %leaf (stag %tas (cold %$ bus)))
+              (stag %leaf (stag %tas (cold %$ buc)))
               (stag %leaf (stag %t qut))
               (stag %leaf (sear |=(a/coin ?:(?=($$ -.a) (some +.a) ~)) nuck:so))
             ==
@@ -13465,7 +13465,7 @@
         ;~  pfix  cen
           ;~  pose
             (stag %clsg (sear |~({a/@ud b/tyke} (posh ~ ~ a b)) porc))
-            (stag %rock (stag %tas (cold %$ bus)))
+            (stag %rock (stag %tas (cold %$ buc)))
             (stag %rock (stag %f (cold & pad)))
             (stag %rock (stag %f (cold | bar)))
             (stag %rock (stag %t qut))
@@ -13646,7 +13646,7 @@
       %-  stew
       ^.  stet  ^.  limo
       :~  :-  '$'
-            ;~  pfix  bus
+            ;~  pfix  buc
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %bscl exqs)]
@@ -13713,11 +13713,11 @@
                   ['*' (rune tar %brtr exqc)]
                   ['=' (rune tis %brts exqc)]
                   ['?' (rune wut %brwt expa)]
-                  ['$' (rune bus %brbs exqe)]
+                  ['$' (rune buc %brbs exqe)]
               ==
             ==
           :-  '$'
-            ;~  pfix  bus
+            ;~  pfix  buc
               %-  stew
               ^.  stet  ^.  limo
               :~  ['@' (stag %ktcl (rune vat %bsvt exqb))]
@@ -13797,7 +13797,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  ['|' (rune bar %sgbr expb)]
-                  ['$' (rune bus %sgbs expf)]
+                  ['$' (rune buc %sgbs expf)]
                   ['_' (rune cab %sgcb expb)]
                   ['%' (rune cen %sgcn hind)]
                   ['/' (rune net %sgnt hine)]
@@ -13886,7 +13886,7 @@
                     (jest '+-')   ::  XX deprecated
                   ==
           ;~  plug
-            ;~(pfix gap ;~(pose (cold %$ bus) sym))
+            ;~(pfix gap ;~(pose (cold %$ buc) sym))
             ;~(pfix gap loaf)
           ==
         ==
@@ -14255,7 +14255,7 @@
       (cold [%| 0 ~] com)
       %+  cook
         |=({a/(list) b/term} ?~(a b [%| (lent a) `b]))
-      ;~(plug (star ket) ;~(pose sym (cold %$ bus)))
+      ;~(plug (star ket) ;~(pose sym (cold %$ buc)))
     ::
       %+  cook
         |=(a/axis [%& a])

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13198,7 +13198,7 @@
               tash:so
               ;~(pfix dot perd:so)
               ;~(pfix sig ;~(pose twid:so (easy [%$ %n 0])))
-              ;~(pfix cen ;~(pose sym buc pad bar qut nuck:so))
+              ;~(pfix cen ;~(pose sym buc pam bar qut nuck:so))
             ==
           ::
             ;~(simu whit (easy ~))
@@ -13367,7 +13367,7 @@
           ;~  pfix  cen
             ;~  pose
               (stag %leaf (stag %tas (cold %$ buc)))
-              (stag %leaf (stag %f (cold & pad)))
+              (stag %leaf (stag %f (cold & pam)))
               (stag %leaf (stag %f (cold | bar)))
               (stag %leaf (stag %t qut))
               (stag %leaf (sear |=(a/coin ?:(?=($$ -.a) (some +.a) ~)) nuck:so))
@@ -13466,7 +13466,7 @@
           ;~  pose
             (stag %clsg (sear |~({a/@ud b/tyke} (posh ~ ~ a b)) porc))
             (stag %rock (stag %tas (cold %$ buc)))
-            (stag %rock (stag %f (cold & pad)))
+            (stag %rock (stag %f (cold & pam)))
             (stag %rock (stag %f (cold | bar)))
             (stag %rock (stag %t qut))
             (cook (jock &) nuck:so)
@@ -13476,9 +13476,9 @@
       :-  '&'
         ;~  pose
           (cook |=(a/wing [%cnts a ~]) rope)
-          (stag %wtpd ;~(pfix pad (ifix [lit rit] (most ace wide))))
-          ;~(plug (stag %rock (stag %f (cold & pad))) wede)
-          (stag %sand (stag %f (cold & pad)))
+          (stag %wtpd ;~(pfix pam (ifix [lit rit] (most ace wide))))
+          ;~(plug (stag %rock (stag %f (cold & pam))) wede)
+          (stag %sand (stag %f (cold & pam)))
         ==
       :-  '\''
         (stag %sand (stag %t qut))
@@ -13656,7 +13656,7 @@
                   ['^' (rune ket %bskt exqb)]
                   ['~' (rune sig %bssg exqd)]
                   ['|' (rune bar %bsbr exqc)]
-                  ['&' (rune pad %bspd exqc)]
+                  ['&' (rune pam %bspd exqc)]
                   ['@' (rune vat %bsvt exqb)]
                   ['_' (rune cab %bscb expa)]
                   ['-' (rune hep %bshp exqb)]
@@ -13727,7 +13727,7 @@
                   ['<' (stag %ktcl (rune led %bsld exqb))]
                   ['>' (stag %ktcl (rune ban %bsbn exqb))]
                   ['|' (stag %ktcl (rune bar %bsbr exqc))]
-                  ['&' (stag %ktcl (rune pad %bspd exqc))]
+                  ['&' (stag %ktcl (rune pam %bspd exqc))]
                   ['^' (stag %ktcl (rune ket %bskt exqb))]
                   ['~' (stag %ktcl (rune sig %bssg exqd))]
                   ['-' (stag %ktcl (rune hep %bshp exqb))]
@@ -13783,7 +13783,7 @@
                   ['.' (rune dot %ktdt expb)]
                   ['-' (rune hep %kthp exqc)]
                   ['+' (rune lus %ktls expb)]
-                  ['&' (rune pad %ktpd expa)]
+                  ['&' (rune pam %ktpd expa)]
                   ['~' (rune sig %ktsg expa)]
                   ['=' (rune tis %ktts expj)]
                   ['?' (rune wut %ktwt expa)]
@@ -13804,7 +13804,7 @@
                   ['<' (rune led %sgld hinb)]
                   ['>' (rune ban %sgbn hinb)]
                   ['+' (rune lus %sgls hinc)]
-                  ['&' (rune pad %sgpd hinf)]
+                  ['&' (rune pam %sgpd hinf)]
                   ['?' (rune wut %sgwt hing)]
                   ['=' (rune tis %sgts expb)]
                   ['!' (rune zap %sgzp expb)]
@@ -13855,7 +13855,7 @@
                   ['=' ;~(pfix tis (toad txts))]
                   ['#' ;~(pfix hax (toad txhx))]
                   ['+' ;~(pfix lus (toad txls))]
-                  ['&' (rune pad %wtpd exps)]
+                  ['&' (rune pam %wtpd exps)]
                   ['@' ;~(pfix vat (toad tkvt))]
                   ['~' ;~(pfix sig (toad tksg))]
                   ['!' (rune zap %wtzp expa)]
@@ -14261,7 +14261,7 @@
         |=(a/axis [%& a])
       ;~  pose
         ;~(pfix lus dim:ag)
-        ;~(pfix pad (cook |=(a/@ ?:(=(0 a) 0 (mul 2 +($(a (dec a)))))) dim:ag))
+        ;~(pfix pam (cook |=(a/@ ?:(=(0 a) 0 (mul 2 +($(a (dec a)))))) dim:ag))
         ;~(pfix bar (cook |=(a/@ ?:(=(0 a) 1 +((mul 2 $(a (dec a)))))) dim:ag))
         ven
         (cold 1 dot)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13022,7 +13022,7 @@
             (cold [%end %stet] duz)                     ::  == end of markdown
           ::
             (cold [%one %rule] ;~(plug hep hep hep))    ::  --- horizontal ruler
-            (cold [%one %fens] ;~(plug tec tec tec))    ::  ``` code fence
+            (cold [%one %fens] ;~(plug tic tic tic))    ::  ``` code fence
             (cold [%one %expr] mic)                     ::  ;sail expression
           ::
             (cold [%new %head] ;~(plug (star hax) ace)) ::  # heading
@@ -13035,7 +13035,7 @@
         ==
       ::
       ::
-      ++  calf                                          ::  cash but for tec tec
+      ++  calf                                          ::  cash but for tic tic
         |*  tem=rule
         %-  star
         ;~  pose
@@ -13146,7 +13146,7 @@
         ::
         ::  `classic markdown quote`
         ::
-          (stag %code (ifix [tec tec] (calf tec)))
+          (stag %code (ifix [tic tic] (calf tic)))
         ::
         ::  ++arm, +-arm, +$arm, +*arm, ++arm:core, ...
         ::
@@ -13268,22 +13268,22 @@
         %+  cold  [[%hr ~] ~]~
         ;~(plug (star ace) hep hep hep (star hep) (just '\0a'))
       ::
-      ++  tecs
-        ;~(plug tec tec tec (just '\0a'))
+      ++  tics
+        ;~(plug tic tic tic (just '\0a'))
       ::
       ++  fens
         |=  col/@u  ~+
         =/  ind  (stun [(dec col) (dec col)] ace)
-        =/  ind-tecs  ;~(plug ind tecs)
+        =/  ind-tics  ;~(plug ind tics)
         %+  cook  |=(txt/tape `tarp`[[%pre ~] ;/(txt) ~]~)
         ::
         ::  leading outdent is ok since container may
         ::  have already been parsed and consumed
-        %+  ifix  [;~(plug (star ace) tecs) ind-tecs]
+        %+  ifix  [;~(plug (star ace) tics) ind-tics]
         %^  stir  ""  |=({a/tape b/tape} "{a}\0a{b}")
         ;~  pose
           %+  ifix  [ind (just '\0a')]
-          ;~(less tecs (star prn))
+          ;~(less tics (star prn))
         ::
           (cold "" ;~(plug (star ace) (just '\0a')))
         ==
@@ -13563,16 +13563,16 @@
           (cold [%base %cell] ket)
         ==
       :-  '`'
-        ;~  pfix  tec
+        ;~  pfix  tic
           ;~  pose
             %+  cook
               |=({a/@ta b/hoon} [%ktls [%sand a 0] [%ktls [%sand %$ 0] b]])
-            ;~(pfix vat ;~(plug mota ;~(pfix tec wide)))
+            ;~(pfix vat ;~(plug mota ;~(pfix tic wide)))
             ;~  pfix  tar
-              (stag %kthp (stag [%base %noun] ;~(pfix tec wide)))
+              (stag %kthp (stag [%base %noun] ;~(pfix tic wide)))
             ==
-            (stag %kthp ;~(plug wyde ;~(pfix tec wide)))
-            (stag %ktls ;~(pfix lus ;~(plug wide ;~(pfix tec wide))))
+            (stag %kthp ;~(plug wyde ;~(pfix tic wide)))
+            (stag %ktls ;~(pfix lus ;~(plug wide ;~(pfix tic wide))))
             (cook |=(a/hoon [[%rock %n ~] a]) wide)
           ==
         ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5643,7 +5643,7 @@
 ++  gaw  (cold ~ (star ;~(pose vul gah)))               ::  classic white
 ++  gay  ;~(pose gap (easy ~))                          ::
 ++  gon  ;~(pose ;~(plug bat gay net) (easy ~))         ::  long numbers \ /
-++  gul  ;~(pose (cold 2 led) (cold 3 ban))             ::  axis syntax < >
+++  gul  ;~(pose (cold 2 gal) (cold 3 gar))             ::  axis syntax < >
 ++  hex  (bass 16 (most gon hit))                       ::  hex to atom
 ++  hig  (shim 'A' 'Z')                                 ::  uppercase
 ++  hit  ;~  pose                                       ::  hex digits
@@ -12212,7 +12212,7 @@
     ++  body
       ;~  pose
         ;~  plug                                        :: can duplicate ::
-          (into ;~(pfix (punt ;~(plug null col ban step)) line))
+          (into ;~(pfix (punt ;~(plug null col gar step)) line))
           (easy ~)
         ==
         ;~  plug
@@ -12244,11 +12244,11 @@
     ::
     ++  indo
       |*  bod/rule
-      ;~(pfix col ban ;~(sfix bod (just `@`10) (punt gap)))
+      ;~(pfix col gar ;~(sfix bod (just `@`10) (punt gap)))
     ::
     ++  exit
       |*  bod/rule
-      ;~(pfix (star ace) col led step bod)
+      ;~(pfix (star ace) col gal step bod)
     ::
     ::  fill: full definition
     ::
@@ -12559,7 +12559,7 @@
         (stag %& tall-elem)
         (stag %| wide-quote)
         (stag %| ;~(pfix tis tall-tail))
-        (stag %& ;~(pfix ban gap (stag [%div ~] cram)))
+        (stag %& ;~(pfix gar gap (stag [%div ~] cram)))
         (stag %| ;~(plug ;~((glue gap) tuna-mode tall) (easy ~)))
         (easy %| [;/("\0a")]~)
       ==
@@ -13028,7 +13028,7 @@
             (cold [%new %head] ;~(plug (star hax) ace)) ::  # heading
             (cold [%new %lint] ;~(plug hep ace))        ::  - line item
             (cold [%new %lite] ;~(plug lus ace))        ::  + line item
-            (cold [%new %bloc] ;~(plug ban ace))        ::  > block-quote
+            (cold [%new %bloc] ;~(plug gar ace))        ::  > block-quote
           ::
             (easy [%old %text])                         ::  anything else
           ==
@@ -13612,9 +13612,9 @@
       :-  '/'
         rood
       :-  '<'
-        (ifix [led ban] (stag %tell (most ace wide)))
+        (ifix [gal gar] (stag %tell (most ace wide)))
       :-  '>'
-        (ifix [ban led] (stag %yell (most ace wide)))
+        (ifix [gar gal] (stag %yell (most ace wide)))
     ==
   ++  soil
     ;~  pose
@@ -13651,8 +13651,8 @@
               ^.  stet  ^.  limo
               :~  [':' (rune col %bscl exqs)]
                   ['%' (rune cen %bscn exqs)]
-                  ['<' (rune led %bsld exqb)]
-                  ['>' (rune ban %bsbn exqb)]
+                  ['<' (rune gal %bsld exqb)]
+                  ['>' (rune gar %bsbn exqb)]
                   ['^' (rune ket %bskt exqb)]
                   ['~' (rune sig %bssg exqd)]
                   ['|' (rune bar %bsbr exqc)]
@@ -13724,8 +13724,8 @@
                   ['_' (stag %ktcl (rune cab %bscb expa))]
                   [':' (stag %ktcl (rune col %bscl exqs))]
                   ['%' (stag %ktcl (rune cen %bscn exqs))]
-                  ['<' (stag %ktcl (rune led %bsld exqb))]
-                  ['>' (stag %ktcl (rune ban %bsbn exqb))]
+                  ['<' (stag %ktcl (rune gal %bsld exqb))]
+                  ['>' (stag %ktcl (rune gar %bsbn exqb))]
                   ['|' (stag %ktcl (rune bar %bsbr exqc))]
                   ['&' (stag %ktcl (rune pam %bspd exqc))]
                   ['^' (stag %ktcl (rune ket %bskt exqb))]
@@ -13801,8 +13801,8 @@
                   ['_' (rune cab %sgcb expb)]
                   ['%' (rune cen %sgcn hind)]
                   ['/' (rune net %sgnt hine)]
-                  ['<' (rune led %sgld hinb)]
-                  ['>' (rune ban %sgbn hinb)]
+                  ['<' (rune gal %sgld hinb)]
+                  ['>' (rune gar %sgbn hinb)]
                   ['+' (rune lus %sgls hinc)]
                   ['&' (rune pam %sgpd hinf)]
                   ['?' (rune wut %sgwt hing)]
@@ -13832,8 +13832,8 @@
                   [':' (rune col %tscl expp)]
                   ['/' (rune net %tsnt expo)]
                   [';' (rune mic %tsmc expo)]
-                  ['<' (rune led %tsld expb)]
-                  ['>' (rune ban %tsbn expb)]
+                  ['<' (rune gal %tsld expb)]
+                  ['>' (rune gar %tsbn expb)]
                   ['-' (rune hep %tshp expb)]
                   ['*' (rune tar %tstr expg)]
                   [',' (rune com %tscm expb)]
@@ -13848,8 +13848,8 @@
               :~  ['|' (rune bar %wtbr exps)]
                   [':' (rune col %wtcl expc)]
                   ['.' (rune dot %wtdt expc)]
-                  ['<' (rune led %wtld expb)]
-                  ['>' (rune ban %wtbn expb)]
+                  ['<' (rune gal %wtld expb)]
+                  ['>' (rune gar %wtbn expb)]
                   ['-' ;~(pfix hep (toad txhp))]
                   ['^' ;~(pfix ket (toad tkkt))]
                   ['=' ;~(pfix tis (toad txts))]
@@ -13869,8 +13869,8 @@
                   ['.' ;~(pfix dot (toad |.(loaf(bug |))))]
                   [',' (rune com %zpcm expb)]
                   [';' (rune mic %zpmc expb)]
-                  ['>' (rune ban %zpbn expa)]
-                  ['<' (rune led %zpld exqc)]
+                  ['>' (rune gar %zpbn expa)]
+                  ['<' (rune gal %zpld exqc)]
                   ['@' (rune pat %zpvt expy)]
                   ['=' (rune tis %zpts expa)]
                   ['?' (rune wut %zpwt hinh)]
@@ -14158,12 +14158,12 @@
     ++  hine  |.(;~(gunk bonk loaf))                    ::  jet-hint and hoon
     ++  hinf  |.                                        ::  0-3 >s, two hoons
       ;~  pose
-        ;~(gunk (cook lent (stun [1 3] ban)) loaf loaf)
+        ;~(gunk (cook lent (stun [1 3] gar)) loaf loaf)
         (stag 0 ;~(gunk loaf loaf))
       ==
     ++  hing  |.                                        ::  0-3 >s, three hoons
       ;~  pose
-        ;~(gunk (cook lent (stun [1 3] ban)) loaf loaf loaf)
+        ;~(gunk (cook lent (stun [1 3] gar)) loaf loaf loaf)
         (stag 0 ;~(gunk loaf loaf loaf))
       ==
     ++  bonk                                            ::  jet signature

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5642,7 +5642,7 @@
          ==
 ++  gaw  (cold ~ (star ;~(pose vul gah)))               ::  classic white
 ++  gay  ;~(pose gap (easy ~))                          ::
-++  gon  ;~(pose ;~(plug bat gay net) (easy ~))         ::  long numbers \ /
+++  gon  ;~(pose ;~(plug bas gay fas) (easy ~))         ::  long numbers \ /
 ++  gul  ;~(pose (cold 2 gal) (cold 3 gar))             ::  axis syntax < >
 ++  hex  (bass 16 (most gon hit))                       ::  hex to atom
 ++  hig  (shim 'A' 'Z')                                 ::  uppercase
@@ -5683,8 +5683,8 @@
              ;~(less ;~(plug (just `@`10) soz) (just `@`10))
          ==
 ++  qit  ;~  pose                                       ::  chars in a cord
-             ;~(less bat soq prn)
-             ;~(pfix bat ;~(pose bat soq mes))          ::  escape chars
+             ;~(less bas soq prn)
+             ;~(pfix bas ;~(pose bas soq mes))          ::  escape chars
          ==
 ++  qut  ;~  simu  soq                                  ::  cord
            ;~  pose
@@ -5799,7 +5799,7 @@
              (cook tuft (ifix [sig dot] hex))
              ;~(pfix sig ;~(pose sig dot))
            ==
-  ++  voy  ;~(pfix bat ;~(pose bat soq bix))
+  ++  voy  ;~(pfix bas ;~(pose bas soq bix))
   --
 ++  ag
   |%
@@ -6330,7 +6330,7 @@
 ++  spat  |=(pax/path (crip (spud pax)))                ::  render path to cord
 ++  spud  |=(pax/path ~(ram re (smyt pax)))             ::  render path to tape
 ++  stab                                                ::  parse cord to path
-  =+  fel=;~(pfix net (more net urs:ab))
+  =+  fel=;~(pfix fas (more fas urs:ab))
   |=(zep/@t `path`(rash zep fel))
 ::
 ::::  4n: virtualization
@@ -12131,7 +12131,7 @@
   ++  gash  %+  cook                                    ::  parse path
               |=  a/(list tyke)  ^-  tyke
               ?~(a ~ (weld i.a $(a t.a)))
-            (more net limp)
+            (more fas limp)
   ++  gasp  ;~  pose                                    ::  parse =path= etc.
               %+  cook
                 |=({a/tyke b/tyke c/tyke} :(weld a b c))
@@ -12156,7 +12156,7 @@
               |=  {a/(list) b/tyke}
               ?~  a  b
               $(a t.a, b [`[%sand %tas %$] b])
-            ;~(plug (star net) gasp)
+            ;~(plug (star fas) gasp)
   ++  mota  %+  cook
               |=({a/tape b/tape} (rap 3 (weld a b)))
             ;~(plug (star low) (star hig))
@@ -12334,7 +12334,7 @@
   ++  porc
     ;~  plug
       (cook |=(a/(list) (lent a)) (star cen))
-      ;~(pfix net gash)
+      ;~(pfix fas gash)
     ==
   ::
   ++  rump
@@ -12344,7 +12344,7 @@
     ;~(plug rope ;~(pose (stag ~ wede) (easy ~)))
   ::
   ++  rood
-    ;~  pfix  net
+    ;~  pfix  fas
       (stag %clsg poor)
     ==
   ::
@@ -12542,7 +12542,7 @@
         ;~  plug
           (punt ;~(plug (cold %id hax) (cook trip sym)))
           (cook en-class (star ;~(plug (cold %class dot) sym)))
-          (punt ;~(plug ;~(pose (cold %href net) (cold %src pat)) soil))
+          (punt ;~(plug ;~(pose (cold %href fas) (cold %src pat)) soil))
           (easy ~)
         ==
       ::
@@ -13391,7 +13391,7 @@
       :-  '*'
         (cold [%base %noun] tar)
       :-  '/'
-        ;~(pfix net (stag %loop ;~(pose (cold %$ buc) sym)))
+        ;~(pfix fas (stag %loop ;~(pose (cold %$ buc) sym)))
       :-  '@'
         ;~(pfix pat (stag %base (stag %atom mota)))
       :-  '?'
@@ -13426,7 +13426,7 @@
         ==
       :-  ['a' 'z']
         ;~  pose
-          (stag %bsts ;~(plug sym ;~(pfix ;~(pose net tis) wyde)))
+          (stag %bsts ;~(plug sym ;~(pfix ;~(pose fas tis) wyde)))
           (stag %like (most col rope))
         ==
     ==
@@ -13530,7 +13530,7 @@
         ;~  pfix  col
           ;~  pose
             (stag %mccl (ifix [pal par] (most ace wide)))
-            ;~(pfix net (stag %mcnt wide))
+            ;~(pfix fas (stag %mcnt wide))
           ==
         ==
       :-  '='
@@ -13800,7 +13800,7 @@
                   ['$' (rune buc %sgbs expf)]
                   ['_' (rune cab %sgcb expb)]
                   ['%' (rune cen %sgcn hind)]
-                  ['/' (rune net %sgnt hine)]
+                  ['/' (rune fas %sgnt hine)]
                   ['<' (rune gal %sgld hinb)]
                   ['>' (rune gar %sgbn hinb)]
                   ['+' (rune lus %sgls hinc)]
@@ -13815,7 +13815,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
-                  ['/' (rune net %mcnt expa)]
+                  ['/' (rune fas %mcnt expa)]
                   ['<' (rune gal %mcgl exp1)]
                   ['~' (rune sig %mcsg expi)]
                   [';' (rune mic %mcmc exqc)]
@@ -13830,7 +13830,7 @@
                   ['?' (rune wut %tswt expw)]
                   ['^' (rune ket %tskt expt)]
                   [':' (rune col %tscl expp)]
-                  ['/' (rune net %tsnt expo)]
+                  ['/' (rune fas %tsnt expo)]
                   [';' (rune mic %tsmc expo)]
                   ['<' (rune gal %tsld expb)]
                   ['>' (rune gar %tsbn expb)]
@@ -14287,9 +14287,7 @@
           term
         [%name term %spec u.unit %base %noun]
       ;~  plug  sym
-        ::  XX: net deprecated
-        ::
-        (punt ;~(pfix ;~(pose net tis) wyde))
+        (punt ;~(pfix ;~(pose fas tis) wyde))
       ==
     ::
       %+  cook
@@ -14307,7 +14305,7 @@
   ++  wede                                              ::  wide bulb
     ::  XX: lus deprecated
     ::
-    ;~(pfix ;~(pose lus net) wide)
+    ;~(pfix ;~(pose lus fas) wide)
   ++  wide                                              ::  full wide form
     %+  knee  *hoon
     |.(~+((wart ;~(pose expression:(norm |) long apex:(sail |)))))

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5563,47 +5563,59 @@
 ::
 ::::  4h: parsing (ascii glyphs)
   ::
-++  ace  (just ' ')
-++  ban  (just '>')
-++  bar  (just '|')
-++  bas  (just '\\')  ::  XX deprecated
-++  bat  (just '\\')
-++  buc  (just '$')   ::  XX deprecated
-++  bus  (just '$')
-++  cab  (just '_')
-++  cen  (just '%')
-++  col  (just ':')
-++  com  (just ',')
-++  dot  (just '.')
-++  fas  (just '/')  ::  XX deprecated?
-++  gal  (just '<')   ::  XX deprecated
-++  gar  (just '>')   ::  XX deprecated
-++  vat  (just '@')   ::  pronounced "at"
-++  hax  (just '#')
-++  hep  (just '-')   ::  pronounced "ep"
-++  ket  (just '^')
-++  leb  (just '{')
-++  led  (just '<')
-++  lob  (just '{')
-++  lit  (just '(')
-++  lac  (just '[')
-++  lus  (just '+')
-++  mic  (just ';')   ::  pronounced "mick"
-++  net  (just '/')
-++  pad  (just '&')
-++  rac  (just ']')
-++  reb  (just '}')
-++  rob  (just '}')
-++  rit  (just ')')
-++  say  (just '\'')
-++  sig  (just '~')
-++  tar  (just '*')
-++  tec  (just '`')
-++  tis  (just '=')   ::  pronounced "is"
-++  toc  (just '"')   ::  XX deprecated
-++  yel  (just '"')
-++  wut  (just '?')
-++  zap  (just '!')
+++  ace  (just ' ')                                     ::  spACE
+++  bar  (just '|')                                     ::  vertical BAR
+++  bas  (just '\\')                                    ::  Back Slash (escaped)
+++  buc  (just '$')                                     ::  dollars BUCks
+++  cab  (just '_')                                     ::  CABoose
+++  cen  (just '%')                                     ::  perCENt
+++  col  (just ':')                                     ::  COLon
+++  com  (just ',')                                     ::  COMma
+++  doq  (just '"')                                     ::  Double Quote
+++  dot  (just '.')                                     ::  dot dot dot ...
+++  fas  (just '/')                                     ::  Forward Slash
+++  gal  (just '<')                                     ::  Greater Left
+++  gar  (just '>')                                     ::  Greater Right
+++  hax  (just '#')                                     ::  Hash
+++  hep  (just '-')                                     ::  HyPhen
+++  kel  (just '{')                                     ::  Curly Left
+++  ker  (just '}')                                     ::  Curly Right
+++  ket  (just '^')                                     ::  CareT
+++  lus  (just '+')                                     ::  pLUS
+++  mic  (just ';')                                     ::  seMIColon
+++  pal  (just '(')                                     ::  Paren Left
+++  pam  (just '&')                                     ::  AMPersand pampersand
+++  par  (just ')')                                     ::  Paren Right
+++  pat  (just '@')                                     ::  AT pat
+++  sel  (just '[')                                     ::  Square Left
+++  ser  (just ']')                                     ::  Square Right
+++  sig  (just '~')                                     ::  SIGnature squiggle
+++  soq  (just '\'')                                    ::  Single Quote
+++  tar  (just '*')                                     ::  sTAR
+++  tic  (just '`')                                     ::  backTiCk
+++  tis  (just '=')                                     ::  'tis tis, it is
+++  wut  (just '?')                                     ::  wut, what?
+++  zap  (just '!')                                     ::  zap! bang! crash!!
+::
+++  ban  (just '>')   ::  XX deprecated, use gar
+++  bat  (just '\\')  ::  XX deprecated, use bas
+++  bus  (just '$')   ::  XX deprecated, use buc
+++  lac  (just '[')   ::  XX deprecated, use sel
+++  leb  (just '{')   ::  XX deprecated, use kel
+++  led  (just '<')   ::  XX deprecated, use gal
+++  lit  (just '(')   ::  XX deprecated, use pal
+++  lob  (just '{')   ::  XX deprecated, use kel
+++  net  (just '/')   ::  XX deprecated, use fas
+++  pad  (just '&')   ::  XX deprecated, use pam
+++  rac  (just ']')   ::  XX deprecated, use ser
+++  reb  (just '}')   ::  XX deprecated, use ker
+++  rit  (just ')')   ::  XX deprecated, use par
+++  rob  (just '}')   ::  XX deprecated, use ker
+++  say  (just '\'')  ::  XX deprecated, use soq
+++  tec  (just '`')   ::  XX deprecated, use tic
+++  toc  (just '"')   ::  XX deprecated, use doq
+++  vat  (just '@')   ::  XX deprecated, use pat
+++  yel  (just '"')   ::  XX deprecated, use doq
 ::
 ::::  4i: parsing (useful idioms)
   ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12145,7 +12145,7 @@
   ++  glam  ~+((glue ace))
   ++  hasp  ;~  pose                                    ::  path element
               (ifix [lac rac] wide)
-              (stag %cncl (ifix [lit rit] (most ace wide)))
+              (stag %cncl (ifix [pal par] (most ace wide)))
               (stag %sand (stag %tas (cold %$ buc)))
               (stag %sand (stag %t qut))
               %+  cook
@@ -12433,7 +12433,7 @@
     ++  wide-attrs                                      ::  wide attributes
       %+  cook  |=(a/(unit mart:hoot) (fall a ~))
       %-  punt
-      %+  ifix  [lit rit]
+      %+  ifix  [pal par]
       %+  more  (jest ', ')
       ;~((glue ace) a-mane hopefully-quote)
     ::
@@ -12449,7 +12449,7 @@
     ++  wide-paren-elems                                ::  wide flow
       %+  cook  |=(a/marl:hoot a)
       %+  cook  join-tops
-      (ifix [lit rit] (more ace wide-inner-top))
+      (ifix [pal par] (more ace wide-inner-top))
     ::
     ::+|
     ::
@@ -13161,7 +13161,7 @@
           %+  stag  %link
           ;~  (glue (punt whit))
             (ifix [lac rac] (cool (cash rac) werk))
-            (ifix [lit rit] (cash rit))
+            (ifix [pal par] (cash par))
           ==
         ::
         ::  ![alt text](url)
@@ -13170,7 +13170,7 @@
           ;~  pfix  zap
             ;~  (glue (punt whit))
               (ifix [lac rac] (cash rac))
-              (ifix [lit rit] (cash rit))
+              (ifix [pal par] (cash par))
             ==
           ==
         ::
@@ -13377,7 +13377,7 @@
       :-  '('
         %+  cook  |=(spec +<)
         %+  stag  %make
-        %+  ifix  [lit rit]
+        %+  ifix  [pal par]
         ;~  plug
           wide
           ;~(pose ;~(pfix ace (most ace wyde)) (easy ~))
@@ -13397,7 +13397,7 @@
       :-  '?'
         ;~  pose
           %+  stag  %bswt
-          ;~(pfix wut (ifix [lit rit] (most ace wyde)))
+          ;~(pfix wut (ifix [pal par] (most ace wyde)))
         ::
           (cold [%base %flag] wut)
         ==
@@ -13476,14 +13476,14 @@
       :-  '&'
         ;~  pose
           (cook |=(a/wing [%cnts a ~]) rope)
-          (stag %wtpd ;~(pfix pam (ifix [lit rit] (most ace wide))))
+          (stag %wtpd ;~(pfix pam (ifix [pal par] (most ace wide))))
           ;~(plug (stag %rock (stag %f (cold & pam))) wede)
           (stag %sand (stag %f (cold & pam)))
         ==
       :-  '\''
         (stag %sand (stag %t qut))
       :-  '('
-        (stag %cncl (ifix [lit rit] (most ace wide)))
+        (stag %cncl (ifix [pal par] (most ace wide)))
       :-  '{'
         (stag %ktcl (stag %bscl (ifix [lob rob] (most ace wyde))))
       :-  '*'
@@ -13495,7 +13495,7 @@
         ;~(pfix pat (stag %base (stag %atom mota)))
       :-  '+'
         ;~  pose
-          (stag %dtls ;~(pfix lus (ifix [lit rit] wide)))
+          (stag %dtls ;~(pfix lus (ifix [pal par] wide)))
         ::
           %+  cook
             |=  a/(list (list woof))
@@ -13529,14 +13529,14 @@
       :-  ':'
         ;~  pfix  col
           ;~  pose
-            (stag %mccl (ifix [lit rit] (most ace wide)))
+            (stag %mccl (ifix [pal par] (most ace wide)))
             ;~(pfix net (stag %mcnt wide))
           ==
         ==
       :-  '='
         ;~  pfix  tis
           ;~  pose
-            (stag %dtts (ifix [lit rit] ;~(glam wide wide)))
+            (stag %dtts (ifix [pal par] ;~(glam wide wide)))
           ::
             %+  sear
               ::  mainly used for +skin formation
@@ -13551,7 +13551,7 @@
       :-  '?'
         ;~  pose
           %+  stag  %ktcl
-          (stag %bswt ;~(pfix wut (ifix [lit rit] (most ace wyde))))
+          (stag %bswt ;~(pfix wut (ifix [pal par] (most ace wyde))))
         ::
           (cold [%base %flag] wut)
         ==
@@ -13586,7 +13586,7 @@
       :-  '|'
         ;~  pose
           (cook |=(a/wing [%cnts a ~]) rope)
-          (stag %wtbr ;~(pfix bar (ifix [lit rit] (most ace wide))))
+          (stag %wtbr ;~(pfix bar (ifix [pal par] (most ace wide))))
           ;~(plug (stag %rock (stag %f (cold | bar))) wede)
           (stag %sand (stag %f (cold | bar)))
         ==
@@ -13600,7 +13600,7 @@
             ::
               %+  stag  %cnsg
               %+  ifix
-                [lit rit]
+                [pal par]
               ;~(glam rope wide (most ace wide))
             ::
               (cook (jock |) twid:so)
@@ -14007,7 +14007,7 @@
     ++  toad                                            ::  untrap parser exp
       =+  har=expa
       |@  ++  $
-            =+  dur=(ifix [lit rit] $:har(tol |))
+            =+  dur=(ifix [pal par] $:har(tol |))
             ?:(tol ;~(pose ;~(pfix gap $:har(tol &)) dur) dur)
       --
     ::
@@ -14192,7 +14192,7 @@
       ;~  pose
         (cold ~ sig)
         %+  ifix
-          ?:(tol [;~(plug duz gap) ;~(plug gap duz)] [lit rit])
+          ?:(tol [;~(plug duz gap) ;~(plug gap duz)] [pal par])
         (more mash ;~(gunk ;~(pfix cen sym) loaf))
       ==
     --
@@ -14230,7 +14230,7 @@
         ;~(plug (cold %ket ket) wide)
         ;~  plug
           (easy %lit)
-          (ifix [lit rit] lobo)
+          (ifix [pal par] lobo)
         ==
       ==
     ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12542,7 +12542,7 @@
         ;~  plug
           (punt ;~(plug (cold %id hax) (cook trip sym)))
           (cook en-class (star ;~(plug (cold %class dot) sym)))
-          (punt ;~(plug ;~(pose (cold %href net) (cold %src vat)) soil))
+          (punt ;~(plug ;~(pose (cold %href net) (cold %src pat)) soil))
           (easy ~)
         ==
       ::
@@ -13393,7 +13393,7 @@
       :-  '/'
         ;~(pfix net (stag %loop ;~(pose (cold %$ buc) sym)))
       :-  '@'
-        ;~(pfix vat (stag %base (stag %atom mota)))
+        ;~(pfix pat (stag %base (stag %atom mota)))
       :-  '?'
         ;~  pose
           %+  stag  %bswt
@@ -13492,7 +13492,7 @@
           (cold [%base %noun] tar)
         ==
       :-  '@'
-        ;~(pfix vat (stag %base (stag %atom mota)))
+        ;~(pfix pat (stag %base (stag %atom mota)))
       :-  '+'
         ;~  pose
           (stag %dtls ;~(pfix lus (ifix [lit rit] wide)))
@@ -13567,7 +13567,7 @@
           ;~  pose
             %+  cook
               |=({a/@ta b/hoon} [%ktls [%sand a 0] [%ktls [%sand %$ 0] b]])
-            ;~(pfix vat ;~(plug mota ;~(pfix tic wide)))
+            ;~(pfix pat ;~(plug mota ;~(pfix tic wide)))
             ;~  pfix  tar
               (stag %kthp (stag [%base %noun] ;~(pfix tic wide)))
             ==
@@ -13657,7 +13657,7 @@
                   ['~' (rune sig %bssg exqd)]
                   ['|' (rune bar %bsbr exqc)]
                   ['&' (rune pam %bspd exqc)]
-                  ['@' (rune vat %bsvt exqb)]
+                  ['@' (rune pat %bsvt exqb)]
                   ['_' (rune cab %bscb expa)]
                   ['-' (rune hep %bshp exqb)]
                   ['=' (rune tis %bsts exqg)]
@@ -13704,7 +13704,7 @@
               ^.  stet  ^.  limo
               :~  ['_' (rune cab %brcb exqr)]
                   ['%' (runo cen %brcn ~ expe)]
-                  ['@' (runo vat %brvt ~ expe)]
+                  ['@' (runo pat %brvt ~ expe)]
                   [':' (rune col %brcl expb)]
                   ['.' (rune dot %brdt expa)]
                   ['-' (rune hep %brhp expa)]
@@ -13720,7 +13720,7 @@
             ;~  pfix  buc
               %-  stew
               ^.  stet  ^.  limo
-              :~  ['@' (stag %ktcl (rune vat %bsvt exqb))]
+              :~  ['@' (stag %ktcl (rune pat %bsvt exqb))]
                   ['_' (stag %ktcl (rune cab %bscb expa))]
                   [':' (stag %ktcl (rune col %bscl exqs))]
                   ['%' (stag %ktcl (rune cen %bscn exqs))]
@@ -13856,7 +13856,7 @@
                   ['#' ;~(pfix hax (toad txhx))]
                   ['+' ;~(pfix lus (toad txls))]
                   ['&' (rune pam %wtpd exps)]
-                  ['@' ;~(pfix vat (toad tkvt))]
+                  ['@' ;~(pfix pat (toad tkvt))]
                   ['~' ;~(pfix sig (toad tksg))]
                   ['!' (rune zap %wtzp expa)]
               ==
@@ -13871,7 +13871,7 @@
                   [';' (rune mic %zpmc expb)]
                   ['>' (rune ban %zpbn expa)]
                   ['<' (rune led %zpld exqc)]
-                  ['@' (rune vat %zpvt expy)]
+                  ['@' (rune pat %zpvt expy)]
                   ['=' (rune tis %zpts expa)]
                   ['?' (rune wut %zpwt hinh)]
               ==

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -1047,7 +1047,7 @@
     ::
     ++  hoon
       %+  wide-or-tall
-        (ifix [lac rac] (stag %cltr (most ace wide:hoon-parser)))
+        (ifix [sel ser] (stag %cltr (most ace wide:hoon-parser)))
       ;~(pfix gap tall:hoon-parser)
     --
   ::  +static-path: parses a path

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -985,7 +985,7 @@
     ::
     ++  parse-alts
       %+  wide-or-tall
-        (ifix [lit rit] (most ace subcrane))
+        (ifix [pal par] (most ace subcrane))
       ;~(sfix (star subcrane) gap duz)
     ::  +parse-face: parse a face around a subcrane
     ::

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -942,7 +942,7 @@
           (stag %fssg ;~(pfix sig hoon))
           ::  `/$`  process query string
           ::
-          (stag %fsbc ;~(pfix bus hoon))
+          (stag %fsbc ;~(pfix buc hoon))
           ::  `/|`  first of many options that succeeds
           ::
           (stag %fsbr ;~(pfix bar parse-alts))

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -957,7 +957,7 @@
           (stag %fscm ;~(pfix com parse-switch))
           ::  `/&`  pass through a series of mark
           ::
-          (stag %fspm ;~(pfix pad parse-pipe))
+          (stag %fspm ;~(pfix pam parse-pipe))
           ::  `/_`  run a crane on each file in the current directory
           ::
           (stag %fscb ;~(pfix cab subcrane))
@@ -1010,7 +1010,7 @@
     ::
     ++  parse-pipe
       %+  wide-or-tall
-        ;~(plug (plus ;~(sfix sym pad)) subcrane)
+        ;~(plug (plus ;~(sfix sym pam)) subcrane)
       =+  (cook |=(a=term [a ~]) sym)
       ;~(pfix gap ;~(plug - subcrane))
     ::  +parse-gate: parses a gate applied to a crane

--- a/pkg/arvo/sys/vane/ford.hoon
+++ b/pkg/arvo/sys/vane/ford.hoon
@@ -882,19 +882,19 @@
       ::  parses the zuse version, eg "/?  309"
       ::
         ;~  pose
-          (ifix [;~(plug net wut gap) gap] dem)
+          (ifix [;~(plug fas wut gap) gap] dem)
           (easy zuse)
         ==
       ::  pareses the structures, eg "/-  types"
       ::
         ;~  pose
-          (ifix [;~(plug net hep gap) gap] (most ;~(plug com gaw) cable))
+          (ifix [;~(plug fas hep gap) gap] (most ;~(plug com gaw) cable))
           (easy ~)
         ==
       ::  parses the libraries, eg "/+  lib1, lib2"
       ::
         ;~  pose
-          (ifix [;~(plug net lus gap) gap] (most ;~(plug com gaw) cable))
+          (ifix [;~(plug fas lus gap) gap] (most ;~(plug com gaw) cable))
           (easy ~)
         ==
       ::
@@ -907,7 +907,7 @@
   ++  beam
     %+  sear  de-beam
     ;~  pfix
-      net
+      fas
       (sear plex (stag %clsg poor)):hoon-parser
     ==
   ::  +cable: parses a +^cable, a reference to something on the filesystem
@@ -935,7 +935,7 @@
     |%
     ++  apex
       %+  knee  *^crane  |.  ~+
-      ;~  pfix  net
+      ;~  pfix  fas
         ;~  pose
           ::  `/~`  hoon literal
           ::
@@ -975,10 +975,10 @@
           (stag %fstr ;~(pfix tar subcrane))
           ::  `/!mark/ evaluate as hoon, then pass through mark
           ::
-          (stag %fszp ;~(pfix zap ;~(sfix sym net)))
+          (stag %fszp ;~(pfix zap ;~(sfix sym fas)))
           ::  `/mark/` passes current path through :mark
           ::
-          (stag %fszy ;~(sfix sym net))
+          (stag %fszy ;~(sfix sym fas))
         ==
       ==
     ::  +parse-alts: parse a set of alternatives
@@ -1005,7 +1005,7 @@
       %+  wide-or-tall
         fail
       =-  ;~(sfix (star -) gap duz)
-      ;~(pfix gap net ;~(plug static-path subcrane))
+      ;~(pfix gap fas ;~(plug static-path subcrane))
     ::  +parse-pipe: parses a pipe of mark conversions
     ::
     ++  parse-pipe
@@ -1053,11 +1053,11 @@
   ::  +static-path: parses a path
   ::
   ++  static-path
-    (sear plex (stag %clsg (more net hasp))):hoon-parser
+    (sear plex (stag %clsg (more fas hasp))):hoon-parser
   ::  +late-bound-path: a path whose time varies
   ::
   ++  late-bound-path
-    ;~  pfix  net
+    ;~  pfix  fas
       %+  cook  |=(a=truss a)
       =>  hoon-parser
       ;~  plug

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6727,7 +6727,7 @@
       ==
     ::                                                  ::  ++obje:de-json:html
     ++  obje                                            ::  object list
-      %+  ifix  [(wish leb) (wish reb)]
+      %+  ifix  [(wish kel) (wish ker)]
       (more (wish com) pear)
     ::                                                  ::  ++obox:de-json:html
     ++  obox                                            ::  object

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6883,7 +6883,7 @@
       ==
     ::                                                  ::  ++escp:de-xml:html
     ++  escp                                            ::
-      ;~(pose ;~(less led ban pam prn) enty)
+      ;~(pose ;~(less gal gar pam prn) enty)
     ::                                                  ::  ++enty:de-xml:html
     ++  enty                                            ::  entity
       %+  ifix  pam^mic
@@ -6902,7 +6902,7 @@
       ;~(plug ;~(plug name attr) (cold ~ (star whit)))
     ::                                                  ::  ++head:de-xml:html
     ++  head                                            ::  opening tag
-      (ifix [gal ban] ;~(plug name attr))
+      (ifix [gal gar] ;~(plug name attr))
     ::                                                  ::  ++many:de-xml:html
     ++  many                                            ::  contents
       ;~(pfix (star comt) (star ;~(sfix ;~(pose apex chrd cdat) (star comt))))
@@ -6917,7 +6917,7 @@
       ;~(pose ;~(plug ;~(sfix chx col) chx) chx)
     ::                                                  ::  ++tail:de-xml:html
     ++  tail                                            ::  closing tag
-      (ifix [(jest '</') ban] name)
+      (ifix [(jest '</') gar] name)
     ::                                                  ::  ++whit:de-xml:html
     ++  whit                                            ::  whitespace
       (mask ~[' ' `@`0x9 `@`0xa])

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6696,7 +6696,7 @@
           =*  wow  `(map @t @)`(malt lip)
           (sear ~(get by wow) low)
         =*  tuf  ;~(pfix (just 'u') (cook tuft qix:ab))
-        ;~(pose yel net soq bas loo tuf)
+        ;~(pose doq net soq bas loo tuf)
       ==
     ::                                                  ::  ++expo:de-json:html
     ++  expo                                            ::  exponent
@@ -6710,7 +6710,7 @@
       ;~(plug dot digs)
     ::                                                  ::  ++jcha:de-json:html
     ++  jcha                                            ::  string character
-      ;~(pose ;~(less yel bas prn) esca)
+      ;~(pose ;~(less doq bas prn) esca)
     ::                                                  ::  ++mayb:de-json:html
     ++  mayb                                            ::  optional
       |*(bus/rule ;~(pose bus (easy ~)))
@@ -6741,7 +6741,7 @@
       (cook |=(a/@ [a ~]) bus)
     ::                                                  ::  ++stri:de-json:html
     ++  stri                                            ::  string
-      (cook crip (ifix [yel yel] (star jcha)))
+      (cook crip (ifix [doq doq] (star jcha)))
     ::                                                  ::  ++tops:de-json:html
     ++  tops                                            ::  strict value
       ;~(pose abox obox)
@@ -6849,9 +6849,9 @@
         ;~(pfix (plus whit) name)
         ;~  pose
           %+  ifix
-            :_  yel
-            ;~(plug (ifix [. .]:(star whit) tis) yel)
-          (star ;~(less yel escp))
+            :_  doq
+            ;~(plug (ifix [. .]:(star whit) tis) doq)
+          (star ;~(less doq escp))
         ::
           %+  ifix
             :_  soq
@@ -6872,7 +6872,7 @@
     ::                                                  ::  ++chrd:de-xml:html
     ++  chrd                                            ::  character data
       %+  cook  |=(a/tape ^-(mars ;/(a)))
-      (plus ;~(less yel ;~(pose (just `@`10) escp)))
+      (plus ;~(less doq ;~(pose (just `@`10) escp)))
     ::                                                  ::  ++comt:de-xml:html
     ++  comt                                            ::  comments
       =-  (ifix [(jest '<!--') (jest '-->')] (star -))
@@ -7082,7 +7082,7 @@
       ;~(pose pure pesc psub col pat)
     ::                                                  ::  ++pcok:de-purl:html
     ++  pcok                                            ::  cookie char
-      ;~(less bas mic com yel prn)
+      ;~(less bas mic com doq prn)
     ::                                                  ::  ++pesc:de-purl:html
     ++  pesc                                            ::  2396 escaped
       ;~(pfix cen mes)
@@ -7122,7 +7122,7 @@
       (cook crip (plus pcok))
     ::                                                  ::  ++tosk:de-purl:html
     ++  tosk                                            ::  6265 quoted value
-      ;~(pose tock (ifix [yel yel] tock))
+      ;~(pose tock (ifix [doq doq] tock))
     ::                                                  ::  ++toke:de-purl:html
     ++  toke                                            ::  2616 token
       (cook crip (plus ptok))

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6664,7 +6664,7 @@
     ::                                                  ::  ++abox:de-json:html
     ++  abox                                            ::  array
       %+  stag  %a
-      (ifix [lac (wish rac)] (more (wish com) apex))
+      (ifix [sel (wish ser)] (more (wish com) apex))
     ::                                                  ::  ++apex:de-json:html
     ++  apex                                            ::  any value
       %+  knee  *json  |.  ~+

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7101,13 +7101,13 @@
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose
-        zap  bus  pad  say  lit  rit
+        zap  buc  pad  say  lit  rit
         tar  lus  com  mic  tis
       ==
     ::                                                  ::  ++ptok:de-purl:html
     ++  ptok                                            ::  2616 token
       ;~  pose
-        aln  zap  hax  bus  cen  pad  say  tar  lus
+        aln  zap  hax  buc  cen  pad  say  tar  lus
         hep  dot  ket  cab  tec  bar  sig
       ==
     ::                                                  ::  ++scem:de-purl:html

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6696,7 +6696,7 @@
           =*  wow  `(map @t @)`(malt lip)
           (sear ~(get by wow) low)
         =*  tuf  ;~(pfix (just 'u') (cook tuft qix:ab))
-        ;~(pose yel net say bas loo tuf)
+        ;~(pose yel net soq bas loo tuf)
       ==
     ::                                                  ::  ++expo:de-json:html
     ++  expo                                            ::  exponent
@@ -6854,9 +6854,9 @@
           (star ;~(less yel escp))
         ::
           %+  ifix
-            :_  say
-            ;~(plug (ifix [. .]:(star whit) tis) say)
-          (star ;~(less say escp))
+            :_  soq
+            ;~(plug (ifix [. .]:(star whit) tis) soq)
+          (star ;~(less soq escp))
         ::
           (easy ~)
         ==
@@ -7101,13 +7101,13 @@
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose
-        zap  buc  pam  say  lit  rit
+        zap  buc  pam  soq  lit  rit
         tar  lus  com  mic  tis
       ==
     ::                                                  ::  ++ptok:de-purl:html
     ++  ptok                                            ::  2616 token
       ;~  pose
-        aln  zap  hax  buc  cen  pam  say  tar  lus
+        aln  zap  hax  buc  cen  pam  soq  tar  lus
         hep  dot  ket  cab  tic  bar  sig
       ==
     ::                                                  ::  ++scem:de-purl:html

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7108,7 +7108,7 @@
     ++  ptok                                            ::  2616 token
       ;~  pose
         aln  zap  hax  buc  cen  pad  say  tar  lus
-        hep  dot  ket  cab  tec  bar  sig
+        hep  dot  ket  cab  tic  bar  sig
       ==
     ::                                                  ::  ++scem:de-purl:html
     ++  scem                                            ::  2396 scheme

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6125,7 +6125,7 @@
       [(rash a fel) b]
     ::                                                  ::  ++pa:dejs:format
     ++  pa                                              ::  string as path
-      (su ;~(pfix net (more net urs:ab)))
+      (su ;~(pfix fas (more fas urs:ab)))
     ::                                                  ::  ++pe:dejs:format
     ++  pe                                              ::  prefix
       |*  {pre/* wit/fist}
@@ -6696,7 +6696,7 @@
           =*  wow  `(map @t @)`(malt lip)
           (sear ~(get by wow) low)
         =*  tuf  ;~(pfix (just 'u') (cook tuft qix:ab))
-        ;~(pose doq net soq bas loo tuf)
+        ;~(pose doq fas soq bas loo tuf)
       ==
     ::                                                  ::  ++expo:de-json:html
     ++  expo                                            ::  exponent
@@ -7032,7 +7032,7 @@
     ::                                                  ::  ++apat:de-purl:html
     ++  apat                                            ::  2396 abs_path
       %+  cook  deft
-      ;~(pfix net (more net smeg))
+      ;~(pfix fas (more fas smeg))
     ::                                                  ::  ++aurf:de-purl:html
     ++  aurf                                            ::  2396 with fragment
       %+  cook  |~(a/purf a)
@@ -7059,7 +7059,7 @@
     ::                                                  ::  ++htts:de-purl:html
     ++  htts                                            ::  scheme
       %+  sear  ~(get by (malt `(list (pair term ?))`[http+| https+& ~]))
-      ;~(sfix scem ;~(plug col net net))
+      ;~(sfix scem ;~(plug col fas fas))
     ::                                                  ::  ++cock:de-purl:html
     ++  cock                                            ::  cookie
       %+  most  ;~(plug mic ace)
@@ -7091,10 +7091,10 @@
       (cold ' ' (just '+'))
     ::                                                  ::  ++pque:de-purl:html
     ++  pque                                            ::  3986 query char
-      ;~(pose pcar net wut)
+      ;~(pose pcar fas wut)
     ::                                                  ::  ++pquo:de-purl:html
     ++  pquo                                            ::  normal query char
-      ;~(pose pure pesc pold net wut col com)
+      ;~(pose pure pesc pold fas wut col com)
     ::                                                  ::  ++pure:de-purl:html
     ++  pure                                            ::  2396 unreserved
       ;~(pose aln hep dot cab sig)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7053,7 +7053,7 @@
         [q.a [[p.a r.a] b]]
       ::
       ;~  plug
-        ;~(plug htts (punt ;~(sfix urt:ab vat)) thor)
+        ;~(plug htts (punt ;~(sfix urt:ab pat)) thor)
         ;~(plug ;~(pose apat (easy *pork)) yque)
       ==
     ::                                                  ::  ++htts:de-purl:html
@@ -7079,7 +7079,7 @@
       (cook crip (star pquo))
     ::                                                  ::  ++pcar:de-purl:html
     ++  pcar                                            ::  2396 path char
-      ;~(pose pure pesc psub col vat)
+      ;~(pose pure pesc psub col pat)
     ::                                                  ::  ++pcok:de-purl:html
     ++  pcok                                            ::  cookie char
       ;~(less bas mic com yel prn)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -7101,7 +7101,7 @@
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose
-        zap  buc  pam  soq  lit  rit
+        zap  buc  pam  soq  pal  par
         tar  lus  com  mic  tis
       ==
     ::                                                  ::  ++ptok:de-purl:html
@@ -8590,7 +8590,7 @@
     ::
     ++  function
       |*  [tag=@tas fun=@t rul=rule]
-      ;~(plug (cold tag (jest fun)) (ifix [lit rit] rul))
+      ;~(plug (cold tag (jest fun)) (ifix [pal par] rul))
     ::
     ++  shipname
       ;~(pfix sig fed:ag)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6883,10 +6883,10 @@
       ==
     ::                                                  ::  ++escp:de-xml:html
     ++  escp                                            ::
-      ;~(pose ;~(less led ban pad prn) enty)
+      ;~(pose ;~(less led ban pam prn) enty)
     ::                                                  ::  ++enty:de-xml:html
     ++  enty                                            ::  entity
-      %+  ifix  pad^mic
+      %+  ifix  pam^mic
       ;~  pose
         =+  def=^+(ent (my:nl [%gt '>'] [%lt '<'] [%amp '&'] [%quot '"'] ~))
         %+  sear  ~(get by (~(uni by def) ent))
@@ -7101,13 +7101,13 @@
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose
-        zap  buc  pad  say  lit  rit
+        zap  buc  pam  say  lit  rit
         tar  lus  com  mic  tis
       ==
     ::                                                  ::  ++ptok:de-purl:html
     ++  ptok                                            ::  2616 token
       ;~  pose
-        aln  zap  hax  buc  cen  pad  say  tar  lus
+        aln  zap  hax  buc  cen  pam  say  tar  lus
         hep  dot  ket  cab  tic  bar  sig
       ==
     ::                                                  ::  ++scem:de-purl:html
@@ -7164,7 +7164,7 @@
         ::  proper query
         ::
         %+  more
-          ;~(pose pad mic)
+          ;~(pose pam mic)
         ;~(plug fque ;~(pose ;~(pfix tis fquu) (easy '')))
         ::
         ::  funky query


### PR DESCRIPTION
      update "XX deprecated" comments to match:
      https://urbit.org/docs/tutorials/hoon/hoon-syntax/#reading-hoon-aloud
      restore mnemonics

Replaces https://github.com/urbit/urbit/pull/2930.

I will add `bus` to `buc`, etc commits as I finish them, but you can pull at any time.