### PR TITLE
ames: add |ames-wake

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -140,7 +140,7 @@
   `..on-init
 ::
 ++  on-save
-  !>([%4 lac])
+  !>([%5 lac])
 ::
 ++  on-load
   |=  =old-state=vase

--- a/pkg/arvo/gen/hood/ames-wake.hoon
+++ b/pkg/arvo/gen/hood/ames-wake.hoon
@@ -1,0 +1,5 @@
+::  Set timers for any ames flows that lack them
+::
+:-  %say
+|=  [^ ~ ~]
+[%helm-ames-wake ~]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -185,6 +185,10 @@
   |=  veb=(list verb:ames)  =<  abet
   (emit %pass /helm %arvo %a %spew veb)
 ::
+++  poke-ames-wake
+  |=  ~  =<  abet
+  (emit %pass /helm %arvo %a %stir '')
+::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet
   (emit %pass /helm %arvo %d %knob error-tag level)
@@ -205,6 +209,7 @@
     %helm-send-hi          =;(f (f !<(_+<.f vase)) poke-send-hi)
     %helm-ames-sift        =;(f (f !<(_+<.f vase)) poke-ames-sift)
     %helm-ames-verb        =;(f (f !<(_+<.f vase)) poke-ames-verb)
+    %helm-ames-wake        =;(f (f !<(_+<.f vase)) poke-ames-wake)
     %helm-verb             =;(f (f !<(_+<.f vase)) poke-verb)
     %helm-knob             =;(f (f !<(_+<.f vase)) poke-knob)
     %helm-rekey            =;(f (f !<(_+<.f vase)) poke-rekey)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -599,6 +599,7 @@
       %jilt  (on-jilt:event-core ship.task)
       %sift  (on-sift:event-core ships.task)
       %spew  (on-spew:event-core veb.task)
+      %stir  (on-stir:event-core arg.task)
       %trim  on-trim:event-core
       %vega  on-vega:event-core
       %wegh  on-wegh:event-core
@@ -819,6 +820,52 @@
         %rot  acc(rot %.y)
       ==
     event-core
+  ::  +on-stir: start timers for any flow that lack them
+  ::
+  ::    .arg is unused, meant to ease future debug commands
+  ::
+  ++  on-stir
+    |=  arg=@t
+    =/  states=(list [ship peer-state])
+      %+  murn  ~(tap by peers.ames-state)
+      |=  [=ship =ship-state]
+      ^-  (unit [^ship peer-state])
+      ~&  checking=ship
+      ?.  ?=(%known -.ship-state)
+        ~
+      `[ship +.ship-state]
+    =/  snds=(list (list [ship bone message-pump-state]))
+      %+  turn  states
+      |=  [=ship peer-state]
+      %+  turn  ~(tap by snd)
+      |=  [=bone =message-pump-state]
+      [ship bone message-pump-state]
+    =/  next-wakes
+      %+  turn  `(list [ship bone message-pump-state])`(zing snds)
+      |=  [=ship =bone message-pump-state]
+      [ship bone next-wake.packet-pump-state]
+    =/  next-real-wakes=(list [=ship =bone =@da])
+      %+  murn  next-wakes
+      |=  [=ship =bone tym=(unit @da)]
+      ^-  (unit [^ship ^bone @da])
+      ?~(tym ~ `[ship bone u.tym])
+    =/  timers
+      %-  silt
+      ;;  (list [@da ^duct])
+      =<  q.q  %-  need  %-  need
+      %-  scry-gate
+      [[%141 %noun] ~ %b [[our %timers da+now] /]]
+    =/  to-stir
+      %+  skip  next-real-wakes
+      |=  [=ship =bone =@da]
+      (~(has in timers) [da `^duct`~[a+(make-pump-timer-wire ship bone) /ames]])
+    ~&  [%stirring to-stir]
+    |-  ^+  event-core
+    ?~  to-stir
+      event-core
+    =/  =wire  (make-pump-timer-wire [ship bone]:i.to-stir)
+    =.  event-core  (emit duct %pass wire %b %wait da.i.to-stir)
+    $(to-stir t.to-stir)
   ::  +on-crud: handle event failure; print to dill
   ::
   ++  on-crud

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -410,6 +410,7 @@
           $>(%init vane-task)
           [%sift ships=(list ship)]
           [%spew veb=(list verb)]
+          [%stir arg=@t]
           $>(%trim vane-task)
           $>(%vega vane-task)
           $>(%wegh vane-task)


### PR DESCRIPTION
Somehow we ended up with flows which expected to awaken but did not wake
up.  This was likely caused by the error in r920j OTA, urbit-os-v1.0.18,
insufficiently mitigated in somam, urbit-os-v1.0.19.

This adds a command which ensures that every flow has an active timer.
I expect this to be needed only once, but it's a pretty general tool, so
it's worth keeping.

I've included an unused @t parameter to more easily add simple debug
commands to ames without having to add a new task

Includes #2948 because we don't want to keep reloading hood.  Officially this is considered a "backport" cherry-pick since that has already been merged into a release branch.