### PR TITLE
dbug fe: coax searchable list key into string

### DIFF
--- a/pkg/interface/dbug/src/js/components/searchable-list.js
+++ b/pkg/interface/dbug/src/js/components/searchable-list.js
@@ -33,7 +33,7 @@ export class SearchableList extends Component {
 
     let items = props.items.filter(item => {
       return state.query.split(' ').reduce((match, query) => {
-        return match && item.key.includes(query);
+        return match && ('' + item.key).includes(query);
       }, true);
     })
     items = items.map(item =>


### PR DESCRIPTION
includes() only works on strings, but we might pass in other types as keys.

Ames.js hits this, apparently:

https://github.com/urbit/urbit/blob/53b919965f50741cae6d51ccb283f8c9b38e6df3/pkg/interface/dbug/src/js/views/ames.js#L153

causes a `t.key.includes is not a function` error in the SearchableList component.

Observed this when trying to debug someone else's ship, haven't been able to whip up a repro locally. This should do the trick regardless.