### PR TITLE
jael: Breach-related fixes

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1432,6 +1432,9 @@
     ::
     ?:  already-pending
       event-core
+    ::  NB: we specifically look for this wire in +public-keys-give in
+    ::  Jael.  if you change it here, you must change it there.
+    ::
     (emit duct %pass /public-keys %j %public-keys [n=ship ~ ~])
   ::  +send-blob: fire packet at .ship and maybe sponsors
   ::

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -866,7 +866,8 @@
       ::  if changing rift upward, then signal a breach
       ::
       =?    ..feel
-          ?&  ?=(%rift -.a-diff)
+          ?&  ?=(^ maybe-point)
+              ?=(%rift -.a-diff)
               (gth to.a-diff rift.point)
           ==
         %+  public-keys-give

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -664,7 +664,8 @@
   ::
   ++  public-keys-give
     |=  [yen=(set duct) =public-keys-result]
-    =+  yez=~(tap in yen)
+    |^
+    =+  yez=(sort ~(tap in yen) sorter)
     |-  ^+  this-su
     ?~  yez  this-su
     =*  d  i.yez
@@ -675,6 +676,18 @@
       %-  emit
       [d %give %boon %public-keys-result public-keys-result]
     $(yez t.yez)
+    ::
+    ::  We want to notify Ames, then Clay, then Gall.  This happens to
+    ::  be alphabetical, but this is mostly a coincidence.
+    ::
+    ++  sorter
+      |=  [a=duct b=duct]
+      ?.  ?=([[@ *] *] a)
+        |
+      ?.  ?=([[@ *] *] b)
+        &
+      (lth i.i.a i.i.b)
+    --
   ::
   ++  get-source
     |=  who=@p

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -669,7 +669,7 @@
     ?~  yez  this-su
     =*  d  i.yez
     =.  this-su
-      ?.  &(?=([[%a @ @ *] *] d) !=(%pubs i.t.i.d))
+      ?.  &(?=([[%a @ @ *] *] d) !=(%public-keys i.t.i.d))
         %-  emit
         [d %give %public-keys public-keys-result]
       %-  emit


### PR DESCRIPTION
Still testing, but seems correct so far.  See #2952 for details.  Also copying the description of the first commit:

We inspect the wire of our subscriber to see if we need to produce the
result as a %public-keys or a %boon.  This is bad -- we should proxy the
subscription to avoid this need, but this doesn't make that change yet.

%pubs is an old name that doesn't exist anymore (last existed around
September 2019).  The new version is /public-keys, but it's worked so
far because /public-keys has only one item in the path, so it missed the
conditional.  This commit makes the intent more clear.

The [%a @ @ *] could be just [%a @ *], but I leave it to reduce the
chance of breaking stuff.