### PR TITLE
serf: disable automatic |pack

### DIFF
--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -427,7 +427,7 @@ _worker_lame(u3_noun now, u3_noun ovo, u3_noun why, u3_noun tan)
 {
   u3_noun rep;
   u3_noun wir, tag, cad;
-  c3_o pac_o = c3n;
+  c3_o rec_o = c3n;
   c3_d evt_d = u3V.sen_d;
 
   u3V.sen_d = u3V.dun_d;
@@ -467,16 +467,16 @@ _worker_lame(u3_noun now, u3_noun ovo, u3_noun why, u3_noun tan)
                              u3nc(u3k(tag), u3k(cad))));
   }
 
-  pac_o = _(c3__meme == why);
+  //  reclaim memory on bail:meme?
+  //
+  rec_o = __(c3__meme == why);
 
   _worker_send_replace(evt_d, u3nc(now, rep));
 
   u3z(ovo); u3z(why); u3z(tan);
 
-  //  XX review, always pack on meme?
-  //
-  if ( c3y == pac_o ) {
-    _worker_pack();
+  if ( c3y == rec_o ) {
+    u3m_reclaim();
   }
 }
 
@@ -554,16 +554,13 @@ _worker_sure_feck(u3_noun ovo, u3_noun vir, c3_w pre_w)
 
     if ( (pre_w > low_w) && !(pos_w > low_w) ) {
       //  XX set flag(s) in u3V so we don't repeat endlessly?
-      //  XX pack here too?
       //
-      pac_o = c3y;
       rec_o = c3y;
       pri   = 1;
     }
     else if ( (pre_w > hig_w) && !(pos_w > hig_w) ) {
       //  XX we should probably jam/cue our entire state at this point
       //
-      pac_o = c3y;
       rec_o = c3y;
       pri   = 0;
     }


### PR DESCRIPTION
`|pack` (added in #1984) only works up to some threshold of memory usage (as currently implemented), so it's unsafe to run automatically. Restoring this kind of automatic memory compaction remains a goal, but it'll require more significant development efforts.

Examples of this problem abound -- #2677 is representative.
