### PR TITLE
eyre: respect "forwarded" header from localhost

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a22f2797c2cbbff171cb0a4c14afaca4353f41f49f1fcdc5f5dbf3e8056a7e3
-size 13813374
+oid sha256:960df352aa78135a409e87d0946bf2665605bf3918c19e3e290ad40edb740769
+size 17295261

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1470,6 +1470,53 @@
         ::
         (gte i.b 224)
     ==
+  ::  +ipa: parse ip address
+  ::
+  ++  ipa
+    ;~(pose (stag %ipv4 ip4) (stag %ipv6 ip6))
+  ::  +ip4: parse ipv4 address
+  ::
+  ++  ip4
+    =+  byt=(ape:ag ted:ab)
+    (bass 256 ;~(plug byt (stun [3 3] ;~(pfix dot byt))))
+  ::  +ip6: parse ipv6 address
+  ::
+  ++  ip6
+    %+  bass  0x1.0000
+    %+  sear
+      |=  hexts=(list $@(@ [~ %zeros]))
+      ^-  (unit (list @))
+      ::  not every list of hextets is an ipv6 address
+      ::
+      =/  legit=?
+        =+  l=(lent hexts)
+        =+  c=|=(a=* ?=([~ %zeros] a))
+        ?|  &((lth l 8) ?=([* ~] (skim hexts c)))
+            &(=(8 l) !(lien hexts c))
+        ==
+      ?.  legit  ~
+      %-  some
+      ::  expand zeros
+      ::
+      %-  zing
+      %+  turn  hexts
+      |=  hext=$@(@ [~ %zeros])
+      ?@  hext  [hext]~
+      (reap (sub 9 (lent hexts)) 0)
+    ::  parse hextets, producing cell for shorthand zeroes
+    ::
+    |^  %+  cook
+          |=  [a=(list @) b=(list [~ %zeros]) c=(list @)]
+          :(welp a b c)
+        ;~  plug
+          (more col het)
+          (stun [0 1] cel)
+          (more col het)
+        ==
+    ++  cel  (cold `%zeros ;~(plug col col))
+    ++  het  (bass 16 (stun [1 4] six:ab))
+    --
+  ::
   ++  rout  {p/(list host) q/path r/oryx s/path}        ::  http route (new)
   ++  user  knot                                        ::  username
   --  ::eyre

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -357,6 +357,45 @@
       t.header-list
     ::
     [i.header-list $(header-list t.header-list)]
+  ::  +unpack-header: parse header field values
+  ::
+  ++  unpack-header
+    |^  |=  value=@t
+        ^-  (unit (list (map @t @t)))
+        (rust (cass (trip value)) values)
+    ::
+    ++  values
+      %+  more
+        (ifix [. .]:(star ;~(pose ace (just '\09'))) com)
+      pairs
+    ::
+    ++  pairs
+      %+  cook
+        ~(gas by *(map @t @t))
+      %+  more  (ifix [. .]:(star ace) mic)
+      ;~(plug token ;~(pose ;~(pfix tis value) (easy '')))
+    ::
+    ++  value
+      ;~(pose token quoted-string)
+    ::
+    ++  token                                         ::  7230 token
+      %+  cook  crip
+      ::NOTE  this is ptok:de-purl:html, but can't access that here
+      %-  plus
+      ;~  pose
+        aln  zap  hax  bus  cen  pad  say  tar  lus
+        hep  dot  ket  cab  tec  bar  sig
+      ==
+    ::
+    ++  quoted-string                                 ::  7230 quoted string
+      %+  cook  crip
+      %+  ifix  [. .]:;~(less (jest '\\"') yel)
+      %-  star
+      ;~  pose
+        ;~(pfix bat ;~(pose (just '\09') ace prn))
+        ;~(pose (just '\09') ;~(less (mask "\22\5c\7f") (shim 0x20 0xff)))
+      ==
+    --
   ::  +simple-payload: a simple, one event response used for generators
   ::
   +$  simple-payload


### PR DESCRIPTION
See also #2723, which this fixes, for prior commentary.

It's not uncommon for people to run their ships behind a reverse proxy. In that situation, requests to Eyre will always appear to be coming from localhost.

[RFC7239](https://tools.ietf.org/html/rfc7239) describes the Forwarded header, which proxy servers can use to send along the original IP address, among other details.

This PR makes Eyre respect that header if the request came from localhost, updating the `address` associated with the request before further processing.