### PR TITLE
eyre: 303 redirect on successful login

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a22f2797c2cbbff171cb0a4c14afaca4353f41f49f1fcdc5f5dbf3e8056a7e3
-size 13813374
+oid sha256:50821a0866e2ed901404a5c7bba9c4e2acb14a9658e32fd4719a642df77ff5e7
+size 13813430

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -979,7 +979,7 @@
       =/  actual-redirect  ?:(=(u.redirect '') '/' u.redirect)
       %-  handle-response
       :*  %start
-          :-  status-code=307
+          :-  status-code=303
           ^=  headers
             :~  ['location' actual-redirect]
                 ['set-cookie' cookie-line]

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -613,12 +613,12 @@
             ^-  (hypo sign:http-server-gate)  :-  *type
             :*  %g  %unto  %fact
                 %http-response-header
-                !>([307 ['location' '/~/login?redirect=/~landscape/inner-path']~])
+                !>([303 ['location' '/~/login?redirect=/~landscape/inner-path']~])
             ==
          ==
       ^=  expected-move
         :~  :*  duct=~[/http-blah]  %give  %response
-                [%start [307 ['location' '/~/login?redirect=/~landscape/inner-path']~] ~ %.n]
+                [%start [303 ['location' '/~/login?redirect=/~landscape/inner-path']~] ~ %.n]
     ==  ==  ==
   ::  the browser then fetches the login page
   ::
@@ -2152,7 +2152,7 @@
                 %give
                 %response
                 %start
-                :-  307
+                :-  303
                 :~  ['location' '/~landscape']
                     :-  'set-cookie'
                     'urbauth-~nul=0v3.q0p7t.mlkkq.cqtto.p0nvi.2ieea; Path=/; Max-Age=604800'


### PR DESCRIPTION
Changes the HTTP status code of the redirect that occurs upon a
successful login from 307 to 303. 307 preserves the method of the
original request, so the redirected request is a POST. With the new SPA,
this causes a 404 as app/file-server validates the method of the
request, something that did not happen in earlier versions of landscape.
303 instead changes the method to always produce a GET request.

