### PR TITLE
eyre: provide logout endpoint

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:960df352aa78135a409e87d0946bf2665605bf3918c19e3e290ad40edb740769
-size 17295261
+oid sha256:dfaee098f2dca396c17aa1ddf1d2755f5f7d8639864b0e970fce0290d67008cc
+size 20306202

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1012,7 +1012,7 @@
       ::
       =/  response=$>(%start http-event:http)
         :*  %start
-            response-header=[307 ['location' '/~/login']~]
+            response-header=[303 ['location' '/~/login']~]
             data=~
             complete=%.y
         ==

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2445,7 +2445,7 @@
       %~2019.10.6
     =^  success  bindings.server-state.old
       %+  insert-binding
-        [[~ /~/logout] ~ [%logout ~]]
+        [[~ /~/logout] [/e/load/logout]~ [%logout ~]]
       bindings.server-state.old
     ~?  !success  [%e %failed-to-setup-logout-endpoint]
     %_  $

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1314,6 +1314,9 @@
         ::  internal authentication page
         ::
         [%authentication ~]
+        ::  internal logout page
+        ::
+        [%logout ~]
         ::  gall channel system
         ::
         [%channel ~]

--- a/pkg/interface/dbug/src/js/views/eyre.js
+++ b/pkg/interface/dbug/src/js/views/eyre.js
@@ -168,6 +168,12 @@ export class Eyre extends Component {
 
       <h4>Cookies</h4>
       <button onClick={this.loadAuthenticationState}>refresh</button>
+      <form method="post" action="/~/logout">
+        <button type="submit">logout</button>
+      </form>
+      <form method="post" action="/~/logout">
+        <button type="submit" name="all">logout all</button>
+      </form>
       {sessionItems}
     </>);
   }


### PR DESCRIPTION
Set up, by default, on /~/logout.

Sending a POST request to this expires the current session and redirects to the login page. If the "all" key is set in the request body, expires all open sessions.

This provides the backend for #2649. @urcades might want to think about integrating these actions into the frontend. For now, I just added a pair of buttons to the debug dashboard.