### PR TITLE
interface: improve webpack dev config

### DIFF
--- a/pkg/interface/config/urbitrc-sample
+++ b/pkg/interface/config/urbitrc-sample
@@ -1,5 +1,6 @@
 module.exports = {
   URBIT_PIERS: [
     "/Users/user/ships/zod/home",
-  ]
+  ],
+  herb: false
 };

--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -2,6 +2,41 @@ const path = require('path');
 // const HtmlWebpackPlugin = require('html-webpack-plugin');
 // const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const urbitrc = require('./urbitrc');
+const fs = require('fs');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+function copyFile(src,dest) {
+  return new Promise((res,rej) =>
+    fs.copyFile(src,dest, err => err ? rej(err) : res()));
+}
+
+class UrbitShipPlugin {
+  constructor(urbitrc) {
+    this.piers = urbitrc.URBIT_PIERS;
+    this.herb = urbitrc.herb || false;
+  }
+
+  apply(compiler) {
+    compiler.hooks.afterCompile.tapPromise(
+      'UrbitShipPlugin',
+      async (compilation) => {
+        const src = path.resolve(compiler.options.output.path, 'index.js');
+        return Promise.all(this.piers.map(pier => {
+          const dst = path.resolve(pier, 'app/landscape/js/index.js');
+          copyFile(src, dst).then(() => {
+            if(!this.herb) {
+              return;
+            }
+            pier = pier.split('/');
+            const desk = pier.pop();
+            return exec(`herb -p hood -d '+hood/commit %${desk}' ${pier.join('/')}`);
+          });
+        }));
+      }
+    )
+  }
+}
 
 module.exports = {
   mode: 'development',
@@ -49,16 +84,18 @@ module.exports = {
   //   historyApiFallback: true
   // },
   plugins: [
+    new UrbitShipPlugin(urbitrc)
     // new CleanWebpackPlugin(),
     // new HtmlWebpackPlugin({
     //   title: 'Hot Module Replacement',
     //   template: './public/index.html',
     // }),
   ],
+  watch: true,
   output: {
     filename: 'index.js',
     chunkFilename: 'index.js',
-    path: path.resolve(urbitrc.URBIT_PIERS[0] + '/app/landscape/', 'js'),
+    path: path.resolve(__dirname, '../dist'),
     publicPath: '/'
   },
   optimization: {


### PR DESCRIPTION
Fixes an issue where only the first ship would receive the updated files
from webpack. Enables watch mode. If herb is set to true in the urbitrc,
then webpack will commit the desk for each change on every ship.