### PR TITLE
jael: always restart subscription to breached ship

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd9ee3401fd2a29fc49ef84aa51754be5929f2cddbb7e378ffac4641695e886c
-size 13838435
+oid sha256:46d79f0b3dc1c4ff5f7ca56f1601a26a0fbc67540ab0ebcc672dc282fe8bbe74
+size 13825786

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -883,9 +883,17 @@
               ?=(%rift -.a-diff)
               (gth to.a-diff rift.point)
           ==
-        %+  public-keys-give
-          (subscribers-on-ship who)
-        [%breach who]
+        =.  ..feel
+          %+  public-keys-give
+            (subscribers-on-ship who)
+          [%breach who]
+        =/  sor  (~(get by sources-reverse) %& who)
+        ?~  sor
+          ..feel
+        ::  delay resubscribing because Ames is going to clear any
+        ::  messages we send now.
+        ::
+        (emit hen %pass /breach/(scot %ud u.sor) %b %wait now)
       ::
       =.  point
         ?-  -.a-diff


### PR DESCRIPTION
Something I noticed recently is that in some cases we don't correctly restart the Jael-to-Jael subscription when the other ship breaches.  For example, if another planet breaches while we were asking for their moon's keys, that subscription will be broken.

This is particularly a problem when you boot a new moon to test software hosted on another moon -- often you don't wait for keys to download, so you hear about any historical breaches by that planet after you started asking for its moon's keys, so you never get to talk to that moon.