### PR TITLE
shoe: optionally auto-run commands on entry

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -451,6 +451,7 @@
   ::
   ++  parser
     |^
+      %+  stag  |
       %+  knee  *command  |.  ~+
       =-  ;~(pose ;~(pfix mic -) message)
       ;~  pose

--- a/pkg/arvo/app/shoe.hoon
+++ b/pkg/arvo/app/shoe.hoon
@@ -40,8 +40,8 @@
 ::
 ++  command-parser
   |=  sole-id=@ta
-  ^+  |~(nail *(like command))
-  (cold ~ (jest 'demo'))
+  ^+  |~(nail *(like [? command]))
+  (cold [& ~] (jest 'demo'))
 ::
 ++  tab-list
   |=  sole-id=@ta

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -35,14 +35,20 @@
   |*  command-type=mold
   $_  ^|
   |_  bowl:gall
+  ::  +command-parser: input parser for a specific session
+  ::
+  ::    if the head of the result is true, instantly run the command
+  ::
   ++  command-parser
     |~  sole-id=@ta
-    |~(nail *(like command-type))
+    |~(nail *(like [? command-type]))
+  ::  +tab-list: autocomplete options for the session (to match +command-parser)
   ::
   ++  tab-list
     |~  sole-id=@ta
     ::  (list [@t tank])
     *(list (option:auto tank))
+  ::  +on-command: called when a valid command is run
   ::
   ++  on-command
     |~  [sole-id=@ta command=command-type]
@@ -106,7 +112,8 @@
   |*  [shoe=* command-type=mold]
   |_  =bowl:gall
   ++  command-parser
-    (easy *command-type)
+    |=  sole-id=@ta
+    (easy *[? command-type])
   ::
   ++  tab-list
     ~
@@ -193,9 +200,9 @@
       (~(gut by soles) sole-id *sole-share)
     |^  =^  [cards=(list card) =_cli-state]  shoe
           ?-  -.dat.act
-            %det  [(apply-edit +.dat.act) shoe]
+            %det  (apply-edit +.dat.act)
             %clr  [[~ cli-state] shoe]
-            %ret  run-command
+            %ret  try-command
             %tab  [(tab +.dat.act) shoe]
           ==
         :-  (deal cards)
@@ -208,15 +215,18 @@
     ::
     ++  apply-edit
       |=  =sole-change
-      ^-  (quip card _cli-state)
+      ^+  [[*(list card) cli-state] shoe]
       =^  inverse  cli-state
         (~(transceive sole cli-state) sole-change)
       ::  res: & for fully parsed, | for parsing failure at location
       ::
-      =/  res=(each (unit) @ud)
+      =/  res=(each (unit [run=? cmd=command-type]) @ud)
         %+  rose  (tufa buf.cli-state)
         (command-parser:og sole-id)
-      ?:  ?=(%& -.res)  [~ cli-state]
+      ?:  ?=(%& -.res)
+        ?~  p.res  [[~ cli-state] shoe]
+        (run-command cmd.u.p.res)
+      :_  shoe
       ::  parsing failed
       ::
       ?.  &(?=(%del -.inverse) =(+(p.inverse) (lent buf.cli-state)))
@@ -234,14 +244,18 @@
           [%err p.res]  ::  cursor to error location
       ==
     ::
-    ++  run-command
+    ++  try-command
       ^+  [[*(list card) cli-state] shoe]
-      =/  cmd=(unit command-type)
+      =/  res=(unit [? cmd=command-type])
         %+  rust  (tufa buf.cli-state)
         (command-parser:og sole-id)
-      ?~  cmd
-        [[[(effect %bel ~)]~ cli-state] shoe]
-      =^  cards  shoe  (on-command:og sole-id u.cmd)
+      ?^  res  (run-command cmd.u.res)
+      [[[(effect %bel ~)]~ cli-state] shoe]
+    ::
+    ++  run-command
+      |=  cmd=command-type
+      ^+  [[*(list card) cli-state] shoe]
+      =^  cards  shoe  (on-command:og sole-id cmd)
       ::  clear buffer
       ::
       =^  clear  cli-state  (~(transmit sole cli-state) [%set ~])

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -116,6 +116,7 @@
     (easy *[? command-type])
   ::
   ++  tab-list
+    |=  sole-id=@ta
     ~
   ::
   ++  on-command

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -225,7 +225,8 @@
         %+  rose  (tufa buf.cli-state)
         (command-parser:og sole-id)
       ?:  ?=(%& -.res)
-        ?~  p.res  [[~ cli-state] shoe]
+        ?.  &(?=(^ p.res) run.u.p.res) 
+          [[~ cli-state] shoe]
         (run-command cmd.u.p.res)
       :_  shoe
       ::  parsing failed


### PR DESCRIPTION
Seems generally useful for cli apps wanting to do single-keystroke commands or other "fast cli input" ux. I want this for something I'm working on, and ~litter-wolfur expressed wanting this for their srs app's cli.

The `+command-parser` must now produce both a flag and a command noun.
If the flag is true, instantly runs the command from the noun.
If false, maintains standard behavior and only runs it on-return.