### PR TITLE
drum: add %file-server to boot priority

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -361,7 +361,8 @@
           %metadata-store
       ==
       :: ensure chat-cli can sub to invites
-      (sy ~[%chat-hook])
+      :: and file server can receive pokes
+      (sy ~[%chat-hook %file-server])
     ==
   ++  sort-by-priorities
     =/  priorities  priorities


### PR DESCRIPTION
File server needs to be started with priority in order to ensure the
-view apps can poke it, regardless of set ordering.