### PR TITLE
contact-hook: fix /~/default poke

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -137,7 +137,7 @@
   ^-  (list card)
   ::  local
   ?:  (team:title our.bol src.bol)
-    ?.  (~(has by synced) path)  ~
+    ?.  |(=(path /~/default) (~(has by synced) path))  ~
     =/  shp  ?:(=(path /~/default) our.bol (~(got by synced) path))
     =/  appl  ?:(=(shp our.bol) %contact-store %contact-hook)
     [%pass / %agent [shp appl] %poke %contact-action !>(act)]~


### PR DESCRIPTION
We don't maintain a synced entry in the state for /~/default, so ignore
the synced check if modifying the /~/default contacts.