### PR TITLE
group-hook: add /synced scry

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -286,7 +286,13 @@
     ==
   ::
   ++  on-leave  on-leave:def
-  ++  on-peek   on-peek:def
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?.  ?=([%x %synced ~] path)
+      (on-peek:def path)
+    ``noun+!>(synced)
+  ::
   ++  on-arvo   on-arvo:def
   ++  on-fail   on-fail:def
   --


### PR DESCRIPTION
Adds a simple /synced scry to ease the migration of splitting group-hook
into group-push-hook and group-pull-hook.

Needs to be OTA'd before new groups is rolled out. Ping @ixv 