### PR TITLE
arvo: compile hoon/arvo in separate roads

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1213,7 +1213,7 @@
   ::
   =/  raw
     ~&  [%hoon-compile `@p`(mug hun)]
-    (mure |.((ride %noun hun)))
+    (road |.((ride %noun hun)))
   ::  activate the new compiler gate, producing +ride
   ::
   =/  cop  .*(0 +.raw)
@@ -1230,7 +1230,7 @@
     ?:  =(nex hoon-version)
       [raw cop]
     ~&  [%hoon-compile-upgrade nex]
-    %-  mure  |.
+    %-  road  |.
     =/  hot  (slum cop [%noun hun])
     [hot .*(0 +.hot)]
   ::  extract the hoon core from the outer gate (+ride)
@@ -1243,7 +1243,7 @@
   ::
   =/  rav
     ~&  [%arvo-compile `@p`(mug hyp) `@p`(mug van)]
-    (mure |.((slum cop [hyp van])))
+    (road |.((slum cop [hyp van])))
   ::  activate arvo, and extract the arvo core from the outer gate
   ::
   =/  voc  .*(hoc [%7 +.rav %0 7])

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1213,7 +1213,7 @@
   ::
   =/  raw
     ~&  [%hoon-compile `@p`(mug hun)]
-    (ride %noun hun)
+    (mure |.((ride %noun hun)))
   ::  activate the new compiler gate, producing +ride
   ::
   =/  cop  .*(0 +.raw)
@@ -1226,11 +1226,13 @@
   ::
   ::    hot: raw compiler formula
   ::
-  =>  ?:  =(nex hoon-version)
-        [hot=`*`raw .]
-      ~&  [%hoon-compile-upgrade nex]
-      =/  hot  (slum cop [%noun hun])
-      .(cop .*(0 +.hot))
+  =^  hot=*  cop
+    ?:  =(nex hoon-version)
+      [raw cop]
+    ~&  [%hoon-compile-upgrade nex]
+    %-  mure  |.
+    =/  hot  (slum cop [%noun hun])
+    [hot .*(0 +.hot)]
   ::  extract the hoon core from the outer gate (+ride)
   ::
   =/  hoc  .*(cop [%0 7])
@@ -1241,7 +1243,7 @@
   ::
   =/  rav
     ~&  [%arvo-compile `@p`(mug hyp) `@p`(mug van)]
-    (slum cop [hyp van])
+    (mure |.((slum cop [hyp van])))
   ::  activate arvo, and extract the arvo core from the outer gate
   ::
   =/  voc  .*(hoc [%7 +.rav %0 7])

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12035,6 +12035,15 @@
   ?~  a  !!
   ~_(i.a $(a t.a))
 ::
+++  mure
+  |*  =(trap *)
+  ^+  $:trap
+  =/  res  (mule trap)
+  ?-  -.res
+    %&  p.res
+    %|  (mean leaf+"mure: road" p.res)
+  ==
+::
 ++  slew                                                ::  get axis in vase
   |=  {axe/@ vax/vase}  ^-  (unit vase)
   ?.  |-  ^-  ?

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12035,13 +12035,13 @@
   ?~  a  !!
   ~_(i.a $(a t.a))
 ::
-++  mure
+++  road
   |*  =(trap *)
   ^+  $:trap
   =/  res  (mule trap)
   ?-  -.res
     %&  p.res
-    %|  (mean leaf+"mure: road" p.res)
+    %|  (mean leaf+"road: new" p.res)
   ==
 ::
 ++  slew                                                ::  get axis in vase


### PR DESCRIPTION
Adds +mure to run a trap in a separate road.  This should eventually be
just a hint.

Vega was running inside a mule, but since +load was called within vega,
the new kernel was all run within the same mule, so it didn't actually
get to reclaim the space after hoon compiled.

We verified this with printfs in u3m_fall.  On the test ship (from
mainnet) which had 800MB used, vega was taking interior free space from
950MB to 450 over the course of compiling hoon, then each vane would go
from about 450 to 350 and then back to 450 once it finished (which
proves they were correctly isolated).  With this change, after hoon
compiles the free space goes back up to 950MB.  This gives us a lot more
space to compile OTAs.

We had to slightly refactor the logic for doubly-recompiling hoon, since
+mure as written produces a `?(!! _trap)`, and you can't find faces in the
result of the trap.  We could bake mure, but that's rather awkward.  I
wonder if there's a way to fix this as a wet gate.