### PR TITLE
zuse: fix jet mismatch in aes-siv

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe08c187082637e7bc29b0c8865a1b035e0e534dfd999daa19c088aed9ea9c4e
-size 13818020
+oid sha256:aacd15519a11badc17cbb3de42500a4673c0189d1cee11d759b6472629a88722
+size 13817804

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46d79f0b3dc1c4ff5f7ca56f1601a26a0fbc67540ab0ebcc672dc282fe8bbe74
-size 13825786
+oid sha256:fe08c187082637e7bc29b0c8865a1b035e0e534dfd999daa19c088aed9ea9c4e
+size 13818020

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3642,42 +3642,36 @@
     ::                                                  ::  ++s2va:aes:crypto
     ++  s2va                                            ::  AES-128 S2V
       ~/  %s2va
-      |=  {key/@H ads/(list @)}
-      =+  res=(maca key `16 0x0)
-      %^  maca  key  ~
-      |-  ^-  @uxH
+      |=  [key=@H ads=(list @)]
       ?~  ads  (maca key `16 0x1)
+      =/  res  (maca key `16 0x0)
+      %+  maca  key
+      |-  ^-  [[~ @ud] @uxH]
       ?~  t.ads
-        ?:  (gte (xeb i.ads) 128)
-          (mix i.ads res)
-        %+  mix
-          (doub res)
-          (mpad (met 3 i.ads) i.ads)
+        =/  wyt  (met 3 i.ads)
+        ?:  (gte wyt 16)
+          [`wyt (mix i.ads res)]
+        [`16 (mix (doub res) (mpad wyt i.ads))]
       %=  $
-        res  %+  mix
-               (doub res)
-               (maca key ~ i.ads)
         ads  t.ads
+        res  (mix (doub res) (maca key ~ i.ads))
       ==
     ::                                                  ::  ++s2vb:aes:crypto
     ++  s2vb                                            ::  AES-192 S2V
       ~/  %s2vb
-      |=  {key/@I ads/(list @)}
-      =+  res=(macb key `16 0x0)
-      %^  macb  key  ~
-      |-  ^-  @uxH
+      |=  [key=@I ads=(list @)]
       ?~  ads  (macb key `16 0x1)
+      =/  res  (macb key `16 0x0)
+      %+  macb  key
+      |-  ^-  [[~ @ud] @uxH]
       ?~  t.ads
-        ?:  (gte (xeb i.ads) 128)
-          (mix i.ads res)
-        %+  mix
-          (doub res)
-          (mpad (met 3 i.ads) i.ads)
+        =/  wyt  (met 3 i.ads)
+        ?:  (gte wyt 16)
+          [`wyt (mix i.ads res)]
+        [`16 (mix (doub res) (mpad wyt i.ads))]
       %=  $
-        res  %+  mix
-               (doub res)
-               (macb key ~ i.ads)
         ads  t.ads
+        res  (mix (doub res) (macb key ~ i.ads))
       ==
     ::                                                  ::  ++s2vc:aes:crypto
     ++  s2vc                                            ::  AES-256 S2V

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3682,22 +3682,19 @@
     ::                                                  ::  ++s2vc:aes:crypto
     ++  s2vc                                            ::  AES-256 S2V
       ~/  %s2vc
-      |=  {key/@I ads/(list @)}
-      =+  res=(macc key `16 0x0)
-      %^  macc  key  ~
-      |-  ^-  @uxH
+      |=  [key=@I ads=(list @)]
       ?~  ads  (macc key `16 0x1)
+      =/  res  (macc key `16 0x0)
+      %+  macc  key
+      |-  ^-  [[~ @ud] @uxH]
       ?~  t.ads
-        ?:  (gte (xeb i.ads) 128)
-          (mix i.ads res)
-        %+  mix
-          (doub res)
-          (mpad (met 3 i.ads) i.ads)
+        =/  wyt  (met 3 i.ads)
+        ?:  (gte wyt 16)
+          [`wyt (mix i.ads res)]
+        [`16 (mix (doub res) (mpad wyt i.ads))]
       %=  $
-        res  %+  mix
-               (doub res)
-               (macc key ~ i.ads)
         ads  t.ads
+        res  (mix (doub res) (macc key ~ i.ads))
       ==
     ::                                                  ::  ++siva:aes:crypto
     ++  siva                                            ::  AES-128 SIV

--- a/pkg/arvo/tests/sys/zuse/crypto/aes.hoon
+++ b/pkg/arvo/tests/sys/zuse/crypto/aes.hoon
@@ -567,7 +567,7 @@
   ^-  (list vector-siv)
   :~
   ::
-  ::  failed in the wild
+  ::  failed in the wild, see https://github.com/urbit/urbit/pull/3013
   ::
     :^    0xfdef.6253.d284.a940.1b5d.d1b7.fbcd.4489.
             3071.bf93.ace9.37da.7c5d.77d2.1f3e.cda4.

--- a/pkg/arvo/tests/sys/zuse/crypto/aes.hoon
+++ b/pkg/arvo/tests/sys/zuse/crypto/aes.hoon
@@ -567,6 +567,18 @@
   ^-  (list vector-siv)
   :~
   ::
+  ::  failed in the wild
+  ::
+    :^    0xfdef.6253.d284.a940.1b5d.d1b7.fbcd.4489.
+            3071.bf93.ace9.37da.7c5d.77d2.1f3e.cda4.
+            83be.1c51.a88b.c9ba.8741.e1ee.935b.c0ef.
+            888a.feff.0249.bdb6.1344.0ff9.4e1b.fca5
+        ad=~
+      inp=0x97.0341.38e3.960e.87e1
+    :+  iv=0x249f.85e3.c9a8.29b6.3122.ec22.cde6.76df
+      len=9
+    cph=0xdc.bdcd.e4f1.4fd4.2d8d
+  ::
   :: from RFC 5297, with extended key
   ::
     :^    0xfffe.fdfc.fbfa.f9f8.f7f6.f5f4.f3f2.f1f0.

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -161,25 +161,25 @@ static c3_c* _141_hex_aes_cbcc_ha[] = {
   0
 };
 
-static u3j_core _141_hex_aes_siva_d[] =
-  { { "en", 7, _141_hex_aes_siva_en_a, 0, _141_hex_aes_siva_en_ha },
-    { "de", 7, _141_hex_aes_siva_de_a, 0, _141_hex_aes_siva_de_ha },
+static u3j_core _141_hex_aes_siva_d[] = {
+  // { { "en", 7, _141_hex_aes_siva_en_a, 0, _141_hex_aes_siva_en_ha },
+  //   { "de", 7, _141_hex_aes_siva_de_a, 0, _141_hex_aes_siva_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_siva_ha[] = {
   0
 };
-static u3j_core _141_hex_aes_sivb_d[] =
-  { { "en", 7, _141_hex_aes_sivb_en_a, 0, _141_hex_aes_sivb_en_ha },
-    { "de", 7, _141_hex_aes_sivb_de_a, 0, _141_hex_aes_sivb_de_ha },
+static u3j_core _141_hex_aes_sivb_d[] = {
+  // { { "en", 7, _141_hex_aes_sivb_en_a, 0, _141_hex_aes_sivb_en_ha },
+  //   { "de", 7, _141_hex_aes_sivb_de_a, 0, _141_hex_aes_sivb_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_sivb_ha[] = {
   0
 };
-static u3j_core _141_hex_aes_sivc_d[] =
-  { { "en", 7, _141_hex_aes_sivc_en_a, 0, _141_hex_aes_sivc_en_ha },
-    { "de", 7, _141_hex_aes_sivc_de_a, 0, _141_hex_aes_sivc_de_ha },
+static u3j_core _141_hex_aes_sivc_d[] = {
+  // { { "en", 7, _141_hex_aes_sivc_en_a, 0, _141_hex_aes_sivc_en_ha },
+  //   { "de", 7, _141_hex_aes_sivc_de_a, 0, _141_hex_aes_sivc_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_sivc_ha[] = {

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -161,25 +161,25 @@ static c3_c* _141_hex_aes_cbcc_ha[] = {
   0
 };
 
-static u3j_core _141_hex_aes_siva_d[] = {
-  // { { "en", 7, _141_hex_aes_siva_en_a, 0, _141_hex_aes_siva_en_ha },
-  //   { "de", 7, _141_hex_aes_siva_de_a, 0, _141_hex_aes_siva_de_ha },
+static u3j_core _141_hex_aes_siva_d[] =
+  { { "en", 7, _141_hex_aes_siva_en_a, 0, _141_hex_aes_siva_en_ha },
+    { "de", 7, _141_hex_aes_siva_de_a, 0, _141_hex_aes_siva_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_siva_ha[] = {
   0
 };
-static u3j_core _141_hex_aes_sivb_d[] = {
-  // { { "en", 7, _141_hex_aes_sivb_en_a, 0, _141_hex_aes_sivb_en_ha },
-  //   { "de", 7, _141_hex_aes_sivb_de_a, 0, _141_hex_aes_sivb_de_ha },
+static u3j_core _141_hex_aes_sivb_d[] =
+  { { "en", 7, _141_hex_aes_sivb_en_a, 0, _141_hex_aes_sivb_en_ha },
+    { "de", 7, _141_hex_aes_sivb_de_a, 0, _141_hex_aes_sivb_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_sivb_ha[] = {
   0
 };
-static u3j_core _141_hex_aes_sivc_d[] = {
-  // { { "en", 7, _141_hex_aes_sivc_en_a, 0, _141_hex_aes_sivc_en_ha },
-  //   { "de", 7, _141_hex_aes_sivc_de_a, 0, _141_hex_aes_sivc_de_ha },
+static u3j_core _141_hex_aes_sivc_d[] =
+  { { "en", 7, _141_hex_aes_sivc_en_a, 0, _141_hex_aes_sivc_en_ha },
+    { "de", 7, _141_hex_aes_sivc_de_a, 0, _141_hex_aes_sivc_de_ha },
     {}
   };
 static c3_c* _141_hex_aes_sivc_ha[] = {


### PR DESCRIPTION
This PR fixes a jet mismatch in our AES-SIV implementations. The mismatch was created by #2902, which added the jets. But the fault was with the pre-existing hoon implementation. The fundamental issue was a mishandling of leading zeros on incremental values in the SIV calculation (`+s2vc:aes:crypto`). I've fixed it, and the 128 and 192 bit varieties in the same manner.

---------------------------------------------------------------------------

The following is a walkthrough of the mismatch itself. @philipcmonk tracked down this test case, and I was able use it find and fix the mismatch.

Here's our inputs, and the correct output, as generated by the jet:

```
> =key 0xfdef.6253.d284.a940.1b5d.d1b7.fbcd.4489.
         3071.bf93.ace9.37da.7c5d.77d2.1f3e.cda4.
         83be.1c51.a88b.c9ba.8741.e1ee.935b.c0ef.
         888a.feff.0249.bdb6.1344.0ff9.4e1b.fca5
> =inp 0x97.0341.38e3.960e.87e1
> (~(en sivc:aes:crypto key ~) inp)
[p=0x249f.85e3.c9a8.29b6.3122.ec22.cde6.76df q=9 r=0xdc.bdcd.e4f1.4fd4.2d8d]
> =(`inp (~(de sivc:aes:crypto key ~) [p=0x249f.85e3.c9a8.29b6.3122.ec22.cde6.76df q=9 r=0xdc.bdcd.e4f1.4fd4.2d8d]))
%.y
```

With the jet disabled (or not yet present, for those running a version older the `v0.10.5`), we get different, roundtrip-able ciphertext:

```
> (~(en sivc:aes:crypto key ~) inp)
[p=0xb883.b075.6a73.44fa.76c4.5b40.62aa.a831 q=9 r=0xe0.e419.ad35.242e.cd56]
> =(`inp (~(de sivc:aes:crypto key ~) [p=0xb883.b075.6a73.44fa.76c4.5b40.62aa.a831 q=9 r=0xe0.e419.ad35.242e.cd56]))
%.y
```

NB: with the jet enabled, we can *also* decrypt this output:

Turning on debug printfs in lib_aes-siv (used by the jet), we get the following output (cleaned up):


```
> (~(en sivc:aes:crypto key ~) inp)
      CMAC(zero):  cbe5321b da024c9d 3fdd8450 0df939bf
      pad:         97034138 e3960e87 e1800000 00000000 
      xor:         00c9250f 579297bd 9e3b08a0 1bf273f9 
      CMAC(final): 249f85e3 c9a829b6 3122ec22 cde676df 
      ciphertext:  dcbdcde4 f14fd42d 8d
[p=0x249f.85e3.c9a8.29b6.3122.ec22.cde6.76df q=9 r=0xdc.bdcd.e4f1.4fd4.2d8d]
```

the IV is created as follows:

```
> (s2vc:aes:crypto (rsh 8 1 key) ~[inp])
0xb883.b075.6a73.44fa.76c4.5b40.62aa.a831
```

manually expanding the (old) implementation:

```
> =cmac0 `@ux`(macc:aes:crypto (rsh 8 1 key) `16 0x0)
> cmac0
0xcbe5.321b.da02.4c9d.3fdd.8450.0df9.39bf
> (gte (xeb inp) 128)
%.n
> =dub-cmac0 `@ux`(doub:aes:crypto cmac-0)
> dub-cmac0
0x97ca.6437.b404.993a.7fbb.08a0.1bf2.73f9
> =pad-inp `@ux`(mpad:aes:crypto (met 3 inp) inp)
> pad-inp
0x9703.4138.e396.0e87.e180.0000.0000.0000
> `@ux`(mix dub-cmac0 pad-inp)
0xc9.250f.5792.97bd.9e3b.08a0.1bf2.73f9
> `@ux`(macc:aes:crypto (rsh 8 1 key) ~ (mix dub-cmac0 pad-inp))
0xb883.b075.6a73.44fa.76c4.5b40.62aa.a831
```

Our values all match the debug output up to the final CMAC. That last "xor" value notably has leading zeros, and our call to `+macc` is not accounting for them (by passing the optional length). Resolving that:

```
> `@ux`(macc:aes:crypto (rsh 8 1 key) `16 (mix dub-cmac0 pad-inp))
0x249f.85e3.c9a8.29b6.3122.ec22.cde6.76df
```

And we have the correct iv.