### PR TITLE
chat-hook: pull on store path when removing

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -381,6 +381,7 @@
     :*  [%give %kick ~[[%mailbox path.act]] ~]
         [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]
         (pull-wire u.ship [%mailbox path.act])
+        (pull-wire u.ship [%store path.act])
         (pull-backlog-subscriptions u.ship path.act)
     ==
   ==


### PR DESCRIPTION
Not sure which branch I should be targeting. Arguably its a hotfix, but @philipcmonk if you're doing a release soon, maybe I should target your branch?