### PR TITLE
clay: make reachable-takos linear instead of exponential

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2515,13 +2515,17 @@
     ++  reachable-takos                                 ::  reachable
       |=  p/tako
       ^-  (set tako)
+      =|  s=(set tako)
+      |-  ^-  (set tako)
+      =.  s  (~(put in s) p)
       =+  y=(tako-to-yaki p)
-      %+  roll  p.y
-      =<  .(s (~(put in *(set tako)) p))
-      |=  {q/tako s/(set tako)}
-      ?:  (~(has in s) q)                               ::  already done
-        s                                               ::  hence skip
-      (~(uni in s) ^$(p q))                             ::  otherwise traverse
+      |-  ^-  (set tako)
+      ?~  p.y
+        s
+      ?:  (~(has in s) i.p.y)
+        $(p.y t.p.y)
+      =.  s  ^$(p i.p.y)
+      $(p.y t.p.y)
     ::
     ::  Get the data at a node.
     ::


### PR DESCRIPTION
When merging, +reachable-takos is called roughly once per merge commit
in the ancestry of the new commit.  +reachable-takos was exponential in
the number of merge commits in the ancestry of the commit it's looking
at, due to mishandling of the accumulator.  This makes it linear.

Of course, linear x linear is still quadratic, which is not great.  I
doubt +reachable-takos can be made asymptotically better, but
+reduce-merge-points/+find-merge-points probably can.  50 merge commits
already gives about 14.000 iterations through the loop in
+reachable-takos.  Another option is to try to memoize this somehow, but
a simple ~+ is insufficient since `s` is usually different.

In local tests on macOS with a -L copy of ~wicdev-wisryt, this speeds up
OTAs significantly.  The majority of time was spent on this.  This is especially
true for updates which didn't involve changes to /sys, since those involve a
lot of compiling.