### PR TITLE
publish: edit post content no longer tied to api

### DIFF
--- a/pkg/interface/src/apps/groups/components/lib/s3-upload.js
+++ b/pkg/interface/src/apps/groups/components/lib/s3-upload.js
@@ -84,7 +84,7 @@ export class S3Upload extends Component {
                  accept="image/*"
                  onChange={this.onChange.bind(this)} />
           <img className="invert-d"
-               src="/~groups/img/ImageUpload.png"
+               src="/~landscape/img/ImageUpload.png"
                width="32"
                height="32"
                onClick={this.onClick.bind(this)} />

--- a/pkg/interface/src/apps/publish/components/lib/edit-post.js
+++ b/pkg/interface/src/apps/publish/components/lib/edit-post.js
@@ -25,16 +25,18 @@ export class EditPost extends Component {
 
   componentDidUpdate(prevProps) {
     const { props, state } = this;
+    const contents = props.notebooks[props.ship]?.[props.book]?.notes?.[props.note]?.file;
     if (prevProps && prevProps.api !== props.api) {
-      if (!(props.notebooks[props.ship]?.[props.book]?.notes?.[props.note]?.file)) {
+      if (!contents) {
         props.api?.fetchNote(props.ship, props.book, props.note);
-      } else if (state.body === '') {
-        const notebook = props.notebooks[props.ship][props.book];
-        const note = notebook.notes[props.note];
-        const file = note.file;
-        const body = file.slice(file.indexOf(';>') + 3);
-        this.setState({ body: body });
       }
+    }
+    if (contents && state.body === '') {
+      const notebook = props.notebooks[props.ship][props.book];
+      const note = notebook.notes[props.note];
+      const file = note.file;
+      const body = file.slice(file.indexOf(';>') + 3);
+      this.setState({ body: body });
     }
   }
 
@@ -95,7 +97,7 @@ export class EditPost extends Component {
     };
 
     return (
-      <div className="f9 h-100 relative">
+      <div className="f9 h-100 relative publish">
         <div className="w-100 tl pv4 flex justify-center">
           <SidebarSwitcher
             sidebarShown={props.sidebarShown}


### PR DESCRIPTION
The component for editing a post was tied up in checking for API
instantiation -- we want the check for a blank body to be independent
of that.

Addresses #3040.