### PR TITLE
dbug: init new channel on start

### DIFF
--- a/pkg/arvo/app/debug/index.html
+++ b/pkg/arvo/app/debug/index.html
@@ -12,8 +12,8 @@
 <body class="w-100 h-100">
   <div id="root" class="w-100 h-100">
   </div>
-  <script src="/~channel/channel.js"></script>
-  <script src="/~modulo/session.js"></script>
+  <script src="/~landscape/js/channel.js"></script>
+  <script src="/~landscape/js/session.js"></script>
   <script src="/~debug/js/index.js"></script>
 </body>
 

--- a/pkg/interface/dbug/src/index.js
+++ b/pkg/interface/dbug/src/index.js
@@ -9,6 +9,7 @@ api.setAuthTokens({
   ship: window.ship
 });
 
+window.urb = new window.channel();
 subscription.start();
 
 ReactDOM.render((


### PR DESCRIPTION
Landscape rearchitecture removes `window.urb` from userspace. This initiates it as a fresh channel at dbug start.

Partially addresses #3035.