### PR TITLE
behn, vere: some improvements

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -767,7 +767,7 @@
 ++  v-behn
   |%
   ++  timers
-    (scry ,(list [date=@da =duct]) %b %timers ~)
+    (scry ,(list [date=@da =duct]) %bx %$ /debug/timers)
   --
 ::
 ::  clay

--- a/pkg/arvo/gen/timers.hoon
+++ b/pkg/arvo/gen/timers.hoon
@@ -1,5 +1,5 @@
 ::  Find list of currently running Behn timers
 :-  %say
-|=  *
+|=  [[now=@da *] *]
 :-  %tang
-[>.^((list [date=@da =duct]) %b /=timers=)< ~]
+[>.^((list [date=@da =duct]) %bx /=//(scot %da now)/debug/timers)< ~]

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -191,7 +191,7 @@
   ?.  ?=({@ @ @ @ *} u.pux)  ~
   =+  :*  hyr=(slaw %tas i.u.pux)
           fal=(slaw %p i.t.u.pux)
-          dyc=(slaw %tas i.t.t.u.pux)
+          dyc=?~(i.t.t.u.pux (some %$) (slaw %tas i.t.t.u.pux))
           ved=(slay i.t.t.t.u.pux)
           tyl=t.t.t.t.u.pux
       ==

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -430,11 +430,14 @@
       [~ ~]
     :^  ~  ~  %noun
     !>  ^-  (list @da)
-    %-  zing
-    %+  turn  (tap:timer-map timers)
-    |=  [date=@da q=(qeu duct)]
-    ?:  (gth date u.til)  ~
-    (reap ~(wyt in q) date)
+    =/  tiz=(list [date=@da q=(qeu duct)])
+      (tap:timer-map timers)
+    |-  ^-  (list @da)
+    ?~  tiz  ~
+    ?:  (gth date.i.tiz u.til)  ~
+    %+  weld
+      (reap ~(wyt in q.i.tiz) date.i.tiz)
+    $(tiz t.tiz)
   ==
 ::
 ++  stay  state

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -389,18 +389,53 @@
 ++  scry
   |=  [fur=(unit (set monk)) ren=@tas why=shop syd=desk lot=coin tyl=path]
   ^-  (unit (unit cage))
+  ::  only respond for the local identity, %$ desk, current timestamp
   ::
-  ?.  ?=(%& -.why)
+  ?.  ?&  =(&+our why)
+          =([%$ %da now] lot)
+          =(%$ syd)
+      ==
     ~
-  ?.  ?=(%timers syd)
-    [~ ~]
-  =/  tiz=(list [@da duct])
+  ::  /bx/debug/timers  (list [@da duct])  all timers and their ducts
+  ::  /bx/timers        (list @da)         all timer timestamps
+  ::  /bx/timers/next   (unit @da)         the very next timer to fire
+  ::  /bx/timers/[da]   (list @da)         all timers up to and including da
+  ::
+  ?.  ?=(%x ren)  ~
+  ?+  tyl  [~ ~]
+      [%debug %timers ~]
+    :^  ~  ~  %noun
+    !>  ^-  (list [@da duct])
     %-  zing
     %+  turn  (tap:timer-map timers)
     |=  [date=@da q=(qeu duct)]
     %+  turn  ~(tap to q)
     |=(d=duct [date d])
-  [~ ~ %noun !>(tiz)]
+  ::
+      [%timers ~]
+    :^  ~  ~  %noun
+    !>  ^-  (list @da)
+    %-  zing
+    %+  turn  (tap:timer-map timers)
+    |=  [date=@da q=(qeu duct)]
+    (reap ~(wyt in q) date)
+  ::
+      [%timers %next ~]
+    :^  ~  ~  %noun
+    !>  ^-  (unit @da)
+    (bind (peek:timer-map timers) head)
+  ::
+      [%timers @ ~]
+    ?~  til=(slaw %da i.t.tyl)
+      [~ ~]
+    :^  ~  ~  %noun
+    !>  ^-  (list @da)
+    %-  zing
+    %+  turn  (tap:timer-map timers)
+    |=  [date=@da q=(qeu duct)]
+    ?:  (gth date u.til)  ~
+    (reap ~(wyt in q) date)
+  ==
 ::
 ++  stay  state
 ++  take

--- a/pkg/urbit/vere/io/behn.c
+++ b/pkg/urbit/vere/io/behn.c
@@ -16,7 +16,7 @@
   typedef struct _u3_behn {
     u3_auto    car_u;                   //  driver
     uv_timer_t tim_u;                   //  behn timer
-    c3_o       alm;                     //  alarm
+    c3_o       alm_o;                   //  alarm
   } u3_behn;
 
 static void _behn_scry_cb(void* vod_p, u3_noun nun);
@@ -27,7 +27,7 @@ static void
 _behn_time_cb(uv_timer_t* tim_u)
 {
   u3_behn* teh_u = tim_u->data;
-  teh_u->alm = c3n;
+  teh_u->alm_o = c3n;
 
   //  take initiative to start the next timer, just in case
   //
@@ -62,9 +62,9 @@ _behn_ef_doze(u3_behn* teh_u, u3_noun wen)
     teh_u->car_u.liv_o = c3y;
   }
 
-  if ( c3y == teh_u->alm ) {
+  if ( c3y == teh_u->alm_o ) {
     uv_timer_stop(&teh_u->tim_u);
-    teh_u->alm = c3n;
+    teh_u->alm_o = c3n;
   }
 
   if ( (c3y == u3du(wen)) &&
@@ -76,7 +76,7 @@ _behn_ef_doze(u3_behn* teh_u, u3_noun wen)
     u3_noun now = u3_time_in_tv(&tim_tv);
     c3_d gap_d = u3_time_gap_ms(now, u3k(u3t(wen)));
 
-    teh_u->alm = c3y;
+    teh_u->alm_o = c3y;
     uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
   } else if (u3_nul != wen) {
     u3m_p("behn: invalid doze", wen);
@@ -93,14 +93,14 @@ _behn_scry_cb(void* vod_p, u3_noun nun)
   u3_behn* teh_u = vod_p;
   u3_weak  tim   = u3r_at(7, nun);
 
-  if (c3y == teh_u->alm) {
+  if (c3y == teh_u->alm_o) {
     //  timer already set while we were scrying, no-op
   }
   else if (u3_none == tim) {
     //  fall back to a timer for 10 minutes
     //
     c3_d gap_d = 10 * 60 * 1000;
-    teh_u->alm = c3y;
+    teh_u->alm_o = c3y;
     uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
   } else {
     _behn_ef_doze(teh_u, u3k(tim));
@@ -170,7 +170,7 @@ u3_auto*
 u3_behn_io_init(u3_pier* pir_u)
 {
   u3_behn* teh_u = c3_calloc(sizeof(*teh_u));
-  teh_u->alm = c3n;
+  teh_u->alm_o = c3n;
 
   uv_timer_init(u3L, &teh_u->tim_u);
   teh_u->tim_u.data = teh_u;

--- a/pkg/urbit/vere/io/behn.c
+++ b/pkg/urbit/vere/io/behn.c
@@ -17,6 +17,7 @@
     u3_auto    car_u;                   //  driver
     uv_timer_t tim_u;                   //  behn timer
     c3_o       alm_o;                   //  alarm
+    c3_o       see_o;                   //  can scry
   } u3_behn;
 
 static void _behn_scry_cb(void* vod_p, u3_noun nun);
@@ -36,11 +37,15 @@ _behn_time_cb(uv_timer_t* tim_u)
   //  to fail, we can't proceed with the timers, but if it was a
   //  transient error, this will get us past it.
   //
-  {
+  if (c3y == teh_u->see_o) {
     u3_noun pax = u3i_trel(u3i_string("timers"), u3i_string("next"), u3_nul);
     u3_lord_peek_last(teh_u->car_u.pir_u->god_u, u3_nul,
                       c3_s2('b', 'x'), u3_nul, pax,
                       teh_u, _behn_scry_cb);
+  }
+  else {
+    //  if scry is known to not work, short-circuit
+    _behn_scry_cb(teh_u, u3_nul);
   }
 
   // send timer event
@@ -97,8 +102,9 @@ _behn_scry_cb(void* vod_p, u3_noun nun)
     //  timer already set while we were scrying, no-op
   }
   else if (u3_none == tim) {
-    //  fall back to a timer for 10 minutes
+    //  remember scry doesn't work, fall back to a timer for 10 minutes
     //
+    teh_u->see_o = c3n;
     c3_d gap_d = 10 * 60 * 1000;
     teh_u->alm_o = c3y;
     uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
@@ -171,6 +177,7 @@ u3_behn_io_init(u3_pier* pir_u)
 {
   u3_behn* teh_u = c3_calloc(sizeof(*teh_u));
   teh_u->alm_o = c3n;
+  teh_u->see_o = c3y;
 
   uv_timer_init(u3L, &teh_u->tim_u);
   teh_u->tim_u.data = teh_u;

--- a/pkg/urbit/vere/io/behn.c
+++ b/pkg/urbit/vere/io/behn.c
@@ -19,6 +19,8 @@
     c3_o       alm;                     //  alarm
   } u3_behn;
 
+static void _behn_scry_cb(void* vod_p, u3_noun nun);
+
 /* _behn_time_cb(): timer callback.
 */
 static void
@@ -27,7 +29,7 @@ _behn_time_cb(uv_timer_t* tim_u)
   u3_behn* teh_u = tim_u->data;
   teh_u->alm = c3n;
 
-  //  start another timer for 10 minutes
+  //  take initiative to start the next timer, just in case
   //
   //  This is a backstop to deal with the case where a %doze is not
   //  properly sent, for example after a crash.  If the timer continues
@@ -35,9 +37,10 @@ _behn_time_cb(uv_timer_t* tim_u)
   //  transient error, this will get us past it.
   //
   {
-    c3_d gap_d = 10 * 60 * 1000;
-    teh_u->alm = c3y;
-    uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
+    u3_noun pax = u3i_trel(u3i_string("timers"), u3i_string("next"), u3_nul);
+    u3_lord_peek_last(teh_u->car_u.pir_u->god_u, u3_nul,
+                      c3_s2('b', 'x'), u3_nul, pax,
+                      teh_u, _behn_scry_cb);
   }
 
   // send timer event
@@ -80,6 +83,29 @@ _behn_ef_doze(u3_behn* teh_u, u3_noun wen)
   }
 
   u3z(wen);
+}
+
+/* _behn_scry_cb(): next timer scry result callback.
+*/
+static void
+_behn_scry_cb(void* vod_p, u3_noun nun)
+{
+  u3_behn* teh_u = vod_p;
+  u3_weak  tim   = u3r_at(7, nun);
+
+  if (c3y == teh_u->alm) {
+    //  timer already set while we were scrying, no-op
+  }
+  else if (u3_none == tim) {
+    //  fall back to a timer for 10 minutes
+    //
+    c3_d gap_d = 10 * 60 * 1000;
+    teh_u->alm = c3y;
+    uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
+  } else {
+    _behn_ef_doze(teh_u, u3k(tim));
+  }
+  u3z(nun);
 }
 
 /* _behn_io_talk(): notify %behn that we're live

--- a/pkg/urbit/vere/io/behn.c
+++ b/pkg/urbit/vere/io/behn.c
@@ -64,8 +64,7 @@ _behn_ef_doze(u3_behn* teh_u, u3_noun wen)
     teh_u->alm = c3n;
   }
 
-  if ( (u3_nul != wen) &&
-       (c3y == u3du(wen)) &&
+  if ( (c3y == u3du(wen)) &&
        (c3y == u3ud(u3t(wen))) )
   {
     struct timeval tim_tv;
@@ -76,6 +75,8 @@ _behn_ef_doze(u3_behn* teh_u, u3_noun wen)
 
     teh_u->alm = c3y;
     uv_timer_start(&teh_u->tim_u, _behn_time_cb, gap_d, 0);
+  } else if (u3_nul != wen) {
+    u3m_p("behn: invalid doze", wen);
   }
 
   u3z(wen);


### PR DESCRIPTION
Primarily:

- Rewrites behn.hoon's scry interface to use cares, not misuse the desk, provide more endpoints, and expose ducts only on an explicitly debug-oriented endpoint.
- Rewrites behn.c's "backstop" logic to scry into behn for the next timer instead of setting one for ten minutes into the future. (But still falls back to doing so if the scry doesn't succeed.)

Note that f714d90 touches arvo to make `%$` be considered a valid value for the desk. `+slaw` doesn't parse the empty string as a `%tas`. Arguably that's a bug in `+slaw`, but it's parsing behavior for `%tas` is a bit funky already and I'd rather not make the broader-scope change right now.

@joemfb I made some notes during our call yesterday about some oddities in behn.hoon's implementation, but chose not to do the fixes for those right now. They seem better off cushioned in other work. Happy to still do the safe ones right now if you think it's worth it.

(Is the convention for vere commits just the `vere:` prefix always? `behn:` would get confusing wrt arvo vs runtime changes... Maybe `behn.c:`?)