### PR TITLE
libsigsegv: disable stack vma check (or: Make Linux Fast)

### DIFF
--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -16,9 +16,14 @@ let
     exe   = ''${meta.bin} ${pkgs.lib.strings.concatStringsSep " " meta.flags}'';
   };
 
+  sigseg =
+    pkgs.libsigsegv.overrideAttrs (oldAttrs: rec {
+      patches = [ ./libsigsegv_fix.patch ];
+    });
+
   deps =
     with pkgs;
-    [ curl gmp libsigsegv ncurses openssl zlib lmdb ];
+    [ curl gmp sigseg ncurses openssl zlib lmdb ];
 
   vendor =
     [ argon2 softfloat3 ed25519 ent ge-additions libaes_siv h2o scrypt uv murmur3 secp256k1 sni ivory-header ca-header ];

--- a/nix/pkgs/urbit/libsigsegv_fix.patch
+++ b/nix/pkgs/urbit/libsigsegv_fix.patch
@@ -1,9 +1,3 @@
-source $setup
-
-tar -xf $src
-
-cd libsigsegv-$version
-patch -p1 << 'HEREDOC'
 --- a/src/fault-linux-i386.h    2020-06-25 23:46:02.099235491 +0000
 +++ b/src/fault-linux-i386.h    2020-06-25 23:45:48.679156892 +0000
 @@ -18,6 +18,7 @@
@@ -14,17 +8,3 @@ patch -p1 << 'HEREDOC'
  #if defined __x86_64__
  /* 64 bit registers */
 
-HEREDOC
-cd ..
-
-mkdir build
-cd build
-
-../libsigsegv-$version/configure \
-  --host=$host \
-  --prefix=$out \
-  --enable-static=yes \
-  --enable-shared=no
-
-make
-make install


### PR DESCRIPTION
This is a draft PR pending testing stack overflow handling and nix hygiene.  Can someone who knows nix take a look at this?  @brendanhay @eglaysher 

This patches libsigsegv to not check the stack vma on Linux, since that
involves reading procfs, and we make very heavy use of sigsegv.  This
eliminates most of urbit's performance discrepancy between Linux and
MacOS.  These are the benchmarks used; note this is a local MBP vs a
cloud Linux server, and the MBP is almost certainly faster hardware.

We take two benchmarks, one of which decrements 10 million times and the
other simply allocates 125MB of memory.  These are the results:

cpu-heavy ==  =/ n 10.000.000 |-(?~(n n $(n (dec n))))
mem-heavy == =a (bex 1.000.000.008)

macos, cpu-heavy: 6 seconds
macos, mem-heavy: 1 second

linux-before, cpu-heavy: 30 seconds
linux-before, mem-heavy: 160 seconds

linux-after, cpu-heavy 9 seconds
linux-after, mem-heavy 1.3 seconds

This represents a 3x speedup for the cpu-heavy operation and a 120x
speedup for the memory-heavy operation.

This check was used to try to distinguish stack overflow from other
forms of segmentation fault.  In the comments in src/handler-unix.c, it
describes three heuristics it uses, depending on what's available from
the OS.  In the linux-i386 case, all three are availble, so we simply
disable the slow one.  Further testing is required to determine if it
continues to acceptably distinguish stack overflows.

Not sure I'm doing the nix stuff correctly, but this works for `make`.
Need to test release and nix-shell.