### PR TITLE
metadata-store: add cleanup utility

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -61,9 +61,27 @@
     ^-  (quip card _this)
     ?>  (team:title our.bowl src.bowl)
     =^  cards  state
-      ?:  ?=(%metadata-action mark)
+      ?+  mark  [~ state]
+          %metadata-action
         (poke-metadata-action:mc !<(metadata-action vase))
-      (on-poke:def mark vase)
+          %noun
+        =/  val=(each [%cleanup path] tang)
+          (mule |.(!<([%cleanup path] vase)))
+        ?:  ?=(%& -.val)
+          =/  group=path  +.p.val
+          =/  res=(set resource)  (~(get ju group-indices) group)
+          =.  group-indices  (~(del by group-indices) group)
+          :-  ~
+          %+  roll  ~(tap in res)
+          |=  [r=resource out=_state]
+          =.  resource-indices.out  (~(del by resource-indices.out) r)
+          =.  app-indices.out
+            %-  ~(del ju app-indices.out)
+            [app-name.r group app-path.r]
+          =.  associations.out  (~(del by associations.out) group r)
+          out
+        [~ state]
+      ==
     [cards this]
   ::
   ++  on-watch

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -61,26 +61,26 @@
     ^-  (quip card _this)
     ?>  (team:title our.bowl src.bowl)
     =^  cards  state
-      ?+  mark  [~ state]
+      ?+  mark  (on-poke:def mark vase)
           %metadata-action
         (poke-metadata-action:mc !<(metadata-action vase))
           %noun
         =/  val=(each [%cleanup path] tang)
           (mule |.(!<([%cleanup path] vase)))
-        ?:  ?=(%& -.val)
-          =/  group=path  +.p.val
-          =/  res=(set resource)  (~(get ju group-indices) group)
-          =.  group-indices  (~(del by group-indices) group)
-          :-  ~
-          %+  roll  ~(tap in res)
-          |=  [r=resource out=_state]
-          =.  resource-indices.out  (~(del by resource-indices.out) r)
-          =.  app-indices.out
-            %-  ~(del ju app-indices.out)
-            [app-name.r group app-path.r]
-          =.  associations.out  (~(del by associations.out) group r)
-          out
-        [~ state]
+        ?.  ?=(%& -.val)
+          (on-poke:def mark vase)
+        =/  group=path  +.p.val
+        =/  res=(set resource)  (~(get ju group-indices) group)
+        =.  group-indices  (~(del by group-indices) group)
+        :-  ~
+        %+  roll  ~(tap in res)
+        |=  [r=resource out=_state]
+        =.  resource-indices.out  (~(del by resource-indices.out) r)
+        =.  app-indices.out
+          %-  ~(del ju app-indices.out)
+          [app-name.r group app-path.r]
+        =.  associations.out  (~(del by associations.out) group r)
+        out
       ==
     [cards this]
   ::


### PR DESCRIPTION
Adds a utility to metadata-store to remove by group-path

Theres a problem on the mainnet where if you migrate a group to a new ship, you can get lots of old useless metadata lying around, which then can cause the frontend to misrepresent what channels are present in a group. 

This issue will have to be revisited at some point to fix the root problem. Probably better to wait for the new groups stuff to land first though. For now, this PR just gives people the ability to manually erase metadata by group-path, which can be used to solve this problem.