### PR TITLE
chat fe: don't embed webms as images

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/message.js
+++ b/pkg/interface/src/apps/chat/components/lib/message.js
@@ -72,7 +72,7 @@ export class Message extends Component {
       );
     } else if ('url' in letter) {
       let imgMatch =
-        /(jpg|img|png|gif|tiff|jpeg|JPG|IMG|PNG|TIFF|GIF|webp|WEBP|webm|WEBM|svg|SVG)$/
+        /(jpg|img|png|gif|tiff|jpeg|JPG|IMG|PNG|TIFF|GIF|webp|WEBP|svg|SVG)$/
         .exec(letter.url);
       const youTubeRegex = new RegExp(String(/(?:https?:\/\/(?:[a-z]+.)?)/.source) // protocol
       + /(?:youtu\.?be(?:\.com)?\/)(?:embed\/)?/.source // short and long-links


### PR DESCRIPTION
Fixes this:

<img width="351" alt="image" src="https://user-images.githubusercontent.com/3829764/86065410-d40d5080-ba6f-11ea-85c3-1b9aed7c2a23.png">
