### PR TITLE
spa: restore previous line-height, padding

### DIFF
--- a/pkg/interface/src/App.js
+++ b/pkg/interface/src/App.js
@@ -32,7 +32,6 @@ import GlobalApi from './api/global';
 
 const Root = styled.div`
   font-family: ${p => p.theme.fonts.sans};
-  line-height: ${p => p.theme.lineHeights.regular};
   height: 100%;
   width: 100%;
   padding: 0;

--- a/pkg/interface/src/apps/chat/components/lib/channel-item.js
+++ b/pkg/interface/src/apps/chat/components/lib/channel-item.js
@@ -23,7 +23,7 @@ export class ChannelItem extends Component {
 
     return (
       <div
-        className={'z1 ph4 pb1 ' + selectedCss}
+        className={'z1 ph4 pv1 ' + selectedCss}
         onClick={this.onClick.bind(this)}
       >
         <div className="w-100 v-mid">

--- a/pkg/interface/src/apps/chat/components/lib/chat-tabbar.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-tabbar.js
@@ -51,7 +51,7 @@ export class ChatTabBar extends Component {
         <a href={'/~chat/popout/room' + props.station} rel="noopener noreferrer"
         target="_blank"
         className="dib fr pr1"
-        style={{ paddingTop: '5px' }}
+        style={{ paddingTop: '8px' }}
         >
           <img
             className={'flex-shrink-0 pr3 dn ' + hidePopoutIcon}

--- a/pkg/interface/src/apps/chat/components/sidebar.js
+++ b/pkg/interface/src/apps/chat/components/sidebar.js
@@ -138,7 +138,7 @@ export class Sidebar extends Component {
     return (
       <div
         className={`h-100-minus-96-s h-100 w-100 overflow-x-hidden flex
-      bg-gray0-d flex-column relative z1`}
+      bg-gray0-d flex-column relative z1 lh-solid`}
       >
         <div className="w-100 bg-transparent pa4">
           <a

--- a/pkg/interface/src/apps/launch/app.js
+++ b/pkg/interface/src/apps/launch/app.js
@@ -35,7 +35,7 @@ export default class LaunchApp extends React.Component {
           weather={props.weather}
         />
       </div>
-      <div className="gray2-d gray2 ml4 mb4 f8"> {props.baseHash} </div>
+      <div className="absolute bottom-0 left-0 f9 gray2 ml4 mb4 f8"> {props.baseHash} </div>
     </div>
     );
   }

--- a/pkg/interface/src/apps/publish/components/lib/notebook.js
+++ b/pkg/interface/src/apps/publish/components/lib/notebook.js
@@ -158,7 +158,7 @@ export class Notebook extends Component {
         newPost = (
           <Link
             to={newUrl}
-            className='NotebookButton bg-light-green green2 ph2 pt3'
+            className='NotebookButton bg-light-green green2 pa2'
           >
             New Post
           </Link>
@@ -169,7 +169,7 @@ export class Notebook extends Component {
     const unsub = (window.ship === props.ship.slice(1))
       ?  null
       :  <button onClick={this.unsubscribe}
-             className="NotebookButton bg-white bg-gray0-d black white-d ba b--black b--gray2-d ml3"
+             className="NotebookButton bg-white bg-gray0-d black white-d ba b--black b--gray2-d ml3 ph1"
          >
            Unsubscribe
          </button>;

--- a/pkg/interface/src/components/SidebarSwitch.js
+++ b/pkg/interface/src/components/SidebarSwitch.js
@@ -8,7 +8,7 @@ export class SidebarSwitcher extends Component {
 
     const classes = this.props.classes ? this.props.classes : '';
 
-    const paddingTop = this.props.classes ? '0px' : '5px';
+    const paddingTop = this.props.classes ? '0px' : '8px';
 
     return (
       <div className={classes} style={{ paddingTop: paddingTop }}>


### PR DESCRIPTION
Setting a line-height across the board of 1.5 was patched during SPA development with a few padding tweaks here and there; but in general we decided to just restore the inconsistent line-height we had before and set a consistent line-height during the Indigo refactor work in progress in FE.