### PR TITLE
interface: update production build for typescript

### DIFF
--- a/pkg/interface/config/webpack.prod.js
+++ b/pkg/interface/config/webpack.prod.js
@@ -11,7 +11,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js?$/,
+        test: /\.(j|t)sx?$/,
         use: {
           loader: 'babel-loader',
           options: {
@@ -39,7 +39,7 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: ['.js']
+    extensions: ['.js', '.ts', '.tsx']
   },
   devtool: 'inline-source-map',
   // devServer: {
@@ -58,7 +58,7 @@ module.exports = {
   output: {
     filename: 'index.js',
     chunkFilename: 'index.js',
-    path: path.resolve(urbitrc.URBIT_PIERS[0] + '/app/landscape/', 'js'),
+    path: path.resolve(__dirname, '../../arvo/app/landscape/js'),
     publicPath: '/'
   },
   optimization: {


### PR DESCRIPTION
- `npm run build:prod` outputs in `pkg/arvo/landscape/js` instead of urbitrc
- production builds were failing due to some missing typescript configs, brought the prod config to parity with dev