### PR TITLE
nix: handle vere version in 'urbit' derivation

### DIFF
--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -29,8 +29,11 @@ let
     [ argon2 softfloat3 ed25519 ent ge-additions libaes_siv h2o scrypt uv murmur3 secp256k1 sni ivory-header ca-header ];
 
   urbit = pkgs.stdenv.mkDerivation {
-    inherit name meta;
+    inherit meta;
+    pname   = name;
+    version = "0.10.7";
     exename = name;
+
     src     = ../../../pkg/urbit;
     nativeBuildInputs = deps ++ vendor;
 

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -2,7 +2,12 @@
 
 set -e
 
-URBIT_VERSION="0.10.7"
+if [ ! -z "$version" ]; then
+  URBIT_VERSION="$version"
+else
+  echo "'version' variable not set" >&2
+  exit 1
+fi
 
 deps="                                                                    \
   curl gmp sigsegv argon2 ed25519 ent h2o scrypt sni uv murmur3 secp256k1 \


### PR DESCRIPTION
Previously, one needed to edit the URBIT_VERSION variable in pkg/urbit/configure before building in order to specify a new version of Vere.  From this change forward, one should instead edit the "version" attribute in nix/pkgs/urbit/default.nix.  The URBIT_VERSION variable is then simply assigned the value of that attribute when building.

The motivation here is to reflect the Vere version in its derivation as well.  By specifying 'pname' and 'version' attributes, the stdenv builder will automatically name the derivation 'pname-version'.  This leads to derivations named e.g. 'urbit-0.10.7' and 'urbit-debug-0.10.7', rather than the plain 'urbit' and 'urbit-debug'.

cc @philipcmonk 