### PR TITLE
kiln: Small fixes

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -39,7 +39,14 @@
   [d this]
 ::
 ++  on-leave  on-leave:def
-++  on-peek   on-peek:def
+++  on-peek
+  |=  =path
+  ~&  peeking=path
+  ^-  (unit (unit cage))
+  ?+  path  (on-peek:def path)
+    [* %kiln *]  (on-peek:kiln-core path)
+  ==
+::
 ++  on-save   !>(state)
 ++  on-load
   |=  =old-state=vase

--- a/pkg/arvo/gen/trouble.hoon
+++ b/pkg/arvo/gen/trouble.hoon
@@ -43,7 +43,12 @@
   ==
 ::
 ++  base-hash
-  =/  parent  (scot %p (sein:title our now our))
-  =+  .^(=cass:clay %cs /[parent]/kids/1/late/foo)
-  .^(@uv %cz /[parent]/kids/(scot %ud ud.cass))
+  =+  .^  ota=(unit [=ship =desk =aeon:clay])
+          %gx  /(scot %p our)/hood/(scot %da now)/kiln/ota/noun
+      ==
+  ?~  ota
+    *@uv
+  =/  parent  (scot %p ship.u.ota)
+  =+  .^(=cass:clay %cs /[parent]/[desk.u.ota]/1/late/foo)
+  .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
 --

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -104,6 +104,13 @@
   =.  +<+.$.abet  old
   ..abet
 ::
+++  on-peek
+  |=  =path
+  ^-  (unit (unit cage))
+  ?.  ?=([%x %kiln %ota ~] path)
+    [~ ~]
+  ``noun+!>(ota)
+::
 ++  poke-commit
   |=  [mon/kiln-commit auto=?]
   =<  abet

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2366,7 +2366,8 @@
           |=  [pax=path *]
           =((~(got by new.dal) pax) (~(got by new.dob) pax))
         ?:  &(?=(%mate germ) ?=(^ con))
-          [%| %mate-conflict ~]
+          =+  (turn ~(tap by `(map path *)`con) |=([path *] >[+<-]<))
+          [%| %mate-conflict -]
         =/  old=(map path lobe)                         ::  oldies but goodies
           %+  roll  ~(tap by (~(uni by old.dal) old.dob))
           =<  .(old q.bas)


### PR DESCRIPTION
Produces conflict list on mate-conflict, and also makes +trouble look at where we're actually getting OTAs from instead of guessing that it's our parent.  This still crashes if you haven't received any clay updates from them.