### PR TITLE
chat: fix sigil overlay perf issue

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/overlay-sigil.js
+++ b/pkg/interface/src/apps/chat/components/lib/overlay-sigil.js
@@ -19,29 +19,24 @@ export class OverlaySigil extends Component {
 
     this.profileShow = this.profileShow.bind(this);
     this.profileHide = this.profileHide.bind(this);
+    this.updateContainerInterval = null;
+  }
+
+  profileShow() {
+    this.updateContainerOffset();
+    this.setState({ profileClicked: true });
     this.updateContainerInterval = setInterval(
       this.updateContainerOffset.bind(this),
       1000
     );
   }
 
-  componentDidMount() {
-    this.updateContainerOffset();
-  }
-
-  componentWillUnmount() {
-    if (this.updateContainerInterval) {
+  profileHide() {
+    this.setState({ profileClicked: false });
+    if(this.updateContainerInterval) {
       clearInterval(this.updateContainerInterval);
       this.updateContainerInterval = null;
     }
-  }
-
-  profileShow() {
-    this.setState({ profileClicked: true });
-  }
-
-  profileHide() {
-    this.setState({ profileClicked: false });
   }
 
   updateContainerOffset() {


### PR DESCRIPTION
Changes the sigil overlay to only start checking for its position when it
becomes visible.

Fixes: #3055
