### PR TITLE
eyre: give scry function to generators

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -807,21 +807,33 @@
       =/  cag=cage  (need (need ski))
       ?>  =(%vase p.cag)
       =/  gat=vase  !<(vase q.cag)
-      =/  res=(each vase tang)
-        %-  mule  |.
+      =/  res=toon
+        %-  mock  :_  (sloy scry)
+        :_  [%9 2 %0 1]  |.
         %+  slam
           %+  slam  gat
           !>([[now=now eny=eny bek=bek] ~ ~])
         !>([authenticated request])
-      ?:  ?=(%| -.res)
+      ?:  ?=(%2 -.res)
         =+  connection=(~(got by connections.state) duct)
         %^  return-static-data-on-duct  500  'text/html'
         %:  internal-server-error
             authenticated.inbound-request.connection
             url.request.inbound-request.connection
+            leaf+"generator crashed"
             p.res
         ==
-      =/  result  !<(simple-payload:http p.res)
+      ?:  ?=(%1 -.res)
+        =+  connection=(~(got by connections.state) duct)
+        %^  return-static-data-on-duct  500  'text/html'
+        %:  internal-server-error
+            authenticated.inbound-request.connection
+            url.request.inbound-request.connection
+            leaf+"scry blocked on"
+            >p.res<
+            ~
+        ==
+      =/  result  ;;(simple-payload:http +.p.res)
       ::  ensure we have a valid content-length header
       ::
       ::    We pass on the response and the headers the generator produces, but


### PR DESCRIPTION
In Ford Fusion, Clay builds generators but Dojo and Eyre run them.  Dojo
is already virtualized with a scry function, so +mule is fine, but Eyre
is not, so Eyre needs to use +mock and explicitly supply the scry
function.  This does that.  Fortunately, the produced result is simple
and easily clammable.

Fixes #3089

Given the impact of the bug and the fact that it worked for the person who reported the bug, I'll likely deploy right away.