### PR TITLE
chat-store: don't trim on %messages, either

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3816099db71192c99702c62a78adf997ceb82ee32b492961e29b8fb4da413d70
-size 16639705
+oid sha256:6614c1334e3e27722a31e0ae41cfda9b5e1915d5fe75daa3a0ec8423a9574bc6
+size 16649737

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -252,7 +252,6 @@
   |-  ^-  (quip card _state)
   ?~  envelopes.act
     :_  state(inbox (~(put by inbox) path.act u.mailbox))
-    :-  [%pass /trim %agent [our.bol %chat-store] %poke %noun !>([%trim ~])]
     %+  send-diff  path.act
     [%messages path.act 0 (lent evaluated-envelopes) evaluated-envelopes]
   =.  letter.i.envelopes.act  (evaluate-letter [author letter]:i.envelopes.act)


### PR DESCRIPTION
#3083 removed auto-trimming when receiving individual messages, but didn't touch the `%messages` case.

It's... not nice that there's duplicate logic for `%message` and `%messages`, but that's probably out of scope here.

(Targetting master, maybe we want to push this out as a hotfix.)