### PR TITLE
vere: more readable http server status

### DIFF
--- a/pkg/urbit/vere/http.c
+++ b/pkg/urbit/vere/http.c
@@ -1267,9 +1267,9 @@ _http_serv_start(u3_http* htp_u)
               htp_u->rox_u->por_s);
     }
     else {
-      u3l_log("http: live (%s, %s) on %d\n",
-              (c3y == htp_u->sec) ? "secure" : "insecure",
-              (c3y == htp_u->lop) ? "loopback" : "public",
+      u3l_log("http: %s live on %s://localhost:%d\n",
+              (c3y == htp_u->lop) ? "loopback" : "web interface",
+              (c3y == htp_u->sec) ? "https" : "http",
               htp_u->por_s);
     }
 


### PR DESCRIPTION
Not touching the proxy message because that seems gone on ipc-redux.

Fixes #1332 in the dumbest way.

```
http: web interface live on http://localhost:8081
http: loopback live on http://localhost:12322
```