### PR TITLE
group-filter: specify local api for all cases

### DIFF
--- a/pkg/interface/src/components/GroupFilter.js
+++ b/pkg/interface/src/components/GroupFilter.js
@@ -97,7 +97,7 @@ export default class GroupFilter extends Component {
       selected: selected,
       results: []
     }, (() => {
-        this.props.api.setSelected(this.state.selected);
+        this.props.api.local.setSelected(this.state.selected);
         localStorage.setItem('urbit-selectedGroups', JSON.stringify(this.state.selected));
     }));
   }
@@ -108,7 +108,7 @@ export default class GroupFilter extends Component {
       return e !== group;
     });
     this.setState({ selected: selected }, (() => {
-      this.props.api.setSelected(this.state.selected);
+      this.props.api.local.setSelected(this.state.selected);
       localStorage.setItem('urbit-selectedGroups', JSON.stringify(this.state.selected));
     }));
   }


### PR DESCRIPTION
See #3096 for details on the issue. 

During the migration to global store (#3038), the API became
structured such that you must specify the local (app-specific) API.
Some cases were missed. This includes them.