### PR TITLE
Memory compaction

### DIFF
--- a/nix/nixcrpkgs/pkgs.nix
+++ b/nix/nixcrpkgs/pkgs.nix
@@ -24,10 +24,6 @@ rec {
     inherit crossenv;
   };
 
-  ncurses = import ./pkgs/ncurses {
-    inherit crossenv;
-  };
-
   pdcurses = import ./pkgs/pdcurses {
     inherit crossenv;
   };

--- a/pkg/urbit/include/c/motes.h
+++ b/pkg/urbit/include/c/motes.h
@@ -248,6 +248,7 @@
 #   define c3__cow    c3_s3('c','o','w')
 #   define c3__cpu    c3_s3('c','p','u')
 #   define c3__crad   c3_s4('c','r','a','d')
+#   define c3__cram   c3_s4('c','r','a','m')
 #   define c3__crap   c3_s4('c','r','a','p')
 #   define c3__cret   c3_s4('c','r','e','t')
 #   define c3__crib   c3_s4('c','r','i','b')

--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -465,6 +465,16 @@
           c3_w
           u3a_mark_road(FILE* fil_u);
 
+        /* u3a_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+        */
+          void
+          u3a_reclaim(void);
+
+        /* u3a_rewrite_compact(): rewrite pointers in ad-hoc persistent road structures.
+        */
+          void
+          u3a_rewrite_compact(void);
+
         /* u3a_rewrite_ptr(): mark a pointer as already having been rewritten
         */
           c3_o
@@ -484,11 +494,6 @@
         */
           u3_noun
           u3a_rewritten_noun(u3_noun som);
-
-        /* u3a_compact(): compact (north) road.
-        */
-          void
-          u3a_compact();
 
         /* u3a_count_noun(): count size of noun.
         */
@@ -517,6 +522,16 @@
         */
           c3_w
           u3a_sweep(void);
+
+        /* u3a_pack_seek(): sweep the heap, modifying boxes to record new addresses.
+        */
+          void
+          u3a_pack_seek(u3a_road* rod_u);
+
+        /* u3a_pack_move(): sweep the heap, moving boxes to new addresses.
+        */
+          void
+          u3a_pack_move(u3a_road* rod_u);
 
         /* u3a_sane(): check allocator sanity.
         */

--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -465,6 +465,31 @@
           c3_w
           u3a_mark_road(FILE* fil_u);
 
+        /* u3a_rewrite_ptr(): mark a pointer as already having been rewritten
+        */
+          c3_o
+          u3a_rewrite_ptr(void* ptr_v);
+
+        /* u3a_rewrite_noun(): rewrite a noun for compaction.
+        */
+          void
+          u3a_rewrite_noun(u3_noun som);
+
+        /* u3a_rewritten(): rewrite a pointer for compaction.
+        */
+          u3_post
+          u3a_rewritten(u3_post som_p);
+
+        /* u3a_rewritten(): rewritten noun pointer for compaction.
+        */
+          u3_noun
+          u3a_rewritten_noun(u3_noun som);
+
+        /* u3a_compact(): compact (north) road.
+        */
+          void
+          u3a_compact();
+
         /* u3a_count_noun(): count size of noun.
         */
           c3_w

--- a/pkg/urbit/include/noun/hashtable.h
+++ b/pkg/urbit/include/noun/hashtable.h
@@ -139,6 +139,11 @@
         c3_w
         u3h_mark(u3p(u3h_root) har_p);
 
+      /* u3h_rewrite(): rewrite hashtable for compaction.
+      */
+        void
+        u3h_rewrite(u3p(u3h_root) har_p);
+
       /* u3h_count(): count hashtable for gc.
       */
         c3_w

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -287,6 +287,21 @@
         c3_w
         u3j_mark(FILE* fil_u);
 
+      /* u3j_rite_rewrite(): rewrite u3j_rite for compaction.
+      */
+        void
+        u3j_rite_rewrite(u3j_rite* rit_u);
+
+      /* u3j_site_rewrite(): rewrite u3j_site for compaction.
+      */
+        void
+        u3j_site_rewrite(u3j_site* sit_u);
+
+      /* u3j_rewrite_compact(): rewrite jet state for compaction.
+      */
+        void
+        u3j_rewrite_compact();
+
       /* u3j_free_hank(): free an entry from the hank cache.
       */
         void

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -287,16 +287,6 @@
         c3_w
         u3j_mark(FILE* fil_u);
 
-      /* u3j_rite_rewrite(): rewrite u3j_rite for compaction.
-      */
-        void
-        u3j_rite_rewrite(u3j_rite* rit_u);
-
-      /* u3j_site_rewrite(): rewrite u3j_site for compaction.
-      */
-        void
-        u3j_site_rewrite(u3j_site* sit_u);
-
       /* u3j_rewrite_compact(): rewrite jet state for compaction.
       */
         void

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -287,17 +287,17 @@
         c3_w
         u3j_mark(FILE* fil_u);
 
-      /* u3j_rewrite_compact(): rewrite jet state for compaction.
-      */
-        void
-        u3j_rewrite_compact();
-
-      /* u3j_free_hank(): free an entry from the hank cache.
-      */
-        void
-        u3j_free_hank(u3_noun kev);
-
       /* u3j_free(): free jet state.
       */
         void
         u3j_free(void);
+
+      /* u3j_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+      */
+        void
+        u3j_reclaim(void);
+
+      /* u3j_rewrite_compact(): rewrite jet state for compaction.
+      */
+        void
+        u3j_rewrite_compact();

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -141,6 +141,11 @@
         void
         u3m_reclaim(void);
 
+      /* u3m_pack: compact (defragment) memory.
+      */
+        c3_w
+        u3m_pack(void);
+
       /* u3m_rock_stay(): jam state into [dir_c] at [evt_d]
       */
         c3_o

--- a/pkg/urbit/include/noun/nock.h
+++ b/pkg/urbit/include/noun/nock.h
@@ -117,6 +117,11 @@
       c3_w
       u3n_mark(FILE* fil_u);
 
+    /* u3n_rewrite_compact(): rewrite bytecode cache for compaction.
+     */
+      void
+      u3n_rewrite_compact();
+
     /* u3n_free(): free bytecode cache.
      */
       void

--- a/pkg/urbit/include/noun/nock.h
+++ b/pkg/urbit/include/noun/nock.h
@@ -117,6 +117,11 @@
       c3_w
       u3n_mark(FILE* fil_u);
 
+    /* u3n_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+    */
+      void
+      u3n_reclaim(void);
+
     /* u3n_rewrite_compact(): rewrite bytecode cache for compaction.
      */
       void

--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -103,3 +103,8 @@
     */
       c3_w
       u3v_mark(FILE* fil_u);
+
+    /* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
+    */
+      void
+      u3v_rewrite_compact();

--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -104,6 +104,11 @@
       c3_w
       u3v_mark(FILE* fil_u);
 
+    /* u3v_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+    */
+      void
+      u3v_reclaim(void);
+
     /* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
     */
       void

--- a/pkg/urbit/include/vere/serf.h
+++ b/pkg/urbit/include/vere/serf.h
@@ -24,10 +24,10 @@
       u3_noun
       u3_serf_init(u3_serf* sef_u);
 
-    /* u3_serf_unpack(): initialize from rock at [eve_d].
+    /* u3_serf_uncram(): initialize from rock at [eve_d].
     */
       void
-      u3_serf_unpack(u3_serf* sef_u, c3_d eve_d);
+      u3_serf_uncram(u3_serf* sef_u, c3_d eve_d);
 
     /* u3_serf_writ(): apply writ [wit], producing plea [*pel] on c3y.
     */
@@ -58,3 +58,8 @@
     */
       void
       u3_serf_post(u3_serf* sef_u);
+
+    /* u3_serf_grab(): garbage collect.
+    */
+      void
+      u3_serf_grab(void);

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -398,8 +398,9 @@
           u3_writ_peek = 1,
           u3_writ_play = 2,
           u3_writ_save = 3,
-          u3_writ_pack = 4,
-          u3_writ_exit = 5
+          u3_writ_cram = 4,
+          u3_writ_pack = 5,
+          u3_writ_exit = 6
         } u3_writ_type;
 
       /* u3_writ: ipc message from king to serf
@@ -433,7 +434,7 @@
           void (*work_done_f)(void*, u3_ovum*, u3_fact*, u3_gift*);
           void (*work_bail_f)(void*, u3_ovum*, u3_noun lud);
           void (*save_f)(void*);
-          void (*pack_f)(void*);
+          void (*cram_f)(void*);
           void (*bail_f)(void*);
           void (*exit_f)(void*);
         } u3_lord_cb;
@@ -942,10 +943,10 @@
         c3_o
         u3_lord_save(u3_lord* god_u);
 
-      /* u3_lord_pack(): save portable state.
+      /* u3_lord_cram(): save portable state.
       */
         c3_o
-        u3_lord_pack(u3_lord* god_u);
+        u3_lord_cram(u3_lord* god_u);
 
       /* u3_lord_work(): attempt work.
       */
@@ -1215,10 +1216,10 @@
         c3_o
         u3_pier_save(u3_pier* pir_u);
 
-      /* u3_pier_pack(): save a portable snapshot.
+      /* u3_pier_cram(): save a portable snapshot.
       */
         c3_o
-        u3_pier_pack(u3_pier* pir_u);
+        u3_pier_cram(u3_pier* pir_u);
 
       /* u3_pier_info(): print status info.
       */

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -2231,11 +2231,19 @@ u3a_sweep(void)
 void
 u3a_compact(void)
 {
-  sleep(10);
+  // sleep(10);  // in case you need to attach a debugger
+
+  /* Note if u3m_reclaim changes to not reclaim something, or if other
+   * things are added to the loom, they will need to be added to the
+   * tracing step
+  */
   u3m_reclaim();
+
   assert(c3y == u3a_is_north(u3R));
   u3_post box_p = _(u3a_is_north(u3R)) ? u3R->rut_p : u3R->hat_p;
   u3_post end_p = _(u3a_is_north(u3R)) ? u3R->hat_p : u3R->rut_p;
+
+  fprintf(stderr, "compact: sweep 1 beginning\r\n");
 
   /* Sweep through arena, recording new address
    *
@@ -2311,6 +2319,7 @@ u3a_compact(void)
         c3_w i_w;
         if ( new_w > box_w ) {
           fprintf(stderr, "compact: whoa new_w %p, i_w %d\r\n", new_w, i_w);
+          c3_assert(0);
         }
         for ( i_w = 0; i_w < siz_w - 1; i_w++ ) {
           new_w[i_w] = box_w[i_w];
@@ -2321,7 +2330,6 @@ u3a_compact(void)
 
       box_w += siz_w;
     }
-    fprintf(stderr, "compact: box_w %lx new_w %lx\r\n", u3a_outa(box_w), u3a_outa(new_w));
   }
 
   fprintf(stderr, "compact: sweep 2 complete\r\n");
@@ -2341,10 +2349,20 @@ u3a_compact(void)
 
     u3n_ream();
 
+    fprintf(stderr, "compact: running |mass to verify correct compaction\r\n");
     u3m_mark(stderr);
     fprintf(stderr, "compact: marked\r\n");
     u3a_sweep();
     fprintf(stderr, "compact: swept\r\n");
+    c3_w lid_w = u3a_idle(u3R);
+    if ( 0 == lid_w ) {
+      fprintf(stderr, "free lists: B/0\r\n");
+    }
+    else {
+      u3a_print_memory(stderr, "free lists", u3a_idle(u3R));
+    }
+
+    fprintf(stderr, "compact: done\r\n");
   }
 }
 

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -374,10 +374,10 @@ u3a_reflux(void)
   }
 }
 
-/* u3a_reclaim(): reclaim from memoization cache.
+/* _ca_reclaim_half(): reclaim from memoization cache.
 */
-void
-u3a_reclaim(void)
+static void
+_ca_reclaim_half(void)
 {
   //  XX u3l_log avoid here, as it can
   //  cause problems when handling errors
@@ -435,7 +435,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
 
           //  memory nearly empty; reclaim; should not be needed
           //
-          // if ( (u3a_open(u3R) + u3R->all.fre_w) < 65536 ) { u3a_reclaim(); }
+          // if ( (u3a_open(u3R) + u3R->all.fre_w) < 65536 ) { _ca_reclaim_half(); }
           box_u = _ca_box_make_hat(siz_w, ald_w, alp_w, 1);
 
           /* Flush a bunch of cell cache, then try again.
@@ -447,7 +447,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
               return _ca_willoc(len_w, ald_w, alp_w);
             }
             else {
-              u3a_reclaim();
+              _ca_reclaim_half();
               return _ca_willoc(len_w, ald_w, alp_w);
             }
           }
@@ -534,7 +534,7 @@ _ca_walloc(c3_w len_w, c3_w ald_w, c3_w alp_w)
     if ( 0 != ptr_v ) {
       break;
     }
-    u3a_reclaim();
+    _ca_reclaim_half();
   }
   return ptr_v;
 }
@@ -1951,10 +1951,21 @@ u3a_mark_road(FILE* fil_u)
   return   u3a_maid(fil_u, "total road stuff", tot_w);
 }
 
+/* u3a_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3a_reclaim(void)
+{
+  //  clear the memoization cache
+  //
+  u3h_free(u3R->cax.har_p);
+  u3R->cax.har_p = u3h_new();
+}
+
 /* u3a_rewrite_compact(): rewrite pointers in ad-hoc persistent road structures.
 */
 void
-u3a_rewrite_compact()
+u3a_rewrite_compact(void)
 {
   u3a_rewrite_noun(u3R->ski.gul);
   u3a_rewrite_noun(u3R->bug.tax);
@@ -2225,144 +2236,219 @@ u3a_sweep(void)
   return neg_w;
 }
 
-
-/* u3a_compact(): compact road.
+/* u3a_pack_seek(): sweep the heap, modifying boxes to record new addresses.
 */
 void
-u3a_compact(void)
+u3a_pack_seek(u3a_road* rod_u)
 {
-  // sleep(10);  // in case you need to attach a debugger
+  //  the heap in [rod_u] is swept from "front" to "back".
+  //  new locations are calculated for each in-use allocation box
+  //  (simply the "deepest" linearly-available location),
+  //  and stored in the box itself
+  //
+  //  box_w: front of the heap
+  //  end_w: back of the heap
+  //  new_p: initial new location (data of first box)
+  //
+  c3_w*    box_w = u3a_into(rod_u->rut_p);
+  c3_w*    end_w = u3a_into(rod_u->hat_p);
+  u3_post  new_p = (rod_u->rut_p + c3_wiseof(u3a_box));
+  u3a_box* box_u;
+  c3_w     siz_w;
 
-  /* Note if u3m_reclaim changes to not reclaim something, or if other
-   * things are added to the loom, they will need to be added to the
-   * tracing step
-  */
-  u3m_reclaim();
-
-  assert(c3y == u3a_is_north(u3R));
-  u3_post box_p = _(u3a_is_north(u3R)) ? u3R->rut_p : u3R->hat_p;
-  u3_post end_p = _(u3a_is_north(u3R)) ? u3R->hat_p : u3R->rut_p;
-
-  fprintf(stderr, "compact: sweep 1 beginning\r\n");
-
-  /* Sweep through arena, recording new address
-   *
-   * Don't trace to preserve memory locality
-  */
-  {
-    u3_post new_p = c3_wiseof(u3a_box) + 1;
-    c3_w*   box_w = u3a_into(box_p);
-    c3_w*   end_w = u3a_into(end_p);
-
+  if ( c3y == u3a_is_north(rod_u) ) {
+    //  north roads are swept low to high
+    //
+    //    new locations are recorded in the trailing size word
+    //
     while ( box_w < end_w ) {
-      u3a_box* box_u = (void *)box_w;
+      box_u = (void *)box_w;
+      siz_w = box_u->siz_w;
 
-      /* If not free, rewrite trailing size word to be new pointer.
-       *
-       * Another option would be to use the refcount and just
-       * regenerate it by tracing.
-      */
-      if ( box_u->use_w > 0 ) {
-        //fprintf(stderr, "compact: found size %d at box_u %p, setting to new_p %x\r\n", box_u->siz_w, box_u, new_p);
-        box_w[box_u->siz_w - 1] = new_p;
-        new_p += box_u->siz_w;
-        //fprintf(stderr, "compact: adding to new_p %x\r\n", new_p);
-      }
-
-      box_w += box_u->siz_w;
-    }
-  }
-
-  fprintf(stderr, "compact: sweep 1 complete\r\n");
-
-  /* Trace through arena, rewriting pointers
-   *
-   * Don't sweep because it's ad-hoc polymorphic
-  */
-  {
-    u3v_rewrite_compact();
-    u3j_rewrite_compact();
-    u3n_rewrite_compact();
-    u3a_rewrite_compact();
-  }
-
-  fprintf(stderr, "compact: trace complete\r\n");
-
-  c3_w* new_w = (void*)u3a_botox(u3a_into(c3_wiseof(u3a_box) + 1));
-
-  /* Sweep through arena, moving nouns
-   *
-   * Don't trace because you need to move in order
-  */
-  {
-    c3_w* box_w = u3a_into(box_p);
-    c3_w* end_w = u3a_into(end_p);
-
-    while ( box_w < end_w ) {
-      u3a_box* old_u = (void *)box_w;
-      c3_w siz_w = old_u->siz_w; // store because we're about to overwrite
-
-      /* Unmark if marked
-      */
-      old_u->use_w &= 0x7fffffff;
-
-      //fprintf(stderr, "compact: 364 == %d\r\n", *((c3_w*)0x200000364));
-      //fprintf(stderr, "compact: found size %d at old_u %p\r\n", old_u->siz_w, old_u);
-
-
-      /* If not free, move to new home
-      */
-      if ( old_u->use_w > 0 ) {
-        //fprintf(stderr, "compact: writing to %p from %p\r\n", u3a_botox(u3a_into(box_w[siz_w - 1])), box_w);
-        assert(new_w == (c3_w*)u3a_botox(u3a_into(box_w[siz_w - 1])));
-        new_w = (c3_w*)u3a_botox(u3a_into(box_w[siz_w - 1]));
-        c3_w i_w;
-        if ( new_w > box_w ) {
-          fprintf(stderr, "compact: whoa new_w %p, i_w %d\r\n", new_w, i_w);
-          c3_assert(0);
-        }
-        for ( i_w = 0; i_w < siz_w - 1; i_w++ ) {
-          new_w[i_w] = box_w[i_w];
-        }
-        new_w[siz_w - 1] = siz_w;
-        new_w += siz_w;
+      if ( box_u->use_w ) {
+        box_w[siz_w - 1] = new_p;
+        new_p += siz_w;
       }
 
       box_w += siz_w;
     }
   }
+  //  XX untested!
+  //
+  else {
+    //  south roads are swept high to low
+    //
+    //    new locations are recorded in the leading size word
+    //
+    //    since we traverse backward, [siz_w] holds the size of the next box,
+    //    and we must initially offset to point to the head of the first box
+    //
+    siz_w  = box_w[-1];
+    box_w -= siz_w;
+    new_p -= siz_w;
 
-  fprintf(stderr, "compact: sweep 2 complete\r\n");
+    while ( end_w < box_w ) {
+      box_u = (void *)box_w;
+      siz_w = box_w[-1];
 
-  /* Set new end of heap.
-  */
+      if ( box_u->use_w ) {
+        box_u->siz_w = new_p;
+        new_p -= siz_w;
+      }
+
+      box_w -= siz_w;
+    }
+  }
+}
+static u3_post
+_ca_pack_move_north(c3_w* box_w, c3_w* end_w, u3_post new_p)
+{
+  u3a_box* old_u;
+  c3_w     siz_w;
+
+  //  relocate allocation boxes
+  //
+  //    new locations have been recorded in the trailing size word,
+  //    and are recalculated and asserted to ensure sanity
+  //
+  while ( box_w < end_w ) {
+    old_u = (void *)box_w;
+    siz_w = old_u->siz_w;
+
+    old_u->use_w &= 0x7fffffff;
+
+    if ( old_u->use_w ) {
+      c3_w* new_w = (void*)u3a_botox(u3a_into(new_p));
+
+      c3_assert( box_w[siz_w - 1] == new_p );
+
+      //  note: includes leading size
+      //
+      if ( new_w < box_w ) {
+        c3_w i_w;
+
+        for ( i_w = 0; i_w < siz_w - 1; i_w++ ) {
+          new_w[i_w] = box_w[i_w];
+        }
+      }
+      else {
+        c3_assert( new_w == box_w );
+      }
+
+      //  restore trailing size
+      //
+      new_w[siz_w - 1] = siz_w;
+
+      new_p += siz_w;
+    }
+
+    box_w += siz_w;
+  }
+
+  return new_p;
+}
+
+//  XX untested!
+//
+static u3_post
+_ca_pack_move_south(c3_w* box_w, c3_w* end_w, u3_post new_p)
+{
+  u3a_box* old_u;
+  c3_w     siz_w;
+  c3_o     yuz_o;
+
+  //  offset initial addresses (point to the head of the first box)
+  //
+  siz_w  = box_w[-1];
+  box_w -= siz_w;
+  new_p -= siz_w;
+
+  //  relocate allocation boxes
+  //
+  //    new locations have been recorded in the leading size word,
+  //    and are recalculated and asserted to ensure sanity
+  //
+  while ( 1 ) {
+    old_u = (void *)box_w;
+
+    old_u->use_w &= 0x7fffffff;
+
+    if ( old_u->use_w ) {
+      c3_w* new_w = (void*)u3a_botox(u3a_into(new_p));
+
+      c3_assert( old_u->siz_w == new_p );
+
+      //  note: includes trailing size
+      //
+      if ( new_w > box_w ) {
+        c3_w i_w;
+
+        for ( i_w = 1; i_w < siz_w; i_w++ ) {
+          new_w[i_w] = box_w[i_w];
+        }
+      }
+      else {
+        c3_assert( new_w == box_w );
+      }
+
+      //  restore leading size
+      //
+      new_w[0] = siz_w;
+
+      yuz_o = c3y;
+    }
+    else {
+      yuz_o = c3n;
+    }
+
+    //  move backwards only if there is more work to be done
+    //
+    if ( box_w > end_w ) {
+      siz_w  = box_w[-1];
+      box_w -= siz_w;
+
+      if ( c3y == yuz_o ) {
+        new_p -= siz_w;
+      }
+    }
+    else {
+      c3_assert( end_w == box_w );
+      break;
+    }
+  }
+
+  return new_p;
+}
+
+/* u3a_pack_move(): sweep the heap, moving boxes to new addresses.
+*/
+void
+u3a_pack_move(u3a_road* rod_u)
+{
+  //  box_w: front of the heap
+  //  end_w: back of the heap
+  //  new_p: initial new location (data of first box)
+  //  las_p: newly calculated last location
+  //
+  c3_w*   box_w = u3a_into(rod_u->rut_p);
+  c3_w*   end_w = u3a_into(rod_u->hat_p);
+  u3_post new_p = (rod_u->rut_p + c3_wiseof(u3a_box));
+  u3_post las_p = ( c3y == u3a_is_north(rod_u) )
+                  ? _ca_pack_move_north(box_w, end_w, new_p)
+                  : _ca_pack_move_south(box_w, end_w, new_p);
+
+  rod_u->hat_p  = (las_p - c3_wiseof(u3a_box));
+
+  //  clear free lists and cell allocator
+  //
   {
-    u3R->hat_p = u3a_outa(new_w);
-
     c3_w i_w;
     for ( i_w = 0; i_w < u3a_fbox_no; i_w++ ) {
       u3R->all.fre_p[i_w] = 0;
     }
 
-    u3R->all.cel_p = 0;
     u3R->all.fre_w = 0;
-
-    u3n_ream();
-
-    fprintf(stderr, "compact: running |mass to verify correct compaction\r\n");
-    u3m_mark(stderr);
-    fprintf(stderr, "compact: marked\r\n");
-    u3a_sweep();
-    fprintf(stderr, "compact: swept\r\n");
-    c3_w lid_w = u3a_idle(u3R);
-    if ( 0 == lid_w ) {
-      fprintf(stderr, "free lists: B/0\r\n");
-    }
-    else {
-      u3a_print_memory(stderr, "free lists", u3a_idle(u3R));
-    }
-
-    fprintf(stderr, "compact: done\r\n");
+    u3R->all.cel_p = 0;
   }
 }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -148,7 +148,7 @@ u3e_fault(void* adr_v, c3_i ser_i)
     if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
       fprintf(stderr, "strange page: %d, at %p, off %x\r\n",
               pag_w, adr_w, off_w);
-      c3_assert(0);
+      // c3_assert(0);
       return 0;
     }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -148,7 +148,7 @@ u3e_fault(void* adr_v, c3_i ser_i)
     if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
       fprintf(stderr, "strange page: %d, at %p, off %x\r\n",
               pag_w, adr_w, off_w);
-      // c3_assert(0);
+      c3_assert(0);
       return 0;
     }
 

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -913,6 +913,58 @@ _ch_mark_node(u3h_node* han_u, c3_w lef_w)
   return tot_w;
 }
 
+// XXX reorg
+/* _ch_rewrite_buck(): rewrite buck for compaction.
+*/
+void
+_ch_rewrite_buck(u3h_buck* hab_u)
+{
+  if ( c3n == u3a_rewrite_ptr(hab_u) ) return;
+  c3_w i_w;
+
+  for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
+    u3_noun som = u3h_slot_to_noun(hab_u->sot_w[i_w]);
+    hab_u->sot_w[i_w] = u3h_noun_to_slot(u3a_rewritten_noun(som));
+    u3a_rewrite_noun(som);
+  }
+}
+
+/* _ch_rewrite_node(): rewrite node for compaction.
+*/
+void
+_ch_rewrite_node(u3h_node* han_u, c3_w lef_w)
+{
+  if ( c3n == u3a_rewrite_ptr(han_u) ) return;
+
+  c3_w len_w = _ch_popcount(han_u->map_w);
+  c3_w i_w;
+
+  lef_w -= 5;
+
+  for ( i_w = 0; i_w < len_w; i_w++ ) {
+    c3_w sot_w = han_u->sot_w[i_w];
+
+    if ( _(u3h_slot_is_noun(sot_w)) ) {
+      u3_noun kev = u3h_slot_to_noun(sot_w);
+      han_u->sot_w[i_w] = u3h_noun_to_slot(u3a_rewritten_noun(kev));
+
+      u3a_rewrite_noun(kev);
+    }
+    else {
+      void* hav_v = u3h_slot_to_node(sot_w);
+      u3h_node* nod_u = u3to(u3h_node,u3a_rewritten(u3of(u3h_node,hav_v)));
+      han_u->sot_w[i_w] = u3h_node_to_slot(nod_u);
+
+      if ( 0 == lef_w ) {
+        _ch_rewrite_buck(hav_v);
+      } else {
+        _ch_rewrite_node(hav_v, lef_w);
+      }
+    }
+  }
+}
+
+
 /* u3h_mark(): mark hashtable for gc.
 */
 c3_w
@@ -940,6 +992,35 @@ u3h_mark(u3p(u3h_root) har_p)
   tot_w += u3a_mark_ptr(har_u);
 
   return tot_w;
+}
+
+/* u3h_rewrite(): rewrite pointers during compaction.
+*/
+void
+u3h_rewrite(u3p(u3h_root) har_p)
+{
+  u3h_root* har_u = u3to(u3h_root, har_p);
+  c3_w        i_w;
+
+  if ( c3n == u3a_rewrite_ptr(har_u) ) return;
+
+  for ( i_w = 0; i_w < 64; i_w++ ) {
+    c3_w sot_w = har_u->sot_w[i_w];
+
+    if ( _(u3h_slot_is_noun(sot_w)) ) {
+      u3_noun kev = u3h_slot_to_noun(sot_w);
+      har_u->sot_w[i_w] = u3h_noun_to_slot(u3a_rewritten_noun(kev));
+
+      u3a_rewrite_noun(kev);
+    }
+    else if ( _(u3h_slot_is_node(sot_w)) ) {
+      u3h_node* han_u = u3h_slot_to_node(sot_w);
+      u3h_node* nod_u = u3to(u3h_node,u3a_rewritten(u3of(u3h_node,han_u)));
+      har_u->sot_w[i_w] = u3h_node_to_slot(nod_u);
+
+      _ch_rewrite_node(han_u, 25);
+    }
+  }
 }
 
 /* _ch_count_buck(): count bucket for gc.

--- a/pkg/urbit/noun/hashtable.c
+++ b/pkg/urbit/noun/hashtable.c
@@ -913,7 +913,35 @@ _ch_mark_node(u3h_node* han_u, c3_w lef_w)
   return tot_w;
 }
 
-// XXX reorg
+/* u3h_mark(): mark hashtable for gc.
+*/
+c3_w
+u3h_mark(u3p(u3h_root) har_p)
+{
+  c3_w tot_w = 0;
+  u3h_root* har_u = u3to(u3h_root, har_p);
+  c3_w        i_w;
+
+  for ( i_w = 0; i_w < 64; i_w++ ) {
+    c3_w sot_w = har_u->sot_w[i_w];
+
+    if ( _(u3h_slot_is_noun(sot_w)) ) {
+      u3_noun kev = u3h_slot_to_noun(sot_w);
+
+      tot_w += u3a_mark_noun(kev);
+    }
+    else if ( _(u3h_slot_is_node(sot_w)) ) {
+      u3h_node* han_u = u3h_slot_to_node(sot_w);
+
+      tot_w += _ch_mark_node(han_u, 25);
+    }
+  }
+
+  tot_w += u3a_mark_ptr(har_u);
+
+  return tot_w;
+}
+
 /* _ch_rewrite_buck(): rewrite buck for compaction.
 */
 void
@@ -962,36 +990,6 @@ _ch_rewrite_node(u3h_node* han_u, c3_w lef_w)
       }
     }
   }
-}
-
-
-/* u3h_mark(): mark hashtable for gc.
-*/
-c3_w
-u3h_mark(u3p(u3h_root) har_p)
-{
-  c3_w tot_w = 0;
-  u3h_root* har_u = u3to(u3h_root, har_p);
-  c3_w        i_w;
-
-  for ( i_w = 0; i_w < 64; i_w++ ) {
-    c3_w sot_w = har_u->sot_w[i_w];
-
-    if ( _(u3h_slot_is_noun(sot_w)) ) {
-      u3_noun kev = u3h_slot_to_noun(sot_w);
-
-      tot_w += u3a_mark_noun(kev);
-    }
-    else if ( _(u3h_slot_is_node(sot_w)) ) {
-      u3h_node* han_u = u3h_slot_to_node(sot_w);
-
-      tot_w += _ch_mark_node(han_u, 25);
-    }
-  }
-
-  tot_w += u3a_mark_ptr(har_u);
-
-  return tot_w;
 }
 
 /* u3h_rewrite(): rewrite pointers during compaction.

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -2339,6 +2339,104 @@ u3j_mark(FILE* fil_u)
   return u3a_maid(fil_u, "total jet stuff", tot_w);
 }
 
+/* _cj_fink_rewrite(): rewrite a u3j_fink for compaction.
+*/
+static void
+_cj_fink_rewrite(u3j_fink* fin_u)
+{
+  if ( c3n == u3a_rewrite_ptr(fin_u) ) return;
+  c3_w i_w;
+  u3a_rewrite_noun(fin_u->sat);
+  fin_u->sat = u3a_rewritten_noun(fin_u->sat);
+
+  for ( i_w = 0; i_w < fin_u->len_w; ++i_w ) {
+    u3j_fist* fis_u = &(fin_u->fis_u[i_w]);
+    u3a_rewrite_noun(fis_u->bat);
+    u3a_rewrite_noun(fis_u->pax);
+    fis_u->bat = u3a_rewritten_noun(fis_u->bat);
+    fis_u->pax = u3a_rewritten_noun(fis_u->pax);
+  }
+}
+
+/* u3j_rite_rewrite(): rewrite u3j_rite for compaction.
+*/
+void
+u3j_rite_rewrite(u3j_rite* rit_u)
+{
+  if ( (c3y == rit_u->own_o) && u3_none != rit_u->clu ) {
+    u3a_rewrite_noun(rit_u->clu);
+    _cj_fink_rewrite(u3to(u3j_fink, rit_u->fin_p));
+    rit_u->clu = u3a_rewritten_noun(rit_u->clu);
+    rit_u->fin_p = u3a_rewritten(rit_u->fin_p);
+  }
+}
+
+/* u3j_site_rewrite(): rewrite u3j_site for compaction.
+*/
+void
+u3j_site_rewrite(u3j_site* sit_u)
+{
+  u3a_rewrite_noun(sit_u->axe);
+  sit_u->axe = u3a_rewritten_noun(sit_u->axe);
+
+  if ( u3_none != sit_u->bat ) {
+    u3a_rewrite_noun(sit_u->bat);
+    sit_u->bat = u3a_rewritten_noun(sit_u->bat);
+  }
+  if ( u3_none != sit_u->bas ) {
+    u3a_rewrite_noun(sit_u->bas);
+    sit_u->bas = u3a_rewritten_noun(sit_u->bas);
+  }
+  if ( u3_none != sit_u->loc ) {
+    u3a_rewrite_noun(sit_u->loc);
+    u3a_rewrite_noun(sit_u->lab);
+    sit_u->loc = u3a_rewritten_noun(sit_u->loc);
+    sit_u->lab = u3a_rewritten_noun(sit_u->lab);
+    if ( c3y == sit_u->fon_o ) {
+      _cj_fink_rewrite(u3to(u3j_fink, sit_u->fin_p));
+      sit_u->fin_p = u3a_rewritten(sit_u->fin_p);
+    }
+  }
+}
+
+/* _cj_rewrite_hank(): rewrite hank cache for compaction.
+*/
+static void
+_cj_rewrite_hank(u3_noun kev)
+{
+  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
+  if ( c3n == u3a_rewrite_ptr(han_u) ) return;
+  if ( u3_none != han_u->hax ) {
+    u3a_rewrite_noun(han_u->hax);
+    u3j_site_rewrite(&(han_u->sit_u));
+
+    han_u->hax = u3a_rewritten_noun(han_u->hax);
+  }
+}
+
+/* u3j_rewrite_compact(): rewrite jet state for compaction.
+*/
+void
+u3j_rewrite_compact()
+{
+  u3h_walk(u3R->jed.han_p, _cj_rewrite_hank);
+
+  u3h_rewrite(u3R->jed.war_p);
+  u3h_rewrite(u3R->jed.cod_p);
+  u3h_rewrite(u3R->jed.han_p);
+  u3h_rewrite(u3R->jed.bas_p);
+
+  if ( u3R == &(u3H->rod_u) ) {
+    u3h_rewrite(u3R->jed.hot_p);
+    u3R->jed.hot_p = u3a_rewritten(u3R->jed.hot_p);
+  }
+
+  u3R->jed.war_p = u3a_rewritten(u3R->jed.war_p);
+  u3R->jed.cod_p = u3a_rewritten(u3R->jed.cod_p);
+  u3R->jed.han_p = u3a_rewritten(u3R->jed.han_p);
+  u3R->jed.bas_p = u3a_rewritten(u3R->jed.bas_p);
+}
+
 /* u3j_free_hank(): free an entry from the hank cache.
 */
 void

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -2339,88 +2339,20 @@ u3j_mark(FILE* fil_u)
   return u3a_maid(fil_u, "total jet stuff", tot_w);
 }
 
-/* _cj_fink_rewrite(): rewrite a u3j_fink for compaction.
-*/
-static void
-_cj_fink_rewrite(u3j_fink* fin_u)
-{
-  if ( c3n == u3a_rewrite_ptr(fin_u) ) return;
-  c3_w i_w;
-  u3a_rewrite_noun(fin_u->sat);
-  fin_u->sat = u3a_rewritten_noun(fin_u->sat);
-
-  for ( i_w = 0; i_w < fin_u->len_w; ++i_w ) {
-    u3j_fist* fis_u = &(fin_u->fis_u[i_w]);
-    u3a_rewrite_noun(fis_u->bat);
-    u3a_rewrite_noun(fis_u->pax);
-    fis_u->bat = u3a_rewritten_noun(fis_u->bat);
-    fis_u->pax = u3a_rewritten_noun(fis_u->pax);
-  }
-}
-
-/* u3j_rite_rewrite(): rewrite u3j_rite for compaction.
-*/
-void
-u3j_rite_rewrite(u3j_rite* rit_u)
-{
-  if ( (c3y == rit_u->own_o) && u3_none != rit_u->clu ) {
-    u3a_rewrite_noun(rit_u->clu);
-    _cj_fink_rewrite(u3to(u3j_fink, rit_u->fin_p));
-    rit_u->clu = u3a_rewritten_noun(rit_u->clu);
-    rit_u->fin_p = u3a_rewritten(rit_u->fin_p);
-  }
-}
-
-/* u3j_site_rewrite(): rewrite u3j_site for compaction.
-*/
-void
-u3j_site_rewrite(u3j_site* sit_u)
-{
-  u3a_rewrite_noun(sit_u->axe);
-  sit_u->axe = u3a_rewritten_noun(sit_u->axe);
-
-  if ( u3_none != sit_u->bat ) {
-    u3a_rewrite_noun(sit_u->bat);
-    sit_u->bat = u3a_rewritten_noun(sit_u->bat);
-  }
-  if ( u3_none != sit_u->bas ) {
-    u3a_rewrite_noun(sit_u->bas);
-    sit_u->bas = u3a_rewritten_noun(sit_u->bas);
-  }
-  if ( u3_none != sit_u->loc ) {
-    u3a_rewrite_noun(sit_u->loc);
-    u3a_rewrite_noun(sit_u->lab);
-    sit_u->loc = u3a_rewritten_noun(sit_u->loc);
-    sit_u->lab = u3a_rewritten_noun(sit_u->lab);
-    if ( c3y == sit_u->fon_o ) {
-      _cj_fink_rewrite(u3to(u3j_fink, sit_u->fin_p));
-      sit_u->fin_p = u3a_rewritten(sit_u->fin_p);
-    }
-  }
-}
-
-/* _cj_rewrite_hank(): rewrite hank cache for compaction.
-*/
-static void
-_cj_rewrite_hank(u3_noun kev)
-{
-  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
-  if ( c3n == u3a_rewrite_ptr(han_u) ) return;
-  if ( u3_none != han_u->hax ) {
-    u3a_rewrite_noun(han_u->hax);
-    u3j_site_rewrite(&(han_u->sit_u));
-
-    han_u->hax = u3a_rewritten_noun(han_u->hax);
-  }
-}
-
 /* u3j_rewrite_compact(): rewrite jet state for compaction.
+ *
+ * NB: u3R->jed.han_p *must* be cleared (currently via u3m_reclaim)
+ * since it contains hanks which are not nouns but have loom pointers.
+ * Alternately, rewrite the entries with u3h_walk, using u3j_mark as a
+ * template for how to walk.  There's an untested attempt at this in git
+ * history at e8a307a.
+ *
+ * bas_p is also cleared in u3m_reclaim, but I think it would be
+ * rewritten just fine.
 */
 void
 u3j_rewrite_compact()
 {
-  u3h_walk(u3R->jed.han_p, _cj_rewrite_hank);
-
   u3h_rewrite(u3R->jed.war_p);
   u3h_rewrite(u3R->jed.cod_p);
   u3h_rewrite(u3R->jed.han_p);

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -2339,16 +2339,61 @@ u3j_mark(FILE* fil_u)
   return u3a_maid(fil_u, "total jet stuff", tot_w);
 }
 
+/* _cj_free_hank(): free an entry from the hank cache.
+*/
+static void
+_cj_free_hank(u3_noun kev)
+{
+  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
+  if ( u3_none != han_u->hax ) {
+    u3z(han_u->hax);
+    u3j_site_lose(&(han_u->sit_u));
+  }
+  u3a_wfree(han_u);
+}
+
+/* u3j_free(): free jet state.
+*/
+void
+u3j_free(void)
+{
+  u3h_walk(u3R->jed.han_p, _cj_free_hank);
+  u3h_free(u3R->jed.war_p);
+  u3h_free(u3R->jed.cod_p);
+  u3h_free(u3R->jed.han_p);
+  u3h_free(u3R->jed.bas_p);
+  if ( u3R == &(u3H->rod_u) ) {
+    u3h_free(u3R->jed.hot_p);
+  }
+}
+
+/* u3j_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3j_reclaim(void)
+{
+  //  re-establish the warm jet state
+  //
+  //    XX might this reduce fragmentation?
+  //
+  // if ( &(u3H->rod_u) == u3R ) {
+  //   u3j_ream();
+  // }
+
+  //  clear the jet hank cache
+  //
+  u3h_walk(u3R->jed.han_p, _cj_free_hank);
+  u3h_free(u3R->jed.han_p);
+  u3R->jed.han_p = u3h_new();
+}
+
 /* u3j_rewrite_compact(): rewrite jet state for compaction.
  *
- * NB: u3R->jed.han_p *must* be cleared (currently via u3m_reclaim)
+ * NB: u3R->jed.han_p *must* be cleared (currently via u3j_reclaim above)
  * since it contains hanks which are not nouns but have loom pointers.
  * Alternately, rewrite the entries with u3h_walk, using u3j_mark as a
  * template for how to walk.  There's an untested attempt at this in git
  * history at e8a307a.
- *
- * bas_p is also cleared in u3m_reclaim, but I think it would be
- * rewritten just fine.
 */
 void
 u3j_rewrite_compact()
@@ -2368,32 +2413,3 @@ u3j_rewrite_compact()
   u3R->jed.han_p = u3a_rewritten(u3R->jed.han_p);
   u3R->jed.bas_p = u3a_rewritten(u3R->jed.bas_p);
 }
-
-/* u3j_free_hank(): free an entry from the hank cache.
-*/
-void
-u3j_free_hank(u3_noun kev)
-{
-  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
-  if ( u3_none != han_u->hax ) {
-    u3z(han_u->hax);
-    u3j_site_lose(&(han_u->sit_u));
-  }
-  u3a_wfree(han_u);
-}
-
-/* u3j_free(): free jet state.
-*/
-void
-u3j_free(void)
-{
-  u3h_walk(u3R->jed.han_p, u3j_free_hank);
-  u3h_free(u3R->jed.war_p);
-  u3h_free(u3R->jed.cod_p);
-  u3h_free(u3R->jed.han_p);
-  u3h_free(u3R->jed.bas_p);
-  if ( u3R == &(u3H->rod_u) ) {
-    u3h_free(u3R->jed.hot_p);
-  }
-}
-

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1849,42 +1849,52 @@ u3m_wipe(void)
 void
 u3m_reclaim(void)
 {
+  u3v_reclaim();
+  u3j_reclaim();
+  u3n_reclaim();
+  u3a_reclaim();
+}
+
+/* _cm_pack_rewrite(): trace through arena, rewriting pointers.
+*/
+static void
+_cm_pack_rewrite(void)
+{
+  //  XX fix u3a_rewrit* to support south roads
+  //
   c3_assert( &(u3H->rod_u) == u3R );
 
-  //  clear the u3v_wish cache
+  //  NB: these implementations must be kept in sync with u3m_reclaim();
+  //  anything not reclaimed must be rewritable
   //
-  //    NB: this will leak if not on the home road
-  //
-  u3z(u3A->yot);
-  u3A->yot = u3_nul;
+  u3v_rewrite_compact();
+  u3j_rewrite_compact();
+  u3n_rewrite_compact();
+  u3a_rewrite_compact();
+}
 
-  //  clear the memoization cache
-  //
-  u3h_free(u3R->cax.har_p);
-  u3R->cax.har_p = u3h_new();
+/* u3m_pack: compact (defragment) memory.
+*/
+c3_w
+u3m_pack(void)
+{
+  c3_w pre_w = u3a_open(u3R);
 
-  //  clear the jet battery hash cache
+  //  reclaim first, to free space, and discard anything we can't/don't rewrite
   //
-  u3h_free(u3R->jed.bas_p);
-  u3R->jed.bas_p = u3h_new();
+  u3m_reclaim();
 
-  //  re-establish the warm jet state
+  //  sweep the heap, finding and saving new locations
   //
-  //    XX might this reduce fragmentation?
-  //
-  // u3j_ream();
+  u3a_pack_seek(u3R);
 
-  //  clear the jet hank cache
+  //  trace roots, rewriting inner pointers
   //
-  u3h_walk(u3R->jed.han_p, u3j_free_hank);
-  u3h_free(u3R->jed.han_p);
-  u3R->jed.han_p = u3h_new();
+  _cm_pack_rewrite();
 
-  //  clear the bytecode cache
+  //  sweep the heap, relocating objects to their new locations
   //
-  //    We can't just u3h_free() -- the value is a post to a u3n_prog.
-  //    Note that this requires that the hank cache also be freed.
-  //
-  u3n_free();
-  u3R->byc.har_p = u3h_new();
+  u3a_pack_move(u3R);
+
+  return (u3a_open(u3R) - pre_w);
 }

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -2597,11 +2597,25 @@ u3n_mark(FILE* fil_u)
   return  u3a_maid(fil_u, "total nock stuff", bam_w + har_w);
 }
 
+/* u3n_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3n_reclaim(void)
+{
+  //  clear the bytecode cache
+  //
+  //    We can't just u3h_free() -- the value is a post to a u3n_prog.
+  //    Note that the hank cache *must* also be freed (in u3j_reclaim())
+  //
+  u3n_free();
+  u3R->byc.har_p = u3h_new();
+}
+
 /* u3n_rewrite_compact(): rewrite the bytecode cache for compaction.
  *
- * NB: u3R->byc.har_p *must* be cleared (currently via u3m_reclaim,
- * which calls u3n_free) since it contains things that look like nouns
- * but aren't.  Specifically, it contains "cells" where the tail is a
+ * NB: u3R->byc.har_p *must* be cleared (currently via u3n_reclaim above),
+ * since it contains things that look like nouns but aren't.
+ * Specifically, it contains "cells" where the tail is a
  * pointer to a u3a_malloc'ed block that contains loom pointers.
  *
  * You should be able to walk this with u3h_walk and rewrite the

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -2597,6 +2597,51 @@ u3n_mark(FILE* fil_u)
   return  u3a_maid(fil_u, "total nock stuff", bam_w + har_w);
 }
 
+/* _n_prog_rewrite(): rewrite program for compaction.
+*/
+static void
+_n_prog_rewrite(u3n_prog* pog_u)
+{
+  c3_w i_w;
+
+  for ( i_w = 0; i_w < pog_u->lit_u.len_w; ++i_w ) {
+    u3a_rewrite_noun(pog_u->lit_u.non[i_w]);
+  }
+
+  for ( i_w = 0; i_w < pog_u->mem_u.len_w; ++i_w ) {
+    u3a_rewrite_noun(pog_u->mem_u.sot_u[i_w].key);
+  }
+
+  for ( i_w = 0; i_w < pog_u->cal_u.len_w; ++i_w ) {
+    u3j_site_rewrite(&(pog_u->cal_u.sit_u[i_w]));
+  }
+
+  for ( i_w = 0; i_w < pog_u->reg_u.len_w; ++i_w ) {
+    u3j_rite_rewrite(&(pog_u->reg_u.rit_u[i_w]));
+  }
+}
+
+/* _n_rewrite(): u3h_walk_with helper for u3n_rewrite_compact
+ */
+static void
+_n_rewrite(u3_noun kev)
+{
+  u3n_prog* pog = u3to(u3n_prog, u3t(kev));
+  _n_prog_rewrite(pog);
+}
+
+/* u3n_rewrite_compact(): rewrite the bytecode cache for compaction.
+ */
+void
+u3n_rewrite_compact()
+{
+  u3h_walk(u3R->byc.har_p, _n_rewrite);
+
+  u3h_rewrite(u3R->byc.har_p);
+  u3R->byc.har_p = u3a_rewritten(u3R->byc.har_p);
+}
+
+
 /* _n_feb(): u3h_walk helper for u3n_free
  */
 static void

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -2597,46 +2597,22 @@ u3n_mark(FILE* fil_u)
   return  u3a_maid(fil_u, "total nock stuff", bam_w + har_w);
 }
 
-/* _n_prog_rewrite(): rewrite program for compaction.
-*/
-static void
-_n_prog_rewrite(u3n_prog* pog_u)
-{
-  c3_w i_w;
-
-  for ( i_w = 0; i_w < pog_u->lit_u.len_w; ++i_w ) {
-    u3a_rewrite_noun(pog_u->lit_u.non[i_w]);
-  }
-
-  for ( i_w = 0; i_w < pog_u->mem_u.len_w; ++i_w ) {
-    u3a_rewrite_noun(pog_u->mem_u.sot_u[i_w].key);
-  }
-
-  for ( i_w = 0; i_w < pog_u->cal_u.len_w; ++i_w ) {
-    u3j_site_rewrite(&(pog_u->cal_u.sit_u[i_w]));
-  }
-
-  for ( i_w = 0; i_w < pog_u->reg_u.len_w; ++i_w ) {
-    u3j_rite_rewrite(&(pog_u->reg_u.rit_u[i_w]));
-  }
-}
-
-/* _n_rewrite(): u3h_walk_with helper for u3n_rewrite_compact
- */
-static void
-_n_rewrite(u3_noun kev)
-{
-  u3n_prog* pog = u3to(u3n_prog, u3t(kev));
-  _n_prog_rewrite(pog);
-}
-
 /* u3n_rewrite_compact(): rewrite the bytecode cache for compaction.
+ *
+ * NB: u3R->byc.har_p *must* be cleared (currently via u3m_reclaim,
+ * which calls u3n_free) since it contains things that look like nouns
+ * but aren't.  Specifically, it contains "cells" where the tail is a
+ * pointer to a u3a_malloc'ed block that contains loom pointers.
+ *
+ * You should be able to walk this with u3h_walk and rewrite the
+ * pointers, but you need to be careful to handle that u3a_malloc
+ * pointers can't be turned into a box by stepping back two words. You
+ * must step back one word to get the padding, step then step back that
+ * many more words (plus one?).
  */
 void
 u3n_rewrite_compact()
 {
-  u3h_walk(u3R->byc.har_p, _n_rewrite);
-
   u3h_rewrite(u3R->byc.har_p);
   u3R->byc.har_p = u3a_rewritten(u3R->byc.har_p);
 }

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -327,6 +327,21 @@ u3v_mark(FILE* fil_u)
   return   u3a_maid(fil_u, "total arvo stuff", tot_w);
 }
 
+/* u3v_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3v_reclaim(void)
+{
+  //  clear the u3v_wish cache
+  //
+  //    NB: this would leak if not on the home road
+  //
+  if ( &(u3H->rod_u) == u3R ) {
+    u3z(u3A->yot);
+    u3A->yot = u3_nul;
+  }
+}
+
 /* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
 */
 void

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -326,3 +326,24 @@ u3v_mark(FILE* fil_u)
   tot_w += u3a_maid(fil_u, "  wish cache", u3a_mark_noun(arv_u->yot));
   return   u3a_maid(fil_u, "total arvo stuff", tot_w);
 }
+
+/* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
+*/
+void
+u3v_rewrite_compact()
+{
+  u3v_arvo* arv_u = &(u3H->arv_u);
+
+  u3a_rewrite_noun(arv_u->roc);
+  u3a_rewrite_noun(arv_u->now);
+  u3a_rewrite_noun(arv_u->wen);
+  u3a_rewrite_noun(arv_u->sen);
+  u3a_rewrite_noun(arv_u->yot);
+
+  arv_u->roc = u3a_rewritten_noun(arv_u->roc);
+  arv_u->now = u3a_rewritten_noun(arv_u->now);
+  arv_u->wen = u3a_rewritten_noun(arv_u->wen);
+  arv_u->sen = u3a_rewritten_noun(arv_u->sen);
+  arv_u->yot = u3a_rewritten_noun(arv_u->yot);
+}
+

--- a/pkg/urbit/vere/lord.c
+++ b/pkg/urbit/vere/lord.c
@@ -25,9 +25,10 @@
 ::
 +$  writ
   $%  $:  %live
-          $%  [%exit cod=@]
+          $%  [%cram eve=@]
+              [%exit cod=@]
               [%save eve=@]
-              [%pack eve=@]
+              [%pack ~]
       ==  ==
       [%peek mil=@ now=@da lyc=gang pat=path]
       [%play eve=@ lit=(list ?((pair @da ovum) *))]
@@ -108,6 +109,7 @@ _lord_writ_free(u3_writ* wit_u)
     } break;
 
     case u3_writ_save:
+    case u3_writ_cram:
     case u3_writ_pack:
     case u3_writ_exit: {
     } break;
@@ -196,6 +198,7 @@ _lord_writ_str(u3_writ_type typ_e)
     case u3_writ_peek: return "peek";
     case u3_writ_play: return "play";
     case u3_writ_save: return "save";
+    case u3_writ_cram: return "cram";
     case u3_writ_pack: return "pack";
     case u3_writ_exit: return "exit";
   }
@@ -258,8 +261,14 @@ _lord_plea_live(u3_lord* god_u, u3_noun dat)
       god_u->cb_u.save_f(god_u->cb_u.ptr_v);
     } break;
 
+    case u3_writ_cram: {
+      god_u->cb_u.cram_f(god_u->cb_u.ptr_v);
+    } break;
+
     case u3_writ_pack: {
-      god_u->cb_u.pack_f(god_u->cb_u.ptr_v);
+      //  XX wire into cb
+      //
+      u3l_log("pier: pack complete\n");
     } break;
   }
 
@@ -738,8 +747,12 @@ _lord_writ_jam(u3_lord* god_u, u3_writ* wit_u)
         msg = u3nt(c3__live, c3__save, u3i_chubs(1, &god_u->eve_d));
       } break;
 
+      case u3_writ_cram: {
+        msg = u3nt(c3__live, c3__cram, u3i_chubs(1, &god_u->eve_d));
+      } break;
+
       case u3_writ_pack: {
-        msg = u3nt(c3__live, c3__pack, u3i_chubs(1, &god_u->eve_d));
+        msg = u3nt(c3__live, c3__pack, u3_nul);
       } break;
 
       case u3_writ_exit: {
@@ -938,17 +951,17 @@ u3_lord_save(u3_lord* god_u)
   }
 }
 
-/* u3_lord_pack(): save portable state.
+/* u3_lord_cram(): save portable state.
 */
 c3_o
-u3_lord_pack(u3_lord* god_u)
+u3_lord_cram(u3_lord* god_u)
 {
   if ( god_u->dep_w ) {
     return c3n;
   }
   else {
     u3_writ* wit_u = _lord_writ_new(god_u);
-    wit_u->typ_e = u3_writ_pack;
+    wit_u->typ_e = u3_writ_cram;
     _lord_writ_plan(god_u, wit_u);
     return c3y;
   }
@@ -1053,7 +1066,7 @@ u3_lord_init(c3_c* pax_c, c3_w wag_w, c3_d key_d[4], u3_lord_cb cb_u)
   //  spawn new process and connect to it
   //
   {
-    c3_c* arg_c[7];
+    c3_c* arg_c[8];
     c3_c  key_c[256];
     c3_c  wag_c[11];
     c3_c  hap_c[11];
@@ -1070,21 +1083,22 @@ u3_lord_init(c3_c* pax_c, c3_w wag_w, c3_d key_d[4], u3_lord_cb cb_u)
     sprintf(hap_c, "%u", u3_Host.ops_u.hap_w);
 
     arg_c[0] = god_u->bin_c;            //  executable
-    arg_c[1] = god_u->pax_c;            //  path to checkpoint directory
-    arg_c[2] = key_c;                   //  disk key
-    arg_c[3] = wag_c;                   //  runtime config
-    arg_c[4] = hap_c;                   //  hash table size
+    arg_c[1] = "serf";                  //  protocol
+    arg_c[2] = god_u->pax_c;            //  path to checkpoint directory
+    arg_c[3] = key_c;                   //  disk key
+    arg_c[4] = wag_c;                   //  runtime config
+    arg_c[5] = hap_c;                   //  hash table size
 
     if ( u3_Host.ops_u.roc_c ) {
       //  XX validate
       //
-      arg_c[5] = u3_Host.ops_u.roc_c;
+      arg_c[6] = u3_Host.ops_u.roc_c;
     }
     else {
-      arg_c[5] = "0";
+      arg_c[6] = "0";
     }
 
-    arg_c[6] = 0;
+    arg_c[7] = 0;
 
     uv_pipe_init(u3L, &god_u->inn_u.pyp_u, 0);
     uv_timer_init(u3L, &god_u->out_u.tim_u);

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -597,8 +597,8 @@ _pier_play(u3_play* pay_u)
 
       //  XX temporary hack
       //
-      u3l_log("pier: replay barrier reached, packing\r\n");
-      u3_pier_pack(pir_u);
+      u3l_log("pier: replay barrier reached, cramming\r\n");
+      u3_pier_cram(pir_u);
     }
     else if ( pay_u->eve_d == log_u->dun_d ) {
       _pier_work_init(pir_u);
@@ -868,21 +868,21 @@ _pier_on_lord_save(void* ptr_v)
   // _pier_next(pir_u);
 }
 
-/* _pier_on_lord_pack(): worker state-export complete (portable snapshot).
+/* _pier_on_lord_cram(): worker state-export complete (portable snapshot).
 */
 static void
-_pier_on_lord_pack(void* ptr_v)
+_pier_on_lord_cram(void* ptr_v)
 {
   u3_pier* pir_u = ptr_v;
 
 #ifdef VERBOSE_PIER
-  fprintf(stderr, "pier: (%" PRIu64 "): lord: pack\r\n", pir_u->god_u->eve_d);
+  fprintf(stderr, "pier: (%" PRIu64 "): lord: cram\r\n", pir_u->god_u->eve_d);
 #endif
 
   //  XX temporary hack
   //
   if ( u3_psat_play == pir_u->sat_e ) {
-    u3l_log("pier: pack complete, shutting down\r\n");
+    u3l_log("pier: cram complete, shutting down\r\n");
     u3_pier_bail(pir_u);
     exit(0);
   }
@@ -1189,7 +1189,7 @@ _pier_init(c3_w wag_w, c3_c* pax_c)
       .work_done_f = _pier_on_lord_work_done,
       .work_bail_f = _pier_on_lord_work_bail,
       .save_f = _pier_on_lord_save,
-      .pack_f = _pier_on_lord_pack,
+      .cram_f = _pier_on_lord_cram,
       .bail_f = _pier_on_lord_bail,
       .exit_f = _pier_on_lord_exit
     };
@@ -1469,33 +1469,33 @@ u3_pier_save(u3_pier* pir_u)
 }
 
 static void
-_pier_pack_cb(void* ptr_v, c3_d eve_d)
+_pier_cram_cb(void* ptr_v, c3_d eve_d)
 {
   u3_pier* pir_u = ptr_v;
 
 #ifdef VERBOSE_PIER
-  fprintf(stderr, "pier: (%" PRIu64 "): snap: send at %" PRIu64 "\r\n", pir_u->god_u->eve_d, eve_d);
+  fprintf(stderr, "pier: (%" PRIu64 "): cram: send at %" PRIu64 "\r\n", pir_u->god_u->eve_d, eve_d);
 #endif
 
-  u3_lord_pack(pir_u->god_u);
+  u3_lord_cram(pir_u->god_u);
 }
 
-/* u3_pier_pack(): save a portable snapshot.
+/* u3_pier_cram(): save a portable snapshot.
 */
 c3_o
-u3_pier_pack(u3_pier* pir_u)
+u3_pier_cram(u3_pier* pir_u)
 {
 #ifdef VERBOSE_PIER
-  fprintf(stderr, "pier: (%" PRIu64 "): snap: plan\r\n", pir_u->god_u->eve_d);
+  fprintf(stderr, "pier: (%" PRIu64 "): cram: plan\r\n", pir_u->god_u->eve_d);
 #endif
 
   if ( u3_psat_play == pir_u->sat_e ) {
-    u3_lord_pack(pir_u->god_u);
+    u3_lord_cram(pir_u->god_u);
     return c3y;
   }
 
   if ( u3_psat_work == pir_u->sat_e ) {
-    _pier_wall_plan(pir_u, 0, pir_u, _pier_pack_cb);
+    _pier_wall_plan(pir_u, 0, pir_u, _pier_cram_cb);
     return c3y;
   }
 
@@ -1666,7 +1666,9 @@ u3_pier_bail(u3_pier* pir_u)
 
   //  exig i/o drivers
   //
-  if ( pir_u->wok_u ) {
+  if (  (u3_psat_work == pir_u->sat_e)
+     && pir_u->wok_u )
+  {
     _pier_work_close(pir_u->wok_u);
     pir_u->wok_u = 0;
   }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -298,7 +298,8 @@ _cw_pack(c3_i argc, c3_c* argv[])
   c3_c* dir_c = argv[2];
 
   u3m_boot(dir_c);
-  u3a_compact();
+  u3a_print_memory(stderr, "urbit-worker: pack: gained", u3m_pack());
+
   u3e_save();
 }
 

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -188,6 +188,12 @@ main(c3_i argc, c3_c* argv[])
     u3C.slog_f = _newt_send_slog;
   }
 
+  if (u3_Host.ops_u.hap_w == 1337) {
+    u3a_compact();
+    u3e_save();
+    return 0;
+  }
+
   //  start serf
   //
   {

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -26,51 +26,51 @@ static u3_serf   u3V;             //  one serf per process
 static u3_moat inn_u;             //  input stream
 static u3_mojo out_u;             //  output stream
 
-/* _newt_fail(): failure stub.
+/* _cw_serf_fail(): failure stub.
 */
 static void
-_newt_fail(void* vod_p, const c3_c* wut_c)
+_cw_serf_fail(void* vod_p, const c3_c* wut_c)
 {
   fprintf(stderr, "serf: fail: %s\r\n", wut_c);
   exit(1);
 }
 
-/* _newt_send(): send plea back to daemon.
+/* _cw_serf_send(): send plea back to daemon.
 */
 static void
-_newt_send(u3_noun pel)
+_cw_serf_send(u3_noun pel)
 {
   u3_newt_write(&out_u, u3ke_jam(pel));
 }
 
-/* _newt_send_slog(): send hint output (hod is [priority tank]).
+/* _cw_serf_send_slog(): send hint output (hod is [priority tank]).
 */
 static void
-_newt_send_slog(u3_noun hod)
+_cw_serf_send_slog(u3_noun hod)
 {
-  _newt_send(u3nc(c3__slog, hod));
+  _cw_serf_send(u3nc(c3__slog, hod));
 }
 
-/* _newt_send_stdr(): send stderr output
+/* _cw_serf_send_stdr(): send stderr output
 */
 static void
-_newt_send_stdr(c3_c* str_c)
+_cw_serf_send_stdr(c3_c* str_c)
 {
-  _newt_send_slog(u3nc(0, u3i_string(str_c)));
+  _cw_serf_send_slog(u3nc(0, u3i_string(str_c)));
 }
 
-/* _newt_writ():
+/* _cw_serf_writ():
 */
 static void
-_newt_writ(void* vod_p, u3_noun mat)
+_cw_serf_writ(void* vod_p, u3_noun mat)
 {
   u3_noun ret;
 
   if ( c3n == u3_serf_writ(&u3V, u3ke_cue(mat), &ret) ) {
-    _newt_fail(0, "bad jar");
+    _cw_serf_fail(0, "bad jar");
   }
   else {
-    _newt_send(ret);
+    _cw_serf_send(ret);
 
     //  all references must now be counted, and all roots recorded
     //
@@ -78,10 +78,10 @@ _newt_writ(void* vod_p, u3_noun mat)
   }
 }
 
-/* main(): main() when run as urbit-worker
+/* _cw_serf_stdio(): fix up std io handles
 */
-c3_i
-main(c3_i argc, c3_c* argv[])
+static void
+_cw_serf_stdio(c3_i* inn_i, c3_i* out_i)
 {
   //  the serf is spawned with [FD 0] = events and [FD 1] = effects
   //  we dup [FD 0 & 1] so we don't accidently use them for something else
@@ -89,22 +89,34 @@ main(c3_i argc, c3_c* argv[])
   //  we replace [FD 1] (stdout) with a dup of [FD 2] (stderr)
   //
   c3_i nul_i = open("/dev/null", O_RDWR, 0);
-  c3_i inn_i = dup(0);
-  c3_i out_i = dup(1);
+
+  *inn_i = dup(0);
+  *out_i = dup(1);
+
   dup2(nul_i, 0);
   dup2(2, 1);
-  close(nul_i);
 
-  c3_assert( 6 == argc );
+  close(nul_i);
+}
+
+/* _cw_serf_commence(); initialize and run serf
+*/
+static void
+_cw_serf_commence(c3_i argc, c3_c* argv[])
+{
+  c3_i inn_i, out_i;
+  _cw_serf_stdio(&inn_i, &out_i);
+
+  c3_assert( 7 == argc );
 
   uv_loop_t* lup_u = uv_default_loop();
-  c3_c*      dir_c = argv[1];
-  c3_c*      key_c = argv[2];
-  c3_c*      wag_c = argv[3];
-  c3_c*      hap_c = argv[4];
+  c3_c*      dir_c = argv[2];
+  c3_c*      key_c = argv[3];
+  c3_c*      wag_c = argv[4];
+  c3_c*      hap_c = argv[5];
   c3_d       eve_d = 0;
 
-  if ( 1 != sscanf(argv[5], "%" PRIu64 "", &eve_d) ) {
+  if ( 1 != sscanf(argv[6], "%" PRIu64 "", &eve_d) ) {
     fprintf(stderr, "serf: rock: invalid number '%s'\r\n", argv[4]);
   }
 
@@ -160,13 +172,13 @@ main(c3_i argc, c3_c* argv[])
   //  set up writing
   //
   out_u.ptr_v = &u3V;
-  out_u.bal_f = _newt_fail;
+  out_u.bal_f = _cw_serf_fail;
 
   //  set up reading
   //
   inn_u.ptr_v = &u3V;
-  inn_u.pok_f = _newt_writ;
-  inn_u.bal_f = _newt_fail;
+  inn_u.pok_f = _cw_serf_writ;
+  inn_u.bal_f = _cw_serf_fail;
 
   //  setup loom
   //
@@ -175,7 +187,7 @@ main(c3_i argc, c3_c* argv[])
     u3V.sen_d = u3V.dun_d = u3m_boot(dir_c);
 
     if ( eve_d ) {
-      u3_serf_unpack(&u3V, eve_d);
+      u3_serf_uncram(&u3V, eve_d);
     }
   }
 
@@ -184,20 +196,14 @@ main(c3_i argc, c3_c* argv[])
   //    XX must be after u3m_boot due to u3l_log
   //
   {
-    u3C.stderr_log_f = _newt_send_stdr;
-    u3C.slog_f = _newt_send_slog;
-  }
-
-  if (u3_Host.ops_u.hap_w == 1337) {
-    u3a_compact();
-    u3e_save();
-    return 0;
+    u3C.stderr_log_f = _cw_serf_send_stdr;
+    u3C.slog_f = _cw_serf_send_slog;
   }
 
   //  start serf
   //
   {
-    _newt_send(u3_serf_init(&u3V));
+    _cw_serf_send(u3_serf_init(&u3V));
   }
 
   //  start reading
@@ -207,6 +213,163 @@ main(c3_i argc, c3_c* argv[])
   //  enter loop
   //
   uv_run(lup_u, UV_RUN_DEFAULT);
+}
+
+/* _cw_info(); print pier info
+*/
+static void
+_cw_info(c3_i argc, c3_c* argv[])
+{
+  c3_assert( 3 <= argc );
+
+  c3_c* dir_c = argv[2];
+  c3_d  eve_d = u3m_boot(dir_c);
+
+  fprintf(stderr, "urbit-worker: %s at event %" PRIu64 "\r\n", dir_c, eve_d);
+}
+
+/* _cw_grab(); gc pier.
+*/
+static void
+_cw_grab(c3_i argc, c3_c* argv[])
+{
+  c3_assert( 3 <= argc );
+
+  c3_c* dir_c = argv[2];
+  u3m_boot(dir_c);
+  u3_serf_grab();
+}
+
+/* _cw_cram(); jam persistent state (rock), and exit.
+*/
+static void
+_cw_cram(c3_i argc, c3_c* argv[])
+{
+  c3_assert( 3 <= argc );
+
+  c3_c* dir_c = argv[2];
+  c3_d  eve_d = u3m_boot(dir_c);
+
+  fprintf(stderr, "urbit-worker: cram: preparing\r\n");
+
+  if ( c3n == u3m_rock_stay(dir_c, eve_d) ) {
+    fprintf(stderr, "urbit-worker: cram: unable to jam state\r\n");
+    exit(1);
+  }
+
+  fprintf(stderr, "urbit-worker: cram: rock saved at event %" PRIu64 "\r\n", eve_d);
+}
+
+/* _cw_queu(); cue rock, save, and exit.
+*/
+static void
+_cw_queu(c3_i argc, c3_c* argv[])
+{
+  c3_assert( 4 <= argc );
+
+  c3_c* dir_c = argv[2];
+  c3_c* eve_c = argv[3];
+  c3_d  eve_d;
+
+  if ( 1 != sscanf(eve_c, "%" PRIu64 "", &eve_d) ) {
+    fprintf(stderr, "urbit-worker: queu: invalid number '%s'\r\n", eve_c);
+    exit(1);
+  }
+  else {
+    fprintf(stderr, "urbit-worker: queu: preparing\r\n");
+
+    memset(&u3V, 0, sizeof(u3V));
+    u3V.dir_c = strdup(dir_c);
+    u3V.sen_d = u3V.dun_d = u3m_boot(dir_c);
+    u3_serf_uncram(&u3V, eve_d);
+    u3e_save();
+
+    fprintf(stderr, "urbit-worker: queu: rock loaded at event %" PRIu64 "\r\n", eve_d);
+  }
+}
+
+/* _cw_pack(); compact memory, save, and exit.
+*/
+static void
+_cw_pack(c3_i argc, c3_c* argv[])
+{
+  c3_assert( 3 <= argc );
+
+  c3_c* dir_c = argv[2];
+
+  u3m_boot(dir_c);
+  u3a_compact();
+  u3e_save();
+}
+
+/* _cw_usage(): print urbit-worker usage.
+*/
+static void
+_cw_usage(c3_i argc, c3_c* argv[])
+{
+  fprintf(stderr,
+          "\rurbit-worker usage:\n"
+          "  print pier info:\n"
+          "    %s info <pier>\n\n"
+          "  gc persistent state:\n"
+          "    %s grab <pier>\n\n"
+          "  compact persistent state:\n"
+          "    %s pack <pier>\n\n"
+          "  jam persistent state:\n"
+          "    %s cram <pier>\n\n"
+          "  cue persistent state:\n"
+          "    %s queu <pier> <at-event>\n\n"
+          "  run as a 'serf':\n"
+          "    %s serf <pier> <key> <flags> <cache-size> <at-event>\n",
+          argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
+}
+
+/* main(): main() when run as urbit-worker
+*/
+c3_i
+main(c3_i argc, c3_c* argv[])
+{
+  //  urbit-worker commands and positional arguments, by analogy
+  //
+  //    $@  ~               ;; usage
+  //    $%  [%cram dir=@t]
+  //        [%queu dir=@t eve=@ud]
+  //        [%pack dir=@t]
+  //        [%serf dir=@t key=@t wag=@t hap=@ud eve=@ud]
+  //    ==
+  //
+  //    NB: don't print to anything other than stderr;
+  //    other streams may have special requirements (in the case of "serf")
+  //
+  if ( 2 > argc ) {
+    _cw_usage(argc, argv);
+    exit(1);
+  }
+  else {
+    if ( 0 == strcmp("serf", argv[1]) ) {
+      _cw_serf_commence(argc, argv);
+    }
+    else if ( 0 == strcmp("info", argv[1]) ) {
+      _cw_info(argc, argv);
+    }
+    else if ( 0 == strcmp("grab", argv[1]) ) {
+      _cw_grab(argc, argv);
+    }
+    else if ( 0 == strcmp("cram", argv[1]) ) {
+      _cw_cram(argc, argv);
+    }
+    else if ( 0 == strcmp("queu", argv[1]) ) {
+      _cw_queu(argc, argv);
+    }
+    else if ( 0 == strcmp("pack", argv[1]) ) {
+      _cw_pack(argc, argv);
+    }
+    else {
+      fprintf(stderr, "unknown command '%s'\r\n", argv[1]);
+      _cw_usage(argc, argv);
+      exit(1);
+    }
+  }
 
   return 0;
 }

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -256,10 +256,6 @@ _serf_grab(u3_serf* sef_u)
 
     u3z(sef_u->sac);
     sef_u->sac = u3_nul;
-
-    {
-      u3a_compact();
-    }
   }
 }
 

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -257,6 +257,8 @@ _serf_grab(u3_serf* sef_u)
 
     u3z(sef_u->sac);
     sef_u->sac = u3_nul;
+
+    u3l_log("\n");
   }
 }
 
@@ -309,12 +311,13 @@ u3_serf_post(u3_serf* sef_u)
   //  XX this runs on replay too, |mass s/b elsewhere
   //
   if ( c3y == sef_u->mut_o ) {
-    sef_u->mut_o = c3n;
     _serf_grab(sef_u);
+    sef_u->mut_o = c3n;
   }
 
   if ( c3y == sef_u->pac_o ) {
-    u3a_compact();
+    u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
+    u3l_log("\n");
     sef_u->pac_o = c3n;
   }
 }
@@ -979,7 +982,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
       }
       else {
         u3z(com);
-        u3a_compact();
+        u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
         *ret = u3nc(c3__live, u3_nul);
         return c3y;
       }

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -256,6 +256,10 @@ _serf_grab(u3_serf* sef_u)
 
     u3z(sef_u->sac);
     sef_u->sac = u3_nul;
+
+    {
+      u3a_compact();
+    }
   }
 }
 


### PR DESCRIPTION
This compacts memory on the home road, allowing you to reclaim contiguous free space.

Read [this](https://github.com/urbit/urbit/blob/69f8602e55c9467f6a8b714af5cd9ecd7224eb04/doc/spec/u3.md) if you're interested in the basics of how our memory allocator works.  Importantly, while you can free memory on the home road (permament memory, vs inner roads which exist and are freed during an event), it's unlikely to be at the edge of the heap, so you end up with framgented memory.  Processing events happen in inner roads, which only exist in the contigous free space between the home road's stack and heap.

Some ships end up with badly fragmented home road heaps, such that most of their loom is unusable.  |pack solves this by serializing, deduplicating, and deserializing, but it's quite slow, doesn't work for too much data (which is when you want it!), and it allocates on the heap as it's working, which fails if you have too little contiguous free space -- the very problem it's trying to solve.

This algorithm does *not* deduplicate since that's a relatively complex operation to do efficiently, and you need heap space somewhere (hopefully not on the loom).  Instead, it simply compacts the memory.  The basic algorithm (u3a_compact in pkg/urbit/noun/allocate.c) is:

- Sweep through the heap with a pointer starting at the beginning of the heap.  Write the current value of that pointer to the trailing size in the box and increment the pointer by the size of the box.  This is the intended new address of that box.  Note that everything in the heap is a "box" which starts and ends with its size and also includes a reference count (if zero it's free memory).
- Trace through the heap starting from the same roots used for |mass and |pack, rewriting all pointers by looking at the destination of the pointer for what we just put in the trailing size word.
- Sweep through the heap again, actually moving each box to the new address, and writing the correct size to the trailing size word.  Since we only ever move left (to lower addresses), this is safe to do in place.

This is fast, not much slower than `|mass`, and it uses no heap space, only the C stack.

This is a draft PR since it's not hooked up to a convenient interface.  To run this for now, download the static binaries here:

Linux: https://bootstrap.urbit.org/c184752f8dd9ed0b0c8175570f9c9209f78b1fcc-linux64.tgz
MacOS: https://bootstrap.urbit.org/c184752f8dd9ed0b0c8175570f9c9209f78b1fcc-darwin.tgz

Then run with the `-C 1337` flag.  This will compact and then immediately exit.  It will end with `pier: serf error: end of file` or similar, which is normal.  Run with a standard binary after that and run |mass -- you should see that "free lists" are very small (a few MB at most, all created since starting the ship again).