### PR TITLE
chat: profile overlay links to group profile

### DIFF
--- a/pkg/interface/src/apps/chat/components/chat.tsx
+++ b/pkg/interface/src/apps/chat/components/chat.tsx
@@ -385,7 +385,8 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
           paddingTop={paddingTop}
           paddingBot={paddingBot}
           pending={Boolean(msg.pending)}
-          group={props.association}
+          group={props.group}
+          association={props.association}
         />
       );
       if (unread > 0 && i === unread - 1) {

--- a/pkg/interface/src/apps/chat/components/lib/profile-overlay.js
+++ b/pkg/interface/src/apps/chat/components/lib/profile-overlay.js
@@ -54,7 +54,7 @@ export class ProfileOverlay extends Component {
       ? '/~groups/me'
       : `/~groups/view${association['group-path']}/${window.ship}`;
 
-    const img = (contact && (contact.avatar !== null))
+    let img = (contact && (contact.avatar !== null))
       ? <img src={contact.avatar} height={160} width={160} className="brt2 dib" />
       : <Sigil
         ship={ship}
@@ -63,6 +63,10 @@ export class ProfileOverlay extends Component {
         classes="brt2"
         svgClass="brt2"
         />;
+
+      if (!group.hidden) {
+        img = <Link to={`/~groups/view${association['group-path']}/${ship}`}>{img}</Link>;
+      }
 
     return (
       <div


### PR DESCRIPTION
See the request in #2623.

Also discovered and fixed a bug where we were passing `props.association` as `props.group` to the Message component, which passes that all the way down through `OverlaySigil` and `ProfileOverlay`, so the conditional check for hidden group was just silently producing `undefined` while there was no association prop to check, causing crashes on `ProfileOverlay` render.