### PR TITLE
zuse,behn,gall: fix %huck and |reset

### DIFF
--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -75,9 +75,9 @@
   ::    Useful if you want to continue working after other moves finish.
   ::
   ++  huck
-    |=  mov=vase
+    |=  syn=sign-arvo
     =<  [moves state]
-    event-core(moves [duct %give %meta mov]~)
+    event-core(moves [duct %give %heck syn]~)
   ::  +drip:  XX
   ::
   ++  drip
@@ -286,7 +286,7 @@
       %crud  (crud:event-core [p q]:task)
       %rest  (rest:event-core date=p.task)
       %drip  (drip:event-core move=p.task)
-      %huck  (huck:event-core move=p.task)
+      %huck  (huck:event-core syn.task)
       %trim  trim:event-core
       %vega  vega:event-core
       %wait  (wait:event-core date=p.task)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -199,9 +199,7 @@
         (mean >mote.u.dud< tang.u.dud)
       ?:  =(/sys/lyv wire)
         (molt duct ~)
-      ::  TODO: test this or remove and assert /sys/lyv
-      ::
-      (molt duct `[duct %pass wire %b %huck !>(sign)])
+      (molt duct `[duct %pass wire %b %huck sign])
     ::
     ++  load
       |^
@@ -752,14 +750,13 @@
   ::
   ++  mo-handle-use
     ~/  %mo-handle-use
-    |=  [=path hin=(hypo sign-arvo)]
+    |=  [=path =sign-arvo]
     ^+  mo-core
     ::
     ?.  ?=([@ @ *] path)
       ~&  [%mo-handle-use-bad-path path]
       !!
     ::
-    =/  =sign-arvo  q.hin
     ?.  ?=([?(%g %b) %unto *] sign-arvo)
       =/  app
         =/  =term  i.path
@@ -1509,7 +1506,7 @@
       =.  ap-core
         (ap-pass wire %agent dock %leave ~)
       =/  way  [%out (scot %p p.dock) q.dock wire]
-      (ap-pass way %arvo %b %huck !>([%unto %kick ~]))
+      (ap-pass way %arvo %b %huck `sign-arvo`[%g %unto %kick ~])
     ::  +ap-mule: run virtualized with intercepted scry, preserving type
     ::
     ::    Compare +mute and +mule.  Those pass through scry, which
@@ -1737,7 +1734,7 @@
 ::
 ++  take
   ~/  %gall-take
-  |=  [=wire =duct dud=(unit goof) hin=(hypo sign-arvo)]
+  |=  [=wire =duct dud=(unit goof) typ=type syn=sign-arvo]
   ^-  [(list move) _gall-payload]
   ?^  dud
     ~&(%gall-take-dud ((slog tang.u.dud) [~ gall-payload]))
@@ -1745,13 +1742,11 @@
     [~ gall-payload]
   ::
   ~|  [%gall-take-failed wire]
-  ::
   ?>  ?=([?(%sys %use) *] wire)
-  =/  mo-core  (mo-abed:mo duct)
-  =/  =sign-arvo  q.hin
-  =>  ?-  i.wire
-        %sys  (mo-handle-sys:mo-core t.wire sign-arvo)
-        %use  (mo-handle-use:mo-core t.wire hin)
-      ==
-  mo-abet
+  =<  mo-abet
+  %.  [t.wire ?:(?=([%b %heck *] syn) syn.syn syn)]
+  ?-  i.wire
+    %sys  mo-handle-sys:(mo-abed:mo duct)
+    %use  mo-handle-use:(mo-abed:mo duct)
+  ==
 --

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -795,6 +795,7 @@
       $%  [%doze p=(unit @da)]                          ::  next alarm
           [%wake error=(unit tang)]                     ::  wakeup or failed
           [%meta p=vase]
+          [%heck syn=sign-arvo]                         ::  response to %huck
       ==
     ++  task                                            ::  in request ->$
       $~  [%vega ~]                                     ::
@@ -802,7 +803,7 @@
           $>(%crud vane-task)                           ::  error with trace
           [%rest p=@da]                                 ::  cancel alarm
           [%drip p=vase]                                ::  give in next event
-          [%huck p=vase]                                ::  give back
+          [%huck syn=sign-arvo]                         ::  give back
           $>(%trim vane-task)                           ::  trim state
           $>(%vega vane-task)                           ::  report upgrade
           [%wait p=@da]                                 ::  set alarm


### PR DESCRIPTION
This fixes https://github.com/urbit/urbit/issues/3102 by modifying Behn's `%huck` facility to accept and produce a `$sign-arvo` directly instead of using Arvo's meta-vase reduction.

This has the potential downside that Behn's `$task` now depends on `$sign-arvo`.  I'm not aware of any immediate problems from doing that, but maybe it could make future Zuse changes more difficult somehow, so I'm flagging it here.

I have tested `|reset` but not the other use of `%huck` in Gall.  I also confirmed that after applying this fix, changing Zuse still causes a successful `+molt`.