### PR TITLE
-build-{cast,file,mark}: accept full beams; load from any desk

### DIFF
--- a/pkg/arvo/ted/build-cast.hoon
+++ b/pkg/arvo/ted/build-cast.hoon
@@ -5,8 +5,9 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([a=mark b=mark ~] arg)
-;<  =bowl:spider  bind:m  get-bowl:strandio
-=/  bek=beak  [our q.byk da+now]:bowl
-;<  =tube:clay  bind:m  (build-cast:strandio bek a b)
+=+  !<([pax=path ~] arg)
+?~  bem=(de-beam:format pax)
+  (strand-fail:strand %path-not-beam >pax< ~)
+=/  =mars:clay  [i.t i]:?>(?=([@ @ ~] s.u.bem) s.u.bem)
+;<  =tube:clay  bind:m  (build-cast:strandio -.u.bem mars)
 (pure:m !>(tube))

--- a/pkg/arvo/ted/build-file.hoon
+++ b/pkg/arvo/ted/build-file.hoon
@@ -1,11 +1,11 @@
 /-  spider
-/+  strandio
+/+  strand, strandio
 =,  strand=strand:spider
 ^-  thread:spider
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
 =+  !<([pax=path ~] arg)
-;<  =bowl:spider  bind:m  get-bowl:strandio
-=/  bek=beak  [our q.byk da+now]:bowl
-(build-file:strandio bek (flop pax))
+?^  bem=(de-beam:format pax)
+  (build-file:strandio u.bem)
+(strand-fail:strand %path-not-beam >pax< ~)

--- a/pkg/arvo/ted/build-mark.hoon
+++ b/pkg/arvo/ted/build-mark.hoon
@@ -5,8 +5,9 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([mak=mark ~] arg)
-;<  =bowl:spider  bind:m  get-bowl:strandio
-=/  bek=beak  [our q.byk da+now]:bowl
-;<  =dais:clay  bind:m  (build-mark:strandio bek mak)
+=+  !<([pax=path ~] arg)
+?~  bem=(de-beam:format pax)
+  (strand-fail:strand %path-not-beam >pax< ~)
+=/  =mark  (head s.u.bem)
+;<  =dais:clay  bind:m  (build-mark:strandio -.u.bem mark)
 (pure:m !>(dais))


### PR DESCRIPTION
Take a full beam in `-build-file`, `-build-cast`, and `-build-mark` threads so that they can run Ford builds from any desk.

They're now callable from dojo like this:
```
=f -build-file %/lib/sole/hoon
=c -build-cast /=work=/mime/txt
=m -build-mark %/mime
```