### PR TITLE
file-server: print a warning when binding fails

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -218,6 +218,7 @@
   ?+  +<.sign  (on-arvo:def wire sign)
       %bound
     ?:  accepted.sign  [~ this]
+    ~&  [dap.bowl %failed-to-bind path.binding.sign]
     [~ this(serving (~(del by serving) path.binding.sign))]
   ==
 ::


### PR DESCRIPTION
We probably shouldn't be eating these without telling the user/developer.

Ideally you want to just nack the poke that configures this, but that's less trivial. You could scry into eyre to find out if the binding will succeed or not, I guess?