### PR TITLE
tab completion in chat-cli completes without prefix char

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -177,9 +177,7 @@
   ::
   ++  tab-list
     |=  sole-id=@ta
-    %+  turn  tab-list:sh:tc
-    |=  [term=cord detail=tank]
-    [(cat 3 ';' term) detail]
+    tab-list:sh:tc
   ::
   ++  on-command
     |=  [sole-id=@ta =command]
@@ -649,24 +647,24 @@
   ++  tab-list
     ^-  (list [@t tank])
     :~
-      [%join leaf+";join ~ship/chat-name (glyph)"]
-      [%leave leaf+";leave ~ship/chat-name"]
+      [';join' leaf+";join ~ship/chat-name (glyph)"]
+      [';leave' leaf+";leave ~ship/chat-name"]
       ::
-      [%create leaf+";create [type] /chat-name (glyph)"]
-      [%delete leaf+";delete /chat-name"]
-      [%invite leaf+";invite /chat-name ~ships"]
-      [%banish leaf+";banish /chat-name ~ships"]
+      [';create' leaf+";create [type] /chat-name (glyph)"]
+      [';delete' leaf+";delete /chat-name"]
+      [';invite' leaf+";invite /chat-name ~ships"]
+      [';banish' leaf+";banish /chat-name ~ships"]
     ::
-      [%bind leaf+";bind [glyph] ~ship/chat-name"]
-      [%unbind leaf+";unbind [glyph]"]
-      [%what leaf+";what (~ship/chat-name) (glyph)"]
+      [';bind' leaf+";bind [glyph] ~ship/chat-name"]
+      [';unbind' leaf+";unbind [glyph]"]
+      [';what' leaf+";what (~ship/chat-name) (glyph)"]
     ::
-      [%settings leaf+";settings"]
-      [%set leaf+";set key (value)"]
-      [%unset leaf+";unset key"]
+      [';settings' leaf+";settings"]
+      [';set' leaf+";set key (value)"]
+      [';unset' leaf+";unset key"]
     ::
-      [%chats leaf+";chats"]
-      [%help leaf+";help"]
+      [';chats' leaf+";chats"]
+      [';help' leaf+";help"]
     ==
   ::  +work: run user command
   ::

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -177,7 +177,9 @@
   ::
   ++  tab-list
     |=  sole-id=@ta
-    tab-list:sh:tc
+    %+  turn  tab-list:sh:tc
+    |=  [term=cord detail=tank]
+    [(cat 3 ';' term) detail]
   ::
   ++  on-command
     |=  [sole-id=@ta =command]


### PR DESCRIPTION
Describe the bug
In chat-cli, seem like the command tab completion triggers without the necessary prefix char (; in chat-cli) but not with it.

To Reproduce
Hit tab at a clear prompt in chat-cli, see completions for ; commands. Enter ; and hit tab, no more completions.

Expected behaviour
Should see completions after ;

Notify maintainers
@Fang-
