### PR TITLE
weather: don't double-nest json on-watch

### DIFF
--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -42,8 +42,10 @@
     ?.  ?=([%all ~] wire)  (on-watch:def wire)
     =/  jon
       %-  pairs:enjs:format
-      :~  [%weather data]
-          [%location s+location]
+      :*  ['location' s+location]
+        ::
+          ?.  ?=([%o *] data)  ~
+          ~(tap by p.data)
       ==
     :_  this
     [%give %fact ~ %json !>(jon)]~


### PR DESCRIPTION
Because we nest data in a weather key and save that
in app state, we don't need to nest the data in weather twice over when
giving initial data to new subscribers.

(Thanks to @Fang- who basically wrote this within 10 seconds once I pointed out what I suspected the problem was ... tested it on fakezod in both subscribe / on-poke cases and it indeed corrects the issue.)