### PR TITLE
hoon: fix wtts axis for simple wings

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -7762,11 +7762,13 @@
   ++  teal
     |=  mod/spec
     ^-  spec
+    ?:  ?=(%& -.tik)  mod
     [%over [%& 3]~ mod]
   ::
   ++  tele
     |=  syn/skin
     ^-  skin
+    ?:  ?=(%& -.tik)  syn
     [%over [%& 3]~ syn]
   ::
   ++  gray


### PR DESCRIPTION
The tiki expansion for `?=` assumed that the case was in axis 3, but this is only true for "named wings," which are factored out into a `=+`. For "simple wings," `?=` can operate on the wing directly, so there's no need for an `%over` at all.

Previous behavior:

```
> =a ?(%foo)
> =b %foo
> ?=(a b)
-find.a
```

New behavior:

```
> =a ?(%foo)
> =b %foo
> ?=(a b)
%.y
```

(I'm kind of surprised this went unnoticed for so long...? This seems like it would break a lot of code.)
(EDIT: I'm no longer surprised. Even with this bug, `?=` will work fine as long as the wing can be found in `+3`, which is pretty much always the case.)

Initially reported here: https://groups.google.com/a/urbit.org/forum/#!topic/dev/IZJVJN7-PYY