### PR TITLE
interface: show base hash

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -223,7 +223,28 @@
   ==
 ::
 ++  on-leave  on-leave:def
-++  on-peek   on-peek:def
+++  on-peek   
+  |=  =path
+  ^-  (unit (unit cage))
+  |^
+  ?+  path  (on-peek:def path)
+    [%x %clay %base %hash ~]  ``hash+!>(base-hash)
+  ==
+  ::  stolen from +trouble
+  ::  TODO: move to a lib?
+  ++  base-hash
+    ^-  @uv
+    =+  .^  ota=(unit [=ship =desk =aeon:clay])
+            %gx  /(scot %p our.bowl)/hood/(scot %da now.bowl)/kiln/ota/noun
+        ==
+    ?~  ota
+      *@uv
+    =/  parent  (scot %p ship.u.ota)
+    =+  .^(=cass:clay %cs /[parent]/[desk.u.ota]/1/late/foo)
+    %^  end  3  3
+    .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
+  --
+  
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -41,7 +41,6 @@
 ++  on-leave  on-leave:def
 ++  on-peek
   |=  =path
-  ~&  peeking=path
   ^-  (unit (unit cage))
   ?+  path  (on-peek:def path)
     [* %kiln *]  (on-peek:kiln-core path)

--- a/pkg/arvo/mar/hash.hoon
+++ b/pkg/arvo/mar/hash.hoon
@@ -1,0 +1,14 @@
+|_  hash=@uv
+::
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  hash
+  ++  json
+    s+(rsh 3 2 (scot %uv hash))
+  --
+++  grab
+  |%
+  ++  noun  @uv
+  --
+--

--- a/pkg/interface/src/App.js
+++ b/pkg/interface/src/App.js
@@ -61,6 +61,7 @@ export default class App extends React.Component {
 
   componentDidMount() {
     this.subscription.start();
+    this.api.local.getBaseHash();
   }
 
   render() {
@@ -69,6 +70,7 @@ export default class App extends React.Component {
     const associations = this.state.associations ? this.state.associations : { contacts: {} };
     const selectedGroups = this.state.selectedGroups ? this.state.selectedGroups : [];
     const { state } = this;
+    const baseHash = this.state.baseHash;
 
     return (
       <ThemeProvider theme={light}>
@@ -77,6 +79,7 @@ export default class App extends React.Component {
             <StatusBarWithRouter props={this.props}
             associations={associations}
             invites={this.state.invites}
+            baseHash={baseHash}
             api={this.api}
             />
             <Content>

--- a/pkg/interface/src/App.js
+++ b/pkg/interface/src/App.js
@@ -70,7 +70,6 @@ export default class App extends React.Component {
     const associations = this.state.associations ? this.state.associations : { contacts: {} };
     const selectedGroups = this.state.selectedGroups ? this.state.selectedGroups : [];
     const { state } = this;
-    const baseHash = this.state.baseHash;
 
     return (
       <ThemeProvider theme={light}>
@@ -79,7 +78,6 @@ export default class App extends React.Component {
             <StatusBarWithRouter props={this.props}
             associations={associations}
             invites={this.state.invites}
-            baseHash={baseHash}
             api={this.api}
             />
             <Content>

--- a/pkg/interface/src/api/base.ts
+++ b/pkg/interface/src/api/base.ts
@@ -53,4 +53,8 @@ export default class BaseApi<S extends object = {}> {
       );
     });
   }
+
+  scry<T>(app: string, path: Path): Promise<T> {
+    return fetch(`/~/scry/${app}${path}.json`).then(r => r.json() as Promise<T>);
+  }
 }

--- a/pkg/interface/src/api/local.ts
+++ b/pkg/interface/src/api/local.ts
@@ -2,9 +2,13 @@ import BaseApi from "./base";
 import { StoreState } from "../store/type";
 import { SelectedGroup } from "../types/local-update";
 
-
-
 export default class LocalApi extends BaseApi<StoreState> {
+  getBaseHash() {
+    this.scry<string>('file-server', '/clay/base/hash').then(baseHash => {
+      this.store.handleEvent({ data: { local: { baseHash } } });
+    });
+  }
+
   setSelected(selected: SelectedGroup[]) {
     this.store.handleEvent({
       data: {

--- a/pkg/interface/src/apps/launch/app.js
+++ b/pkg/interface/src/apps/launch/app.js
@@ -24,6 +24,7 @@ export default class LaunchApp extends React.Component {
     const { props } = this;
 
     return (
+      <div className="h-100 flex flex-column h-100">
       <div className='v-mid ph2 dtc-m dtc-l dtc-xl flex justify-between flex-wrap' style={{ maxWidth: '40rem' }}>
         <Welcome firstTime={props.launch.firstTime} api={props.api} />
         <Tiles
@@ -34,6 +35,8 @@ export default class LaunchApp extends React.Component {
           weather={props.weather}
         />
       </div>
+      <div className="gray2-d gray2 ml4 mb4 f8"> {props.baseHash} </div>
+    </div>
     );
   }
 }

--- a/pkg/interface/src/components/StatusBar.js
+++ b/pkg/interface/src/components/StatusBar.js
@@ -66,9 +66,6 @@ const StatusBar = (props) => {
         }
          <p className="dib f9 v-mid inter ml2 white-d">{locationName}</p>
       </div>
-    <div className="tr gray2-d gray2 mr4 f9">
-    { props.baseHash }
-    </div>
     </div>
   );
 };

--- a/pkg/interface/src/components/StatusBar.js
+++ b/pkg/interface/src/components/StatusBar.js
@@ -66,6 +66,9 @@ const StatusBar = (props) => {
         }
          <p className="dib f9 v-mid inter ml2 white-d">{locationName}</p>
       </div>
+    <div className="tr gray2-d gray2 mr4 f9">
+    { props.baseHash }
+    </div>
     </div>
   );
 };

--- a/pkg/interface/src/reducers/local.ts
+++ b/pkg/interface/src/reducers/local.ts
@@ -3,7 +3,7 @@ import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { LocalUpdate } from '../types/local-update';
 
-type LocalState = Pick<StoreState, 'sidebarShown' | 'selectedGroups'>;
+type LocalState = Pick<StoreState, 'sidebarShown' | 'selectedGroups' | 'baseHash'>;
 
 export default class LocalReducer<S extends LocalState> {
     reduce(json: Cage, state: S) {
@@ -11,7 +11,13 @@ export default class LocalReducer<S extends LocalState> {
         if (data) {
             this.sidebarToggle(data, state);
             this.setSelected(data, state);
+            this.baseHash(data, state);
         }
+    }
+    baseHash(obj: LocalUpdate, state: S) {
+      if ('baseHash' in obj) {
+        state.baseHash = obj.baseHash;
+      }
     }
 
     sidebarToggle(obj: LocalUpdate, state: S) {

--- a/pkg/interface/src/store/store.ts
+++ b/pkg/interface/src/store/store.ts
@@ -38,6 +38,7 @@ export default class GlobalStore extends BaseStore<StoreState> {
       pendingMessages: new Map(),
       chatInitialized: false,
       sidebarShown: true,
+      baseHash: null,
       invites: {},
       associations: {
         chat: {},

--- a/pkg/interface/src/store/type.ts
+++ b/pkg/interface/src/store/type.ts
@@ -16,6 +16,7 @@ export interface StoreState {
   // local state
   sidebarShown: boolean;
   selectedGroups: SelectedGroup[];
+  baseHash: string | null;
   // invite state
   invites: Invites;
   // metadata state

--- a/pkg/interface/src/types/local-update.ts
+++ b/pkg/interface/src/types/local-update.ts
@@ -2,7 +2,8 @@ import { Path } from './noun';
 
 export type LocalUpdate =
   LocalUpdateSidebarToggle
-| LocalUpdateSelectedGroups;
+| LocalUpdateSelectedGroups
+| LocalUpdateBaseHash;
 
 interface LocalUpdateSidebarToggle {
   sidebarToggle: boolean;
@@ -10,6 +11,10 @@ interface LocalUpdateSidebarToggle {
 
 interface LocalUpdateSelectedGroups {
   selected: SelectedGroup[];
+}
+
+interface LocalUpdateBaseHash {
+  baseHash: string;
 }
 
 export type SelectedGroup = [Path, string];


### PR DESCRIPTION
Makes the base desk hash accessible through scry and then shows it in the status bar. Unfortunately, we can't scry this in the login page because we don't yet have a session to do scries with. 

Preview (see dhk61 in top right):
![Screen Shot 2020-07-15 at 2 47 44 pm](https://user-images.githubusercontent.com/46801558/87506814-90415a80-c6af-11ea-9441-ac3aa6a1f529.png)

![Screen Shot 2020-07-15 at 2 48 03 pm](https://user-images.githubusercontent.com/46801558/87506806-8d466a00-c6af-11ea-8552-af7b81622187.png)
