### PR TITLE
interface: UX renovations for new groups

### DIFF
--- a/pkg/interface/src/apps/chat/app.tsx
+++ b/pkg/interface/src/apps/chat/app.tsx
@@ -147,7 +147,7 @@ export default class ChatApp extends React.Component<ChatAppProps, {}> {
         />
         <Route
           exact
-          path="/~chat/new/dm/:ship"
+          path="/~chat/new/dm/:ship?"
           render={(props) => {
             const ship = props.match.params.ship;
 

--- a/pkg/interface/src/apps/chat/components/join.js
+++ b/pkg/interface/src/apps/chat/components/join.js
@@ -23,8 +23,7 @@ export class JoinScreen extends Component {
   componentDidUpdate(prevProps, prevState) {
     const { props, state } = this;
 
-    if ((props.autoJoin !== '/undefined/undefined' &&
-      props.autoJoin !== '/~/undefined/undefined') &&
+    if ((props.autoJoin !== '/undefined/undefined') &&
       (props.api && (prevProps?.api !== props.api))) {
       let station = props.autoJoin.split('/');
 

--- a/pkg/interface/src/apps/chat/components/lib/channel-item.js
+++ b/pkg/interface/src/apps/chat/components/lib/channel-item.js
@@ -13,7 +13,7 @@ export class ChannelItem extends Component {
   render() {
     const { props } = this;
 
-    const unreadElem = props.unread ? 'fw6' : '';
+    const unreadElem = props.unread ? 'fw6 white-d' : '';
 
     const title = props.title;
 
@@ -23,7 +23,7 @@ export class ChannelItem extends Component {
 
     return (
       <div
-        className={'z1 ph4 pv1 ' + selectedCss}
+        className={'z1 ph5 pv1 ' + selectedCss}
         onClick={this.onClick.bind(this)}
       >
         <div className="w-100 v-mid">

--- a/pkg/interface/src/apps/chat/components/lib/group-item.js
+++ b/pkg/interface/src/apps/chat/components/lib/group-item.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import { ChannelItem } from './channel-item';
 
 export class GroupItem extends Component {
@@ -14,10 +15,10 @@ export class GroupItem extends Component {
     }
 
     const channels = props.channels ? props.channels : [];
-    const first = (props.index === 0) ? 'pt1' : 'pt4';
+    const first = (props.index === 0) ? 'mt1 ' : 'mt4 ';
 
     const channelItems = channels.sort((a, b) => {
-      if (props.index === '/~/') {
+      if (props.index === 'dm') {
         const aPreview = props.messagePreviews[a];
         const bPreview = props.messagePreviews[b];
         const aWhen = aPreview ? aPreview.when : 0;
@@ -63,10 +64,23 @@ export class GroupItem extends Component {
         />
       );
     });
+
+    let dmLink = <div />;
+
+    if (props.index === 'dm') {
+      dmLink = <Link
+                className="absolute right-0 f9 top-0 mr4 green2 bg-gray5 bg-gray1-d b--transparent br1"
+                to="/~chat/new/dm"
+                style={{ padding: '0rem 0.2rem' }}
+               >
+               + DM
+               </Link>;
+    }
     return (
-      <div className={first}>
+      <div className={first + 'relative'}>
       <p className="f9 ph4 fw6 pb2 gray3">{title}</p>
-      {channelItems}
+        {dmLink}
+        {channelItems}
       </div>
     );
   }

--- a/pkg/interface/src/apps/chat/components/lib/group-item.js
+++ b/pkg/interface/src/apps/chat/components/lib/group-item.js
@@ -65,6 +65,10 @@ export class GroupItem extends Component {
       );
     });
 
+    if (channelItems.length === 0) {
+      channelItems.push(<p className="gray2 mt4 f9 tc">No direct messages</p>);
+    }
+
     let dmLink = <div />;
 
     if (props.index === 'dm') {

--- a/pkg/interface/src/apps/chat/components/lib/group-item.js
+++ b/pkg/interface/src/apps/chat/components/lib/group-item.js
@@ -15,7 +15,7 @@ export class GroupItem extends Component {
     }
 
     const channels = props.channels ? props.channels : [];
-    const first = (props.index === 0) ? 'mt1 ' : 'mt4 ';
+    const first = (props.index === 0) ? 'mt1 ' : 'mt6 ';
 
     const channelItems = channels.sort((a, b) => {
       if (props.index === 'dm') {
@@ -82,7 +82,7 @@ export class GroupItem extends Component {
     }
     return (
       <div className={first + 'relative'}>
-      <p className="f9 ph4 fw6 pb2 gray3">{title}</p>
+      <p className="f9 ph4 gray3">{title}</p>
         {dmLink}
         {channelItems}
       </div>

--- a/pkg/interface/src/apps/chat/components/lib/message.js
+++ b/pkg/interface/src/apps/chat/components/lib/message.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import { OverlaySigil } from './overlay-sigil';
 import { uxToHex, cite, writeText } from '../../../../lib/util';
 import moment from 'moment';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
+import urbitOb from 'urbit-ob';
 
 const DISABLED_BLOCK_TOKENS = [
   'indentedCode',
@@ -71,7 +73,7 @@ export class Message extends Component {
         </div>
       );
     } else if ('url' in letter) {
-      let imgMatch =
+      const imgMatch =
         /(jpg|img|png|gif|tiff|jpeg|JPG|IMG|PNG|TIFF|GIF|webp|WEBP|svg|SVG)$/
         .exec(letter.url);
       const youTubeRegex = new RegExp(String(/(?:https?:\/\/(?:[a-z]+.)?)/.source) // protocol
@@ -122,7 +124,6 @@ export class Message extends Component {
           <div>
           <a href={letter.url}
           className="f7 lh-copy v-top bb b--white-d word-break-all"
-          href={letter.url}
           target="_blank"
           rel="noopener noreferrer"
           >
@@ -154,6 +155,22 @@ export class Message extends Component {
         </p>
       );
     } else {
+      const group = letter.text.match(
+        /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z])+([/-])?)+/
+      );
+      if ((group !== null) // matched possible chatroom
+        && (group[2].length > 2) // possible ship?
+        && (urbitOb.isValidPatp(group[2]) // valid patp?
+          && (group[0] === letter.text))) { // entire message is room name?
+        return (
+          <Link
+            className="bb b--black b--white-d f7 mono lh-copy v-top"
+            to={'/~groups/join/' + group.input}
+          >
+            {letter.text}
+          </Link>
+        );
+      } else {
         return (
           <section className="chat-md-message">
             <MessageMarkdown
@@ -163,6 +180,7 @@ export class Message extends Component {
         );
     }
   }
+}
 
   render() {
     const { props, state } = this;

--- a/pkg/interface/src/apps/chat/components/new-dm.js
+++ b/pkg/interface/src/apps/chat/components/new-dm.js
@@ -1,26 +1,36 @@
-import React, { Component } from "react";
-import { Spinner } from "../../../components/Spinner";
-import { Link } from "react-router-dom";
-import urbitOb from "urbit-ob";
+import React, { Component } from 'react';
+import { Spinner } from '../../../components/Spinner';
+import { Link } from 'react-router-dom';
+import { InviteSearch } from '../../../components/InviteSearch';
+import urbitOb from 'urbit-ob';
+import { deSig } from '../../../lib/util';
 
 export class NewDmScreen extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      ship: null,
+      ships: [],
       station: null,
-      awaiting: false
+      awaiting: false,
+      title: '',
+      idName: '',
+      description: ''
     };
 
+    this.titleChange = this.titleChange.bind(this);
+    this.descriptionChange = this.descriptionChange.bind(this);
     this.onClickCreate = this.onClickCreate.bind(this);
+    this.setInvite = this.setInvite.bind(this);
   }
 
   componentDidMount() {
     const { props } = this;
     if (props.autoCreate && urbitOb.isValidPatp(props.autoCreate)) {
+      const addedShip = this.state.ships;
+      addedShip.push(props.autoCreate.slice(1));
       this.setState(
         {
-          ship: props.autoCreate.slice(1),
+          ships: addedShip,
           awaiting: true
         },
         this.onClickCreate
@@ -40,65 +50,188 @@ export class NewDmScreen extends Component {
     }
   }
 
+  titleChange(event) {
+    const asciiSafe = event.target.value.toLowerCase()
+      .replace(/[^a-z0-9~_.-]/g, '-');
+    this.setState({
+      idName: asciiSafe,
+      title: event.target.value
+    });
+  }
+
+  descriptionChange(event) {
+    this.setState({
+      description: event.target.value
+    });
+  }
+
+  setInvite(value) {
+    this.setState({
+      ships: value.ships
+    });
+  }
+
   onClickCreate() {
     const { props, state } = this;
 
-    const station = `/~${window.ship}/dm--${state.ship}`;
+    if (state.ships.length === 1) {
+      const station = `/~${window.ship}/dm--${state.ships[0]}`;
 
-    const theirStation = `/~${state.ship}/dm--${window.ship}`;
+      const theirStation = `/~${state.ships[0]}/dm--${window.ship}`;
 
-    if (station in props.inbox) {
-      props.history.push(`/~chat/room${station}`);
-      return;
-    }
-
-    if (theirStation in props.inbox) {
-      props.history.push(`/~chat/room${theirStation}`);
-      return;
-    }
-
-    const aud = state.ship !== window.ship ? [`~${state.ship}`] : [];
-
-    this.setState(
-      {
-        station
-      },
-      () => {
-        const groupPath = `/ship${station}`;
-        props.api.chat.create(
-          `~${window.ship} <-> ~${state.ship}`,
-          "",
-          station,
-          groupPath,
-          { invite: { pending: aud } },
-          aud,
-          true,
-          false
-        );
+      if (station in props.inbox) {
+        props.history.push(`/~chat/room${station}`);
+        return;
       }
-    );
+
+      if (theirStation in props.inbox) {
+        props.history.push(`/~chat/room${theirStation}`);
+        return;
+      }
+
+      const aud = state.ship !== window.ship ? [`~${state.ships[0]}`] : [];
+
+      let title = `~${window.ship} <-> ~${state.ships[0]}`;
+
+      if (state.title !== '') {
+        title = state.title;
+      }
+      this.setState(
+        {
+          station, awaiting: true
+        },
+        () => {
+          const groupPath = `/ship/~${window.ship}/dm--${state.ships[0]}`;
+          props.api.chat.create(
+            title,
+            state.description,
+            station,
+            groupPath,
+            { invite: { pending: aud } },
+            aud,
+            true,
+            false
+          );
+        }
+      );
+    }
+
+    if (state.ships.length > 1) {
+      const aud = state.ships.map(mem => `~${deSig(mem.trim())}`);
+
+      let title = 'Direct Message';
+
+      if (state.title !== '') {
+        title = state.title;
+      } else {
+        const asciiSafe = title.toLowerCase()
+          .replace(/[^a-z0-9~_.-]/g, '-');
+        this.setState({ idName: asciiSafe });
+      }
+
+      const station = `/~${window.ship}/${state.idName}-${Math.floor(Math.random() * 10000)}`;
+
+      this.setState(
+        {
+          station, awaiting: true
+        },
+        () => {
+          const groupPath = `/ship${station}`;
+          props.api.chat.create(
+            title,
+            state.description,
+            station,
+            groupPath,
+            { invite: { pending: aud } },
+            aud,
+            true,
+            false
+          );
+        }
+      );
+    }
   }
 
   render() {
+    const { props, state } = this;
+
+    const createClasses = (state.idName || state.ships.length >= 1)
+      ? 'pointer dib f9 green2 bg-gray0-d ba pv3 ph4 b--green2 mt4'
+      : 'pointer dib f9 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3 mt4';
+
+    const idClasses =
+      'f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 ' +
+      'focus-b--black focus-b--white-d mt1 ';
+
     return (
       <div
         className={
-          "h-100 w-100 mw6 pa3 pt4 overflow-x-hidden " +
-          "bg-gray0-d white-d flex flex-column"
+          'h-100 w-100 mw6 pa3 pt4 overflow-x-hidden ' +
+          'bg-gray0-d white-d flex flex-column'
         }
       >
         <div className="w-100 dn-m dn-l dn-xl inter pt1 pb6 f8">
-          <Link to="/~chat/">{"⟵ All Chats"}</Link>
+          <Link to="/~chat/">{'⟵ All Chats'}</Link>
         </div>
-        <h2 className="mb3 f8">New DM</h2>
+        <h2 className="mb3 f8">New Direct Message</h2>
         <div className="w-100">
+          <p className="f8 mt4 db">
+            Name
+            <span className="gray3"> (Optional)</span>
+          </p>
+          <textarea
+            className={idClasses}
+            placeholder="The Passage"
+            rows={1}
+            style={{
+              resize: 'none'
+            }}
+            onChange={this.titleChange}
+          />
+          <p className="f8 mt4 db">
+            Description
+            <span className="gray3"> (Optional)</span>
+          </p>
+          <textarea
+            className={idClasses}
+            placeholder="The most beautiful direct message"
+            rows={1}
+            style={{
+              resize: 'none'
+            }}
+            onChange={this.descriptionChange}
+          />
+          <p className="f8 mt4 db">
+            Invite Members
+          </p>
+          <p className="f9 gray2 db mv1">
+            Selected ships will be invited to the direct message
+          </p>
+        <InviteSearch
+          groups={props.groups}
+          contacts={props.contacts}
+          associations={props.associations}
+          groupResults={false}
+          shipResults={true}
+          invites={{
+            groups: [],
+            ships: state.ships
+          }}
+          setInvite={this.setInvite}
+        />
+        <button
+          onClick={this.onClickCreate.bind(this)}
+          className={createClasses}
+        >
+          Create Direct Message
+          </button>
           <Spinner
             awaiting={this.state.awaiting}
             classes="mt4"
-            text="Creating chat..."
+            text="Creating Direct Message..."
           />
         </div>
-      </div>
+        </div>
     );
   }
 }

--- a/pkg/interface/src/apps/chat/components/new.js
+++ b/pkg/interface/src/apps/chat/components/new.js
@@ -3,7 +3,6 @@ import { InviteSearch } from '../../../components/InviteSearch';
 import { Spinner } from '../../../components/Spinner';
 import { Link } from 'react-router-dom';
 import { deSig } from '../../../lib/util';
-import urbitOb from 'urbit-ob';
 
 export class NewScreen extends Component {
   constructor(props) {
@@ -14,9 +13,8 @@ export class NewScreen extends Component {
       idName: '',
       groups: [],
       ships: [],
-      privacy: 'open',
+      privacy: 'invite',
       idError: false,
-      inviteError: false,
       allowHistory: true,
       createGroup: false,
       awaiting: false
@@ -24,10 +22,7 @@ export class NewScreen extends Component {
 
     this.titleChange = this.titleChange.bind(this);
     this.descriptionChange = this.descriptionChange.bind(this);
-    this.allowHistoryChange = this.allowHistoryChange.bind(this);
     this.setInvite = this.setInvite.bind(this);
-    this.createGroupChange = this.createGroupChange.bind(this);
-    this.privacyChange = this.privacyChange.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -63,42 +58,13 @@ export class NewScreen extends Component {
     });
   }
 
-  createGroupChange(event) {
-    if (event.target.checked) {
-      this.setState({
-        createGroup: Boolean(event.target.checked)
-      });
-    } else {
-      this.setState({
-        createGroup: Boolean(event.target.checked)
-      });
-    }
-  }
-
-  privacyChange(event) {
-    if (event.target.checked) {
-      this.setState({
-        privacy: 'open'
-      });
-    } else {
-      this.setState({
-        privacy: 'invite'
-      });
-    }
-  }
-
-  allowHistoryChange(event) {
-    this.setState({ allowHistory: Boolean(event.target.checked) });
-  }
-
   onClickCreate() {
     const { props, state } = this;
     const grouped = (this.state.createGroup || (this.state.groups.length > 0));
 
     if (!state.title) {
       this.setState({
-        idError: true,
-        inviteError: false
+        idError: true
       });
       return;
     }
@@ -107,33 +73,13 @@ export class NewScreen extends Component {
 
     if (station in props.inbox) {
       this.setState({
-        inviteError: false,
         idError: true,
         success: false
       });
       return;
     }
 
-    let isValid = true;
     const aud = state.ships.map(mem => `~${deSig(mem.trim())}`);
-    aud.forEach((mem) => {
-      if (!urbitOb.isValidPatp(mem)) {
-        isValid = false;
-      }
-    });
-
-    if(state.ships.length === 1 && state.privacy === 'invite' && !state.createGroup) {
-      props.history.push(`/~chat/new/dm/${aud[0]}`);
-    }
-
-    if (!isValid) {
-      this.setState({
-        inviteError: true,
-        idError: false,
-        success: false
-      });
-      return;
-    }
 
     if (this.textarea) {
       this.textarea.value = '';
@@ -148,13 +94,7 @@ export class NewScreen extends Component {
       ships: [],
       awaiting: true
     }, () => {
-      // if we want a "proper group" that can be managed from the contacts UI,
-      // we make a path of the form /~zod/cool-group
-      // if not, we make a path of the form /~/~zod/free-chat
-      let appPath = `/~${window.ship}${station}`;
-      // if (!state.createGroup && state.groups.length === 0) {
-      //   appPath = `/~${appPath}`;
-      // }
+      const appPath = `/~${window.ship}${station}`;
       let groupPath = `/ship${appPath}`;
       if (state.groups.length > 0) {
         groupPath = state.groups[0];
@@ -178,21 +118,14 @@ export class NewScreen extends Component {
 
   render() {
     const { props, state } = this;
-    let privacySwitchClasses = (state.privacy === 'invite')
-      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
-
-    const createGroupClasses = state.createGroup
-      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
 
     const createClasses = state.idName
-      ? 'pointer db f9 green2 bg-gray0-d ba pv3 ph4 b--green2'
-      : 'pointer db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3';
+      ? 'pointer db f9 green2 bg-gray0-d ba pv3 ph4 b--green2 mt4'
+      : 'pointer db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3 mt4';
 
     const idClasses =
       'f7 ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 ' +
-      'focus-b--black focus-b--white-d ';
+      'focus-b--black focus-b--white-d mt1 ';
 
     let idErrElem = (<span />);
     if (state.idError) {
@@ -200,24 +133,6 @@ export class NewScreen extends Component {
         <span className="f9 inter red2 db pt2">
           Chat must have a valid name.
         </span>
-      );
-    }
-
-    let createGroupToggle = <div />;
-    if (state.groups.length === 0) {
-      createGroupToggle = (
-        <div className="mv7">
-          <input
-            type="checkbox"
-            style={{ WebkitAppearance: 'none', width: 28 }}
-            className={createGroupClasses}
-            onChange={this.createGroupChange}
-          />
-          <span className="dib f9 white-d inter ml3">Create Group</span>
-          <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
-            Participants will share this group across applications
-          </p>
-        </div>
       );
     }
 
@@ -231,9 +146,9 @@ export class NewScreen extends Component {
         <div className="w-100 dn-m dn-l dn-xl inter pt1 pb6 f8">
           <Link to="/~chat/">{'⟵ All Chats'}</Link>
         </div>
-        <h2 className="mb3 f8">New Chat</h2>
+        <h2 className="mb4 f8">New Group Chat</h2>
         <div className="w-100">
-          <p className="f8 mt3 lh-copy db">Name</p>
+          <p className="f8 mt4 db">Name</p>
           <textarea
             className={idClasses}
             placeholder="Secret Chat"
@@ -244,7 +159,7 @@ export class NewScreen extends Component {
             onChange={this.titleChange}
           />
               {idErrElem}
-          <p className="f8 mt3 lh-copy db">
+          <p className="f8 mt4 db">
             Description
             <span className="gray3"> (Optional)</span>
           </p>
@@ -257,38 +172,27 @@ export class NewScreen extends Component {
             }}
             onChange={this.descriptionChange}
           />
-          <p className="f8 mt4 lh-copy db">
-            Invite
-            <span className="gray3"> (Optional)</span>
+          <div className="mt4 db relative">
+            <p className="f8">
+              Select Group
           </p>
-          <p className="f9 gray2 db mb2 pt1">
-            Selected groups or ships will be able to post to chat
+          <Link className="green2 absolute right-0 bottom-0 f9" to="/~groups/new">+New</Link>
+            <p className="f9 gray2 db mv1">
+              Chat will be added to selected group
           </p>
+          </div>
           <InviteSearch
             groups={props.groups}
             contacts={props.contacts}
             associations={props.associations}
             groupResults={true}
-            shipResults={true}
+            shipResults={false}
             invites={{
               groups: state.groups,
-              ships: state.ships
+              ships: []
             }}
             setInvite={this.setInvite}
           />
-          {createGroupToggle}
-          <div className="mv7">
-            <input
-              type="checkbox"
-              style={{ WebkitAppearance: 'none', width: 28 }}
-              className={privacySwitchClasses}
-              onChange={this.privacyChange}
-            />
-            <span className="dib f9 white-d inter ml3">Private</span>
-            <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
-              Users will have to be invited to join
-            </p>
-          </div>
           <button
             onClick={this.onClickCreate.bind(this)}
             className={createClasses}

--- a/pkg/interface/src/apps/chat/components/settings.js
+++ b/pkg/interface/src/apps/chat/components/settings.js
@@ -451,29 +451,6 @@ export class SettingsScreen extends Component {
         </div>
         <div className="w-100 pl3 mt4 cf">
           <h2 className="f8 pb2">Chat Settings</h2>
-          <div className="w-100 mt3">
-            <p className="f8 mt3 lh-copy">Share</p>
-            <p className="f9 gray2 mb4">Share a shortcode to join this chat</p>
-            <div className="relative w-100 flex"
-              style={{ maxWidth: '29rem' }}
-            >
-              <input
-                className="f8 mono ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
-                disabled={true}
-                value={props.station.substr(1)}
-              />
-              <span className="f8 pointer absolute pa3 inter"
-                style={{ right: 12, top: 1 }}
-                ref="copy"
-                onClick={() => {
-                  writeText(props.station.substr(1));
-                  this.refs.copy.innerText = 'Copied';
-                }}
-              >
-                Copy
-              </span>
-            </div>
-          </div>
           {this.renderGroupify()}
           {this.renderDelete()}
           {this.renderMetadataSettings()}

--- a/pkg/interface/src/apps/chat/components/sidebar.js
+++ b/pkg/interface/src/apps/chat/components/sidebar.js
@@ -1,40 +1,17 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 
 import Welcome from './lib/welcome';
 import { alphabetiseAssociations } from '../../../lib/util';
 import { SidebarInvite } from './lib/sidebar-invite';
 import { GroupItem } from './lib/group-item';
-import { ShipSearchInput } from './lib/ship-search';
 
 export class Sidebar extends Component {
-  constructor() {
-    super();
-    this.state = {
-      dmOverlay: false
-    };
-  }
-
   onClickNew() {
     this.props.history.push('/~chat/new');
   }
 
-  onClickDm() {
-    this.setState(({ dmOverlay }) => ({ dmOverlay: !dmOverlay }) );
-  }
-
-  onClickJoin() {
-    this.props.history.push('/~chat/join');
-  }
-
-  goDm(ship) {
-    this.setState({ dmOverlay: false }, () => {
-      this.props.history.push(`/~chat/new/dm/~${ship}`);
-    });
-  }
-
   render() {
-    const { props, state } = this;
+    const { props } = this;
 
     const selectedGroups = props.selectedGroups ? props.selectedGroups : [];
 
@@ -60,12 +37,12 @@ export class Sidebar extends Component {
           groupedChannels[path] = [box];
         }
       } else {
-        if (groupedChannels['/~/']) {
-          const array = groupedChannels['/~/'];
+        if (groupedChannels['dm']) {
+          const array = groupedChannels['dm'];
           array.push(box);
-          groupedChannels['/~/'] = array;
+          groupedChannels['dm'] = array;
         } else {
-          groupedChannels['/~/'] = [box];
+          groupedChannels['dm'] = [box];
         }
       }
     });
@@ -109,29 +86,21 @@ export class Sidebar extends Component {
           />
         );
       });
-      if (groupedChannels['/~/'] && groupedChannels['/~/'].length !== 0) {
+      if (groupedChannels['dm'] && groupedChannels['dm'].length !== 0) {
         groupedItems.push(
           <GroupItem
-            association={'/~/'}
+            association={'dm'}
             chatMetadata={chatAssoc}
-            channels={groupedChannels['/~/']}
+            channels={groupedChannels['dm']}
             inbox={props.inbox}
             station={props.station}
             unreads={props.unreads}
-            index={'/~/'}
-            key={'/~/'}
+            index={'dm'}
+            key={'dm'}
             {...props}
           />
         );
       }
-    const candidates = state.dmOverlay
-          ? _.chain(this.props.contacts)
-               .values()
-               .map(_.keys)
-               .flatten()
-               .uniq()
-               .value()
-          : [];
 
     return (
       <div
@@ -143,33 +112,7 @@ export class Sidebar extends Component {
             className="dib f9 pointer green2 gray4-d mr4"
             onClick={this.onClickNew.bind(this)}
           >
-            New Chat
-          </a>
-
-          <div className="dib relative mr4">
-            { state.dmOverlay && (
-              <ShipSearchInput
-                className="absolute"
-                contacts={{}}
-                candidates={candidates}
-                onSelect={this.goDm.bind(this)}
-                onClear={this.onClickDm.bind(this)}
-
-              />
-            )}
-          <a
-            className="f9 pointer green2 gray4-d"
-            onClick={this.onClickDm.bind(this)}
-          >
-            DM
-          </a>
-          </div>
-
-          <a
-            className="dib f9 pointer gray4-d"
-            onClick={this.onClickJoin.bind(this)}
-          >
-            Join Chat
+            New Group Chat
           </a>
         </div>
         <div className="overflow-y-auto h-100">

--- a/pkg/interface/src/apps/chat/components/sidebar.js
+++ b/pkg/interface/src/apps/chat/components/sidebar.js
@@ -86,21 +86,20 @@ export class Sidebar extends Component {
           />
         );
       });
-      if (groupedChannels['dm'] && groupedChannels['dm'].length !== 0) {
-        groupedItems.push(
-          <GroupItem
-            association={'dm'}
-            chatMetadata={chatAssoc}
-            channels={groupedChannels['dm']}
-            inbox={props.inbox}
-            station={props.station}
-            unreads={props.unreads}
-            index={'dm'}
-            key={'dm'}
-            {...props}
-          />
-        );
-      }
+      // add direct messages after groups
+      groupedItems.push(
+        <GroupItem
+          association={'dm'}
+          chatMetadata={chatAssoc}
+          channels={groupedChannels['dm']}
+          inbox={props.inbox}
+          station={props.station}
+          unreads={props.unreads}
+          index={'dm'}
+          key={'dm'}
+          {...props}
+        />
+      );
 
     return (
       <div

--- a/pkg/interface/src/apps/groups/app.tsx
+++ b/pkg/interface/src/apps/groups/app.tsx
@@ -104,8 +104,10 @@ export default class GroupsApp extends Component<GroupsAppProps, {}> {
               );
             }}
           />
-          <Route exact path="/~groups/join"
+        <Route exact path="/~groups/join/:ship?/:name?"
             render={(props) => {
+              const ship = props.match.params.ship || '';
+              const name = props.match.params.name || '';
               return (
                 <Skeleton
                   history={props.history}
@@ -122,6 +124,8 @@ export default class GroupsApp extends Component<GroupsAppProps, {}> {
                     groups={groups}
                     contacts={contacts}
                     api={api}
+                    ship={ship}
+                    name={name}
                   />
                 </Skeleton>
               );

--- a/pkg/interface/src/apps/groups/components/join.js
+++ b/pkg/interface/src/apps/groups/components/join.js
@@ -20,7 +20,7 @@ export class JoinScreen extends Component {
   componentDidMount() {
     // direct join from incoming URL
     if ((this.props.ship) && (this.props.name)) {
-      const incomingGroup = `/${this.props.ship}/${this.props.notebook}`;
+      const incomingGroup = `${this.props.ship}/${this.props.name}`;
       this.setState({ group: incomingGroup }, () => {
         this.onClickJoin();
       });
@@ -117,7 +117,7 @@ export class JoinScreen extends Component {
             onClick={this.onClickJoin.bind(this)}
             className={joinClasses}
           >Join Group</button>
-          <Spinner awaiting={this.state.awaiting} classes="mt4" text={this.state.text} />
+          <Spinner awaiting={this.state.awaiting} classes="mt4" text="Joining group..." />
         </div>
       </div>
     );

--- a/pkg/interface/src/apps/groups/components/join.js
+++ b/pkg/interface/src/apps/groups/components/join.js
@@ -18,21 +18,31 @@ export class JoinScreen extends Component {
   }
 
   componentDidMount() {
-    // direct join from incoming URL
-    if ((this.props.ship) && (this.props.name)) {
-      const incomingGroup = `${this.props.ship}/${this.props.name}`;
+    this.componentDidUpdate();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { props, state } = this;
+    // autojoin by URL, waits for group information
+    if ((props.ship && props.name) &&
+    (prevProps && (prevProps.groups !== props.groups))) {
+      console.log('autojoining');
+      const incomingGroup = `${props.ship}/${props.name}`;
+      // push to group if already exists
+      if (`/ship/${incomingGroup}` in props.groups) {
+        this.props.history.push(`/~groups/ship/${incomingGroup}`);
+        return;
+      }
       this.setState({ group: incomingGroup }, () => {
         this.onClickJoin();
       });
     }
-  }
-
-  componentDidUpdate() {
-    if (this.props.groups) {
-      if (this.state.awaiting) {
-        const group = `/ship/${this.state.group}`;
-        if (group in this.props.groups) {
-          this.props.history.push(`/~groups${group}`);
+    // once we've joined, push to group page
+    if (props.groups) {
+      if (state.awaiting) {
+        const group = `/ship/${state.group}`;
+        if (group in props.groups) {
+          props.history.push(`/~groups${group}`);
         }
       }
     }
@@ -41,6 +51,7 @@ export class JoinScreen extends Component {
 
   onClickJoin() {
     const { props, state } = this;
+    console.log('i am joining');
 
     const { group } = state;
     const [ship, name] = group.split('/');

--- a/pkg/interface/src/apps/groups/components/lib/group-detail.js
+++ b/pkg/interface/src/apps/groups/components/lib/group-detail.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Spinner } from '../../../../components/Spinner';
 import { GroupView } from '../../../../components/Group';
-import { deSig, uxToHex } from '../../../../lib/util';
-
+import { deSig, uxToHex, writeText } from '../../../../lib/util';
 
 export class GroupDetail extends Component {
   constructor(props) {
@@ -174,7 +173,7 @@ export class GroupDetail extends Component {
   renderSettings() {
     const { props } = this;
 
-    const { group, association } = props; 
+    const { group, association } = props;
 
     const groupOwner = (deSig(props.match.params.ship) === window.ship);
 
@@ -186,11 +185,39 @@ export class GroupDetail extends Component {
       { description: 'Janitor', tag: 'janitor', addDescription: 'Make Janitor' }
     ];
 
+    let shortcode = <div />;
+
+    if (group?.policy?.open) {
+      shortcode = <div className="mt4">
+        <p className="f9 mt4 lh-copy">Share</p>
+        <p className="f9 gray2 mb2">Share a shortcode to join this group</p>
+        <div className="relative w-100 flex"
+          style={{ maxWidth: '29rem' }}
+        >
+          <input
+            className="f8 mono ba b--gray3 b--gray2-d bg-gray0-d white-d pa3 db w-100 flex-auto mr3"
+            disabled={true}
+            value={props.path.substr(6)}
+          />
+          <span className="lh-solid f8 pointer absolute pa3 inter"
+            style={{ right: 12, top: 1 }}
+            ref="copy"
+            onClick={() => {
+              writeText(props.path.substr(6));
+              this.refs.copy.innerText = 'Copied';
+            }}
+          >
+            Copy
+              </span>
+        </div>
+      </div>;
+    }
     return (
       <div className="pa4 w-100 h-100 white-d overflow-y-auto">
         <div className="f8 f9-m f9-l f9-xl w-100">
           <Link to={'/~groups/detail' + props.path}>{'⟵ Channels'}</Link>
         </div>
+        {shortcode}
       { group && <GroupView permissions className="mt6" resourcePath={props.path} group={group} tags={tags} api={props.api} /> }
         <div className={(groupOwner) ? '' : 'o-30'}>
           <p className="f9 mt3 lh-copy">Rename</p>

--- a/pkg/interface/src/apps/launch/components/welcome.js
+++ b/pkg/interface/src/apps/launch/components/welcome.js
@@ -6,7 +6,7 @@ export default class Welcome extends React.Component {
     super();
     this.state = {
       show: true
-    }
+    };
     this.disableWelcome = this.disableWelcome.bind(this);
   }
 
@@ -16,19 +16,23 @@ export default class Welcome extends React.Component {
   }
 
   render() {
-    let firstTime = this.props.firstTime;
+    const firstTime = this.props.firstTime;
     return (firstTime && this.state.show) ? (
       <div className={'fl ma2 bg-white bg-gray0-d white-d overflow-hidden ' +
-      'ba b--black b--gray1-d pa2 lh-copy'}>
+      'ba b--black b--gray1-d pa2 lh-copy'}
+      >
         <p className="f9">Welcome. This virtual computer belongs to you completely. The Urbit ID you used to boot it is yours as well.</p>
         <p className="f9 pt2">Since your ID and OS belong to you, it’s up to you to keep them safe. Be sure your ID is somewhere you won’t lose it and you keep your OS on a machine you trust.</p>
         <p className="f9 pt2">Urbit OS is designed to keep your data secure and hard to lose. But the system is still young — so don’t put anything critical in here just yet.</p>
         <p className="f9 pt2">To begin exploring, you should probably pop into a chat and verify there are signs of life in this new place. If you were invited by a friend, you probably already have access to a few groups.</p>
-        <p className="f9 pt2">If you don't know where to go, feel free to <Link className="no-underline bb b--black b--gray1-d dib" to="/~chat/join/~/~dopzod/urbit-help">join our lobby.</Link>
+        <p className="f9 pt2">If you don't know where to go, feel free to <Link className="no-underline bb b--black b--gray1-d dib" to="/~groups/join/~bitbet-bolbel/urbit-community">join the Urbit Community group</Link>.
         </p>
         <p className="f9 pt2">Have fun!</p>
         <p className="dib f9 pt2 bb b--black b--gray1-d pointer"
-          onClick={(() => {this.disableWelcome()})}>
+          onClick={(() => {
+            this.disableWelcome();
+          })}
+        >
           Close this note
         </p>
       </div>

--- a/pkg/interface/src/apps/links/components/new.js
+++ b/pkg/interface/src/apps/links/components/new.js
@@ -23,7 +23,6 @@ export class NewScreen extends Component {
     this.titleChange = this.titleChange.bind(this);
     this.descriptionChange = this.descriptionChange.bind(this);
     this.setInvite = this.setInvite.bind(this);
-    this.createGroupChange = this.createGroupChange.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -56,12 +55,6 @@ export class NewScreen extends Component {
     this.setState({
       groups: value.groups,
       ships: value.ships
-    });
-  }
-
-  createGroupChange(event) {
-    this.setState({
-      createGroup: Boolean(event.target.checked)
     });
   }
 
@@ -136,10 +129,6 @@ export class NewScreen extends Component {
   render() {
     const { props, state } = this;
 
-    const createGroupClasses = state.createGroup
-      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
-
     const createClasses = state.idName
       ? 'pointer db f9 mt7 green2 bg-gray0-d ba pv3 ph4 b--green2'
       : 'pointer db f9 mt7 gray2 ba bg-gray0-d pa2 pv3 ph4 b--gray3';
@@ -154,24 +143,6 @@ export class NewScreen extends Component {
         <span className="f9 inter red2 db pt2">
           Collection must have a valid name.
         </span>
-      );
-    }
-
-    let createGroupToggle = <div />;
-    if (state.groups.length === 0) {
-      createGroupToggle = (
-        <div className="mt7">
-          <input
-            type="checkbox"
-            style={{ WebkitAppearance: 'none', width: 28 }}
-            className={createGroupClasses}
-            onChange={this.createGroupChange}
-          />
-          <span className="dib f9 white-d inter ml3">Create Group</span>
-          <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
-            Participants will share this group across applications
-          </p>
-        </div>
       );
     }
 
@@ -211,13 +182,16 @@ export class NewScreen extends Component {
             }}
             onChange={this.descriptionChange}
           />
-          <p className="f8 mt4 lh-copy db">
-            Invite
-            <span className="gray3"> (Optional)</span>
+          <div className="mt4 db relative">
+            <p className="f8">
+              Invite
+              <span className="gray3"> (Optional)</span>
           </p>
-          <p className="f9 gray2 db mb2 pt1">
-            Selected groups or ships will be able to post to collection
+            <Link className="green2 absolute right-0 bottom-0 f9" to="/~groups/new">Create Group</Link>
+            <p className="f9 gray2 db mv1">
+              Selected group or ships will be invited to the collection
           </p>
+          </div>
           <InviteSearch
             associations={props.associations.contacts}
             groups={props.groups}
@@ -230,7 +204,6 @@ export class NewScreen extends Component {
             }}
             setInvite={this.setInvite}
           />
-          {createGroupToggle}
           <button
             onClick={this.onClickCreate.bind(this)}
             className={createClasses}

--- a/pkg/interface/src/apps/publish/components/lib/new.js
+++ b/pkg/interface/src/apps/publish/components/lib/new.js
@@ -23,7 +23,6 @@ export class NewScreen extends Component {
     this.idChange = this.idChange.bind(this);
     this.descriptionChange = this.descriptionChange.bind(this);
     this.setInvite = this.setInvite.bind(this);
-    this.createGroupChange = this.createGroupChange.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -46,10 +45,6 @@ export class NewScreen extends Component {
     this.setState({
       description: event.target.value
     });
-  }
-
-  createGroupChange(event) {
-    this.setState({ createGroup: Boolean(event.target.checked) });
   }
 
   setInvite(value) {
@@ -99,30 +94,11 @@ export class NewScreen extends Component {
   }
 
   render() {
-     const createGroupClasses = this.state.createGroup
-       ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-       : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
 
     let createClasses = 'pointer db f9 green2 bg-gray0-d ba pv3 ph4 mv7 b--green2';
     if (!this.state.idName || this.state.disabled) {
       createClasses = 'db f9 gray2 ba bg-gray0-d pa2 pv3 ph4 mv7 b--gray3';
     }
-
-    const createGroupToggle =
-      !((this.state.invites.ships.length > 0) && (this.state.invites.groups.length === 0))
-    ?  null
-    :  <div className="mv7">
-         <input
-           type="checkbox"
-           style={{ WebkitAppearance: 'none', width: 28 }}
-           className={createGroupClasses}
-           onChange={this.createGroupChange}
-         />
-         <span className="dib f9 white-d inter ml3">Create Group</span>
-         <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
-           Participants will share this group across applications
-         </p>
-       </div>;
 
     let idErrElem = <span />;
     if (this.state.idError) {
@@ -182,14 +158,17 @@ export class NewScreen extends Component {
             onChange={this.descriptionChange}
             value={this.state.description}
           />
-          <p className="f8 mt4 lh-copy db">
-            Invite
-            <span className="gray3 ml1">(Optional)</span>
+          <div className="mt4 db relative">
+            <p className="f8">
+              Invite
+              <span className="gray3"> (Optional)</span>
+            </p>
+            <Link className="green2 absolute right-0 bottom-0 f9" to="/~groups/new">Create Group</Link>
+            <p className="f9 gray2 db mv1 pb4">
+              Selected ships will be invited to read your notebook. Selected
+              groups will be invited to read and write notes.
           </p>
-          <p className="f9 gray2 db mb2 pt1">
-            Selected ships will be invited to read your notebook. Selected
-            groups will be invited to read and write notes.
-          </p>
+          </div>
           <InviteSearch
             associations={this.props.associations}
             groupResults={true}
@@ -199,7 +178,6 @@ export class NewScreen extends Component {
             invites={this.state.invites}
             setInvite={this.setInvite}
           />
-          {createGroupToggle}
           <button
             disabled={this.state.disabled}
             onClick={this.onClickCreate.bind(this)}

--- a/pkg/interface/src/apps/publish/components/lib/settings.js
+++ b/pkg/interface/src/apps/publish/components/lib/settings.js
@@ -205,32 +205,9 @@ export class Settings extends Component {
       ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
       : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
 
-    const copyShortcode = <div>
-      {this.renderHeader('Share', 'Share a shortcode to join this notebook')}
-      <div className="relative w-100 flex" style={{ maxWidth: '29rem' }}>
-        <input
-          className={'f8 mono ba b--gray3 b--gray2-d bg-gray0-d white-d ' +
-            'pa3 db w-100 flex-auto mr3'}
-          disabled={true}
-          value={`${this.props.host}/${this.props.book}` || ''}
-        />
-        <span className="f8 pointer absolute pa3 inter"
-          style={{ right: 12, top: 1 }}
-          ref="copy"
-          onClick={() => {
-            writeText(`${this.props.host}/${this.props.book}`);
-            this.refs.copy.innerText = 'Copied';
-          }}
-        >
-            Copy
-          </span>
-      </div>
-    </div>;
-
     if (this.props.host.slice(1) === window.ship) {
       return (
         <div className="flex-column">
-          {copyShortcode}
           {this.renderGroupify()}
           {this.renderHeader(
             'Delete Notebook',

--- a/pkg/interface/src/apps/publish/components/lib/sidebar.js
+++ b/pkg/interface/src/apps/publish/components/lib/sidebar.js
@@ -123,9 +123,6 @@ export class Sidebar extends Component {
           <Link to="/~publish/new" className="green2 pa4 f9 dib">
             New Notebook
           </Link>
-          <Link to="/~publish/join" className="f9 gray2">
-            Join Notebook
-          </Link>
         </div>
         <div className="overflow-y-auto pb1"
         style={{ height: 'calc(100% - 82px)' }}

--- a/pkg/interface/src/components/InviteSearch.tsx
+++ b/pkg/interface/src/components/InviteSearch.tsx
@@ -124,6 +124,7 @@ export class InviteSearch extends Component<
 
   search(event) {
     const searchTerm = event.target.value.toLowerCase().replace('~', '');
+    const { state, props } = this;
 
     this.setState({ searchValue: event.target.value });
 
@@ -132,26 +133,26 @@ export class InviteSearch extends Component<
     }
 
     if (searchTerm.length > 0) {
-      if (this.state.inviteError === true) {
+      if (state.inviteError === true) {
         this.setState({ inviteError: false });
       }
 
-      let groupMatches = !this.props.groupResults ? [] :
-        this.state.groups.filter((e) => {
+      let groupMatches = !props.groupResults ? [] :
+        state.groups.filter((e) => {
           return (
             e[0].includes(searchTerm) || e[1].toLowerCase().includes(searchTerm)
           );
         });
 
-      let shipMatches = !this.props.shipResults ? []  :
-         this.state.peers.filter((e) => {
+      let shipMatches = !props.shipResults ? []  :
+         state.peers.filter((e) => {
           return (
-            e.includes(searchTerm) && !this.props.invites.ships.includes(e)
+            e.includes(searchTerm) && !props.invites.ships.includes(e)
           );
         });
 
-        for (const contact of this.state.contacts.keys()) {
-          const thisContact = this.state.contacts.get(contact) || [];
+        for (const contact of state.contacts.keys()) {
+          const thisContact = state.contacts.get(contact) || [];
           const match = thisContact.filter((e) => {
             return e.toLowerCase().includes(searchTerm);
           });
@@ -167,11 +168,11 @@ export class InviteSearch extends Component<
           isValid = false;
         }
 
-        if (isValid && shipMatches.findIndex((s) => s === searchTerm) < 0) {
+        if (props.shipResults && isValid && shipMatches.findIndex((s) => s === searchTerm) < 0) {
           shipMatches.unshift(searchTerm);
         }
 
-      const { selected } = this.state;
+      const { selected } = state;
       const groupIdx = groupMatches.findIndex(([path]) => path === selected);
       const shipIdx = shipMatches.findIndex((ship) => ship === selected);
       const staleSelection = groupIdx < 0 && shipIdx < 0;


### PR DESCRIPTION
<img width="674" alt="Screen Shot 2020-07-15 at 4 16 34 PM" src="https://user-images.githubusercontent.com/20846414/87591863-faa9c900-c6b6-11ea-85e2-e2edd6b366ba.png">

- Fixes a bug where invite search would return valid patps regardless of what `shipResults` was set to.
- Fixes a bug where Groups autojoin wasn't receiving props from the route and still had some cruft from its Publish scaffolding code.
- Drastically simplifies new Chat flows — 'New Chat' requires a group and links to Groups to create new ones; 'New DM' adds the ability to name and create group DMs and is graphically separated in the sidebar.
- Removes "Create group" toggle from all "New..." flows.
- Adds "Create group" link to Groups above the Invite Search input on New screens.
- Removes "Join [chat,notebook]" from sidebars.
- Removes shortcode references from Chat and Publish.
- Adds a link to join Urbit Community directly from the Launch welcome message.
- Restores shortcode links in Chat — they now link to Groups and automatically join the group (if the group is public).