### PR TITLE
landscape clock: render sun+moon after night

### DIFF
--- a/pkg/interface/src/apps/launch/components/tiles/clock.js
+++ b/pkg/interface/src/apps/launch/components/tiles/clock.js
@@ -258,6 +258,17 @@ class Clock extends React.Component {
       '#FF611E'
     );
 
+    // Night
+    degArc(
+      ctx,
+      ctr,
+      ctr,
+      ctr / 2,
+      state.night,
+      state.nightEnd,
+      'rgb(26, 26, 26)'
+    );
+
     if (
       radToDeg(this.angle) > splitArc(state.sunriseEnd, state.nightEnd)
       && radToDeg(this.angle) < splitArc(state.sunset, state.night)
@@ -308,16 +319,6 @@ class Clock extends React.Component {
       );
     }
 
-    // Night
-    degArc(
-      ctx,
-      ctr,
-      ctr,
-      ctr / 2,
-      state.night,
-      state.nightEnd,
-      'rgb(26, 26, 26)'
-    );
 
     // Outer borders
     circleOutline(


### PR DESCRIPTION
The clock renders the sun+moon before rendering the part of the image for the night section.

This ends up hiding the moon behind the night part of the image.

Layer the sun+moon after the night section to make the moon visible during night time.