### PR TITLE
vere: fix warnings flagged by gcc 8

### DIFF
--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -6,7 +6,7 @@ URBIT_VERSION="0.10.7"
 
 deps="                                                                \
   curl gmp sigsegv argon2 ed25519 ent h2o scrypt uv murmur3 secp256k1 \
-  softfloat3 ssl crypto z lmdb ge-additions aes_siv                   \
+  softfloat3 ssl crypto z lmdb ge-additions aes_siv pthread           \
 "
 
 headers="             \

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -883,9 +883,9 @@ static c3_o
 _ce_image_move(u3e_image* img_u, c3_o bak_o)
 {
   c3_c old_c[8193];
-  c3_c new_c[8193];
-  snprintf(old_c, 8192, "%s/.urb/chk/%s.bin", u3P.dir_c, img_u->nam_c);
-  snprintf(new_c, 8192, "%s.bak", old_c);
+  c3_c new_c[8197];
+  snprintf(old_c, 8193, "%s/.urb/chk/%s.bin", u3P.dir_c, img_u->nam_c);
+  snprintf(new_c, 8197, "%s.bak", old_c);
 
   c3_i ret_i;
 

--- a/pkg/urbit/noun/trace.c
+++ b/pkg/urbit/noun/trace.c
@@ -285,8 +285,8 @@ u3t_trace_open(c3_c* dir_c)
     mkdir(fil_c, 0700);
   }
 
-  c3_c lif_c[2048];
-  snprintf(lif_c, 2048, "%s/%d.json", fil_c, u3_Host.tra_u.fun_w);
+  c3_c lif_c[2056];
+  snprintf(lif_c, 2056, "%s/%d.json", fil_c, u3_Host.tra_u.fun_w);
 
   u3_Host.tra_u.fil_u = fopen(lif_c, "w");
   u3_Host.tra_u.nid_w = (int)getpid();

--- a/pkg/urbit/vere/io/cttp.c
+++ b/pkg/urbit/vere/io/cttp.c
@@ -850,12 +850,8 @@ _cttp_creq_connect(u3_creq* ceq_u)
 
   // set hostname for TLS handshake
   if ( ceq_u->hot_c && c3y == ceq_u->sec ) {
-    c3_w len_w  = 1 + strlen(ceq_u->hot_c);
-    c3_c* hot_c = c3_malloc(len_w);
-    strncpy(hot_c, ceq_u->hot_c, len_w);
-
     c3_free(ceq_u->cli_u->ssl.server_name);
-    ceq_u->cli_u->ssl.server_name = hot_c;
+    ceq_u->cli_u->ssl.server_name = strdup(ceq_u->hot_c);
   }
 
   _cttp_creq_fire(ceq_u);

--- a/pkg/urbit/vere/io/unix.c
+++ b/pkg/urbit/vere/io/unix.c
@@ -108,9 +108,9 @@ _unix_down(c3_c* pax_c, c3_c* sub_c)
   c3_w sub_w = strlen(sub_c);
   c3_c* don_c = c3_malloc(pax_w + sub_w + 2);
 
-  strncpy(don_c, pax_c, pax_w);
+  strcpy(don_c, pax_c);
   don_c[pax_w] = '/';
-  strncpy(don_c + pax_w + 1, sub_c, sub_w);
+  strcpy(don_c + pax_w + 1, sub_c);
   don_c[pax_w + 1 + sub_w] = '\0';
 
   return don_c;
@@ -666,9 +666,9 @@ _unix_create_dir(u3_udir* dir_u, u3_udir* par_u, u3_noun nam)
   c3_w  pax_w = strlen(par_u->pax_c);
   c3_c* pax_c = c3_malloc(pax_w + 1 + nam_w + 1);
 
-  strncpy(pax_c, par_u->pax_c, pax_w);
+  strcpy(pax_c, par_u->pax_c);
   pax_c[pax_w] = '/';
-  strncpy(pax_c + pax_w + 1, nam_c, nam_w);
+  strcpy(pax_c + pax_w + 1, nam_c);
   pax_c[pax_w + 1 + nam_w] = '\0';
 
   c3_free(nam_c);
@@ -1111,11 +1111,11 @@ _unix_sync_file(u3_unix* unx_u, u3_udir* par_u, u3_noun nam, u3_noun ext, u3_nou
   c3_w  ext_w = strlen(ext_c);
   c3_c* pax_c = c3_malloc(par_w + 1 + nam_w + 1 + ext_w + 1);
 
-  strncpy(pax_c, par_u->pax_c, par_w);
+  strcpy(pax_c, par_u->pax_c);
   pax_c[par_w] = '/';
-  strncpy(pax_c + par_w + 1, nam_c, nam_w);
+  strcpy(pax_c + par_w + 1, nam_c);
   pax_c[par_w + 1 + nam_w] = '.';
-  strncpy(pax_c + par_w + 1 + nam_w + 1, ext_c, ext_w);
+  strcpy(pax_c + par_w + 1 + nam_w + 1, ext_c);
   pax_c[par_w + 1 + nam_w + 1 + ext_w] = '\0';
 
   c3_free(nam_c); c3_free(ext_c);

--- a/pkg/urbit/vere/walk.c
+++ b/pkg/urbit/vere/walk.c
@@ -115,7 +115,8 @@ _walk_mkdirp(c3_c* bas_c, u3_noun pax)
   len_w = 1 + fas_w + pax_w;
 
   pax_c = c3_malloc(1 + len_w);
-  strncpy(pax_c, bas_c, len_w);
+  strcpy(pax_c, bas_c);
+
   pax_c[fas_w] = '/';
   waq_y = (void*)(1 + pax_c + fas_w);
   u3r_bytes(0, pax_w, waq_y, u3h(pax));

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -220,8 +220,8 @@ _serf_grab(u3_serf* sef_u)
         mkdir(nam_c, 0700);
       }
 
-      c3_c man_c[2048];
-      snprintf(man_c, 2048, "%s/%s-serf.txt", nam_c, wen_c);
+      c3_c man_c[2054];
+      snprintf(man_c, 2053, "%s/%s-serf.txt", nam_c, wen_c);
 
       fil_u = fopen(man_c, "w");
       fprintf(fil_u, "%s\r\n", wen_c);
@@ -603,7 +603,7 @@ u3_noun
 u3_serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
 {
   c3_t  tac_t = ( 0 != u3_Host.tra_u.fil_u );
-  c3_c  lab_c[2048];
+  c3_c  lab_c[2056];
   u3_noun pro;
 
   // XX refactor tracing
@@ -615,7 +615,7 @@ u3_serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
     {
       c3_c* cad_c = u3m_pretty(cad);
       c3_c* wir_c = u3m_pretty_path(wir);
-      snprintf(lab_c, 2048, "work [%s %s]", wir_c, cad_c);
+      snprintf(lab_c, 2056, "work [%s %s]", wir_c, cad_c);
       c3_free(cad_c);
       c3_free(wir_c);
     }
@@ -870,8 +870,8 @@ _serf_writ_live_exit(c3_w cod_w)
         mkdir(nam_c, 0700);
       }
 
-      c3_c man_c[2048];
-      snprintf(man_c, 2048, "%s/%s.txt", nam_c, wen_c);
+      c3_c man_c[2054];
+      snprintf(man_c, 2053, "%s/%s.txt", nam_c, wen_c);
 
       fil_u = fopen(man_c, "w");
 


### PR DESCRIPTION
This ports #2991 to ipc-redux (minus the currently-impractical upgrade of nixpkgs), and fixes a couple additional warnings that showed up in CI.

@brendanhay, can you confirm this works in your environment?