### PR TITLE
zuse: parse rfc2396 unreserved chars correctly

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6567,7 +6567,7 @@
       ;~(pose pure pesc pold net wut col com)
     ::                                                  ::  ++pure:de-purl:html
     ++  pure                                            ::  2396 unreserved
-      ;~(pose aln hep dot cab sig)
+      ;~(pose aln hep cab dot zap sig tar say lit rit)
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose


### PR DESCRIPTION
Trying to deal with http requests sent by an external application. Its requests weren't getting passed to the correct handler (an app), instead redirecting to login page.

Turns out the URL of the request contained a `)` in a query parameter, and this was tripping our parser up.

One class of characters allowed in URIs are "unreserved" characters. [RFC2396 defines](https://tools.ietf.org/html/rfc2396#appendix-A) unreserved characters as alphanumerics and nine "mark" characters. We were only parsing for four of those, missing `)` among others, leading to parsing failure for valid URLs.


Before:

```hoon
> (de-purl:html 'http://localhost/some?thing=or)&other=!')
~
```

After

```hoon
> (de-purl:html 'http://localhost/some?thing=or)&other=!')
[ ~
  [ p=[p=%.n q=~ r=[%.y p=<|localhost|>]]
    q=[p=~ q=<|some|>]
    r=~[[p='thing' q='or)'] [p='other' q='!']]
  ]
]
```

