### PR TITLE
interface: two design tweaks

### DIFF
--- a/pkg/interface/src/apps/groups/components/lib/group-detail.js
+++ b/pkg/interface/src/apps/groups/components/lib/group-detail.js
@@ -108,7 +108,7 @@ export class GroupDetail extends Component {
             </div>
               <div className="flex flex-column flex-auto">
                 <p className="f9 inter ml2 w-100">{each.title}</p>
-                <p className="f9 inter ml2 w-100">
+                <p className="f9 inter mt2 ml2 w-100">
                   <span className="f9 di mr2 inter">{each.app}</span>
                   <Link className="f9 di green2" to={each.link}>
                     Open

--- a/pkg/interface/src/apps/launch/app.js
+++ b/pkg/interface/src/apps/launch/app.js
@@ -1,9 +1,5 @@
 import React from 'react';
 
-import LaunchApi from '../../api/launch';
-import LaunchStore from '../../store/launch';
-import LaunchSubscription from '../../subscription/launch';
-
 import './css/custom.css';
 
 import Tiles from './components/tiles';
@@ -35,7 +31,7 @@ export default class LaunchApp extends React.Component {
           weather={props.weather}
         />
       </div>
-      <div className="absolute bottom-0 left-0 f9 gray2 ml4 mb4 f8"> {props.baseHash} </div>
+      <div className="absolute mono bottom-0 left-0 f9 gray2 ml4 mb4 f8"> {props.baseHash} </div>
     </div>
     );
   }


### PR DESCRIPTION
If I can squeeze these in here I'd like to — 

- base hash uses `mono`
- group-detail has a correction for the line-height of its items