### PR TITLE
clay: ignore extraneous /sys/lyv results

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -622,7 +622,12 @@
     %+  roll  nex
     |=  [[=care:clay =^path] cor=_mo-core]
     ^+  cor
-    ?>  =(%a care)
+    ::  We throw away %z results because we only have them to guarantee
+    ::  molting.  Clay will tell us if e.g. changing hoon.hoon affects
+    ::  the result of a particular app (usually it will).
+    ::
+    ?.  =(%a care)
+      cor
     =/  dap  dap:;;([%app dap=@tas %hoon ~] path)
     =/  rag  (mo-scry-agent-cage dap p.sign-arvo)
     ?:  ?=(%| -.rag)


### PR DESCRIPTION
In +mo-subscribe-to-agent-builds we subscribe to `%a` on all our apps to get updates when they change, but we also subscribe to `%z` on hoon/arvo/zuse/gall so that even if no built app changes, we'll still get a ping from clay, so we'll molt.

This change makes it so that if for some reason we get a `%z` response at another time, we ignore it.  ~dev ran into this bug, and this change fixed it.

Tagging @Fang- since Ted's out.