### PR TITLE
chat-js: save unsent message for each station

### DIFF
--- a/pkg/interface/src/apps/chat/components/chat.tsx
+++ b/pkg/interface/src/apps/chat/components/chat.tsx
@@ -93,6 +93,7 @@ interface ChatScreenState {
   scrollLocked: boolean;
   read: number;
   active: boolean;
+  messages: Map<string, string>;
   lastScrollHeight: number | null;
 }
 
@@ -117,6 +118,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
       scrollLocked: false,
       read: props.read,
       active: true,
+      messages: new Map(),
       // only for FF
       lastScrollHeight: null,
     };
@@ -592,8 +594,12 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
           envelopes={props.envelopes}
           contacts={props.contacts}
           onEnter={() => this.setState({ scrollLocked: false })}
+          onChange={(msg: string) => this.setState({
+            messages: this.state.messages.set(props.station, msg)
+          })}
           s3={props.s3}
           placeholder="Message..."
+          message={this.state.messages.get(props.station) || ""}
         />
       </div>
     );

--- a/pkg/interface/src/apps/chat/components/lib/chat-input.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-input.js
@@ -150,6 +150,7 @@ export class ChatInput extends Component {
     if(patpSearch !== null) {
       this.patpAutocomplete(value, false);
     }
+    this.props.onChange(value);
   }
 
   getLetterType(letter) {
@@ -364,6 +365,7 @@ export class ChatInput extends Component {
           style={{ flexGrow: 1, maxHeight: '224px', width: 'calc(100% - 72px)' }}
         >
           <CodeEditor
+            value={this.props.message}
             options={options}
             editorDidMount={(editor) => {
             this.editor = editor;


### PR DESCRIPTION
Previous behavior:

1. Type message in chat without submitting it
2. Navigate to other chat
3. Navigate back
4. Message has been cleared

New behavior: message is not cleared. This matches the behavior of Discord, Slack, etc.