### PR TITLE
king: drop ames packets when >1k are unprocessed

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -126,8 +126,7 @@ ames'
   -> RIO e ([Ev], RAcquire e (DriverApi NewtEf))
 ames' who isFake stderr = do
   -- Unfortunately, we cannot use TBQueue because the only behavior
-  -- provided for when full is to block the writer, and we want to
-  -- instead drop the incoming packet on the floor. The implementation
+  -- provided for when full is to block the writer. The implementation
   -- below uses materially the same data structures as TBQueue, however.
   ventQ :: TQueue EvErr <- newTQueueIO
   avail :: TVar Word <- newTVarIO queueBound

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -2,7 +2,7 @@
   Ames IO Driver
 -}
 
-module Urbit.Vere.Ames (ames, ames') where
+module Urbit.Vere.Ames (ames, ames', PacketOutcome(..)) where
 
 import Urbit.Prelude
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -19,7 +19,7 @@ import Urbit.Vere.Ames.UDP (UdpServ(..), fakeUdpServ, realUdpServ)
 
 -- Constants -------------------------------------------------------------------
 
--- | How many unprocessed ames packets to allow in the queue before we stop
+-- | How many unprocessed ames packets to allow in the queue before we start
 -- dropping incoming packets.
 queueBound :: Word
 queueBound = 1000

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -6,7 +6,6 @@ module Urbit.Vere.Ames (ames, ames') where
 
 import Urbit.Prelude
 
-import Control.Concurrent.STM.TVar        (stateTVar)
 import Network.Socket              hiding (recvFrom, sendTo)
 import Urbit.Arvo                  hiding (Fake)
 import Urbit.King.Config
@@ -210,7 +209,10 @@ ames env who isFake enqueueEv stderr = (initialEvents, runAmes)
     case outcome of
       Intake -> pure ()
       Ouster -> do
-        d <- atomically $ stateTVar dropCtr (\d -> (d, d + 1))
+        d <- atomically $ do
+          d <- readTVar dropCtr
+          writeTVar dropCtr (d + 1)
+          pure d
         when (d `rem` packetsDroppedPerComplaint == 0) $
           logWarn "ames: queue full; dropping inbound packets"
 

--- a/pkg/hs/urbit-king/test/AmesTests.hs
+++ b/pkg/hs/urbit-king/test/AmesTests.hs
@@ -80,8 +80,8 @@ runGala
 runGala point = do
     env <- ask
     que <- newTQueueIO
-    let (_, runAmes) =
-          ames env (fromIntegral point) True (writeTQueue que) noStderr
+    let enqueue = \p -> writeTQueue que p $> Intake
+    let (_, runAmes) = ames env (fromIntegral point) True enqueue noStderr
     cb <- runAmes
     io (cb turfEf)
     pure (que, cb)


### PR DESCRIPTION
The C king already provides this behavior, which is necessary to prevent OOMs on highly trafficked infra ships.