### PR TITLE
ota: show information instead of disable by default

### DIFF
--- a/pkg/arvo/gen/hood/ota.hoon
+++ b/pkg/arvo/gen/hood/ota.hoon
@@ -8,7 +8,11 @@
   ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=?(~ [her=@p sud=@tas ~]) ~]
+        [arg=?(~ [%disable ~] [her=@p sud=@tas ~]) ~]
     ==
+?~  arg
+  :-  %kiln-ota-info  ~
 :-  %kiln-ota
-?~(arg ~ `[her sud]:arg)
+?:  ?=([%disable ~] arg)
+  ~
+`[her sud]:arg

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -341,13 +341,22 @@
     abet:(spam (render "already syncing" [sud her syd]:hos) ~)
   abet:abet:start-sync:(auto hos)
 ::
+++  ota-info
+  ?~  ota
+    "OTAs disabled"
+  "OTAs enabled from {<desk.u.ota>} on {<ship.u.ota>}"
+::
+++  poke-ota-info
+  |=  *
+  =<  abet  %-  spam
+  :~  [%leaf ota-info]
+      [%leaf "use |ota %disable or |ota ~sponsor %kids to reset it"]
+  ==
+::
 ++  poke-syncs                                        ::  print sync config
   |=  ~
   =<  abet  %-  spam
-  :-  :-  %leaf
-      ?~  ota
-        "OTAs disabled"
-      "OTAs from {<desk.u.ota>} on {<ship.u.ota>}"
+  :-  [%leaf ota-info]
   ?:  =(0 ~(wyt by syn))
     [%leaf "no other syncs configured"]~
   %+  turn  ~(tap in ~(key by syn))
@@ -416,6 +425,7 @@
     %kiln-merge              =;(f (f !<(_+<.f vase)) poke-merge)
     %kiln-mount              =;(f (f !<(_+<.f vase)) poke-mount)
     %kiln-ota                =;(f (f !<(_+<.f vase)) poke:update)
+    %kiln-ota-info           =;(f (f !<(_+<.f vase)) poke-ota-info)
     %kiln-permission         =;(f (f !<(_+<.f vase)) poke-permission)
     %kiln-rm                 =;(f (f !<(_+<.f vase)) poke-rm)
     %kiln-schedule           =;(f (f !<(_+<.f vase)) poke-schedule)


### PR DESCRIPTION
Instead of `|ota` cancel the OTA, make it show the current setting.
Make the cancel need a more explicit argument.

```
   |ota                 shows the current setting
   |ota disable         disable OTA
   |ota ~sponsor %desk  reset to a different sponsor/desk
```

Because most of the time the expected desk is going to be %kids, use
that in the "help message".