### PR TITLE
vere: refactors new memory compaction

### DIFF
--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -465,6 +465,11 @@
           c3_w
           u3a_mark_road(FILE* fil_u);
 
+        /* u3a_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+        */
+          void
+          u3a_reclaim(void);
+
         /* u3a_rewrite_ptr(): mark a pointer as already having been rewritten
         */
           c3_o

--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -470,6 +470,11 @@
           void
           u3a_reclaim(void);
 
+        /* u3a_rewrite_compact(): rewrite pointers in ad-hoc persistent road structures.
+        */
+          void
+          u3a_rewrite_compact(void);
+
         /* u3a_rewrite_ptr(): mark a pointer as already having been rewritten
         */
           c3_o
@@ -489,11 +494,6 @@
         */
           u3_noun
           u3a_rewritten_noun(u3_noun som);
-
-        /* u3a_compact(): compact (north) road.
-        */
-          void
-          u3a_compact();
 
         /* u3a_count_noun(): count size of noun.
         */
@@ -522,6 +522,16 @@
         */
           c3_w
           u3a_sweep(void);
+
+        /* u3a_pack_seek(): sweep the heap, modifying boxes to record new addresses.
+        */
+          void
+          u3a_pack_seek(u3a_road* rod_u);
+
+        /* u3a_pack_move(): sweep the heap, moving boxes to new addresses.
+        */
+          void
+          u3a_pack_move(u3a_road* rod_u);
 
         /* u3a_sane(): check allocator sanity.
         */

--- a/pkg/urbit/include/noun/jets.h
+++ b/pkg/urbit/include/noun/jets.h
@@ -287,17 +287,17 @@
         c3_w
         u3j_mark(FILE* fil_u);
 
-      /* u3j_rewrite_compact(): rewrite jet state for compaction.
-      */
-        void
-        u3j_rewrite_compact();
-
-      /* u3j_free_hank(): free an entry from the hank cache.
-      */
-        void
-        u3j_free_hank(u3_noun kev);
-
       /* u3j_free(): free jet state.
       */
         void
         u3j_free(void);
+
+      /* u3j_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+      */
+        void
+        u3j_reclaim(void);
+
+      /* u3j_rewrite_compact(): rewrite jet state for compaction.
+      */
+        void
+        u3j_rewrite_compact();

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -141,6 +141,11 @@
         void
         u3m_reclaim(void);
 
+      /* u3m_pack: compact (defragment) memory.
+      */
+        c3_w
+        u3m_pack(void);
+
       /* u3m_rock_stay(): jam state into [dir_c] at [evt_d]
       */
         c3_o

--- a/pkg/urbit/include/noun/nock.h
+++ b/pkg/urbit/include/noun/nock.h
@@ -117,6 +117,11 @@
       c3_w
       u3n_mark(FILE* fil_u);
 
+    /* u3n_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+    */
+      void
+      u3n_reclaim(void);
+
     /* u3n_rewrite_compact(): rewrite bytecode cache for compaction.
      */
       void

--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -104,6 +104,11 @@
       c3_w
       u3v_mark(FILE* fil_u);
 
+    /* u3v_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+    */
+      void
+      u3v_reclaim(void);
+
     /* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
     */
       void

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -374,10 +374,10 @@ u3a_reflux(void)
   }
 }
 
-/* u3a_reclaim(): reclaim from memoization cache.
+/* _ca_reclaim_half(): reclaim from memoization cache.
 */
-void
-u3a_reclaim(void)
+static void
+_ca_reclaim_half(void)
 {
   //  XX u3l_log avoid here, as it can
   //  cause problems when handling errors
@@ -435,7 +435,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
 
           //  memory nearly empty; reclaim; should not be needed
           //
-          // if ( (u3a_open(u3R) + u3R->all.fre_w) < 65536 ) { u3a_reclaim(); }
+          // if ( (u3a_open(u3R) + u3R->all.fre_w) < 65536 ) { _ca_reclaim_half(); }
           box_u = _ca_box_make_hat(siz_w, ald_w, alp_w, 1);
 
           /* Flush a bunch of cell cache, then try again.
@@ -447,7 +447,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w alp_w)
               return _ca_willoc(len_w, ald_w, alp_w);
             }
             else {
-              u3a_reclaim();
+              _ca_reclaim_half();
               return _ca_willoc(len_w, ald_w, alp_w);
             }
           }
@@ -534,7 +534,7 @@ _ca_walloc(c3_w len_w, c3_w ald_w, c3_w alp_w)
     if ( 0 != ptr_v ) {
       break;
     }
-    u3a_reclaim();
+    _ca_reclaim_half();
   }
   return ptr_v;
 }
@@ -1949,6 +1949,17 @@ u3a_mark_road(FILE* fil_u)
   tot_w += u3a_maid(fil_u, "  new profile trace", u3a_mark_noun(u3R->pro.trace));
   tot_w += u3a_maid(fil_u, "  memoization cache", u3h_mark(u3R->cax.har_p));
   return   u3a_maid(fil_u, "total road stuff", tot_w);
+}
+
+/* u3a_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3a_reclaim(void)
+{
+  //  clear the memoization cache
+  //
+  u3h_free(u3R->cax.har_p);
+  u3R->cax.har_p = u3h_new();
 }
 
 /* u3a_rewrite_compact(): rewrite pointers in ad-hoc persistent road structures.

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -2339,16 +2339,61 @@ u3j_mark(FILE* fil_u)
   return u3a_maid(fil_u, "total jet stuff", tot_w);
 }
 
+/* _cj_free_hank(): free an entry from the hank cache.
+*/
+static void
+_cj_free_hank(u3_noun kev)
+{
+  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
+  if ( u3_none != han_u->hax ) {
+    u3z(han_u->hax);
+    u3j_site_lose(&(han_u->sit_u));
+  }
+  u3a_wfree(han_u);
+}
+
+/* u3j_free(): free jet state.
+*/
+void
+u3j_free(void)
+{
+  u3h_walk(u3R->jed.han_p, _cj_free_hank);
+  u3h_free(u3R->jed.war_p);
+  u3h_free(u3R->jed.cod_p);
+  u3h_free(u3R->jed.han_p);
+  u3h_free(u3R->jed.bas_p);
+  if ( u3R == &(u3H->rod_u) ) {
+    u3h_free(u3R->jed.hot_p);
+  }
+}
+
+/* u3j_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3j_reclaim(void)
+{
+  //  re-establish the warm jet state
+  //
+  //    XX might this reduce fragmentation?
+  //
+  // if ( &(u3H->rod_u) == u3R ) {
+  //   u3j_ream();
+  // }
+
+  //  clear the jet hank cache
+  //
+  u3h_walk(u3R->jed.han_p, _cj_free_hank);
+  u3h_free(u3R->jed.han_p);
+  u3R->jed.han_p = u3h_new();
+}
+
 /* u3j_rewrite_compact(): rewrite jet state for compaction.
  *
- * NB: u3R->jed.han_p *must* be cleared (currently via u3m_reclaim)
+ * NB: u3R->jed.han_p *must* be cleared (currently via u3j_reclaim above)
  * since it contains hanks which are not nouns but have loom pointers.
  * Alternately, rewrite the entries with u3h_walk, using u3j_mark as a
  * template for how to walk.  There's an untested attempt at this in git
  * history at e8a307a.
- *
- * bas_p is also cleared in u3m_reclaim, but I think it would be
- * rewritten just fine.
 */
 void
 u3j_rewrite_compact()
@@ -2368,32 +2413,3 @@ u3j_rewrite_compact()
   u3R->jed.han_p = u3a_rewritten(u3R->jed.han_p);
   u3R->jed.bas_p = u3a_rewritten(u3R->jed.bas_p);
 }
-
-/* u3j_free_hank(): free an entry from the hank cache.
-*/
-void
-u3j_free_hank(u3_noun kev)
-{
-  _cj_hank* han_u = u3to(_cj_hank, u3t(kev));
-  if ( u3_none != han_u->hax ) {
-    u3z(han_u->hax);
-    u3j_site_lose(&(han_u->sit_u));
-  }
-  u3a_wfree(han_u);
-}
-
-/* u3j_free(): free jet state.
-*/
-void
-u3j_free(void)
-{
-  u3h_walk(u3R->jed.han_p, u3j_free_hank);
-  u3h_free(u3R->jed.war_p);
-  u3h_free(u3R->jed.cod_p);
-  u3h_free(u3R->jed.han_p);
-  u3h_free(u3R->jed.bas_p);
-  if ( u3R == &(u3H->rod_u) ) {
-    u3h_free(u3R->jed.hot_p);
-  }
-}
-

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1849,42 +1849,8 @@ u3m_wipe(void)
 void
 u3m_reclaim(void)
 {
-  c3_assert( &(u3H->rod_u) == u3R );
-
-  //  clear the u3v_wish cache
-  //
-  //    NB: this will leak if not on the home road
-  //
-  u3z(u3A->yot);
-  u3A->yot = u3_nul;
-
-  //  clear the memoization cache
-  //
-  u3h_free(u3R->cax.har_p);
-  u3R->cax.har_p = u3h_new();
-
-  //  clear the jet battery hash cache
-  //
-  u3h_free(u3R->jed.bas_p);
-  u3R->jed.bas_p = u3h_new();
-
-  //  re-establish the warm jet state
-  //
-  //    XX might this reduce fragmentation?
-  //
-  // u3j_ream();
-
-  //  clear the jet hank cache
-  //
-  u3h_walk(u3R->jed.han_p, u3j_free_hank);
-  u3h_free(u3R->jed.han_p);
-  u3R->jed.han_p = u3h_new();
-
-  //  clear the bytecode cache
-  //
-  //    We can't just u3h_free() -- the value is a post to a u3n_prog.
-  //    Note that this requires that the hank cache also be freed.
-  //
-  u3n_free();
-  u3R->byc.har_p = u3h_new();
+  u3v_reclaim();
+  u3j_reclaim();
+  u3n_reclaim();
+  u3a_reclaim();
 }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1860,6 +1860,10 @@ u3m_reclaim(void)
 static void
 _cm_pack_rewrite(void)
 {
+  //  XX fix u3a_rewrit* to support south roads
+  //
+  c3_assert( &(u3H->rod_u) == u3R );
+
   //  NB: these implementations must be kept in sync with u3m_reclaim();
   //  anything not reclaimed must be rewritable
   //

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -2597,11 +2597,25 @@ u3n_mark(FILE* fil_u)
   return  u3a_maid(fil_u, "total nock stuff", bam_w + har_w);
 }
 
+/* u3n_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3n_reclaim(void)
+{
+  //  clear the bytecode cache
+  //
+  //    We can't just u3h_free() -- the value is a post to a u3n_prog.
+  //    Note that the hank cache *must* also be freed (in u3j_reclaim())
+  //
+  u3n_free();
+  u3R->byc.har_p = u3h_new();
+}
+
 /* u3n_rewrite_compact(): rewrite the bytecode cache for compaction.
  *
- * NB: u3R->byc.har_p *must* be cleared (currently via u3m_reclaim,
- * which calls u3n_free) since it contains things that look like nouns
- * but aren't.  Specifically, it contains "cells" where the tail is a
+ * NB: u3R->byc.har_p *must* be cleared (currently via u3n_reclaim above),
+ * since it contains things that look like nouns but aren't.
+ * Specifically, it contains "cells" where the tail is a
  * pointer to a u3a_malloc'ed block that contains loom pointers.
  *
  * You should be able to walk this with u3h_walk and rewrite the

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -327,6 +327,21 @@ u3v_mark(FILE* fil_u)
   return   u3a_maid(fil_u, "total arvo stuff", tot_w);
 }
 
+/* u3v_reclaim(): clear ad-hoc persistent caches to reclaim memory.
+*/
+void
+u3v_reclaim(void)
+{
+  //  clear the u3v_wish cache
+  //
+  //    NB: this would leak if not on the home road
+  //
+  if ( &(u3H->rod_u) == u3R ) {
+    u3z(u3A->yot);
+    u3A->yot = u3_nul;
+  }
+}
+
 /* u3v_rewrite_compact(): rewrite arvo kernel for compaction.
 */
 void

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -298,7 +298,12 @@ _cw_pack(c3_i argc, c3_c* argv[])
   c3_c* dir_c = argv[2];
 
   u3m_boot(dir_c);
-  u3a_compact();
+
+  {
+    c3_w len_w = u3m_pack();
+    u3a_print_memory(stderr, "urbit-worker: pack: gained", len_w);
+  }
+
   u3e_save();
 }
 

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -298,11 +298,7 @@ _cw_pack(c3_i argc, c3_c* argv[])
   c3_c* dir_c = argv[2];
 
   u3m_boot(dir_c);
-
-  {
-    c3_w len_w = u3m_pack();
-    u3a_print_memory(stderr, "urbit-worker: pack: gained", len_w);
-  }
+  u3a_print_memory(stderr, "urbit-worker: pack: gained", u3m_pack());
 
   u3e_save();
 }

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -257,6 +257,8 @@ _serf_grab(u3_serf* sef_u)
 
     u3z(sef_u->sac);
     sef_u->sac = u3_nul;
+
+    u3l_log("\n");
   }
 }
 
@@ -309,12 +311,13 @@ u3_serf_post(u3_serf* sef_u)
   //  XX this runs on replay too, |mass s/b elsewhere
   //
   if ( c3y == sef_u->mut_o ) {
-    sef_u->mut_o = c3n;
     _serf_grab(sef_u);
+    sef_u->mut_o = c3n;
   }
 
   if ( c3y == sef_u->pac_o ) {
-    u3m_pack();
+    u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
+    u3l_log("\n");
     sef_u->pac_o = c3n;
   }
 }
@@ -979,7 +982,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
       }
       else {
         u3z(com);
-        u3m_pack();
+        u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
         *ret = u3nc(c3__live, u3_nul);
         return c3y;
       }

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -314,7 +314,7 @@ u3_serf_post(u3_serf* sef_u)
   }
 
   if ( c3y == sef_u->pac_o ) {
-    u3a_compact();
+    u3m_pack();
     sef_u->pac_o = c3n;
   }
 }
@@ -979,7 +979,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
       }
       else {
         u3z(com);
-        u3a_compact();
+        u3m_pack();
         *ret = u3nc(c3__live, u3_nul);
         return c3y;
       }


### PR DESCRIPTION
This PR moves `u3a_compact()` to `u3m_pack()`, factors out its internal operations, and makes a fair bit of progress towards generalizing the implementation across north/south roads.

The missing generalized operations are the `u3a_rewrit*` functions used in the ad-hoc tracing step. I started new implementations, but there's still a ways to go. These changes aren't important enough to block #3099 and #3064, so I'm PR'ing what I have now -- further improvements will come later.

My main goal in this work was to better understand the implementation. To that end, I rewrote the two sweeping traversals to be more similar to each other, then generalized them across roads. In a north road, new locations are stored in the trailing size word as before; in a south road, they're stored in the leading size word. This is necessary to be able to consistently traverse the heap and calculate new locations starting with the "deepest" allocation box.
