### PR TITLE
moon: print key with correct life

### DIFF
--- a/pkg/arvo/gen/hood/moon-cycle-keys.hoon
+++ b/pkg/arvo/gen/hood/moon-cycle-keys.hoon
@@ -36,7 +36,7 @@
     public-key
   =/  cub  (pit:nu:crub:crypto 512 (shaz (jam mon life eny)))
   =/  =seed:able:jael
-    [mon 1 sec:ex:cub ~]
+    [mon life sec:ex:cub ~]
   %-  %-  slog
       :~  leaf+"moon: {(scow %p mon)}"
           leaf+(scow %uw (jam seed))


### PR DESCRIPTION
We were sending the correct life to Jael, but the ticket we printed had
the life hardcoded to 1.  This makes it use the correct life in both
places.