### PR TITLE
file-server: base hash is same as +trouble

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -287,7 +287,6 @@
       *@uv
     =/  parent  (scot %p ship.u.ota)
     =+  .^(=cass:clay %cs /[parent]/[desk.u.ota]/1/late/foo)
-    %^  end  3  3
     .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
   --
   


### PR DESCRIPTION
Tested on a fake ship. +trouble and base-hash in landscape are the same upon boot.