### PR TITLE
file-server: fix base-hash trimming

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -269,7 +269,7 @@
   ==
 ::
 ++  on-leave  on-leave:def
-++  on-peek   
+++  on-peek
   |=  =path
   ^-  (unit (unit cage))
   |^
@@ -287,10 +287,10 @@
       *@uv
     =/  parent  (scot %p ship.u.ota)
     =+  .^(=cass:clay %cs /[parent]/[desk.u.ota]/1/late/foo)
-    %^  end  3  3
+    %^  end  0  25
     .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
   --
-  
+
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -290,7 +290,6 @@
     %^  end  0  25
     .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
   --
-
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def
 --


### PR DESCRIPTION
See #3159. Maintains parity with +trouble, tested by booting a fake ~zod and a fake ~marzod.