### PR TITLE
groups: fix autojoin on first boot case

### DIFF
--- a/pkg/interface/src/apps/groups/components/join.js
+++ b/pkg/interface/src/apps/groups/components/join.js
@@ -6,7 +6,6 @@ import urbitOb from 'urbit-ob';
 export class JoinScreen extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       group: '',
       error: false,
@@ -21,12 +20,11 @@ export class JoinScreen extends Component {
     this.componentDidUpdate();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { props, state } = this;
     // autojoin by URL, waits for group information
     if ((props.ship && props.name) &&
-    (prevProps && (prevProps.groups !== props.groups))) {
-      console.log('autojoining');
+      (props.contacts && (Object.keys(props.contacts).length > 0) && !state.group)) {
       const incomingGroup = `${props.ship}/${props.name}`;
       // push to group if already exists
       if (`/ship/${incomingGroup}` in props.groups) {
@@ -48,10 +46,8 @@ export class JoinScreen extends Component {
     }
   }
 
-
   onClickJoin() {
     const { props, state } = this;
-    console.log('i am joining');
 
     const { group } = state;
     const [ship, name] = group.split('/');


### PR DESCRIPTION
In #3133 I added a "fix" for groups autojoin to wait for first data load, in the case where you went *directly* to the join route without any data in state.

We want to avoid sending a join if we're already in UC.

Instead, that fix prohibited most of the use cases it was written for — because users, on first boot, *have* data instantiated and use the link in the welcome CTA to join UC. Because `prevProps.groups` and `props.groups` stay identical in the "I'm in no groups case" *and* in the "I'm using `<Link>` to come here" case, linkified joins to groups never work.

In this commit, we instead look for `props.contacts && Object.keys(props.contacts).length > 0` — contacts is the only data we have that is guaranteed to go from "empty" to "has an entry" from first boot; so, all in all, it's our best catch for "is the data instantiated". If it is, then we process the autojoin request if we haven't done so already...