### PR TITLE
metadata-store,hook: ignore bad paths in on-load

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -85,15 +85,16 @@
         old  [%2 +.old]
       ::
           cards
-        %+  turn
+        %+  murn
           ~(tap in ~(key by group-indices.old))
         |=  =group-path
-        ^-  card
-        =/  rid=resource
-          (de-path:resource group-path)
-        ?:  =(our.bowl entity.rid)
-          (poke-md-hook %add-owned group-path)
-        (poke-md-hook %add-synced entity.rid group-path)
+        ^-  (unit card)
+        =/  rid=(unit resource)
+          (de-path-soft:resource group-path)
+        ?~  rid  ~
+        ?:  =(our.bowl entity.u.rid)
+          `(poke-md-hook %add-owned group-path)
+        `(poke-md-hook %add-synced entity.u.rid group-path)
       ==
     =/  new-state=state-one
       %*  .  *state-one


### PR DESCRIPTION
should resolve the failure to process the most recent OTA on ~bitbet-bolbel. The path is malformed on ~bitbet because of what i assume to be migration jank. However, ships other than ~bitbet have reported the OTA failing and so I'm drafting this PR until I can confirm that we can safely discard that metadata.