### PR TITLE
groups: add private group toggle

### DIFF
--- a/pkg/interface/src/apps/chat/components/settings.js
+++ b/pkg/interface/src/apps/chat/components/settings.js
@@ -6,6 +6,7 @@ import { Spinner } from '../../../components/Spinner';
 import { ChatTabBar } from './lib/chat-tabbar';
 import { InviteSearch } from '../../../components/InviteSearch';
 import SidebarSwitcher from '../../../components/SidebarSwitch';
+import Toggle from '../../../components/toggle';
 
 export class SettingsScreen extends Component {
   constructor(props) {
@@ -195,18 +196,12 @@ export class SettingsScreen extends Component {
     } else {
       let inclusiveToggle = <div />;
       if (state.targetGroup) {
-        // TODO toggle component into /lib
-        const inclusiveClasses = state.inclusive
-          ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-          : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
         inclusiveToggle = (
           <div className="mt4">
-            <input
-              type="checkbox"
-              style={{ WebkitAppearance: 'none', width: 28 }}
-              className={inclusiveClasses}
-              onChange={this.changeInclusive}
-            />
+          <Toggle
+            boolean={state.inclusive}
+            change={this.changeInclusive}
+          />
             <span className="dib f9 white-d inter ml3">
               Add all members to group
             </span>

--- a/pkg/interface/src/apps/groups/components/new.tsx
+++ b/pkg/interface/src/apps/groups/components/new.tsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { InviteSearch, Invites } from '../../../components/InviteSearch';
 import { Spinner } from '../../../components/Spinner';
+import { Toggle } from '../../../components/toggle';
 import { RouteComponentProps } from 'react-router-dom';
 import { Groups, GroupPolicy, Resource } from '../../../types/group-update';
 import { Contacts, Rolodex } from '../../../types/contact-update';
@@ -129,9 +130,6 @@ export class NewScreen extends Component<NewScreenProps, NewScreenState> {
         </span>
       );
     }
-    const privacySwitchClasses = this.state.privacy
-      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
 
     return (
       <div className='h-100 w-100 mw6 pa3 pt4 overflow-x-hidden bg-gray0-d white-d flex flex-column'>
@@ -174,11 +172,9 @@ export class NewScreen extends Component<NewScreenProps, NewScreenState> {
             onChange={this.descriptionChange}
           />
           <div className='mv7'>
-            <input
-              type='checkbox'
-              style={{ WebkitAppearance: 'none', width: 28 }}
-              onChange={this.groupPrivacyChange}
-              className={privacySwitchClasses}
+            <Toggle
+            boolean={this.state.privacy}
+            change={this.groupPrivacyChange}
             />
             <span className='dib f9 white-d inter ml3'>Private Group</span>
             <p className='f9 gray2 pt1' style={{ paddingLeft: 40 }}>

--- a/pkg/interface/src/apps/publish/components/lib/settings.js
+++ b/pkg/interface/src/apps/publish/components/lib/settings.js
@@ -133,7 +133,7 @@ export class Settings extends Component {
       // don't give the option to make inclusive if we don't own the target
       // group
       const targetOwned = (state.targetGroup)
-        ? state.targetGroup.slice(0, window.ship.length+3) === `/~${window.ship}/`
+        ? Boolean(state.targetGroup.includes(`/~${window.ship}/`))
         : false;
       let inclusiveToggle = <div />;
       if (targetOwned) {

--- a/pkg/interface/src/apps/publish/components/lib/settings.js
+++ b/pkg/interface/src/apps/publish/components/lib/settings.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import { writeText } from '../../../../lib/util';
 import { Spinner } from '../../../../components/Spinner';
 import { InviteSearch } from '../../../../components/InviteSearch';
+import Toggle from '../../../../components/toggle';
 
 export class Settings extends Component {
   constructor(props) {
@@ -137,18 +137,12 @@ export class Settings extends Component {
         : false;
       let inclusiveToggle = <div />;
       if (targetOwned) {
-        // TODO toggle component into /lib
-        const inclusiveClasses = state.inclusive
-          ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-          : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
         inclusiveToggle = (
           <div className="mt4">
-            <input
-              type="checkbox"
-              style={{ WebkitAppearance: 'none', width: 28 }}
-              className={inclusiveClasses}
-              onChange={this.changeInclusive}
-            />
+          <Toggle
+            boolean={state.inclusive}
+            change={this.changeInclusive}
+          />
             <span className="dib f9 white-d inter ml3">
               Add all members to group
             </span>
@@ -201,10 +195,6 @@ export class Settings extends Component {
   }
 
   render() {
-    const commentsSwitchClasses = (this.state.comments)
-      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
-      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
-
     if (this.props.host.slice(1) === window.ship) {
       return (
         <div className="flex-column">
@@ -274,11 +264,9 @@ export class Settings extends Component {
             />
           </div>
           <div className="mv6">
-            <input
-              type="checkbox"
-              style={{ WebkitAppearance: 'none', width: 28 }}
-              className={commentsSwitchClasses}
-              onChange={this.changeComments}
+            <Toggle
+              boolean={this.state.comments}
+              change={this.changeComments}
             />
             <span className="dib f9 white-d inter ml3">Comments</span>
             <p className="f9 gray2 pt1" style={{ paddingLeft: 40 }}>
@@ -293,7 +281,7 @@ export class Settings extends Component {
         </div>
       );
     } else {
-      return copyShortcode;
+      return '';
     }
   }
 }

--- a/pkg/interface/src/components/toggle.js
+++ b/pkg/interface/src/components/toggle.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+
+export class Toggle extends Component {
+  render() {
+    const switchClasses = (this.props.boolean)
+      ? 'relative checked bg-green2 br3 h1 toggle v-mid z-0'
+      : 'relative bg-gray4 bg-gray1-d br3 h1 toggle v-mid z-0';
+
+    return (
+      <input
+        type="checkbox"
+        style={{ WebkitAppearance: 'none', width: 28 }}
+        className={switchClasses}
+        onChange={this.props.change}
+      />
+    );
+  }
+}
+
+export default Toggle;

--- a/pkg/interface/src/reducers/group-update.ts
+++ b/pkg/interface/src/reducers/group-update.ts
@@ -6,6 +6,7 @@ import {
   Group,
   Tags,
   GroupPolicy,
+  GroupPolicyDiff,
   OpenPolicyDiff,
   OpenPolicy,
   InvitePolicyDiff,
@@ -179,6 +180,8 @@ export default class GroupReducer<S extends GroupState> {
         this.openChangePolicy(diff.open, policy);
       } else if ('invite' in policy && 'invite' in diff) {
         this.inviteChangePolicy(diff.invite, policy);
+      } else if ('replace' in diff) {
+        state.groups[resourcePath].policy = diff.replace;
       } else {
         console.log('bad policy diff');
       }


### PR DESCRIPTION
- Fixed a latent bug where only the group's owner could change group settings, regardless of roles. Now any admin can change settings (given this pokes *our* ship, does this propagate?)
- Makes the "toggler" checkbox type into a common component and dedupes its use in the codebase. cc @g-a-v-i-n 
- Adds UI for toggling the group's privacy policy, as well as some reducer behaviour for the new policy.