### PR TITLE
vere: cleans up handling of fatal db errors

### DIFF
--- a/pkg/urbit/vere/db/lmdb.c
+++ b/pkg/urbit/vere/db/lmdb.c
@@ -38,7 +38,7 @@ u3_lmdb_init(const c3_c* pax_c, size_t siz_i)
   c3_w     ret_w;
 
   if ( (ret_w = mdb_env_create(&env_u)) ) {
-    fprintf(stderr, "lmdb: init fail: %s\n", mdb_strerror(ret_w));
+    fprintf(stderr, "lmdb: init fail: %s\r\n", mdb_strerror(ret_w));
     return 0;
   }
 
@@ -61,7 +61,7 @@ u3_lmdb_init(const c3_c* pax_c, size_t siz_i)
   }
 
   if ( (ret_w = mdb_env_open(env_u, pax_c, 0, 0664)) ) {
-    fprintf(stderr, "lmdb: failed to open event log: %s\n",
+    fprintf(stderr, "lmdb: failed to open event log: %s\r\n",
                      mdb_strerror(ret_w));
     //  XX dispose env_u
     //
@@ -93,7 +93,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
   //    XX why no MDB_RDONLY?
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, 0, &txn_u)) ) {
-    fprintf(stderr, "lmdb: gulf: txn_begin fail: %s\n", mdb_strerror(ret_w));
+    fprintf(stderr, "lmdb: gulf: txn_begin fail: %s\r\n", mdb_strerror(ret_w));
     return c3n;
   }
 
@@ -103,7 +103,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
     c3_w ops_w = MDB_CREATE | MDB_INTEGERKEY;
 
     if ( (ret_w = mdb_dbi_open(txn_u, "EVENTS", ops_w, &mdb_u)) ) {
-      fprintf(stderr, "lmdb: gulf: dbi_open fail: %s\n", mdb_strerror(ret_w));
+      fprintf(stderr, "lmdb: gulf: dbi_open fail: %s\r\n", mdb_strerror(ret_w));
       //  XX confirm
       //
       mdb_txn_abort(txn_u);
@@ -120,7 +120,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
     //  creates a cursor to point to the last event
     //
     if ( (ret_w = mdb_cursor_open(txn_u, mdb_u, &cur_u)) ) {
-      fprintf(stderr, "lmdb: gulf: cursor_open fail: %s\n",
+      fprintf(stderr, "lmdb: gulf: cursor_open fail: %s\r\n",
                       mdb_strerror(ret_w));
       //  XX confirm
       //
@@ -140,7 +140,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
       return c3y;
     }
     else if ( ret_w ) {
-      fprintf(stderr, "lmdb: gulf: head fail: %s\n",
+      fprintf(stderr, "lmdb: gulf: head fail: %s\r\n",
                       mdb_strerror(ret_w));
       mdb_cursor_close(cur_u);
       mdb_txn_abort(txn_u);
@@ -191,7 +191,7 @@ u3_lmdb_read(MDB_env* env_u,
   //  create a read-only transaction.
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
-    fprintf(stderr, "lmdb: read txn_begin fail: %s\n", mdb_strerror(ret_w));
+    fprintf(stderr, "lmdb: read txn_begin fail: %s\r\n", mdb_strerror(ret_w));
     return c3n;
   }
 
@@ -201,7 +201,7 @@ u3_lmdb_read(MDB_env* env_u,
     c3_w ops_w = MDB_CREATE | MDB_INTEGERKEY;
 
     if ( (ret_w = mdb_dbi_open(txn_u, "EVENTS", ops_w, &mdb_u)) ) {
-      fprintf(stderr, "lmdb: read: dbi_open fail: %s\n", mdb_strerror(ret_w));
+      fprintf(stderr, "lmdb: read: dbi_open fail: %s\r\n", mdb_strerror(ret_w));
       //  XX confirm
       //
       mdb_txn_abort(txn_u);
@@ -220,7 +220,7 @@ u3_lmdb_read(MDB_env* env_u,
     //  creates a cursor to iterate over keys starting at [eve_d]
     //
     if ( (ret_w = mdb_cursor_open(txn_u, mdb_u, &cur_u)) ) {
-      fprintf(stderr, "lmdb: read: cursor_open fail: %s\n",
+      fprintf(stderr, "lmdb: read: cursor_open fail: %s\r\n",
                       mdb_strerror(ret_w));
       //  XX confirm
       //
@@ -312,7 +312,7 @@ u3_lmdb_save(MDB_env* env_u,
   //  create a write transaction
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, 0, &txn_u)) ) {
-    fprintf(stderr, "lmdb: write: txn_begin fail: %s\n", mdb_strerror(ret_w));
+    fprintf(stderr, "lmdb: write: txn_begin fail: %s\r\n", mdb_strerror(ret_w));
     return c3n;
   }
 
@@ -322,7 +322,7 @@ u3_lmdb_save(MDB_env* env_u,
     c3_w ops_w = MDB_CREATE | MDB_INTEGERKEY;
 
     if ( (ret_w = mdb_dbi_open(txn_u, "EVENTS", ops_w, &mdb_u)) ) {
-      fprintf(stderr, "lmdb: write: dbi_open fail: %s\n", mdb_strerror(ret_w));
+      fprintf(stderr, "lmdb: write: dbi_open fail: %s\r\n", mdb_strerror(ret_w));
       mdb_txn_abort(txn_u);
       return c3n;
     }
@@ -343,7 +343,7 @@ u3_lmdb_save(MDB_env* env_u,
         MDB_val val_u = { .mv_size = siz_i[i_d],   .mv_data = byt_p[i_d] };
 
         if ( (ret_w = mdb_put(txn_u, mdb_u, &key_u, &val_u, ops_w)) ) {
-          fprintf(stderr, "lmdb: write failed on event %" PRIu64 "\n", key_d);
+          fprintf(stderr, "lmdb: write failed on event %" PRIu64 "\r\n", key_d);
           mdb_txn_abort(txn_u);
           return c3n;
         }
@@ -354,7 +354,7 @@ u3_lmdb_save(MDB_env* env_u,
   //  commit transaction
   //
   if ( (ret_w = mdb_txn_commit(txn_u)) ) {
-    fprintf(stderr, "lmdb: write failed: %s\n", mdb_strerror(ret_w));
+    fprintf(stderr, "lmdb: write failed: %s\r\n", mdb_strerror(ret_w));
     return c3n;
   }
 
@@ -376,7 +376,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
   //  create a read transaction
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
-    fprintf(stderr, "lmdb: meta read: txn_begin fail: %s\n",
+    fprintf(stderr, "lmdb: meta read: txn_begin fail: %s\r\n",
                     mdb_strerror(ret_w));
     return read_f(ptr_v, 0, 0);
   }
@@ -384,7 +384,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
   //  open the database in the transaction
   //
   if ( (ret_w =  mdb_dbi_open(txn_u, "META", 0, &mdb_u)) ) {
-    fprintf(stderr, "lmdb: meta read: dbi_open fail: %s\n",
+    fprintf(stderr, "lmdb: meta read: dbi_open fail: %s\r\n",
                     mdb_strerror(ret_w));
     mdb_txn_abort(txn_u);
     return read_f(ptr_v, 0, 0);
@@ -396,7 +396,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
     MDB_val val_u;
 
     if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, &val_u)) ) {
-      fprintf(stderr, "lmdb: read failed: %s\n", mdb_strerror(ret_w));
+      fprintf(stderr, "lmdb: read failed: %s\r\n", mdb_strerror(ret_w));
       mdb_txn_abort(txn_u);
       return read_f(ptr_v, 0, 0);
     }
@@ -425,7 +425,7 @@ u3_lmdb_save_meta(MDB_env*    env_u,
   //  create a write transaction
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, 0, &txn_u)) ) {
-    fprintf(stderr, "lmdb: meta write: txn_begin fail: %s\n",
+    fprintf(stderr, "lmdb: meta write: txn_begin fail: %s\r\n",
                     mdb_strerror(ret_w));
     return c3n;
   }
@@ -433,7 +433,7 @@ u3_lmdb_save_meta(MDB_env*    env_u,
   //  opens the database in the transaction
   //
   if ( (ret_w = mdb_dbi_open(txn_u, "META", MDB_CREATE, &mdb_u)) ) {
-    fprintf(stderr, "lmdb: meta write: dbi_open fail: %s\n",
+    fprintf(stderr, "lmdb: meta write: dbi_open fail: %s\r\n",
                     mdb_strerror(ret_w));
     mdb_txn_abort(txn_u);
     return c3n;
@@ -446,7 +446,7 @@ u3_lmdb_save_meta(MDB_env*    env_u,
     MDB_val val_u = { .mv_size = val_i,         .mv_data = val_p };
 
     if ( (ret_w = mdb_put(txn_u, mdb_u, &key_u, &val_u, 0)) ) {
-      fprintf(stderr, "lmdb: write failed: %s\n", mdb_strerror(ret_w));
+      fprintf(stderr, "lmdb: write failed: %s\r\n", mdb_strerror(ret_w));
       mdb_txn_abort(txn_u);
       return c3n;
     }
@@ -455,7 +455,7 @@ u3_lmdb_save_meta(MDB_env*    env_u,
   //  commit txn
   //
   if ( (ret_w = mdb_txn_commit(txn_u)) ) {
-    fprintf(stderr, "lmdb: meta write: commit failed: %s\n",
+    fprintf(stderr, "lmdb: meta write: commit failed: %s\r\n",
                     mdb_strerror(ret_w));
     return c3n;
   }

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -692,7 +692,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
   //
   {
     if ( 0 == (log_u->dir_u = u3_foil_folder(pax_c)) ) {
-      fprintf(stderr, "disk: failed to load pier at %s", pax_c);
+      fprintf(stderr, "disk: failed to load pier at %s\r\n", pax_c);
       c3_free(log_u);
       return 0;
     }
@@ -707,7 +707,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
     strcat(urb_c, "/.urb");
 
     if ( 0 == (log_u->urb_u = u3_foil_folder(urb_c)) ) {
-      fprintf(stderr, "disk: failed to load /.urb in %s", pax_c);
+      fprintf(stderr, "disk: failed to load /.urb in %s\r\n", pax_c);
       c3_free(urb_c);
       c3_free(log_u);
       return 0;
@@ -740,7 +740,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
     strcat(log_c, "/.urb/log");
 
     if ( 0 == (log_u->com_u = u3_foil_folder(log_c)) ) {
-      fprintf(stderr, "disk: failed to load /.urb/log in %s", pax_c);
+      fprintf(stderr, "disk: failed to load /.urb/log in %s\r\n", pax_c);
       c3_free(log_c);
       c3_free(log_u);
       return 0;
@@ -755,7 +755,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
       const size_t siz_i = 1099511627776;
 
       if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {
-        fprintf(stderr, "disk: failed to initialize database");
+        fprintf(stderr, "disk: failed to initialize database\r\n");
         c3_free(log_c);
         c3_free(log_u);
         return 0;
@@ -772,7 +772,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
     c3_d fir_d;
 
     if ( c3n == u3_lmdb_gulf(log_u->mdb_u, &fir_d, &log_u->dun_d) ) {
-      fprintf(stderr, "disk: failed to load latest event from database");
+      fprintf(stderr, "disk: failed to load latest event from database\r\n");
       c3_free(log_u);
       return 0;
     }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1210,7 +1210,13 @@ _pier_init(c3_w wag_w, c3_c* pax_c)
 u3_pier*
 u3_pier_stay(c3_w wag_w, u3_noun pax)
 {
-  u3_pier* pir_u = _pier_init(wag_w, u3r_string(pax));
+  u3_pier* pir_u;
+
+  if ( !(pir_u = _pier_init(wag_w, u3r_string(pax))) ) {
+    fprintf(stderr, "pier: stay: init fail\r\n");
+    u3_king_bail();
+    return 0;
+  }
 
   if ( c3n == u3_disk_read_meta(pir_u->log_u,  pir_u->who_d,
                                &pir_u->fak_o, &pir_u->lif_w) )
@@ -1420,7 +1426,13 @@ u3_pier_boot(c3_w  wag_w,                   //  config flags
              u3_noun pil,                   //  type-of/path-to pill
              u3_noun pax)                   //  path to pier
 {
-  u3_pier* pir_u = _pier_init(wag_w, u3r_string(pax));
+  u3_pier* pir_u;
+
+  if ( !(pir_u = _pier_init(wag_w, u3r_string(pax))) ) {
+    fprintf(stderr, "pier: boot: init fail\r\n");
+    u3_king_bail();
+    return 0;
+  }
 
   if ( c3n == _pier_boot_plan(pir_u, who, ven, pil) ) {
     fprintf(stderr, "pier: boot plan fail\r\n");


### PR DESCRIPTION
The error printfs in the database weren't all properly formatted, and top-level initialization failure was not being handled (resulting in a segmentation fault, as opposed to an error message and `exit(1);`).

/cc @botter-nidnul