### PR TITLE
kiln: get germ for actual desk

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -208,7 +208,7 @@
   ::
   ++  get-germ
     |=  =desk
-    =+  .^(=cass:clay %cw /(scot %p our)/home/(scot %da now))
+    =+  .^(=cass:clay %cw /(scot %p our)/[desk]/(scot %da now))
     ?-  ud.cass
       %0  %init
       %1  %that


### PR DESCRIPTION
This causes new ships to get a `%merge-no-merge-base` error after downloading the initial ota while merging into their own kids desk.  Not that big a deal since it merges correctly into their home desk.  For anyone who runs into this, you can workaround by manually running `|merge %kids (sein:title our now our) %kids, =gem %that`.