### PR TITLE
gen: use spur in +timers

### DIFF
--- a/pkg/arvo/gen/timers.hoon
+++ b/pkg/arvo/gen/timers.hoon
@@ -5,5 +5,5 @@
   [%tang >timers< ~]
 .^  (list [date=@da =duct])
   %bx
-  (en-beam:format [p.bec %$ r.bec] /debug/timers)
+  (en-beam:format [p.bec %$ r.bec] /timers/debug)
 ==


### PR DESCRIPTION
+en-beam expects a spur, reversing it for the final path rendering.