### PR TITLE
publish: fix issues with new groups

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -255,6 +255,11 @@
       =/  =group-path  (stab (slav %t i.t.t.path))
       =/  =md-resource    [`@tas`i.t.t.t.path (stab (slav %t i.t.t.t.t.path))]
       ``noun+!>((~(get by associations) [group-path md-resource]))
+    ::
+        [%x %resource @ *]
+      =/  app=@tas         i.t.t.path
+      =/  app-path=^path   t.t.t.path
+      ``noun+!>((~(get by resource-indices) app app-path))
     ==
   ::
   ++  on-agent  on-agent:def

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -2048,9 +2048,11 @@
       (emit-updates-and-state host.del book.del data.del del sty)
     =/  rid=resource
       (de-path:resource writers.data.del)
+    =?  cards  !=(our.bol entity.rid)
+      :_  cards
+      (group-pull-hook-poke [%add host.del rid])
     :_  state
-    :*  (group-pull-hook-poke [%add host.del rid])
-        (metadata-hook-poke [%add-synced host.del writers.data.del])
+    :*  (metadata-hook-poke [%add-synced host.del writers.data.del])
         cards
     ==
   ::

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1811,12 +1811,16 @@
       (de-path:resource writers.book)
     =/  =group
       (need (scry-group:grup rid))
-    :_  state(books (~(del by books) who.act book.act))
-    :~  `card`[%pass wir %agent [who.act %publish] %leave ~]
-        `card`[%give %fact [/primary]~ %publish-primary-delta !>(del)]
-        (group-proxy-poke who.act %remove-members rid (sy our.bol ~))
-        (group-poke %remove-group rid ~)
-    ==
+    =/  cards=(list card)
+      :~  [%pass wir %agent [who.act %publish] %leave ~]
+          [%give %fact [/primary]~ %publish-primary-delta !>(del)]
+      ==
+    =?  cards  hidden.group
+      %+  weld  cards
+      :~  (group-proxy-poke who.act %remove-members rid (sy our.bol ~))
+          (group-poke %remove-group rid ~)
+      ==
+    [cards state(books (~(del by books) who.act book.act))]
   ::  %read
   ::
       %read

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -54,6 +54,7 @@
       [%3 state-three]
       [%4 state-three]
       [%5 state-three]
+      [%6 state-three]
   ==
 ::
 +$  metadata-delta
@@ -69,7 +70,7 @@
   ==
 --
 ::
-=|  [%5 state-three]
+=|  [%6 state-three]
 =*  state  -
 %-  agent:dbug
 %+  verb  |
@@ -86,7 +87,6 @@
     :_  this
     :~  [%pass /view-bind %arvo %e %connect [~ /'publish-view'] %publish]
         [%pass /read/paths %arvo %c %warp our.bol q.byk.bol `rav]
-        [%pass /permissions %agent [our.bol %permission-store] %watch /updates]
         (invite-poke:main [%create /publish])
         :*  %pass  /invites  %agent  [our.bol %invite-store]  %watch
             /invitatory/publish
@@ -218,6 +218,26 @@
       ==
     ::
         %5
+      %=  $
+          -.p.old-state  %6
+          cards
+        %+  weld  cards
+        %+  roll  ~(tap by books.p.old-state)
+        |=  [[[who=@p book=@tas] nb=notebook] out=(list card)]
+        ^-  (list card)
+        ?.  =(who our.bol)
+          out
+        =/  rid  (de-path:resource writers.nb)
+        =/  grp=(unit group)  (scry-group:grup:main rid)
+        ?~  grp  out
+        ?:  hidden.u.grp
+          out
+        =/  =tag  [%publish (cat 3 'writers-' book)]
+        :_  out
+        (group-proxy-poke entity.rid %add-tag rid tag members.u.grp)
+      ==
+    ::
+        %6
       [cards this(state p.old-state)]
     ==
     ++  convert-notebook-3-4
@@ -995,6 +1015,22 @@
     [~ state]
   :_  state
   %-  zing
+  :-  ^-  (list card)
+    %+  roll  ~(tap by books)
+    |=  [[[who=@p book=@tas] nb=notebook] out=(list card)]
+    ^-  (list card)
+    ?.  =(who our.bol)
+      out
+    ?.  =(writers.nb path)
+      out
+    =/  rid  (de-path:resource writers.nb)
+    =/  grp=(unit group)  (scry-group:grup rid)
+    ?~  grp  out
+    ?:  hidden.u.grp
+      out
+    =/  =tag  [%publish (cat 3 'writers-' book)]
+    :_  out
+    (group-proxy-poke entity.rid %add-tag rid tag members.u.grp)
   %+  turn  ~(tap in ships)
   |=  who=@p
   ?.  (allowed who %read u.book)
@@ -1226,12 +1262,19 @@
   ^-  [(list card) write=path read=path]
   ?>  ?=(^ group-path.group)
   =/  scry-path
-    ;:(welp /(scot %p our.bol)/group-store/(scot %da now.bol) [%groups group-path.group] /noun)
-  =/  grp  .^((unit ^group) %gx scry-path)
+    ;:  welp
+      /(scot %p our.bol)/group-store/(scot %da now.bol)
+      [%groups group-path.group]
+      /noun
+    ==
+  =/  rid=resource  (de-path:resource group-path.group)
+  =/  grp=(unit ^group)  (scry-group:grup rid)
   ?:  use-preexisting.group
     ?~  grp  !!
     ?.  (is-managed group-path.group)  !!
-    `[group-path.group group-path.group]
+    =/  =tag  [%publish (cat 3 'writers-' book)]
+    :_  [group-path.group group-path.group]
+    [(group-proxy-poke entity.rid %add-tag rid tag members.u.grp)]~
   ::
   =/  =policy
     *open:policy
@@ -1684,10 +1727,9 @@
     ?>  ?=(^ subscribers.u.book)
     =/  cards=(list card)
       ~[(delete-dir pax)]
-
     =/  rid=resource
       (de-path:resource writers.u.book)
-    =?  cards  (is-managed:grup rid)
+    =?  cards  !(is-managed:grup rid)
       [(group-poke %remove-group rid ~) cards]
     [cards state]
   ::  %del-note:
@@ -1791,6 +1833,10 @@
     ?>  (team:title our.bol src.bol)
     =/  join-wire=wire
       /join-group/[(scot %p who.act)]/[book.act]
+    =/  meta=(unit (set path))
+      (metadata-resource-scry %publish /(scot %p who.act)/[book.act])
+    ?^  meta
+      (subscribe-notebook who.act book.act)
     =/  rid=resource
       [who.act book.act]
     =/  =cage
@@ -1954,6 +2000,19 @@
     %publish
     (scot %t (spat app-path))
     /noun
+  ==
+::
+++  metadata-resource-scry
+  |=  [app=@tas app-path=path]
+  ^-  (unit (set path))
+  ?.  .^(? %gu (scot %p our.bol) %metadata-store (scot %da now.bol) ~)  ~
+  .^  (unit (set path))
+    %gx
+    ;:  weld
+      /(scot %p our.bol)/metadata-store/(scot %da now.bol)/resource/[app]
+      app-path
+      /noun
+    ==
   ==
 ::
 ++  emit-metadata


### PR DESCRIPTION
Fixes the following issues
- stops leaving/deleting a group associated with a notebook just because you left the notebook
- stops publish from telling your group-pull-hook to subscribe to your group-hook, which causes an infinite loop
- sets group tags for notebooks to allow multiple writers, which fixes the disappearance of the "new post" button