### PR TITLE
vere: change lmdb mapsize for aarch64

### DIFF
--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -30,7 +30,7 @@ if [ -n "${HOST-}" ]
 then os=$(sed 's$^[^-]*-\([^-]*\)-.*$\1$' <<< "$HOST")
      cpu=$(sed 's$-.*$$' <<< ${HOST})
 else os=$(uname -s)
-     cpu=$(uname -p)
+     cpu=$(uname -m)
 fi
 
 case $(tr A-Z a-z <<< $cpu) in

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -46,6 +46,10 @@ case $(tr A-Z a-z <<< $cpu) in
   x86_64)
      defmacro U3_OS_ENDIAN_little 1
      ;;
+  aarch64)
+     defmacro U3_OS_ENDIAN_little 1
+     defmacro U3_CPU_aarch64 1
+     ;;
   *)
      echo "Unknown or unsupported CPU: '$cpu'" >&2
      exit 1

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -752,7 +752,11 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
     //  "[..] on 64-bit there is no penalty for making this huge (say 1TB)."
     //
     {
-      const size_t siz_i = 1099511627776;
+      #if defined(U3_CPU_aarch64) && defined(U3_OS_linux)
+        const size_t siz_i = 64424509440;
+      #else
+        const size_t siz_i = 1099511627776;
+      #endif
 
       if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {
         fprintf(stderr, "disk: failed to initialize database");


### PR DESCRIPTION
Adds aarch64 lines to `pkg/urbit/configure` and defines a new macro, `U3_CPU_aarch64`.

That macro is used in `pkg/urbit/vere/disk.c` to change the lmdb mapsize from 1TB to 60GB for aarch64 on linux, which was the previous (working) behavior #3014 

This fixes a problem with the mapsize on aarch64, tangentially discussed in #3173 

Uses #if defined instead of #ifdef in anticipation of macos on aarch64 being a thing before the end of the year.

@joemfb 