### PR TITLE
libsigsegv: disable stack vma check on arm

### DIFF
--- a/nix/nixcrpkgs/pkgs/libsigsegv/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libsigsegv/builder.sh
@@ -3,7 +3,7 @@ source $setup
 tar -xf $src
 
 cd libsigsegv-$version
-patch -p1 << 'HEREDOC'
+patch -p1 << 'PATCH_I386'
 --- a/src/fault-linux-i386.h    2020-06-25 23:46:02.099235491 +0000
 +++ b/src/fault-linux-i386.h    2020-06-25 23:45:48.679156892 +0000
 @@ -18,6 +18,7 @@
@@ -14,11 +14,31 @@ patch -p1 << 'HEREDOC'
  #if defined __x86_64__
  /* 64 bit registers */
 
-HEREDOC
+PATCH_I386
+patch -p1 << 'PATCH_ARM'
+--- a/src/fault-linux-arm.h
++++ b/src/fault-linux-arm.h
+@@ -17,6 +17,7 @@
+
+ #include "fault-posix-ucontext.h"
+
++#define HAVE_STACKVMA 0
+ #if defined(__aarch64__) || defined(__ARM_64BIT_STATE) || defined(__ARM_PCS_AAPCS64) /* 64-bit */
+
+ /* See glibc/sysdeps/unix/sysv/linux/aarch64/sys/ucontext.h.
+ 
+PATCH_ARM
 cd ..
 
 mkdir build
 cd build
+
+# Hack
+if [ $host = aarch64-linux-musleabi ]
+then
+  sed -i 's/^CFG_FAULT=$/CFG_FAULT=fault-linux-arm.h/' \
+    ../libsigsegv-$version/configure
+fi
 
 ../libsigsegv-$version/configure \
   --host=$host \

--- a/nix/pkgs/urbit/libsigsegv_fix.patch
+++ b/nix/pkgs/urbit/libsigsegv_fix.patch
@@ -7,4 +7,14 @@
 +#define HAVE_STACKVMA 0
  #if defined __x86_64__
  /* 64 bit registers */
+ 
+--- a/src/fault-linux-arm.h
++++ b/src/fault-linux-arm.h
+@@ -17,6 +17,7 @@
 
+ #include "fault-posix-ucontext.h"
+
++#define HAVE_STACKVMA 0
+ #if defined(__aarch64__) || defined(__ARM_64BIT_STATE) || defined(__ARM_PCS_AAPCS64) /* 64-bit */
+
+ /* See glibc/sysdeps/unix/sysv/linux/aarch64/sys/ucontext.h.


### PR DESCRIPTION
Adds the equivalent arm patches to the i386 patches added in #3054

These result in a dramatic speedup in running  `=a (bex 1.000.000.000)` just as they do on x86_x64

This also sneaks in a hack to `/nix/nixcrpkgs/pkgs/libsigsegv/builder.sh` that allows libsigsegv to configure itself properly when cross compiling release binaries from x86_64 to aarch64.

It won’t trigger for you, since you’re not doing that (yet) but it will make it a little easier for me to maintain my aarch64 static release binaries if that `if [ $host = aarch64-linux-musleabi ]` section is upstreamed.

@philipcmonk 