### PR TITLE
chat-hook: identify DMs correctly

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -20,8 +20,10 @@
       state-3
       state-4
       state-5
+      state-6
   ==
 ::
++$  state-6  [%6 state-base]
 +$  state-5  [%5 state-base]
 +$  state-4  [%4 state-base]
 +$  state-3  [%3 state-base]
@@ -50,7 +52,7 @@
   $%  [%chat-update update:store]
   ==
 --
-=|  state-5
+=|  state-6
 =*  state  -
 ::
 %-  agent:dbug
@@ -79,14 +81,14 @@
     =/  old  !<(versioned-state old-vase)
     =|  cards=(list card)
     |-
-    ?:  ?=(%5 -.old)
+    ?:  ?=(%6 -.old)
       [cards this(state old)]
-    ?:  ?=(?(%3 %4) -.old)
+    ?:  ?=(?(%3 %4 %5) -.old)
       =.  cards
         %+  weld  cards
         ^-  (list card)
         [%pass /pokeme %agent [our.bol %chat-hook] %poke %noun !>(%fix-dm)]~
-      $(-.old %5)
+      $(-.old %6)
     ?:  ?=(%2 -.old)
       =.  cards
         %+  weld  cards
@@ -397,15 +399,15 @@
   |=  [=path host=ship]
   ^-  (list card)
   ?>  ?=([@ @ *] path)
-  ?.  =('~' i.path)
-    ~
-  =/  =ship  (slav %p i.t.path)
+  =/  =ship  (slav %p i.path)
   ?:  =(ship our.bol)
     ::  local dm, no need to do cleanup
     ~
   ?:  ?=(^ (groups-of-chat path))
     ::  correctly initialized, no need to do cleanup
     ::
+    ~
+  ?.  =((end 3 4 i.t.path) 'dm--')
     ~
   :-  =-  [%pass /fixdm %agent [our.bol %chat-view] %poke %chat-view-action -]
       !>  ^-  action:view


### PR DESCRIPTION
The previous fix assumed that unmanaged chats are prepending with sig, which is no longer the case. Unfortunately, this means we can no longer reliably disambiguate unmanaged chats from managed ones. Instead, we check for `dm--` prefix. This has the potential risk of returning false negatives. 