### PR TITLE
gen: add validate-ship generator

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -172,7 +172,12 @@
     ==
   ::
   ++  on-leave  on-leave:def
-  ++  on-peek   on-peek:def
+  ++  on-peek   
+    |=  =path
+    ^-  (unit (unit cage))
+    ?.  ?=([%x %synced ~] path)
+      (on-peek:def path)
+    ``noun+!>(synced)
   ++  on-arvo   on-arvo:def
   ++  on-fail   on-fail:def
   --

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -49,7 +49,12 @@
     `this
   ::
   ++  on-leave  on-leave:def
-  ++  on-peek   on-peek:def
+  ++  on-peek   
+    |=  =path
+    ^-  (unit (unit cage))
+    ?.  ?=([%x %synced ~] path)
+      (on-peek:def path)
+    ``noun+!>(synced)
   ++  on-arvo   on-arvo:def
   ++  on-fail   on-fail:def
   ++  on-poke

--- a/pkg/arvo/gen/validate-ship.hoon
+++ b/pkg/arvo/gen/validate-ship.hoon
@@ -1,0 +1,108 @@
+::  Validate userspace state
+::
+::  /hoon/validate-ship/gen
+::
+/+  resource
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [~ ~]
+    ==
+:-  %noun
+=|  issues=(list tape)
+|^
+=.  issues
+  check-group-syncs
+issues
+::
+++  scry-synced
+  |=  app=term
+  ^-  (set path)
+  %~  key  by
+  .^  (map path ship)
+    %gx
+    (scot %p p.beak)
+    app
+    (scot %da now)
+    /synced/noun
+  ==
+::
+++  scry-grp-push-syncs
+  ^-  (set resource)
+  .^  (set resource) 
+    %gx
+    (scot %p p.beak)
+    %group-push-hook
+    (scot %da now)
+    /synced/noun
+  ==
+::
+++  scry-grp-pull-syncs
+  ^-  (set resource)
+  %~  key  by
+  .^  (map resource ship)
+    %gx
+    (scot %p p.beak)
+    %group-pull-hook
+    (scot %da now)
+    /synced/noun
+  ==
+::
+++  report-missing-syncs
+  |*  [app=term syncs=(set)]
+  ^+  issues
+  %+  weld
+    issues
+  %+  turn
+    ~(tap in syncs)
+  |=(thing=* "{<app>}-hook missing: {<thing>}")
+::  +check-group-syncs: validate sync for group
+::
+::    ensure that syncs are correctly set up for each
+::    hook that has group associated resources
+++  check-group-syncs
+  ^+  issues
+  =/  groups=(set resource)
+    %-  sy
+    %+  turn
+      %~  tap  in
+      %~  key  by
+      =<  dir
+      .^  arch
+        %gy
+        (scot %p p.beak)
+        %group-store
+        (scot %da now)
+        /groups
+      ==
+    (corl de-path:resource stab)
+  =/  [ours=(list resource) theirs=(list resource)]
+     (skid ~(tap by groups) |=(rid=resource =(p.beak entity.rid)))
+  =/  pull-syncs=(set resource)
+    scry-grp-pull-syncs
+  =/  push-syncs=(set resource)
+    scry-grp-push-syncs
+  =/  group-paths=(set path)
+    (sy (turn ~(tap in groups) en-path:resource))
+  =/  md-syncs=(set path)
+    (scry-synced %metadata-hook)
+  =/  contact-syncs=(set path)
+    (scry-synced %contact-hook)
+  =.  issues
+    %+  report-missing-syncs
+      %metadata
+    (~(dif in md-syncs) group-paths)
+  =.  issues
+    %+  report-missing-syncs
+      %contact
+    (~(dif in contact-syncs) group-paths)
+  =.  issues
+    %+  report-missing-syncs
+      %group-push
+    (~(dif in push-syncs) (silt ours))
+  =.  issues
+    %+  report-missing-syncs
+      %group-pull
+    (~(dif in pull-syncs) (silt theirs))
+  issues
+--
+

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -209,7 +209,11 @@
         =^  cards  pull-hook
           (on-fail:og term tang)
         [cards this]
-      ++  on-peek   on-peek:def
+      ++  on-peek   
+        |=  =path
+        ?:  ?=([%x %synced ~] path)
+          ``noun+!>(tracking)
+        (on-peek:def path)
     --
   |_  =bowl:gall
   +*  og   ~(. pull-hook bowl)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -194,7 +194,12 @@
         =^  cards  push-hook
           (on-fail:og term tang)
         [cards this]
-      ++  on-peek   on-peek:og
+      ++  on-peek   
+        |=  =path
+        ^-  (unit (unit cage))
+        ?.  ?=([%x %synced ~] path)
+          (on-peek:def path)
+        ``noun+!>(sharing)
     --
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)


### PR DESCRIPTION
+validate-ship scries for the groups the ship belongs to and then
validates that the associated syncs are setup in their hooks.

In future, this should be expanded to validate all of our foreign-key type relations, their associated syncs and path structure where relevant.

