### PR TITLE
Hid vertical overflow on group join box

### DIFF
--- a/pkg/interface/src/apps/groups/components/join.js
+++ b/pkg/interface/src/apps/groups/components/join.js
@@ -101,14 +101,12 @@ export class JoinScreen extends Component {
           <p className="f8 lh-copy mt3 db">Enter a <span className="mono">~ship/group-name</span></p>
           <p className="f9 gray2 mb4">Group names use lowercase, hyphens, and slashes.</p>
           <textarea
-            ref={ (e) => {
-            this.textarea = e;
-            } }
             className={'f7 mono ba bg-gray0-d white-d pa3 mb2 db ' +
-            'focus-b--black focus-b--white-d b--gray3 b--gray2-d nowrap '}
+            'focus-b--black focus-b--white-d b--gray3 b--gray2-d nowrap overflow-y-hidden'}
             placeholder="~zod/group-name"
             spellCheck="false"
             rows={1}
+            cols={32}
             onKeyPress={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
@@ -116,7 +114,7 @@ export class JoinScreen extends Component {
               }
             }}
             style={{
-              resize: 'none'
+              resize: 'none',
             }}
             onChange={this.groupChange}
             value={this.state.group}


### PR DESCRIPTION
The vertical overflow on this box has always bugged me. I assume you didn't make it an `<input />` because you wanted the scrollability. If 'nowrap' is set, 'overflow-y-hidden' follows naturally...right?