### PR TITLE
groups: admins and mods can invite users

### DIFF
--- a/pkg/interface/src/apps/groups/components/lib/contact-sidebar.tsx
+++ b/pkg/interface/src/apps/groups/components/lib/contact-sidebar.tsx
@@ -155,7 +155,7 @@ export class ContactSidebar extends Component<ContactSidebarProps, ContactSideba
         <div className="overflow-auto h-100">
           <Link
             to={'/~groups/add' + props.path}
-            className={((props.path.includes(window.ship))
+            className={((role === "admin" || role === "moderator")
               ? 'dib'
               : 'dn')}
           >


### PR DESCRIPTION
Check for our role in the group instead of checking the path, in order to check whether we should allow the user to attempt to invite members to the group.