### PR TITLE
chat: truncate long nicknames

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/message.js
+++ b/pkg/interface/src/apps/chat/components/lib/message.js
@@ -85,8 +85,8 @@ export class Message extends Component {
             <p className={`v-mid f9 gray2 dib mr3 c-default`}>
               <span
                 className={
-                  'pointer ' +
-                  (contact.nickname || state.copied ? null : 'mono')
+                  'mw5 dib truncate pointer ' +
+                  (contact.nickname || state.copied ? '' : 'mono')
                 }
                 onClick={() => {
                   writeText(props.msg.author);

--- a/pkg/interface/src/apps/chat/components/lib/profile-overlay.js
+++ b/pkg/interface/src/apps/chat/components/lib/profile-overlay.js
@@ -46,7 +46,7 @@ export class ProfileOverlay extends Component {
     if (!(top || bottom)) {
       bottom = `-${Math.round(OVERLAY_HEIGHT / 2)}px`;
     }
-    const containerStyle = { top, bottom, left: '100%' };
+    const containerStyle = { top, bottom, left: '100%', maxWidth: '160px' };
 
     const isOwn = window.ship === ship;
 
@@ -79,7 +79,7 @@ export class ProfileOverlay extends Component {
         </div>
         <div className="pv3 pl3 pr2">
           {contact && contact.nickname && (
-            <div className="b white-d">{contact.nickname}</div>
+            <div className="b white-d truncate">{contact.nickname}</div>
           )}
           <div className="mono gray2">{cite(`~${ship}`)}</div>
           {!isOwn && (


### PR DESCRIPTION
- Prevents overlay panel from expanding beyond 160px, truncates long nicknames
- Messages truncate nicknames beyond `mw5`, which still allows for moderately long names without creating too much overflow.