### PR TITLE
Interface: Add smart scrolling to group member list

### DIFF
--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -5985,6 +5985,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -7489,6 +7494,15 @@
         "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "readable-stream": {
@@ -9565,7 +9579,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9586,12 +9601,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9606,17 +9623,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9733,7 +9753,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9745,6 +9766,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9759,6 +9781,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9766,12 +9789,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9790,6 +9815,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -9851,7 +9877,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -9879,7 +9906,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9891,6 +9919,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9968,7 +9997,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10004,6 +10034,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10023,6 +10054,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10066,12 +10098,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10552,7 +10586,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10573,12 +10608,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10593,17 +10630,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10720,7 +10760,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10732,6 +10773,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10746,6 +10788,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10753,12 +10796,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10777,6 +10822,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -10838,7 +10884,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -10866,7 +10913,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10878,6 +10926,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10955,7 +11004,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10991,6 +11041,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11010,6 +11061,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11053,12 +11105,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^16.8.6",
     "react-markdown": "^4.3.1",
     "react-router-dom": "^5.0.0",
+    "react-window": "^1.8.5",
     "remark-disable-tokenizers": "^1.0.24",
     "style-loader": "^1.2.1",
     "styled-components": "^5.1.0",

--- a/pkg/interface/src/apps/groups/components/lib/contact-sidebar.tsx
+++ b/pkg/interface/src/apps/groups/components/lib/contact-sidebar.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import { FixedSizeList as List } from 'react-window';
+
 import { ContactItem } from './contact-item';
 import { ShareSheet } from './share-sheet';
 import { Sigil } from '../../../../lib/sigil';
@@ -23,6 +25,7 @@ interface ContactSidebarProps {
 }
 interface ContactSidebarState {
 	awaiting: boolean;
+  memberboxHeight: number;
 }
 
 
@@ -31,9 +34,20 @@ export class ContactSidebar extends Component<ContactSidebarProps, ContactSideba
   constructor(props) {
     super(props);
     this.state = {
-      awaiting: false
+      awaiting: false,
+      memberboxHeight: 0
     };
+    this.memberbox = this.memberbox.bind(this);
   }
+
+  memberbox(element) {
+    if (element) {
+      this.setState({
+        memberboxHeight: element.getBoundingClientRect().height
+      })
+    }
+  }
+
   render() {
     const { props } = this;
 
@@ -145,14 +159,14 @@ export class ContactSidebar extends Component<ContactSidebarProps, ContactSideba
     const detailHref = `/~groups/detail${props.path}`;
 
     return (
-      <div className={'bn br-m br-l br-xl b--gray4 b--gray1-d lh-copy h-100 ' +
+      <div ref={this.memberbox} className={'bn br-m br-l br-xl b--gray4 b--gray1-d lh-copy h-100 ' +
       'flex-basis-100-s flex-basis-30-ns mw5-m mw5-l mw5-xl relative ' +
       'overflow-hidden flex-shrink-0 ' + responsiveClasses}
       >
         <div className="pt3 pb5 pl3 f8 db dn-m dn-l dn-xl">
           <Link to="/~groups/">{'⟵ All Groups'}</Link>
         </div>
-        <div className="overflow-auto h-100">
+        <div className="overflow-auto h-100 flex flex-column">
           <Link
             to={'/~groups/add' + props.path}
             className={((props.path.includes(window.ship))
@@ -166,8 +180,20 @@ export class ContactSidebar extends Component<ContactSidebarProps, ContactSideba
           >Channels</Link>
           {shareSheet}
           <h2 className="f9 pt4 pr4 pb2 pl4 gray2 c-default">Members</h2>
-          {contactItems}
-          {groupItems}
+          <List
+            height={this.state.memberboxHeight}
+            className="flex-auto"
+            itemCount={contactItems.length + groupItems.length}
+            itemSize={44}
+            width="100%"
+          >
+            {({ index, style }) => (<div style={style}>{
+              index <= (contactItems.length - 1) // If the index is within the length of contact items,
+                ? contactItems[index] // show a contact item
+                : groupItems[index - contactItems.length] // Otherwise show a group item
+              }</div>)}
+          </List>
+
         </div>
         <Spinner awaiting={this.state.awaiting} text="Removing from group..." classes="pa2 ba absolute right-1 bottom-1 b--gray1-d" />
         </div>

--- a/pkg/interface/src/components/Group.tsx
+++ b/pkg/interface/src/components/Group.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import _, { capitalize } from 'lodash';
+import { FixedSizeList as List } from 'react-window';
+
 import { Dropdown } from '../apps/publish/components/lib/dropdown';
 import { cite, deSig } from '../lib/util';
 import { roleForShip, resourceFromPath } from '../lib/group';
@@ -199,52 +201,45 @@ export class GroupView extends Component<
     });
   }
 
-  renderMembers() {
+  memberElements() {
     const { group, permissions } = this.props;
     const { members } = group;
     const isAdmin = this.isAdmin();
-    return (
-      <div className='flex flex-column'>
-        <div className='f9 gray2 mt6 mb3'>Members</div>
-        {Array.from(members).map((ship) => {
-          const role = roleForShip(group, deSig(ship));
-          const onRoleRemove =
-            role && isAdmin
-              ? () => {
-                  this.removeTag(ship, { tag: role });
-                }
-              : undefined;
-          const [present, missing] = this.getAppTags(ship);
-          const options = this.optionsForShip(ship, missing);
+    return Array.from(members).map((ship) => {
+      const role = roleForShip(group, deSig(ship));
+      const onRoleRemove =
+        role && isAdmin
+          ? () => {
+              this.removeTag(ship, { tag: role });
+            }
+          : undefined;
+      const [present, missing] = this.getAppTags(ship);
+      const options = this.optionsForShip(ship, missing);
 
-          return (
-            <div key={ship} className='flex flex-column pv3'>
-              <GroupMember ship={ship} options={options}>
-                {((permissions && role) || present.length > 0) && (
-                  <div className='flex mt1'>
-                    {role && (
-                      <Tag
-                        onRemove={onRoleRemove}
-                        description={capitalize(role)}
-                      />
-                    )}
-                    {present.map((tag, idx) => (
-                      <Tag
-                        key={idx}
-                        onRemove={this.doIfAdmin(() =>
-                          this.removeTag(ship, tag)
-                        )}
-                        description={tag.desc}
-                      />
-                    ))}
-                  </div>
-                )}
-              </GroupMember>
+      return (
+        <GroupMember ship={ship} options={options}>
+          {((permissions && role) || present.length > 0) && (
+            <div className='flex mt1'>
+              {role && (
+                <Tag
+                  onRemove={onRoleRemove}
+                  description={capitalize(role)}
+                />
+              )}
+              {present.map((tag, idx) => (
+                <Tag
+                  key={idx}
+                  onRemove={this.doIfAdmin(() =>
+                    this.removeTag(ship, tag)
+                  )}
+                  description={tag.desc}
+                />
+              ))}
             </div>
-          );
-        })}
-      </div>
-    );
+          )}
+        </GroupMember>
+      );
+    })
   }
 
   setInvites(invites: Invites) {
@@ -321,6 +316,7 @@ export class GroupView extends Component<
   render() {
     const { group, resourcePath, className } = this.props;
     const resource = resourceFromPath(resourcePath);
+    const memberElements = this.memberElements();
 
     return (
       <div className={className}>
@@ -332,7 +328,17 @@ export class GroupView extends Component<
         </div>
         {'invite' in group.policy && this.renderInvites(group.policy)}
         {'open' in group.policy && this.renderBanned(group.policy)}
-        {this.renderMembers()}
+        <div className='flex flex-column'>
+          <div className='f9 gray2 mt6 mb3'>Members</div>
+          <List
+            height={500}
+            itemCount={memberElements.length}
+            itemSize={44}
+            width="100%"
+          >
+          {({ index, style }) => <div key={index} style={style} className='flex flex-column pv3'>{memberElements[index]}</div>}
+          </List>
+        </div>
 
         <Spinner
           awaiting={this.state.awaiting}


### PR DESCRIPTION
This uses `react-window`, which is a minimal rewrite of `react-virtualized` mentioned by @galenwp  in #2983.
Basically it combines the "members" and "contacts" into an array, and given an index, either returns members first or contacts if it's shown all the members.

It's not pretty but...it works?