### PR TITLE
king: ames: add stderr when sending before having turfs

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -229,7 +229,7 @@ ames env who isFake enqueueEv stderr = (initialEvents, runAmes)
 
     NewtEfSend (_id, ()) dest (MkBytes bs) -> do
       atomically (readTVar aTurfs) >>= \case
-        Nothing    -> pure ()
+        Nothing    -> stderr "ames: send before turfs" >> pure ()
         Just turfs -> sendPacket drv mode dest bs
 
   sendPacket :: AmesDrv -> NetworkMode -> AmesDest -> ByteString -> RIO e ()


### PR DESCRIPTION
This will help us investigate #3176. We have the hypothesis that this condition leads to delay in sending ames messages on kh start. But since I can't repro the issue, I can't test this hypoth. OTOH, if users run into this problem in the wild, they will be able to inform us whether they see these messages or not.