### PR TITLE
publish-js: account for missing group

### DIFF
--- a/pkg/interface/src/apps/publish/components/lib/notebook.js
+++ b/pkg/interface/src/apps/publish/components/lib/notebook.js
@@ -179,7 +179,7 @@ export class Notebook extends Component {
 
 
     const group = props.groups[notebook?.['writers-group-path']];
-    const role = roleForShip(group, window.ship);
+    const role = group ? roleForShip(group, window.ship) : undefined;
 
     const subsComponent = (this.props.ship.slice(1) === window.ship) || (role === 'admin') 
       ? (<Link to={subs} className={tabStyles.subscribers}>


### PR DESCRIPTION
does what it says on the tin. the group is only missing because we haven't loaded it yet i.e. creating a new unmanaged notebook. 