### PR TITLE
Remove lodash dependency

### DIFF
--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -14,7 +14,6 @@
     "codemirror": "^5.51.0",
     "css-loader": "^3.5.3",
     "formik": "^2.1.4",
-    "lodash": "^4.17.15",
     "markdown-to-jsx": "^6.11.4",
     "moment": "^2.20.1",
     "mousetrap": "^1.6.5",

--- a/pkg/interface/src/apps/chat/components/lib/chat-input.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-input.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import moment from 'moment';
 import { UnControlled as CodeEditor } from 'react-codemirror2';
 import CodeMirror from 'codemirror';
@@ -339,12 +338,10 @@ export class ChatInput extends Component {
         classes={sigilClass}
         />;
 
-    const candidates = _.chain(this.props.envelopes)
-      .defaultTo([])
-      .map('author')
-      .uniq()
-      .reverse()
-      .value();
+    const candidates = this.props.envelopes
+      .map(envelope => envelope.author)
+      .filter((value, index, self) => self.indexOf(value) === index)
+      .reverse();
 
     const codeTheme = state.code ? ' code' : '';
 

--- a/pkg/interface/src/apps/chat/components/lib/ship-search.js
+++ b/pkg/interface/src/apps/chat/components/lib/ship-search.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import urbitOb from 'urbit-ob';
 import Mousetrap from 'mousetrap';
 
@@ -119,35 +118,30 @@ export class ShipSearch extends Component {
 
       return (
         hay.startsWith(needle) ||
-        _.some(_.words(hay), s => s.startsWith(needle))
+        hay.split(/\s/).some(s => s.startsWith(needle))
       );
     };
 
     let candidates = this.state.suggestions;
 
     if (isStale || this.state.suggestions.length === 0) {
-      const contacts = _.chain(this.props.contacts)
-        .defaultTo({})
-        .map((details, ship) => ({ ...details, ship }))
-        .filter(
-          ({ nickname, ship }) => matchString(nickname) || matchString(ship)
-        )
-        .map('ship')
-        .value();
+      const contacts = Object.keys(this.props.contacts)
+        .map((ship) => ({ ...this.props.contacts[ship], ship}))
+        .filter(({ nickname, ship }) => matchString(nickname) || matchString(ship))
+        .map((details) => details.ship);
 
       const exactMatch = urbitOb.isValidPatp(`~${needle}`) ? [needle] : [];
 
-      candidates = _.chain(this.props.candidates)
-        .defaultTo([])
-        .union(contacts)
-        .union(exactMatch)
-        .value();
+      candidates = this.props.candidates
+        .concat(contacts)
+        .concat(exactMatch)
+        .filter((value, index, self) => self.indexOf(value) === index);
+
     }
 
-    const suggestions = _.chain(candidates)
+    const suggestions = candidates
       .filter(matchString)
-      .filter(s => s.length < 28) // exclude comets
-      .value();
+      .filter(s => s.length < 28); // exclude comets
 
     this.bindShortcuts();
     this.setState({ suggestions, selected: suggestions[0] });

--- a/pkg/interface/src/apps/dojo/api.js
+++ b/pkg/interface/src/apps/dojo/api.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export default class Api {
   constructor(ship, channel) {
     this.ship = ship;
@@ -9,7 +7,7 @@ export default class Api {
   }
 
   bind(path, method, ship = this.ship, appl = 'dojo', success, fail) {
-    this.bindPaths = _.uniq([...this.bindPaths, path]);
+    this.bindPaths = [...this.bindPaths, path].filter((value, index, self) => self.indexOf(value) === index);
 
     window.subscriptionId = this.channel.subscribe(ship, appl, path,
       (err) => {

--- a/pkg/interface/src/apps/groups/components/lib/add-contact.tsx
+++ b/pkg/interface/src/apps/groups/components/lib/add-contact.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import { Link } from 'react-router-dom';
 import { InviteSearch, Invites } from '../../../../components/InviteSearch';
 import { Spinner } from '../../../../components/Spinner';

--- a/pkg/interface/src/apps/links/app.js
+++ b/pkg/interface/src/apps/links/app.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 
-import _ from 'lodash';
-
 import './css/custom.css';
 
 import { Skeleton } from './components/skeleton';
@@ -41,7 +39,7 @@ export class LinksApp extends Component {
   render() {
     const { props } = this;
 
-    const contacts = props.contacts ? props.contacts : {}; 
+    const contacts = props.contacts ? props.contacts : {};
 
     const groups = props.groups ? props.groups : {};
 
@@ -54,17 +52,14 @@ export class LinksApp extends Component {
     const selectedGroups = props.selectedGroups ? props.selectedGroups : [];
 
     const selGroupPaths = selectedGroups.map(g => g[0]);
-    const totalUnseen = _.reduce(
-      links,
-      (acc, collection, path) => {
+    const totalUnseen = Object.entries(links)
+      .reduce((acc, [path, collection]) => {
         if(selGroupPaths.length > 0
            && !selGroupPaths.includes(associations.link?.[path]?.['group-path'])) {
           return acc;
         }
-        return acc + collection.unseenCount;
-      },
-      0
-    );
+        return acc + (collection.unseenCount || 0);
+      }, 0);
 
     if(totalUnseen !== this.totalUnseen) {
       document.title = totalUnseen !== 0 ? `(${totalUnseen}) OS1 - Links` : 'OS1 - Links';

--- a/pkg/interface/src/apps/publish/app.js
+++ b/pkg/interface/src/apps/publish/app.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import _ from 'lodash';
 
 import './css/custom.css';
 
@@ -46,19 +45,17 @@ export default class PublishApp extends React.Component {
 
     const notebooks = props.notebooks ? props.notebooks : {};
 
-    const unreadTotal = _.chain(notebooks)
-      .values()
-      .map(_.values)
-      .flatten() // flatten into array of notebooks
+    const unreadTotal = Object.values(notebooks)
+      .map((owner) => Object.values(owner))
+      .flat()
       .filter((each) => {
         return ((selectedGroups.map((e) => {
           return e[0];
         }).includes(each?.['writers-group-path'])) ||
         (selectedGroups.length === 0));
       })
-      .map('num-unread')
-      .reduce((acc, count) => acc + count, 0)
-      .value();
+      .map((each) => each['num-unread'])
+      .reduce((acc, count) => acc + count, 0);
 
     if (this.unreadTotal !== unreadTotal) {
       document.title = unreadTotal > 0 ? `(${unreadTotal}) OS1 - Publish` : 'OS1 - Publish';

--- a/pkg/interface/src/components/Group.tsx
+++ b/pkg/interface/src/components/Group.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _, { capitalize } from 'lodash';
 import { FixedSizeList as List } from 'react-window';
 
 import { Dropdown } from '../apps/publish/components/lib/dropdown';
@@ -181,7 +180,7 @@ export class GroupView extends Component<
           (acc, role) => [
             ...acc,
             {
-              text: `Make ${capitalize(role)}`,
+              text: `Make ${role.charAt(0).toUpperCase()}${role.slice(1).toLowerCase()}`,
               onSelect: () => this.addTag(ship, { tag: role }),
             },
           ],
@@ -200,10 +199,14 @@ export class GroupView extends Component<
   getAppTags(ship: Patp): [GroupViewAppTag[], GroupViewAppTag[]] {
     const { tags } = this.props.group;
     const { appTags } = this.props;
-
-    return _.partition(appTags, ({ app, tag }) => {
+    const criterion = ({ app, tag }) => {
       return tags?.[app]?.[tag]?.has(ship);
-    });
+    };
+
+    return appTags ? [
+      appTags.filter(appTag => criterion(appTag)),
+      appTags.filter(appTag => !criterion(appTag)),
+    ] : [[], []];
   }
 
   memberElements() {
@@ -228,7 +231,7 @@ export class GroupView extends Component<
               {role && (
                 <Tag
                   onRemove={onRoleRemove}
-                  description={capitalize(role)}
+                  description={`${role.charAt(0).toUpperCase()}${role.slice(1).toLowerCase()}`}
                 />
               )}
               {present.map((tag, idx) => (

--- a/pkg/interface/src/components/InviteSearch.tsx
+++ b/pkg/interface/src/components/InviteSearch.tsx
@@ -1,5 +1,4 @@
 import React, { Component, createRef } from 'react';
-import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 import urbitOb from 'urbit-ob';
 import { Sigil } from '../lib/sigil';
@@ -90,7 +89,8 @@ export class InviteSearch extends Component<
     const peerSet = new Set<PatpNoSig>();
     const contacts = new Map();
 
-    _.map(this.props.groups, (group, path) => {
+    Object.keys(this.props.groups).forEach((path) => {
+      const group = this.props.groups[path];
       if (group.members.size > 0) {
         const groupEntries = group.members.values();
         for (const member of groupEntries) {
@@ -98,7 +98,7 @@ export class InviteSearch extends Component<
         }
       }
 
-	    const groupContacts = this.props.contacts[path];
+      const groupContacts = this.props.contacts[path];
 
       if (groupContacts) {
         const groupEntries = group.members.values();
@@ -117,6 +117,7 @@ export class InviteSearch extends Component<
         }
       }
     });
+
     peers = Array.from(peerSet);
 
     this.setState({ groups: groups, peers: peers, contacts: contacts });
@@ -177,7 +178,7 @@ export class InviteSearch extends Component<
       const shipIdx = shipMatches.findIndex((ship) => ship === selected);
       const staleSelection = groupIdx < 0 && shipIdx < 0;
       if (!selected || staleSelection) {
-        const newSelection = _.get(groupMatches, '[0][0]') || shipMatches[0];
+        const newSelection = (groupMatches[0] && groupMatches[0].length) ? groupMatches[0][0] : shipMatches[0];
         this.setState({ selected: newSelection });
       }
 
@@ -236,7 +237,7 @@ export class InviteSearch extends Component<
     let shipIdx = ships.findIndex((ship) => ship === selected);
     if (groupIdx >= 0) {
       backward ? groupIdx-- : groupIdx++;
-      let selected = _.get(groups, [groupIdx, 0]);
+      let selected = groups[groupIdx][0];
       if (groupIdx === groups.length) {
         selected = ships.length === 0 ? groups[0][0] : ships[0];
       }

--- a/pkg/interface/src/lib/util.js
+++ b/pkg/interface/src/lib/util.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export function resourceAsPath(resource) {
   const { name, ship } = resource;
   return `/ship/~${ship}/${name}`;
@@ -88,7 +86,7 @@ function hexToDec(hex) {
 }
 
 export function hexToRgba(hex, a) {
-  const [r,g,b] = _.chunk(hex, 2).map(hexToDec);
+  const [r,g,b] = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex).map(hexToDec);
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 

--- a/pkg/interface/src/reducers/chat-update.ts
+++ b/pkg/interface/src/reducers/chat-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { ChatUpdate } from '../types/chat-update';
@@ -26,7 +25,7 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   initial(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'initial', false);
+    const data = json['initial'] || false;
     if (data) {
       state.inbox = data;
       state.chatInitialized = true;
@@ -38,7 +37,7 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   message(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'message', false);
+    const data = json['message'] || false;
     if (data) {
       state.inbox[data.path].envelopes.unshift(data.envelope);
       state.inbox[data.path].config.length
@@ -47,7 +46,7 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   messages(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'messages', false);
+    const data = json['message'] || false;
     if (data) {
       state.inbox[data.path].envelopes =
         state.inbox[data.path].envelopes.concat(data.envelopes);
@@ -55,7 +54,7 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   read(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'read', false);
+    const data = json['read'] || false;
     if (data) {
       state.inbox[data.path].config.read =
         state.inbox[data.path].config.length;
@@ -63,7 +62,7 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   create(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'create', false);
+    const data = json['create'] || false;
     if (data) {
       state.inbox[data.path] = {
         envelopes: [],
@@ -76,14 +75,14 @@ export default class ChatReducer<S extends ChatState> {
   }
 
   delete(json: ChatUpdate, state: S) {
-    const data = _.get(json, 'delete', false);
+    const data = json['delete'] || false;
     if (data) {
       delete state.inbox[data.path];
     }
   }
 
   pending(json: ChatUpdate, state: S) {
-    const msg = _.get(json, 'message', false);
+    const data = json['message'] || false;
     if (!msg || !state.pendingMessages.has(msg.path)) {
       return;
     }

--- a/pkg/interface/src/reducers/connection.ts
+++ b/pkg/interface/src/reducers/connection.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 

--- a/pkg/interface/src/reducers/contact-update.ts
+++ b/pkg/interface/src/reducers/contact-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { ContactUpdate } from '../types/contact-update';
@@ -19,28 +18,28 @@ export default class ContactReducer<S extends ContactState>  {
   }
 
   initial(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'initial', false);
+    const data = json['initial'] || false;
     if (data) {
       state.contacts = data;
     }
   }
 
   create(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'create', false);
+    const data = json['create'] || false;
     if (data) {
       state.contacts[data.path] = {};
     }
   }
 
   delete(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'delete', false);
+    const data = json['delete'] || false;
     if (data) {
       delete state.contacts[data.path];
     }
   }
 
   add(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'add', false);
+    const data = json['add'] || false;
     if (
       data &&
       (data.path in state.contacts)
@@ -50,7 +49,7 @@ export default class ContactReducer<S extends ContactState>  {
   }
 
   remove(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'remove', false);
+    const data = json['remove'] || false;
     if (
       data &&
       (data.path in state.contacts) &&
@@ -61,7 +60,7 @@ export default class ContactReducer<S extends ContactState>  {
   }
 
   edit(json: ContactUpdate, state: S) {
-    const data = _.get(json, 'edit', false);
+    const data = json['edit'] || false;
     if (
       data &&
       (data.path in state.contacts) &&

--- a/pkg/interface/src/reducers/invite-update.ts
+++ b/pkg/interface/src/reducers/invite-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { InviteUpdate } from '../types/invite-update';
@@ -20,42 +19,42 @@ export default class InviteReducer<S extends InviteState> {
   }
 
   initial(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'initial', false);
+    const data = json['initial'] || false;
     if (data) {
       state.invites = data;
     }
   }
 
   create(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'create', false);
+    const data = json['create'] || false;
     if (data) {
       state.invites[data.path] = {};
     }
   }
 
   delete(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'delete', false);
+    const data = json['delete'] || false;
     if (data) {
       delete state.invites[data.path];
     }
   }
 
   invite(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'invite', false);
+    const data = json['invite'] || false;
     if (data) {
       state.invites[data.path][data.uid] = data.invite;
     }
   }
 
   accepted(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'accepted', false);
+    const data = json['accepted'] || false;
     if (data) {
       delete state.invites[data.path][data.uid];
     }
   }
 
   decline(json: InviteUpdate, state: S) {
-    const data = _.get(json, 'decline', false);
+    const data = json['decline'] || false;
     if (data) {
       delete state.invites[data.path][data.uid];
     }

--- a/pkg/interface/src/reducers/launch-update.ts
+++ b/pkg/interface/src/reducers/launch-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { LaunchUpdate } from '../types/launch-update';
 import { Cage } from '../types/cage';
 import { StoreState } from '../store/type';
@@ -7,7 +6,7 @@ type LaunchState = Pick<StoreState, 'launch' | 'weather' | 'userLocation'>;
 
 export default class LaunchReducer<S extends LaunchState> {
   reduce(json: Cage, state: S) {
-    const data = _.get(json, 'launch-update', false);
+    const data = json['launch-update'] || false;
     if (data) {
       this.initial(data, state);
       this.changeFirstTime(data, state);
@@ -16,40 +15,40 @@ export default class LaunchReducer<S extends LaunchState> {
       this.changeIsShown(data, state);
     }
 
-    const weatherData = _.get(json, 'weather', false);
+    const weatherData = json['weather'] || false;
     if (weatherData) {
       state.weather = weatherData;
     }
 
-    const locationData = _.get(json, 'location', false);
+    const locationData = json['location'] || false;
     if (locationData) {
       state.userLocation = locationData;
     }
   }
 
   initial(json: LaunchUpdate, state: S) {
-    const data = _.get(json, 'initial', false);
+    const data = json['initial'] || false;
     if (data) {
       state.launch = data;
     }
   }
 
   changeFirstTime(json: LaunchUpdate, state: S) {
-    const data = _.get(json, 'changeFirstTime', false);
+    const data = json['changeFirstTime'] || false;
     if (data) {
       state.launch.firstTime = data;
     }
   }
 
   changeOrder(json: LaunchUpdate, state: S) {
-    const data = _.get(json, 'changeOrder', false);
+    const data = json['changeOrder'] || false;
     if (data) {
       state.launch.tileOrdering = data;
     }
   }
 
   changeIsShown(json: LaunchUpdate, state: S) {
-    const data = _.get(json, 'changeIsShown', false);
+    const data = json['changeIsShown'] || false;
     console.log(json, data);
     if (data) {
       let tile = state.launch.tiles[data.name];

--- a/pkg/interface/src/reducers/link-update.ts
+++ b/pkg/interface/src/reducers/link-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { LinkUpdate, Pagination } from '../types/link-update';
 
@@ -11,7 +10,7 @@ type LinkState = Pick<StoreState, 'linksSeen' | 'links' | 'linkListening' | 'lin
 
 export default class LinkUpdateReducer<S extends LinkState> {
   reduce(json: any, state: S) {
-    const data = _.get(json, 'link-update', false);
+    const data = json['link-update'] || false;
     if(data) {
       this.submissionsPage(data, state);
       this.submissionsUpdate(data, state);
@@ -23,7 +22,7 @@ export default class LinkUpdateReducer<S extends LinkState> {
   }
 
   submissionsPage(json: LinkUpdate, state: S) {
-    const data = _.get(json, 'initial-submissions', false);
+    const data = json['initial-submissions'] || false;
     if (data) {
       //  { "initial-submissions": {
       //    "/~ship/group": {
@@ -71,7 +70,7 @@ export default class LinkUpdateReducer<S extends LinkState> {
   }
 
   submissionsUpdate(json: LinkUpdate, state: S) {
-    const data = _.get(json, 'submissions', false);
+    const data = json['submissions'] || false;
     if (data) {
       //  { "submissions": {
       //    path: /~ship/group
@@ -97,7 +96,7 @@ export default class LinkUpdateReducer<S extends LinkState> {
   }
 
   discussionsPage(json: LinkUpdate, state: S) {
-    const data = _.get(json, 'initial-discussions', false);
+    const data = json['initial-discussions'] || false;
     if (data) {
       //  { "initial-discussions": {
       //    path: "/~ship/group"
@@ -135,7 +134,7 @@ export default class LinkUpdateReducer<S extends LinkState> {
   }
 
   discussionsUpdate(json: LinkUpdate, state: S) {
-    const data = _.get(json, 'discussions', false);
+    const data = json['discussions'] || false;
     if (data) {
       //  { "discussions": {
       //    path: /~ship/path
@@ -154,7 +153,7 @@ export default class LinkUpdateReducer<S extends LinkState> {
   }
 
   observationUpdate(json: LinkUpdate, state: S) {
-    const data = _.get(json, 'observation', false);
+    const data = json['observation'] || false;
     if (data) {
       //  { "observation": {
       //    path: /~ship/path

--- a/pkg/interface/src/reducers/listen-update.ts
+++ b/pkg/interface/src/reducers/listen-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { LinkListenUpdate } from '../types/link-listen-update';
@@ -7,7 +6,7 @@ type LinkListenState = Pick<StoreState, 'linkListening'>;
 
 export default class LinkListenReducer<S extends LinkListenState> {
   reduce(json: Cage, state: S) {
-    const data = _.get(json, 'link-listen-update', false);
+    const data = json['link-listen-update'] || false;
     if (data) {
       this.listening(data, state);
       this.watch(data, state);
@@ -16,21 +15,21 @@ export default class LinkListenReducer<S extends LinkListenState> {
   }
 
   listening(json: LinkListenUpdate, state: S) {
-    const data = _.get(json, 'listening', false);
+    const data = json['listening'] || false;
     if (data) {
       state.linkListening = new Set(data);
     }
   }
 
   watch(json: LinkListenUpdate, state: S) {
-    const data = _.get(json, 'watch', false);
+    const data = json['watch'] || false;
     if (data) {
       state.linkListening.add(data);
     }
   }
 
   leave(json: LinkListenUpdate, state: S) {
-    const data = _.get(json, 'leave', false);
+    const data = json['leave'] || false;
     if (data) {
       state.linkListening.delete(data);
     }

--- a/pkg/interface/src/reducers/local.ts
+++ b/pkg/interface/src/reducers/local.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { LocalUpdate } from '../types/local-update';

--- a/pkg/interface/src/reducers/metadata-update.ts
+++ b/pkg/interface/src/reducers/metadata-update.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { StoreState } from '../store/type';
 
 import { MetadataUpdate } from '../types/metadata-update';
@@ -19,7 +17,7 @@ export default class MetadataReducer<S extends MetadataState> {
   }
 
   associations(json: MetadataUpdate, state: S) {
-    let data = _.get(json, 'associations', false);
+    let data = json['associations'] || false;
     if (data) {
       let metadata = state.associations;
       Object.keys(data).forEach((key) => {
@@ -40,7 +38,7 @@ export default class MetadataReducer<S extends MetadataState> {
   }
 
   add(json: MetadataUpdate, state: S) {
-    let data = _.get(json, 'add', false);
+    let data = json['add'] || false;
     if (data) {
       let metadata = state.associations;
       let appName = data['app-name'];
@@ -59,7 +57,7 @@ export default class MetadataReducer<S extends MetadataState> {
   }
 
   update(json: MetadataUpdate, state: S) {
-    let data = _.get(json, 'update-metadata', false);
+    let data = json['update-metadata'] || false;
     if (data) {
       let metadata = state.associations;
       let appName = data['app-name'];
@@ -78,7 +76,7 @@ export default class MetadataReducer<S extends MetadataState> {
   }
 
   remove(json: MetadataUpdate, state: S) {
-    let data = _.get(json, 'remove', false);
+    let data = json['remove'] || false;
     if (data) {
       let metadata = state.associations;
       let appName = data['app-name'];

--- a/pkg/interface/src/reducers/permission-update.ts
+++ b/pkg/interface/src/reducers/permission-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { PermissionUpdate } from '../types/permission-update';
@@ -7,7 +6,7 @@ type PermissionState = Pick<StoreState, "permissions">;
 
 export default class PermissionReducer<S extends PermissionState> {
   reduce(json: Cage, state: S) {
-    const data = _.get(json, 'permission-update', false);
+    const data = json['permission-update'] || false;
     if (data) {
       this.initial(data, state);
       this.create(data, state);
@@ -18,7 +17,7 @@ export default class PermissionReducer<S extends PermissionState> {
   }
 
   initial(json: PermissionUpdate, state: S) {
-    const data = _.get(json, 'initial', false);
+    const data = json['initial'] || false;
     if (data) {
       for (const perm in data) {
         state.permissions[perm] = {
@@ -30,7 +29,7 @@ export default class PermissionReducer<S extends PermissionState> {
   }
 
   create(json: PermissionUpdate, state: S) {
-    const data = _.get(json, 'create', false);
+    const data = json['create'] || false;
     if (data) {
       state.permissions[data.path] = {
         kind: data.kind,
@@ -40,14 +39,14 @@ export default class PermissionReducer<S extends PermissionState> {
   }
 
   delete(json: PermissionUpdate, state: S) {
-    const data = _.get(json, 'delete', false);
+    const data = json['delete'] || false;
     if (data) {
       delete state.permissions[data.path];
     }
   }
 
   add(json: PermissionUpdate, state: S) {
-    const data = _.get(json, 'add', false);
+    const data = json['add'] || false;
     if (data) {
       for (const member of data.who) {
         state.permissions[data.path].who.add(member);
@@ -56,7 +55,7 @@ export default class PermissionReducer<S extends PermissionState> {
   }
 
   remove(json: PermissionUpdate, state: S) {
-    const data = _.get(json, 'remove', false);
+    const data = json['remove'] || false;
     if (data) {
       for (const member of data.who) {
         state.permissions[data.path].who.delete(member);

--- a/pkg/interface/src/reducers/publish-response.ts
+++ b/pkg/interface/src/reducers/publish-response.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 
@@ -6,7 +5,7 @@ type PublishState = Pick<StoreState, 'notebooks'>;
 
 export default class PublishResponseReducer<S extends PublishState> {
   reduce(json: Cage, state: S) {
-    const data = _.get(json, 'publish-response', false);
+    const data = json['publish-response'] || false;
     if (!data) { return; }
     switch(data.type) {
       case "notebooks":

--- a/pkg/interface/src/reducers/publish-update.ts
+++ b/pkg/interface/src/reducers/publish-update.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { PublishUpdate } from '../types/publish-update';
 import { Cage } from '../types/cage';
 import { StoreState } from '../store/type';
@@ -108,7 +106,7 @@ export default class PublishUpdateReducer<S extends PublishState> {
 
       if (state.notebooks[host][book].notes[note].comments) {
         let limboCommentIdx =
-          _.findIndex(state.notebooks[host][book].notes[note].comments, (o) => {
+        state.notebooks[host][book].notes[note].comments.findIndex((o) => {
           let oldVal = o[getTagFromFrond(o)];
           let newVal = comment[Object.keys(comment)[0]];
           return (oldVal.pending &&

--- a/pkg/interface/src/reducers/s3-update.ts
+++ b/pkg/interface/src/reducers/s3-update.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { StoreState } from '../store/type';
 import { Cage } from '../types/cage';
 import { S3Update } from '../types/s3-update';
@@ -7,7 +6,7 @@ type S3State = Pick<StoreState, 's3'>;
 
 export default class S3Reducer<S extends S3State> {
   reduce(json: Cage, state: S) {
-    const data = _.get(json, 's3-update', false);
+    const data = json['s3-update'] || false;
     if (data) {
       this.credentials(data, state);
       this.configuration(data, state);
@@ -21,14 +20,14 @@ export default class S3Reducer<S extends S3State> {
   }
 
   credentials(json: S3Update, state: S) {
-    const data = _.get(json, 'credentials', false);
+    const data = json['credentials'] || false;
     if (data) {
       state.s3.credentials = data;
     }
   }
 
   configuration(json: S3Update, state: S) {
-    const data = _.get(json, 'configuration', false);
+    const data = json['configuration'] || false;
     if (data) {
       state.s3.configuration = {
         buckets: new Set(data.buckets),
@@ -38,14 +37,14 @@ export default class S3Reducer<S extends S3State> {
   }
 
   currentBucket(json: S3Update, state: S) {
-    const data = _.get(json, 'setCurrentBucket', false);
+    const data = json['setCurrentBucket'] || false;
     if (data && state.s3) {
 
     }
   }
 
   addBucket(json: S3Update, state: S) {
-    const data = _.get(json, 'addBucket', false);
+    const data = json['addBucket'] || false;
     if (data) {
       state.s3.configuration.buckets =
         state.s3.configuration.buckets.add(data);
@@ -53,28 +52,28 @@ export default class S3Reducer<S extends S3State> {
   }
 
   removeBucket(json: S3Update, state: S) {
-    const data = _.get(json, 'removeBucket', false);
+    const data = json['removeBucket'] || false;
     if (data) {
       state.s3.configuration.buckets.delete(data);
     }
   }
 
   endpoint(json: S3Update, state: S) {
-    const data = _.get(json, 'setEndpoint', false);
+    const data = json['setEndpoint'] || false;
     if (data && state.s3.credentials) {
       state.s3.credentials.endpoint = data;
     }
   }
 
   accessKeyId(json: S3Update , state: S) {
-    const data = _.get(json, 'setAccessKeyId', false);
+    const data = json['setAccessKeyId'] || false;
     if (data && state.s3.credentials) {
       state.s3.credentials.accessKeyId = data;
     }
   }
 
   secretAccessKey(json: S3Update, state: S) {
-    const data = _.get(json, 'setSecretAccessKey', false);
+    const data = json['setSecretAccessKey'] || false;
     if (data && state.s3.credentials) {
       state.s3.credentials.secretAccessKey = data;
     }

--- a/pkg/interface/src/subscription/global.ts
+++ b/pkg/interface/src/subscription/global.ts
@@ -1,8 +1,6 @@
 import BaseSubscription from './base';
 import { StoreState } from '../store/type';
 import { Path } from '../types/noun';
-import _ from 'lodash';
-
 
 /**
  * Path to subscribe on and app to subscribe to
@@ -54,7 +52,8 @@ export default class GlobalSubscription extends BaseSubscription<StoreState> {
 
   restart() {
     super.restart();
-    _.mapValues(this.openSubscriptions, (subs, app: AppName) => {
+    Object.keys(this.openSubscriptions).forEach((app: AppName) => {
+      const subs = this.openSubscriptions[app];
       if(subs.length > 0) {
         this.stopApp(app);
         this.startApp(app);


### PR DESCRIPTION
Tell me if this isn't welcome, but

I think it's twenty twenty and transpiled (Java/Type)Script can do a lot more than when lodash was invented. It's not like landscape leans heavily on it. There are a *few* places where the vanilla replacement is more awkward but I think in general native JavaScript is more expressive. It's a little bit lighter.