### PR TITLE
ISSUE_TEMPLATEs: use +trouble instead of .^(@uv %cz /=base=)

### DIFF
--- a/.github/ISSUE_TEMPLATE/kernel-or-runtime-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/kernel-or-runtime-bug-report.md
@@ -30,7 +30,7 @@ If applicable, add screenshots to help explain your problem.
 **System (please supply the following information, if relevant):**
  - OS: [e.g. macOS, linux64, FreeBSD]
  - Vere and Urbit OS versions
- - Your ship's `%base` hash (use `.^(@uv %cz /=base=)` to check)
+ - Your ship's `%base` hash (use `+trouble` to check)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/os1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/os1-bug-report.md
@@ -27,13 +27,13 @@ If applicable, add screenshots to help explain your problem. If possible, please
 **Desktop (please complete the following information):**
  - OS: [e.g. MacOS 10.15.3]
  - Browser [e.g. chrome, safari]
- - Base hash of your urbit ship. Run ` .^(@uv %cz /=base=)` in Dojo to see this.
+ - Base hash of your urbit ship. Run `+trouble` in Dojo to see this.
 
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
- - Base hash of your urbit ship. Run ` .^(@uv %cz /=base=)` in Dojo to see this.
+ - Base hash of your urbit ship. Run `+trouble` in Dojo to see this.
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Changes with Ford Fusion make `.^(@uv %cz /=base=)` no longer a good way to check the base hash. 

I changed the issue templates to ask users to use `+trouble` to find their base hashes instead.