### PR TITLE
chat: names use db, not dib

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/message.js
+++ b/pkg/interface/src/apps/chat/components/lib/message.js
@@ -85,7 +85,7 @@ export class Message extends Component {
             <p className={`v-mid f9 gray2 dib mr3 c-default`}>
               <span
                 className={
-                  'mw5 dib truncate pointer ' +
+                  'mw5 db truncate pointer ' +
                   (contact.nickname || state.copied ? '' : 'mono')
                 }
                 onClick={() => {


### PR DESCRIPTION
#3226 caused the name line-height to be severely skewed due to `inline-block`ing and truncating the name (previously it was `inline`). Treating the span as a `block` not an `inline-block` standardises the line-height without any change to layout. Still preserves the truncation, too. I'm honestly not sure why the box model works that way.

Tested and works in Safari, Firefox, Brave.