### PR TITLE
publish: send reads on nav, distinguish unreads

### DIFF
--- a/pkg/interface/src/apps/publish/components/lib/note.js
+++ b/pkg/interface/src/apps/publish/components/lib/note.js
@@ -12,7 +12,8 @@ export class Note extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      deleting: false
+      deleting: false,
+      sentRead: false
     };
     moment.updateLocale('en', {
       relativeTime: {
@@ -46,16 +47,19 @@ export class Note extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { props } = this;
+    const { props, state } = this;
     if ((prevProps && prevProps.api !== props.api) || props.api) {
       if (!(props.notebooks[props.ship]?.[props.book]?.notes?.[props.note]?.file)) {
         props.api.publish.fetchNote(props.ship, props.book, props.note);
       }
 
-      if (prevProps) {
-        if ((prevProps.book !== props.book) ||
-          (prevProps.note !== props.note) ||
-          (prevProps.ship !== props.ship)) {
+      if (prevProps && prevProps.note !== props.note) {
+        this.setState({ sentRead: false });
+      }
+
+      if (!state.sentRead &&
+        props.notebooks?.[props.ship]?.[props.book]?.notes?.[props.note] &&
+        !props.notebooks[props.ship][props.book].notes[props.note].read) {
           const readAction = {
             read: {
               who: props.ship.slice(1),
@@ -63,9 +67,10 @@ export class Note extends Component {
               note: props.note
             }
           };
-          props.api.publish.publishAction(readAction);
+          this.setState({ sentRead: true }, () => {
+            props.api.publish.publishAction(readAction);
+          });
         }
-      }
     }
   }
 

--- a/pkg/interface/src/apps/publish/components/lib/notebook-posts.js
+++ b/pkg/interface/src/apps/publish/components/lib/notebook-posts.js
@@ -84,7 +84,7 @@ export class NotebookPosts extends Component {
                ' gray2 mr3'}
                title={note.author}
               >{name}</div>
-              <div className="gray2 mr3">{date}</div>
+              <div className={((note.read) ? "gray2 " : "green2 ") + "mr3"}>{date}</div>
               <div className="gray2">{comment}</div>
             </div>
           </div>


### PR DESCRIPTION
A bandaid for the @galenwp in the audience.

During the SPA refactor we did a rather large renovation of the Publish back-end / front-end interaction pattern. It worked via API calls on navigation instead of the PHP-style state injection. I wrote the logic to pre-empt sending read actions before we knew what we were looking at, by ensuring we had state instantiated first. Here I did so clumsily, so that reads would never send. My bad.

I also went ahead and decided to follow Links in how it marks "unread content": unread posts now have their dates written in green. No "mark all as read" button yet (we'll have to do [something like this](https://github.com/urbit/urbit/blob/master/pkg/interface/src/apps/dojo/components/input.js#L90-L99) where we reduce an array of notes with Promises, waiting for each subsequent Promise to resolve before proceeding with the next, which would be very slow and not ideal in Publish's case, potentially).