### PR TITLE
omnibox: two UX tweaks

### DIFF
--- a/pkg/interface/src/components/OmniboxResult.js
+++ b/pkg/interface/src/components/OmniboxResult.js
@@ -10,6 +10,18 @@ export class OmniboxResult extends Component {
       hovered: false
     };
     this.setHover = this.setHover.bind(this);
+    this.result = React.createRef();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { props, state } = this;
+    if (prevProps &&
+      !state.hovered &&
+      prevProps.selected !== props.selected &&
+      props.selected === props.link
+      ) {
+        this.result.current.scrollIntoView({ block: 'nearest' });
+      }
   }
 
   setHover(boolean) {
@@ -55,6 +67,7 @@ export class OmniboxResult extends Component {
           }
           onClick={navigate}
           width="100%"
+          ref={this.result}
         >
           {this.state.hovered || selected === link ? (
             <>

--- a/pkg/interface/src/lib/omnibox.js
+++ b/pkg/interface/src/lib/omnibox.js
@@ -100,6 +100,8 @@ export default function index(associations, apps) {
       const obj = result(apps[e].type.basic.title, apps[e].type.basic.linkedUrl, apps[e].type.basic.title, null);
       applications.push(obj);
   });
+  // add groups separately
+  applications.push(result('Groups', '/~groups', 'groups', null));
   index.set('apps', applications);
 
   return index;


### PR DESCRIPTION
- If you had many results (eg. typing 'book' or 'chat' will generally show all notebooks and chats), scrolling with your arrow keys would ... scroll offscreen. We now push offscreen results into view as you scroll up or down, as you'd expect.
- Groups is not in Launch; thus it's not indexed as an app. This adds Groups to the index manually.