### PR TITLE
hoon: add +lead and +late

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -262,6 +262,9 @@
 ++  tail  |*(^ ,:+<+)                                   ::  get tail
 ++  test  |=(^ =(+<- +<+))                              ::  equality
 ::
+++  lead  |*(h=* |*(* [h +<]))                          ::  put head
+++  late  |*(t=* |*(* [+< t]))                          ::  put tail
+::
 ::  #  %containers
 ::
 ::    the most basic of data types


### PR DESCRIPTION
For tacking some head or tail onto some noun, respectively.

I find myself doing things in the vein of `(turn my-list |=(=item [%constant item]))` often enough that I wanted a little function to just be there for me. Appropriately filed under the "functional hacks" section.