### PR TITLE
chat: prevent saving sent message on navigation

### DIFF
--- a/pkg/interface/src/apps/chat/components/chat.tsx
+++ b/pkg/interface/src/apps/chat/components/chat.tsx
@@ -94,7 +94,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
       props.chatSynced &&
       !(props.station in props.chatSynced) &&
       props.envelopes.length > 0;
-    
+
     const unreadCount = props.length - props.read;
     const unreadMsg = unreadCount > 0 && props.envelopes[unreadCount - 1];
 
@@ -141,6 +141,9 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
           s3={props.s3}
           placeholder="Message..."
           message={this.state.messages.get(props.station) || ""}
+          deleteMessage={() => this.setState({
+            messages: this.state.messages.set(props.station, "")
+          })}
         />
       </div>
     );

--- a/pkg/interface/src/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-editor.js
@@ -124,7 +124,7 @@ export default class ChatEditor extends Component {
           onChange={(e, d, v) => this.messageChange(e, d, v)}
           editorDidMount={(editor) => {
             this.editor = editor;
-            if (BROWSER_REGEX.test(navigator.userAgent)) {
+            if (!(BROWSER_REGEX.test(navigator.userAgent))) {
               editor.focus();
             }
           }}

--- a/pkg/interface/src/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-editor.js
@@ -80,11 +80,17 @@ export default class ChatEditor extends Component {
       return;
     }
 
+    this.setState({ message: '' });
     this.props.submit(editorMessage);
     this.editor.setValue('');
   }
 
   messageChange(editor, data, value) {
+    if (this.state.message !== '' && value == '') {
+      this.setState({
+        message: value
+      });
+    }
     if (value == this.props.message || value == '' || value == ' ') {
       return;
     }

--- a/pkg/interface/src/apps/chat/components/lib/chat-input.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-input.js
@@ -10,7 +10,7 @@ const URL_REGEX = new RegExp(String(/^((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\
 export class ChatInput extends Component {
   constructor(props) {
     super(props);
-    
+
     this.state = {
       inCodeMode: false,
     };
@@ -140,6 +140,8 @@ export class ChatInput extends Component {
       // Add any remaining message
       messages.push(message);
     }
+
+    props.deleteMessage();
 
     messages.forEach((message) => {
       if (message.length > 0) {


### PR DESCRIPTION
- Fixes an issue where chat would autofocus on mobile devices, instead of on desktop.
- Fixes an issue where chat input would preserve a sent message during navigation due to retaining the message in state at the lowest component (editor), but not in any levels above (all props were empty strings).