### PR TITLE
leap: small fixes

### DIFF
--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -4,7 +4,7 @@
     <title>OS1</title>
     <meta charset="utf-8" />
     <meta name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+      content="width=device-width, initial-scale=1, shrink-to-fit=no,user-scalable=0"/>
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-touch-fullscreen" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -4,7 +4,7 @@
     <title>OS1</title>
     <meta charset="utf-8" />
     <meta name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no,user-scalable=0"/>
+      content="width=device-width, initial-scale=1, shrink-to-fit=no,maximum-scale=1"/>
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-touch-fullscreen" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/pkg/interface/src/components/Omnibox.js
+++ b/pkg/interface/src/components/Omnibox.js
@@ -217,7 +217,7 @@ export class Omnibox extends Component {
 
     return (
         <Box
-          backgroundColor='lightGray'
+          backgroundColor='scales.black30'
           width='100vw'
           height='100vh'
           position='absolute'

--- a/pkg/interface/src/components/Omnibox.js
+++ b/pkg/interface/src/components/Omnibox.js
@@ -192,7 +192,7 @@ export class Omnibox extends Component {
       {categoryResult}
     </Box>;
 
-      ['commands', 'subscriptions', 'groups', 'apps'].map((category, i) => {
+      ['apps', 'commands', 'groups', 'subscriptions'].map((category, i) => {
       const categoryResults = state.results.get(category);
       if (categoryResults.length > 0) {
         const each = categoryResults.map((result, i) => {

--- a/pkg/interface/src/components/Omnibox.js
+++ b/pkg/interface/src/components/Omnibox.js
@@ -104,7 +104,7 @@ export class Omnibox extends Component {
 
   search(event) {
     const { state } = this;
-    const query = event.target.value;
+    let query = event.target.value;
     const results = this.initialResults();
 
     this.setState({ query: query });
@@ -119,6 +119,8 @@ export class Omnibox extends Component {
     if (query.length === 1) {
       return;
     }
+
+    query = query.toLowerCase();
 
     ['commands', 'subscriptions', 'groups', 'apps'].map((category) => {
       const categoryIndex = state.index.get(category);

--- a/pkg/interface/src/components/Omnibox.js
+++ b/pkg/interface/src/components/Omnibox.js
@@ -68,6 +68,7 @@ export class Omnibox extends Component {
     }
 
     if (evt.key === 'Enter') {
+      evt.preventDefault();
       if (this.state.selected !== '') {
         this.navigate(this.state.selected);
       } else {

--- a/pkg/interface/src/components/OmniboxInput.js
+++ b/pkg/interface/src/components/OmniboxInput.js
@@ -15,6 +15,7 @@ export class OmniboxInput extends Component {
       placeholder='Search...'
       onKeyDown={props.control}
       onChange={props.search}
+      spellCheck={false}
       value={props.query}
     />
     );


### PR DESCRIPTION
(Everyone calls it "leap" and "leap" is four characters, I guess I'll start calling it "leap" after this.)

- Enter no longer propagates to inputs you navigate to.
- Search queries are now case insensitive.
- Results are sorted 'apps', 'commands', 'groups', 'subs'
- Background darkens in both light and dark mode (using `scales.black30` instead of `lightGray`, which swaps between white and black in each mode with some opacity)

Still pining after #3274, but it needs some investigation; I'm getting infinite loops trying to track down how to execute, and these are self contained.

@tylershuster wrote a duplicate PR of these as I was writing them. Sorry Tyler.