### PR TITLE
chat: fix syntax of regex check

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/apps/chat/components/lib/chat-editor.js
@@ -8,7 +8,7 @@ import 'codemirror/addon/display/placeholder';
 import 'codemirror/lib/codemirror.css';
 
 const BROWSER_REGEX =
-  new RegExp(String(!/Android|webOS|iPhone|iPad|iPod|BlackBerry/i));
+  new RegExp(String(/Android|webOS|iPhone|iPad|iPod|BlackBerry/i));
 
 
 const MARKDOWN_CONFIG = {


### PR DESCRIPTION
When I was hotfixing last night, I put in a patch at #3273 that reversed the boolean to autofocus the regex test for if we were on mobile or not. I did this because taking the boolean straight produced no autofocus on desktop; reversing it restored the autofocus.

Today, I noticed my iOS app still pops the input up every single time I navigate, which is what I was trying to avoid with that patch. 

I looked more at the regex and it appears we coax a string into a regex object while keeping the `!` from the previous iteration of the code as an accidental prefix before the `/`, which I believe causes the regex to treat `!/Android|webOS|iPhone|iPad|iPod|BlackBerry/i` to be treated as a single, long string to test against, not as regex syntax with a bunch of `or` clauses.

By removing the `!` iOS no longer autofocuses, but desktop does, so I believe this hypothesis is right.