### PR TITLE
interface: autojoining known channels

### DIFF
--- a/pkg/interface/src/apps/chat/components/lib/chat-window.tsx
+++ b/pkg/interface/src/apps/chat/components/lib/chat-window.tsx
@@ -20,7 +20,7 @@ export class ChatWindow extends Component {
     };
 
     this.hasAskedForMessages = false;
-    
+
     this.dismissUnread = this.dismissUnread.bind(this);
     this.scrollIsAtBottom = this.scrollIsAtBottom.bind(this);
     this.scrollIsAtTop = this.scrollIsAtTop.bind(this);
@@ -60,20 +60,20 @@ export class ChatWindow extends Component {
     const { props, state } = this;
 
     if (props.isChatMissing) {
-      props.history.push("/~chat");
+      props.history.push(`/~chat/join${props.station}`);
     } else if (props.messages.length >= prevProps.messages.length + 10) {
       this.hasAskedForMessages = false;
-      let numPages = props.unreadCount > 0 ? 
+      let numPages = props.unreadCount > 0 ?
         Math.ceil(props.unreadCount / PAGE_SIZE) : this.state.numPages;
 
       if (this.state.numPages === numPages) {
         if (props.unreadCount > 20) {
-          this.scrollToUnread();    
+          this.scrollToUnread();
         }
       } else {
         this.setState({ numPages }, () => {
           if (props.unreadCount > 20) {
-            this.scrollToUnread();    
+            this.scrollToUnread();
           }
         });
       }

--- a/pkg/interface/src/apps/links/app.js
+++ b/pkg/interface/src/apps/links/app.js
@@ -120,8 +120,9 @@ export class LinksApp extends Component {
 
             const autoJoin = () => {
               try {
-                api.links.joinCollection(resourcePath);
-                props.history.push(makeRoutePath(resourcePath));
+                api.links.joinCollection(resourcePath).then(() => {
+                  props.history.push(makeRoutePath(resourcePath));
+                });
               } catch(err) {
                 setTimeout(autoJoin, 2000);
               }
@@ -258,6 +259,8 @@ export class LinksApp extends Component {
                   amOwner={amOwner}
                   popout={popout}
                   sidebarShown={sidebarShown}
+                  listening={listening}
+                  subscription={this.props.subscription}
                   api={api}
                   />
                 </Skeleton>

--- a/pkg/interface/src/apps/links/components/links-list.js
+++ b/pkg/interface/src/apps/links/components/links-list.js
@@ -37,6 +37,15 @@ export class Links extends Component {
     ) {
       this.props.api?.links.getPage(this.props.resourcePath, this.props.page);
     }
+    // if we are subscribed to links, but don't have this,
+    // join it
+    const subscribed = (
+      this.props.subscription?.openSubscriptions.link &&
+      this.props.subscription.openSubscriptions.link.length > 0
+      );
+      if (subscribed && !this.props.listening.has(this.props.resourcePath)) {
+        this.props.history.push(`/~link/join${this.props.resourcePath}`);
+      };
   }
 
   render() {

--- a/pkg/interface/src/apps/publish/app.js
+++ b/pkg/interface/src/apps/publish/app.js
@@ -219,6 +219,7 @@ export default class PublishApp extends React.Component {
                     sidebarShown={sidebarShown}
                     popout={popout}
                     api={api}
+                    subscription={this.props.subscription}
                     {...props}
                   />
                 </Skeleton>

--- a/pkg/interface/src/apps/publish/components/lib/notebook.js
+++ b/pkg/interface/src/apps/publish/components/lib/notebook.js
@@ -44,8 +44,15 @@ export class Notebook extends Component {
     const { props } = this;
     if ((prevProps && (prevProps.api !== props.api)) || props.api) {
       const notebook = props.notebooks?.[props.ship]?.[props.book];
+      const subscribed = (
+        props.subscription?.openSubscriptions.publish &&
+        props.subscription.openSubscriptions.publish.length > 0
+        );
       if (!notebook?.subscribers) {
         props.api.publish.fetchNotebook(props.ship, props.book);
+      }
+      if (subscribed && !notebook) {
+        props.history.push(`/~publish/join/${props.ship}/${props.book}`);
       }
     }
   }
@@ -181,7 +188,7 @@ export class Notebook extends Component {
     const group = props.groups[notebook?.['writers-group-path']];
     const role = group ? roleForShip(group, window.ship) : undefined;
 
-    const subsComponent = (this.props.ship.slice(1) === window.ship) || (role === 'admin') 
+    const subsComponent = (this.props.ship.slice(1) === window.ship) || (role === 'admin')
       ? (<Link to={subs} className={tabStyles.subscribers}>
           Subscribers
         </Link>)


### PR DESCRIPTION
Hi all — this is a RFC, since this PR produces some weird behaviour and quirks.

In #3274, I noted that since we iterate through metadata-store in the Leap prompt, we see channels our group is aware of but we aren't necessarily subscribed to. Right now, if you go to any of those options, nothing happens — you get a default template page in all apps, without any data. 

The ideal case is that if you go to these channels, our apps just automatically grab them for you and subscribe. 

In this PR, I attempt to check if we have an open subscription to the app in question; if we do, and we aren't subscribed to the channel, go join it via the `/join` route.

This *mostly* works, but ...

## Known issues
- If any channel is *invalid* — most commonly this is because the host breached, or the channel was deleted, but the metadata was preserved — basically every app we have can't handle it. Chat and Links go into infinite loops between join and the channel page; Publish idles on the join screen.

We used to say "check your console for a stack trace" (itself *not* a solution to just writing error case handling for joining channels) but we no longer have stack traces in the console. We don't produce any notion of an error in FE or console at all, in fact. 

Somewhere in the APIs being rewritten twice during the SPA work and the global store rewrite, we no longer report `console.error()`, so writing a `catch()` for the rejected promise and throwing an error in FE is not possible. @liam-fitzgerald @tacryt-socryp Any ideas here?

- Links, no matter what, loops at least a few times. We want to wait for the resource to be thrown into `listening` before proceeding to the page, but instead we make the API call and proceed upon it succeeding, which leads to a delay of a few seconds, and thus on first pageload the links are doubled or tripled. This resolves on a refresh.

- But that said, going directly to a Links page now redirects you to the join prompt as well, even if already listening for it, suggesting the `subscribed` constant I'm defining here isn't even tripping correctly. Confusing.

@Fang- suggestions on catching this correctly? We'll be migrating this soon, I know, but you wrote a lot of this FE too.