### PR TITLE
publish: no-op when joining our own notebook

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1831,6 +1831,8 @@
   ::
       %subscribe
     ?>  (team:title our.bol src.bol)
+    ?:  =(our.bol who.act)
+      [~ state]
     =/  join-wire=wire
       /join-group/[(scot %p who.act)]/[book.act]
     =/  meta=(unit (set path))


### PR DESCRIPTION
See #3300. 

There's a critical fail state on hosted ships at the moment when using Leap to go to their own notebooks; this is because we attempt to join ourselves. This commit adds a check to see if our ship and the notebook host are the same; if so, we just return a no-op.

Works in basic testing on a fakezod — a `~&`d cord showed when I joined my own notebook; not when I tried to join a hypothetical outside ship. With this commit, could leap to it; without this commit, was spinning forever in FE (but not in Dojo?) trying to join it, and lost the notebook from Publish state, for some reason.