### PR TITLE
chat: serialize %keys to JSON for chat update

### DIFF
--- a/pkg/arvo/lib/chat-store.hoon
+++ b/pkg/arvo/lib/chat-store.hoon
@@ -61,8 +61,9 @@
     ^-  json
     %+  frond  %chat-update
     %-  pairs
-    :~
-    ?:  ?=(%initial -.upd)
+    :_  ~
+    ?-  -.upd
+        %initial
       :-  %initial
       %-  pairs
       %+  turn  ~(tap by inbox.upd)
@@ -73,31 +74,37 @@
       :~  [%envelopes [%a (turn envelopes.mailbox envelope)]]
           [%config (config config.mailbox)]
       ==
-    ?:  ?=(%message -.upd)
-        :-  %message
-        %-  pairs
-        :~  [%path (path path.upd)]
-            [%envelope (envelope envelope.upd)]
-        ==
-    ?:  ?=(%messages -.upd)
-        :-  %messages
-        %-  pairs
-        :~  [%path (path path.upd)]
-            [%start (numb start.upd)]
-            [%end (numb end.upd)]
-            [%envelopes [%a (turn envelopes.upd envelope)]]
-        ==
-    ?:  ?=(%read -.upd)
-        [%read (pairs [%path (path path.upd)]~)]
-    ?:  ?=(%create -.upd)
-        [%create (pairs [%path (path path.upd)]~)]
-    ?:  ?=(%delete -.upd)
-        [%delete (pairs [%path (path path.upd)]~)]
-    ?>  ?=(%keys -.upd)
-        :-  %keys
-        :-  %a
-        %+  turn  ~(tap by keys.upd)
-        |=  pax=^path  (path pax)
+    ::
+        %message
+      :-  %message
+      %-  pairs
+      :~  [%path (path path.upd)]
+          [%envelope (envelope envelope.upd)]
+      ==
+    ::
+        %messages
+      :-  %messages
+      %-  pairs
+      :~  [%path (path path.upd)]
+          [%start (numb start.upd)]
+          [%end (numb end.upd)]
+          [%envelopes [%a (turn envelopes.upd envelope)]]
+      ==
+    ::
+        %read
+      [%read (pairs [%path (path path.upd)]~)]
+    ::
+        %create
+      [%create (pairs [%path (path path.upd)]~)]
+    ::
+        %delete
+      [%delete (pairs [%path (path path.upd)]~)]
+    ::
+        %keys
+      :-  %keys
+      :-  %a
+      %+  turn  ~(tap by keys.upd)
+      |=  pax=^path  (path pax)
     ==
   --
 ++  dejs

--- a/pkg/arvo/lib/chat-store.hoon
+++ b/pkg/arvo/lib/chat-store.hoon
@@ -93,7 +93,11 @@
         [%create (pairs [%path (path path.upd)]~)]
     ?:  ?=(%delete -.upd)
         [%delete (pairs [%path (path path.upd)]~)]
-    [*@t *json]
+    ?>  ?=(%keys -.upd)
+        :-  %keys
+        :-  %a
+        %+  turn  ~(tap by keys.upd)
+        |=  pax=^path  (path pax)
     ==
   --
 ++  dejs


### PR DESCRIPTION
This was missing from the serialization, resulting in the value of keys being null in the JSON produced.

And an extra patch to use `?-` in the serialization instead of a sequence of `?:  ?=`.