### PR TITLE
dojo: restore `??` and `???` syntax

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -589,9 +589,7 @@
                   ?-  p.p.mad
                     %0  ~
                     %1  [[%rose [~ "  " ~] (skol p.q.cay) ~] maar]
-                    ::  XX  actually print something meaningful here
-                    ::
-                    %2  [[%rose [~ "  " ~] *tank ~] maar]
+                    %2  [[%rose [~ "  " ~] (dy-show-type-noun p.q.cay) ~] maar]
                     ::%3  handled above 
                     %4  ~
                     %5  [[%rose [~ "  " ~] (xskol p.q.cay) ~] maar]
@@ -638,6 +636,26 @@
           :-  i=""
           t=(turn `wain`?~(r.hit ~ (to-wain:format q.u.r.hit)) trip)
       ==
+    ++  dy-show-type-noun
+      |=  a/type  ^-  tank
+    =-  >[-]<
+    |-  ^-  $?  $%  {$atom @tas (unit @)}
+                    {$cell _$ _$}
+                    {$face $@(term tune) _$}
+                    {$fork (set _$)}
+                    {$hold _$ hoon}
+                ==
+                wain                :: "<|core|>"
+                $?($noun $void)
+            ==
+    ?+  a  a
+      {$face ^}  a(q $(a q.a))
+      {$cell ^}  a(p $(a p.a), q $(a q.a))
+      {$fork *}  a(p (silt (turn ~(tap in p.a) |=(b/type ^$(a b)))))
+      {$hint *}  !!
+      {$core ^}  `wain`/core
+      {$hold *}  a(p $(a p.a))
+    ==
   ::
   ::  XX needs filter
   ::

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -503,7 +503,7 @@
       ::  XX needs filter
       ::
       ?:  ?=({$show $3} -.mad)
-        (dy-rash %tan (dy-show-source q.mad) ~)       ::  XX separate command
+        (dy-rash %tan (dy-show-source q.mad) ~)
       ?:  ?=($brev -.mad)
         =.  var  (~(del by var) p.mad)
         =<  dy-amok
@@ -654,6 +654,7 @@
             {$sa mark}
             {$as mark dy-shown}
             {$do hoon dy-shown}
+            {$te term (list dy-shown)}
             {$ge path (list dy-shown) (map term (unit dy-shown))}
             {$dv path}
         ==
@@ -664,8 +665,7 @@
     =-  >[-]<
     =+  `{@ bil/dojo-build}`a
     |-  ^-  dy-shown
-    ::?-  -.bil
-    ?+  -.bil  dv+/[-.bil]/todo
+    ?-  -.bil
       $?($ur $dv $sa)  bil
       $ex  ?.  ?=({$cltr *} p.bil)  p.bil
                |-  ^-  hoon
@@ -678,6 +678,7 @@
            [^$(bil q.i.p.bil) $(p.bil t.p.bil)]
       $as  bil(q $(bil q.q.bil))
       $do  bil(q $(bil q.q.bil))
+      $te  bil(q (turn q.bil ..$))
       $ge  :+  %ge  q.p.p.bil
            [(turn p.q.p.bil ..$) (~(run by q.q.p.bil) (lift ..$))]
     ==

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -502,8 +502,8 @@
       ^+  +>
       ::  XX needs filter
       ::
-      :: ?:  ?=({$show $3} -.mad)
-      ::  (dy-rash %tan (dy-show-source q.mad) ~)       ::  XX separate command
+      ?:  ?=({$show $3} -.mad)
+        (dy-rash %tan (dy-show-source q.mad) ~)       ::  XX separate command
       ?:  ?=($brev -.mad)
         =.  var  (~(del by var) p.mad)
         =<  dy-amok
@@ -592,7 +592,7 @@
                     ::  XX  actually print something meaningful here
                     ::
                     %2  [[%rose [~ "  " ~] *tank ~] maar]
-                    %3  ~
+                    ::%3  handled above 
                     %4  ~
                     %5  [[%rose [~ "  " ~] (xskol p.q.cay) ~] maar]
                   ==
@@ -638,6 +638,49 @@
           :-  i=""
           t=(turn `wain`?~(r.hit ~ (to-wain:format q.u.r.hit)) trip)
       ==
+  ::
+  ::  XX needs filter
+  ::
+  ++  dy-shown
+    =/  jank-bucwut  :: FIXME just $? fishes when defined for some reason
+      |*  [a=mold b=mold]
+      |=(c=_`*`*a ?:(& (a c) (b c)))
+    ::
+    ::$?  hoon
+    ;:    jank-bucwut
+        hoon
+        $^  {dy-shown dy-shown}
+        $%  {$ur cord}
+            {$sa mark}
+            {$as mark dy-shown}
+            {$do hoon dy-shown}
+            {$ge path (list dy-shown) (map term (unit dy-shown))}
+            {$dv path}
+        ==
+    ==
+  ::
+  ++  dy-show-source
+    |=  a/dojo-source  ^-  tank
+    =-  >[-]<
+    =+  `{@ bil/dojo-build}`a
+    |-  ^-  dy-shown
+    ::?-  -.bil
+    ?+  -.bil  dv+/[-.bil]/todo
+      $?($ur $dv $sa)  bil
+      $ex  ?.  ?=({$cltr *} p.bil)  p.bil
+               |-  ^-  hoon
+               ?~  p.p.bil  !!
+               ?~  t.p.p.bil  i.p.p.bil
+               [i.p.p.bil $(p.p.bil t.p.p.bil)]
+      $tu  ?~  p.bil  !!
+           |-
+           ?~  t.p.bil  ^$(bil q.i.p.bil)
+           [^$(bil q.i.p.bil) $(p.bil t.p.bil)]
+      $as  bil(q $(bil q.q.bil))
+      $do  bil(q $(bil q.q.bil))
+      $ge  :+  %ge  q.p.p.bil
+           [(turn p.q.p.bil ..$) (~(run by q.q.p.bil) (lift ..$))]
+    ==
     ::
     ++  dy-edit                                         ::  handle edit
       |=  cal/sole-change
@@ -874,6 +917,8 @@
       ^+  +>+>
       ?>  ?=(~ cud)
       ?:  =(nex num)
+        dy-over
+      ?:  =([%show %3] -.mad)                           :: just show source
         dy-over
       dy-make(cud `[nex (~(got by job) nex)])
     --

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -636,8 +636,8 @@
           :-  i=""
           t=(turn `wain`?~(r.hit ~ (to-wain:format q.u.r.hit)) trip)
       ==
-    ++  dy-show-type-noun
-      |=  a/type  ^-  tank
+  ++  dy-show-type-noun
+    |=  a/type  ^-  tank
     =-  >[-]<
     |-  ^-  $?  $%  {$atom @tas (unit @)}
                     {$cell _$ _$}


### PR DESCRIPTION
Unsure what happened here, we appears to have ended up at a `?` and a `?????` and nothing in between, documented as "val/type/hoon/xray".

Grabbed original implementations out of git history, there was an ominous warning about "filtering" but I don't have the context for what it means - these operations cannot have side effects, so worst case you can just not run them. (Possibly after rebooting a hung pier?)

Contains some questionable type hackery around the 79aa1cb redefinition of `$?` to disallow multiple "complex" types, if anyone can come up with a real solution here I'll be overjoyed if you push commits to that effect.