### PR TITLE
interface: adds absolute path resolution to imports

### DIFF
--- a/pkg/interface/.babelrc
+++ b/pkg/interface/.babelrc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    [
+      "babel-plugin-root-import",
+      {
+        "paths": [
+          {
+            "rootPathSuffix": "./src"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -2362,6 +2362,15 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-root-import": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-root-import/-/babel-plugin-root-import-6.5.0.tgz",
+      "integrity": "sha512-PTD8fPl4v1kwn01u9d4rgRavDs5Z+jv4qa4/y6iYtoSgM4/xmjwMqo66j5A/BTZQEMA6OV5iFgyZ1PIhroJqqg==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
+      }
+    },
     "babel-plugin-styled-components": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
@@ -8418,6 +8427,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "slice-ansi": {

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/parser": "^3.8.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-root-import": "^6.5.0",
     "clean-webpack-plugin": "^3.0.0",
     "cross-env": "^7.0.2",
     "eslint": "^6.8.0",

--- a/pkg/interface/src/logic/api/base.ts
+++ b/pkg/interface/src/logic/api/base.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { uuid } from "../lib/util";
-import { Patp, Path } from "../types/noun";
+import { Patp, Path } from "~/types/noun";
 import BaseStore from '../store/base';
 
 export default class BaseApi<S extends object = {}> {

--- a/pkg/interface/src/logic/api/chat.ts
+++ b/pkg/interface/src/logic/api/chat.ts
@@ -1,7 +1,7 @@
 import BaseApi from './base';
 import { uuid } from '../lib/util';
-import { Letter, ChatAction, Envelope } from '../types/chat-update';
-import { Patp, Path, PatpNoSig } from '../types/noun';
+import { Letter, ChatAction, Envelope } from '~/types/chat-update';
+import { Patp, Path, PatpNoSig } from '~/types/noun';
 import { StoreState } from '../store/type';
 import BaseStore from '../store/base';
 

--- a/pkg/interface/src/logic/api/contacts.ts
+++ b/pkg/interface/src/logic/api/contacts.ts
@@ -1,8 +1,8 @@
 import BaseApi from './base';
 import { StoreState } from '../store/type';
-import { Patp, Path, Enc } from '../types/noun';
-import { Contact, ContactEdit } from '../types/contact-update';
-import { GroupPolicy, Resource } from '../types/group-update';
+import { Patp, Path, Enc } from '~/types/noun';
+import { Contact, ContactEdit } from '~/types/contact-update';
+import { GroupPolicy, Resource } from '~/types/group-update';
 
 export default class ContactsApi extends BaseApi<StoreState> {
   create(

--- a/pkg/interface/src/logic/api/global.ts
+++ b/pkg/interface/src/logic/api/global.ts
@@ -1,4 +1,4 @@
-import { Patp } from '../types/noun';
+import { Patp } from '~/types/noun';
 import BaseApi from './base';
 import ChatApi from './chat';
 import { StoreState } from '../store/type';

--- a/pkg/interface/src/logic/api/groups.ts
+++ b/pkg/interface/src/logic/api/groups.ts
@@ -1,13 +1,13 @@
 import BaseApi from './base';
 import { StoreState } from '../store/type';
-import { Path, Patp, Enc } from '../types/noun';
+import { Path, Patp, Enc } from '~/types/noun';
 import {
   GroupAction,
   GroupPolicy,
   Resource,
   Tag,
   GroupPolicyDiff,
-} from '../types/group-update';
+} from '~/types/group-update';
 
 export default class GroupsApi extends BaseApi<StoreState> {
   remove(resource: Resource, ships: Patp[]) {

--- a/pkg/interface/src/logic/api/invite.ts
+++ b/pkg/interface/src/logic/api/invite.ts
@@ -1,6 +1,6 @@
 import BaseApi from "./base";
 import { StoreState } from "../store/type";
-import { Serial, Path } from "../types/noun";
+import { Serial, Path } from "~/types/noun";
 
 export default class InviteApi extends BaseApi<StoreState> {
   accept(app: Path, uid: Serial) {

--- a/pkg/interface/src/logic/api/links.ts
+++ b/pkg/interface/src/logic/api/links.ts
@@ -2,7 +2,7 @@ import { stringToTa } from '../lib/util';
 
 import BaseApi from './base';
 import { StoreState } from '../store/type';
-import { Path } from '../types/noun';
+import { Path } from '~/types/noun';
 
 export default class LinksApi extends BaseApi<StoreState> {
 

--- a/pkg/interface/src/logic/api/metadata.ts
+++ b/pkg/interface/src/logic/api/metadata.ts
@@ -1,7 +1,7 @@
 
 import BaseApi from './base';
 import { StoreState } from '../store/type';
-import { Path, Patp } from '../types/noun';
+import { Path, Patp } from '~/types/noun';
 
 export default class MetadataApi extends BaseApi<StoreState> {
 

--- a/pkg/interface/src/logic/api/publish.ts
+++ b/pkg/interface/src/logic/api/publish.ts
@@ -1,7 +1,7 @@
 import BaseApi from './base';
-import { PublishResponse } from '../types/publish-response';
-import { PatpNoSig } from '../types/noun';
-import { BookId, NoteId } from '../types/publish-update';
+import { PublishResponse } from '~/types/publish-response';
+import { PatpNoSig } from '~/types/noun';
+import { BookId, NoteId } from '~/types/publish-update';
 
 export default class PublishApi extends BaseApi {
   handleEvent(data: PublishResponse) {

--- a/pkg/interface/src/logic/lib/group.ts
+++ b/pkg/interface/src/logic/lib/group.ts
@@ -1,5 +1,5 @@
-import { roleTags, RoleTags, Group, Resource } from '../../types/group-update';
-import { PatpNoSig, Path } from '../../types/noun';
+import { roleTags, RoleTags, Group, Resource } from '~/types/group-update';
+import { PatpNoSig, Path } from '~/types/noun';
 
 
 export function roleForShip(group: Group, ship: PatpNoSig): RoleTags | undefined {

--- a/pkg/interface/src/logic/reducers/chat-update.ts
+++ b/pkg/interface/src/logic/reducers/chat-update.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import { StoreState } from '../../../store/type';
-import { Cage } from '../../types/cage';
-import { ChatUpdate } from '../../types/chat-update';
-import { ChatHookUpdate } from '../../types/chat-hook-update';
+import { Cage } from '~/types/cage';
+import { ChatUpdate } from '~/types/chat-update';
+import { ChatHookUpdate } from '~/types/chat-hook-update';
 
 type ChatState = Pick<StoreState, 'chatInitialized' | 'chatSynced' | 'inbox' | 'pendingMessages'>;
 

--- a/pkg/interface/src/logic/reducers/connection.ts
+++ b/pkg/interface/src/logic/reducers/connection.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
+import { Cage } from '~/types/cage';
 
 type LocalState = Pick<StoreState, 'connection'>;
 

--- a/pkg/interface/src/logic/reducers/contact-update.ts
+++ b/pkg/interface/src/logic/reducers/contact-update.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { ContactUpdate } from '../../types/contact-update';
+import { Cage } from '~/types/cage';
+import { ContactUpdate } from '~/types/contact-update';
 
 type ContactState  = Pick<StoreState, 'contacts'>;
 

--- a/pkg/interface/src/logic/reducers/group-update.ts
+++ b/pkg/interface/src/logic/reducers/group-update.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
+import { Cage } from '~/types/cage';
 import {
   GroupUpdate,
   Group,
@@ -11,8 +11,8 @@ import {
   OpenPolicy,
   InvitePolicyDiff,
   InvitePolicy,
-} from '../../types/group-update';
-import { Enc, PatpNoSig } from '../../types/noun';
+} from '~/types/group-update';
+import { Enc, PatpNoSig } from '~/types/noun';
 import { resourceAsPath } from '../lib/util';
 
 type GroupState = Pick<StoreState, 'groups' | 'groupKeys'>;

--- a/pkg/interface/src/logic/reducers/invite-update.ts
+++ b/pkg/interface/src/logic/reducers/invite-update.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { InviteUpdate } from '../../types/invite-update';
+import { Cage } from '~/types/cage';
+import { InviteUpdate } from '~/types/invite-update';
 
 type InviteState = Pick<StoreState, "invites">;
 

--- a/pkg/interface/src/logic/reducers/launch-update.ts
+++ b/pkg/interface/src/logic/reducers/launch-update.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { LaunchUpdate } from '../../types/launch-update';
-import { Cage } from '../../types/cage';
+import { LaunchUpdate } from '~/types/launch-update';
+import { Cage } from '~/types/cage';
 import { StoreState } from '../../store/type';
 
 type LaunchState = Pick<StoreState, 'launch' | 'weather' | 'userLocation'>;

--- a/pkg/interface/src/logic/reducers/link-update.ts
+++ b/pkg/interface/src/logic/reducers/link-update.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { LinkUpdate, Pagination } from '../../types/link-update';
+import { LinkUpdate, Pagination } from '~/types/link-update';
 
 // page size as expected from link-view.
 // must change in parallel with the +page-size in /app/link-view to

--- a/pkg/interface/src/logic/reducers/listen-update.ts
+++ b/pkg/interface/src/logic/reducers/listen-update.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { LinkListenUpdate } from '../../types/link-listen-update';
+import { Cage } from '~/types/cage';
+import { LinkListenUpdate } from '~/types/link-listen-update';
 
 type LinkListenState = Pick<StoreState, 'linkListening'>;
 

--- a/pkg/interface/src/logic/reducers/local.ts
+++ b/pkg/interface/src/logic/reducers/local.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { LocalUpdate } from '../../types/local-update';
+import { Cage } from '~/types/cage';
+import { LocalUpdate } from '~/types/local-update';
 
 type LocalState = Pick<StoreState, 'sidebarShown' | 'omniboxShown' | 'dark' | 'baseHash'>;
 

--- a/pkg/interface/src/logic/reducers/metadata-update.ts
+++ b/pkg/interface/src/logic/reducers/metadata-update.ts
@@ -2,8 +2,8 @@ import _ from 'lodash';
 
 import { StoreState } from '../../store/type';
 
-import { MetadataUpdate } from '../../types/metadata-update';
-import { Cage } from '../../types/cage';
+import { MetadataUpdate } from '~/types/metadata-update';
+import { Cage } from '~/types/cage';
 
 type MetadataState = Pick<StoreState, 'associations'>;
 

--- a/pkg/interface/src/logic/reducers/permission-update.ts
+++ b/pkg/interface/src/logic/reducers/permission-update.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { PermissionUpdate } from '../../types/permission-update';
+import { Cage } from '~/types/cage';
+import { PermissionUpdate } from '~/types/permission-update';
 
 type PermissionState = Pick<StoreState, "permissions">;
 

--- a/pkg/interface/src/logic/reducers/publish-response.ts
+++ b/pkg/interface/src/logic/reducers/publish-response.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
+import { Cage } from '~/types/cage';
 
 type PublishState = Pick<StoreState, 'notebooks'>;
 

--- a/pkg/interface/src/logic/reducers/publish-update.ts
+++ b/pkg/interface/src/logic/reducers/publish-update.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
-import { PublishUpdate } from '../../types/publish-update';
-import { Cage } from '../../types/cage';
+import { PublishUpdate } from '~/types/publish-update';
+import { Cage } from '~/types/cage';
 import { StoreState } from '../../store/type';
-import { getTagFromFrond } from '../../types/noun';
+import { getTagFromFrond } from '~/types/noun';
 
 type PublishState = Pick<StoreState, 'notebooks'>;
 

--- a/pkg/interface/src/logic/reducers/s3-update.ts
+++ b/pkg/interface/src/logic/reducers/s3-update.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { StoreState } from '../../store/type';
-import { Cage } from '../../types/cage';
-import { S3Update } from '../../types/s3-update';
+import { Cage } from '~/types/cage';
+import { S3Update } from '~/types/s3-update';
 
 type S3State = Pick<StoreState, 's3'>;
 

--- a/pkg/interface/src/logic/store/store.ts
+++ b/pkg/interface/src/logic/store/store.ts
@@ -5,7 +5,7 @@ import LocalReducer from '../reducers/local';
 import ChatReducer from '../reducers/chat-update';
 
 import { StoreState } from './type';
-import { Cage } from '../types/cage';
+import { Cage } from '~/types/cage';
 import ContactReducer from '../reducers/contact-update';
 import LinkUpdateReducer from '../reducers/link-update';
 import S3Reducer from '../reducers/s3-update';

--- a/pkg/interface/src/logic/store/type.ts
+++ b/pkg/interface/src/logic/store/type.ts
@@ -1,16 +1,16 @@
-import { Inbox, Envelope } from '../types/chat-update';
-import { ChatHookUpdate } from '../types/chat-hook-update';
-import { Path } from '../types/noun';
-import { Invites } from '../types/invite-update';
-import { Associations } from '../types/metadata-update';
-import { Rolodex } from '../types/contact-update';
-import { Notebooks } from '../types/publish-update';
-import { Groups } from '../types/group-update';
-import { S3State } from '../types/s3-update';
-import { Permissions } from '../types/permission-update';
-import { LaunchState, WeatherState } from '../types/launch-update';
-import { LinkComments, LinkCollections, LinkSeen } from '../types/link-update';
-import { ConnectionStatus } from '../types/connection';
+import { Inbox, Envelope } from '~/types/chat-update';
+import { ChatHookUpdate } from '~/types/chat-hook-update';
+import { Path } from '~/types/noun';
+import { Invites } from '~/types/invite-update';
+import { Associations } from '~/types/metadata-update';
+import { Rolodex } from '~/types/contact-update';
+import { Notebooks } from '~/types/publish-update';
+import { Groups } from '~/types/group-update';
+import { S3State } from '~/types/s3-update';
+import { Permissions } from '~/types/permission-update';
+import { LaunchState, WeatherState } from '~/types/launch-update';
+import { LinkComments, LinkCollections, LinkSeen } from '~/types/link-update';
+import { ConnectionStatus } from '~/types/connection';
 
 export interface StoreState {
   // local state

--- a/pkg/interface/src/logic/subscription/base.ts
+++ b/pkg/interface/src/logic/subscription/base.ts
@@ -1,6 +1,6 @@
 import BaseStore from "../store/base";
 import BaseApi from "../api/base";
-import { Path } from "../types/noun";
+import { Path } from "~/types/noun";
 
 export default class BaseSubscription<S extends object> {
   private errorCount = 0;

--- a/pkg/interface/src/logic/subscription/global.ts
+++ b/pkg/interface/src/logic/subscription/global.ts
@@ -1,6 +1,6 @@
 import BaseSubscription from './base';
 import { StoreState } from '../store/type';
-import { Path } from '../types/noun';
+import { Path } from '~/types/noun';
 import _ from 'lodash';
 
 

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -18,11 +18,11 @@ import StatusBar from './components/StatusBar';
 import Omnibox from './components/Omnibox';
 import ErrorComponent from './components/Error';
 
-import GlobalStore from '../logic/store/store';
-import GlobalSubscription from '../logic/subscription/global';
-import GlobalApi from '../logic/api/global';
-import { uxToHex } from '../logic/lib/util';
-import { Sigil } from '../logic/lib/sigil';
+import GlobalStore from '~/logic/store/store';
+import GlobalSubscription from '~/logic/subscription/global';
+import GlobalApi from '~/logic/api/global';
+import { uxToHex } from '~/logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
 
 const Root = styled.div`
   font-family: ${p => p.theme.fonts.sans};

--- a/pkg/interface/src/views/apps/chat/app.tsx
+++ b/pkg/interface/src/views/apps/chat/app.tsx
@@ -11,11 +11,11 @@ import { SettingsScreen } from './components/settings';
 import { NewScreen } from './components/new';
 import { JoinScreen } from './components/join';
 import { NewDmScreen } from './components/new-dm';
-import { PatpNoSig } from '../../../types/noun';
-import GlobalApi from '../../logic/api/global';
-import { StoreState } from '../../logic/store/type';
-import GlobalSubscription from '../../logic/subscription/global';
-import {groupBunts} from '../../../types/group-update';
+import { PatpNoSig } from '~/types/noun';
+import GlobalApi from '~/logic/api/global';
+import { StoreState } from '~/logic/store/type';
+import GlobalSubscription from '~/logic/subscription/global';
+import {groupBunts} from '~/types/group-update';
 
 type ChatAppProps = StoreState & {
   ship: PatpNoSig;

--- a/pkg/interface/src/views/apps/chat/components/chat.tsx
+++ b/pkg/interface/src/views/apps/chat/components/chat.tsx
@@ -6,15 +6,15 @@ import { Link, RouteComponentProps } from "react-router-dom";
 import { ChatWindow } from './lib/chat-window';
 import { ChatHeader } from './lib/chat-header';
 import { ChatInput } from "./lib/chat-input";
-import { deSig } from "../../../../logic/lib/util";
-import { ChatHookUpdate } from "../../../../types/chat-hook-update";
-import ChatApi from "../../../../logic/api/chat";
-import { Inbox, Envelope } from "../../../../types/chat-update";
-import { Contacts } from "../../../../types/contact-update";
-import { Path, Patp } from "../../../../types/noun";
-import GlobalApi from "../../../../logic/api/global";
-import { Association } from "../../../../types/metadata-update";
-import {Group} from "../../../../types/group-update";
+import { deSig } from "~/logic/lib/util";
+import { ChatHookUpdate } from "~/types/chat-hook-update";
+import ChatApi from "~/logic/api/chat";
+import { Inbox, Envelope } from "~/types/chat-update";
+import { Contacts } from "~/types/contact-update";
+import { Path, Patp } from "~/types/noun";
+import GlobalApi from "~/logic/api/global";
+import { Association } from "~/types/metadata-update";
+import {Group} from "~/types/group-update";
 
 
 type ChatScreenProps = RouteComponentProps<{

--- a/pkg/interface/src/views/apps/chat/components/join.js
+++ b/pkg/interface/src/views/apps/chat/components/join.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import urbitOb from 'urbit-ob';
 
 export class JoinScreen extends Component {

--- a/pkg/interface/src/views/apps/chat/components/lib/chat-header.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-header.js
@@ -2,8 +2,8 @@ import React, { Component, Fragment } from "react";
 import { Link } from "react-router-dom";
 
 import { ChatTabBar } from "./chat-tabbar";
-import { SidebarSwitcher } from "../../../../components/SidebarSwitch";
-import { deSig } from "../../../../../logic/lib/util";
+import { SidebarSwitcher } from "~/views/components/SidebarSwitch";
+import { deSig } from "~/logic/lib/util";
 
 
 export const ChatHeader = (props) => {

--- a/pkg/interface/src/views/apps/chat/components/lib/chat-input.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-input.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import ChatEditor from './chat-editor';
 import { S3Upload } from './s3-upload'
 ;
-import { uxToHex } from '../../../../../logic/lib/util';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { uxToHex } from '~/logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
 
 
 const URL_REGEX = new RegExp(String(/^((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)/.source));

--- a/pkg/interface/src/views/apps/chat/components/lib/chat-scroll-container.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-scroll-container.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from "react";
 
-import { scrollIsAtTop, scrollIsAtBottom } from "../../../../../logic/lib/util";
+import { scrollIsAtTop, scrollIsAtBottom } from "~/logic/lib/util";
 
 // Restore chat position on FF when new messages come in
 const recalculateScrollTop = (lastScrollHeight, scrollContainer) => {

--- a/pkg/interface/src/views/apps/chat/components/lib/groupify-button.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/groupify-button.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import Toggle from '../../../../components/toggle';
-import { InviteSearch } from '../../../../components/InviteSearch';
+import Toggle from '~/views/components/toggle';
+import { InviteSearch } from '~/views/components/InviteSearch';
 
 
 export class GroupifyButton extends Component {

--- a/pkg/interface/src/views/apps/chat/components/lib/invite-element.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/invite-element.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { InviteSearch } from '../../../../components/InviteSearch';
-import { Spinner } from '../../../../components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 
 export class InviteElement extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/chat/components/lib/message.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/message.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { OverlaySigil } from './overlay-sigil';
 import MessageContent from './message-content';
-import { uxToHex, cite, writeText } from '../../../../../logic/lib/util';
+import { uxToHex, cite, writeText } from '~/logic/lib/util';
 import moment from 'moment';
 
 

--- a/pkg/interface/src/views/apps/chat/components/lib/metadata-color.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/metadata-color.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import { uxToHex } from '../../../../../logic/lib/util';
+import { uxToHex } from '~/logic/lib/util';
 
 
 export class MetadataColor extends Component {

--- a/pkg/interface/src/views/apps/chat/components/lib/metadata-settings.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/metadata-settings.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import { MetadataColor } from './metadata-color';
 import { MetadataInput } from './metadata-input';
-import { uxToHex } from '../../../../../logic/lib/util';
+import { uxToHex } from '~/logic/lib/util';
 
 
 export const MetadataSettings = (props) => {

--- a/pkg/interface/src/views/apps/chat/components/lib/overlay-sigil.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/overlay-sigil.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { Sigil } from '~/logic/lib/sigil';
 import {
   ProfileOverlay,
   OVERLAY_HEIGHT

--- a/pkg/interface/src/views/apps/chat/components/lib/profile-overlay.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/profile-overlay.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { cite } from '../../../../../logic/lib/util';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { cite } from '~/logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
 
 export const OVERLAY_HEIGHT = 250;
 

--- a/pkg/interface/src/views/apps/chat/components/lib/s3-upload.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/s3-upload.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import S3Client from '../../../../../logic/lib/s3';
+import S3Client from '~/logic/lib/s3';
 
 export class S3Upload extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/chat/components/new-dm.js
+++ b/pkg/interface/src/views/apps/chat/components/new-dm.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
-import { InviteSearch } from '../../../components/InviteSearch';
+import { InviteSearch } from '~/views/components/InviteSearch';
 import urbitOb from 'urbit-ob';
-import { deSig } from '../../../../logic/lib/util';
+import { deSig } from '~/logic/lib/util';
 
 export class NewDmScreen extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/chat/components/new.js
+++ b/pkg/interface/src/views/apps/chat/components/new.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { InviteSearch } from '../../../components/InviteSearch';
-import { Spinner } from '../../../components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
-import { deSig } from '../../../../logic/lib/util';
+import { deSig } from '~/logic/lib/util';
 
 export class NewScreen extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/chat/components/settings.js
+++ b/pkg/interface/src/views/apps/chat/components/settings.js
@@ -1,14 +1,14 @@
 import React, { Component, Fragment } from 'react';
-import { deSig } from '../../../../logic/lib/util';
+import { deSig } from '~/logic/lib/util';
 import { Link } from 'react-router-dom';
 
 import { ChatHeader } from './lib/chat-header';
 import { MetadataSettings } from './lib/metadata-settings';
 import { DeleteButton } from './lib/delete-button';
 import { GroupifyButton } from './lib/groupify-button';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import { ChatTabBar } from './lib/chat-tabbar';
-import SidebarSwitcher from '../../../components/SidebarSwitch';
+import SidebarSwitcher from '~/views/components/SidebarSwitch';
 
 
 export class SettingsScreen extends Component {

--- a/pkg/interface/src/views/apps/chat/components/sidebar.js
+++ b/pkg/interface/src/views/apps/chat/components/sidebar.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 
 import Welcome from './lib/welcome';
-import { alphabetiseAssociations } from '../../../../logic/lib/util';
-import SidebarInvite from '../../../components/SidebarInvite';
+import { alphabetiseAssociations } from '~/logic/lib/util';
+import SidebarInvite from '~/views/components/SidebarInvite';
 import { GroupItem } from './lib/group-item';
 
 export class Sidebar extends Component {

--- a/pkg/interface/src/views/apps/chat/components/skeleton.js
+++ b/pkg/interface/src/views/apps/chat/components/skeleton.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
-import ErrorBoundary from '../../../components/ErrorBoundary';
+import ErrorBoundary from '~/views/components/ErrorBoundary';
 
 export class Skeleton extends Component {
   render() {

--- a/pkg/interface/src/views/apps/dojo/components/input.js
+++ b/pkg/interface/src/views/apps/dojo/components/input.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { cite } from '../../../../logic/lib/util';
-import { Spinner } from '../../../components/Spinner';
+import { cite } from '~/logic/lib/util';
+import { Spinner } from '~/views/components/Spinner';
 
 export class Input extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/groups/app.tsx
+++ b/pkg/interface/src/views/apps/groups/app.tsx
@@ -11,10 +11,10 @@ import { AddScreen } from './components/lib/add-contact';
 import { JoinScreen } from './components/join';
 import GroupDetail from './components/lib/group-detail';
 
-import { PatpNoSig } from '../../../types/noun';
-import GlobalApi from '../../../logic/api/global';
-import { StoreState } from '../../../logic/store/type';
-import GlobalSubscription from '../../../logic/subscription/global';
+import { PatpNoSig } from '~/types/noun';
+import GlobalApi from '~/logic/api/global';
+import { StoreState } from '~/logic/store/type';
+import GlobalSubscription from '~/logic/subscription/global';
 
 
 type GroupsAppProps = StoreState & {

--- a/pkg/interface/src/views/apps/groups/components/join.js
+++ b/pkg/interface/src/views/apps/groups/components/join.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import urbitOb from 'urbit-ob';
 
 export class JoinScreen extends Component {

--- a/pkg/interface/src/views/apps/groups/components/lib/add-contact.tsx
+++ b/pkg/interface/src/views/apps/groups/components/lib/add-contact.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { InviteSearch, Invites } from '../../../../components/InviteSearch';
-import { Spinner } from '../../../../components/Spinner';
+import { InviteSearch, Invites } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 import { uuid } from '../../../../lib/util';
-import { Groups } from '../../../../types/group-update';
-import { Rolodex } from '../../../../types/contact-update';
-import { Path } from '../../../../types/noun';
+import { Groups } from '~/types/group-update';
+import { Rolodex } from '~/types/contact-update';
+import { Path } from '~/types/noun';
 import GlobalApi from '../../../../api/global';
 import { History } from 'history';
 

--- a/pkg/interface/src/views/apps/groups/components/lib/contact-card.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/contact-card.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { Sigil } from '~/logic/lib/sigil';
 
 import { Link } from 'react-router-dom';
 import { EditElement } from './edit-element';
-import { Spinner } from '../../../../components/Spinner';
-import { uxToHex } from '../../../../../logic/lib/util';
+import { Spinner } from '~/views/components/Spinner';
+import { uxToHex } from '~/logic/lib/util';
 import { S3Upload } from './s3-upload';
 
 export class ContactCard extends Component {

--- a/pkg/interface/src/views/apps/groups/components/lib/contact-item.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/contact-item.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Sigil } from '../../../../../logic/lib/sigil';
-import { uxToHex, cite } from '../../../../../logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
+import { uxToHex, cite } from '~/logic/lib/util';
 
 export class ContactItem extends Component {
   render() {

--- a/pkg/interface/src/views/apps/groups/components/lib/contact-sidebar.tsx
+++ b/pkg/interface/src/views/apps/groups/components/lib/contact-sidebar.tsx
@@ -4,14 +4,14 @@ import { FixedSizeList as List } from 'react-window';
 
 import { ContactItem } from './contact-item';
 import { ShareSheet } from './share-sheet';
-import { Sigil } from '../../../../../logic/lib/sigil';
-import { Spinner } from '../../../../components/Spinner';
-import { cite } from '../../../../../logic/lib/util';
-import { roleForShip, resourceFromPath } from '../../../../../logic/lib/group';
-import { Path, PatpNoSig } from '../../../../../types/noun';
-import { Rolodex, Contacts, Contact } from '../../../../../types/contact-update';
-import { Groups, Group } from '../../../../../types/group-update';
-import GlobalApi from '../../../../../logic/api/global';
+import { Sigil } from '~/logic/lib/sigil';
+import { Spinner } from '~/views/components/Spinner';
+import { cite } from '~/logic/lib/util';
+import { roleForShip, resourceFromPath } from '~/logic/lib/group';
+import { Path, PatpNoSig } from '~/types/noun';
+import { Rolodex, Contacts, Contact } from '~/types/contact-update';
+import { Groups, Group } from '~/types/group-update';
+import GlobalApi from '~/logic/api/global';
 
 interface ContactSidebarProps {
 	activeDrawer: 'contacts' | 'detail' | 'rightPanel';

--- a/pkg/interface/src/views/apps/groups/components/lib/group-detail.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/group-detail.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Spinner } from '../../../../components/Spinner';
-import { Toggle } from '../../../../components/toggle';
-import { GroupView } from '../../../../components/Group';
+import { Spinner } from '~/views/components/Spinner';
+import { Toggle } from '~/views/components/toggle';
+import { GroupView } from '~/views/components/Group';
 
-import { deSig, uxToHex, writeText } from '../../../../../logic/lib/util';
-import { roleForShip, resourceFromPath } from '../../../../../logic/lib/group';
+import { deSig, uxToHex, writeText } from '~/logic/lib/util';
+import { roleForShip, resourceFromPath } from '~/logic/lib/group';
 
 export class GroupDetail extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/groups/components/lib/group-sidebar.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/group-sidebar.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react';
 
 import { Link } from 'react-router-dom';
 import { GroupItem } from './group-item';
-import SidebarInvite from '../../../../components/SidebarInvite';
+import SidebarInvite from '~/views/components/SidebarInvite';
 import { Welcome } from './welcome';
 
-import { cite } from '../../../../../logic/lib/util';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { cite } from '~/logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
 
 
 export class GroupSidebar extends Component {

--- a/pkg/interface/src/views/apps/groups/components/lib/s3-upload.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/s3-upload.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import S3Client from '../../../../../logic/lib/s3';
+import S3Client from '~/logic/lib/s3';
 
 export class S3Upload extends Component {
 

--- a/pkg/interface/src/views/apps/groups/components/new.tsx
+++ b/pkg/interface/src/views/apps/groups/components/new.tsx
@@ -1,15 +1,15 @@
 import React, { Component } from 'react';
 
 import { Link } from 'react-router-dom';
-import { InviteSearch, Invites } from '../../../components/InviteSearch';
-import { Spinner } from '../../../components/Spinner';
-import { Toggle } from '../../../components/toggle';
+import { InviteSearch, Invites } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
+import { Toggle } from '~/views/components/toggle';
 import { RouteComponentProps } from 'react-router-dom';
 
-import { Groups, GroupPolicy, Resource } from '../../../../types/group-update';
-import { Contacts, Rolodex } from '../../../../types/contact-update';
-import GlobalApi from '../../../../logic/api/global';
-import { Patp, PatpNoSig, Enc } from '../../../../types/noun';
+import { Groups, GroupPolicy, Resource } from '~/types/group-update';
+import { Contacts, Rolodex } from '~/types/contact-update';
+import GlobalApi from '~/logic/api/global';
+import { Patp, PatpNoSig, Enc } from '~/types/noun';
 
 type NewScreenProps = Pick<RouteComponentProps, 'history'> & {
   groups: Groups;

--- a/pkg/interface/src/views/apps/groups/components/skeleton.js
+++ b/pkg/interface/src/views/apps/groups/components/skeleton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { GroupSidebar } from './lib/group-sidebar';
-import ErrorBoundary from '../../../components/ErrorBoundary';
+import ErrorBoundary from '~/views/components/ErrorBoundary';
 
 export class Skeleton extends Component {
   render() {

--- a/pkg/interface/src/views/apps/launch/components/tiles/basic.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/basic.js
@@ -1,7 +1,7 @@
 import React  from 'react';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
-import defaultApps from '../../../../../logic/lib/default-apps';
+import defaultApps from '~/logic/lib/default-apps';
 
 import Tile from './tile';
 

--- a/pkg/interface/src/views/apps/links/app.js
+++ b/pkg/interface/src/views/apps/links/app.js
@@ -16,7 +16,7 @@ import {
   makeRoutePath,
   amOwnerOfGroup,
   base64urlDecode
-} from '../../../logic/lib/util';
+} from '~/logic/lib/util';
 
 
 export class LinksApp extends Component {

--- a/pkg/interface/src/views/apps/links/components/lib/channel-sidebar.js
+++ b/pkg/interface/src/views/apps/links/components/lib/channel-sidebar.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 
 import { Link } from 'react-router-dom';
 import { GroupItem } from './group-item';
-import SidebarInvite from '../../../../components/SidebarInvite';
+import SidebarInvite from '~/views/components/SidebarInvite';
 import { Welcome } from './welcome';
-import { alphabetiseAssociations } from '../../../../../logic/lib/util';
+import { alphabetiseAssociations } from '~/logic/lib/util';
 
 export class ChannelsSidebar extends Component {
   // drawer to the left

--- a/pkg/interface/src/views/apps/links/components/lib/channels-item.js
+++ b/pkg/interface/src/views/apps/links/components/lib/channels-item.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { makeRoutePath } from '../../../../../logic/lib/util';
+import { makeRoutePath } from '~/logic/lib/util';
 
 export class ChannelsItem extends Component {
   render() {

--- a/pkg/interface/src/views/apps/links/components/lib/comment-item.js
+++ b/pkg/interface/src/views/apps/links/components/lib/comment-item.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Sigil } from '../../../../../logic/lib/sigil';
-import { cite } from '../../../../../logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
+import { cite } from '~/logic/lib/util';
 import moment from 'moment';
 
 export class CommentItem extends Component {

--- a/pkg/interface/src/views/apps/links/components/lib/comments-pagination.js
+++ b/pkg/interface/src/views/apps/links/components/lib/comments-pagination.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { makeRoutePath } from '../../../../../logic/lib/util';
+import { makeRoutePath } from '~/logic/lib/util';
 
 export class CommentsPagination extends Component {
   render() {

--- a/pkg/interface/src/views/apps/links/components/lib/comments.js
+++ b/pkg/interface/src/views/apps/links/components/lib/comments.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { CommentItem } from './comment-item';
 import { CommentsPagination } from './comments-pagination';
 
-import { getContactDetails } from '../../../../../logic/lib/util';
+import { getContactDetails } from '~/logic/lib/util';
 export class Comments extends Component {
   constructor(props) {
     super(props);

--- a/pkg/interface/src/views/apps/links/components/lib/invite-element.js
+++ b/pkg/interface/src/views/apps/links/components/lib/invite-element.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { InviteSearch } from '../../../../components/InviteSearch';
-import { Spinner } from '../../../../components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 
 export class InviteElement extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/links/components/lib/link-detail-preview.js
+++ b/pkg/interface/src/views/apps/links/components/lib/link-detail-preview.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { cite } from '../../../../../logic/lib/util';
+import { cite } from '~/logic/lib/util';
 import moment from 'moment';
 
 export class LinkPreview extends Component {

--- a/pkg/interface/src/views/apps/links/components/lib/link-item.js
+++ b/pkg/interface/src/views/apps/links/components/lib/link-item.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import moment from 'moment';
 
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { Sigil } from '~/logic/lib/sigil';
 import { Link } from 'react-router-dom';
-import { makeRoutePath, cite } from '../../../../../logic/lib/util';
+import { makeRoutePath, cite } from '~/logic/lib/util';
 
 export class LinkItem extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/links/components/lib/link-submit.js
+++ b/pkg/interface/src/views/apps/links/components/lib/link-submit.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Spinner } from '../../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 
 export class LinkSubmit extends Component {
   constructor() {

--- a/pkg/interface/src/views/apps/links/components/lib/links-tabbar.js
+++ b/pkg/interface/src/views/apps/links/components/lib/links-tabbar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { makeRoutePath } from '../../../../../logic/lib/util';
+import { makeRoutePath } from '~/logic/lib/util';
 
 export class LinksTabBar extends Component {
   render() {

--- a/pkg/interface/src/views/apps/links/components/lib/member-element.js
+++ b/pkg/interface/src/views/apps/links/components/lib/member-element.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Sigil } from '../../../../../logic/lib/sigil';
-import { uxToHex, cite } from '../../../../../logic/lib/util';
+import { Sigil } from '~/logic/lib/sigil';
+import { uxToHex, cite } from '~/logic/lib/util';
 export class MemberElement extends Component {
   onRemove() {
     const { props } = this;

--- a/pkg/interface/src/views/apps/links/components/lib/pagination.js
+++ b/pkg/interface/src/views/apps/links/components/lib/pagination.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { makeRoutePath } from '../../../../../logic/lib/util';
+import { makeRoutePath } from '~/logic/lib/util';
 
 export class Pagination extends Component {
   render() {

--- a/pkg/interface/src/views/apps/links/components/link.js
+++ b/pkg/interface/src/views/apps/links/components/link.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { LinksTabBar } from './lib/links-tabbar';
 import { LinkPreview } from './lib/link-detail-preview';
-import { SidebarSwitcher } from '../../../components/SidebarSwitch';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
 import { Link } from 'react-router-dom';
 import { Comments } from './lib/comments';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import { LoadingScreen } from './loading';
-import { makeRoutePath, getContactDetails } from '../../../../logic/lib/util';
+import { makeRoutePath, getContactDetails } from '~/logic/lib/util';
 import CommentItem from './lib/comment-item';
 
 export class LinkDetail extends Component {

--- a/pkg/interface/src/views/apps/links/components/links-list.js
+++ b/pkg/interface/src/views/apps/links/components/links-list.js
@@ -3,13 +3,13 @@ import React, { Component } from 'react';
 import { LoadingScreen } from './loading';
 import { MessageScreen } from './lib/message-screen';
 import { LinksTabBar } from './lib/links-tabbar';
-import { SidebarSwitcher } from '../../../components/SidebarSwitch';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
 import { Link } from 'react-router-dom';
 import { LinkItem } from './lib/link-item';
 import { LinkSubmit } from './lib/link-submit';
 import { Pagination } from './lib/pagination';
 
-import { makeRoutePath, getContactDetails } from '../../../../logic/lib/util';
+import { makeRoutePath, getContactDetails } from '~/logic/lib/util';
 
 export class Links extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/links/components/member.js
+++ b/pkg/interface/src/views/apps/links/components/member.js
@@ -5,9 +5,9 @@ import { Link } from 'react-router-dom';
 import { LoadingScreen } from './loading';
 import { LinksTabBar } from './lib/links-tabbar';
 import { MemberElement } from './lib/member-element';
-import { SidebarSwitcher } from '../../../components/SidebarSwitch';
-import { makeRoutePath } from '../../../../logic/lib/util';
-import { GroupView } from '../../../components/Group';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
+import { makeRoutePath } from '~/logic/lib/util';
+import { GroupView } from '~/views/components/Group';
 
 export class MemberScreen extends Component {
   render() {

--- a/pkg/interface/src/views/apps/links/components/new.js
+++ b/pkg/interface/src/views/apps/links/components/new.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { InviteSearch } from '../../../components/InviteSearch';
-import { Spinner } from '../../../components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
-import { makeRoutePath, deSig } from '../../../../logic/lib/util';
+import { makeRoutePath, deSig } from '~/logic/lib/util';
 import urbitOb from 'urbit-ob';
 
 export class NewScreen extends Component {

--- a/pkg/interface/src/views/apps/links/components/settings.js
+++ b/pkg/interface/src/views/apps/links/components/settings.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 
-import { uxToHex, makeRoutePath } from '../../../../logic/lib/util';
+import { uxToHex, makeRoutePath } from '~/logic/lib/util';
 import { Link } from 'react-router-dom';
 
 import { LoadingScreen } from './loading';
-import { Spinner } from '../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import { LinksTabBar } from './lib/links-tabbar';
-import SidebarSwitcher from '../../../components/SidebarSwitch';
+import SidebarSwitcher from '~/views/components/SidebarSwitch';
 
 export class SettingsScreen extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/links/components/skeleton.js
+++ b/pkg/interface/src/views/apps/links/components/skeleton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { ChannelsSidebar } from './lib/channel-sidebar';
-import ErrorBoundary from '../../../components/ErrorBoundary';
+import ErrorBoundary from '~/views/components/ErrorBoundary';
 
 export class Skeleton extends Component {
   render() {

--- a/pkg/interface/src/views/apps/publish/components/lib/comment-item.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/comment-item.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import moment from 'moment';
-import { Sigil } from '../../../../../logic/lib/sigil';
+import { Sigil } from '~/logic/lib/sigil';
 import CommentInput from './comment-input';
-import { uxToHex, cite } from '../../../../../logic/lib/util';
+import { uxToHex, cite } from '~/logic/lib/util';
 
 export class CommentItem extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/comments.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/comments.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { CommentItem } from './comment-item';
 import CommentInput from './comment-input';
-import { dateToDa } from '../../../../../logic/lib/util';
-import { Spinner } from '../../../../components/Spinner';
+import { dateToDa } from '~/logic/lib/util';
+import { Spinner } from '~/views/components/Spinner';
 
 export class Comments extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/edit-post.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/edit-post.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
-import { SidebarSwitcher } from '../../../../components/SidebarSwitch';
-import { Spinner } from '../../../../components/Spinner';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
 import { Controlled as CodeMirror } from 'react-codemirror2';
-import { dateToDa } from '../../../../../logic/lib/util';
+import { dateToDa } from '~/logic/lib/util';
 
 import 'codemirror/mode/markdown/markdown';
 

--- a/pkg/interface/src/views/apps/publish/components/lib/join.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/join.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Spinner } from '../../../../components/Spinner';
+import { Spinner } from '~/views/components/Spinner';
 import urbitOb from 'urbit-ob';
 
 export class JoinScreen extends Component {

--- a/pkg/interface/src/views/apps/publish/components/lib/new-post.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/new-post.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
-import { SidebarSwitcher } from '../../../../components/SidebarSwitch';
-import { Spinner } from '../../../../components/Spinner';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
 import { Controlled as CodeMirror } from 'react-codemirror2';
-import { dateToDa, stringToSymbol } from '../../../../../logic/lib/util';
+import { dateToDa, stringToSymbol } from '~/logic/lib/util';
 
 import 'codemirror/mode/markdown/markdown';
 

--- a/pkg/interface/src/views/apps/publish/components/lib/new.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/new.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { InviteSearch } from '../../../../components/InviteSearch';
-import { Spinner } from '../../../../components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import { Spinner } from '~/views/components/Spinner';
 import { Link } from 'react-router-dom';
-import { stringToSymbol } from '../../../../../logic/lib/util';
+import { stringToSymbol } from '~/logic/lib/util';
 
 export class NewScreen extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/note.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/note.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { SidebarSwitcher } from '../../../../components/SidebarSwitch';
-import { Spinner } from '../../../../components/Spinner';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
+import { Spinner } from '~/views/components/Spinner';
 import { Comments } from './comments';
 import { NoteNavigation } from './note-navigation';
 import moment from 'moment';
 import ReactMarkdown from 'react-markdown';
-import { cite } from '../../../../../logic/lib/util';
+import { cite } from '~/logic/lib/util';
 
 export class Note extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/notebook-posts.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/notebook-posts.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
-import { cite } from '../../../../../logic/lib/util';
+import { cite } from '~/logic/lib/util';
 
 export class NotebookPosts extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/notebook.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/notebook.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { SidebarSwitcher } from '../../../../components/SidebarSwitch';
+import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
 import { NotebookPosts } from './notebook-posts';
 import { Subscribers } from './subscribers';
 import { Settings } from './settings';
-import { cite } from '../../../../../logic/lib/util';
-import { roleForShip } from '../../../../../logic/lib/group';
+import { cite } from '~/logic/lib/util';
+import { roleForShip } from '~/logic/lib/group';
 
 export class Notebook extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/settings.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/settings.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import { Spinner } from '../../../../components/Spinner';
-import { InviteSearch } from '../../../../components/InviteSearch';
-import Toggle from '../../../../components/toggle';
+import { Spinner } from '~/views/components/Spinner';
+import { InviteSearch } from '~/views/components/InviteSearch';
+import Toggle from '~/views/components/toggle';
 
 export class Settings extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/lib/sidebar.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/sidebar.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import SidebarInvite from '../../../../components/SidebarInvite';
+import SidebarInvite from '~/views/components/SidebarInvite';
 import { Welcome } from './welcome';
 import { GroupItem } from './group-item';
-import { alphabetiseAssociations } from '../../../../../logic/lib/util';
+import { alphabetiseAssociations } from '~/logic/lib/util';
 
 export class Sidebar extends Component {
   render() {

--- a/pkg/interface/src/views/apps/publish/components/lib/subscribers.js
+++ b/pkg/interface/src/views/apps/publish/components/lib/subscribers.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { GroupView } from '../../../../components/Group';
-import { resourceFromPath } from '../../../../../logic/lib/group';
+import { GroupView } from '~/views/components/Group';
+import { resourceFromPath } from '~/logic/lib/group';
 
 export class Subscribers extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/apps/publish/components/skeleton.js
+++ b/pkg/interface/src/views/apps/publish/components/skeleton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Sidebar } from './lib/sidebar';
-import ErrorBoundary from '../../../components/ErrorBoundary';
+import ErrorBoundary from '~/views/components/ErrorBoundary';
 
 export class Skeleton extends Component {
   render() {

--- a/pkg/interface/src/views/components/Group.tsx
+++ b/pkg/interface/src/views/components/Group.tsx
@@ -3,22 +3,22 @@ import _, { capitalize } from 'lodash';
 import { FixedSizeList as List } from 'react-window';
 
 import { Dropdown } from '../apps/publish/components/lib/dropdown';
-import { cite, deSig } from '../../logic/lib/util';
-import { roleForShip, resourceFromPath } from '../../logic/lib/group';
+import { cite, deSig } from '~/logic/lib/util';
+import { roleForShip, resourceFromPath } from '~/logic/lib/group';
 import {
   Group,
   InvitePolicy,
   OpenPolicy,
   roleTags,
   Groups,
-} from '../../types/group-update';
-import { Path, PatpNoSig, Patp } from '../../types/noun';
+} from '~/types/group-update';
+import { Path, PatpNoSig, Patp } from '~/types/noun';
 import GlobalApi from '../api/global';
 import { Menu, MenuButton, MenuList, MenuItem } from '@tlon/indigo-react';
 import InviteSearch, { Invites } from './InviteSearch';
 import { Spinner } from './Spinner';
-import { Rolodex } from '../../types/contact-update';
-import { Associations } from '../../types/metadata-update';
+import { Rolodex } from '~/types/contact-update';
+import { Associations } from '~/types/metadata-update';
 
 class GroupMember extends Component<{ ship: Patp; options: any[] }, {}> {
   render() {

--- a/pkg/interface/src/views/components/InviteSearch.tsx
+++ b/pkg/interface/src/views/components/InviteSearch.tsx
@@ -2,11 +2,11 @@ import React, { Component, createRef } from 'react';
 import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 import urbitOb from 'urbit-ob';
-import { Sigil } from '../../logic/lib/sigil';
-import { PatpNoSig, Path } from '../../types/noun';
-import { Groups} from '../../types/group-update';
-import { Rolodex, Contact } from '../../types/contact-update';
-import { Associations } from '../../types/metadata-update';
+import { Sigil } from '~/logic/lib/sigil';
+import { PatpNoSig, Path } from '~/types/noun';
+import { Groups} from '~/types/group-update';
+import { Rolodex, Contact } from '~/types/contact-update';
+import { Associations } from '~/types/metadata-update';
 
 export interface Invites {
   ships: PatpNoSig[];

--- a/pkg/interface/src/views/components/Omnibox.js
+++ b/pkg/interface/src/views/components/Omnibox.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { Box, Row, Rule, Text } from '@tlon/indigo-react';
-import index from '../../logic/lib/omnibox';
+import index from '~/logic/lib/omnibox';
 import Mousetrap from 'mousetrap';
 import OmniboxInput from './OmniboxInput';
 import OmniboxResult from './OmniboxResult';
 
-import { cite } from '../../logic/lib/util';
+import { cite } from '~/logic/lib/util';
 
 export class Omnibox extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/components/OmniboxResult.js
+++ b/pkg/interface/src/views/components/OmniboxResult.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Row, Icon, Text } from '@tlon/indigo-react';
-import defaultApps from '../../logic/lib/default-apps';
+import defaultApps from '~/logic/lib/default-apps';
 
 export class OmniboxResult extends Component {
   constructor(props) {

--- a/pkg/interface/src/views/components/SidebarInvite.tsx
+++ b/pkg/interface/src/views/components/SidebarInvite.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Invite } from '../types/invite-update';
+import { Invite } from '~/types/invite-update';
 
 export class SidebarInvite extends Component<{invite: Invite, onAccept: Function, onDecline: Function}, {}> {
   render() {

--- a/pkg/interface/tsconfig.json
+++ b/pkg/interface/tsconfig.json
@@ -12,7 +12,11 @@
     "target": "es2015",
     "module": "es2015",
     "strict": true,
-    "jsx": "react"
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
**Problem**: Deeply nested import structure often leads to lines like `../../../../../../views/components/component`

**Solution**: Use the `babel-plugin-root-import` plugin to resolve `~/` to the `src` directory.