### PR TITLE
chat: account for digits in group name links

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/text.js
@@ -41,7 +41,7 @@ export default class TextContent extends Component {
     const content = props.content;
 
     const group = content.text.match(
-      /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z])+([/-])?)+/
+      /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z0-9])+([/-])?)+/
     );
     if ((group !== null) // matched possible chatroom
       && (group[2].length > 2) // possible ship?

--- a/pkg/interface/src/views/apps/chat/components/lib/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/text.js
@@ -41,7 +41,7 @@ export default class TextContent extends Component {
     const content = props.content;
 
     const group = content.text.match(
-      /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z0-9])+([/-])?)+/
+      /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z0-9-])+([/-])?)+/
     );
     if ((group !== null) // matched possible chatroom
       && (group[2].length > 2) // possible ship?


### PR DESCRIPTION
**Problem**: When a group name has digits in it, it does not automatically link when sent on its own line in chat

**Solution**: Make the regex capture digits too