### PR TITLE
groups: join fixes

### DIFF
--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -164,10 +164,7 @@
           (fact-group-update:cc wire !<(update:group-store q.cage.sign))
         [cards this]
       ::
-          %invite-update
-        =^  cards  state
-          (fact-invite-update:cc wire !<(invite-update q.cage.sign))
-        [cards this]
+        %invite-update  [~ this]
       ==
     ==
   ::
@@ -480,17 +477,6 @@
     =/  act=invite-action  [%invite /contacts (shaf %msg-uid eny.bol) invite]
     [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
   --
-::
-++  fact-invite-update
-  |=  [wir=wire fact=invite-update]
-  ^-  (quip card _state)
-  ?+  -.fact  [~ state]
-      %accepted
-    =/  rid=resource
-      (de-path:resource path.invite.fact)
-    :_  state
-    ~[(contact-view-poke %join rid)]
-  ==
 ::
 ++  group-hook-poke
   |=  =action:group-hook

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -227,8 +227,11 @@
 
 ++  peek-group-join
   |=  [rid=resource =ship]
-  =/  =group
-    (~(gut by groups) rid *group)
+  =/  ugroup
+    (~(get by groups) rid)
+  ?~  ugroup
+    %.n
+  =*  group   u.ugroup
   =*  policy  policy.group
   ?-  -.policy
       %invite

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -225,7 +225,8 @@
     ++  add
       |=  [=ship =resource]
       ~|  resource
-      ?<  (~(has by tracking) resource)
+      ?:  (~(has by tracking) resource)
+        [~ state]
       =.  tracking
         (~(put by tracking) resource ship)
       :_  state


### PR DESCRIPTION
- contact-hook: no-op on accepted invite

The contact-hook was attempting to join a group upon it's invite being
accepted. However, the join poke is also sent from the frontend, causing
a potential race condition. Changes contact-hook to no-op on an
%invite-update.

- group-store: disallow joining a non-existent group
- pull-hook: no-op on pulling a resource we already have

Should address issues with joining groups
