### PR TITLE
natpmp: By default, only try to talk to the router on private ips.

### DIFF
--- a/pkg/hs/natpmp-static/cbits/natpmp.c
+++ b/pkg/hs/natpmp-static/cbits/natpmp.c
@@ -57,6 +57,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 LIBSPEC int initnatpmp(natpmp_t * p, int forcegw, in_addr_t forcedgw)
 {
+  fprintf(stderr, "[] top of initnatpmp\r\n");
+
 #ifdef WIN32
 	u_long ioctlArg = 1;
 #else
@@ -82,16 +84,21 @@ LIBSPEC int initnatpmp(natpmp_t * p, int forcegw, in_addr_t forcedgw)
 	if(forcegw) {
 		p->gateway = forcedgw;
 	} else {
+      fprintf(stderr, "[] starting looking for gateway\r\n");
 		if(getdefaultgateway(&(p->gateway)) < 0)
 			return NATPMP_ERR_CANNOTGETGATEWAY;
+      fprintf(stderr, "[] found gateway\r\n");
 	}
 
+    fprintf(stderr, "[] about to connect()\r\n");
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(NATPMP_PORT);
 	addr.sin_addr.s_addr = p->gateway;
-	if(connect(p->s, (struct sockaddr *)&addr, sizeof(addr)) < 0)
-		return NATPMP_ERR_CONNECTERR;
+	if(connect(p->s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+      return NATPMP_ERR_CONNECTERR;
+    }
+    fprintf(stderr, "[] connect()ed\r\n");
 	return 0;
 }
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -19,7 +19,7 @@ import System.Environment (getProgName)
 data Host = Host
   { hSharedHttpPort  :: Maybe Word16
   , hSharedHttpsPort :: Maybe Word16
-  , hUseNatPmp       :: Bool
+  , hUseNatPmp       :: Maybe NatSetting
   }
  deriving (Show)
 
@@ -69,6 +69,11 @@ data BootType
 data PillSource
   = PillSourceFile FilePath
   | PillSourceURL String
+  deriving (Show)
+
+data NatSetting
+  = NatSettingAlways
+  | NatSettingWhenPrivateNetwork
   deriving (Show)
 
 data New = New
@@ -427,11 +432,17 @@ host = do
     <> hidden
 
   hUseNatPmp <-
-    fmap not
-    $  switch
-    $  long "no-port-forwarding"
+     ( flag' (Just NatSettingAlways)
+     $ long "port-forwarding"
+    <> help "Always try to search for a router to forward ames ports"
+    <> hidden
+     ) <|>
+     ( flag' Nothing
+     $ long "no-port-forwarding"
     <> help "Disable trying to ask the router to forward ames ports"
     <> hidden
+     ) <|>
+     (pure $ Just NatSettingWhenPrivateNetwork)
 
   pure (Host{..})
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -19,7 +19,7 @@ import System.Environment (getProgName)
 data Host = Host
   { hSharedHttpPort  :: Maybe Word16
   , hSharedHttpsPort :: Maybe Word16
-  , hUseNatPmp       :: Maybe NatSetting
+  , hUseNatPmp       :: Nat
   }
  deriving (Show)
 
@@ -71,9 +71,10 @@ data PillSource
   | PillSourceURL String
   deriving (Show)
 
-data NatSetting
-  = NatSettingAlways
-  | NatSettingWhenPrivateNetwork
+data Nat
+  = NatAlways
+  | NatWhenPrivateNetwork
+  | NatNever
   deriving (Show)
 
 data New = New
@@ -432,17 +433,23 @@ host = do
     <> hidden
 
   hUseNatPmp <-
-     ( flag' (Just NatSettingAlways)
+     ( flag' NatAlways
      $ long "port-forwarding"
     <> help "Always try to search for a router to forward ames ports"
     <> hidden
      ) <|>
-     ( flag' Nothing
+     ( flag' NatNever
      $ long "no-port-forwarding"
     <> help "Disable trying to ask the router to forward ames ports"
     <> hidden
      ) <|>
-     (pure $ Just NatSettingWhenPrivateNetwork)
+     ( flag' NatWhenPrivateNetwork
+     $ long "port-forwarding-when-internal"
+    <> help ("Try asking the router to forward when ip is 192.168.0.0/24 or" <>
+             "10.0.0.0/8 (default).")
+    <> hidden
+     ) <|>
+     (pure $ NatWhenPrivateNetwork)
 
   pure (Host{..})
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -590,15 +590,14 @@ runShip (CLI.Run pierPath) opts daemon = do
         mStart
 
 
-buildPortHandler :: HasLogFunc e => Maybe CLI.NatSetting -> RIO e PortControlApi
-buildPortHandler Nothing  = pure buildInactivePorts
+buildPortHandler :: HasLogFunc e => CLI.Nat -> RIO e PortControlApi
+buildPortHandler CLI.NatNever  = pure buildInactivePorts
 -- TODO: Figure out what to do about logging here. The "port: " messages are
 -- the sort of thing that should be put on the muxed terminal log, but we don't
 -- have that at this layer.
-buildPortHandler (Just CLI.NatSettingAlways) =
-  buildNatPorts TryNatAlways (io . hPutStrLn stderr . unpack)
-buildPortHandler (Just CLI.NatSettingWhenPrivateNetwork) =
-  buildNatPorts TryNatWhenPrivate (io . hPutStrLn stderr . unpack)
+buildPortHandler CLI.NatAlways = buildNatPorts (io . hPutStrLn stderr . unpack)
+buildPortHandler CLI.NatWhenPrivateNetwork =
+  buildNatPortsWhenPrivate (io . hPutStrLn stderr . unpack)
 
 startBrowser :: HasLogFunc e => FilePath -> RIO e ()
 startBrowser pierPath = runRAcquire $ do

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -590,12 +590,15 @@ runShip (CLI.Run pierPath) opts daemon = do
         mStart
 
 
-buildPortHandler :: HasLogFunc e => Bool -> RIO e PortControlApi
-buildPortHandler False  = pure buildInactivePorts
+buildPortHandler :: HasLogFunc e => Maybe CLI.NatSetting -> RIO e PortControlApi
+buildPortHandler Nothing  = pure buildInactivePorts
 -- TODO: Figure out what to do about logging here. The "port: " messages are
 -- the sort of thing that should be put on the muxed terminal log, but we don't
 -- have that at this layer.
-buildPortHandler True   = buildNatPorts (io . hPutStrLn stderr . unpack)
+buildPortHandler (Just CLI.NatSettingAlways) =
+  buildNatPorts TryNatAlways (io . hPutStrLn stderr . unpack)
+buildPortHandler (Just CLI.NatSettingWhenPrivateNetwork) =
+  buildNatPorts TryNatWhenPrivate (io . hPutStrLn stderr . unpack)
 
 startBrowser :: HasLogFunc e => FilePath -> RIO e ()
 startBrowser pierPath = runRAcquire $ do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
@@ -1,5 +1,6 @@
 module Urbit.Vere.Ports (HasPortControlApi(..),
                          PortControlApi,
+                         TryNat(..),
                          buildInactivePorts,
                          buildNatPorts,
                          requestPortAccess) where
@@ -30,12 +31,24 @@ buildInactivePorts = PortControlApi noop noop
  where
   noop x = pure ()
 
+data TryNat
+  = TryNatAlways
+  | TryNatWhenPrivate
+
 -- | Builds a PortControlApi struct which tries to hole-punch by talking to the
 -- NAT gateway over NAT-PMP.
 buildNatPorts :: (HasLogFunc e)
-              => (Text -> RIO e ())
+              => TryNat
+              -> (Text -> RIO e ())
               -> RIO e PortControlApi
-buildNatPorts stderr = do
+
+buildNatPorts TryNatWhenPrivate stderr = do
+  behind <- likelyBehindRouter
+  if behind
+    then buildNatPorts TryNatAlways stderr
+    else pure buildInactivePorts
+
+buildNatPorts TryNatAlways stderr = do
   q <- newTQueueIO
   async $ portThread q stderr
 
@@ -221,6 +234,14 @@ likelyIPAddress = liftIO do
   case sockAddr of
     SockAddrInet _ addr -> pure $ Just $ hostAddressToTuple addr
     _                   -> pure $ Nothing
+
+likelyBehindRouter :: MonadIO m => m Bool
+likelyBehindRouter = do
+  likelyIPAddress >>= \case
+    Just ip@(192, 168, _, _) -> pure True
+    Just ip@(10, _, _, _)    -> pure True
+    _                        -> pure False
+
 
 -- Acquire a port for the duration of the RAcquire.
 requestPortAccess :: forall e. (HasPortControlApi e) => Word16 -> RAcquire e ()


### PR DESCRIPTION
Since startup hangs for seconds when you are not behind a router,
but still attempt to ask one to open ports for you, by default,
only try to contact the router if the local ip is `192.168.*.*` or
`10.*.*.*`.

Also make port forwarding force on/off.