### PR TITLE
chat: several design tweaks

### DIFF
--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -11,7 +11,7 @@
     "@tlon/indigo-light": "^1.0.3",
     "@tlon/indigo-react": "^1.1.15",
     "classnames": "^2.2.6",
-    "codemirror": "^5.51.0",
+    "codemirror": "^5.55.0",
     "css-loader": "^3.5.3",
     "formik": "^2.1.4",
     "lodash": "^4.17.15",

--- a/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
@@ -15,7 +15,7 @@ const MARKDOWN_CONFIG = {
   name: 'markdown',
   tokenTypeOverrides: {
     header: 'presentation',
-    quote: 'presentation',
+    quote: 'quote',
     list1: 'presentation',
     list2: 'presentation',
     list3: 'presentation',

--- a/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
@@ -121,16 +121,18 @@ export default class ChatEditor extends Component {
 
     return (
       <div
-        className="chat fr h-100 flex bg-gray0-d lh-copy pl2 w-100 items-center"
-        style={{ flexGrow: 1, maxHeight: '224px', width: 'calc(100% - 72px)' }}
-      >
+        className={
+          'chat fr h-100 flex bg-gray0-d lh-copy pl2 w-100 items-center' +
+          (props.inCodeMode ? ' code' : '')
+        }
+        style={{ flexGrow: 1, maxHeight: '224px', width: 'calc(100% - 72px)' }}>
         <CodeEditor
           value={props.message}
           options={options}
           onChange={(e, d, v) => this.messageChange(e, d, v)}
           editorDidMount={(editor) => {
             this.editor = editor;
-            if (!(BROWSER_REGEX.test(navigator.userAgent))) {
+            if (!BROWSER_REGEX.test(navigator.userAgent)) {
               editor.focus();
             }
           }}

--- a/pkg/interface/src/views/apps/chat/components/lib/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/code.js
@@ -11,14 +11,14 @@ export default class CodeContent extends Component {
       (Boolean(content.code.output) &&
        content.code.output.length && content.code.output.length > 0) ?
       (
-        <pre className={`f7 clamp-attachment pa1 mt0 mb0 b--gray4 b--gray1-d bl br bb`}>
+        <pre className={`code f7 clamp-attachment pa1 mt0 mb0 b--gray4 b--gray1-d bl br bb`}>
           {content.code.output[0].join('\n')}
         </pre>
       ) : null;
-    
+
     return (
       <div className="mv2">
-        <pre className={`f7 clamp-attachment pa1 mt0 mb0 bg-light-gray b--gray4 b--gray1-d ba`}>
+        <pre className={`code f7 clamp-attachment pa1 mt0 mb0 bg-light-gray b--gray4 b--gray1-d ba`}>
           {content.code.expression}
         </pre>
         {outputElement}

--- a/pkg/interface/src/views/apps/chat/components/lib/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/code.js
@@ -11,14 +11,14 @@ export default class CodeContent extends Component {
       (Boolean(content.code.output) &&
        content.code.output.length && content.code.output.length > 0) ?
       (
-        <pre className={`code f7 clamp-attachment pa1 mt0 mb0 b--gray4 b--gray1-d bl br bb`}>
+        <pre className={`code f7 clamp-attachment pa1 mt0 mb0`}>
           {content.code.output[0].join('\n')}
         </pre>
       ) : null;
 
     return (
       <div className="mv2">
-        <pre className={`code f7 clamp-attachment pa1 mt0 mb0 bg-light-gray b--gray4 b--gray1-d ba`}>
+        <pre className={`code f7 clamp-attachment pa1 mt0 mb0`}>
           {content.code.expression}
         </pre>
         {outputElement}

--- a/pkg/interface/src/views/apps/chat/components/lib/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/text.js
@@ -6,7 +6,6 @@ import urbitOb from 'urbit-ob';
 
 const DISABLED_BLOCK_TOKENS = [
   'indentedCode',
-  'blockquote',
   'atxHeading',
   'thematicBreak',
   'list',

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -256,7 +256,11 @@ blockquote {
     font-family: 'Inter';
 }
 
-.chat .CodeMirror.cm-s-code.chat .cm-s-tlon * {
+.code, .chat.code .react-codemirror2 .CodeMirror * {
+  font-family: 'Source Code Pro';
+}
+
+.chat .CodeMirror.cm-s-code.chat * {
    font-family: 'Source Code Pro';
 }
 

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -256,6 +256,10 @@ blockquote {
     font-family: 'Inter';
 }
 
+code, pre.code {
+  background-color: var(--light-gray);
+}
+
 code, .code, .chat.code .react-codemirror2 .CodeMirror * {
   font-family: 'Source Code Pro';
 }

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -258,7 +258,6 @@ blockquote {
 
 .chat .CodeMirror.cm-s-code.chat .cm-s-tlon * {
    font-family: 'Source Code Pro';
-
 }
 
 .chat .CodeMirror-selected { background:#BAE3FE !important; color: black; }
@@ -267,6 +266,7 @@ pre.CodeMirror-placeholder.CodeMirror-line-like { color: var(--gray); }
 .chat .cm-s-tlon span { font-family: "Inter"}
 .chat .cm-s-tlon span.cm-meta { color: var(--gray); }
 .chat .cm-s-tlon span.cm-number { color: var(--gray); }
+.chat .cm-s-tlon span.cm-quote { color: var(--gray); }
 .chat .cm-s-tlon span.cm-keyword { line-height: 1em; font-weight: bold; color: var(--gray); }
 .chat .cm-s-tlon span.cm-atom { font-weight: bold; color: var(--gray); }
 .chat .cm-s-tlon span.cm-def { color: black; }

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -256,7 +256,7 @@ blockquote {
     font-family: 'Inter';
 }
 
-.code, .chat.code .react-codemirror2 .CodeMirror * {
+code, .code, .chat.code .react-codemirror2 .CodeMirror * {
   font-family: 'Source Code Pro';
 }
 


### PR DESCRIPTION
- Not the sidebar PR yet, sorry @galenwp.
- Adds blockquotes (#3338). @urcades?

<img width="340" alt="Screen Shot 2020-08-18 at 5 20 37 PM" src="https://user-images.githubusercontent.com/20846414/90566949-56181c80-e177-11ea-8277-ad9c31d6d1a8.png">

- Code mode swaps placeholder and text with Source Code Pro.
- Add code messages now use Source Code Pro instead of being reset to Consolas.
- Updated codemirror to 5.55.0 to test my hypothesis from #2828.