### PR TITLE
dojo: fixes whitescreen on mobile

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -30,6 +30,8 @@ const Root = styled.div`
   width: 100%;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-flow: column nowrap;
 `;
 
 const StatusBarWithRouter = withRouter(StatusBar);

--- a/pkg/interface/src/views/apps/dojo/app.js
+++ b/pkg/interface/src/views/apps/dojo/app.js
@@ -48,7 +48,7 @@ export default class DojoApp extends Component {
     return (
       <div
         className="bg-white bg-gray0-d"
-        style={{ height: 'calc(100vh - 45px)' }}
+        style={{ height: '100%' }}
       >
         <Route
           exact

--- a/pkg/interface/src/views/apps/dojo/components/input.js
+++ b/pkg/interface/src/views/apps/dojo/components/input.js
@@ -80,7 +80,7 @@ export class Input extends Component {
   render() {
     return (
       <div className="flex flex-row flex-grow-1 relative">
-        <div className="flex-shrink-0">{cite(this.props.ship)}:dojo
+        <div className="flex-shrink-0"><span class="dn-s">{cite(this.props.ship)}:</span>dojo
         </div>
         <span id="prompt">
           {this.props.prompt}


### PR DESCRIPTION
DWISOTT. 

Does this by affecting the whole app, though. IMO not a bad solution as it prevents the need for `calc(100vh - $headerheight)` hacks in the future.

Also hides the ship name on mobile to save space.

Also learned how to serve on my local network for phone testing so that's cool.