### PR TITLE
natpmp: change nat-pmp startup behaviour.

### DIFF
--- a/pkg/hs/natpmp-static/cbits/binding.c
+++ b/pkg/hs/natpmp-static/cbits/binding.c
@@ -55,22 +55,22 @@ int readNatResponseSynchronously(natpmp_t* natpmp, natpmpresp_t * response)
 		r = select(FD_SETSIZE, &fds, NULL, NULL, &timeout);
 		sav_errno = errno;
 		if(r<0) {
-			fprintf(stderr, "select():  errno=%d '%s'\n",
-			        sav_errno, strerror(sav_errno));
+			/* fprintf(stderr, "select():  errno=%d '%s'\n", */
+			/*         sav_errno, strerror(sav_errno)); */
 			return 1;
 		}
 		r = readnatpmpresponseorretry(natpmp, response);
 		sav_errno = errno;
 		/* printf("readnatpmpresponseorretry returned %d (%s)\n", */
 		/*        r, r==0?"OK":(r==NATPMP_TRYAGAIN?"TRY AGAIN":"FAILED")); */
-		if(r<0 && r!=NATPMP_TRYAGAIN) {
-#ifdef ENABLE_STRNATPMPERR
-			fprintf(stderr, "readnatpmpresponseorretry() failed : %s\n",
-			        strnatpmperr(r));
-#endif
-			fprintf(stderr, "  errno=%d '%s'\n",
-			        sav_errno, strerror(sav_errno));
-		}
+/* 		if(r<0 && r!=NATPMP_TRYAGAIN) { */
+/* #ifdef ENABLE_STRNATPMPERR */
+/* 			fprintf(stderr, "readnatpmpresponseorretry() failed : %s\n", */
+/* 			        strnatpmperr(r)); */
+/* #endif */
+/* 			fprintf(stderr, "  errno=%d '%s'\n", */
+/* 			        sav_errno, strerror(sav_errno)); */
+/* 		} */
 	} while(r==NATPMP_TRYAGAIN);
 
     return r;

--- a/pkg/hs/natpmp-static/cbits/natpmp.c
+++ b/pkg/hs/natpmp-static/cbits/natpmp.c
@@ -282,11 +282,19 @@ int readnatpmpresponseorretry(natpmp_t * p, natpmpresp_t * response)
 			gettimeofday(&now, NULL);	// check errors !
 			if(timercmp(&now, &p->retry_time, >=)) {
 				int delay, r;
-				if(p->try_number >= 9) {
+                // NOTE: This used to be 9, and was changed for the haskell
+                // bindings to be 5.
+				if(p->try_number >= 5) {
 					return NATPMP_ERR_NOGATEWAYSUPPORT;
 				}
 				/*printf("retry! %d\n", p->try_number);*/
-				delay = 250 * (1<<p->try_number);	// ms
+
+                // NOTE: Changed how delays are calculated. Waiting up to four
+                // minutes for a packet that might never get a response is not
+                // a good user experience. Instead, retry up to 2 seconds.
+                //
+				// delay = 250 * (1<<p->try_number);	// ms
+                delay = 250 * p->try_number;	// ms
 				/*for(i=0; i<p->try_number; i++)
 					delay += delay;*/
 				p->retry_time.tv_sec += (delay / 1000);

--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -19,7 +19,7 @@ import System.Environment (getProgName)
 data Host = Host
   { hSharedHttpPort  :: Maybe Word16
   , hSharedHttpsPort :: Maybe Word16
-  , hUseNatPmp       :: Bool
+  , hUseNatPmp       :: Maybe NatSetting
   }
  deriving (Show)
 
@@ -69,6 +69,11 @@ data BootType
 data PillSource
   = PillSourceFile FilePath
   | PillSourceURL String
+  deriving (Show)
+
+data NatSetting
+  = NatSettingAlways
+  | NatSettingWhenPrivateNetwork
   deriving (Show)
 
 data New = New
@@ -427,11 +432,17 @@ host = do
     <> hidden
 
   hUseNatPmp <-
-    fmap not
-    $  switch
-    $  long "no-port-forwarding"
+     ( flag' (Just NatSettingAlways)
+     $ long "port-forwarding"
+    <> help "Always try to search for a router to forward ames ports"
+    <> hidden
+     ) <|>
+     ( flag' Nothing
+     $ long "no-port-forwarding"
     <> help "Disable trying to ask the router to forward ames ports"
     <> hidden
+     ) <|>
+     (pure $ Just NatSettingWhenPrivateNetwork)
 
   pure (Host{..})
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -445,8 +445,8 @@ host = do
      ) <|>
      ( flag' NatWhenPrivateNetwork
      $ long "port-forwarding-when-internal"
-    <> help ("Try asking the router to forward when ip is 192.168.0.0/24 or" <>
-             "10.0.0.0/8 (default).")
+    <> help ("Try asking the router to forward when ip is 192.168.0.0/16, " <>
+             "172.16.0.0/12 or 10.0.0.0/8 (default).")
     <> hidden
      ) <|>
      (pure $ NatWhenPrivateNetwork)

--- a/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/CLI.hs
@@ -19,7 +19,7 @@ import System.Environment (getProgName)
 data Host = Host
   { hSharedHttpPort  :: Maybe Word16
   , hSharedHttpsPort :: Maybe Word16
-  , hUseNatPmp       :: Maybe NatSetting
+  , hUseNatPmp       :: Nat
   }
  deriving (Show)
 
@@ -71,9 +71,10 @@ data PillSource
   | PillSourceURL String
   deriving (Show)
 
-data NatSetting
-  = NatSettingAlways
-  | NatSettingWhenPrivateNetwork
+data Nat
+  = NatAlways
+  | NatWhenPrivateNetwork
+  | NatNever
   deriving (Show)
 
 data New = New
@@ -432,17 +433,23 @@ host = do
     <> hidden
 
   hUseNatPmp <-
-     ( flag' (Just NatSettingAlways)
+     ( flag' NatAlways
      $ long "port-forwarding"
     <> help "Always try to search for a router to forward ames ports"
     <> hidden
      ) <|>
-     ( flag' Nothing
+     ( flag' NatNever
      $ long "no-port-forwarding"
     <> help "Disable trying to ask the router to forward ames ports"
     <> hidden
      ) <|>
-     (pure $ Just NatSettingWhenPrivateNetwork)
+     ( flag' NatWhenPrivateNetwork
+     $ long "port-forwarding-when-internal"
+    <> help ("Try asking the router to forward when ip is 192.168.0.0/24 or" <>
+             "10.0.0.0/8 (default).")
+    <> hidden
+     ) <|>
+     (pure $ NatWhenPrivateNetwork)
 
   pure (Host{..})
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -590,15 +590,14 @@ runShip (CLI.Run pierPath) opts daemon = do
         mStart
 
 
-buildPortHandler :: HasLogFunc e => Maybe CLI.NatSetting -> RIO e PortControlApi
-buildPortHandler Nothing  = pure buildInactivePorts
+buildPortHandler :: HasLogFunc e => CLI.Nat -> RIO e PortControlApi
+buildPortHandler CLI.NatNever  = pure buildInactivePorts
 -- TODO: Figure out what to do about logging here. The "port: " messages are
 -- the sort of thing that should be put on the muxed terminal log, but we don't
 -- have that at this layer.
-buildPortHandler (Just CLI.NatSettingAlways) =
-  buildNatPorts TryNatAlways (io . hPutStrLn stderr . unpack)
-buildPortHandler (Just CLI.NatSettingWhenPrivateNetwork) =
-  buildNatPorts TryNatWhenPrivate (io . hPutStrLn stderr . unpack)
+buildPortHandler CLI.NatAlways = buildNatPorts (io . hPutStrLn stderr . unpack)
+buildPortHandler CLI.NatWhenPrivateNetwork =
+  buildNatPortsWhenPrivate (io . hPutStrLn stderr . unpack)
 
 startBrowser :: HasLogFunc e => FilePath -> RIO e ()
 startBrowser pierPath = runRAcquire $ do

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -590,12 +590,15 @@ runShip (CLI.Run pierPath) opts daemon = do
         mStart
 
 
-buildPortHandler :: HasLogFunc e => Bool -> RIO e PortControlApi
-buildPortHandler False  = pure buildInactivePorts
+buildPortHandler :: HasLogFunc e => Maybe CLI.NatSetting -> RIO e PortControlApi
+buildPortHandler Nothing  = pure buildInactivePorts
 -- TODO: Figure out what to do about logging here. The "port: " messages are
 -- the sort of thing that should be put on the muxed terminal log, but we don't
 -- have that at this layer.
-buildPortHandler True   = buildNatPorts (io . hPutStrLn stderr . unpack)
+buildPortHandler (Just CLI.NatSettingAlways) =
+  buildNatPorts TryNatAlways (io . hPutStrLn stderr . unpack)
+buildPortHandler (Just CLI.NatSettingWhenPrivateNetwork) =
+  buildNatPorts TryNatWhenPrivate (io . hPutStrLn stderr . unpack)
 
 startBrowser :: HasLogFunc e => FilePath -> RIO e ()
 startBrowser pierPath = runRAcquire $ do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
@@ -104,6 +104,8 @@ portThread q stderr = do
     Left err -> do
       likelyIPAddress >>= \case
         Just ip@(192, 168, _, _) -> warnBehindRouterAndErr ip err
+        Just ip@(172, x, _, _)
+          | (x >= 16 && x <= 31) -> warnBehindRouterAndErr ip err
         Just ip@(10, _, _, _)    -> warnBehindRouterAndErr ip err
         _                        -> assumeOnPublicInternet
     Right pmp -> foundRouter pmp
@@ -245,6 +247,8 @@ likelyBehindRouter :: MonadIO m => m Bool
 likelyBehindRouter = do
   likelyIPAddress >>= \case
     Just ip@(192, 168, _, _) -> pure True
+    Just ip@(172, x, _, _)
+      | (x >= 16 && x <= 31) -> pure True
     Just ip@(10, _, _, _)    -> pure True
     _                        -> pure False
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ports.hs
@@ -1,5 +1,6 @@
 module Urbit.Vere.Ports (HasPortControlApi(..),
                          PortControlApi,
+                         TryNat(..),
                          buildInactivePorts,
                          buildNatPorts,
                          requestPortAccess) where
@@ -30,12 +31,24 @@ buildInactivePorts = PortControlApi noop noop
  where
   noop x = pure ()
 
+data TryNat
+  = TryNatAlways
+  | TryNatWhenPrivate
+
 -- | Builds a PortControlApi struct which tries to hole-punch by talking to the
 -- NAT gateway over NAT-PMP.
 buildNatPorts :: (HasLogFunc e)
-              => (Text -> RIO e ())
+              => TryNat
+              -> (Text -> RIO e ())
               -> RIO e PortControlApi
-buildNatPorts stderr = do
+
+buildNatPorts TryNatWhenPrivate stderr = do
+  behind <- likelyBehindRouter
+  if behind
+    then buildNatPorts TryNatAlways stderr
+    else pure buildInactivePorts
+
+buildNatPorts TryNatAlways stderr = do
   q <- newTQueueIO
   async $ portThread q stderr
 
@@ -221,6 +234,14 @@ likelyIPAddress = liftIO do
   case sockAddr of
     SockAddrInet _ addr -> pure $ Just $ hostAddressToTuple addr
     _                   -> pure $ Nothing
+
+likelyBehindRouter :: MonadIO m => m Bool
+likelyBehindRouter = do
+  likelyIPAddress >>= \case
+    Just ip@(192, 168, _, _) -> pure True
+    Just ip@(10, _, _, _)    -> pure True
+    _                        -> pure False
+
 
 -- Acquire a port for the duration of the RAcquire.
 requestPortAccess :: forall e. (HasPortControlApi e) => Word16 -> RAcquire e ()


### PR DESCRIPTION
- Only tries to perform port forwarding if we detect we're on a private network, with explicit always try
  and never try command line flags.

- Fixes problems with the library we use where it could wait up to 4 minutes for a timeout. 

- Fixes a problem in the binding layer where if we failed to get a public address, we'd block Ames
  from ever successfully sending a packet.