### PR TITLE
king: upgrade king haskell to ghc 8.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     before_install:
       - sh/travis-install-stack
     install:
-      - stack --no-terminal --install-ghc build urbit-king --only-dependencies
+      - stack --no-terminal --no-install-ghc build urbit-king --fast --only-dependencies
     script:
       - stack test
       - sh/release-king-linux64-dynamic
@@ -54,7 +54,7 @@ jobs:
     before_install:
       - sh/travis-install-stack
     install:
-      - stack --no-terminal --install-ghc build urbit-king --only-dependencies
+      - stack --no-terminal --install-ghc build urbit-king --fast --only-dependencies
     script:
       - stack test
       - sh/release-king-darwin-dynamic

--- a/pkg/hs/default.nix
+++ b/pkg/hs/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   cabalPackageName = "urbit-king";
-  compiler = "ghc865"; # matching stack.yaml
+  compiler = "ghc883"; # matching stack.yaml
 
   # Pin static-haskell-nix version.
   static-haskell-nix =

--- a/pkg/hs/racquire/lib/Data/RAcquire.hs
+++ b/pkg/hs/racquire/lib/Data/RAcquire.hs
@@ -18,9 +18,7 @@ import qualified Control.Exception     as E
 import qualified Control.Monad.Catch   as C ()
 import qualified Data.Acquire.Internal as Act
 
-import Control.Applicative     (Applicative(..))
-import Control.Monad           (ap, liftM)
-import Control.Monad.IO.Unlift (MonadIO(..), MonadUnliftIO, withRunInIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
 import Control.Monad.Reader
 import Data.Typeable           (Typeable)
 

--- a/pkg/hs/stack.yaml
+++ b/pkg/hs/stack.yaml
@@ -18,6 +18,8 @@ extra-deps:
   - lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00
   - urbit-hob-0.3.1@sha256:afbdc7ad071eefc6ca85f5b598b6c62ed49079d15d1840dac27438a3b3150303
   - para-1.1@sha256:a90eebb063ad70271e6e2a7f00a93e8e8f8b77273f100f39852fbf8301926f81
+  - web3-0.9.1.0@sha256:6b7faac0b63e7d0aae46588dd9a42e11f54ce0fdf4c2744bdf4cc6c5cbf39aa2
+  - vinyl-0.12.3@sha256:66553fc71cabfa86837bf5f98558e3e6d1807c47af5f5f1cd758081d3fb023ea
 
 # This allows building on NixOS.
 nix:

--- a/pkg/hs/stack.yaml
+++ b/pkg/hs/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.21
+resolver: lts-16.10
 
 packages:
   - lmdb-static
@@ -14,7 +14,6 @@ packages:
   - urbit-noun-core
 
 extra-deps:
-  - flat-0.3.4@sha256:002a0e0ae656ea8cc02a772d0bcb6ea7dbd7f2e79070959cc748ad1e7138eb38
   - base58-bytestring-0.1.0@sha256:a1da72ee89d5450bac1c792d9fcbe95ed7154ab7246f2172b57bd4fd9b5eab79
   - lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00
   - urbit-hob-0.3.1@sha256:afbdc7ad071eefc6ca85f5b598b6c62ed49079d15d1840dac27438a3b3150303

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
@@ -3,8 +3,7 @@
 -}
 module Urbit.Arvo.Event where
 
-import Urbit.Noun.Tree (HoonMap, HoonSet)
-import Urbit.Prelude   hiding (Term)
+import Urbit.Prelude hiding (Term)
 
 import Urbit.Arvo.Common (KingId(..), ServId(..))
 import Urbit.Arvo.Common (Desk, Mime)

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -87,14 +87,11 @@ import Urbit.Vere.Pier.Types
 import Urbit.Vere.Serf
 import Urbit.King.App
 
-import Control.Concurrent     (myThreadId)
-import Control.Exception      (AsyncException(UserInterrupt))
-import Control.Lens           ((&))
-import System.Process         (system)
-import Text.Show.Pretty       (pPrint)
-import Urbit.Noun.Conversions (cordToUW)
-import Urbit.Noun.Time        (Wen)
-import Urbit.Vere.LockFile    (lockFile)
+import Control.Concurrent  (myThreadId)
+import Control.Exception   (AsyncException(UserInterrupt))
+import System.Process      (system)
+import Urbit.Noun.Time     (Wen)
+import Urbit.Vere.LockFile (lockFile)
 
 import qualified Data.Set                as Set
 import qualified Data.Text               as T

--- a/pkg/hs/urbit-king/lib/Urbit/Prelude.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Prelude.hs
@@ -15,15 +15,16 @@ module Urbit.Prelude
     , module RIO
     , io, rio
     , logTrace
+    , fail
     ) where
 
 import ClassyPrelude
 import Urbit.Noun
 
-import Control.Lens hiding (Each, Index, cons, index, snoc, uncons, unsnoc,
-                     (<.>), (<|))
-
 import Control.Arrow    ((<<<), (>>>))
+import Control.Lens hiding (Each, Index, cons, index, snoc, uncons, unsnoc,
+                            (<.>), (<|))
+import Control.Monad.Fail (fail)
 import Data.Acquire     (Acquire, mkAcquire, with)
 import Data.RAcquire    (RAcquire, mkRAcquire, rwith)
 import Data.RAcquire    (MonadAcquire(..), MonadRIO(..))

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
@@ -16,8 +16,6 @@
   TODO How to detect socket closed during server run?
 -}
 
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 module Urbit.Vere.Eyre.Serv
   ( ServApi(..)
   , TlsConfig(..)
@@ -140,8 +138,12 @@ openFreePort hos = do
       Right ps -> pure (Right ps)
  where
   doBind sok = do
-    adr <- Net.inet_addr hos
-    Net.bind sok (Net.SockAddrInet Net.defaultPort adr)
+    adr <-
+      Net.getAddrInfo (Just Net.defaultHints) (Just hos) Nothing >>= \case
+        [] -> error ("unable to determine numeric hostname from " ++ hos)
+        x:_ -> pure (Net.addrAddress x)
+      
+    Net.bind sok adr
     Net.listen sok 1
     port <- Net.socketPort sok
     pure (fromIntegral port, sok)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
@@ -139,9 +139,9 @@ openFreePort hos = do
  where
   doBind sok = do
     adr <-
-      Net.getAddrInfo (Just Net.defaultHints) (Just hos) Nothing >>= \case
-        [] -> error ("unable to determine numeric hostname from " ++ hos)
-        x:_ -> pure (Net.addrAddress x)
+      Net.getAddrInfo Nothing (Just hos) Nothing >>= \case
+        []     -> error ("unable to determine numeric hostname from " ++ hos)
+        ip : _ -> pure (Net.addrAddress ip)
       
     Net.bind sok adr
     Net.listen sok 1

--- a/pkg/hs/urbit-king/package.yaml
+++ b/pkg/hs/urbit-king/package.yaml
@@ -75,7 +75,6 @@ dependencies:
   - racquire
   - random
   - regex-tdfa
-  - regex-tdfa-text
   - resourcet
   - rio
   - semigroups

--- a/pkg/hs/urbit-noun-core/lib/Urbit/Noun/Convert.hs
+++ b/pkg/hs/urbit-noun-core/lib/Urbit/Noun/Convert.hs
@@ -14,7 +14,7 @@ import ClassyPrelude hiding (hash)
 
 import Urbit.Noun.Core
 
-import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fail (MonadFail (fail))
 
 
 -- Types -----------------------------------------------------------------------
@@ -31,12 +31,11 @@ instance Applicative IResult where
     pure  = ISuccess
     (<*>) = ap
 
-instance Fail.MonadFail IResult where
+instance MonadFail IResult where
     fail err = IError [] err
 
 instance Monad IResult where
     return = pure
-    fail   = Fail.fail
     ISuccess a      >>= k = k a
     IError path err >>= _ = IError path err
 
@@ -66,12 +65,11 @@ instance Applicative Result where
     pure  = Success
     (<*>) = ap
 
-instance Fail.MonadFail Result where
+instance MonadFail Result where
     fail err = Error err
 
 instance Monad Result where
     return = pure
-    fail   = Fail.fail
 
     Success a >>= k = k a
     Error err >>= _ = Error err
@@ -111,9 +109,8 @@ instance Monad Parser where
     m >>= g = Parser $ \path kf ks -> let ks' a = runParser (g a) path kf ks
                                        in runParser m path kf ks'
     return = pure
-    fail = Fail.fail
 
-instance Fail.MonadFail Parser where
+instance MonadFail Parser where
     fail msg = Parser $ \path kf _ks -> kf (reverse path) msg
 
 instance Functor Parser where

--- a/pkg/hs/urbit-noun-core/lib/Urbit/Noun/Cue.hs
+++ b/pkg/hs/urbit-noun-core/lib/Urbit/Noun/Cue.hs
@@ -12,14 +12,15 @@ import ClassyPrelude
 import Urbit.Atom
 import Urbit.Noun.Core
 
-import Data.Bits        (shiftL, shiftR, (.&.), (.|.))
-import Data.Function    ((&))
-import Foreign.Ptr      (Ptr, castPtr, plusPtr, ptrToWordPtr)
-import Foreign.Storable (peek)
-import GHC.Prim         (ctz#)
-import GHC.Word         (Word(..))
-import System.IO.Unsafe (unsafePerformIO)
-import Text.Printf      (printf)
+import Control.Monad.Fail (MonadFail (fail))
+import Data.Bits          (shiftL, shiftR, (.&.), (.|.))
+import Data.Function      ((&))
+import Foreign.Ptr        (Ptr, castPtr, plusPtr, ptrToWordPtr)
+import Foreign.Storable   (peek)
+import GHC.Prim           (ctz#)
+import GHC.Word           (Word(..))
+import System.IO.Unsafe   (unsafePerformIO)
+import Text.Printf        (printf)
 
 import qualified Data.ByteString.Unsafe as BS
 import qualified Data.HashTable.IO      as H
@@ -136,6 +137,7 @@ instance Monad Get where
         runGet (f x') end tbl s'
     {-# INLINE (>>=) #-}
 
+instance MonadFail Get where
     fail msg = Get $ \end tbl s -> do
       badEncoding end s msg
     {-# INLINE fail #-}

--- a/pkg/hs/urbit-noun-core/lib/Urbit/Noun/TH.hs
+++ b/pkg/hs/urbit-noun-core/lib/Urbit/Noun/TH.hs
@@ -4,6 +4,7 @@
 module Urbit.Noun.TH (deriveNoun, deriveToNoun, deriveFromNoun) where
 
 import ClassyPrelude              hiding (fromList)
+import Control.Monad.Fail         (fail)
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Urbit.Noun.Convert

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
@@ -17,6 +17,7 @@ module Urbit.Noun.Conversions
 import ClassyPrelude hiding (hash)
 
 import Control.Lens         hiding (Each, Index, (<.>))
+import Control.Monad.Fail   (fail)
 import Data.Void
 import Data.Word
 import Text.Regex.TDFA
@@ -33,7 +34,7 @@ import GHC.Types        (Char(C#))
 import GHC.Word         (Word32(W32#))
 import Prelude          ((!!))
 import RIO.FilePath     (joinPath, splitDirectories, takeBaseName,
-                         takeDirectory, takeExtension, (<.>))
+                         takeDirectory, takeExtension)
 import Urbit.Noun.Cue   (cue)
 import Urbit.Noun.Jam   (jam)
 

--- a/pkg/hs/urbit-noun/package.yaml
+++ b/pkg/hs/urbit-noun/package.yaml
@@ -20,7 +20,6 @@ dependencies:
   - lens
   - murmur3
   - regex-tdfa
-  - regex-tdfa-text
   - rio
   - text
   - time


### PR DESCRIPTION
Given the GHC and stack resolver in use were coming up on 2~ years old, along with a plethora of stale dependencies - this PR upgrades `pkg/hs/stack.yaml` to the latest stackage LTS which is based on GHC `8.8.3`. (Ideally we'd move to `8.10.2` directly - but that proved a bridge too far, for now.)

There are two changes + possibly still open questions:

* The use of `Control.Monad.Fail.fail` within the `Web3` monad - for which there is no `MonadFail` instance. This primarily rears its head in `Urbit.Vere.Dawn` which previously used `fail` to signal errors. Since this simply specialised to `IO` / `userError` - I've replaced it as such.
* The `network` package long ago deprecated `Network.Socket.inet_addr` - it was bemusing to see the "workaround" for this in `Urbit.Vere.Eyre.Serve` was to set `-Wno-deprecations`? I've replaced it with `getNameInfo` - but this will probably need the mosting eyes/testing of all the changes.



