### PR TITLE
+roll and +reel stack space

### DIFF
--- a/pkg/urbit/jets/b/reel.c
+++ b/pkg/urbit/jets/b/reel.c
@@ -10,14 +10,11 @@
             u3_noun b)
   {
     u3_noun pro = u3k(u3x_at(u3x_sam_3, b));
-    if ( u3_nul == a ) {
-      return pro;
-    }
-    else {
+    if ( u3_nul != a ) {
       u3j_site sit_u;
       u3_noun  i, t = a;
       c3_w     j_w, len_w = 0, all_w = 89, pre_w = 55;
-      u3_noun* vec = u3a_malloc(all_w);
+      u3_noun* vec = u3a_malloc(all_w * sizeof(u3_noun));
 
       // stuff list into an array
       do {
@@ -30,7 +27,7 @@
             // grow vec fib-wise
             all_w += pre_w;
             pre_w = len_w;
-            vec = u3a_realloc(vec, all_w);
+            vec = u3a_realloc(vec, all_w * sizeof(u3_noun));
           }
           vec[len_w++] = i;
         }
@@ -43,8 +40,8 @@
       }
       u3j_gate_lose(&sit_u);
       u3a_free(vec);
-      return pro;
     }
+    return pro;
   }
   u3_noun
   u3wb_reel(u3_noun cor)

--- a/pkg/urbit/jets/b/reel.c
+++ b/pkg/urbit/jets/b/reel.c
@@ -3,35 +3,48 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _reel_in(u3j_site* sit_u, u3_noun a, u3_noun b)
-  {
-    if ( 0 == a ) {
-      return b;
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3m_bail(c3__exit);
-    }
-    else {
-      u3_noun gim = u3k(u3h(a));
-      u3_noun hur = _reel_in(sit_u, u3t(a), b);
-
-      return u3j_gate_slam(sit_u, u3nc(gim, hur));
-    }
-  }
-
 /* functions
 */
   u3_noun
   u3qb_reel(u3_noun a,
             u3_noun b)
   {
-    u3_noun  pro;
-    u3j_site sit_u;
-    u3j_gate_prep(&sit_u, u3k(b));
-    pro = _reel_in(&sit_u, a, u3k(u3x_at(u3x_sam_3, b)));
-    u3j_gate_lose(&sit_u);
-    return pro;
+    u3_noun pro = u3k(u3x_at(u3x_sam_3, b));
+    if ( u3_nul == a ) {
+      return pro;
+    }
+    else {
+      u3j_site sit_u;
+      u3_noun  i, t = a;
+      c3_w     j_w, len_w = 0, all_w = 89, pre_w = 55;
+      u3_noun* vec = u3a_malloc(all_w);
+
+      // stuff list into an array
+      do {
+        if ( c3n == u3r_cell(t, &i, &t) ) {
+          u3a_free(vec);
+          return u3m_bail(c3__exit);
+        }
+        else {
+          if ( len_w == all_w ) {
+            // grow vec fib-wise
+            all_w += pre_w;
+            pre_w = len_w;
+            vec = u3a_realloc(vec, all_w);
+          }
+          vec[len_w++] = i;
+        }
+      } while ( u3_nul != t );
+
+      // now we can iterate backwards
+      u3j_gate_prep(&sit_u, u3k(b));
+      for ( j_w = len_w; j_w > 0; ) {
+        pro = u3j_gate_slam(&sit_u, u3nc(u3k(vec[--j_w]), pro));
+      }
+      u3j_gate_lose(&sit_u);
+      u3a_free(vec);
+      return pro;
+    }
   }
   u3_noun
   u3wb_reel(u3_noun cor)

--- a/pkg/urbit/jets/b/reel.c
+++ b/pkg/urbit/jets/b/reel.c
@@ -12,34 +12,25 @@
     u3_noun pro = u3k(u3x_at(u3x_sam_3, b));
     if ( u3_nul != a ) {
       u3j_site sit_u;
+      u3_noun* top;
       u3_noun  i, t = a;
-      c3_w     j_w, len_w = 0, all_w = 89, pre_w = 55;
-      u3_noun* vec = u3a_malloc(all_w * sizeof(u3_noun));
+      c3_w     len_w = 0;
 
-      // stuff list into an array
+      // push list onto road stack
       do {
-        if ( c3n == u3r_cell(t, &i, &t) ) {
-          u3a_free(vec);
-          return u3m_bail(c3__exit);
-        }
-        else {
-          if ( len_w == all_w ) {
-            // grow vec fib-wise
-            all_w += pre_w;
-            pre_w = len_w;
-            vec = u3a_realloc(vec, all_w * sizeof(u3_noun));
-          }
-          vec[len_w++] = i;
-        }
+        u3x_cell(t, &i, &t);
+        top = (c3_w*) u3a_push(sizeof(u3_noun));
+        *top = i;
+        ++len_w;
       } while ( u3_nul != t );
 
-      // now we can iterate backwards
       u3j_gate_prep(&sit_u, u3k(b));
-      for ( j_w = len_w; j_w > 0; ) {
-        pro = u3j_gate_slam(&sit_u, u3nc(u3k(vec[--j_w]), pro));
+      while ( len_w-- > 0 ) {
+        top = u3a_peek(sizeof(u3_noun));
+        u3a_pop(sizeof(u3_noun));
+        pro = u3j_gate_slam(&sit_u, u3nc(u3k(*top), pro));
       }
       u3j_gate_lose(&sit_u);
-      u3a_free(vec);
     }
     return pro;
   }

--- a/pkg/urbit/jets/b/roll.c
+++ b/pkg/urbit/jets/b/roll.c
@@ -3,32 +3,25 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _roll_in(u3j_site* sit_u, u3_noun a, u3_noun b)
-  {
-    if ( 0 == a ) {
-      return b;
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3m_bail(c3__exit);
-    }
-    else {
-      b = u3j_gate_slam(sit_u, u3nc(u3k(u3h(a)), b));
-      return _roll_in(sit_u, u3t(a), b);
-    }
-  }
-
 /* functions
 */
   u3_noun
   u3qb_roll(u3_noun a,
             u3_noun b)
   {
-    u3_noun  pro;
-    u3j_site sit_u;
-    u3j_gate_prep(&sit_u, u3k(b));
-    pro = _roll_in(&sit_u, a, u3k(u3x_at(u3x_sam_3, b)));
-    u3j_gate_lose(&sit_u);
+    u3_noun pro = u3k(u3x_at(u3x_sam_3, b));
+
+    if ( u3_nul != a ) {
+      u3j_site sit_u;
+      u3_noun  i, t = a;
+      u3j_gate_prep(&sit_u, u3k(b));
+      do {
+        u3x_cell(t, &i, &t);
+        pro = u3j_gate_slam(&sit_u, u3nc(u3k(i), pro));
+      } while ( u3_nul != t );
+      u3j_gate_lose(&sit_u);
+    }
+
     return pro;
   }
   u3_noun


### PR DESCRIPTION
The jet for +roll was tail recursive, but +reel for sure consumed stack space to iterate backwards over the input list. Both jets have been made into while loops, and +reel uses a vector to remember the list instead of the call stack.