### PR TITLE
chat: updated Leave Group copy

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/delete-button.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/delete-button.js
@@ -1,51 +1,54 @@
-import React, { Component } from 'react';
+import React, { memo } from 'react';
 
+export const DeleteButton = memo(({ isOwner, station, changeLoading, association, contacts, api }) => {
+  const leaveButtonClasses = (!isOwner) ? 'pointer' : 'c-default';
+  const deleteButtonClasses = (isOwner) ? 
+    'b--red2 red2 pointer bg-gray0-d' :
+    'b--gray3 gray3 bg-gray0-d c-default';
 
-export const DeleteButton = (props) => {
-    const { isOwner, station, changeLoading, api } = props;
-    const leaveButtonClasses = (!isOwner) ? 'pointer' : 'c-default';
-    const deleteButtonClasses = (isOwner) ? 
-      'b--red2 red2 pointer bg-gray0-d' :
-      'b--gray3 gray3 bg-gray0-d c-default';
-
-    const deleteChat = () => {
-      changeLoading(
-        true,
-        true,
-        isOwner ? 'Deleting chat...' : 'Leaving chat...',
-        () => {
-          api.chat.delete(station);
-        }
-      );
-    };
-
-    return (
-      <div className="w-100 cf">
-        <div className={'w-100 fl mt3 ' + ((isOwner) ? 'o-30' : '')}>
-          <p className="f8 mt3 lh-copy db">Leave Chat</p>
-          <p className="f9 gray2 db mb4">
-            Remove this chat from your chat list.{' '}
-            You will need to request for access again.
-          </p>
-          <a onClick={(!isOwner) ? deleteChat : null}
-             className={
-               'dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d ' +
-               leaveButtonClasses
-             }>
-            Leave this chat
-          </a>
-        </div>
-        <div className={'w-100 fl mt3 ' + ((!isOwner) ? 'o-30' : '')}>
-          <p className="f8 mt3 lh-copy db">Delete Chat</p>
-            <p className="f9 gray2 db mb4">
-              Permanently delete this chat.{' '}
-              All current members will no longer see this chat.
-            </p>
-            <a onClick={(isOwner) ? deleteChat : null}
-             className={'dib f9 ba pa2 ' + deleteButtonClasses}
-            >Delete this chat</a>
-        </div>
-      </div>
+  const deleteChat = () => {
+    changeLoading(
+      true,
+      true,
+      isOwner ? 'Deleting chat...' : 'Leaving chat...',
+      () => {
+        api.chat.delete(station);
+      }
     );
-};
+  };
 
+  const groupPath = association['group-path'];
+  const unmanagedVillage = !contacts[groupPath];
+
+  return (
+    <div className="w-100 cf">
+      <div className={'w-100 fl mt3 ' + ((isOwner) ? 'o-30' : '')}>
+        <p className="f8 mt3 lh-copy db">Leave Chat</p>
+        <p className="f9 gray2 db mb4">
+          Remove this chat from your chat list.{' '}
+          {unmanagedVillage 
+            ? 'You will need to request for access again'
+            : 'You will need to join again from the group page.'
+          }
+        </p>
+        <a onClick={(!isOwner) ? deleteChat : null}
+           className={
+             'dib f9 black gray4-d bg-gray0-d ba pa2 b--black b--gray1-d ' +
+             leaveButtonClasses
+           }>
+          Leave this chat
+        </a>
+      </div>
+      <div className={'w-100 fl mt3 ' + ((!isOwner) ? 'o-30' : '')}>
+        <p className="f8 mt3 lh-copy db">Delete Chat</p>
+          <p className="f9 gray2 db mb4">
+            Permanently delete this chat.{' '}
+            All current members will no longer see this chat.
+          </p>
+          <a onClick={(isOwner) ? deleteChat : null}
+           className={'dib f9 ba pa2 ' + deleteButtonClasses}
+          >Delete this chat</a>
+      </div>
+    </div>
+  );
+})

--- a/pkg/interface/src/views/apps/chat/components/settings.js
+++ b/pkg/interface/src/views/apps/chat/components/settings.js
@@ -89,6 +89,8 @@ export class SettingsScreen extends Component {
           isOwner={isOwner}
           changeLoading={this.changeLoading}
           station={station}
+          association={association}
+          contacts={contacts}
           api={api} />
         <MetadataSettings
           isOwner={isOwner}


### PR DESCRIPTION
The current "Leave Group" copy says "You will need to request access again" which after the groups refactor is not accurate. Changing that is the primary purpose of this PR.

I'm also wondering about two things: one of which I changed, the other I didn't.

1. `React.PureComponent`: I don't have a lot of experience with these but it seems like it might be appropriate here. If here, than quite a few other places. I've been in the habit of using functional components but *they say* these have performance benefits.

2. The other is maybe an @urcades question: Why do we gray out the unusable buttons instead of just removing them? Seems like in especially this case you wouldn't want to have both "Leave Group" and "Delete Group" on the same screen, ever. I have used the settings page to reference a chat description before but it's hard to read anyway. Maybe we should just add the description and get rid of the text box. Off-topic but RFC.