### PR TITLE
hoon: allow tec in pattern mode

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c61d44c8cf9e09b07ff0df4c65a491851f33afd6ad70d558de9b55614abd704c
-size 6282949
+oid sha256:e1536dc7df8496ca994b68a9e431fca131d0743c824bc32d25a0c0f8e015e5e5
+size 6294748

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13420,6 +13420,10 @@
           (stag %like (most col rope))
           (cold [%base %cell] ket)
         ==
+      :-  '`'
+        ;~  pfix  tec
+          (cook |=(s=spec [%bscl [%base %null] ~[s]]) wyde)
+        ==
       :-  '='
         ;~  pfix  tis
           %+  sear
@@ -13581,7 +13585,14 @@
             ;~  pfix  tar
               (stag %kthp (stag [%base %noun] ;~(pfix tec wide)))
             ==
-            (stag %kthp ;~(plug wyde ;~(pfix tec wide)))
+            ::
+            %+  stag
+              %kthp
+            ;~  plug
+              ;~(less ;~(pfix tec (easy ~)) wyde)
+              ;~(pfix tec wide)
+            ==
+            ::
             (stag %ktls ;~(pfix lus ;~(plug wide ;~(pfix tec wide))))
             (cook |=(a/hoon [[%rock %n ~] a]) wide)
           ==


### PR DESCRIPTION
Addresses half of #2336.

```
?=(``@ ``1)
%.y
```