### PR TITLE
chat: restore join functionality

### DIFF
--- a/pkg/interface/src/views/apps/chat/app.tsx
+++ b/pkg/interface/src/views/apps/chat/app.tsx
@@ -207,7 +207,7 @@ export default class ChatApp extends React.Component<ChatAppProps, {}> {
                 <JoinScreen
                   api={api}
                   inbox={inbox}
-                  autoJoin={station}
+                  station={station}
                   chatSynced={chatSynced || {}}
                   {...props}
                 />

--- a/pkg/interface/src/views/apps/chat/components/join.js
+++ b/pkg/interface/src/views/apps/chat/components/join.js
@@ -25,7 +25,6 @@ const schema = Yup.object().shape({
 export class JoinScreen extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       awaiting: false
     };
@@ -38,17 +37,17 @@ export class JoinScreen extends Component {
   }
 
   onSubmit(values) {
-    console.log(values);
+    const { props } = this;
     this.setState({ awaiting: true }, () => {
-      console.log(values);
       const station = values.station.trim();
-      if (`/${station}` in this.props.chatSynced) {
-        this.props.history.push(`/~chat/room/${station}`);
+      if (`/${station}` in props.chatSynced) {
+        props.history.push(`/~chat/room${station}`);
         return;
       }
+      const ship = station.substr(1).slice(0,station.substr(1).indexOf('/'));
 
-      props.api.chat.join(ship, station, true)
-      this.props.history.push(`/~chat/room/${station}`);
+      props.api.chat.join(ship, station, true);
+      props.history.push(`/~chat/room${station}`);
     });
   }
 
@@ -84,7 +83,7 @@ export class JoinScreen extends Component {
                 mt={4}
                 id="station"
                 placeholder="~zod/chatroom"
-                fontFamily="mono" 
+                fontFamily="mono"
                 caption="Chat names use lowercase, hyphens, and slashes." />
               <Button>Join Chat</Button>
               <Spinner


### PR DESCRIPTION
See #3371. 

New join behaviour in release/next-userspace had a few issues (no `station` prop passed; using `props` as if `const { props } = this` was there when it wasn't; and a double `/` in the route it redirected you to). All resolved. You can join chats again.