### PR TITLE
chat-input: detect mobile user agents correctly

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/chat-editor.js
@@ -8,7 +8,7 @@ import 'codemirror/addon/display/placeholder';
 import 'codemirror/lib/codemirror.css';
 
 const BROWSER_REGEX =
-  new RegExp(String(/Android|webOS|iPhone|iPad|iPod|BlackBerry/i));
+  new RegExp(String(/Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile/i));
 
 
 const MARKDOWN_CONFIG = {


### PR DESCRIPTION
FF for android and brave for android do not appear to include `Android` in the user agent. They do, however both include the string `Mobile`. Check against this to prevent desktop behaviour on these browsers.