### PR TITLE
chat: break overflowing one-word messages

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/content/text.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
 import urbitOb from 'urbit-ob';
+import { Box } from '@tlon/indigo-react';
 
 const DISABLED_BLOCK_TOKENS = [
   'indentedCode',
@@ -55,9 +56,9 @@ export default class TextContent extends Component {
       );
     } else {
       return (
-        <section className="chat-md-message">
+        <Box style={{ overflowWrap: 'break-word' }}>
           <MessageMarkdown source={content.text} />
-        </section>
+        </Box>
       );
     }
   }

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -70,10 +70,6 @@ h2 {
   line-height: 16px;
 }
 
-.chat-md-message > pre {
-  overflow-x: auto;
-}
-
 .mono {
   font-family: "Source Code Pro", monospace;
 }


### PR DESCRIPTION
See #3358. Sometimes you dump a base64 string and it makes the entire chat scroll horizontally. It happens.

Adds `overflow-wrap: break-word` to text messages. We also use indigo-react instead of adding another atomic CSS declaration; I also discovered the only thing using the old class declaration was a code overflow-wrap fix that ... isn't currently in use anyway, so it's unnecessarily in the CSS. Deleted.