### PR TITLE
clay: expose mergebase as base-hash

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -1,5 +1,5 @@
 /-  srv=file-server, glob
-/+  *server, default-agent, verb, dbug
+/+  *server, default-agent, verb, dbug, version
 |%
 +$  card  card:agent:gall
 +$  serving  (map url-base=path [=content public=?])
@@ -291,24 +291,11 @@
 ++  on-peek
   |=  =path
   ^-  (unit (unit cage))
-  |^
   ?+  path  (on-peek:def path)
-    [%x %clay %base %hash ~]  ``hash+!>(base-hash)
+      [%x %clay %base %hash ~]
+    =/  versions  (base-hash:version [our now]:bowl)
+    ``hash+!>(?~(versions 0v0 (end 0 25 i.versions)))
   ==
-  ::  stolen from +trouble
-  ::  TODO: move to a lib?
-  ++  base-hash
-    ^-  @uv
-    =+  .^  ota=(unit [=ship =desk =aeon:clay])
-            %gx  /(scot %p our.bowl)/hood/(scot %da now.bowl)/kiln/ota/noun
-        ==
-    ?~  ota
-      *@uv
-    =/  parent  (scot %p ship.u.ota)
-    =+  .^(=cass:clay %cs /[parent]/[desk.u.ota]/1/late/foo)
-    %^  end  0  25
-    .^(@uv %cz /[parent]/[desk.u.ota]/(scot %ud ud.cass))
-  --
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/gen/trouble.hoon
+++ b/pkg/arvo/gen/trouble.hoon
@@ -1,5 +1,14 @@
 ::  Print useful diagnostic information
 ::
+::  base-hash: loosely, the most recent successfully applied update.
+::             Technically, the mergebase of %home with OTA source
+::  sour-hash: most recently downloaded update (not necessarily applied)
+::  home-hash: hash of %home desk, which may differ if you have changed
+::             it, for example with notebooks or 3rd party apps
+::  kids-hash: hash of the %kids desk, which is what you serve to your
+::             children
+::  glob-hash: hash of the glob, which is the js for landscape
+::
 :-  %say
 |=  [[now=time * bec=beak] ~ ~]
 =*  our      p.bec
@@ -8,6 +17,7 @@
 =<
 :~
   [%base-hash base-hash]
+  [%sour-hash sour-hash]
   [%home-hash .^(@uv %cz (pathify ~.home ~))]
   [%kids-hash .^(@uv %cz (pathify ~.kids ~))]
   [%glob-hash glob-state]
@@ -44,6 +54,21 @@
   ==
 ::
 ++  base-hash
+  =+  .^  ota=(unit [=ship =desk =aeon:clay])
+          %gx  /(scot %p our)/hood/(scot %da now)/kiln/ota/noun
+      ==
+  ?~  ota
+    ~
+  =/  parent  (scot %p ship.u.ota)
+  =/  takos
+    .^  (list tako:clay)  %cs
+        /(scot %p our)/home/(scot %da now)/base/[parent]/[desk.u.ota]
+    ==
+  %+  turn  takos
+  |=  =tako:clay
+  .^(@uv %cs /(scot %p our)/home/(scot %da now)/hash/(scot %uv tako))
+::
+++  sour-hash
   =+  .^  ota=(unit [=ship =desk =aeon:clay])
           %gx  /(scot %p our)/hood/(scot %da now)/kiln/ota/noun
       ==

--- a/pkg/arvo/gen/trouble.hoon
+++ b/pkg/arvo/gen/trouble.hoon
@@ -9,6 +9,7 @@
 ::             children
 ::  glob-hash: hash of the glob, which is the js for landscape
 ::
+/+  version
 :-  %say
 |=  [[now=time * bec=beak] ~ ~]
 =*  our      p.bec
@@ -16,7 +17,7 @@
 :-  %noun
 =<
 :~
-  [%base-hash base-hash]
+  [%base-hash (base-hash:version our now)]
   [%sour-hash sour-hash]
   [%home-hash .^(@uv %cz (pathify ~.home ~))]
   [%kids-hash .^(@uv %cz (pathify ~.kids ~))]
@@ -52,21 +53,6 @@
       life=lyfe
       rift=ryft
   ==
-::
-++  base-hash
-  =+  .^  ota=(unit [=ship =desk =aeon:clay])
-          %gx  /(scot %p our)/hood/(scot %da now)/kiln/ota/noun
-      ==
-  ?~  ota
-    ~
-  =/  parent  (scot %p ship.u.ota)
-  =/  takos
-    .^  (list tako:clay)  %cs
-        /(scot %p our)/home/(scot %da now)/base/[parent]/[desk.u.ota]
-    ==
-  %+  turn  takos
-  |=  =tako:clay
-  .^(@uv %cs /(scot %p our)/home/(scot %da now)/hash/(scot %uv tako))
 ::
 ++  sour-hash
   =+  .^  ota=(unit [=ship =desk =aeon:clay])

--- a/pkg/arvo/lib/version.hoon
+++ b/pkg/arvo/lib/version.hoon
@@ -1,0 +1,18 @@
+|%
+++  base-hash
+  |=  [our=@p now=@da]
+  ^-  (list @uv)
+  =+  .^  ota=(unit [=ship =desk =aeon:clay])
+          %gx  /(scot %p our)/hood/(scot %da now)/kiln/ota/noun
+      ==
+  ?~  ota
+    ~
+  =/  parent  (scot %p ship.u.ota)
+  =/  takos
+    .^  (list tako:clay)  %cs
+        /(scot %p our)/home/(scot %da now)/base/[parent]/[desk.u.ota]
+    ==
+  %+  turn  takos
+  |=  =tako:clay
+  .^(@uv %cs /(scot %p our)/home/(scot %da now)/hash/(scot %uv tako))
+--

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2083,7 +2083,7 @@
           &+~
         ?:  (~(has in (reachable-takos:ze r.ali-yaki)) r.bob-yaki)
           $(germ %fine)
-        =/  merge-points  find-merge-points
+        =/  merge-points  (find-merge-points ali-yaki bob-yaki)
         ?~  merge-points
           :~  %|  %merge-no-merge-base
               leaf+"consider a %this or %that merge to get a mergebase"
@@ -2134,42 +2134,6 @@
         |=  m=(map path lobe)
         ^-  (map path (each page lobe))
         (~(run by m) |=(=lobe |+lobe))
-      ::
-      ::  Find the most recent common ancestor(s).
-      ::
-      ::    Pretty sure this could be a lot more efficient.
-      ::
-      ++  find-merge-points
-        ^-  (set yaki)
-        %-  reduce-merge-points
-        =+  r=(reachable-takos:ze r.ali-yaki)
-        |-  ^-  (set yaki)
-        ~!  bob-yaki
-        ?:  (~(has in r) r.bob-yaki)  (~(put in *(set yaki)) bob-yaki)
-        %+  roll  p.bob-yaki
-        |=  [t=tako s=(set yaki)]
-        ?:  (~(has in r) t)
-          (~(put in s) (~(got by hut.ran) t))
-        (~(uni in s) ^$(bob-yaki (~(got by hut.ran) t)))
-      ::
-      ::  Eliminate redundant merge-point candidates
-      ::
-      ++  reduce-merge-points
-        |=  unk=(set yaki)
-        =|  gud=(set yaki)
-        =/  zar=(map tako (set tako))
-          %+  roll  ~(tap in unk)
-          |=  [yak=yaki qar=(map tako (set tako))]
-          (~(put by qar) r.yak (reachable-takos:ze r.yak))
-        |-
-        ^-  (set yaki)
-        ?~  unk  gud
-        =+  bun=(~(del in `(set yaki)`unk) n.unk)
-        ?:  %+  levy  ~(tap by (~(uni in gud) bun))
-            |=  yak=yaki
-            !(~(has in (~(got by zar) r.yak)) r.n.unk)
-          $(gud (~(put in gud) n.unk), unk bun)
-        $(unk bun)
       ::
       ::  The set of changes between the mergebase and one of the desks
       ::  being merged
@@ -2424,6 +2388,43 @@
         ==
       --
     --
+  ::
+  ::  Find the most recent common ancestor(s).
+  ::
+  ::    Pretty sure this could be a lot more efficient.
+  ::
+  ++  find-merge-points
+    |=  [=ali=yaki =bob=yaki]
+    ^-  (set yaki)
+    %-  reduce-merge-points
+    =+  r=(reachable-takos:ze r.ali-yaki)
+    |-  ^-  (set yaki)
+    ~!  bob-yaki
+    ?:  (~(has in r) r.bob-yaki)  (~(put in *(set yaki)) bob-yaki)
+    %+  roll  p.bob-yaki
+    |=  [t=tako s=(set yaki)]
+    ?:  (~(has in r) t)
+      (~(put in s) (~(got by hut.ran) t))
+    (~(uni in s) ^$(bob-yaki (~(got by hut.ran) t)))
+  ::
+  ::  Eliminate redundant merge-point candidates
+  ::
+  ++  reduce-merge-points
+    |=  unk=(set yaki)
+    =|  gud=(set yaki)
+    =/  zar=(map tako (set tako))
+      %+  roll  ~(tap in unk)
+      |=  [yak=yaki qar=(map tako (set tako))]
+      (~(put by qar) r.yak (reachable-takos:ze r.yak))
+    |-
+    ^-  (set yaki)
+    ?~  unk  gud
+    =+  bun=(~(del in `(set yaki)`unk) n.unk)
+    ?:  %+  levy  ~(tap by (~(uni in gud) bun))
+        |=  yak=yaki
+        !(~(has in (~(got by zar) r.yak)) r.n.unk)
+      $(gud (~(put in gud) n.unk), unk bun)
+    $(unk bun)
   ::
   ::  Update mime cache
   ::
@@ -3563,7 +3564,7 @@
     ++  read-s
       |=  [yon=aeon pax=path]
       ^-  (unit (unit cage))
-      ?.  ?=([?(%yaki %blob %hash %cage %open %late) * ~] pax)
+      ?.  ?=([?(%yaki %blob %hash %cage %open %late %base) * *] pax)
         `~
       ?-    i.pax
           %yaki
@@ -3600,6 +3601,19 @@
         ``open+!>(prelude:(ford:fusion static-ford-args))
       ::
           %late  !!  :: handled in +aver
+          %base
+        ?>  ?=(^ t.t.pax)
+        :^  ~  ~  %uvs  !>
+        ^-  (list @uv)
+        =/  him  (slav %p i.t.pax)
+        =/  other  dom:((de our now ski hen ruf) him i.t.t.pax)
+        ?:  =(0 let.other)
+          ~
+        =/  our-yaki  (~(got by hut.ran) (~(got by hit.dom) yon))
+        =/  other-yaki  (~(got by hut.ran) (~(got by hit.other) let.other))
+        %+  turn  ~(tap in (find-merge-points other-yaki our-yaki))
+        |=  =yaki
+        r.yaki
       ==
     ::  +read-t: produce the list of paths within a yaki with :pax as prefix
     ::


### PR DESCRIPTION
Change the definition of base-hash to be the mergebase of %home with the
OTA source.  This means it's the most recent successfully-applied
update, which is usually the most important information.

Add sour-hash, which is the hash of the most recently *downloaded*
update, regardless of whether it applied successfuly (ie the old
base-hash).

Add a summary of the various hashes at the top of gen/trouble.

I'll note this takes a few seconds now, since +find-merge-points isn't all that optimized (see #3029)