### PR TITLE
eyre: prevent %eyre-no-channel errors

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1313,14 +1313,15 @@
       ::
           %subscribe
         ::
+        =,  i.requests
         =/  channel-wire=wire
-          /channel/subscription/[channel-id]/(scot %ud request-id.i.requests)
+          (channel-wire channel-id request-id)
         ::
         =.  gall-moves
           :_  gall-moves
           ^-  move
-          :^  duct  %pass  channel-wire
-          =,  i.requests
+          :^  duct  %pass
+            (subscription-wire channel-id request-id ship app)
           :*  %g  %deal  [our ship]  app
               `task:agent:gall`[%watch-as %json path]
           ==
@@ -1328,14 +1329,13 @@
         =.  session.channel-state.state
           %+  ~(jab by session.channel-state.state)  channel-id
           |=  =channel
-          =,  i.requests
           channel(subscriptions (~(put by subscriptions.channel) channel-wire [ship app path duct]))
         ::
         $(requests t.requests)
       ::
           %unsubscribe
         =/  channel-wire=wire
-          /channel/subscription/[channel-id]/(scot %ud subscription-id.i.requests)
+          (channel-wire channel-id subscription-id.i.requests)
         ::
         =/  usession  (~(get by session.channel-state.state) channel-id)
         ?~  usession
@@ -1352,8 +1352,9 @@
         =.  gall-moves
           :_  gall-moves
           ^-  move
-          :^  duc.u.maybe-subscription  %pass  channel-wire
           =,  u.maybe-subscription
+          :^  duc  %pass
+            (subscription-wire channel-id subscription-id.i.requests ship app)
           :*  %g  %deal  [our ship]  app
               `task:agent:gall`[%leave ~]
           ==
@@ -1376,8 +1377,31 @@
     ::  +on-gall-response: turns a gall response into an event
     ::
     ++  on-gall-response
-      |=  [channel-id=@t request-id=@ud =sign:agent:gall]
+      |=  [channel-id=@t request-id=@ud extra=wire =sign:agent:gall]
       ^-  [(list move) server-state]
+      ::  if the channel doesn't exist, we should clean up subscriptions
+      ::
+      ::    this is a band-aid solution. you really want eyre to have cleaned
+      ::    these up on-channel-delete in the first place.
+      ::    until the source of that bug is discovered though, we keep this
+      ::    in place to ensure a slightly tidier home.
+      ::
+      ?:  ?&  !(~(has by session.channel-state.state) channel-id)
+              ?=(?(%fact %watch-ack) -.sign)
+              ?=([@ @ ~] extra)
+          ==
+        =/  =ship     (slav %p i.extra)
+        =*  app=term  i.t.extra
+        =/  =tape
+          %+  weld  "eyre: removing watch for "
+          "non-existent channel {(trip channel-id)} on {(trip app)}"
+        %-  (slog leaf+tape ~)
+        :_  state
+        :_  ~
+        ^-  move
+        :^  duct  %pass
+          (subscription-wire channel-id request-id ship app)
+        [%g %deal [our ship] app `task:agent:gall`[%leave ~]]
       ::
       ?-    -.sign
           %poke-ack
@@ -1552,8 +1576,9 @@
       %+  turn  ~(tap by subscriptions.session)
       |=  [channel-wire=wire ship=@p app=term =path duc=^duct]
       ^-  move
-      ::
-      [duc %pass channel-wire [%g %deal [our ship] app %leave ~]]
+      :^  duc  %pass
+        (weld channel-wire /(scot %p ship)/[app])
+      [%g %deal [our ship] app %leave ~]
     --
   ::  +handle-gall-error: a call to +poke-http-response resulted in a %coup
   ::
@@ -1844,6 +1869,16 @@
   ::  alphabetize based on site
   ::
   (aor ?~(site.a '' u.site.a) ?~(site.b '' u.site.b))
+::
+++  channel-wire
+  |=  [channel-id=@t request-id=@ud]
+  ^-  wire
+  /channel/subscription/[channel-id]/(scot %ud request-id)
+::
+++  subscription-wire
+  |=  [channel-id=@t request-id=@ud =ship app=term]
+  ^-  wire
+  (weld (channel-wire channel-id request-id) /(scot %p ship)/[app])
 --
 ::  end the =~
 ::
@@ -2176,12 +2211,17 @@
     ::
         ?(%poke %subscription)
       ?>  ?=([%g %unto *] sign)
+      ~|  wire
       ?>  ?=([@ @ @t @ *] wire)
+      =*  channel-id  i.t.t.wire
+      =*  request-id  i.t.t.t.wire
+      =*  extra-wire  t.t.t.t.wire
       =/  on-gall-response
         on-gall-response:by-channel:(per-server-event event-args)
       ::  ~&  [%gall-response sign]
       =^  moves  server-state.ax
-        (on-gall-response i.t.t.wire `@ud`(slav %ud i.t.t.t.wire) p.sign)
+        %-  on-gall-response
+        [channel-id (slav %ud request-id) extra-wire p.sign]
       [moves http-server-gate]
     ==
   ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -11,9 +11,9 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
-::  $state-6: overall gall state, versioned
+::  $state-7: overall gall state, versioned
 ::
-+$  state-6  [%6 state]
++$  state-7  [%7 state]
 ::  $state: overall gall state
 ::
 ::    system-duct: TODO document
@@ -111,7 +111,8 @@
 ::  $spore: structures for update, produced by +stay
 ::
 +$  spore
-  $:  %6
+  $:  %7
+      wipe-eyre-subs=_|  ::NOTE  band-aid for #3196, remove on next upgrade
       system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
       contacts=(set ship)
@@ -155,10 +156,12 @@
       =-  [(skip -< |=(move ?=([* %give %onto *] +<))) ->]
       =/  adult  adult-core
       =.  state.adult
-        [%6 system-duct outstanding contacts yokes=~ blocked]:spore
+        [%7 system-duct outstanding contacts yokes=~ blocked]:spore
       =/  mo-core  (mo-abed:mo:adult duct)
       =.  mo-core
         =/  apps=(list [dap=term =egg])  ~(tap by eggs.spore)
+        ~?  wipe-eyre-subs.spore
+          [%g %wiping-eyre-subs]
         |-  ^+  mo-core
         ?~  apps  mo-core
         ~>  %slog.[0 leaf+"gall: upgrading {<dap.i.apps>}"]
@@ -166,6 +169,18 @@
         =^  tan  ap-core  (ap-install:ap-core `old-state.egg.i.apps)
         ?^  tan
           (mean u.tan)
+        =?  ap-core  wipe-eyre-subs.spore
+          =/  ducts=(list ^duct)
+            %+  skim  ~(tap in ~(key by inbound.watches.egg.i.apps))
+            |=  =^duct
+            %+  lien  duct
+            |=  =path
+            ?=(^ (find /e/channel/subscription path))
+          |-
+          ?~  ducts  ap-core
+          =.  ap-core
+            ap-load-delete:ap-core(agent-duct i.ducts)
+          $(ducts t.ducts)
         $(apps t.apps, mo-core ap-abet:ap-core)
       =.  mo-core  (mo-subscribe-to-agent-builds:mo-core now)
       =^  moves  adult-gate  mo-abet:mo-core
@@ -177,7 +192,7 @@
       =*  call-args  +<
       ?:  =(~ eggs.spore)
         ~>  %slog.[0 leaf+"gall: direct morphogenesis"]
-        =.  state.adult-gate  spore(eggs *(map term yoke))
+        =.  state.adult-gate  [- +>]:spore(eggs *(map term yoke))
         (call:adult-core call-args)
       ?^  dud
         ~>  %slog.[0 leaf+"gall: pupa call dud"]
@@ -192,7 +207,7 @@
       =*  take-args  +<
       ?:  =(~ eggs.spore)
         ~>  %slog.[0 leaf+"gall: direct morphogenesis"]
-        =.  state.adult-gate  spore(eggs *(map term yoke))
+        =.  state.adult-gate  [- +>]:spore(eggs *(map term yoke))
         (take:adult-core take-args)
       ?^  dud
         ~>  %slog.[0 leaf+"gall: pupa take dud"]
@@ -208,11 +223,13 @@
       ?.  =(~ eggs.spore)
         pupal-gate
       ~>  %slog.[0 leaf+"gall: direct morphogenesis"]
-      adult-gate(state spore(eggs *(map term yoke)))
+      %_  adult-gate
+        state  [- +>]:spore(eggs *(map term yoke))
+      ==
       ::
       ++  upgrade
         |=  =all-state
-        ^-  ^spore
+        ^-  spore-7
         ::
         =?  all-state  ?=(%0 -.all-state)
           (state-0-to-1 all-state)
@@ -232,15 +249,23 @@
         =?  all-state  ?=(%5 -.all-state)
           (state-5-to-spore-6 all-state)
         ::
-        ?>  ?=(%6 -.all-state)
+        =?  all-state  ?=(%6 -.all-state)
+          (spore-6-to-7 all-state)
+        ::
+        ?>  ?=(%7 -.all-state)
         all-state
       ::  +all-state: upgrade path
       ::
-      +$  all-state  $%(state-0 state-1 state-2 state-3 state-4 state-5 ^spore)
+      +$  all-state
+        $%  state-0  state-1  state-2  state-3  state-4  state-5
+            spore-6  spore-7
+        ==
+      ::
+      ++  spore-6-to-7  |=(s=spore-6 `spore-7`[%7 & +.s])
       ::
       ++  state-5-to-spore-6
         |=  s=state-5
-        ^-  ^spore
+        ^-  spore-6
         %=    s
             -  %6
             outstanding  ~  ::  TODO: do we need to process these somehow?
@@ -254,6 +279,8 @@
       ++  state-1-to-2  |=(s=state-1 `state-2`s(- %2, +< +<.s, +> `+>.s))
       ++  state-0-to-1  |=(s=state-0 `state-1`s(- %1))
       ::
+      +$  spore-7  ^spore
+      +$  spore-6  [%6 _+>:*spore-7]
       +$  state-5  [%5 agents-2]
       +$  state-4  [%4 agents-2]
       +$  state-3  [%3 agents-2]
@@ -306,7 +333,7 @@
     --
 ::  adult gall vane interface, for type compatibility with pupa
 ::
-=|  state=state-6
+=|  state=state-7
 |=  [our=ship now=@da eny=@uvJ ski=sley]
 =*  gall-payload  .
 =<  ~%  %gall-wrap  ..mo  ~
@@ -1732,7 +1759,7 @@
 ::
 ++  stay
   ^-  spore
-  =;  eggs=(map term egg)  state(yokes eggs)
+  =;  eggs=(map term egg)  [- | +]:state(yokes eggs)
   %-  ~(run by yokes.state)
   |=(=yoke `egg`yoke(agent on-save:agent.yoke))
 ::  +take: response

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -904,7 +904,7 @@
           [%leaf "wrong number of moves: {<(lent moves)>}"]~
         ::
         %+  expect-gall-deal
-          :*  /channel/subscription/'0123456789abcdef'/1
+          :*  /channel/subscription/'0123456789abcdef'/1/~nul/two
               [~nul ~nul]  %two  %leave  ~
           ==
           card.i.moves
@@ -942,7 +942,8 @@
       now=(add ~1111.1.2 ~m1)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %watch-ack ~]
@@ -957,7 +958,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '1'] [%n '2'] ~])]
@@ -1158,7 +1160,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %watch-ack ~]
@@ -1201,7 +1204,7 @@
           ::  we want to cancel the subscription id on which we originally subscribed
           ::
           %+  expect-gall-deal
-            :*  /channel/subscription/'0123456789abcdef'/'1'
+            :*  /channel/subscription/'0123456789abcdef'/'1'/~nul/two
                 [~nul ~nul]  %two  %leave  ~
             ==
             card.i.moves
@@ -1259,7 +1262,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %watch-ack ~]
@@ -1302,7 +1306,7 @@
         ::
         ;:  weld
           %+  expect-gall-deal
-            :*  /channel/subscription/'0123456789abcdef'/'2'
+            :*  /channel/subscription/'0123456789abcdef'/'2'/~nul/two
                 [~nul ~nul]  %two
                 %watch-as  %json  /one/two/three
             ==
@@ -1334,7 +1338,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '1'] [%n '2'] ~])]
@@ -1349,7 +1354,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'2'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'2'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '1'] [%n '2'] ~])]
@@ -1451,7 +1457,7 @@
         ::
         ;:  weld
           %+  expect-gall-deal
-            :*  /channel/subscription/'0123456789abcdef'/'1'
+            :*  /channel/subscription/'0123456789abcdef'/'1'/~nul/two
                 [~nul ~nul]  %two  %leave  ~
             ==
             card.i.moves
@@ -1471,7 +1477,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'2'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'2'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '1'] [%n '2'] ~])]
@@ -1547,7 +1554,8 @@
       now=(add ~1111.1.2 ~m2)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %watch-ack ~]
@@ -1618,7 +1626,8 @@
       now=(add ~1111.1.2 ~m4)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '1'] ~])]
@@ -1706,7 +1715,8 @@
       now=(add ~1111.1.2 ~m7)
       scry=scry-provides-code
       ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'  duct=~[/http-put-request]
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
             ^-  (hypo sign:eyre-gate)
             :-  *type
             [%g %unto %fact %json !>(`json`[%a [%n '2'] ~])]
@@ -2189,7 +2199,7 @@
             card.i.moves
         ::
           %+  expect-gall-deal
-            :*  /channel/subscription/'0123456789abcdef'/'1'
+            :*  /channel/subscription/'0123456789abcdef'/'1'/~nul/two
                 [~nul ~nul]  %two
                 %watch-as  %json  /one/two/three
             ==


### PR DESCRIPTION
This is a band-aid fix for #3196. The root cause for that still eludes me. All of the involved code "looks good to me".

Still, the symptoms of #3196 are annoying, so we address those directly. We detect the case that would lead to the error and, instead of trying to talk to the now-gone channel, we `%leave` the subscription that gave us the update. Since this requires new details from the wire, we cannot do this for existing cases, and instead rely on gall to forget all of eyre's subscriptions, "just this once".

Tested on a copy of @galenwp's ship, who was suffering from this issue.

idk what's up with the hercules failures, but it doesn't look like they're relevant here?