### PR TITLE
lib: take json as argument to /lib/server's +json-response

### DIFF
--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -193,7 +193,6 @@
     =/  pax  t.t.t.t.site.url
     =/  envelopes  (envelope-scry [(scot %ud start) (scot %ud end) pax])
     %-  json-response:gen
-    %-  json-to-octs
     %-  update:enjs:store
     [%messages pax start end envelopes]
   ==

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -148,9 +148,7 @@
   ::
   =;  json=(unit json)
     ?~  json  not-found:gen
-    %-  json-response:gen
-    =,  html
-    (as-octt:mimes (en-json u.json))
+    (json-response:gen u.json)
   =,  enjs:format
   ?+  site  ~
     ::  /apps.json: {appname: running?}

--- a/pkg/arvo/app/language-server.hoon
+++ b/pkg/arvo/app/language-server.hoon
@@ -113,7 +113,7 @@
 ++  json-response
   |=  [eyre-id=@ta jon=json]
   ^-  (list card)
-  (give-simple-payload:app eyre-id (json-response:gen (json-to-octs jon)))
+  (give-simple-payload:app eyre-id (json-response:gen jon))
 ::
 ++  give-rpc-notification
   |=  res=out:notification:lsp-sur

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -136,7 +136,7 @@
     ::
     :_  this
     %+  give-simple-payload:app  eyre-id.u.job.state
-    (json-response:gen (json-to-octs jon))
+    (json-response:gen jon)
   ::
   ++  take-sole-effect
     |=  fec=sole-effect
@@ -186,7 +186,7 @@
     %+  give-simple-payload:app  eyre-id.u.job.state
     ?-  -.u.out
         %json
-      (json-response:gen (json-to-octs json.u.out))
+      (json-response:gen json.u.out)
     ::
         %mime
       =/  headers

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -2347,7 +2347,6 @@
   ::  all notebooks, short form
       [[[~ %json] [%'publish-view' %notebooks ~]] ~]
     %-  json-response:gen
-    %-  json-to-octs
     (notebooks-map:enjs our.bol books)
   ::
   ::  notes pagination
@@ -2366,7 +2365,6 @@
     ?~  length
       not-found:gen
     %-  json-response:gen
-    %-  json-to-octs
     :-  %o
     (notes-page:enjs notes.u.book u.start u.length)
   ::
@@ -2390,7 +2388,6 @@
     ?~  length
       not-found:gen
     %-  json-response:gen
-    %-  json-to-octs
     (comments-page:enjs comments.u.note u.start u.length)
   ::
   ::  single notebook with initial 50 notes in short form, as json
@@ -2409,7 +2406,7 @@
       (~(put by p.notebook-json) %subscribers (get-subscribers-json book-name))
     =.  p.notebook-json
       (~(put by p.notebook-json) %writers (get-writers-json u.host book-name))
-    (json-response:gen (json-to-octs (pairs notebook+notebook-json ~)))
+    (json-response:gen (pairs notebook+notebook-json ~))
   ::
   ::  single note, with initial 50 comments, as json
       [[[~ %json] [%'publish-view' @ @ @ ~]] ~]
@@ -2424,7 +2421,7 @@
     ?~  note  not-found:gen
     =/  jon=json
       o+(note-presentation:enjs u.book note-name u.note)
-    (json-response:gen (json-to-octs jon))
+    (json-response:gen jon)
   ==
 ::
 --

--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -92,9 +92,9 @@
     [[200 [['content-type' 'text/javascript'] max-1-da ~]] `octs]
   ::
   ++  json-response
-    |=  =octs
+    |=  =json
     ^-  simple-payload:http
-    [[200 ['content-type' 'application/json']~] `octs]
+    [[200 ['content-type' 'application/json']~] `(json-to-octs json)]
   ::
   ++  css-response
     |=  =octs


### PR DESCRIPTION
This has been bothering me since \**checks git log*\* a year and a half ago. No reason conversion to octs has to happen outside of this function.