### PR TITLE
publish: fix unread counts for long titles

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/lib/NotebookItem.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/NotebookItem.tsx
@@ -18,6 +18,7 @@ function UnreadCount(props: { unread: number }) {
       fontWeight="700"
       py={1}
       borderRadius={1}
+      flexShrink='0'
       color="white"
       bg="lightGray"
     >
@@ -41,7 +42,7 @@ export function NotebookItem(props: NotebookItemProps) {
         justifyContent="space-between"
         alignItems="center"
       >
-        <Box py={1}>{props.title}</Box>
+        <Box py='1' pr='1'>{props.title}</Box>
         {props.unreadCount > 0 && <UnreadCount unread={props.unreadCount} />}
       </HoverBox>
     </Link>


### PR DESCRIPTION
Re: #3283

The Publish refactor partially addressed the issue in question, but produced some flexbox squishing of the unread count instead. We give the title some padding on the right and disable flex-shrink to compensate.

<img width="263" alt="Screenshot 2020-08-27 at 3 34 06 PM" src="https://user-images.githubusercontent.com/20846414/91486995-18a04700-e87b-11ea-8d69-cdacba6f2217.png">
