### PR TITLE
chat: break up inline code

### DIFF
--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -252,6 +252,10 @@ blockquote {
     font-family: 'Inter';
 }
 
+code {
+  white-space: normal;
+}
+
 code, pre.code {
   background-color: var(--light-gray);
 }


### PR DESCRIPTION
Importantly, doesn't affect the white-space of %code messages.

See #3358.