### PR TITLE
chat: only show other participant in dms

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/group-item.js
+++ b/pkg/interface/src/views/apps/chat/components/lib/group-item.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { ChannelItem } from './channel-item';
+import { deSig } from "~/logic/lib/util";
 
 export class GroupItem extends Component {
   render() {
     const { props } = this;
     const association = props.association ? props.association : {};
+    const DEFAULT_TITLE_REGEX = new RegExp(`(( <-> )?~${deSig(window.ship)}( <-> )?)`);
 
     let title = association['app-path'] ? association['app-path'] : 'Direct Messages';
     if (association.metadata && association.metadata.title) {
@@ -47,9 +49,13 @@ export class GroupItem extends Component {
         each in props.chatMetadata &&
         props.chatMetadata[each].metadata
       ) {
-        title = props.chatMetadata[each].metadata.title
-          ? props.chatMetadata[each].metadata.title
-          : each.substr(1);
+        if (props.chatMetadata[each].metadata.title) {
+          title = props.chatMetadata[each].metadata.title
+        }
+      }
+      
+      if (DEFAULT_TITLE_REGEX.test(title) && props.index === "dm") {
+        title = title.replace(DEFAULT_TITLE_REGEX, '');
       }
       const selected = props.station === each;
 


### PR DESCRIPTION
Pretty simple implementation: just tests to see if the title of the chat is going to be the ship name surrounded on either side with ` <-> `, and if so, replaces that same regex with nothing. Works for all my chats:

![secrets](https://marpem-files.sfo2.digitaloceanspaces.com/Screen%20Shot%202020-08-27%20at%204.21.07%20PM.png)