### PR TITLE
clay: minimal -diff thread

### DIFF
--- a/pkg/arvo/ted/diff.hoon
+++ b/pkg/arvo/ted/diff.hoon
@@ -1,0 +1,30 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+|^
+=+  !<([=a=path =b=path ~] arg)
+=/  a-mark=mark  -:(flop a-path)
+=/  b-mark=mark  -:(flop b-path)
+?.  =(a-mark b-mark)
+  (strand-fail:strandio %files-not-same-type ~)
+=/  a-beam  (need (de-beam:format a-path))
+;<  =a=cage     bind:m  (get-file a-path)
+;<  =b=cage     bind:m  (get-file b-path)
+;<  =dais:clay  bind:m  (build-mark:strandio -.a-beam a-mark)
+(pure:m (~(diff dais q.a-cage) q.b-cage))
+::
+++  get-file
+  |=  =path
+  =/  m  (strand ,cage)
+  ^-  form:m
+  =/  beam  (need (de-beam:format path))
+  ;<  =riot:clay  bind:m
+    (warp:strandio p.beam q.beam ~ %sing %x r.beam (flop s.beam))
+  ?~  riot
+    (strand-fail:strandio %file-not-found >path< ~)
+  (pure:m r.u.riot)
+--


### PR DESCRIPTION
Barebones 2-way diff thread.  Example:

```
> +cat /=home=/test/hoon
/~zod/home/~2020.8.28..04.23.09..8445/test/hoon
1
home-change
3

> +cat /=other=/test/hoon
/~zod/other/~2020.8.28..04.23.16..617e/test/hoon
1
other-change
3

> -diff /=home=/test/hoon /=other=/test/hoon
~[[%.y p=1] [%.n p=<|home-change|> q=<|other-change|>] [%.y p=1]]
```

Read this as "1 line of no change, then 'home-change' vs 'other-change', then 1 more line of no change".

Further development should include:

- recognize at least %txt and %hoon diff types as (urge:clay cord) and
print them prettily

- check if they're directories and recurse through them, noting files
that exist in one or the other and diffing ones that exist in both

- support 3-way diffs.  Since we know the desks they're on, we can find
a mergebase (see how +trouble gets the base-hash in #3378) and do a
3-way diff.

- extend the above to support all the useful diffs, including
diff3(a,b), diff2(mergebase(a,b),a) and any other useful ones.