### PR TITLE
ames.c: better stateless forwarding

### DIFF
--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -113,10 +113,10 @@ _ames_pact_free(u3_pact* pac_u)
 */
 static void
 _ames_panc_free(u3_panc* pac_u) {
-  if (0 != pac_u->nex_u) {
+  if ( 0 != pac_u->nex_u ) {
     pac_u->nex_u->pre_u = pac_u->pre_u;
   }
-  if (0 != pac_u->pre_u) {
+  if ( 0 != pac_u->pre_u ) {
     pac_u->pre_u->nex_u = pac_u->nex_u;
   } else {
     c3_assert(pac_u == pac_u->sam_u->pac_u);
@@ -312,7 +312,7 @@ _ames_lane_from_sockaddr(struct sockaddr_in* add_u)
 
 /* _ames_lane_into_cache(): put las for who into cache, including timestamp
 */
-void
+static void
 _ames_lane_into_cache(u3p(u3h_root) lax_p, u3_noun who, u3_noun las) {
   struct timeval tim_tv;
   gettimeofday(&tim_tv, 0);
@@ -324,11 +324,11 @@ _ames_lane_into_cache(u3p(u3h_root) lax_p, u3_noun who, u3_noun las) {
 
 /* _ames_lane_from_cache(): retrieve lane for who from cache, if any & fresh
 */
-u3_weak
+static u3_weak
 _ames_lane_from_cache(u3p(u3h_root) lax_p, u3_noun who) {
   u3_weak lac = u3h_git(lax_p, who);
 
-  if (u3_none != lac) {
+  if ( u3_none != lac ) {
     struct timeval tim_tv;
     gettimeofday(&tim_tv, 0);
     u3_noun now = u3_time_in_tv(&tim_tv);
@@ -336,7 +336,7 @@ _ames_lane_from_cache(u3p(u3h_root) lax_p, u3_noun who) {
 
     //  consider entries older than 2 minutes stale, ignore them
     //
-    if (120000 > u3_time_gap_ms(u3k(den), now)) {
+    if ( 120000 > u3_time_gap_ms(u3k(den), now) ) {
       lac = u3k(u3h(lac));
     } else {
       lac = u3_none;
@@ -359,7 +359,7 @@ _ames_serialize_packet(u3_panc* pac_u, c3_o dop_o)
 
   //  update the body's lane, if desired
   //
-  if (c3y == dop_o) {
+  if ( c3y == dop_o ) {
     //  unpack (jam [(unit lane) body])
     //
     u3_noun lon, bod;
@@ -377,7 +377,7 @@ _ames_serialize_packet(u3_panc* pac_u, c3_o dop_o)
     //      but that doesn't matter: ames.hoon ignores origin in that case,
     //      always using the appropriate galaxy lane instead.
     //
-    if (u3_nul == lon) {
+    if ( u3_nul == lon ) {
       u3z(lon);
       lon = u3nt(u3_nul, c3n, u3_ames_encode_lane(pac_u->ore_u));
       nal_o = c3y;
@@ -413,7 +413,7 @@ _ames_serialize_packet(u3_panc* pac_u, c3_o dop_o)
 
     //  if we updated the origin lane, we need to update the mug too
     //
-    if (c3y == nal_o) {
+    if ( c3y == nal_o ) {
       pac_u->hed_u.mug_l = _ca_mug_body(sen_y + rec_y + bod_u->con_w,
                                         pac_y + 4);
     }
@@ -672,7 +672,7 @@ _ames_forward(u3_panc* pac_u, u3_noun las)
   {
     u3_noun los = las;
     u3_noun pac = _ames_serialize_packet(pac_u, c3y);
-    while (u3_nul != las) {
+    while ( u3_nul != las ) {
       _ames_ef_send(pac_u->sam_u, u3k(u3h(las)), u3k(pac));
       las = u3t(las);
     }
@@ -694,8 +694,8 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
 
   //  if scry fails, remember we can't scry, and just inject the packet
   //
-  if (u3_none == las) {
-    if (5 < ++pac_u->sam_u->saw_d) {
+  if ( u3_none == las ) {
+    if ( 5 < ++pac_u->sam_u->saw_d ) {
       u3l_log("ames: giving up scry\n");
       pac_u->sam_u->see_o = c3n;
     }
@@ -705,7 +705,7 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
     _ames_panc_free(pac_u);
   }
   else {
-    if (0 < pac_u->sam_u->saw_d) {
+    if ( 0 < pac_u->sam_u->saw_d ) {
       pac_u->sam_u->saw_d--;
     }
 
@@ -717,7 +717,7 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
 
     //  if there is no lane, drop the packet
     //
-    if (u3_nul == las) {
+    if ( u3_nul == las ) {
       _ames_panc_free(pac_u);
     }
     //  if there is a lane, forward the packet on it
@@ -747,7 +747,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
 
   //  ensure a sane message size
   //
-  if (4 >= nrd_i) {
+  if ( 4 >= nrd_i ) {
     pas_o = c3n;
   }
   //  unpack the packet header
@@ -800,7 +800,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   c3_d  rec_d[2];
   c3_w  con_w = nrd_i - 4 - sen_y - rec_y;
   c3_y* con_y = NULL;
-  if (c3y == pas_o) {
+  if ( c3y == pas_o ) {
     u3_noun sen = u3i_bytes(sen_y, bod_y);
     u3_noun rec = u3i_bytes(rec_y, bod_y + sen_y);
     u3r_chubs(0, 2, rec_d, rec);
@@ -848,8 +848,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
     //      so can't pluck these out of the event queue like it does in
     //      _ames_cap_queue. as such, blocked on u3_lord_peek_cancel or w/e.
     //
-    if ( (u3_none == lac) && (1000 < sam_u->foq_d) )
-    {
+    if ( (u3_none == lac) && (1000 < sam_u->foq_d) ) {
       c3_free(con_y);
 
       sam_u->fod_d++;
@@ -859,7 +858,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
     }
     //  if we know there's no lane, drop the packet
     //
-    else if (u3_nul == lac) {
+    else if ( u3_nul == lac ) {
       c3_free(con_y);
       u3z(lac);
     }
@@ -879,7 +878,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
       pac_u->bod_u.con_y = con_y;
       pac_u->ore_u = _ames_lane_from_sockaddr((struct sockaddr_in *)adr_u);
 
-      if (0 != sam_u->pac_u) {
+      if ( 0 != sam_u->pac_u ) {
         pac_u->nex_u = sam_u->pac_u;
         sam_u->pac_u->pre_u = pac_u;
       }
@@ -887,7 +886,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
 
       //  if we already know the lane, just forward
       //
-      if (u3_none != lac) {
+      if ( u3_none != lac ) {
         _ames_forward(pac_u, lac);
       }
       //  otherwise, there's space in the scry queue; scry the lane out of ames
@@ -906,7 +905,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
 
   //  if we passed the filter, inject the packet
   //
-  if (c3y == pas_o) {
+  if ( c3y == pas_o ) {
     c3_free(con_y);
     u3_lane ore_u = _ames_lane_from_sockaddr((struct sockaddr_in *)adr_u);
     u3_noun msg   = u3i_bytes((c3_w)nrd_i, (c3_y*)buf_u->base);
@@ -1026,7 +1025,7 @@ _ames_prot_scry_cb(void* vod_p, u3_noun nun)
   u3_ames* sam_u = vod_p;
   u3_weak  ver   = u3r_at(7, nun);
 
-  if (u3_none == ver) {
+  if ( u3_none == ver ) {
     //  assume protocol version 0
     //
     sam_u->ver_y = 0;

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -1209,13 +1209,13 @@ u3_ames_io_init(u3_pier* pir_u)
   //
   //    assuming we store:
   //    a (list lane) with 1 item, 1+8 + 1 + (6*2) = 22 words
-  //    and a @da as timestamp,                       5 words
+  //    and a @da as timestamp,                       8 words
   //    consed together,                              6 words
   //    with worst-case (128-bit) @p keys,            8 words
   //    and an additional cell for the k-v pair,      6 words
-  //    that makes for a per-entry memory use of     47 words => 188 bytes
+  //    that makes for a per-entry memory use of     50 words => 200 bytes
   //
-  //    the 500k entries below would take about 94mb (in the worst case, but
+  //    the 500k entries below would take about 100mb (in the worst case, but
   //    not accounting for hashtable overhead).
   //    we could afford more, but 500k entries is more than we'll likely use
   //    in the near future.

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -679,7 +679,6 @@ _ames_forward(u3_panc* pac_u, u3_noun las)
     u3z(los); u3z(pac);
   }
 
-  pac_u->sam_u->foq_d--;
   _ames_panc_free(pac_u);
 }
 
@@ -691,6 +690,8 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
   u3_panc* pac_u = vod_p;
   u3_weak  las = u3r_at(7, nun);
 
+  pac_u->sam_u->foq_d--;
+
   //  if scry fails, remember we can't scry, and just inject the packet
   //
   if (u3_none == las) {
@@ -701,7 +702,6 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
     _ames_put_packet(pac_u->sam_u,
                      _ames_serialize_packet(pac_u, c3n),
                      pac_u->ore_u);
-    pac_u->sam_u->foq_d--;
     _ames_panc_free(pac_u);
   }
   else {
@@ -718,7 +718,6 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
     //  if there is no lane, drop the packet
     //
     if (u3_nul == las) {
-      pac_u->sam_u->foq_d--;
       _ames_panc_free(pac_u);
     }
     //  if there is a lane, forward the packet on it
@@ -867,8 +866,6 @@ _ames_recv_cb(uv_udp_t*        wax_u,
     //  otherwise, proceed with forwarding
     //
     else {
-      sam_u->foq_d++;
-
       //  store the packet details for later processing
       //
       u3_panc* pac_u = c3_calloc(sizeof(*pac_u));
@@ -896,6 +893,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
       //  otherwise, there's space in the scry queue; scry the lane out of ames
       //
       else {
+        sam_u->foq_d++;
         u3_noun pax = u3nq(u3i_string("peers"),
                            u3dc("scot", 'p', u3i_chubs(2, rec_d)),
                            u3i_string("forward-lane"),

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -705,9 +705,7 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
     _ames_panc_free(pac_u);
   }
   else {
-    if ( 0 < pac_u->sam_u->saw_d ) {
-      pac_u->sam_u->saw_d--;
-    }
+    pac_u->sam_u->saw_d = 0;
 
     //  cache the scry result for later use
     //

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -655,20 +655,25 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
   //  if scry fails, remember we can't scry, and just inject the packet
   //
   if (u3_none == las) {
-    pac_u->sam_u->foq_d--;
     u3l_log("ames: giving up scry\n");
     pac_u->sam_u->see_o = c3n;
     _ames_put_packet(pac_u->sam_u,
                      _ames_serialize_packet(pac_u, c3n),
                      pac_u->ore_u);
+    pac_u->sam_u->foq_d--;
+    _ames_panc_free(pac_u);
+  }
+  //  if there is no lane, drop the packet
+  //
+  else if (u3_nul == las) {
+    pac_u->sam_u->foq_d--;
     _ames_panc_free(pac_u);
   }
   //  if there is a lane, forward the packet on it
   //
-  else if (u3_nul != las) {
+  else {
     _ames_forward(pac_u, u3k(las));
   }
-  //  if there is no lane, drop the packet
 
   u3z(nun);
 }

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -45,6 +45,7 @@
     c3_d             saw_d;             //  successive scry failures
     c3_o             fit_o;             //  filtering active
     c3_y             ver_y;             //  protocol version
+    u3p(u3h_root)    lax_p;             //  lane scry cache
     c3_d             vet_d;             //  version mismatches filtered
     c3_d             mut_d;             //  invalid mugs filtered
     struct _u3_panc* pac_u;             //  packets pending forwards
@@ -307,6 +308,43 @@ _ames_lane_from_sockaddr(struct sockaddr_in* add_u)
   lan_u.por_s = ntohs(add_u->sin_port);
   lan_u.pip_w = ntohl(add_u->sin_addr.s_addr);
   return lan_u;
+}
+
+/* _ames_lane_into_cache(): put las for who into cache, including timestamp
+*/
+void
+_ames_lane_into_cache(u3p(u3h_root) lax_p, u3_noun who, u3_noun las) {
+  struct timeval tim_tv;
+  gettimeofday(&tim_tv, 0);
+  u3_noun now = u3_time_in_tv(&tim_tv);
+  u3_noun val = u3nc(las, now);
+  u3h_put(lax_p, who, val);
+  u3z(who);
+}
+
+/* _ames_lane_from_cache(): retrieve lane for who from cache, if any & fresh
+*/
+u3_weak
+_ames_lane_from_cache(u3p(u3h_root) lax_p, u3_noun who) {
+  u3_weak lac = u3h_git(lax_p, who);
+
+  if (u3_none != lac) {
+    struct timeval tim_tv;
+    gettimeofday(&tim_tv, 0);
+    u3_noun now = u3_time_in_tv(&tim_tv);
+    u3_noun den = u3t(lac);
+
+    //  consider entries older than 2 minutes stale, ignore them
+    //
+    if (120000 > u3_time_gap_ms(u3k(den), now)) {
+      lac = u3k(u3h(lac));
+    } else {
+      lac = u3_none;
+    }
+  }
+
+  u3z(who);
+  return lac;
 }
 
 /* _ames_serialize_packet(): u3_panc to atom, updating the origin lane if dop_o
@@ -627,7 +665,7 @@ static void
 _ames_forward(u3_panc* pac_u, u3_noun las)
 {
   pac_u->sam_u->fow_d++;
-  if ( 0 == (pac_u->sam_u->fow_d % 10000) ) {
+  if ( 0 == (pac_u->sam_u->fow_d % 1000000) ) {
     u3l_log("ames: forwarded %" PRIu64 " total\n", pac_u->sam_u->fow_d);
   }
 
@@ -670,6 +708,13 @@ _ames_lane_scry_cb(void* vod_p, u3_noun nun)
     if (0 < pac_u->sam_u->saw_d) {
       pac_u->sam_u->saw_d--;
     }
+
+    //  cache the scry result for later use
+    //
+    _ames_lane_into_cache(pac_u->sam_u->lax_p,
+                          u3i_chubs(2, pac_u->bod_u.rec_d),
+                          u3k(las));
+
     //  if there is no lane, drop the packet
     //
     if (u3_nul == las) {
@@ -784,7 +829,19 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   {
     pas_o = c3n;
 
-    //  if the queue is full, and we can't forward synchronously,
+    u3_weak lac;
+    //  if the recipient is a galaxy, their lane is always &+~gax
+    //
+    if ( (rec_d[1] == 0) && (256 > rec_d[0]) ) {
+      lac = u3nc(c3y, (c3_y)rec_d[0]);
+    }
+    //  otherwise, try to get the lane from cache
+    //
+    else {
+      lac = _ames_lane_from_cache(sam_u->lax_p, u3i_chubs(2, rec_d));
+    }
+
+    //  if we don't know the lane, and the scry queue is full,
     //  just drop the packet
     //
     //TODO  drop oldest item in forward queue in favor of this one.
@@ -792,15 +849,20 @@ _ames_recv_cb(uv_udp_t*        wax_u,
     //      so can't pluck these out of the event queue like it does in
     //      _ames_cap_queue. as such, blocked on u3_lord_peek_cancel or w/e.
     //
-    if ( (1000 < sam_u->foq_d)
-      && !(rec_d[1] == 0 && (256 > rec_d[0])) )
+    if ( (u3_none == lac) && (1000 < sam_u->foq_d) )
     {
       c3_free(con_y);
 
       sam_u->fod_d++;
-      if ( 0 == (sam_u->fod_d % 100000) ) {
+      if ( 0 == (sam_u->fod_d % 10000) ) {
         u3l_log("ames: dropped %" PRIu64 " forwards total\n", sam_u->fod_d);
       }
+    }
+    //  if we know there's no lane, drop the packet
+    //
+    else if (u3_nul == lac) {
+      c3_free(con_y);
+      u3z(lac);
     }
     //  otherwise, proceed with forwarding
     //
@@ -826,12 +888,12 @@ _ames_recv_cb(uv_udp_t*        wax_u,
       }
       sam_u->pac_u = pac_u;
 
-      //  if the recipient is a galaxy, their lane is always &+~gax
+      //  if we already know the lane, just forward
       //
-      if ( (rec_d[1] == 0) && (256 > rec_d[0]) ) {
-        _ames_forward(pac_u, u3nc(u3nc(c3y, (c3_y)rec_d[0]), u3_nul));
+      if (u3_none != lac) {
+        _ames_forward(pac_u, lac);
       }
-      //  otherwise, if there's space in the queue, scry the lane out of ames
+      //  otherwise, there's space in the scry queue; scry the lane out of ames
       //
       else {
         u3_noun pax = u3nq(u3i_string("peers"),
@@ -1106,6 +1168,8 @@ _ames_exit_cb(uv_handle_t* had_u)
     pac_u = nex_u;
   }
 
+  u3h_free(sam_u->lax_p);
+
   c3_free(sam_u);
 }
 
@@ -1131,6 +1195,7 @@ _ames_io_info(u3_auto* car_u)
   u3l_log("        filtered (ver): %" PRIu64 "\n", sam_u->vet_d);
   u3l_log("        filtered (mug): %" PRIu64 "\n", sam_u->mut_d);
   u3l_log("               crashed: %" PRIu64 "\n", sam_u->fal_d);
+  u3l_log("          cached lanes: %u\n", u3to(u3h_root, sam_u->lax_p)->use_w);
 }
 
 /* u3_ames_io_init(): initialize ames I/O.
@@ -1144,6 +1209,23 @@ u3_ames_io_init(u3_pier* pir_u)
   sam_u->see_o    = c3y;
   sam_u->fit_o    = c3n;
   sam_u->foq_d    = 0;
+
+  //NOTE  some numbers on memory usage for the lane cache
+  //
+  //    assuming we store:
+  //    a (list lane) with 1 item, 1+8 + 1 + (6*2) = 22 words
+  //    and a @da as timestamp,                       5 words
+  //    consed together,                              6 words
+  //    with worst-case (128-bit) @p keys,            8 words
+  //    and an additional cell for the k-v pair,      6 words
+  //    that makes for a per-entry memory use of     47 words => 188 bytes
+  //
+  //    the 500k entries below would take about 94mb (in the worst case, but
+  //    not accounting for hashtable overhead).
+  //    we could afford more, but 500k entries is more than we'll likely use
+  //    in the near future.
+  //
+  sam_u->lax_p = u3h_new_cache(500000);
 
   c3_assert( !uv_udp_init(u3L, &sam_u->wax_u) );
   sam_u->wax_u.data = sam_u;


### PR DESCRIPTION
Fully fixes #3345:

- No longer fail to do bookkeeping on the scry queue in the "scry says we have no lane" case. This would lead to the queue "filling up" with non-existent entries, eventually resulting in all forward requests to be dropped on the floor.

- No longer give up on scrying at the first sight of failure. Instead, only do so if multiple lane scries fail in succession.

- Cache lane scry results for better performance. 

I had the pre-caching version running on ~nus for a while. On average, for every forward request it completed, it would drop three.  
Now, with caching, it seems to keep up with network traffic just fine. It's running at 100% cpu usage continuously to do so, but it's no longer dropping large amounts of packets (only dropping any briefly after booting, due to the empty cache).