### PR TITLE
urbit/.github: adding new design issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-issue-report.md
+++ b/.github/ISSUE_TEMPLATE/design-issue-report.md
@@ -24,7 +24,9 @@ Example:
 **Expected design behavior**
 A clear and concise description of how you expected the design to behave, look, feel, or be implemented.
 
-If you are a designer involved directly as the point-person of the observed design issue, please include screenshot(s) of the intended design in your description of expected behavior. Link to the associated design if it exists.
+If you are a designer involved directly as the point-person of the observed design issue, please include screenshot(s) of the intended design in your description of expected behavior. Link to the associated design if it exists (via Figma or otherwise).
+
+If a textual specification existed to describe the project implementation plan, please include it here.
 
 If the observed design issue involves an Indigo component mis-implementation, please provide a link to the correct implementation of the component.
 

--- a/.github/ISSUE_TEMPLATE/design-issue-report.md
+++ b/.github/ISSUE_TEMPLATE/design-issue-report.md
@@ -1,0 +1,43 @@
+---
+name: Design Issue
+about: 'Use this template to file a report for observed design issues in Landscape. Design issues may include UX/experiential issues, visual design issues, or Indigo implementation issues.'
+title: ''
+labels: landscape, design
+assignees: ''
+
+---
+
+**Describe and screenshoot the design issue**
+A clear and concise description of what the design issue is. 
+Is the observed issue an interface UX/usability issue? Is it a visual design issue? Is Indigo being used incorrectly?
+
+As all user-facing design issues are likely to be visual to a degree, screenshots are mandatory for describing design issues.
+
+**To Reproduce**
+Steps to reproduce/view the behavior:
+
+Example:
+1. Click on dropdown
+2. Note incorrectly-implemented Indigo component
+4. Padding appears off by 2rem
+
+**Expected design behavior**
+A clear and concise description of how you expected the design to behave, look, feel, or be implemented.
+
+If you are a designer involved directly as the point-person of the observed design issue, please include screenshot(s) of the intended design in your description of expected behavior. Link to the associated design if it exists.
+
+If the observed design issue involves an Indigo component mis-implementation, please provide a link to the correct implementation of the component.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. MacOS 10.15.3]
+ - Browser [e.g. chrome, safari]
+ - Base hash of your urbit ship. Run `+trouble` in Dojo to see this.
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Base hash of your urbit ship. Run `+trouble` in Dojo to see this.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Creating a baseline structure for design issue-reporting in Landscape.

Primary differences from the OS 1 issue report are as follows:

1. Explicit direction to include images/screenshots in the report
2. Explicit direction to reference the original design if one is the point designer on a given design project
3. Explicit direction to reference an Indigo component's implementation instruction if the observed issue relates to Indigo component mis-implementation

This seems to capture a large chunk of how we could/should be structuring design QA reporting.