### PR TITLE
zuse: allow xml declaration in +de-xml:html

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7198c05335b7c6f04ced0edfe90e475dfdc87dea62cabc4993d9860c70b29915
-size 6295404
+oid sha256:c61d44c8cf9e09b07ff0df4c65a491851f33afd6ad70d558de9b55614abd704c
+size 6282949

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84ef1d5feadc0d302fa72b3ab1ccb40d8353e22b133bbb0abce00086bad657ee
-size 6263669
+oid sha256:7198c05335b7c6f04ced0edfe90e475dfdc87dea62cabc4993d9860c70b29915
+size 6295404

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6311,9 +6311,10 @@
     |_  ent/_`(map term @t)`[[%apos '\''] ~ ~]
     ::                                                  ::  ++apex:de-xml:html
     ++  apex                                            ::  top level
-      =+  spa=;~(pose comt whit decl)
+      =+  spa=;~(pose comt whit)
       %+  knee  *manx  |.  ~+
-      %+  ifix  [(star spa) (star spa)]
+      %+  ifix  
+        [;~(plug (punt decl) (star spa)) (star spa)]
       ;~  pose
         %+  sear  |=({a/marx b/marl c/mane} ?.(=(c n.a) ~ (some [a b])))
           ;~(plug head many tail)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6311,7 +6311,7 @@
     |_  ent/_`(map term @t)`[[%apos '\''] ~ ~]
     ::                                                  ::  ++apex:de-xml:html
     ++  apex                                            ::  top level
-      =+  spa=;~(pose comt whit)
+      =+  spa=;~(pose comt whit decl)
       %+  knee  *manx  |.  ~+
       %+  ifix  [(star spa) (star spa)]
       ;~  pose
@@ -6359,6 +6359,12 @@
         whit
         ;~(less (jest '-->') hep)
       ==
+    ::
+    ++  decl                                            ::  ++decl:de-xml:html
+      %+  ifix                                          ::  XML declaration
+        [(jest '<?xml') (jest '?>')]
+      %-  star
+      ;~(less (jest '?>') prn)
     ::                                                  ::  ++escp:de-xml:html
     ++  escp                                            ::
       ;~(pose ;~(less led ban pad prn) enty)


### PR DESCRIPTION
Allows for parsing of an xml declaration. Throws it away, as the
datastructure doesn't have anywhere to put the result.

