### PR TITLE
meta: revise developer onboarding, demarcate landscape apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Landscape feature request
+    url: https://github.com/urbit/landscape/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=
+    about: Landscape is comprised of Tlon's user applications and client for Urbit. Submit Landscape feature requests here.
+  - name: urbit-dev mailing list
+    url: https://groups.google.com/a/urbit.org/g/dev
+    about: Developer questions and discussions also take place on the urbit-dev mailing list.

--- a/.github/ISSUE_TEMPLATE/os1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/os1-bug-report.md
@@ -1,6 +1,6 @@
 ---
-name: OS1 Bug report
-about: 'Use this template to file a bug for any OS1 app: Chat, Publish, Links, Groups,
+name: Landscape bug report
+about: 'Use this template to file a bug for any Landscape app: Chat, Publish, Links, Groups,
   Weather or Clock'
 title: ''
 labels: landscape

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,14 @@
 
 Thank you for your interest in contributing to Urbit.
 
-See [urbit.org/docs/getting-started][start] for basic orientation and usage
+See [urbit.org/using/install][start] for basic orientation and usage
 instructions.  You may also want to subscribe to [urbit-dev][list], the Urbit
 development mailing list. For specific information on contributing to the Urbit
 interface, see its [contribution guidelines][interface].
 
-[start]: https://urbit.org/docs/getting-started/#arvo
+For information on Arvo's maintainers, see [pkg/arvo][main].
+
+[start]: https://urbit.org/using/install
 [interface]: /pkg/interface/CONTRIBUTING.md
 
 ## Fake ships
@@ -45,11 +47,10 @@ The canonical source tree is the `master` branch of
 `master` when commencing new work; similarly, when we pull in your
 contribution, we'll do so by merging it to `master`.
 
-Since we use GitHub, it's helpful (though not required) to contribute via a
-GitHub pull request.  You can also post patches to the [mailing list][list],
-email them to maintainers, or request a maintainer pull from your tree directly
--- but note that some maintainers will be more receptive to these methods than
-others.
+Since we use GitHub, we request you contribute via a GitHub pull request. Tag
+the [maintainer][main] for the component. If you have a question for the
+maintainer, you can direct message them from your Urbit ship using that
+information.
 
 When contributing changes, via whatever means, make sure you describe them
 appropriately.  You should attach a reasonably high-level summary of what the
@@ -58,8 +59,8 @@ exist, e.g. a GitHub issue, a mailing list discussion, a UP, etc.  [Here][jbpr]
 is a good example of a pull request with a useful, concise description.
 
 If your changes replace significant extant functionality, be sure to compare
-them with the thing you're replacing.  You may also want to cc maintainers,
-reviewers, or other parties who might have a particular interest in what you're
+them with the thing you're replacing.  You may also want to cc reviewers,
+or other parties who might have a particular interest in what you're
 contributing.
 
 [jbpr]: https://github.com/urbit/urbit/pull/1782
@@ -283,3 +284,4 @@ Questions or other communications about contributing to Urbit can go to
 [reba]: https://git-rebase.io/
 [issu]: https://github.com/urbit/urbit/issues
 [hoon]: https://urbit.org/docs/learn/hoon/style/
+[main]: https://github.com/urbit/urbit/tree/master/pkg/arvo#maintainers

--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 # Urbit
 
-A personal server operating function.
+[Urbit](https://urbit.org) is a personal server stack built from scratch. It
+has an identity layer (Azimuth), virtual machine (Vere), and operating system
+(Arvo).
 
-> The Urbit address space, Azimuth, is now live on the Ethereum blockchain. You
-> can find it at [`0x223c067f8cf28ae173ee5cafea60ca44c335fecb`][azim] or
-> [`azimuth.eth`][aens]. Owners of Azimuth points (galaxies, stars, or planets)
-> can view or manage them using [Bridge][brid], and can also use them to boot
-> [Arvo][arvo], the Urbit OS.
+A running Urbit "ship" is designed to operate with other ships peer-to-peer.
+Urbit is a general-purpose, peer-to-peer computer and network.
 
-[azim]: https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb
-[aens]: https://etherscan.io/address/azimuth.eth
-[brid]: https://github.com/urbit/bridge
+This repository contains:
+
+- The [Arvo OS][arvo]
+- [herb][herb], a tool for Unix control of an Urbit ship
+- Source code for [Landscape's web interface][land]
+- Source code for the [vere][vere] virtual machine.
+
+For more on the identity layer, see [Azimuth][azim]. To manage your Urbit
+identity, use [Bridge][brid].
+
 [arvo]: https://github.com/urbit/urbit/tree/master/pkg/arvo
+[azim]: https://github.com/urbit/azimuth
+[brid]: https://github.com/urbit/bridge
+[herb]: https://github.com/urbit/urbit/tree/master/pkg/herb
+[land]: https://github.com/urbit/urbit/tree/master/pkg/interface
+[vere]: https://github.com/urbit/urbit/tree/master/pkg/urbit
 
 ## Install
 
 To install and run Urbit, please follow the instructions at
-[urbit.org/docs/getting-started/][start].  You'll be on the live network in a
+[urbit.org/using/install][start].  You'll be on the live network in a
 few minutes.
 
 If you're interested in Urbit development, keep reading.
 
-[start]: https://urbit.org/docs/getting-started/
+[start]: https://urbit.org/using/install/
 
 ## Development
 
@@ -38,7 +49,7 @@ The Makefile in the project's root directory contains useful phony targets for
 building, installing, testing, and so on.  You can use it to avoid dealing with
 Nix explicitly.
 
-To build Urbit, for example, use:
+To build the Urbit virtual machine binary, for example, use:
 
 ```
 make build
@@ -68,12 +79,10 @@ Contributions of any form are more than welcome!  Please take a look at our
 [contributing guidelines][cont] for details on our git practices, coding
 styles, how we manage issues, and so on.
 
-You might also be interested in:
+For instructions on contributing to Landscape, see [its][lcont] guidelines.
 
-- joining the [urbit-dev][list] mailing list.
-- [applying to Hoon School][mail], a course we run to teach the Hoon
-  programming language and Urbit application development.
+You might also be interested in joining the [urbit-dev][list] mailing list.
 
 [list]: https://groups.google.com/a/urbit.org/forum/#!forum/dev
-[mail]: mailto:support@urbit.org
 [cont]: https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md
+[lcont]: https://github.com/urbit/urbit/blob/master/pkg/interface/CONTRIBUTING.md

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -1,4 +1,4 @@
-::  chat-hook:
+::  chat-hook [landscape]:
 ::  mirror chat data from foreign to local based on read permissions
 ::  allow sending chat messages to foreign paths based on write perms
 ::
@@ -114,7 +114,7 @@
           i.syncs
         ?>  ?=(^ pax)
         ?.  =('~' i.pax)
-          $(syncs t.syncs) 
+          $(syncs t.syncs)
         =/  new-path=path
           t.pax
         =.  synced.old

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -1,4 +1,6 @@
-:: chat-store: data store that holds linear sequences of chat messages
+:: chat-store [landscape]:
+::
+:: data store that holds linear sequences of chat messages
 ::
 /+  store=chat-store, default-agent, verb, dbug, group-store
 ~%  %chat-store-top  ..is  ~

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -1,4 +1,6 @@
-::  chat-view: sets up chat JS client, paginates data, and combines commands
+::  chat-view [landscape]:
+::
+::  sets up chat JS client, paginates data, and combines commands
 ::  into semantic actions for the UI
 ::
 /-  *permission-store,
@@ -157,7 +159,7 @@
     (on-arvo:def wire sign-arvo)
   ::
   ++  on-save  !>(state)
-  ++  on-load  
+  ++  on-load
     |=  old-vase=vase
     ^-  (quip card _this)
     =/  old  ((soft state-0) q.old-vase)
@@ -212,8 +214,8 @@
   ?-  -.act
       %create
     ?>  ?=(^ app-path.act)
-    ?>  ?|  =(+:group-path.act app-path.act) 
-            =(~(tap in members.act) ~) 
+    ?>  ?|  =(+:group-path.act app-path.act)
+            =(~(tap in members.act) ~)
         ==
     ?^  (chat-scry app-path.act)
       ~&  %chat-already-exists

--- a/pkg/arvo/app/clock.hoon
+++ b/pkg/arvo/app/clock.hoon
@@ -1,4 +1,6 @@
-::  clock: deprecated, should be removed
+::  clock [landscape]:
+::
+::  deprecated, should be removed
 ::
 /+  *server, default-agent, verb, dbug
 =,  format

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -1,4 +1,5 @@
-::  contact-hook:
+::  contact-hook [landscape]
+::
 ::
 /-  group-hook,
     *contact-hook,
@@ -54,7 +55,7 @@
     =/  old  !<(versioned-state old-vase)
     =|  cards=(list card)
     |^
-    |-  ^-  (quip card _this) 
+    |-  ^-  (quip card _this)
     ?:  ?=(%3 -.old)
       [cards this(state old)]
     ?:  ?=(%2 -.old)
@@ -80,7 +81,7 @@
       %_    $
         -.old  %2
         ::
-          synced.old  
+          synced.old
         %-  malt
         %+  turn
           ~(tap by synced.old)
@@ -126,7 +127,7 @@
           %json
         (poke-json:cc !<(json vase))
       ::
-          %contact-action  
+          %contact-action
         (poke-contact-action:cc !<(contact-action vase))
       ::
           %contact-hook-action
@@ -149,7 +150,7 @@
         %kick       [(kick:cc wire) this]
         %watch-ack
       =^  cards  state
-        (watch-ack:cc wire p.sign) 
+        (watch-ack:cc wire p.sign)
       [cards this]
     ::
         %fact
@@ -301,8 +302,8 @@
     [%pass /group %agent [our.bol %group-store] %watch /groups]~
   ::
       [%contacts @ *]
-    =/  wir  
-      ?:  =(%ship i.t.wir) 
+    =/  wir
+      ?:  =(%ship i.t.wir)
         wir
       (migrate wir)
     ?>  ?=([%contacts @ @ *] wir)

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -1,4 +1,6 @@
-:: contact-store: data store that holds group-based contact data
+:: contact-store [landscape]:
+::
+:: data store that holds group-based contact data
 ::
 /+  *contact-json, default-agent, dbug
 |%
@@ -253,7 +255,7 @@
 ++  send-diff
   |=  [pax=path upd=contact-update]
   ^-  (list card)
-  :~  :*  
+  :~  :*
     %give  %fact
     ~[/all /updates [%contacts pax]]
     %contact-update  !>(upd)

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -1,4 +1,6 @@
-::  contact-view: sets up contact JS client and combines commands
+::  contact-view [landscape]:
+::
+::  sets up contact JS client and combines commands
 ::  into semantic actions for the UI
 ::
 /-

--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -1,3 +1,7 @@
+::  file-server [landscape]:
+::
+::  mounts HTTP endpoints for Landscape (and third-party) user applications
+::
 /-  srv=file-server, glob
 /+  *server, default-agent, verb, dbug
 |%
@@ -218,8 +222,8 @@
           ::
               [~ %html]
             %.  file
-            %*    .   html-response:gen 
-                cache  
+            %*    .   html-response:gen
+                cache
               !=(/app/landscape/index/html (slag 3 scry-path))
             ==
         ==

--- a/pkg/arvo/app/glob.hoon
+++ b/pkg/arvo/app/glob.hoon
@@ -1,3 +1,7 @@
+::  glob [landscape]:
+::
+::  prompts content delivery and Gall state storage for Landscape JS blob
+::
 /-  glob
 /+  default-agent, verb, dbug
 |%

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -1,3 +1,6 @@
+::  graph-store [landscape]
+::
+::
 /+  store=graph-store, sigs=signatures, res=resource, default-agent, dbug
 ~%  %graph-store-top  ..is  ~
 |%
@@ -282,7 +285,7 @@
         ?~  index  graph
         =*  atom   i.index
         =/  =node:store
-          ~|  "node does not exist to add signatures to!" 
+          ~|  "node does not exist to add signatures to!"
           (need (get:orm graph atom))
         ::  last index in list
         ::
@@ -327,7 +330,7 @@
         ?~  index  graph
         =*  atom   i.index
         =/  =node:store
-          ~|  "node does not exist to add signatures to!" 
+          ~|  "node does not exist to add signatures to!"
           (need (get:orm graph atom))
         ::  last index in list
         ::
@@ -525,7 +528,7 @@
     =/  update-log=(unit update-log:store)  (~(get by update-logs) [ship term])
     ?~  update-log  [~ ~]
     =/  result=(unit [time update:store])
-      (peek:orm-log:store u.update-log) 
+      (peek:orm-log:store u.update-log)
     ?~  result  [~ ~]
     ``noun+!>([~ -.u.result])
   ==

--- a/pkg/arvo/app/group-hook.hoon
+++ b/pkg/arvo/app/group-hook.hoon
@@ -1,4 +1,6 @@
-::  group-hook: allow syncing group data from foreign paths to local paths
+::  group-hook [landscape]:
+::
+::  allow syncing group data from foreign paths to local paths
 ::
 /-  *group, hook=group-hook, *invite-store
 /+  default-agent, verb, dbug, store=group-store, grpl=group, pull-hook, push-hook, resource
@@ -58,7 +60,7 @@
     :: ignore duplicate publish groups
     ?:  =(4 (lent path))
       ~&  "ignoring: {<path>}"
-      ~ 
+      ~
     =/  pax=^path
       ?:  =('~' i.path)
         t.path

--- a/pkg/arvo/app/group-pull-hook.hoon
+++ b/pkg/arvo/app/group-pull-hook.hoon
@@ -1,5 +1,6 @@
-::  group-hook: allow syncing group data from foreign paths to local paths
+::  group-hook [landscape]:
 ::
+::  allow syncing group data from foreign paths to local paths
 ::
 /-  *group, hook=group-hook, *invite-store, *resource
 /+  default-agent, verb, dbug, store=group-store, grpl=group, pull-hook

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -1,5 +1,6 @@
-::  group-hook: allow syncing group data from foreign paths to local paths
+::  group-hook [landscape]:
 ::
+::  allow syncing group data from foreign paths to local paths
 ::
 /-  *group, hook=group-hook, *invite-store
 /+  default-agent, verb, dbug, store=group-store, grpl=group, push-hook,

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -1,4 +1,6 @@
-::  group-store: Store groups of ships
+::  group-store [landscape]:
+::
+::  Store groups of ships
 ::
 ::    group-store stores groups of ships, so that resources in other apps can be
 ::    associated with a group. The current model of group-store rolls
@@ -128,7 +130,7 @@
       ^-  [resource group]
       =/  members=(set ship)
         (~(got by groups.old) pax)
-      =|  =invite:policy 
+      =|  =invite:policy
       ?>  ?=(^ pax)
       =/  rid=resource
         (resource-from-old-path t.pax)
@@ -149,7 +151,7 @@
       |=  pax=path
       =/  members
         (~(got by groups.old) pax)
-      =|  =invite:policy  
+      =|  =invite:policy
       =/  rid=resource
         (resource-from-old-path pax)
       =/  =tags
@@ -239,7 +241,7 @@
         (~(has in members.group) ship)
     ==
       %open
-    ?!  ?|  
+    ?!  ?|
       (~(has in banned.policy) ship)
       (~(has in ban-ranks.policy) (clan:title ship))
     ==
@@ -285,7 +287,7 @@
     ^-  resource
     ?>  ?=([@ @ *] path)
     :-  (slav %p i.path)
-    i.t.path 
+    i.t.path
   ::
   ++  add-new
     |=  =permission:permission-store
@@ -293,7 +295,7 @@
     ?:  ?=(%black kind.permission)
       [~ ~ [%open ~ who.permission] %.y]
     [who.permission ~ [%invite ~] %.y]
-  ::   
+  ::
   ++  update-existing
     |=  =permission:permission-store
     |=  =group

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -1,4 +1,6 @@
-::  invite-hook: receive invites from any source
+::  invite-hook [landscape]:
+::
+::  receive invites from any source
 ::
 ::    only handles %invite actions. accepts json, but only from the host team.
 ::    can be poked by the host team to send an invite out to someone.

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -1,3 +1,4 @@
+::  invite-store [landscape]
 /+  *invite-json, default-agent, dbug
 |%
 +$  card  card:agent:gall

--- a/pkg/arvo/app/invite-view.hoon
+++ b/pkg/arvo/app/invite-view.hoon
@@ -1,3 +1,7 @@
+:: invite-view [landscape]:
+::
+::  deprecated
+::
 /+  default-agent
 ^-  agent:gall
 |_  =bowl:gall

--- a/pkg/arvo/app/launch.hoon
+++ b/pkg/arvo/app/launch.hoon
@@ -1,3 +1,7 @@
+::  launch [landscape]:
+::
+::  registers Landscape (and third party) applications, tiles
+::
 /+  store=launch-store, default-agent, dbug
 |%
 +$  card  card:agent:gall

--- a/pkg/arvo/app/link-listen-hook.hoon
+++ b/pkg/arvo/app/link-listen-hook.hoon
@@ -1,4 +1,6 @@
-::  link-listen-hook: get your friends' bookmarks
+::  link-listen-hook [landscape]:
+::
+::  get your friends' bookmarks
 ::
 ::    keeps track of a listening=(set app-path). users can manually add to and
 ::    remove from this set.
@@ -118,7 +120,7 @@
           /app-indices
         ==
       |-
-      ?~  resources  
+      ?~  resources
         upgrade-loop(old [%2 +.old])
       =,  i.resources
       =/  members=(set ship)

--- a/pkg/arvo/app/link-proxy-hook.hoon
+++ b/pkg/arvo/app/link-proxy-hook.hoon
@@ -1,4 +1,6 @@
-::  link-proxy-hook: make local pages available to foreign ships
+::  link-proxy-hook [landscape]:
+::
+::  make local pages available to foreign ships
 ::
 ::    this is a "proxy" style hook, relaying foreign subscriptions into local
 ::    stores if permission conditions are met.

--- a/pkg/arvo/app/link-store.hoon
+++ b/pkg/arvo/app/link-store.hoon
@@ -1,4 +1,6 @@
-::  link: social bookmarking
+::  link [landscape]:
+::
+::  social bookmarking
 ::
 ::    the paths under which links are submitted are generally expected to
 ::    correspond to existing group paths. for strictly-local collections of

--- a/pkg/arvo/app/link-view.hoon
+++ b/pkg/arvo/app/link-view.hoon
@@ -1,4 +1,6 @@
-::  link-view: frontend endpoints
+::  link-view [landscape]:
+::
+::frontend endpoints
 ::
 ::  endpoints, mapping onto link-store's paths. p is for page as in pagination.
 ::  only the /0/submissions endpoint provides updates.

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -1,4 +1,6 @@
-::  metadata-hook: allow syncing foreign metadata
+::  metadata-hook [landscape]:
+::
+::  allow syncing foreign metadata
 ::
 ::  watch paths:
 ::  /group/%group-path                      all updates related to this group
@@ -37,7 +39,7 @@
     [[%pass /updates %agent [our.bowl %metadata-store] %watch /updates]~ this]
   ::
   ++  on-save   !>(state)
-  ++  on-load   
+  ++  on-load
     |=  =vase
     =/  old
       !<(versioned-state vase)

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -1,4 +1,6 @@
-::  metadata-store: data store for application metadata and mappings
+::  metadata-store [landscape]:
+::
+::  data store for application metadata and mappings
 ::  between groups and resources within applications
 ::
 ::  group-paths are expected to be an existing group path

--- a/pkg/arvo/app/permission-group-hook.hoon
+++ b/pkg/arvo/app/permission-group-hook.hoon
@@ -1,4 +1,6 @@
-::  permission-group-hook: groups into permissions
+::  permission-group-hook [landscape]:
+::
+::  groups into permissions
 ::
 ::    mirror the ships in specified groups to specified permission paths
 ::

--- a/pkg/arvo/app/permission-hook.hoon
+++ b/pkg/arvo/app/permission-hook.hoon
@@ -1,4 +1,6 @@
-::  permission-hook: mirror remote permissions
+::  permission-hook [landscape]:
+::
+::  mirror remote permissions
 ::
 ::    allows mirroring permissions between local and foreign ships.
 ::    local permission path are exposed according to the permssion paths

--- a/pkg/arvo/app/permission-store.hoon
+++ b/pkg/arvo/app/permission-store.hoon
@@ -1,4 +1,6 @@
-::  permission-store: track black- and whitelists of ships
+::  permission-store [landscape]:
+::
+::  track black- and whitelists of ships
 ::
 /-  *permission-store
 /+  default-agent, verb, dbug

--- a/pkg/arvo/app/pool-group-hook.hoon
+++ b/pkg/arvo/app/pool-group-hook.hoon
@@ -1,4 +1,6 @@
-::  pool-group-hook: maintain groups based on invite pool
+::  pool-group-hook [landscape]:
+::
+::  maintain groups based on invite pool
 ::
 ::    looks at our invite tree, adds our siblings to group at +group-path
 ::

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -1,3 +1,7 @@
+::  publish [landscape]
+::
+::  stores notebooks in clay, subscribes and allow subscriptions to notebooks
+::
 /-  *publish
 /-  *group
 /-  group-hook

--- a/pkg/arvo/app/s3-store.hoon
+++ b/pkg/arvo/app/s3-store.hoon
@@ -1,3 +1,7 @@
+::  s3-store [landscape]:
+::
+::  stores s3 keys for uploading and sharing images and objects
+::
 /-  *s3
 /+  s3-json, default-agent, verb, dbug
 ~%  %s3-top  ..is  ~

--- a/pkg/arvo/app/soto.hoon
+++ b/pkg/arvo/app/soto.hoon
@@ -1,5 +1,6 @@
 ::
-::  Soto: A Dojo relay for Urbit's Landscape interface
+::  soto [landscape]: A Dojo relay for Urbit's Landscape interface
+::
 ::  Relays sole-effects to subscribers and forwards sole-action pokes
 ::
 /-  sole

--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -1,3 +1,7 @@
+::  weather [landscape]:
+::
+::  holds latlong, gets weather data from API, passes it on to subscribers
+::
 /+  *server, default-agent, verb, dbug
 =,  format
 ::

--- a/pkg/interface/README.md
+++ b/pkg/interface/README.md
@@ -1,0 +1,17 @@
+## interface
+
+Landscape is Tlon's suite of userspace applications (and web interface),
+currently bundled as part of Arvo.
+
+This directory comprises the source code for the web interface. For code related
+to the Gall agents that make up the Landscape suite in Arvo, see
+[pkg/arvo][arvo].
+
+### Contributions and feature requests
+
+For information on how to contribute, see [CONTRIBUTING][cont]. To submit
+a feature request, submit to the product board at [urbit/landscape][land].
+
+[arvo]: https://github.com/urbit/urbit/tree/master/pkg/arvo
+[cont]: https://github.com/urbit/urbit/blob/master/pkg/interface/CONTRIBUTING.md
+[land]: https://github.com/urbit/landscape/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=


### PR DESCRIPTION
- Adds external links to refer Landscape feature requests to urbit/landscape; developer questions to urbit-dev.
- Revises the README at root to explain very succinctly the components that comprise Urbit, which components are in this repo, which are elsewhere.
- Adds a link to Arvo's maintainers in the CONTRIBUTING document. Revises contributing pathways slightly, since we do not at this moment provide maintainers' emails. Maybe we should, but we don't right now.
- Adds a README to pkg/interface with basic information.
- Adds `[landscape]` to all the applications that make up Landscape in `pkg/arvo/app`.