### PR TITLE
landscape: updated subscriptions to scry also

### DIFF
--- a/pkg/interface/src/logic/api/base.ts
+++ b/pkg/interface/src/logic/api/base.ts
@@ -54,7 +54,7 @@ export default class BaseApi<S extends object = {}> {
     });
   }
 
-  scry<T>(app: string, path: Path): Promise<T> {
+  scry<T>(path: Path, app: string): Promise<T> {
     return fetch(`/~/scry/${app}${path}.json`).then(r => r.json() as Promise<T>);
   }
 }

--- a/pkg/interface/src/logic/api/local.ts
+++ b/pkg/interface/src/logic/api/local.ts
@@ -3,7 +3,7 @@ import { StoreState } from "../store/type";
 
 export default class LocalApi extends BaseApi<StoreState> {
   getBaseHash() {
-    this.scry<string>('file-server', '/clay/base/hash').then(baseHash => {
+    this.scry<string>('/clay/base/hash', 'file-server').then(baseHash => {
       this.store.handleEvent({ data: { local: { baseHash } } });
     });
   }

--- a/pkg/interface/src/logic/subscription/base.ts
+++ b/pkg/interface/src/logic/subscription/base.ts
@@ -38,6 +38,10 @@ export default class BaseSubscription<S extends object> {
     }, Math.pow(2,this.errorCount - 1) * 750);
   }
 
+  scry(path: Path, app: string) {
+    return this.api.scry(path, app);
+  }
+
   subscribe(path: Path, app: string) {
     return this.api.subscribe(path, 'PUT', this.api.ship, app,
       this.handleEvent.bind(this),

--- a/pkg/interface/src/logic/subscription/global.ts
+++ b/pkg/interface/src/logic/subscription/global.ts
@@ -43,7 +43,8 @@ export default class GlobalSubscription extends BaseSubscription<StoreState> {
     groups: []
   };
   start() {
-    this.subscribe('/all', 'invite-store');
+    this.scry('/all', 'invite-store');
+    this.subscribe('/updates', 'invite-store');
     this.subscribe('/groups', 'group-store');
     this.subscribe('/primary', 'contact-view');
     this.subscribe('/all', 'metadata-store');

--- a/pkg/interface/src/logic/subscription/global.ts
+++ b/pkg/interface/src/logic/subscription/global.ts
@@ -45,11 +45,23 @@ export default class GlobalSubscription extends BaseSubscription<StoreState> {
   start() {
     this.scry('/all', 'invite-store');
     this.subscribe('/updates', 'invite-store');
+
+    this.scry('/groups', 'group-store');
     this.subscribe('/groups', 'group-store');
+
     this.subscribe('/primary', 'contact-view');
-    this.subscribe('/all', 'metadata-store');
+
+    this.scry('/associations', 'metadata-store');
+    this.subscribe('/updates', 'metadata-store');
+
+    this.scry('/credentials', 's3-store');
+    this.scry('/configuration', 's3-store');
     this.subscribe('/all', 's3-store');
+
+    this.scry('/tiles', 'launch');
+    this.scry('/first-time' 'launch');
     this.subscribe('/all', 'launch');
+
     this.subscribe('/all', 'weather');
   }
 


### PR DESCRIPTION
I've made these changes and tested them out and didn't find anything broken. Some of these, s3 for example, have no real subscription that makes sense other than /all. That should probably be changed.