### PR TITLE
hotfix: prevent joining a host that we already host

### DIFF
--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -298,7 +298,7 @@
       ~[(chat-hook-poke %add-synced ship.act app-path.act ask-history.act)]
     =/  rid=resource
       (de-path:resource ship+app-path.act)
-    ?<  =(our.bol entity.rid)
+    ?:  =(our.bol entity.rid)  ~
     =/  =cage
       :-  %group-update
       !>  ^-  action:group-store

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -298,6 +298,7 @@
       ~[(chat-hook-poke %add-synced ship.act app-path.act ask-history.act)]
     =/  rid=resource
       (de-path:resource ship+app-path.act)
+    ?<  =(our.bol entity.rid)
     =/  =cage
       :-  %group-update
       !>  ^-  action:group-store

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -225,6 +225,7 @@
     ++  add
       |=  [=ship =resource]
       ~|  resource
+      ?<  |(=(our.bowl ship) =(our.bowl entity.resource))
       ?:  (~(has by tracking) resource)
         [~ state]
       =.  tracking

--- a/pkg/interface/src/views/apps/chat/app.tsx
+++ b/pkg/interface/src/views/apps/chat/app.tsx
@@ -194,6 +194,11 @@ export default class ChatApp extends React.Component<ChatAppProps, {}> {
             render={(props) => {
               let station = `/${props.match.params.ship}/${props.match.params.station}`;
 
+              // ensure we know joined chats
+              if(!chatInitialized) {
+                return null;
+              }
+
             return (
               <Skeleton
                 associations={associations}


### PR DESCRIPTION
If a chat is leapt to before joined chats are loaded, then the frontend will attempt to join a chat that we already host.

Fixed in chat-view, lib/pull-hook and the frontend
