### PR TITLE
hoon: rewrites +stir using tail-recursion and +roll

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5509,16 +5509,32 @@
 ::
 ++  stir
   ~/  %stir
-  |*  {rud/* raq/_=>(~ |*({a/* b/*} [a b])) fel/rule}
+  |*  [rud=* raq=_=>(~ |*([a=* b=*] [a b])) fel=rule]
   ~/  %fun
-  |=  tub/nail
+  |=  tub=nail
   ^-  (like _rud)
-  =+  vex=(fel tub)
-  ?~  q.vex
-    [p.vex [~ rud tub]]
-  =+  wag=$(tub q.u.q.vex)
-  ?>  ?=(^ q.wag)
-  [(last p.vex p.wag) [~ (raq p.u.q.vex p.u.q.wag) q.u.q.wag]]
+  ::
+  ::  lef: successful interim parse results per .fel
+  ::  wag: initial accumulator
+  ::
+  =+  ^=  [lef wag]
+    =|  lef=(list _(fel tub))
+    =|  wag=[p=hair q=[~ u=[p=_rud q=nail]]]
+    |-  ^+  [lef wag]
+    =+  vex=(fel tub)
+    ?~  q.vex
+      =.  wag  [p.vex [~ rud tub]]
+      [lef wag]
+    $(lef [vex lef], tub q.u.q.vex)
+  ::
+  ::  fold .lef into .wag, combining results with .raq
+  ::
+  %+  roll  lef
+  |=  [vex=_(fel tub) wag=_wag]
+  ^+  wag
+  :-  (last p.vex p.wag)
+  ?>  ?=(^ q.vex)
+  [~ (raq p.u.q.vex p.u.q.wag) q.u.q.wag]
 ::
 ++  stun                                                ::  parse several times
   |*  {lig/{@ @} fel/rule}

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5514,27 +5514,25 @@
   |=  tub=nail
   ^-  (like _rud)
   ::
-  ::  lef: successful interim parse results per .fel
-  ::  wag: initial accumulator
+  ::  lef: successful interim parse results (per .fel)
+  ::  wag: initial accumulator (.rud in .tub at farthest success)
   ::
   =+  ^=  [lef wag]
     =|  lef=(list _(fel tub))
-    =|  wag=[p=hair q=[~ u=[p=_rud q=nail]]]
-    |-  ^+  [lef wag]
+    |-  ^-  [_lef (pair hair [~ u=(pair _rud nail)])]
     =+  vex=(fel tub)
     ?~  q.vex
-      =.  wag  [p.vex [~ rud tub]]
-      [lef wag]
+      :-  lef
+      [p.vex [~ rud tub]]
     $(lef [vex lef], tub q.u.q.vex)
   ::
   ::  fold .lef into .wag, combining results with .raq
   ::
   %+  roll  lef
-  |=  [vex=_(fel tub) wag=_wag]
+  |=  _[vex=(fel tub) wag=wag]  :: q.vex is always (some)
   ^+  wag
   :-  (last p.vex p.wag)
-  ?>  ?=(^ q.vex)
-  [~ (raq p.u.q.vex p.u.q.wag) q.u.q.wag]
+  [~ (raq p.u.+.q.vex p.u.q.wag) q.u.q.wag]
 ::
 ++  stun                                                ::  parse several times
   |*  {lig/{@ @} fel/rule}


### PR DESCRIPTION
The promised hoon side of #3433, adapted somewhat from the initial comment at https://github.com/urbit/urbit/pull/1892#issuecomment-673680540.

I was unable to figure out how to both a) use a correctly-specific type for the parse-result list (`lef`) and b) use `+roll`, so I chose the latter.

The precise type of the parse-result list (which is only bunt-able because it is a list) is:

```
=|  lef=(list [p=hair q=[~ u=_(need q:(fel tub))]])
```

folding that manually is quite straightforward:

```
  |-  ^-  (like _rud)
  ?~  lef  wag
  =*  vex  i.lef
  %=  $
    lef  t.lef
    wag  :-  (last p.vex p.wag)
         [~ (raq p.u.q.vex p.u.q.wag) q.u.q.wag]
  ==
```

but the equivalent `+role`-call fails on empty inputs:

```
  %+  roll  lef
  |=  [vex=[p=hair q=[~ u=_(need q:(fel tub))]] wag=_wag]
  ^+  wag
  :-  (last p.vex p.wag)
  [~ (raq p.u.q.vex p.u.q.wag) q.u.q.wag]
```

More obviously, the idiomatic "item-of-a-list" sample fails in the same manner:

```
|=  [vex=_?>(?=(^ lef) i.lef) wag=_wag]
```

Suggestions welcome!

/cc @frodwith @ohAitch