### PR TITLE
king: change logging from tracing to info in Wai.hs

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Wai.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Wai.hs
@@ -179,7 +179,7 @@ streamBlocks env init getAct = send init >> loop
 
   send "" = pure ()
   send c  = do
-    runRIO env (logTrace (display ("sending chunk " <> tshow c)))
+    runRIO env (logInfo (display ("sending chunk " <> tshow c)))
     yield $ Chunk $ fromByteString c
     yield Flush
 


### PR DESCRIPTION
I noticed that the king's text log file kept filling up, and it's
mostly 'sending chunk "\n"' from eyre. This changes the log level
of every partial send over an active eyre channel to info, instead
of always.