### PR TITLE
dbug: attempt to scry for state

### DIFF
--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -41,9 +41,17 @@
     ::
         %state
       =?  grab.dbug  =('' grab.dbug)  '-'
-      =-  [(sell -)]~
+      =;  product=^vase
+        [(sell product)]~
+      =/  state=^vase
+        ::  if the underlying app has implemented a /dbug/state scry endpoint,
+        ::  use that vase in place of +on-save's.
+        ::
+        =/  result=(each ^vase tang)
+          (mule |.(q:(need (need (on-peek:ag /x/dbug/state)))))
+        ?:(?=(%& -.result) p.result on-save:ag)
       %+  slap
-        (slop on-save:ag !>([bowl=bowl ..zuse]))
+        (slop state !>([bowl=bowl ..zuse]))
       (ream grab.dbug)
     ::
         %incoming

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -325,7 +325,11 @@
     =^  cards  shoe  (on-leave:og path)
     [(deal cards) this]
   ::
-  ++  on-peek  on-peek:og
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?.  =(/x/dbug/state path)  ~
+    ``noun+(slop on-save:og !>(shoe=state))
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]


### PR DESCRIPTION
If the underlying app implements a `/x/dbug/state` endpoint in `+on-peek`,
dbug will now use that for `%state` evaluation. Falls back to the vase
provided by `+on-save` if the peek fails.

This allows apps and (perhaps more usefully) wrapper agents to provide
customized vases to `/lib/dbug`.

Updates `/lib/shoe` to make use of this, properly prepending the wrapped
app's vase to shoe's own, instead of including it as-is.