### PR TITLE
hoon: avoid potential shadow in +late

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -262,8 +262,8 @@
 ++  tail  |*(^ ,:+<+)                                   ::  get tail
 ++  test  |=(^ =(+<- +<+))                              ::  equality
 ::
-++  lead  |*(h=* |*(* [+>+< +<]))                       ::  put head
-++  late  |*(t=* |*(* [+< +>+<]))                       ::  put tail
+++  lead  |*(* |*(* [+<.^$ +<]))                          ::  put head
+++  late  |*(* |*(* [+< +<.^$]))                          ::  put tail
 ::
 ::  #  %containers
 ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -262,8 +262,8 @@
 ++  tail  |*(^ ,:+<+)                                   ::  get tail
 ++  test  |=(^ =(+<- +<+))                              ::  equality
 ::
-++  lead  |*(* |*(* [+<.^$ +<]))                          ::  put head
-++  late  |*(* |*(* [+< +<.^$]))                          ::  put tail
+++  lead  |*(* |*(* [+>+< +<]))                          ::  put head
+++  late  |*(* |*(* [+< +>+<]))                          ::  put tail
 ::
 ::  #  %containers
 ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -262,8 +262,8 @@
 ++  tail  |*(^ ,:+<+)                                   ::  get tail
 ++  test  |=(^ =(+<- +<+))                              ::  equality
 ::
-++  lead  |*(h=* |*(* [h +<]))                          ::  put head
-++  late  |*(t=* |*(* [+< t]))                          ::  put tail
+++  lead  |*(h=* |*(* [+>+< +<]))                       ::  put head
+++  late  |*(t=* |*(* [+< +>+<]))                       ::  put tail
 ::
 ::  #  %containers
 ::


### PR DESCRIPTION
Here's a fun one. Follow-up to #3266.

Previously:

```hoon
> ((late 42) *(list))
mull-grow
-find.t
find-fork
```

By using tree instead of face addressing, we avoid stepping into faces from the
argument noun.

Updates `+lead` for visual symmetry, and the much rarer `-find.h` case.