### PR TITLE
groups: add group deletion confirmation

### DIFF
--- a/pkg/interface/src/views/apps/groups/components/lib/group-detail.js
+++ b/pkg/interface/src/views/apps/groups/components/lib/group-detail.js
@@ -324,11 +324,13 @@ export class GroupDetail extends Component {
           <a className={'dib f9 ba pa2 ' + deleteButtonClasses}
           onClick={() => {
             if (groupOwner) {
-              this.setState({ awaiting: true, type: 'Deleting' }, (() => {
-                props.api.contacts.delete(props.path).then(() => {
-                  props.history.push('/~groups');
-                });
-              }));
+              if (prompt(`To confirm deleting this group, type ${props.path.substr(6)}`) === props.path.substr(6)) {
+                this.setState({ awaiting: true, type: 'Deleting' }, (() => {
+                  props.api.contacts.delete(props.path).then(() => {
+                    props.history.push('/~groups');
+                  });
+                }));
+              }
             }
           }}
           >Delete this group</a>


### PR DESCRIPTION
Addresses https://github.com/urbit/landscape/issues/68

Doesn't use indigo yet. the `destructive` prop doesn't quite work as intended and figured it would be better to get a fix that worked fine out rather than have people accidentally delete groups in the meantime