### PR TITLE
publish: first draft of graph-store migration

### DIFF
--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -306,12 +306,16 @@
       ^-  node:graph-store
       =/  =index:graph-store
         ~[date-created.note]
+      =/  contents=(list content:graph-store)
+        :~  [%text title.note]
+            [%text file.note]
+        ==
       :_  (comments-to-children index note)
       ^-  post:graph-store
       :*  author.note
           index
           date-created.note
-          [%text file.note]~
+          contents
           ~  ~
       ==
     ::

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -18,6 +18,7 @@
 /+  verb
 /+  grpl=group
 /+  group-store
+/+  graph-store
 /+  resource
 ::
 ~%  %publish  ..is  ~
@@ -55,6 +56,7 @@
       [%4 state-three]
       [%5 state-three]
       [%6 state-three]
+      [%7 state-three]
   ==
 ::
 +$  metadata-delta
@@ -70,7 +72,7 @@
   ==
 --
 ::
-=|  [%6 state-three]
+=|  [%7 state-three]
 =*  state  -
 %-  agent:dbug
 %+  verb  |
@@ -238,8 +240,96 @@
       ==
     ::
         %6
+      %_  $
+        -.p.old-state  %7
+        ::
+          cards
+        %+  weld  cards
+        %+  roll  ~(tap by books.p.old-state)
+        |=  [[[who=@p book=@tas] nb=notebook] out=(list card)]
+        ^-  (list card)
+        =/  =resource
+          [who book]
+        ?.  =(who our.bol)
+          :_  out
+          (poke-graph-pull %add who resource)
+        =/  =graph:graph-store
+          (notebook-to-graph nb)
+        %+  weld  out
+        ^-  (list card)
+        :~ 
+          %-  poke-graph-store
+          :*  %0  date-created.nb  %add-graph
+              resource 
+              graph
+              `%graph-validator-publish
+          ==
+          (poke-graph-push %add resource)
+        ==
+      ==
+    ::
+        %7
       [cards this(state p.old-state)]
     ==
+    ++  notebook-to-graph
+      |=  =notebook
+      ^-  graph:graph-store
+      %+  gas:orm:graph-store  *graph:graph-store
+      %+  turn  ~(tap by notes.notebook)
+      |=  [@ta =note]
+      ^-  [atom node:graph-store]
+      :-  date-created.note
+      (note-to-node note)
+    ::
+    ++  comments-to-children
+      |=  [=index:graph-store =note]
+      ^-  internal-graph:graph-store
+      ?:  =(~ comments.note)
+        [%empty ~]
+      :-  %graph
+      %+  gas:orm:graph-store  *graph:graph-store
+      %+  turn  ~(tap by comments.note)
+      |=  [when=@da =comment]
+      ^-  [atom node:graph-store]
+      :-  when
+      :_  [%empty ~]
+      ^-  post:graph-store
+      :*  author.comment
+          (snoc index when)
+          when
+          [%text content.comment]~
+          ~  ~
+      ==
+    ::
+    ++  note-to-node
+      |=  =note
+      ^-  node:graph-store
+      =/  =index:graph-store
+        ~[date-created.note]
+      :_  (comments-to-children index note)
+      ^-  post:graph-store
+      :*  author.note
+          index
+          date-created.note
+          [%text file.note]~
+          ~  ~
+      ==
+    ::
+    ++  poke-our
+      |=  [app=term =cage]
+      [%pass / %agent [our.bol app] %poke cage]
+    ::
+    ++  poke-graph-pull
+      |=  =action:pull-hook
+      (poke-our %graph-pull-hook pull-hook-action+!>(action))
+    ::
+    ++  poke-graph-store
+      |=  =update:graph-store
+      (poke-our %graph-store graph-update+!>(update))
+    ::
+    ++  poke-graph-push
+      |=  =action:push-hook
+      (poke-our %graph-push-hook push-hook-action+!>(action))
     ++  convert-notebook-3-4
       |=  prev=notebook-3
       ^-  notebook-3

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -9,8 +9,15 @@
   ++  noun
     |=  p=*
     =/  ip  ;;(indexed-post p)
-    ?>  (gte 2 (lent index.p.ip))
-    ip
+    |^
+    ?+    index.p.ip  !!
+      [@ @ ~]  ip
+    ::  top level post must have title as first content
+        [@ ~]
+      ?>  ?=(^ contents.p.ip)
+      ?>  ?=(%text -.i.contents.p.ip)
+      ip
+    ==
   --
 ::
 ++  grad  %noun

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -1,0 +1,17 @@
+/-  *post
+|_  i=indexed-post
+++  grow
+  |%
+  ++  noun  i
+  --
+++  grab
+  |%
+  ++  noun
+    |=  p=*
+    =/  ip  ;;(indexed-post p)
+    ?>  (gte 2 (lent index.p.ip))
+    ip
+  --
+::
+++  grad  %noun
+--


### PR DESCRIPTION
State adapter to migrate publish to graph-store.

Just want to check that I understand the graph-store API correctly.

Open questions:
- How should titles be set on notes? We can't attach a metadata entry to a particular graph node. Tempted to just parse the metadata out of the text contents (this is what publish already does). Alternatively, we could put a metadata entry into contents and use that? If we opt for parsing the metadata, should we check the validity inside the publish mark?

- I'm leaving the state untouched, so that a) we don't have any irretrievable data loss and b) we can port read indicators forward when notification-store is shipped.

Pending:
- Graph hook implementation
