### PR TITLE
profile: fix iOS safari behaviour, add react-helmet

### DIFF
--- a/pkg/interface/src/views/apps/profile/profile.tsx
+++ b/pkg/interface/src/views/apps/profile/profile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Box, Text, Row, Col, Center, Icon } from "@tlon/indigo-react";
+import { Box, Text, Row, Col, Icon } from "@tlon/indigo-react";
 
 import { Sigil } from "~/logic/lib/sigil";
 import { uxToHex, MOBILE_BROWSER_REGEX } from "~/logic/lib/util";
@@ -15,7 +15,6 @@ const SidebarItem = ({ children, view, current }) => {
   return (
     <Link to={`/~profile/${view}`}>
       <Row
-        display="flex"
         alignItems="center"
         verticalAlign="middle"
         py={1}
@@ -85,7 +84,7 @@ export default function ProfileScreen(props: any) {
                     <Sigil ship={`~${ship}`} size={80} color={sigilColor} />
                   </Box>
                 </Box>
-                <Box width="100%" py={3}>
+                <Box width="100%" py={3} zIndex='2'>
                   <SidebarItem current={view} view="identity">
                     Your Identity
                   </SidebarItem>

--- a/pkg/interface/src/views/apps/profile/profile.tsx
+++ b/pkg/interface/src/views/apps/profile/profile.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Route, Link, Switch } from "react-router-dom";
+import Helmet from 'react-helmet';
 
 import { Box, Text, Row, Col, Icon } from "@tlon/indigo-react";
 
@@ -6,7 +8,6 @@ import { Sigil } from "~/logic/lib/sigil";
 import { uxToHex, MOBILE_BROWSER_REGEX } from "~/logic/lib/util";
 
 import Settings from "./components/settings";
-import { Route, Link } from "react-router-dom";
 import { ContactCard } from "../groups/components/lib/ContactCard";
 
 const SidebarItem = ({ children, view, current }) => {
@@ -33,6 +34,11 @@ const SidebarItem = ({ children, view, current }) => {
 export default function ProfileScreen(props: any) {
   const { ship, dark } = props;
   return (
+    <>
+    <Helmet defer={false}>
+      <title>OS1 - Profile</title>
+    </Helmet>
+    <Switch>
     <Route
       path={["/~profile/:view", "/~profile"]}
       render={({ match, history }) => {
@@ -119,5 +125,7 @@ export default function ProfileScreen(props: any) {
         );
       }}
     ></Route>
+      </Switch>
+    </>
   );
 }


### PR DESCRIPTION
- The box for the nav was buried under some flexboxes. Adds z-index to fix behaviour on iOS Safari, profile orientation (it worked in landscape?). (#3383)
- Adds react-helmet to the routes since it appeared just before merge.