### PR TITLE
dill: send styled text to runtime as-is

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -551,7 +551,6 @@
 ++  se-show                                           ::  show buffer, raw
   |=  lin/(pair @ud stub)
   ^+  +>
-  =.  p.lin  (add p.lin (lent-stye:klr q.lin))
   ?:  =(mir lin)  +>
   =.  +>  ?:(=(p.mir p.lin) +> (se-blit %hop p.lin))
   =.  +>  ?:(=(q.mir q.lin) +> (se-blit %pom q.lin))
@@ -1115,24 +1114,9 @@
      (fall p.q.a p.q.b)
      (fall q.q.a q.q.b)
   ::
-  ++  lent-stye
-    |=  a/stub  ^-  @
-    (roll (lnts-stye a) add)
-  ::
   ++  lent-char
     |=  a/stub  ^-  @
     (roll (lnts-char a) add)
-  ::
-  ++  lnts-stye                                       ::  stub pair head lengths
-    |=  a/stub  ^-  (list @)
-    %+  turn  a
-    |=  a/(pair stye (list @c))
-    ;:  add                        ::  presumes impl of cvrt:ansi in %dill
-        (mul 5 2)                  ::  bg
-        (mul 5 2)                  ::  fg
-        =+  b=~(wyt in p.p.a)      ::  effect
-        ?:(=(0 b) 0 (mul 4 +(b)))
-    ==
   ::
   ++  lnts-char                                       ::  stub pair tail lengths
     |=  a/stub  ^-  (list @)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -8,7 +8,7 @@
 --                                                      ::
 =>  |%                                                  ::  console protocol
 ++  axle                                                ::
-  $:  %3                                                ::
+  $:  %4                                                ::
       hey/(unit duct)                                   ::  default duct
       dug/(map duct axon)                               ::  conversations
       lit/?                                             ::  boot in lite mode
@@ -21,7 +21,7 @@
       tem/(unit (list dill-belt))                       ::  pending, reverse
       wid/_80                                           ::  terminal width
       pos/@ud                                           ::  cursor position
-      see/(list @c)                                     ::  current line
+      see=$%([%lin (list @c)] [%klr stub])              ::  current line
   ==                                                    ::
 +$  log-level  ?(%hush %soft %loud)                     ::  none, line, full
 --  =>                                                  ::
@@ -170,86 +170,27 @@
           %+  done  %blit
           :~  [%lin p.bit]
               [%mor ~]
-              [%lin see]
+              see
               [%hop pos]
           ==
         ?:  ?=($klr -.bit)
           %+  done  %blit
-          :~  [%lin (cvrt:ansi p.bit)]
+          :~  [%klr p.bit]
               [%mor ~]
-              [%lin see]
+              see
               [%hop pos]
           ==
         ?:  ?=($pro -.bit)
-          (done(see p.bit) %blit [[%lin p.bit] [%hop pos] ~])
+          =.  see  [%lin p.bit]
+          (done %blit [see [%hop pos] ~])
         ?:  ?=($pom -.bit)
-          =.  see  (cvrt:ansi p.bit)
-          (done %blit [[%lin see] [%hop pos] ~])
+          =.  see  [%klr p.bit]
+          (done %blit [see [%hop pos] ~])
         ?:  ?=($hop -.bit)
           (done(pos p.bit) %blit [bit ~])
         ?:  ?=($qit -.bit)
           (dump %logo ~)
         (done %blit [bit ~])
-      ::
-      ++  ansi
-        |%
-        ++  cvrt                                        ::  stub to (list @c)
-          |=  a/stub                                    ::  with ANSI codes
-          ^-  (list @c)
-          %-  zing  %+  turn  a
-          |=  a/(pair stye (list @c))
-          ^-  (list @c)
-          ;:  weld
-              ?:  =(0 ~(wyt in p.p.a))  ~
-              `(list @c)`(zing (turn ~(tap in p.p.a) ef))
-              (bg p.q.p.a)
-              (fg q.q.p.a)
-              q.a
-              ?~(p.p.a ~ (ef ~))
-              (bg ~)
-              (fg ~)
-          ==
-        ::
-        ++  ef  |=(a/^deco (scap (deco a)))             ::  ANSI effect
-        ::
-        ++  fg  |=(a/^tint (scap (tint a)))             ::  ANSI foreground
-        ::
-        ++  bg                                          ::  ANSI background
-          |=  a/^tint
-          %-  scap
-          =>((tint a) [+(p) q])                         ::  (add 10 fg)
-        ::
-        ++  scap                                        ::  ANSI escape seq
-          |=  a/$@(@ (pair @ @))
-          %-  (list @c)
-          :+  27  '['                                   ::  "\033[{a}m"
-          ?@(a :~(a 'm') :~(p.a q.a 'm'))
-        ::
-        ++  deco                                        ::  ANSI effects
-          |=  a/^deco  ^-  @
-          ?-  a
-            ~   '0'
-            $br  '1'
-            $un  '4'
-            $bl  '5'
-          ==
-        ::
-        ++  tint                                        ::  ANSI colors (fg)
-          |=  a/^tint
-          ^-  (pair @ @)
-          :-  '3'
-          ?-  a
-            $k  '0'
-            $r  '1'
-            $g  '2'
-            $y  '3'
-            $b  '4'
-            $m  '5'
-            $c  '6'
-            $w  '7'
-            ~  '9'
-           ==
-        --
       ::  XX move
       ::
       ++  sein
@@ -396,7 +337,7 @@
     =*  duc  (need hey.all)
     =/  app  %hood
     =/  see  (tuba "<awaiting {(trip app)}, this may take a minute>")
-    =/  zon=axon  [app input=[~ ~] width=80 cursor=(lent see) see]
+    =/  zon=axon  [app input=[~ ~] width=80 cursor=(lent see) lin+see]
     ::
     =^  moz  all  abet:(~(into as duc zon) ~)
     [moz ..^$]
@@ -439,7 +380,7 @@
       ++  axle-1
         $:  $1
             hey/(unit duct)
-            dug/(map duct axon)
+            dug/(map duct axon-3)
             lit/?
             $=  hef
             $:  a/(unit mass)
@@ -458,7 +399,7 @@
       ++  axle-2
         $:  %2
             hey/(unit duct)
-            dug/(map duct axon)
+            dug/(map duct axon-3)
             lit/?
             dog/_|
             $=  hef
@@ -476,15 +417,34 @@
             (map @tas log-level)
         ==
       ::
-      ++  axle-any
-        $%(axle-1 axle-2 axle)
+      +$  axle-3
+        $:  %3
+            hey=(unit duct)
+            dug=(map duct axon-3)
+            lit=?
+            $=  veb
+            $~  (~(put by *(map @tas log-level)) %hole %soft)
+            (map @tas log-level)
+        ==
+      +$  axon-3
+        $:  ram=term
+            tem=(unit (list dill-belt))
+            wid=_80
+            pos=@ud
+            see=(list @c)
+        ==
+      ::
+      +$  axle-any
+        $%(axle-1 axle-2 axle-3 axle)
       --
   ::
   |=  old=axle-any
   ?-  -.old
     %1  $(old [%2 [hey dug lit dog=& hef veb]:old])
     %2  $(old [%3 [hey dug lit veb]:old])
-    %3  ..^$(all old)
+    %3  =-  $(old [%4 hey.old - lit.old veb.old])
+        (~(run by dug.old) |=(a=axon-3 a(see lin+see.a)))
+    %4  ..^$(all old)
   ==
 ::
 ++  scry

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1157,6 +1157,7 @@
     $%  {$bel ~}                                        ::  make a noise
         {$clr ~}                                        ::  clear the screen
         {$hop p/@ud}                                    ::  set cursor position
+        [%klr p=stub]                                   ::  set styled line
         {$lin p/(list @c)}                              ::  set current line
         {$mor ~}                                        ::  newline
         {$sag p/path q/*}                               ::  save to jamfile


### PR DESCRIPTION
Depending on the additions to term.c made in #3467 allows dill to
forget about ansi escape codes, and pass styled text nouns straight on
to vere.

Also removes a bit of logic from drum, which assumed things about the
rendering of escape codes to adjust cursor positioning. Now it simply
states the semantic cursor position, letting the runtime deal with the
potential influence of styling.

Supersedes #3436, containing just the dill changes from there, unmodified.

Targeting `release/next-dill`, which shouldn't be pushed out OTA until #3467 (and the matching king haskell change) has been out in the wild for a while. Deploying this to older clients will make their command line prompts and some output lines fail to render.