### PR TITLE
leap: ensure selected is always an array

### DIFF
--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -58,7 +58,7 @@ export class Omnibox extends Component {
   control(evt) {
     if (evt.key === 'Escape') {
       if (this.state.query.length > 0) {
-        this.setState({ query: '', results: this.initialResults() });
+        this.setState({ query: '', results: this.initialResults(), selected: [] });
       } else if (this.props.show) {
         this.props.api.local.setOmnibox();
       }
@@ -78,8 +78,10 @@ export class Omnibox extends Component {
 
     if (evt.key === 'Enter') {
       evt.preventDefault();
-      if (this.state.selected !== []) {
+      if (this.state.selected.length > 0) {
         this.navigate(this.state.selected[0], this.state.selected[1]);
+      } else if (Array.from(this.state.results.values()).flat().length === 0) {
+        return;
       } else {
         this.navigate(
           Array.from(this.state.results.values()).flat()[0].app,
@@ -90,7 +92,7 @@ export class Omnibox extends Component {
 
   handleClickOutside(evt) {
     if (this.props.show && !this.omniBox.contains(evt.target)) {
-      this.setState({ results: this.initialResults(), query: '' }, () => {
+      this.setState({ results: this.initialResults(), query: '', selected: [] }, () => {
         this.props.api.local.setOmnibox();
       });
     }
@@ -158,9 +160,9 @@ export class Omnibox extends Component {
       );
     });
 
-    const flattenedResultLinks = Array.from(results.values()).flat().map(result => result.link);
+    const flattenedResultLinks = Array.from(results.values()).flat().map(result => [result.app, result.link]);
     if (!flattenedResultLinks.includes(selected)) {
-      selected = flattenedResultLinks[0];
+      selected = flattenedResultLinks[0] || [];
     }
 
     this.setState({ results, selected });


### PR DESCRIPTION
In #3451 I changed `selected` to use an array because I realised that Leap *wasn't* third-party application extensible; it would index third-party applications but use react-router, meaning all third-party applications would produce an inexplicable, front-end-based "404".

In Launch we handle this by checking if an application is in our default applications suite — an array of strings in `logic/lib/default-apps.js`. So Leap should do likewise; however, `selected` was using a string containing the link, the simplest solution. We needed it to also hold the 'app' to compare against our suite and see if it's ours or not.

#3451 missed a few cases; and in #3460 I caught most of the cases causing Landscape crashes but missed two:
- When you press Escape, we don't reset `selected` while we do reset the query and the results list, so if the results set selected to `undefined` due to their own bugs, it would never reinstantiate and thus never pass any condition logic for selection using Enter or the arrow keys for the rest of the Landscape session.
- When you search, it would check if our results had `selected` in them; if not, it would set selected to the first result, so that if you pressed Enter, it would automatically go to the first result. This logic was still based on strings, not the `[app, link]` array. It could also end up setting selected to `undefined` ... causing a (thus far) silent error if you pressed Enter.

Anyway, this just catches those cases. Testing all the behaviours (automatic navigation on Enter, Tabbing and Shift Tabbing, etc etc) works for me. Would appreciate a second test.