### PR TITLE
Use logInfo in place of logDebug in most situations

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/DNS.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/DNS.hs
@@ -131,11 +131,11 @@ doResolv gal (prevWen, prevIP) turfs stderr = do
       io (resolv gal turfs) >>= \case
         Nothing -> do
           stderr $ "ames: czar at " ++ galStr ++ ": not found"
-          logDebug $ displayShow ("(ames) Failed to lookup IP for ", gal)
+          logInfo $ displayShow ("(ames) Failed to lookup IP for ", gal)
           pure (prevIP, tim)
         Just (turf, host, port, addr) -> do
           when (Just addr /= prevIP) (printCzar addr)
-          logDebug $ displayShow ("(ames) Looked up ", host, port, turf, addr)
+          logInfo $ displayShow ("(ames) Looked up ", host, port, turf, addr)
           pure (Just addr, tim)
  where
   galStr = renderGalaxy gal
@@ -155,7 +155,7 @@ resolvWorker
 resolvWorker gal vTurfs vLast waitMsg send stderr = async (forever go)
  where
   logDrop =
-    logDebug $ displayShow ("(ames) Dropping packet; no ip for galaxy ", gal)
+    logInfo $ displayShow ("(ames) Dropping packet; no ip for galaxy ", gal)
 
   go :: RIO e ()
   go = do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -80,14 +80,14 @@ forceBind :: HasLogFunc e => PortNumber -> HostAddress -> RIO e Socket
 forceBind por hos = go
  where
   go = do
-    logDebug (display ("AMES: UDP: Opening socket on port " <> tshow por))
+    logInfo (display ("AMES: UDP: Opening socket on port " <> tshow por))
     io (doBind por hos) >>= \case
       Right sk -> do
-        logDebug (display ("AMES: UDP: Opened socket on port " <> tshow por))
+        logInfo (display ("AMES: UDP: Opened socket on port " <> tshow por))
         pure sk
       Left err -> do
-        logDebug (display ("AMES: UDP: " <> tshow err))
-        logDebug ("AMES: UDP: Failed to open UDP socket. Waiting")
+        logInfo (display ("AMES: UDP: " <> tshow err))
+        logInfo ("AMES: UDP: Failed to open UDP socket. Waiting")
         threadDelay 250_000
         go
 
@@ -138,7 +138,7 @@ recvPacket sok = do
 -}
 fakeUdpServ :: HasLogFunc e => RIO e UdpServ
 fakeUdpServ = do
-  logDebug $ displayShow ("AMES", "UDP", "\"Starting\" fake UDP server.")
+  logInfo $ displayShow ("AMES", "UDP", "\"Starting\" fake UDP server.")
   pure UdpServ { .. }
  where
   usSend = \_ _ -> pure ()
@@ -158,7 +158,7 @@ realUdpServ
   -> HostAddress
   -> RIO e UdpServ
 realUdpServ por hos = do
-  logDebug $ displayShow ("AMES", "UDP", "Starting real UDP server.")
+  logInfo $ displayShow ("AMES", "UDP", "Starting real UDP server.")
 
   env <- ask
 
@@ -178,7 +178,7 @@ realUdpServ por hos = do
   -}
   let signalBrokenSocket :: Socket -> RIO e ()
       signalBrokenSocket sock = do
-        logDebug $ displayShow ("AMES", "UDP"
+        logInfo $ displayShow ("AMES", "UDP"
                                , "Socket broken. Requesting new socket"
                                )
         atomically $ do
@@ -242,11 +242,11 @@ realUdpServ por hos = do
             enqueueRecvPacket p a b
 
   let shutdown = do
-        logDebug "AMES: UDP: Shutting down. (killing threads)"
+        logInfo "AMES: UDP: Shutting down. (killing threads)"
         cancel tOpen
         cancel tSend
         cancel tRecv
-        logDebug "AMES: UDP: Shutting down. (closing socket)"
+        logInfo "AMES: UDP: Shutting down. (closing socket)"
         io $ join $ atomically $ do
           res <- readTVar vSock <&> maybe (pure ()) close
           writeTVar vSock Nothing

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
@@ -163,7 +163,7 @@ clay env plan =
     handleEffect :: ClayDrv -> SyncEf -> IO ()
     handleEffect cd = runRIO env . \case
       SyncEfHill _ mountPoints -> do
-        logDebug $ displayShow ("(clay) known mount points:", mountPoints)
+        logInfo $ displayShow ("(clay) known mount points:", mountPoints)
         pierPath <- view pierPathL
         mountPairs <- flip mapM mountPoints $ \desk -> do
           ss <- takeFilesystemSnapshot (pierPath </> (deskToPath desk))
@@ -171,14 +171,14 @@ clay env plan =
         atomically $ writeTVar (cdMountPoints cd) (M.fromList mountPairs)
 
       SyncEfDirk p desk -> do
-        logDebug $ displayShow ("(clay) dirk:", p, desk)
+        logInfo $ displayShow ("(clay) dirk:", p, desk)
         m <- atomically $ readTVar (cdMountPoints cd)
         let snapshot = M.findWithDefault M.empty desk m
         pierPath <- view pierPathL
         let dir = pierPath </> deskToPath desk
         actions <- buildActionListFromDifferences dir snapshot
 
-        logDebug $ displayShow ("(clay) dirk actions: ", actions)
+        logInfo $ displayShow ("(clay) dirk actions: ", actions)
 
         let !intoList = map (actionsToInto dir) actions
 
@@ -196,7 +196,7 @@ clay env plan =
             (applyActionsToMountPoints desk actions)
 
       SyncEfErgo p desk actions -> do
-        logDebug $ displayShow ("(clay) ergo:", p, desk, actions)
+        logInfo $ displayShow ("(clay) ergo:", p, desk, actions)
 
         m <- atomically $ readTVar (cdMountPoints cd)
         let mountPoint = M.findWithDefault M.empty desk m
@@ -211,7 +211,7 @@ clay env plan =
             (applyActionsToMountPoints desk hashedActions)
 
       SyncEfOgre p desk -> do
-        logDebug $ displayShow ("(clay) ogre:", p, desk)
+        logInfo $ displayShow ("(clay) ogre:", p, desk)
         pierPath <- view pierPathL
         removeDirectoryRecursive $ pierPath </> deskToPath desk
         atomically $ modifyTVar (cdMountPoints cd) (M.delete desk)
@@ -229,13 +229,13 @@ clay env plan =
     performAction :: (Map FilePath Int) -> (FilePath, Maybe (Mime, Int))
                   -> RIO e ()
     performAction m (fp, Nothing) = do
-      logDebug $ displayShow ("(clay) deleting file ", fp)
+      logInfo $ displayShow ("(clay) deleting file ", fp)
       removeFile fp
     performAction m (fp, Just ((Mime _ (File (Octs bs)), hash)))
-        | skip = logDebug $
+        | skip = logInfo $
                  displayShow ("(clay) skipping unchanged file update " , fp)
         | otherwise = do
-            logDebug $ displayShow ("(clay) updating file " , fp)
+            logInfo $ displayShow ("(clay) updating file " , fp)
             createDirectoryIfMissing True $ takeDirectory fp
             writeFile fp bs
       where

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
@@ -72,7 +72,7 @@ leaveMultiEyre MultiEyreApi {..} who = do
 
 multiEyre :: HasLogFunc e => MultiEyreConf -> RIO e MultiEyreApi
 multiEyre conf@MultiEyreConf {..} = do
-  logDebug (displayShow ("EYRE", "MULTI", conf))
+  logInfo (displayShow ("EYRE", "MULTI", conf))
 
   vLive <- io emptyLiveReqs >>= newTVarIO
   vPlan <- newTVarIO mempty
@@ -96,7 +96,7 @@ multiEyre conf@MultiEyreConf {..} = do
           Just cb -> cb who reqId
 
   mIns <- for mecHttpPort $ \por -> do
-    logDebug (displayShow ("EYRE", "MULTI", "HTTP", por))
+    logInfo (displayShow ("EYRE", "MULTI", "HTTP", por))
     serv vLive $ ServConf
       { scHost = host
       , scPort = SPChoices $ singleton $ fromIntegral por
@@ -109,7 +109,7 @@ multiEyre conf@MultiEyreConf {..} = do
       }
 
   mSec <- for mecHttpsPort $ \por -> do
-    logDebug (displayShow ("EYRE", "MULTI", "HTTPS", por))
+    logInfo (displayShow ("EYRE", "MULTI", "HTTPS", por))
     serv vLive $ ServConf
       { scHost = host
       , scPort = SPChoices $ singleton $ fromIntegral por

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Serv.hs
@@ -164,7 +164,7 @@ tryOpenChoices
 tryOpenChoices hos = go
  where
   go (p :| ps) = do
-    logDebug (displayShow ("EYRE", "Trying to open port.", p))
+    logInfo (displayShow ("EYRE", "Trying to open port.", p))
     io (tryOpen hos p) >>= \case
       Left err -> do
         logError (displayShow ("EYRE", "Failed to open port.", p))
@@ -185,7 +185,7 @@ tryOpenAny hos = do
       pure (Right (p, s))
 
 logDbg :: (HasLogFunc e, Show a) => [Text] -> a -> RIO e ()
-logDbg ctx msg = logDebug (prefix <> suffix)
+logDbg ctx msg = logInfo (prefix <> suffix)
  where
   prefix = display (concat $ fmap (<> ": ") ctx)
   suffix = displayShow msg
@@ -312,7 +312,7 @@ configCreds TlsConfig {..} =
 fakeServ :: HasLogFunc e => ServConf -> RIO e ServApi
 fakeServ conf = do
   let por = fakePort (scPort conf)
-  logDebug (displayShow ("EYRE", "SERV", "Running Fake Server", por))
+  logInfo (displayShow ("EYRE", "SERV", "Running Fake Server", por))
   pure $ ServApi
     { saKil = pure ()
     , saPor = pure por
@@ -331,7 +331,7 @@ getFirstTlsConfig (MTC var) = do
 
 realServ :: HasLogFunc e => TVar E.LiveReqs -> ServConf -> RIO e ServApi
 realServ vLive conf@ServConf {..} = do
-  logDebug (displayShow ("EYRE", "SERV", "Running Real Server"))
+  logInfo (displayShow ("EYRE", "SERV", "Running Real Server"))
   kil <- newEmptyTMVarIO
   por <- newEmptyTMVarIO
 
@@ -344,7 +344,7 @@ realServ vLive conf@ServConf {..} = do
     }
  where
   runServ vPort = do
-    logDebug (displayShow ("EYRE", "SERV", "runServ"))
+    logInfo (displayShow ("EYRE", "SERV", "runServ"))
     rwith (forceOpenSocket scHost scPort) $ \(por, sok) -> do
       atomically (putTMVar vPort por)
       startServer scType scHost por sok scRedi vLive

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Service.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Service.hs
@@ -31,21 +31,21 @@ restartService
   -> (s -> RIO e ())
   -> RIO e (Either SomeException s)
 restartService vServ sstart kkill = do
-  logDebug "restartService"
+  logInfo "restartService"
   modifyMVar vServ $ \case
     Nothing -> doStart
     Just sv -> doRestart sv
  where
   doRestart :: s -> RIO e (Maybe s, Either SomeException s)
   doRestart serv = do
-    logDebug "doStart"
+    logInfo "doStart"
     try (kkill serv) >>= \case
       Left  exn -> pure (Nothing, Left exn)
       Right ()  -> doStart
 
   doStart :: RIO e (Maybe s, Either SomeException s)
   doStart = do
-    logDebug "doStart"
+    logInfo "doStart"
     try sstart <&> \case
       Right s   -> (Just s, Right s)
       Left  exn -> (Nothing, Left exn)
@@ -59,7 +59,7 @@ stopService
   -> (s -> RIO e ())
   -> RIO e (Either SomeException ())
 stopService vServ kkill = do
-  logDebug "stopService"
+  logInfo "stopService"
   modifyMVar vServ $ \case
     Nothing -> pure (Nothing, Right ())
     Just sv -> do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Wai.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Wai.hs
@@ -179,7 +179,7 @@ streamBlocks env init getAct = send init >> loop
 
   send "" = pure ()
   send c  = do
-    runRIO env (logInfo (display ("sending chunk " <> tshow c)))
+    runRIO env (logDebug (display ("sending chunk " <> tshow c)))
     yield $ Chunk $ fromByteString c
     yield Flush
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Http/Client.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Http/Client.hs
@@ -140,7 +140,7 @@ client env plan = (initialEvents, runHttpClient)
     runReq HttpClientDrv{..} id req = async $
       case cvtReq req of
         Nothing -> do
-          logDebug $ displayShow ("(malformed http client request)", id, req)
+          logInfo $ displayShow ("(malformed http client request)", id, req)
           planEvent id (Cancel ())
         Just r -> do
           logDebug $ displayShow ("(http client request)", id, req)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/LMDB.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/LMDB.hs
@@ -226,7 +226,7 @@ readRowsBatch :: ∀e. HasLogFunc e
 readRowsBatch env dbi first = readRows
   where
     readRows = do
-        logDebug $ display ("(readRowsBatch) From: " <> tshow first)
+        logInfo $ display ("(readRowsBatch) From: " <> tshow first)
         withWordPtr first $ \pIdx ->
             withKVPtrs' (MDB_val 8 (castPtr pIdx)) nullVal $ \pKey pVal ->
             rwith (readTxn env) $ \txn ->

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/NounServ.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/NounServ.hs
@@ -82,7 +82,7 @@ wsConn pre inp out wsc = do
 
     flip finally cleanup $ do
          res <- atomically (waitCatchSTM writer <|> waitCatchSTM reader)
-         logDebug $ displayShow (res :: Either SomeException ())
+         logInfo $ displayShow (res :: Either SomeException ())
 
 
 --------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ wsClient pax por = do
     out <- io $ newTBMChanIO 5
     con <- pure (mkConn inp out)
 
-    logDebug "NOUNSERV (wsClie) Trying to connect"
+    logInfo "NOUNSERV (wsClie) Trying to connect"
 
     tid <- io $ async
               $ WS.runClient "127.0.0.1" por (unpack pax)
@@ -111,7 +111,7 @@ wsServApp :: (HasLogFunc e, ToNoun o, FromNoun i, Show i, Show o)
           -> WS.PendingConnection
           -> RIO e ()
 wsServApp cb pen = do
-    logDebug "NOUNSERV (wsServer) Got connection!"
+    logInfo "NOUNSERV (wsServer) Got connection!"
     wsc <- io $ WS.acceptRequest pen
     inp <- io $ newTBMChanIO 5
     out <- io $ newTBMChanIO 5
@@ -125,10 +125,10 @@ wsServer = do
 
     tid <- async $ do
         env <- ask
-        logDebug "NOUNSERV (wsServer) Starting server"
+        logInfo "NOUNSERV (wsServer) Starting server"
         io $ WS.runServer "127.0.0.1" 9999
            $ runRIO env . wsServApp (writeTBMChan con)
-        logDebug "NOUNSERV (wsServer) Server died"
+        logInfo "NOUNSERV (wsServer) Server died"
         atomically $ closeTBMChan con
 
     pure $ Server (readTBMChan con) tid 9999

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Serf.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Serf.hs
@@ -40,7 +40,7 @@ withSerf config = mkRAcquire startup kill
  where
   startup = do
     (serf, st) <- io $ start config
-    logDebug (displayShow ("serf state", st))
+    logInfo (displayShow ("serf state", st))
     pure serf
   kill serf = do
     void $ rio $ stop serf
@@ -58,7 +58,7 @@ execReplay serf log last = do
  where
   doBoot :: RIO e (Either PlayBail Word)
   doBoot = do
-    logDebug "Beginning boot sequence"
+    logInfo "Beginning boot sequence"
 
     let bootSeqLen = lifecycleLen (Log.identity log)
 
@@ -72,14 +72,14 @@ execReplay serf log last = do
     when (numEvs /= bootSeqLen) $ do
       throwIO (MissingBootEventsInEventLog numEvs bootSeqLen)
 
-    logDebug $ display ("Sending " <> tshow numEvs <> " boot events to serf")
+    logInfo $ display ("Sending " <> tshow numEvs <> " boot events to serf")
 
     io (boot serf evs) >>= \case
       Just err -> do
-        logDebug "Error on replay, exiting"
+        logInfo "Error on replay, exiting"
         pure (Left err)
       Nothing  -> do
-        logDebug "Finished boot events, moving on to more events from log."
+        logInfo "Finished boot events, moving on to more events from log."
         doReplay <&> \case
           Left err  -> Left err
           Right num -> Right (num + numEvs)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
@@ -472,7 +472,7 @@ localClient doneSignal = fst <$> mkRAcquire start stop
                 loop rd
               else if w == 3 then do
                 -- ETX (^C)
-                logDebug $ displayShow "Ctrl-c interrupt"
+                logInfo $ displayShow "Ctrl-c interrupt"
                 atomically $ do
                   writeTQueue wq [Term.Trace "interrupt\r\n"]
                   writeTQueue rq $ Ctl $ Cord "c"


### PR DESCRIPTION
The previously mostly unused "info" level sits between debug and warn. I've moved most things, especially startup trace messages, from debug to info. The idea is if you run with --stderr --log-info, you should get as chatty a ship as possible while still having it be usable. This means in particular that you don't get printouts on every event or http exchange. This would have made my debugging session with @ixv yesterday way better.

One problem remains, which is that on startup you get a bunch of zig-zag as multiple different threads log at the same time. This is a deep issue with RIO logging, which simply fails to guard the egress of logs in a manner appropriate for a concurrent environment.