### PR TITLE
vere: fix crash, cleanup error messages

### DIFF
--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -30,6 +30,7 @@
 #       define c3_assert(x)                       \
           do {                                    \
             if (!(x)) {                           \
+              fflush(stderr);                     \
               fprintf(stderr, "\rAssertion '%s' " \
                       "failed in %s:%d\n",        \
                       #x, __FILE__, __LINE__);    \

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -44,7 +44,7 @@
 
     /* u3_moor_bail: bailout callback function.
     */
-      typedef void (*u3_moor_bail)(void*, const c3_c* err_c);
+      typedef void (*u3_moor_bail)(void*, ssize_t err_i, const c3_c* err_c);
 
     /* u3_meat: blob message block.
     */

--- a/pkg/urbit/vere/io/hind.c
+++ b/pkg/urbit/vere/io/hind.c
@@ -45,8 +45,9 @@ _hind_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
       //
       case c3__trim: {
         ret_o = c3y;
-        u3_auto_plan(car_u, u3_ovum_init(0, u3_blip, u3k(wir), u3k(cad)));
-      }
+        u3_auto_plan(car_u, u3_ovum_init(0, u3_blip,
+                                         u3nc(c3__arvo, u3_nul), u3k(cad)));
+      } break;
 
       case c3__vega: {
         ret_o = c3y;

--- a/pkg/urbit/vere/lord.c
+++ b/pkg/urbit/vere/lord.c
@@ -61,6 +61,7 @@
 */
 static void
 _lord_stop_cb(void*       ptr_v,
+              ssize_t     err_i,
               const c3_c* err_c)
 {
   u3_lord* god_u = ptr_v;
@@ -122,6 +123,7 @@ _lord_writ_free(u3_writ* wit_u)
 */
 static void
 _lord_bail_noop(void*       ptr_v,
+                ssize_t     err_i,
                 const c3_c* err_c)
 {
 }
@@ -986,10 +988,18 @@ _lord_on_serf_exit(uv_process_t* req_u,
 */
 static void
 _lord_on_serf_bail(void*       ptr_v,
+                   ssize_t     err_i,
                    const c3_c* err_c)
 {
   u3_lord* god_u = ptr_v;
-  u3l_log("pier: serf error: %s\r\n", err_c);
+
+  if ( UV_EOF == err_i ) {
+    u3l_log("pier: serf unexpectedly shut down\r\n");
+  }
+  else {
+    u3l_log("pier: serf error: %s\r\n", err_c);
+  }
+
   _lord_bail(god_u);
 }
 

--- a/pkg/urbit/vere/newt.c
+++ b/pkg/urbit/vere/newt.c
@@ -217,7 +217,7 @@ _newt_read(u3_moat*        mot_u,
       fprintf(stderr, "newt: read failed %s\r\n", uv_strerror(len_i));
     }
 
-    mot_u->bal_f(mot_u->ptr_v, uv_strerror(len_i));
+    mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
     return c3n;
   }
   //  EAGAIN/EWOULDBLOCK
@@ -299,7 +299,7 @@ _newt_read_init(u3_moat* mot_u, uv_read_cb read_cb_f)
                                      read_cb_f)) )
     {
       fprintf(stderr, "newt: read failed %s\r\n", uv_strerror(sas_i));
-      mot_u->bal_f(mot_u->ptr_v, uv_strerror(sas_i));
+      mot_u->bal_f(mot_u->ptr_v, sas_i, uv_strerror(sas_i));
     }
   }
 }
@@ -310,7 +310,7 @@ static void
 _moat_stop_cb(uv_handle_t* han_u)
 {
   u3_moat* mot_u = han_u->data;
-  mot_u->bal_f(mot_u->ptr_v, "");
+  mot_u->bal_f(mot_u->ptr_v, -1, "");
 }
 
 /* u3_newt_moat_stop(); newt stop/close input stream.
@@ -407,7 +407,7 @@ _newt_write_cb(uv_write_t* wri_u, c3_i sas_i)
     }
     else {
       fprintf(stderr, "newt: write failed %s\r\n", uv_strerror(sas_i));
-      moj_u->bal_f(moj_u->ptr_v, uv_strerror(sas_i));
+      moj_u->bal_f(moj_u->ptr_v, sas_i, uv_strerror(sas_i));
     }
   }
 }
@@ -418,7 +418,7 @@ static void
 _mojo_stop_cb(uv_handle_t* han_u)
 {
   u3_mojo* moj_u = han_u->data;
-  moj_u->bal_f(moj_u->ptr_v, "");
+  moj_u->bal_f(moj_u->ptr_v, -1, "");
 }
 
 /* u3_newt_mojo_stop(); newt stop/close output stream.
@@ -468,7 +468,7 @@ u3_newt_write(u3_mojo* moj_u, u3_atom mat)
     {
       c3_free(req_u);
       fprintf(stderr, "newt: write failed %s\r\n", uv_strerror(sas_i));
-      moj_u->bal_f(moj_u->ptr_v, uv_strerror(sas_i));
+      moj_u->bal_f(moj_u->ptr_v, sas_i, uv_strerror(sas_i));
     }
   }
 }

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1792,8 +1792,7 @@ u3_pier_exit(u3_pier* pir_u)
 void
 u3_pier_bail(u3_pier* pir_u)
 {
-  pir_u->sat_e = u3_psat_done;
-
+  //  halt serf
   //
   if ( pir_u->god_u ) {
     u3_lord_halt(pir_u->god_u);
@@ -1815,6 +1814,8 @@ u3_pier_bail(u3_pier* pir_u)
     u3_disk_exit(pir_u->log_u);
     pir_u->log_u = 0;
   }
+
+  pir_u->sat_e = u3_psat_done;
 
   _pier_done(pir_u);
 }

--- a/pkg/urbit/worker/main.c
+++ b/pkg/urbit/worker/main.c
@@ -29,9 +29,15 @@ static u3_mojo out_u;             //  output stream
 /* _cw_serf_fail(): failure stub.
 */
 static void
-_cw_serf_fail(void* vod_p, const c3_c* wut_c)
+_cw_serf_fail(void* ptr_v, ssize_t err_i, const c3_c* err_c)
 {
-  fprintf(stderr, "serf: fail: %s\r\n", wut_c);
+  if ( UV_EOF == err_i ) {
+    fprintf(stderr, "serf: pier unexpectedly shut down\r\n");
+  }
+  else {
+    fprintf(stderr, "serf: pier error: %s\r\n", err_c);
+  }
+
   exit(1);
 }
 
@@ -67,7 +73,7 @@ _cw_serf_writ(void* vod_p, u3_noun mat)
   u3_noun ret;
 
   if ( c3n == u3_serf_writ(&u3V, u3ke_cue(mat), &ret) ) {
-    _cw_serf_fail(0, "bad jar");
+    _cw_serf_fail(0, -1, "bad jar");
   }
   else {
     _cw_serf_send(ret);


### PR DESCRIPTION
- v0.10.8 introduced a bug, wherein the vere king would crash if the serf crashed. This was just a dumb mistake in the pier shutdown state machine (advancing the state before dispatching off of it).
- the error message printed on unexpected serf shutdown (manifesting as EOF on the ipc pipe) used to use the default libuv error strings, but this was unhelpful and confusing, so it's been replaced with more specific messages on each side of the pipe.