### PR TITLE
arvo: adds new maintenance commands: |trim and |meld

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e95db06669d81f05d58dfd7a54637eec6aeb1d0d3dc45bf28a7859939fbd388
-size 6376191
+oid sha256:84d815edefd8cf64598cce4b06bd1b3038a265222ada9d45c193a817ce5580bf
+size 6297329

--- a/pkg/arvo/gen/hood/meld.hoon
+++ b/pkg/arvo/gen/hood/meld.hoon
@@ -1,0 +1,13 @@
+::  Helm: unify memory
+::
+::::  /hoon/meld/hood/gen
+  ::
+/?    310
+::
+::::
+  ::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [arg=~ ~]
+    ==
+[%helm-meld ~]

--- a/pkg/arvo/gen/hood/trim.hoon
+++ b/pkg/arvo/gen/hood/trim.hoon
@@ -1,0 +1,13 @@
+::  Helm: trim kernel state
+::
+::::  /hoon/trim/hood/gen
+  ::
+/?    310
+::
+::::
+  ::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [arg=?(~ [pri=@ud ~]) ~]
+    ==
+[%helm-trim ?~(arg 1 pri.arg)]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -187,6 +187,10 @@
     (module-ova:pill top)
   |=([=wire =flog:dill] [%pass wire %arvo %d %flog flog])
 ::
+++  poke-trim
+  |=  pri=@ud  =<  abet
+  (emit %pass /pack %arvo %d %flog %crop pri)
+::
 ++  poke-verb                                         ::  toggle verbose
   |=  ~  =<  abet
   (flog %verb ~)
@@ -232,6 +236,7 @@
     %helm-reset            =;(f (f !<(_+<.f vase)) poke-reset)
     %helm-send-hi          =;(f (f !<(_+<.f vase)) poke-send-hi)
     %helm-serve            =;(f (f !<(_+<.f vase)) poke-serve)
+    %helm-trim             =;(f (f !<(_+<.f vase)) poke-trim)
     %helm-verb             =;(f (f !<(_+<.f vase)) poke-verb)
     %helm-write-sec-atom   =;(f (f !<(_+<.f vase)) poke-sec-atom)
   ==

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -100,6 +100,10 @@
   |=  ~
   abet:(emit %pass way.mass-timer.sat %arvo %b %rest nex.mass-timer.sat)
 ::
+++  poke-meld
+  |=  ~  =<  abet
+  (emit %pass /pack %arvo %d %flog %meld ~)
+::
 ++  poke-pack
   |=  ~  =<  abet
   (emit %pass /pack %arvo %d %flog %pack ~)
@@ -228,6 +232,7 @@
     %helm-hi               =;(f (f !<(_+<.f vase)) poke-hi)
     %helm-knob             =;(f (f !<(_+<.f vase)) poke-knob)
     %helm-mass             =;(f (f !<(_+<.f vase)) poke-mass)
+    %helm-meld             =;(f (f !<(_+<.f vase)) poke-meld)
     %helm-moon             =;(f (f !<(_+<.f vase)) poke-moon)
     %helm-pack             =;(f (f !<(_+<.f vase)) poke-pack)
     %helm-rekey            =;(f (f !<(_+<.f vase)) poke-rekey)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -117,6 +117,7 @@
           $blew  (send %rez p.p.kyz q.p.kyz)
           $heft  (dump %whey ~)
           $lyra  (dump kyz)
+          $meld  (dump kyz)
           $pack  (dump kyz)
           $crop  (dump trim+p.kyz)
           $veer  (dump kyz)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -118,6 +118,7 @@
           $heft  (dump %whey ~)
           $lyra  (dump kyz)
           $pack  (dump kyz)
+          $crop  (dump trim+p.kyz)
           $veer  (dump kyz)
           $verb  (dump kyz)
         ==

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1110,6 +1110,7 @@
           {$init p/@p}                                  ::  set owner
           {$logo ~}                                     ::  logout
           [%lyra hoon=(unit @t) arvo=@t]                ::  upgrade kernel
+          {$meld ~}                                     ::  unify memory
           {$pack ~}                                     ::  compact memory
           {$trim p/@ud}                                 ::  trim kernel state
           {$veer p/@ta q/path r/@t}                     ::  install vane
@@ -1131,6 +1132,7 @@
           {$harm ~}                                     ::  all terms hung up
           $>(%init vane-task)                           ::  after gall ready
           [%lyra hoon=(unit @t) arvo=@t]                ::  upgrade kernel
+          {$meld ~}                                     ::  unify memory
           {$noop ~}                                     ::  no operation
           {$pack ~}                                     ::  compact memory
           {$talk p/tank}                                ::
@@ -1198,6 +1200,7 @@
         {$crud p/@tas q/(list tank)}                    ::
         {$heft ~}                                       ::
         [%lyra hoon=(unit @t) arvo=@t]                  ::  upgrade kernel
+        {$meld ~}                                       ::  unify memory
         {$pack ~}                                       ::  compact memory
         {$text p/tape}                                  ::
         {$veer p/@ta q/path r/@t}                       ::  install vane

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1111,6 +1111,7 @@
           {$logo ~}                                     ::  logout
           [%lyra hoon=(unit @t) arvo=@t]                ::  upgrade kernel
           {$pack ~}                                     ::  compact memory
+          {$trim p/@ud}                                 ::  trim kernel state
           {$veer p/@ta q/path r/@t}                     ::  install vane
           {$verb ~}                                     ::  verbose mode
           [%whey ~]                                     ::  memory report
@@ -1120,6 +1121,7 @@
       $%  {$belt p/belt}                                ::  terminal input
           {$blew p/blew}                                ::  terminal config
           {$boot lit/? p/*}                             ::  weird %dill boot
+          {$crop p/@ud}                                 ::  trim kernel state
           $>(%crud vane-task)                           ::  error with trace
           {$flog p/flog}                                ::  wrapped error
           {$flow p/@tas q/(list gill:gall)}             ::  terminal config
@@ -1192,7 +1194,8 @@
         {$url p/@t}                                     ::  activate url
     ==                                                  ::
   ++  flog                                              ::  sent to %dill
-    $%  {$crud p/@tas q/(list tank)}                    ::
+    $%  {$crop p/@ud}                                   ::  trim kernel state
+        {$crud p/@tas q/(list tank)}                    ::
         {$heft ~}                                       ::
         [%lyra hoon=(unit @t) arvo=@t]                  ::  upgrade kernel
         {$pack ~}                                       ::  compact memory


### PR DESCRIPTION
`%meld` is the name of the new global deduplicator, added in #3235). Support for the effect is also added in that PR, but there's no need to block this addition, or otherwise coordinate the release of these changes -- if the effect is unsupported, the user will merely see a `kick: lost` printf.

The `%trim` effect (triggering memory reclamation via a subsequent `%trim` event) has been long supported, but there was no way to manually trigger it. I've taken the liberty of adding that as well. The triggering task to %dill is named `%crop`, as `%trim` is already reserved for the global memory pressure event.

