### PR TITLE
vere: refactors terminal output implementation for efficiency

### DIFF
--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -183,12 +183,14 @@
     /* u2_utfo: unix terminfo strings.
     */
       typedef struct {
-        struct {
-          uv_buf_t kcuu1_u;              //  key_up
-          uv_buf_t kcud1_u;              //  key_down
-          uv_buf_t kcub1_u;              //  key_back
-          uv_buf_t kcuf1_u;              //  key_forward
-        } inn;
+        //    disabled, currently unused
+        //
+        // struct {
+        //   uv_buf_t kcuu1_u;              //  key_up
+        //   uv_buf_t kcud1_u;              //  key_down
+        //   uv_buf_t kcub1_u;              //  key_back
+        //   uv_buf_t kcuf1_u;              //  key_forward
+        // } inn;
         struct {
           uv_buf_t clear_u;              //  clear_screen
           uv_buf_t el_u;                 //  clr_bol clear to beginning

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -145,9 +145,10 @@
         } siz;
 
         struct {
-          c3_w* lin_w;                      //  current line (utf32)
-          c3_w  len_w;                      //  length of current line
-          c3_w  sap_w;                      //  escape chars in current line
+          c3_y* lin_y;                      //  current line (utf8)
+          c3_w  byt_w;                      //  utf8 line-length
+          c3_w  wor_w;                      //  utf32 line-length
+          c3_w  sap_w;                      //  escape chars in line
           c3_w  cus_w;                      //  cursor position
         } mir;
 

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -136,14 +136,6 @@
         c3_w        pid_w;                  //  pid of checkpoint process
       } u3_save;
 
-    /* u3_ubuf: unix tty i/o buffer.
-    */
-      typedef struct _u3_ubuf {
-        struct _u3_ubuf* nex_u;
-        c3_w             len_w;
-        c3_y             hun_y[0];          //  bytes to send
-      } u3_ubuf;
-
     /* u3_utat: unix terminal state.
     */
       typedef struct {
@@ -191,24 +183,23 @@
     */
       typedef struct {
         struct {
-          const c3_y* kcuu1_y;              //  key_up
-          const c3_y* kcud1_y;              //  key_down
-          const c3_y* kcub1_y;              //  key_back
-          const c3_y* kcuf1_y;              //  key_forward
-          c3_w        max_w;                //  maximum input sequence length
+          uv_buf_t kcuu1_u;              //  key_up
+          uv_buf_t kcud1_u;              //  key_down
+          uv_buf_t kcub1_u;              //  key_back
+          uv_buf_t kcuf1_u;              //  key_forward
         } inn;
         struct {
-          const c3_y* clear_y;              //  clear_screen
-          const c3_y* el_y;                 //  clr_bol clear to beginning
-          // const c3_y* el1_y;                //  clr_eol clear to end
-          const c3_y* ed_y;                 //  clear to end of screen
-          const c3_y* bel_y;                //  bel sound bell
-          const c3_y* cub1_y;               //  parm_left
-          const c3_y* cuf1_y;               //  parm_right
-          const c3_y* cuu1_y;               //  parm_up
-          const c3_y* cud1_y;               //  parm_down
-          // const c3_y* cub_y;                //  parm_left_cursor #num
-          // const c3_y* cuf_y;                //  parm_right_cursor #num
+          uv_buf_t clear_u;              //  clear_screen
+          uv_buf_t el_u;                 //  clr_bol clear to beginning
+          // uv_buf_t el1_u;             //  clr_eol clear to end
+          uv_buf_t ed_u;                 //  clear to end of screen
+          uv_buf_t bel_u;                //  bel sound bell
+          uv_buf_t cub1_u;               //  parm_left
+          uv_buf_t cuf1_u;               //  parm_right
+          uv_buf_t cuu1_u;               //  parm_up
+          uv_buf_t cud1_u;               //  parm_down
+          // uv_buf_t cub_u;             //  parm_left_cursor #num
+          // uv_buf_t cuf_u;             //  parm_right_cursor #num
         } out;
       } u3_utfo;
 

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -169,13 +169,13 @@ u3_term_log_init(void)
     //  configure input escape sequences
     //
     //    NB: terminfo reports the wrong sequence for arrow keys on xterms.
-    //
-    {
-      uty_u->ufo_u.inn.kcuu1_u = TERM_LIT_BUF("\033[A");  //  terminfo reports "\033OA"
-      uty_u->ufo_u.inn.kcud1_u = TERM_LIT_BUF("\033[B");  //  terminfo reports "\033OB"
-      uty_u->ufo_u.inn.kcuf1_u = TERM_LIT_BUF("\033[C");  //  terminfo reports "\033OC"
-      uty_u->ufo_u.inn.kcub1_u = TERM_LIT_BUF("\033[D");  //  terminfo reports "\033OD"
-    }
+    //    disabled, currently unused
+    // {
+    //   uty_u->ufo_u.inn.kcuu1_u = TERM_LIT_BUF("\033[A");  //  terminfo reports "\033OA"
+    //   uty_u->ufo_u.inn.kcud1_u = TERM_LIT_BUF("\033[B");  //  terminfo reports "\033OB"
+    //   uty_u->ufo_u.inn.kcuf1_u = TERM_LIT_BUF("\033[C");  //  terminfo reports "\033OC"
+    //   uty_u->ufo_u.inn.kcub1_u = TERM_LIT_BUF("\033[D");  //  terminfo reports "\033OD"
+    // }
 
     //  Load old terminal state to restore.
     //

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -209,6 +209,7 @@ u3_term_log_init(void)
     {
       uty_u->tat_u.mir.lin_w = 0;
       uty_u->tat_u.mir.len_w = 0;
+      uty_u->tat_u.mir.sap_w = 0;
       uty_u->tat_u.mir.cus_w = 0;
 
       uty_u->tat_u.esc.ape = c3n;

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -286,7 +286,9 @@ u3_term_log_exit(void)
     }
   }
 
-  uv_close((uv_handle_t*)&u3_Host.uty_u->pop_u, 0);
+  if ( u3_Host.uty_u ) {
+    uv_close((uv_handle_t*)&u3_Host.uty_u->pop_u, 0);
+  }
 }
 
 /*  _term_tcsetattr(): tcsetattr w/retry on EINTR.

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -1272,16 +1272,17 @@ _term_ef_blit(u3_utty* uty_u,
     } break;
 
     case c3__sav: {
-      _term_it_save(u3k(u3h(u3t(blt))), u3k(u3t(u3t(blt))));
+      u3_noun pax, dat;
+      u3x_cell(u3t(blt), &pax, &dat);
+
+      _term_it_save(u3k(pax), u3k(dat));
     } break;
 
     case c3__sag: {
-      u3_noun pib = u3k(u3t(u3t(blt)));
-      u3_noun jam;
+      u3_noun pax, dat;
+      u3x_cell(u3t(blt), &pax, &dat);
 
-      jam = u3ke_jam(pib);
-
-      _term_it_save(u3k(u3h(u3t(blt))), jam);
+      _term_it_save(u3k(pax), u3qe_jam(dat));
     } break;
 
     case c3__url: {

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -489,7 +489,17 @@ _term_it_show_line(u3_utty* uty_u, c3_w wor_w, c3_w sap_w)
 {
   u3_utat* tat_u = &uty_u->tat_u;
 
-  _term_it_dump(uty_u, tat_u->mir.byt_w, tat_u->mir.lin_y);
+  //  we have to reallocate the current line on write,
+  //  or we have a data race if a) the write is async,
+  //  and b) a new output line arrives before the write completes.
+  //
+  {
+    c3_w  len_w = tat_u->mir.byt_w;
+    c3_y* hun_y = c3_malloc(len_w);
+    memcpy(hun_y, tat_u->mir.lin_y, len_w);
+
+    _term_it_send(uty_u, len_w, hun_y);
+  }
 
   //  XX refactor to avoid updating state
   //

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -1081,7 +1081,7 @@ _term_it_put_deco(c3_w* lin_w,
 */
 static void
 _term_it_show_stub(u3_utty* uty_u,
-                   u3_noun tub)
+                   u3_noun    tub)
 {
   c3_w tuc_w = u3qb_lent(tub);
 
@@ -1203,6 +1203,28 @@ _term_it_show_stub(u3_utty* uty_u,
   u3z(tub);
 }
 
+/* _term_it_show_tour(): send utf32 to terminal.
+*/
+static void
+_term_it_show_tour(u3_utty* uty_u,
+                   u3_noun    lin)
+{
+  c3_w  len_w = u3qb_lent(lin);
+  c3_w* lin_w = c3_malloc( sizeof(c3_w) * len_w );
+
+  {
+    c3_w i_w;
+
+    for ( i_w = 0; u3_nul != lin; i_w++, lin = u3t(lin) ) {
+      lin_w[i_w] = u3r_word(0, u3h(lin));
+    }
+  }
+
+  _term_it_show_line(uty_u, lin_w, len_w, 0);
+
+  u3z(lin);
+}
+
 /* _term_ef_blit(): send blit to terminal.
 */
 static void
@@ -1239,24 +1261,10 @@ _term_ef_blit(u3_utty* uty_u,
     } break;
 
     case c3__lin: {
-      u3_noun lin = u3t(blt);
-      c3_w    len_w = u3kb_lent(u3k(lin));
-      c3_w*   lin_w = c3_malloc( sizeof(c3_w) * len_w );
-
-      {
-        c3_w i_w;
-
-        for ( i_w = 0; u3_nul != lin; i_w++, lin = u3t(lin) ) {
-          lin_w[i_w] = u3r_word(0, u3h(lin));
-        }
-      }
-
       if ( c3n == u3_Host.ops_u.tem ) {
         _term_it_show_clear(uty_u);
-        _term_it_show_line(uty_u, lin_w, len_w, 0);
-      } else {
-        _term_it_show_line(uty_u, lin_w, len_w, 0);
       }
+      _term_it_show_tour(uty_u, u3k(u3t(blt)));
     } break;
 
     case c3__mor: {

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -439,24 +439,28 @@ _term_it_show_blank(u3_utty* uty_u)
 static void
 _term_it_show_cursor(u3_utty* uty_u, c3_w cur_w)
 {
+  c3_w cus_w = uty_u->tat_u.mir.cus_w;
+  c3_w dif_w;
+
   //NOTE  assumes all styled text precedes the cursor. drum enforces this.
   //
-  cur_w = cur_w + uty_u->tat_u.mir.sap_w;
+  cur_w += uty_u->tat_u.mir.sap_w;
 
-  if ( cur_w < uty_u->tat_u.mir.cus_w ) {
-    c3_w dif_w = (uty_u->tat_u.mir.cus_w - cur_w);
+  if ( cur_w < cus_w ) {
+    dif_w = cus_w - cur_w;
 
     while ( dif_w-- ) {
       _term_it_dump_buf(uty_u, &uty_u->ufo_u.out.cub1_u);
     }
   }
-  else if ( cur_w > uty_u->tat_u.mir.cus_w ) {
-    c3_w dif_w = (cur_w - uty_u->tat_u.mir.cus_w);
+  else if ( cur_w > cus_w ) {
+    dif_w = cur_w - cus_w;
 
     while ( dif_w-- ) {
       _term_it_dump_buf(uty_u, &uty_u->ufo_u.out.cuf1_u);
     }
   }
+
   uty_u->tat_u.mir.cus_w = cur_w;
 }
 

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -15,6 +15,9 @@
 
 //  macros for string literal args/buffers
 //
+//    since (sizeof(s) - 1) is used for vector length, parameters
+//    must be appropriately typed. use with care!
+//
 #define TERM_LIT(s)      sizeof(s) - 1, (const c3_y*)(s)
 #define TERM_LIT_BUF(s)  uv_buf_init(s, sizeof(s) - 1)
 
@@ -150,7 +153,8 @@ u3_term_log_init(void)
 
     //  configure output escape sequences
     //
-    //    (as reported by the terminfo database we bundled)
+    //    our requirements are minimal here, so we bypass terminfo
+    //    and simply use constant sequences.
     //
     {
       uty_u->ufo_u.out.clear_u = TERM_LIT_BUF("\033[H\033[2J");
@@ -380,6 +384,15 @@ _term_it_write(u3_utty*  uty_u,
   }
 }
 
+/* _term_it_dump_buf(): write static buffer.
+*/
+static void
+_term_it_dump_buf(u3_utty*  uty_u,
+                  uv_buf_t* buf_u)
+{
+  _term_it_write(uty_u, buf_u, 0);
+}
+
 /* _term_it_dump(): write static vector.
 */
 static void
@@ -388,16 +401,7 @@ _term_it_dump(u3_utty*    uty_u,
               const c3_y* hun_y)
 {
   uv_buf_t buf_u = uv_buf_init((c3_c*)hun_y, len_w);
-  _term_it_write(uty_u, &buf_u, 0);
-}
-
-/* _term_it_dump_buf(): write static buffer.
-*/
-static void
-_term_it_dump_buf(u3_utty*  uty_u,
-                  uv_buf_t* buf_u)
-{
-  _term_it_write(uty_u, buf_u, 0);
+  _term_it_dump_buf(uty_u, &buf_u);
 }
 
 /* _term_it_send(): write dynamic vector, freeing pointer.
@@ -524,6 +528,7 @@ _term_it_set_line(u3_utty* uty_u,
   //  convert lin_w in-place from utf-32 to utf-8
   //
   //    (this is just a hand-translation of +tuft)
+  //    XX refactor for use here and in a jet
   //
   {
     c3_w car_w, i_w;
@@ -741,10 +746,9 @@ _term_io_suck_char(u3_utty* uty_u, c3_y cay_y)
       u3_noun huv = u3i_bytes(tat_u->fut.wid_w, tat_u->fut.syb_y);
       u3_noun wug;
 
-      // u3l_log("muck-utf8 len %d\n", tat_u->fut.len_w);
-      // u3l_log("muck-utf8 %x\n", huv);
+      //  XX  implement directly here and jet
+      //
       wug = u3do("taft", huv);
-      // u3l_log("muck-utf32 %x\n", tat_u->fut.len_w);
 
       tat_u->fut.len_w = tat_u->fut.wid_w = 0;
       _term_io_belt(uty_u, u3nt(c3__txt, wug, u3_nul));


### PR DESCRIPTION
And, hopefully, for clarity...

This code could still use lots of improvement; in particular, the output state machine seems unnecessarily complex. But I've tried to remove layers of unnecessary indirection, reallocation, measurements of statically-sized outputs, &c. I think the biggest win is the direct utf-32 to utf-8 conversation, and the most questionable change is attempting synchronous writes.

These changes are not particularly high-priority -- I'm mostly just scratching at a longstanding itch. I'd be happy to make any changes you'd like.