### PR TITLE
soto: call resetControllers on mount

### DIFF
--- a/pkg/interface/src/views/apps/dojo/app.js
+++ b/pkg/interface/src/views/apps/dojo/app.js
@@ -20,7 +20,7 @@ export default class DojoApp extends Component {
     this.store.setStateHandler(this.setState.bind(this));
 
     this.state = this.store.state;
-    this.resetControllers();
+    this.resetControllers = this.resetControllers.bind(this);
   }
 
   resetControllers() {
@@ -29,6 +29,7 @@ export default class DojoApp extends Component {
   }
 
   componentDidMount() {
+    this.resetControllers();
     const channel = new window.channel();
     this.api = new Api(this.props.ship, channel);
     this.store.api = this.api;

--- a/pkg/interface/src/views/apps/dojo/app.js
+++ b/pkg/interface/src/views/apps/dojo/app.js
@@ -20,7 +20,6 @@ export default class DojoApp extends Component {
     this.store.setStateHandler(this.setState.bind(this));
 
     this.state = this.store.state;
-    this.resetControllers = this.resetControllers.bind(this);
   }
 
   resetControllers() {


### PR DESCRIPTION
It might address #3483 but too early to tell. Try a reproduction on livenet and in this branch by navigating quickly from apps to Dojo. On livenet, you can navigate between apps fine as fast as you want; but Dojo doesn't like it if you go to it quickly in sequence after another app and doesn't initiate.

I sequence the `resetControllers()` in the onMount and explicitly state what its `this` scope is to prevent any potential issue where `resetControllers()` was called too quickly or just not processing at all (since `this` might not be bound to the component?). It seems to be more reliable this way.