### PR TITLE
vere: fixes -P sample profiling

### DIFF
--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -10,7 +10,6 @@ u3i_bytes(c3_w        a_w,
           const c3_y* b_y)
 {
   u3_noun pro;
-  u3t_on(mal_o);
 
   //  Strip trailing zeroes.
   //
@@ -40,6 +39,7 @@ u3i_bytes(c3_w        a_w,
 
   //  Allocate, fill, return.
   //
+  u3t_on(mal_o);
   {
     c3_w      len_w = (a_w + 3) >> 2;
     c3_w*     nov_w = u3a_walloc((len_w + c3_wiseof(u3a_atom)));
@@ -70,8 +70,8 @@ u3i_bytes(c3_w        a_w,
 
     pro = u3a_to_pug(u3a_outa(nov_w));
   }
-
   u3t_off(mal_o);
+
   return pro;
 }
 
@@ -82,7 +82,6 @@ u3i_words(c3_w        a_w,
           const c3_w* b_w)
 {
   u3_noun pro;
-  u3t_on(mal_o);
 
   //  Strip trailing zeroes.
   //
@@ -101,6 +100,7 @@ u3i_words(c3_w        a_w,
 
   //  Allocate, fill, return.
   //
+  u3t_on(mal_o);
   {
     c3_w*     nov_w = u3a_walloc(a_w + c3_wiseof(u3a_atom));
     u3a_atom* nov_u = (void*)nov_w;
@@ -120,8 +120,8 @@ u3i_words(c3_w        a_w,
 
     pro = u3a_to_pug(u3a_outa(nov_w));
   }
-
   u3t_off(mal_o);
+
   return pro;
 }
 
@@ -132,7 +132,6 @@ u3i_chubs(c3_w        a_w,
           const c3_d* b_d)
 {
   u3_noun pro;
-  u3t_on(mal_o);
 
   //  Strip trailing zeroes.
   //
@@ -151,6 +150,7 @@ u3i_chubs(c3_w        a_w,
 
   //  Allocate, fill, return.
   //
+  u3t_on(mal_o);
   {
     c3_w len_w = 2 * a_w;
 
@@ -192,8 +192,8 @@ u3i_chubs(c3_w        a_w,
 
     pro = u3a_to_pug(u3a_outa(nov_w));
   }
-
   u3t_off(mal_o);
+
   return pro;
 }
 

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -704,10 +704,11 @@ u3_king_commence()
   uv_timer_init(u3L, &u3K.tim_u);
 
   //  start up a "fast-compile" arvo for internal use only
-  //  (with hashboard always disabled)
+  //  (with hashboard and sample-profiling always disabled)
   //
   sag_w = u3C.wag_w;
   u3C.wag_w |= u3o_hashless;
+  u3C.wag_w &= ~u3o_debug_cpu;
 
   u3m_boot_lite();
 


### PR DESCRIPTION
... which I had broke somewhere in the lead up to `v0.10.8`, but adding "allocator" annotations to the `u3i_*()` atom allocation functions, but not accounting for their early returns.

This PR also unconditionally disables sample profiling in the king -- there's currently no way to capture the output, and it'll be easy to turn back on if we ever decide we want to and add such a mechanism.