### PR TITLE
u3: use new road-stack api in noun traversals

### DIFF
--- a/pkg/urbit/include/noun/retrieve.h
+++ b/pkg/urbit/include/noun/retrieve.h
@@ -81,9 +81,9 @@
                      u3_noun c,
                      u3_noun d);
 
-      /* u3r_mug(): MurmurHash3 on a noun.
+      /* u3r_mug(): statefully mug a noun with 31-bit murmur3.
       */
-        c3_w
+        c3_l
         u3r_mug(u3_noun veb);
 
       /* u3r_fing():

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1094,6 +1094,9 @@ _ca_take_cell(u3a_cell* old_u, u3_noun hed, u3_noun tel)
   return new;
 }
 
+/* _ca_take: stack frame for recording cell travesal
+**           (u3_none == hed) == head-frame
+*/
 typedef struct _ca_take
 {
   u3_weak hed;  //  taken head
@@ -1232,7 +1235,7 @@ _ca_take_north(u3_noun veb)
     fam_u = u3a_peek(&pil_u);
 
     do {
-      //  fam_u is a head-frame: stash copy and continue into the tail
+      //  head-frame: stash copy and continue into the tail
       //
       if ( u3_none == fam_u->hed ) {
         u3a_cell* old_u = u3a_to_ptr(fam_u->old);
@@ -1240,7 +1243,7 @@ _ca_take_north(u3_noun veb)
         pro        = _ca_take_next_north(&pil_u, old_u->tel);
         fam_u      = u3a_peek(&pil_u);
       }
-      //  fam_u is a tail-frame: copy cell and pop the stack
+      //  tail-frame: copy cell and pop the stack
       //
       else {
         u3a_cell* old_u = u3a_to_ptr(fam_u->old);
@@ -1272,7 +1275,7 @@ _ca_take_south(u3_noun veb)
     fam_u = u3a_peek(&pil_u);
 
     do {
-      //  fam_u is a head-frame: stash copy and continue into the tail
+      //  head-frame: stash copy and continue into the tail
       //
       if ( u3_none == fam_u->hed ) {
         u3a_cell* old_u = u3a_to_ptr(fam_u->old);
@@ -1280,7 +1283,7 @@ _ca_take_south(u3_noun veb)
         pro        = _ca_take_next_south(&pil_u, old_u->tel);
         fam_u      = u3a_peek(&pil_u);
       }
-      //  fam_u is a tail-frame: copy cell and pop the stack
+      //  tail-frame: copy cell and pop the stack
       //
       else {
         u3a_cell* old_u = u3a_to_ptr(fam_u->old);

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1064,7 +1064,7 @@ _ca_take_atom(u3a_atom* old_u)
   return new;
 }
 
-/* _ca_take_cell(): reallocate a cell atom off the stack.
+/* _ca_take_cell(): reallocate a cell off the stack.
 */
 static inline u3_cell
 _ca_take_cell(u3a_cell* old_u, u3_noun hed, u3_noun tel)

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -2668,59 +2668,33 @@ u3a_walk_fore(u3_noun    a,
               void     (*pat_f)(u3_atom, void*),
               c3_o     (*cel_f)(u3_noun, void*))
 {
-  //  initialize signed stack offsets (relative to N or S road)
-  //
-  c3_o nor_o = u3a_is_north(u3R);
-  c3_ys mov_ys, off_ys;
-  {
-    c3_y wis_y = c3_wiseof(u3_noun);
-    mov_ys = ( c3y == nor_o ? -wis_y : wis_y );
-    off_ys = ( c3y == nor_o ? 0 : -wis_y );
-  }
+  u3_noun*   top;
+  u3a_pile pil_u;
 
-  //  set stack root, push argument
+  //  initialize stack control; push argument
   //
-  u3_noun *top, *don;
-  {
-    don         = u3to(u3_noun, u3R->cap_p + off_ys);
-    u3R->cap_p += mov_ys;
-    top         = u3to(u3_noun, u3R->cap_p + off_ys);
-    *top        = a;
-  }
+  u3a_pile_prep(&pil_u, sizeof(u3_noun));
+  top  = u3a_push(&pil_u);
+  *top = a;
 
-  while ( top != don ) {
+  while ( c3n == u3a_pile_done(&pil_u) ) {
     //  visit an atom, then pop the stack
     //
     if ( c3y == u3a_is_atom(a) ) {
       pat_f(a, ptr_v);
-      u3R->cap_p -= mov_ys;
-      top         = u3to(u3_noun, u3R->cap_p + off_ys);
+      top = u3a_pop(&pil_u);
     }
     //  vist a cell, if c3n, pop the stack
     //
     else if ( c3n == cel_f(a, ptr_v) ) {
-      u3R->cap_p -= mov_ys;
-      top         = u3to(u3_noun, u3R->cap_p + off_ys);
-
+      top = u3a_pop(&pil_u);
     }
     //  otherwise, push the tail and continue into the head
     //
     else {
-      *top        = u3t(a);
-      u3R->cap_p += mov_ys;
-
-      if ( c3y == nor_o ) {
-        if( !(u3R->cap_p > u3R->hat_p) ) {
-          u3m_bail(c3__meme);
-        }
-      }
-      else {
-        if( !(u3R->cap_p < u3R->hat_p) ) {
-          u3m_bail(c3__meme);
-        }
-      }
-
-      top  = u3to(u3_noun, u3R->cap_p + off_ys);
+      *top = u3t(a);
+      top  = u3a_push(&pil_u);
+      u3a_pile_sane(&pil_u);
       *top = u3h(a);
     }
 
@@ -2736,48 +2710,35 @@ u3a_walk_fore_unsafe(u3_noun    a,
                      void     (*pat_f)(u3_atom, void*),
                      c3_o     (*cel_f)(u3_noun, void*))
 {
-  //  initialize signed stack offsets (relative to N or S road)
-  //
-  c3_ys mov_ys, off_ys;
-  {
-    c3_y wis_y = c3_wiseof(u3_noun);
-    c3_o nor_o = u3a_is_north(u3R);
-    mov_ys = ( c3y == nor_o ? -wis_y : wis_y );
-    off_ys = ( c3y == nor_o ? 0 : -wis_y );
-  }
+  u3_noun*   top;
+  u3a_pile pil_u;
 
-  //  set stack root, push argument
+  //  initialize stack control; push argument
   //
-  u3_noun *top, *don;
-  {
-    don         = u3to(u3_noun, u3R->cap_p + off_ys);
-    u3R->cap_p += mov_ys;
-    top         = u3to(u3_noun, u3R->cap_p + off_ys);
-    *top        = a;
-  }
+  u3a_pile_prep(&pil_u, sizeof(u3_noun));
+  top  = u3a_push(&pil_u);
+  *top = a;
 
-  while ( top != don ) {
+  while ( c3n == u3a_pile_done(&pil_u) ) {
     //  visit an atom, then pop the stack
     //
     if ( c3y == u3a_is_atom(a) ) {
       pat_f(a, ptr_v);
-      u3R->cap_p -= mov_ys;
-      top         = u3to(u3_noun, u3R->cap_p + off_ys);
+      top = u3a_pop(&pil_u);
     }
     //  vist a cell, if c3n, pop the stack
     //
     else if ( c3n == cel_f(a, ptr_v) ) {
-      u3R->cap_p -= mov_ys;
-      top         = u3to(u3_noun, u3R->cap_p + off_ys);
-
+      top = u3a_pop(&pil_u);
     }
     //  otherwise, push the tail and continue into the head
     //
     else {
-      *top        = u3t(a);
-      u3R->cap_p += mov_ys;
-      top         = u3to(u3_noun, u3R->cap_p + off_ys);
-      *top        = u3h(a);
+      *top = u3t(a);
+      //  NB: overflow check elided here
+      //
+      top  = u3a_push(&pil_u);
+      *top = u3h(a);
     }
 
     a = *top;

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -221,14 +221,14 @@ u3r_mean(u3_noun som, ...)
 
 //  stack frame for tracking noun comparison and unification
 //
-//    We're always comparing arbitrary nouns in a %none frame.
-//    When we comparing two cells, we change the none frame to
-//    a head-frame and push a new %none frame for the heads.
-//    If the heads were equal, the head-frame has the context to
-//    unify their head pointers. We then repeat with the tails,
+//    we always comparing arbitrary nouns in a none-frame.
+//    when we compare two cells, we change the none-frame to a
+//    head-frame and push a new none-frame for the heads.
+//    if the heads are equal, the head-frame has the context to
+//    unify their head pointers. we then repeat with the tails,
 //    mutatis mutandis.
 //
-//    In Hoon, this structure would be as follows:
+//    in Hoon, this structure would be:
 //
 //    $%  [%none a=* b=*]
 //        [%head a=^ b=^]
@@ -262,7 +262,7 @@ _cr_sing_push(u3a_pile* pil_u, u3_noun a, u3_noun b)
 static inline c3_o
 _cr_sing_mug(u3a_noun* a_u, u3a_noun* b_u)
 {
-  //  XX debug assertions that both mugs are 31-bit
+  //  XX add debug assertions that both mugs are 31-bit
   //  (ie, not u3a_take() relocation references)
   //
   if ( a_u->mug_w && b_u->mug_w && (a_u->mug_w != b_u->mug_w) ) {
@@ -456,7 +456,7 @@ _cr_sing_cape(u3a_pile* pil_u, u3p(u3h_root) har_p)
   return c3y;
 }
 
-/* _cr_sing(): yes if a and b are the same noun, use uni to unify
+/* _cr_sing(): unifying equality.
 */
 static c3_o
 _cr_sing(u3_noun a, u3_noun b)
@@ -550,7 +550,7 @@ _cr_sing(u3_noun a, u3_noun b)
 
     //  [ovr_s] counts comparisons, if it overflows, we've likely hit
     //  a pathological case (highly duplicated tree), so we de-duplicate
-    //  subsequent comparisons by maintaing a set of equal pairs.
+    //  subsequent comparisons by maintaining a set of equal pairs.
     //
     if ( 0 == ++ovr_s ) {
       u3p(u3h_root) har_p = u3h_new();
@@ -1543,7 +1543,7 @@ u3r_mug_cell(u3_noun hed,
   return u3r_mug_both(lus_w, biq_w);
 }
 
-/* _cr_mug: stack frame for recording cell travesal
+/* _cr_mug: stack frame for recording cell traversal
 **          !mug == head-frame
 */
 typedef struct {
@@ -1569,7 +1569,7 @@ _cr_mug_next(u3a_pile* pil_u, u3_noun veb)
 
       //  veb has already been mugged, return memoized value
       //
-      //    XX debug mode, assert 31-bit?
+      //    XX add debug assertion that mug is 31-bit?
       //
       if ( veb_u->mug_w ) {
         return (c3_l)veb_u->mug_w;
@@ -1628,7 +1628,7 @@ u3r_mug(u3_noun veb)
     fam_u = u3a_peek(&pil_u);
 
     do {
-      //  fam_u is a head-frame: stash mug and continue into the tail
+      //  head-frame: stash mug and continue into the tail
       //
       if ( !fam_u->mug_l ) {
         u3a_cell* cel_u = u3a_to_ptr(fam_u->cel);
@@ -1637,7 +1637,7 @@ u3r_mug(u3_noun veb)
         mug_l        = _cr_mug_next(&pil_u, cel_u->tel);
         fam_u        = u3a_peek(&pil_u);
       }
-      //  fam_u is a tail-frame: calculate/memoize cell mug and pop the stack
+      //  tail-frame: calculate/memoize cell mug and pop the stack
       //
       else {
         u3a_cell* cel_u = u3a_to_ptr(fam_u->cel);

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -221,12 +221,12 @@ u3r_mean(u3_noun som, ...)
 
 //  stack frame for tracking noun comparison and unification
 //
-//    we always comparing arbitrary nouns in a none-frame.
-//    when we compare two cells, we change the none-frame to a
-//    head-frame and push a new none-frame for the heads.
-//    if the heads are equal, the head-frame has the context to
-//    unify their head pointers. we then repeat with the tails,
-//    mutatis mutandis.
+//    we always compare arbitrary nouns in a none-frame.
+//    when we compare two cells, we change the none-frame to a head-frame
+//    and push a new none-frame for their heads. if the heads are equal,
+//    we get the cells from the head-frame and unify their head pointers.
+//    then, we convert the head-frame to a tail-frame and repeat with
+//    the tails, mutatis mutandis.
 //
 //    in Hoon, this structure would be:
 //

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -597,7 +597,7 @@ u3s_cue(u3_atom a)
   //  wid:   bitwidth read to produce [pro]
   //  fam_u: stack frame
   //  har_p: backreference table
-  //  pil_u: stack control structur
+  //  pil_u: stack control structure
   //
   u3_noun         pro;
   u3_atom    wid, cur = 0;
@@ -619,7 +619,7 @@ u3s_cue(u3_atom a)
     fam_u = u3a_peek(&pil_u);
 
     do {
-      //  fam_u is a head-frame: stash [pro] and [wid]; continue into the tail
+      //  head-frame: stash [pro] and [wid]; continue into the tail
       //
       if ( u3_none == fam_u->hed ) {
         //  NB: fam_u->wid unused in head-frame
@@ -635,8 +635,7 @@ u3s_cue(u3_atom a)
 
         fam_u = u3a_peek(&pil_u);
       }
-      //  fam_u is a tail-frame: cons cell and save for backrefs,
-      //  recalculate [wid], and pop the stack
+      //  tail-frame: cons cell, recalculate [wid], and pop the stack
       //
       else {
         pro   = u3nc(fam_u->hed, pro);


### PR DESCRIPTION
Building on #3433, this PR refactors/rewrites our big, open-ended noun traversals (pre-order in `u3a_walk_fore/unsafe()` and `u3r_sing()`, post-order in `u3r_mug()`, `u3s_cue()`, `u3a_take()`).

Their manual stack fiddling (and road-direction abstraction) have been replaced with the new road-stack API, and the post-order traversals use two functions with (do) while loops instead of labeled goto. I've also generally cleaned up and commented the implementations, and split `u3a_take()` into north/south variants (it used to work this way, but the old explicit-stack version was so big that I couldn't bring myself to duplicate it).