### PR TITLE
webchat: fix slow scrolling

### DIFF
--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -40,7 +40,8 @@
     "suncalc": "^1.8.0",
     "urbit-ob": "^5.0.0",
     "urbit-sigil-js": "^1.3.2",
-    "yup": "^0.29.3"
+    "yup": "^0.29.3",
+    "normalize-wheel": "1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import _ from 'lodash';
+import normalizeWheel from 'normalize-wheel';
 
 interface VirtualScrollerProps {
   origin: 'top' | 'bottom';
@@ -220,7 +221,8 @@ export default class VirtualScroller extends PureComponent<VirtualScrollerProps,
     if (this.props.origin === 'bottom') {
       element.addEventListener('wheel', (event) => {
         event.preventDefault();
-        element.scrollBy(0, event.deltaY * -1);
+        const normalized = normalizeWheel(event);
+        element.scrollBy(0, normalized.pixelY * -1);
         return false;
       }, { passive: false });
       window.addEventListener('keydown', this.invertedKeyHandler, { passive: false });


### PR DESCRIPTION
Fixes #3492

Most browser give deltaY as pixels on the wheel-event, Firefox gives it in lines (deltamode is 1, not 0: https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode). There are also major inconsistencies with what resolution various hardware and browser combinations fire the event, for example this bug only occurs for me on Firefox AND when using a mouse instead of a touchpad. The picture below logs a single mousescroll with that setup (with Chrome the values are the same).

<img width="444" alt="Screenshot 2020-09-16 at 19 24 24" src="https://user-images.githubusercontent.com/14286382/93366252-8ffe4080-f853-11ea-841b-0f90c9387905.png">

Now I hate adding dependencies as much as the next guy, but this library is just https://gist.github.com/akella/11574989a9f3cc9e0ad47e401c12ccaf, and solves the problem quite nicely.
