### PR TITLE
links: prevents title from being overwritten

### DIFF
--- a/pkg/interface/src/views/apps/links/components/lib/link-submit.tsx
+++ b/pkg/interface/src/views/apps/links/components/lib/link-submit.tsx
@@ -83,11 +83,11 @@ export class LinkSubmit extends Component<LinkSubmitProps, LinkSubmitState> {
         fetch(`https://noembed.com/embed?url=${linkValue}`)
         .then(response => response.json())
         .then((result) => {
-          if (result.title) {
+          if (result.title && !this.state.linkTitle) {
             this.setState({ linkTitle: result.title });
           }
         }).catch((error) => {/*noop*/});
-      } else {
+      } else if (!this.state.linkTitle) {
         this.setState({
           linkTitle: decodeURIComponent(linkValue
             .split('/')


### PR DESCRIPTION
fixes #3481

It checks late to avoid the case where the link title isn't entered, the user enters one while the oembed is fetching, and then it gets overwritten