### PR TITLE
arvo: remove test/example.udon

### DIFF
--- a/pkg/arvo/app/test/example.udon
+++ b/pkg/arvo/app/test/example.udon
@@ -1,8 +1,0 @@
-:-  ~[comments+&]
-;>
-
-# Static
-
-You can put static files in here to serve them to the web.  Actually, you can put static files anywhere in `/web` and see them in a browser.
-
-Docs on static publishing with urbit are forthcoming — but feel free to drop markdown files in `/web` to try it out.


### PR DESCRIPTION
This file dates back to the previous Eyre write; Arvo no longer has a
/web folder, so this seems fine to clean out.

(Reviewers aren't all mandatory, just people who would know if this is a bad thing to remove for whatever reason.)