### PR TITLE
ames: print failed scrys

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -756,6 +756,8 @@
           =([%$ %da now] lot)
           =(%$ syd)
       ==
+    ?.  for.veb.bug.ames-state  ~
+    ~>  %slog.0^leaf/"ames: scry-fail {<[why=why lot=lot now=now syd=syd]>}"
     ~
   ::  /ax/protocol/version           @
   ::  /ax/peers                      (map ship ?(%alien %known))


### PR DESCRIPTION
This should help us debug failing scry requests related to stateless forwarding.  `|ames-verb %for` turns on printing in the `~` case.