### PR TITLE
graph import/export generators

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -474,6 +474,20 @@
       now.bowl
     [%add-graph [ship term] `graph:store`p.u.result q.u.result]
   ::
+      ::  note: near-duplicate of /x/graph
+      ::
+      [%x %archive @ @ ~]
+    =/  =ship   (slav %p i.t.t.path)
+    =/  =term   i.t.t.t.path
+    =/  result=(unit marked-graph:store)
+      (~(get by archive) [ship term])
+    ?~  result  [~ ~]
+    :-  ~  :-  ~  :-  %graph-update
+    !>  ^-  update:store
+    :+  %0
+      now.bowl
+    [%add-graph [ship term] `graph:store`p.u.result q.u.result]
+  ::
       [%x %graph-subset @ @ @ @ ~]
     =/  =ship  (slav %p i.t.t.path)
     =/  =term  i.t.t.t.path

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -482,7 +482,9 @@
     =/  =term   i.t.t.t.path
     =/  result=(unit marked-graph:store)
       (~(get by archive) [ship term])
-    ?~  result  [~ ~]
+    ?~  result
+      ~&  no-archived-graph+[ship term]
+      [~ ~]
     :-  ~  :-  ~  :-  %graph-update
     !>  ^-  update:store
     :+  %0

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -449,6 +449,7 @@
   ^-  (unit (unit cage))
   |^
   ?>  (team:title our.bowl src.bowl)
+  ~&  path=path
   ?+  path  (on-peek:def path)
       [%x %keys ~]
     :-  ~  :-  ~  :-  %graph-update

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -449,7 +449,6 @@
   ^-  (unit (unit cage))
   |^
   ?>  (team:title our.bowl src.bowl)
-  ~&  path=path
   ?+  path  (on-peek:def path)
       [%x %keys ~]
     :-  ~  :-  ~  :-  %graph-update

--- a/pkg/arvo/gen/graph-store/export-graph.hoon
+++ b/pkg/arvo/gen/graph-store/export-graph.hoon
@@ -1,0 +1,11 @@
+/+  graph-store
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [=ship graph=term ~]
+    ==
+:-  %noun
+=/  our  (scot %p p.bec)
+=/  wen  (scot %da now)
+=/  who  (scot %p ship)
+.^(update:graph-store /gx/[our]/graph-store/[wen]/[who]/[graph])

--- a/pkg/arvo/gen/graph-store/export-graph.hoon
+++ b/pkg/arvo/gen/graph-store/export-graph.hoon
@@ -4,7 +4,7 @@
 |=  $:  [now=@da eny=@uvJ bec=beak]
         [[=ship graph=term ~] ~]
     ==
-:-  %noun
+:-  %graph-update
 =/  our  (scot %p p.bec)
 =/  wen  (scot %da now)
 =/  who  (scot %p ship)

--- a/pkg/arvo/gen/graph-store/export-graph.hoon
+++ b/pkg/arvo/gen/graph-store/export-graph.hoon
@@ -2,10 +2,13 @@
 ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [=ship graph=term ~]
+        [[=ship graph=term ~] ~]
     ==
 :-  %noun
 =/  our  (scot %p p.bec)
 =/  wen  (scot %da now)
 =/  who  (scot %p ship)
-.^(update:graph-store /gx/[our]/graph-store/[wen]/[who]/[graph])
+::
+.^  update:graph-store
+  /gx/[our]/graph-store/[wen]/archive/[who]/[graph]/graph-update
+==

--- a/pkg/arvo/gen/graph-store/import-graph.hoon
+++ b/pkg/arvo/gen/graph-store/import-graph.hoon
@@ -1,0 +1,9 @@
+/+  graph-store
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [[graph=term =path ~] ~]
+    ==
+:-  %graph-update
+=-  ~&  update=-  -
+.^(=update:graph-store %cx path)

--- a/pkg/arvo/mar/graph/update.hoon
+++ b/pkg/arvo/mar/graph/update.hoon
@@ -1,15 +1,19 @@
 /+  *graph-store
+=*  as-octs  as-octs:mimes:html
+::
 |_  upd=update
 ++  grad  %noun
 ++  grow
   |%
   ++  noun  upd
   ++  json  (update:enjs upd)
+  ++  mime  [/application/x-urb-graph-update (as-octs (jam upd))]
   --
 ::
 ++  grab
   |%
   ++  noun  update
   ++  json  update:dejs
+  ++  mime  |=([* =octs] ;;(update (cue q.octs)))
   --
 --


### PR DESCRIPTION
To export a graph:
```
+graph-store/export-graph our %graph-name
```
The output can be routed to a jammed Unix noun by using :dojo's `.file/ext` syntax.  This file can then be copied into a Unix mount of an Urbit desk, where it should be given the `.graph-update` file extension so that the Clay file has the right mark.

To import a graph from a Clay file:
```
:graph-store|import-graph %new-graph-name %/full/path/to/graph-update
```