### PR TITLE
vere: fix typo in secp reco jet

### DIFF
--- a/pkg/urbit/jets/e/secp.c
+++ b/pkg/urbit/jets/e/secp.c
@@ -207,7 +207,7 @@ u3qe_reco(u3_atom has,
   ret = secp256k1_ecdsa_recover(ctx_u,                      /* IN: context */
                                 & puk_u,                     /* OUT: pub key */
                                 & sig_u,                        /* IN: signature */
-                                (const c3_y *) & has);        /* IN: message has */
+                                has_y);                       /* IN: message has */
 
   if (1 != ret) {
     u3l_log("\rsecp jet: crypto package error\n");


### PR DESCRIPTION
ecdsa-raw-recover had an erroneous jet. This commit fixes the critical
error so that the jet returns the right result according to the secp
secp256k1 spec, although it still does not match the hoon. The hoon is
subtly wrong, and will be addressed in a future commit.