### PR TITLE
arvo: accept embedded nulls in to-wain:format

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5334,21 +5334,23 @@
   ::                                                    ::::
 ++  format  ^?
   |%
-  ::                                                    ::  ++to-wain:format
-  ++  to-wain                                           ::  atom to line list
+  ::  0 ending a line (invalid @t) is not preserved     ::  ++to-wain:format
+  ++  to-wain                                           ::  @t to line list
     ~%  %leer  ..is  ~
-    |=  txt=@
+    |=  txt=@t
     =/  len=@  (met 3 txt)
+    =/  cut  =+(cut -(a 3, c 1, d txt))
+    =/  sub  sub
     =|  [i=@ out=(list @t)]
     |-  ^+  out
     =+  |-  ^-  j=@
         ?:  ?|  =(i len)
-                =(10 (cut 3 [i 1] txt))
+                =(10 (cut(b i)))
             ==
           i
         $(i +(i))
     =.  out  :_  out
-      (cut 3 [i (sub j i)] txt)
+      (cut(b i, c (sub j i)))
     ?:  =(j len)
       (flop out)
     $(i +(j))

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5336,23 +5336,22 @@
   |%
   ::                                                    ::  ++to-wain:format
   ++  to-wain                                           ::  atom to line list
-    ~%  %lore  ..is  ~
-    |=  lub/@
-    =|  tez/(list @t)
-    |-  ^+  tez
-    =+  ^=  wor
-      =+  [meg=0 i=0]
-      |-  ^-  {meg/@ i/@ end/@f}
-      =+  gam=(cut 3 [i 1] lub)
-      ?:  =(0 gam)
-        [meg i %.y]
-      ?:  =(10 gam)
-        [meg i %.n]
-      $(meg (cat 3 meg gam), i +(i))
-    ?:  end.wor
-      (flop ^+(tez [meg.wor tez]))
-    ?:  =(0 lub)  (flop tez)
-    $(lub (rsh 3 +(i.wor) lub), tez [meg.wor tez])
+    ~%  %leer  ..is  ~
+    |=  txt=@
+    =/  len=@  (met 3 txt)
+    =|  [i=@ out=(list @t)]
+    |-  ^+  out
+    =+  |-  ^-  j=@
+        ?:  ?|  =(i len)
+                =(10 (cut 3 [i 1] txt))
+            ==
+          i
+        $(i +(i))
+    =.  out  :_  out
+      (cut 3 [i (sub j i)] txt)
+    ?:  =(j len)
+      (flop out)
+    $(i +(j))
   ::                                                    ::  ++of-wain:format
   ++  of-wain                                           ::  line list to atom
     |=  tez/(list @t)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5335,13 +5335,14 @@
 ++  format  ^?
   |%
   ::  0 ending a line (invalid @t) is not preserved     ::  ++to-wain:format
-  ++  to-wain                                           ::  @t to line list
+  ++  to-wain                                           ::  cord to line list
     ~%  %leer  ..is  ~
-    |=  txt=@t
+    |=  txt=cord
+    ^-  wain
     =/  len=@  (met 3 txt)
     =/  cut  =+(cut -(a 3, c 1, d txt))
     =/  sub  sub
-    =|  [i=@ out=(list @t)]
+    =|  [i=@ out=wain]
     |-  ^+  out
     =+  |-  ^-  j=@
         ?:  ?|  =(i len)
@@ -5355,8 +5356,8 @@
       (flop out)
     $(i +(j))
   ::                                                    ::  ++of-wain:format
-  ++  of-wain                                           ::  line list to atom
-    |=  tez/(list @t)
+  ++  of-wain                                           ::  line list to cord
+    |=  tez=wain  ^-  cord
     (rap 3 (join '\0a' tez))
   ::                                                    ::  ++of-wall:format
   ++  of-wall                                           ::  line list to tape


### PR DESCRIPTION
This PR includes the hoon changes from #3180, which has the context and previous discussion. The vere changes are in #3523.

For the best user experience (ie, performance), these changes should not be released OTA until the vere changes have been released, and users have had time to upgrade. As a result, ie, since its target is a moving target, this PR doesn't (yet) include pills.