### PR TITLE
publish: correct timestamps on note navigation

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/lib/NoteNavigation.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/NoteNavigation.tsx
@@ -10,7 +10,7 @@ function NavigationItem(props: {
   date: number;
   prev?: boolean;
 }) {
-  const date = moment(date).fromNow();
+  const date = moment(props.date).fromNow();
   return (
     <Box
       justifySelf={props.prev ? "start" : "end"}


### PR DESCRIPTION
Addresses #3489.

Because we didn't access `date` through the function's `props` it was `undefined`; moment, too shy to say anything, just decided to use the timestamp for *right this second* instead.