### PR TITLE
various: s3 dragger uses indigo-react

### DIFF
--- a/pkg/interface/src/views/components/s3-upload.tsx
+++ b/pkg/interface/src/views/components/s3-upload.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Icon } from "@tlon/indigo-react";
+import { Box, Text, Icon } from "@tlon/indigo-react";
 
 import S3Client from '~/logic/lib/s3';
 import { Spinner } from './Spinner';
@@ -7,10 +7,24 @@ import { S3Credentials, S3Configuration } from '~/types';
 import { dateToDa, deSig } from '~/logic/lib/util';
 
 export const SubmitDragger = () => (
-  <div
-    className="top-0 bottom-0 left-0 right-0 absolute bg-gray5 h-100 w-100 flex items-center justify-center z-999"
-    style={{pointerEvents: 'none'}}
-  >Drop a file to upload</div>
+  <Box
+    top='0'
+    bottom='0'
+    left='0'
+    right='0'
+    position='absolute'
+    backgroundColor='white'
+    height='100%'
+    width='100%'
+    display='flex'
+    alignItems='center'
+    justifyContent='center'
+    style={{ pointerEvents: 'none', zIndex: 999 }}
+  >
+      <Text fontSize='1' color='black'>
+        Drop a file to upload
+      </Text>
+    </Box>
 );
 
 interface S3UploadProps {
@@ -116,7 +130,7 @@ export class S3Upload extends Component<S3UploadProps, S3UploadState> {
       accept = '*',
       children = false
     } = this.props;
-    
+
     if (!this.isReady(credentials, configuration)) {
       return null;
     }


### PR DESCRIPTION
The dragger overlay doesn't have dark mode styles; this rewrites the component in indigo-react so that its colour scheme changes to match.

cc @urcades — anything we need to distinguish this further?

<img width="904" alt="Screenshot 2020-09-18 at 10 08 00 PM" src="https://user-images.githubusercontent.com/20846414/93656996-97148280-f9fc-11ea-8b9a-2c54c0ba8b90.png">
