### PR TITLE
publish: fixed error on notebook refresh

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/lib/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/Notebook.tsx
@@ -59,8 +59,10 @@ export class Notebook extends PureComponent<NotebookProps & RouteComponentProps,
   render() {
     const { api, ship, book, notebook, notebookContacts, groups, history, hideNicknames, associations } = this.props;
 
-    const contact = notebookContacts[ship];
     const group = groups[notebook?.["writers-group-path"]];
+    if (!group) return null; // Waitin on groups to populate
+
+    const contact = notebookContacts[ship];
     const role = group ? roleForShip(group, window.ship) : undefined;
     const isOwn = `~${window.ship}` === ship;
     const isAdmin = role === "admin" || isOwn;


### PR DESCRIPTION
fixed #3506

This isn't a very glamorous fix, but it seems to work. Is there a reason a notebook wouldn't have a group? Even if it's unmanaged, the proper path exists in the group object. If I do a check for group later on, then I get `this.props.notebook is undefined` in `Subscribers.tsx` — maybe this need someone more familiar with the architecture, but the problem is definitely there.