### PR TITLE
chat: sort message by number instead of timestamp

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
@@ -228,7 +228,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     let lastMessage = 0;
     
     [...envelopes]
-      .sort((a, b) => a.when - b.when)
+      .sort((a, b) => a.number - b.number)
       .forEach(message => {
         messages.set(message.number, message);
         lastMessage = message.number;


### PR DESCRIPTION
fixes #3534

This is correct behavior.
May cause issues with some people who have messages stored out of order on their computer.
Leaving and rejoining the channel should fix it for them.