### PR TITLE
update/rewrite secp256k1 hoon code

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a528385ae211229e195dd5dc393a18d9a8fbcac41d0b9c8be8c5066c922e99b
-size 6279613
+oid sha256:270136cee93188fd0f27ddc74fb6aa827f4026410651d6d13270454e0243ba0d
+size 6268618

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06808af2c089441d2cb497fc95e3292b6229b3dfa034272d46c7c41f34eb6a3b
-size 6268465
+oid sha256:3a528385ae211229e195dd5dc393a18d9a8fbcac41d0b9c8be8c5066c922e99b
+size 6279613

--- a/pkg/arvo/lib/bip32.hoon
+++ b/pkg/arvo/lib/bip32.hoon
@@ -16,7 +16,7 @@
 ::  dep:  depth in chain
 ::  ind:  index at depth
 ::  pif:  parent fingerprint (4 bytes)
-|_  [prv=@ pub=pont cad=@ dep=@ud ind=@ud pif=@]
+|_  [prv=@ pub=point.ecc cad=@ dep=@ud ind=@ud pif=@]
 ::
 +=  keyc  [key=@ cai=@]  ::  prv/pub key + chain code
 ::
@@ -26,7 +26,7 @@
 ::
 ++  ser-p  compress-point.ecc
 ::
-++  n      ^n:ecc
+++  n      n:t.ecc
 ::
 ::  core initialization
 ::
@@ -46,7 +46,7 @@
   +>(pub (decompress-point.ecc key), cad cai)
 ::
 ++  from-public-point
-  |=  [pon=pont cai=@]
+  |=  [pon=point.ecc cai=@]
   +>(pub pon, cad cai)
 ::
 ++  from-extended
@@ -150,7 +150,7 @@
   ::  rare exception, invalid key, go to the next one
   ?:  (gte left n)  $(i +(i))  ::TODO  or child key is "point at infinity"
   %_  +>.$
-    pub   (jc-add.ecc (point left) pub)
+    pub   (add-points.ecc (point left) pub)
     cad   right
     dep   +(dep)
     ind   i

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4325,6 +4325,10 @@
           (into.j p)
         scalar
       ::
+      ++  valid-hash
+        |=  has=@
+        (lte (met 3 has) bytes)
+      ::
       ++  in-order
         |=  i=@
         ?&  (gth i 0)
@@ -4340,7 +4344,7 @@
         |=  [hash=@ private-key=@]
         ^-  @
         ?>  (in-order private-key)
-        ::  hash is truncated to bytes
+        ?>  (valid-hash hash)
         =/  v  (fil 3 bytes 1)
         =/  k  0
         =.  k  %+  hmc  [bytes k]
@@ -4366,6 +4370,7 @@
       ++  ecdsa-raw-sign
         |=  [hash=@ private-key=@]
         ^-  [r=@ s=@ y=@]
+        ::  make-k and priv-to pub will validate inputs
         =/  k   (make-k hash private-key)
         =/  rp  (priv-to-pub k)
         =*  r   x.rp
@@ -4401,9 +4406,11 @@
       ++  make-k
         ~/  %make
         |=  [hash=@uvI private-key=@]
+        ::  checks sizes
         (make-k:curve hash private-key)
       ++  priv-to-pub
         |=  private-key=@
+        ::  checks sizes
         (priv-to-pub:curve private-key)
       ::
       ++  ecdsa-raw-sign
@@ -4411,6 +4418,7 @@
         |=  [hash=@uvI private-key=@]
         ^-  [v=@ r=@ s=@]
         =/  c  curve
+        ::  raw-sign checks sizes
         =+  (ecdsa-raw-sign.c hash private-key)
         =/  rp=point  [r y]
         =/  s-high  (gte (mul 2 s) n.domain.c)
@@ -4429,7 +4437,7 @@
         ^-  point
         ?>  (lte v.sig 3)
         =/  c   curve
-        ?>  (in-order.c hash)
+        ?>  (valid-hash.c hash)
         ?>  (in-order.c r.sig)
         ?>  (in-order.c s.sig)
         =/  x  ?:  (gte v.sig 2)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4180,6 +4180,280 @@
   ::                                                    ::
   ::::                    ++secp:crypto                 ::  (2b9) secp family
     ::                                                  ::::
+  ++  new-secp  !.
+    ::  TODO: as-octs and hmc are outside of jet parent
+    =>  :+  hmc=hmac-sha256l:hmac:crypto
+          as-octs=as-octs:mimes:html
+        ..is
+    ~%  %secp  ..is  ~
+    |%
+    +=  jacobian   [x=@ y=@ z=@]                    ::  jacobian point
+    +=  point      [x=@ y=@]                        ::  curve point
+    +=  domain
+      $:  p=@                                       ::  prime modulo
+          a=@                                       ::  y^2=x^3+ax+b
+          b=@                                       ::
+          g=point                                   ::  base point
+          n=@                                       ::  prime order of g
+      ==
+    ++  secp
+      |_  [bytes=@ =domain]
+      ++  field-p  ~(. fo p.domain)
+      ++  field-n  ~(. fo n.domain)
+      ++  compress-point
+        |=  =point
+        ^-  @
+        %+  can  3
+        :~  [bytes x.point]
+            [1 (add 2 (cut 0 [0 1] y.point))]
+        ==
+      ::
+      ++  serialize-point
+        |=  =point
+        ^-  @
+        %+  can  3
+        :~  [bytes y.point]
+            [bytes x.point]
+            [1 4]
+        ==
+      ::
+      ++  decompress-point
+        |=  compressed=@
+        ^-  point
+        =/  x=@  (end 3 bytes compressed)
+        ?>  =(3 (mod p.domain 4))
+        =/  fop  field-p
+        =+  [fadd fmul fpow]=[sum.fop pro.fop exp.fop]
+        =/  y=@  %+  fpow  (rsh 0 2 +(p.domain))
+                 %+  fadd  b.domain
+                 %+  fadd  (fpow 3 x)
+                (fmul a.domain x)
+        =/  s=@  (rsh 3 bytes compressed)
+        ~|  [`@ux`s `@ux`compressed]
+        ?>  |(=(2 s) =(3 s))
+        ::  check parity
+        ::
+        =?  y  !=((sub s 2) (mod y 2))
+          (sub p.domain y)
+        [x y]
+      ::
+      ++  jc                                        ::  jacobian math
+        |%
+        ++  from
+          |=  a=jacobian
+          ^-  point
+          =/  fop   field-p
+          =+  [fmul fpow finv]=[pro.fop exp.fop inv.fop]
+          =/  z  (finv z.a)
+          :-  (fmul x.a (fpow 2 z))
+          (fmul y.a (fpow 3 z))
+        ::
+        ++  into
+          |=  point
+          ^-  jacobian
+          [x y 1]
+        ::
+        ++  double
+          |=  jacobian
+          ^-  jacobian
+          ?:  =(0 y)  [0 0 0]
+          =/  fop  field-p
+          =+  [fadd fsub fmul fpow]=[sum.fop dif.fop pro.fop exp.fop]
+          =/  s    :(fmul 4 x (fpow 2 y))
+          =/  m    %+  fadd
+                     (fmul 3 (fpow 2 x))
+                   (fmul a.domain (fpow 4 z))
+          =/  nx   %+  fsub
+                     (fpow 2 m)
+                   (fmul 2 s)
+          =/  ny  %+  fsub
+                    (fmul m (fsub s nx))
+                  (fmul 8 (fpow 4 y))
+          =/  nz  :(fmul 2 y z)
+          [nx ny nz]
+        ::
+        ++  add
+          |=  [a=jacobian b=jacobian]
+          ^-  jacobian
+          ?:  =(0 y.a)  b
+          ?:  =(0 y.b)  a
+          =/  fop  field-p
+          =+  [fadd fsub fmul fpow]=[sum.fop dif.fop pro.fop exp.fop]
+          =/  u1  :(fmul x.a z.b z.b)
+          =/  u2  :(fmul x.b z.a z.a)
+          =/  s1  :(fmul y.a z.b z.b z.b)
+          =/  s2  :(fmul y.b z.a z.a z.a)
+          ?:  =(u1 u2)
+            ?.  =(s1 s2)
+              [0 0 1]
+            (double a)
+          =/  h     (fsub u2 u1)
+          =/  r     (fsub s2 s1)
+          =/  h2    (fmul h h)
+          =/  h3    (fmul h2 h)
+          =/  u1h2  (fmul u1 h2)
+          =/  nx    %+  fsub
+                      (fmul r r)
+                    :(fadd h3 u1h2 u1h2)
+          =/  ny    %+  fsub
+                      (fmul r (fsub u1h2 nx))
+                    (fmul s1 h3)
+          =/  nz    :(fmul h z.a z.b)
+          [nx ny nz]
+        ::
+        ++  mul
+          |=  [a=jacobian scalar=@]
+          ^-  jacobian
+          ?:  =(0 y.a)
+            [0 0 1]
+          ?:  =(0 scalar)
+            [0 0 1]
+          ?:  =(1 scalar)
+            a
+          ?:  (gte scalar n.domain)
+            $(scalar (mod scalar n.domain))
+          ?:  =(0 (mod scalar 2))
+            (double $(scalar (rsh 0 1 scalar)))
+          (add a (double $(scalar (rsh 0 1 scalar))))
+        --
+      ++  mul-point-scalar
+        |=  [p=point scalar=@]
+        ^-  point
+        =/  j  jc
+        %-  from.j
+        %+  mul.j
+          (into.j p)
+        scalar
+      ::
+      ++  in-order
+        |=  i=@
+        ?&  (gth i 0)
+            (lth i n.domain)
+        ==
+      ++  priv-to-pub
+        |=  private-key=@
+        ^-  point
+        ?>  (in-order private-key)
+        (mul-point-scalar g.domain private-key)
+      ::
+      ++  make-k
+        |=  [hash=@ private-key=@]
+        ^-  @
+        ?>  (in-order private-key)
+        ::  hash is truncated to bytes
+        =/  v  (fil 3 bytes 1)
+        =/  k  0
+        =.  k  %+  hmc  [bytes k]
+               %-  as-octs
+               %+  can  3
+               :~  [bytes hash]
+                   [bytes private-key]
+                   [1 0]
+                   [bytes v]
+               ==
+        =.  v  (hmc bytes^k bytes^v)
+        =.  k  %+  hmc  [bytes k]
+               %-  as-octs
+               %+  can  3
+               :~  [bytes hash]
+                   [bytes private-key]
+                   [1 1]
+                   [bytes v]
+               ==
+        =.  v  (hmc bytes^k bytes^v)
+        (hmc bytes^k bytes^v)
+      ::
+      ++  ecdsa-raw-sign
+        |=  [hash=@ private-key=@]
+        ^-  [r=@ s=@ y=@]
+        =/  k   (make-k hash private-key)
+        =/  rp  (priv-to-pub k)
+        =*  r   x.rp
+        ?<  =(0 r)
+        =/  fon  field-n
+        =+  [fadd fmul finv]=[sum.fon pro.fon inv.fon]
+        =/  s  %+  fmul  (finv k)
+               %+  fadd  hash
+               %+  fmul  r
+               private-key
+        ?<  =(0 s)
+        [r s y.rp]
+      ::  general recovery omitted, but possible
+      --
+    ++  secp256k1
+      ~%  %secp256k1  +  ~
+      |%
+      ++  t  :: in the battery for jet matching
+        ^-  domain
+        :*  0xffff.ffff.ffff.ffff.ffff.ffff.ffff.ffff.
+            ffff.ffff.ffff.ffff.ffff.fffe.ffff.fc2f
+            0
+            7
+            :-  0x79be.667e.f9dc.bbac.55a0.6295.ce87.0b07.
+                  029b.fcdb.2dce.28d9.59f2.815b.16f8.1798
+                0x483a.da77.26a3.c465.5da4.fbfc.0e11.08a8.
+                  fd17.b448.a685.5419.9c47.d08f.fb10.d4b8
+            0xffff.ffff.ffff.ffff.ffff.ffff.ffff.fffe.
+              baae.dce6.af48.a03b.bfd2.5e8c.d036.4141
+        ==
+      ::
+      ++  curve  ~(. secp 32 t)
+      ++  make-k
+        ~/  %make
+        |=  [hash=@uvI private-key=@]
+        (make-k:curve hash private-key)
+      ++  priv-to-pub
+        |=  private-key=@
+        (priv-to-pub:curve private-key)
+      ::
+      ++  ecdsa-raw-sign
+        ~/  %sign
+        |=  [hash=@uvI private-key=@]
+        ^-  [v=@ r=@ s=@]
+        =/  c  curve
+        =+  (ecdsa-raw-sign.c hash private-key)
+        =/  rp=point  [r y]
+        =/  s-high  (gte (mul 2 s) n.domain.c)
+        =?  s   s-high
+          (sub n.domain.c s)
+        =?  rp  s-high
+          [x.rp (sub p.domain.c y.rp)]
+        =/  v   (end 0 1 y.rp)
+        =?  v   (gte x.rp n.domain.c)
+          (add v 2)
+        [v x.rp s]
+      ::
+      ++  ecdsa-raw-recover
+        ~/  %reco
+        |=  [hash=@ sig=[v=@ r=@ s=@]]
+        ^-  point
+        ?>  (lte v.sig 3)
+        =/  c   curve
+        ?>  (in-order.c hash)
+        ?>  (in-order.c r.sig)
+        ?>  (in-order.c s.sig)
+        =/  x  ?:  (gte v.sig 2)
+                 (add r.sig n.domain.c)
+               r.sig
+        =/  fop  field-p.c
+        =+  [fadd fmul fpow]=[sum.fop pro.fop exp.fop]
+        =/  ysq   (fadd (fpow 3 x) b.domain.c)
+        =/  beta  (fpow (rsh 0 2 +(p.domain.c)) ysq)
+        =/  y  ?:  =((end 0 1 v.sig) (end 0 1 beta))
+                 beta
+               (sub p.domain.c beta)
+        ?>  =(0 (dif.fop ysq (fmul y y)))
+        =/  nz   (sub n.domain.c hash)
+        =/  j    jc.c
+        =/  gz   (mul.j (into.j g.domain.c) nz)
+        =/  xy   (mul.j (into.j x y) s.sig)
+        =/  qr   (add.j gz xy)
+        =/  qj   (mul.j qr (inv:field-n.c x))
+        =/  pub  (from.j qj)
+        ?<  =([0 0] pub)
+        pub
+      --
+    --
   ++  secp
     ~%  %secp  ..is  ~
     |%

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4180,7 +4180,7 @@
   ::                                                    ::
   ::::                    ++secp:crypto                 ::  (2b9) secp family
     ::                                                  ::::
-  ++  new-secp  !.
+  ++  secp  !.
     ::  TODO: as-octs and hmc are outside of jet parent
     =>  :+  ..is
           hmc=hmac-sha256l:hmac:crypto
@@ -4316,6 +4316,11 @@
             (double $(scalar (rsh 0 1 scalar)))
           (add a (double $(scalar (rsh 0 1 scalar))))
         --
+      ++  add-points
+        |=  [a=point b=point]
+        ^-  point
+        =/  j  jc
+        (from.j (add.j (into.j a) (into.j b)))
       ++  mul-point-scalar
         |=  [p=point scalar=@]
         ^-  point
@@ -4402,7 +4407,12 @@
               baae.dce6.af48.a03b.bfd2.5e8c.d036.4141
         ==
       ::
-      ++  curve  ~(. secp 32 t)
+      ++  curve             ~(. secp 32 t)
+      ++  serialize-point   serialize-point:curve
+      ++  compress-point    compress-point:curve
+      ++  decompress-point  decompress-point:curve
+      ++  add-points        add-points:curve
+      ++  mul-point-scalar  mul-point-scalar:curve
       ++  make-k
         ~/  %make
         |=  [hash=@uvI private-key=@]
@@ -4460,187 +4470,6 @@
         =/  pub  (from.j qj)
         ?<  =([0 0] pub)
         pub
-      --
-    --
-  ++  secp
-    ~%  %secp  ..is  ~
-    |%
-    +=  jaco  [x=@ y=@ z=@]                             ::  jacobian point
-    +=  pont  [x=@ y=@]                                 ::  curve point
-    ::
-    ++  secp256k1
-      %+  secp  32
-      :*  p=0xffff.ffff.ffff.ffff.ffff.ffff.ffff.ffff.  ::  modulo
-              ffff.ffff.ffff.ffff.ffff.fffe.ffff.fc2f
-          a=0                                           ::  y^2=x^3+ax+b
-          b=7
-          ^=  g                                         ::  "prime" point
-          :*  x=0x79be.667e.f9dc.bbac.55a0.6295.ce87.0b07.
-                  029b.fcdb.2dce.28d9.59f2.815b.16f8.1798
-              y=0x483a.da77.26a3.c465.5da4.fbfc.0e11.08a8.
-                  fd17.b448.a685.5419.9c47.d08f.fb10.d4b8
-          ==
-          n=0xffff.ffff.ffff.ffff.ffff.ffff.ffff.fffe.  ::  prime order of g
-              baae.dce6.af48.a03b.bfd2.5e8c.d036.4141
-      ==
-    ::
-    ++  secp
-      ~/  %secp
-      |=  [w=@ p=@ a=@ b=@ g=pont n=@]  :: being passed in from above
-      =/  p  ~(. fo p)
-      =/  n  ~(. fo n)
-      ~%  %helper  ..$  ~
-      |%
-      ++  compress-point
-        ~/  %compress-point
-        |=  pont
-        ^-  @
-        (can 3 ~[w^x 1^(add 0x2 (cut 0 [0 1] y))])
-      ::
-      ++  serialize-point
-        ~/  %serialize-point
-        |=  pont
-        ^-  @
-        (can 3 ~[w^y w^x 1^0x4])
-      ::
-      ++  decompress-point
-        ~/  %decompress-point
-        |=  dat=@
-        ^-  pont
-        =+  x=(end 3 w a)
-        =+  y=:(add (pow x 3) (mul a x) b)
-        =+  s=(rsh 3 32 dat)
-        :-  x
-        ?:  =(0x2 s)  y
-        ?:  =(0x3 s)  y
-        ~|  [`@ux`s `@ux`dat]
-        !!
-      ::
-      ++  priv-to-pub                                   ::  get pub from priv
-        ~/  %priv-to-pub
-        |=  prv=@
-        ^-  pont
-        (jc-mul g prv)
-      ::
-      ++  make-k                                        ::  deterministic nonce
-        ~/  %make-k
-        =,  mimes:html
-        |=  [has=@uvI prv=@]
-        ^-  @
-        =*  hmc  hmac-sha256l:hmac
-        =/  v  (fil 3 w 1)
-        =/  k  0
-        =.  k  (hmc w^k (as-octs (can 3 [w has] [w prv] [1 0x0] [w v] ~)))
-        =.  v  (hmc w^k w^v)
-        =.  k  (hmc w^k (as-octs (can 3 [w has] [w prv] [1 0x1] [w v] ~)))
-        =.  v  (hmc w^k w^v)
-        (hmc w^k w^v)
-      ::
-      ++  ecdsa-raw-sign                                ::  generate signature
-        ~/  %ecdsa-raw-sign
-        |=  [has=@uvI prv=@]
-        ^-  [v=@ r=@ s=@]
-        =/  z  has
-        =/  k  (make-k has prv)
-        =+  [r y]=(jc-mul g k)
-        =/  s  (pro.n `@`(inv.n k) `@`(sum.n z (mul r prv)))
-        =/  big-s  (gte (mul 2 s) ^n)
-        :*  v=(mix (end 0 1 y) ?:(big-s 1 0))
-            r=r
-            s=?.(big-s s (sub ^n s))
-        ==
-      ::
-      ++  ecdsa-raw-recover                             ::  get pubkey from sig
-        ~/  %ecdsa-raw-recover
-        |=  [has=@uvI sig=[v=@ r=@ s=@]]
-        ^-  pont
-        ?>  (lte v.sig 7)
-        =/  x  r.sig
-        =/  ysq  (sum.p b (exp.p 3 x))               ::  omits A=0
-        =/  bet  (exp.p (div +(^p) 4) ysq)
-        =/  y  ?:(=(1 (end 0 1 (mix v.sig bet))) bet (dif.p 0 bet))
-        ?>  =(0 (dif.p ysq (pro.p y y)))
-        ?<  =(0 (sit.n r.sig))
-        ?<  =(0 (sit.n s.sig))
-        =/  gz  (mul:jc [x y 1]:g (dif.n 0 has))
-        =/  xy  (mul:jc [x y 1] s.sig)
-        =/  qr  (add:jc gz xy)
-        (from:jc (mul:jc qr (inv.n r.sig)))
-      ::
-      ++  jc-mul                                        ::  point x scalar
-        |=  [a=pont n=@]
-        ^-  pont
-        (from:jc (mul:jc (into:jc a) n))
-      ::
-      ++  jc-add                                        ::  add points
-        |=  [a=pont b=pont]
-        ^-  pont
-        (from:jc (add:jc (into:jc a) (into:jc b)))
-      ::
-      ++  jc                                            ::  jacobian core
-        |%
-        ++  add                                         ::  addition
-          |=  [a=jaco b=jaco]
-          ^-  jaco
-          ?:  =(0 y.a)  b
-          ?:  =(0 y.b)  a
-          =/  u1  :(pro.p x.a z.b z.b)
-          =/  u2  :(pro.p x.b z.a z.a)
-          =/  s1  :(pro.p y.a z.b z.b z.b)
-          =/  s2  :(pro.p y.b z.a z.a z.a)
-          ?:  =(u1 u2)
-            ?.  =(s1 s2)
-              [0 0 1]
-            (dub a)
-          =/  h  (dif.p u2 u1)
-          =/  r  (dif.p s2 s1)
-          =/  h2  (pro.p h h)
-          =/  h3  (pro.p h2 h)
-          =/  u1h2  (pro.p u1 h2)
-          =/  nx  (dif.p (pro.p r r) :(sum.p h3 u1h2 u1h2))
-          =/  ny  (dif.p (pro.p r (dif.p u1h2 nx)) (pro.p s1 h3))
-          =/  nz  :(pro.p h z.a z.b)
-          [nx ny nz]
-        ::
-        ++  dub                                         ::  double
-          |=  a=jaco
-          ^-  jaco
-          ?:  =(0 y.a)
-            [0 0 0]
-          =/  ysq  (pro.p y.a y.a)
-          =/  s  :(pro.p 4 x.a ysq)
-          =/  m  :(pro.p 3 x.a x.a)                     ::  omits A=0
-          =/  nx  (dif.p (pro.p m m) (sum.p s s))
-          =/  ny  (dif.p (pro.p m (dif.p s nx)) :(pro.p 8 ysq ysq))
-          =/  nz  :(pro.p 2 y.a z.a)
-          [nx ny nz]
-        ::
-        ++  mul                                         :: jaco x scalar
-          |=  [a=jaco n=@]
-          ^-  jaco
-          ?:  =(0 y.a)
-            [0 0 1]
-          ?:  =(0 n)
-            [0 0 1]
-          ?:  =(1 n)
-            a
-          ?:  (gte n ^^n)
-            $(n (mod n ^^n))
-          ?:  =(0 (mod n 2))
-            (dub $(n (div n 2)))
-          (add a (dub $(n (div n 2))))
-        ::
-        ++  from                                        :: jaco -> point
-          |=  a=jaco
-          ^-  pont
-          =/  z  (inv.p z.a)
-          [:(pro.p x.a z z) :(pro.p y.a z z z)]
-        ::
-        ++  into                                        :: point -> jaco
-          |=  pont
-          ^-  jaco
-          [x y z=1]
-        --
       --
     --
   ::

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4182,10 +4182,10 @@
     ::                                                  ::::
   ++  new-secp  !.
     ::  TODO: as-octs and hmc are outside of jet parent
-    =>  :+  hmc=hmac-sha256l:hmac:crypto
-          as-octs=as-octs:mimes:html
-        ..is
-    ~%  %secp  ..is  ~
+    =>  :+  ..is
+          hmc=hmac-sha256l:hmac:crypto
+        as-octs=as-octs:mimes:html
+    ~%  %secp  +<  ~
     |%
     +=  jacobian   [x=@ y=@ z=@]                    ::  jacobian point
     +=  point      [x=@ y=@]                        ::  curve point

--- a/pkg/arvo/tests/sys/zuse/crypto/secp256k1.hoon
+++ b/pkg/arvo/tests/sys/zuse/crypto/secp256k1.hoon
@@ -1,7 +1,7 @@
 ::  tests for secp256k1 elliptic curve cryptography
 ::
 /+  *test
-=/  ecc  secp256k1:new-secp:crypto
+=/  ecc  secp256k1:secp:crypto
 |%
 ::  from libsecp256k1 src/modules/recovery/tests_impl.h
 ::  there are more tests there, ports would be welcome

--- a/pkg/arvo/tests/sys/zuse/crypto/secp256k1.hoon
+++ b/pkg/arvo/tests/sys/zuse/crypto/secp256k1.hoon
@@ -1,0 +1,119 @@
+::  tests for secp256k1 elliptic curve cryptography
+::
+/+  *test
+=/  ecc  secp256k1:new-secp:crypto
+|%
+::  from libsecp256k1 src/modules/recovery/tests_impl.h
+::  there are more tests there, ports would be welcome
+++  test-ecdsa-recovery-end-to-end
+  =/  util
+    =/  eny=@  'ecdsa recovery test "entropy"'
+    =/  rnd  ~(. og eny)
+    =/  dom  t.ecc
+    |%
+    ++  random-scalar-order
+      =*  core  .
+      =^  z  rnd  (rads:rnd (dec n.dom))
+      [`@`.+(z) core]
+    --
+  ::  generate a random key and message
+  %+  category  "random"
+  %-  zing
+  =|  [i=@ out=(list tang)]
+  |-  ^+  out
+  ?:  =(i 64)  out
+  =^  message  util  random-scalar-order:util
+  =^  privkey  util  random-scalar-order:util
+  =/  pubkey   (priv-to-pub.ecc privkey)
+  =/  msghash  (shax (shax message))
+  =/  sig      (ecdsa-raw-sign.ecc msghash privkey)
+  =/  reckey   (ecdsa-raw-recover.ecc msghash sig)
+  %=  $
+    i    .+(i)
+    out  :_  out
+         %+  expect-eq
+           !>  pubkey
+           !>  reckey
+  ==
+  ::
+++  test-ecdsa-recovery-edge-cases
+  =<  %+  category  "edge cases"
+     (zing ~[t1 t2 t3 t4 t5])
+  =/  msg32=@  '...egassem terces yrev a si sihT'
+  =/  r=@ux    0x67cb.285f.9cd1.94e8.
+                 40d6.2939.7af5.5696.
+                 62fd.e446.4999.5963.
+                 179a.7dd1.7bd2.3532
+  =/  s=@ux    0x4b1b.7df3.4ce1.f68e.
+                 694f.f6f1.1ac7.51dd.
+                 7dd7.3e38.7ee4.fc86.
+                 6e1b.e8ec.c7dd.9557
+  =/  r   %+  turn  (gulf 0 3)
+          |=  v=@
+          (mule |.((ecdsa-raw-recover.ecc msg32 v r s)))
+  =/  t1  %+  expect-eq
+            !>  %.n
+            !>  -.&1.r
+  =/  t3  %+  expect-eq
+            !>  %.n
+            !>  -.&3.r
+  =/  t4  %+  expect-eq
+            !>  %.n
+            !>  -.&4.r
+  =/  t2  %+  expect-eq
+            !>  :+  %.y
+                  0x8687.4a6b.24a7.5462.
+                    7116.560e.7ae1.5cd6.
+                    9eb3.3e73.b4d8.c810.
+                    33b2.7c2f.a9cf.5d1c
+                  0xe13f.19fa.8dea.0d1a.
+                    e3e8.4c91.146c.3386.
+                    8f87.730e.31bb.486e.
+                    b370.05d1.40cc.7a55
+            !>  &2.r
+  ::  (4,4) should recover with all 4 recids
+  :_  .
+  ^=  t5
+  %-  expect-eq  :_
+    !>  %+  turn  (gulf 0 3)
+        |=  v=@
+        (mule |.((ecdsa-raw-recover.ecc msg32 v 4 4)))
+    !>
+    :~  :+  %.y
+           0x8a3d.70c0.4104.68e4.
+             5739.39af.01b9.9ea7.
+             b206.4910.6d55.acf9.
+             f558.eba2.8ed5.9a2e
+           0x77eb.58dd.36ed.385b.
+             3dcf.e7d3.62c8.16f3.
+             7d3b.ef3e.4a34.94b8.
+             6fcc.8357.5184.9329
+         :+  %.y
+           0x3e99.0254.a50d.6599.
+             26c9.28ef.8b54.181e.
+             e67e.27ff.bf63.eb69.
+             294b.9ab6.d27b.a225
+           0xa898.847e.931e.9b10.
+             2c0f.9b0f.9597.07ba.
+             f9b8.5e93.6425.fc72.
+             e80c.a868.e535.dfb4
+         :+  %.y
+           0x7e15.24fa.06ba.fd6e.
+             b9c0.2f27.9e13.1314.
+             be93.0570.0fc6.9e80.
+             d54d.29ab.3606.3f23
+           0x3f86.a967.33e7.723d.
+             fdde.4e03.382d.8c45.
+             3493.fa88.9050.5ba5.
+             cfc4.0a8b.226b.1b00
+         :+  %.y
+           0xb337.c9b7.4ca9.9ea9.
+             63c6.560d.2558.cdf0.
+             9c73.0120.8409.649a.
+             8a6d.1fb1.0e1c.b946
+           0x11df.5391.ee11.6de0.
+             a722.bc0f.be5f.6575.
+             3d07.03a9.9925.0581.
+             f7de.cd5e.f0f4.f809
+    ==
+--

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -311,49 +311,26 @@ static c3_c* _141_hex_argon_ha[] = {
   0
 };
 
-  static u3j_harm _141_hex_secp_make_a[] = {{".2", u3we_make, c3y}, {}};
-  static c3_c* _141_hex_secp_make_ha[] = {
-    "171cae298e8f73b6b77c72f957d9d7afd495ed1ca7d78fe9d5f869ea2203bada",
-    0
-  };
-  static u3j_harm _141_hex_secp_sign_a[] = {{".2", u3we_sign, c3y}, {}};
-  static c3_c* _141_hex_secp_sign_ha[] = {
-    "aac58cd537481d41fc4d941a7a0ed247552d64af6c9dce71e0d74c39384e2d60",
-    0
-  };
-  static u3j_harm _141_hex_secp_reco_a[] = {{".2", u3we_reco, c3y}, {}};
-  static c3_c* _141_hex_secp_reco_ha[] = {
-    "390d4cd3a04817b6436035a6fa77fe3008008afa164db732c8f4d5c52954fbee",
-    0
-  };
-static u3j_core _141_hex_secp_secp_helper_d[] =
-  { { "make-k",            7, _141_hex_secp_make_a, 0, _141_hex_secp_make_ha },
-    { "ecdsa-raw-sign",    7, _141_hex_secp_sign_a, 0, _141_hex_secp_sign_ha },
-    { "ecdsa-raw-recover", 7, _141_hex_secp_reco_a, 0, _141_hex_secp_reco_ha },
+static c3_c* _141_hex_secp_secp256k1_make_ha[] = { 0 };
+static u3j_harm _141_hex_secp_secp256k1_make_a[] = {{".2", u3we_make, c3y}, {}};
+static c3_c* _141_hex_secp_secp256k1_sign_ha[] = { 0 };
+static u3j_harm _141_hex_secp_secp256k1_sign_a[] = {{".2", u3we_sign, c3y}, {}};
+static c3_c* _141_hex_secp_secp256k1_reco_ha[] = { 0 };
+static u3j_harm _141_hex_secp_secp256k1_reco_a[] = {{".2", u3we_reco, c3y}, {}};
+
+static c3_c* _141_hex_secp_secp256k1_ha[] = { 0 };
+static u3j_core _141_hex_secp_secp256k1_d[] =
+  { { "make", 7, _141_hex_secp_secp256k1_make_a, 0, _141_hex_secp_secp256k1_make_ha },
+    { "sign", 7, _141_hex_secp_secp256k1_sign_a, 0, _141_hex_secp_secp256k1_sign_ha },
+    { "reco", 7, _141_hex_secp_secp256k1_reco_a, 0, _141_hex_secp_secp256k1_reco_ha },
     {}
   };
-static c3_c* _141_hex_secp_secp_helper_ha[] = {
-  "24175b141f1efc2e2de00c39a2b70cf3491f2b82371e0e15f63dfb6d2d86eac5",
-  0
-};
 
-static u3j_core _141_hex_secp_secp_d[] =
-  { { "helper", 15, 0, _141_hex_secp_secp_helper_d, _141_hex_secp_secp_helper_ha },
-    {}
-  };
-static c3_c* _141_hex_secp_secp_ha[] = {
-  "42f57966a293fdadbce8b0cc2108039f1f7fafe0b12f1fec52b2d1937a8347d7",
-  0
-};
-
+static c3_c* _141_hex_secp_ha[] = { 0 };
 static u3j_core _141_hex_secp_d[] =
-  { { "secp", 7, 0, _141_hex_secp_secp_d, _141_hex_secp_secp_ha },
+  { { "secp256k1", 3, 0, _141_hex_secp_secp256k1_d, _141_hex_secp_secp256k1_ha },
     {}
   };
-static c3_c* _141_hex_secp_ha[] = {
-  "e153a8c88f04bfed03dc882f560f912eaf3f5e3911f55dbb054519c2e1b4d778",
-  0
-};
 
   static u3j_harm _141_hex_blake2b_a[] = {{".2", u3we_blake, c3y}, {}};
   static c3_c* _141_hex_blake2b_ha[] = {
@@ -396,7 +373,7 @@ static u3j_core _141_hex_d[] =
   { "argon",  31, 0, _141_hex_argon_d, _141_hex_argon_ha },
   { "blake",  31, 0, _141_hex_blake_d, _141_hex_blake_ha },
   { "ripemd", 31, 0, _141_hex_ripe_d,  _141_hex_ripe_ha  },
-  { "secp",   31, 0, _141_hex_secp_d,  _141_hex_secp_ha  },
+  { "secp",   6, 0, _141_hex_secp_d, _141_hex_secp_ha },
   {}
 };
 static c3_c* _141_hex_ha[] = {


### PR DESCRIPTION
The previous version of this code had incorrect jet matching semantics (constants in a sample that affect the result but are not checked by the jet) and didn't match the jet w.r.t. the "recovery id" (v) part of the signature. The code has been restructured and tests added.