### PR TITLE
chat: fixes message jump

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
@@ -136,7 +136,6 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
 
     if (stationPendingMessages.length !== prevProps.stationPendingMessages.length) {
       this.virtualList?.calculateVisibleItems();
-      this.virtualList?.scrollToData(mailboxSize);
     }
 
     if (!this.state.fetchPending && prevState.fetchPending) {


### PR DESCRIPTION
@matildepark @vvisigoth 

This should fix the issue you noticed where posting an image would cause the chat to jump. It was caused by an old method that did more harm than good in the new implementation.