### PR TITLE
chat: fixes unread marker on blur

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/lib/ChatWindow.tsx
@@ -100,6 +100,9 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
 
   handleWindowFocus() {
     this.setState({ idle: false });
+    if (this.virtualList?.window?.scrollTop === 0) {
+      this.dismissUnread();
+    }
   }
 
   initialFetch() {
@@ -121,7 +124,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
   }
 
   componentDidUpdate(prevProps: ChatWindowProps, prevState) {
-    const { isChatMissing, history, envelopes, mailboxSize, stationPendingMessages } = this.props;
+    const { isChatMissing, history, envelopes, mailboxSize, stationPendingMessages, unreadCount } = this.props;
 
     if (isChatMissing) {
       history.push("/~chat");
@@ -132,6 +135,12 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     if ((mailboxSize !== prevProps.mailboxSize) || (envelopes.length !== prevProps.envelopes.length)) {
       this.virtualList?.calculateVisibleItems();
       this.stayLockedIfActive();
+    }
+
+    if (unreadCount > prevProps.unreadCount && this.state.idle) {
+      this.setState({
+        lastRead: unreadCount ? mailboxSize - unreadCount : Infinity,
+      });
     }
 
     if (stationPendingMessages.length !== prevProps.stationPendingMessages.length) {


### PR DESCRIPTION
Just some light refinements on how the unread markers behave. Now when you refocus the window, it will mark messages as read if you're at the bottom, thus clearing the banner and the tab icon, but the line will remain.