### PR TITLE
leap: destructure selection logic variables

### DIFF
--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -179,18 +179,15 @@ export class Omnibox extends Component {
         })
       );
       if (currentIndex > 0) {
-        const nextApp = flattenedResults[currentIndex - 1].app;
-        const nextLink = flattenedResults[currentIndex - 1].link;
-        this.setState({ selected: [nextApp, nextLink] });
+        const { app, link } = flattenedResults[currentIndex - 1];
+        this.setState({ selected: [app, link] });
       } else {
-        const nextApp = flattenedResults[totalLength - 1].app;
-        const nextLink = flattenedResults[totalLength - 1].link;
-        this.setState({ selected: [nextApp, nextLink] });
+        const { app, link } = flattenedResults[totalLength - 1];
+        this.setState({ selected: [app, link] });
       }
     } else {
-      const nextApp = flattenedResults[totalLength - 1].app;
-      const nextLink = flattenedResults[totalLength - 1].link;
-      this.setState({ selected: [nextApp, nextLink] });
+      const { app, link } = flattenedResults[totalLength - 1];
+      this.setState({ selected: [app, link] });
     }
   }
 
@@ -204,18 +201,15 @@ export class Omnibox extends Component {
         })
       );
       if (currentIndex < flattenedResults.length - 1) {
-      const nextApp = flattenedResults[currentIndex + 1].app;
-      const nextLink = flattenedResults[currentIndex + 1].link;
-      this.setState({ selected: [nextApp, nextLink] });
+        const { app, link } = flattenedResults[currentIndex + 1];
+        this.setState({ selected: [app, link] });
       } else {
-      const nextApp = flattenedResults[0].app;
-      const nextLink = flattenedResults[0].link;
-      this.setState({ selected: [nextApp, nextLink] });
+        const { app, link } = flattenedResults[0];
+        this.setState({ selected: [app, link] });
       }
     } else {
-      const nextApp = flattenedResults[0].app;
-      const nextLink = flattenedResults[0].link;
-      this.setState({ selected: [nextApp, nextLink] });
+      const { app, link } = flattenedResults[0];
+      this.setState({ selected: [app, link] });
     }
   }
 


### PR DESCRIPTION
A very tiny PR while I'm debugging Leap in Safari 14 — just amending some of these repeated assignments into a single destructure makes the selection logic way easier to follow? — places emphasis on *where* in the array we assign in each case instead of just seeming like code.