### PR TITLE
meta: add link to file design issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Landscape design issue
+    url: https://github.com/urbit/landscape/issues/new?assignees=&labels=design+issue&template=report-a-design-issue.md&title=
+    about: Submit non-functionality, design-specific issues to the Landscape team here.
   - name: Landscape feature request
     url: https://github.com/urbit/landscape/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=
     about: Landscape is comprised of Tlon's user applications and client for Urbit. Submit Landscape feature requests here.


### PR DESCRIPTION
While Landscape source code is bundled with the Arvo repository, not all Landscape issues belong in the urbit repo. That is, urbit/urbit should concern itself with functionality and livenet issues, and QA or design-specific reports should be handled in its own forum. 

Commits can still close cross-repo issues using the repo format, eg. urbit/landscape#25.

cc @urcades 