### PR TITLE
leap: always blur and refocus input on mount

### DIFF
--- a/pkg/interface/src/views/components/leap/OmniboxInput.js
+++ b/pkg/interface/src/views/components/leap/OmniboxInput.js
@@ -8,6 +8,10 @@ export class OmniboxInput extends Component {
     <input
       ref={(el) => {
         this.input = el;
+          if (el) {
+            el.blur();
+            el.focus();
+          }
         }
       }
       className='ba b--transparent w-100 br2 white-d bg-gray0-d inter f9 pa2'

--- a/pkg/interface/src/views/components/leap/OmniboxInput.js
+++ b/pkg/interface/src/views/components/leap/OmniboxInput.js
@@ -8,7 +8,7 @@ export class OmniboxInput extends Component {
     <input
       ref={(el) => {
         this.input = el;
-          if (el) {
+          if (el && document.activeElement.isSameNode(el)) {
             el.blur();
             el.focus();
           }


### PR DESCRIPTION
Safari 14 just came out; and while on Safari 13 Leap's autofocus works fine, in 14 Leap only autofocuses the first time and never again afterward. This is of course very annoying in everyday usage.

The origin appears to be [a change in behaviour in an unclear spec](https://bugs.webkit.org/show_bug.cgi?id=29241) for whether hiding an element automatically blurs it. What happens is that while in all other browsers, the `focus()` event fires every time, in Safari 14 the `focus()` even only fires the first time, because it technically *has never lost focus*? 

And thus it would only work properly if you were Leaping from Dojo or Chat, where there was another element to unfocus.

This commit forces the component to blur *itself* and refocus when it's mounted. This seems to retain the normal behaviour in all cases, but tests always appreciated of course.