### PR TITLE
eyre: remove superfluous connection-state check

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84d815edefd8cf64598cce4b06bd1b3038a265222ada9d45c193a817ce5580bf
-size 6297329
+oid sha256:9b572ea1bc3bafc9ac7ff1a0fcecca16320bc2bbe6d6964cc76a2bc36f201975
+size 6299579

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1516,9 +1516,6 @@
       |=  channel-id=@t
       ^-  [(list move) server-state]
       ::
-      ?~  connection-state=(~(get by connections.state) duct)
-        [~ state]
-      ::
       =/  res
         %-  handle-response
         :*  %continue


### PR DESCRIPTION
This was originally introduced by me in #1814 to address #1811. Eyre was not canceling heartbeat timers on all relevant events making it easy to end up with an infinite behn loop. This check allowed ships that entered an infinite loop to recover, as per my comment at https://github.com/urbit/urbit/pull/1814#discussion_r333477482. Otherwise it's not necessary.