### PR TITLE
zuse: make octs value @ instead of @t

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -79,7 +79,7 @@
 ::
 ::    TODO: Rename to +mime once the current +mime and +mite are gone. The
 ::
-++  octs  {p/@ud q/@t}                                  ::  octet-stream
+++  octs  {p/@ud q/@}                                   ::  octet-stream
 ++  sock  {p/ship q/ship}                               ::  outgoing [our his]
 ::+|
 ::


### PR DESCRIPTION
Because these things aren't always printable/valid `@t`.

There's maybe some argument to be made here around `@t` indicating a specific byte order, but `octs` gets used for both cords and arbitrary bytestreams, so...