### PR TITLE
webdojo: slogs

### DIFF
--- a/pkg/interface/src/views/apps/dojo/components/history.js
+++ b/pkg/interface/src/views/apps/dojo/components/history.js
@@ -15,7 +15,7 @@ export class History extends Component {
           {this.props.commandLog.map((text, index) => {
             return (
               <p className="mono" key={index}
-              style={{ overflowWrap: 'break-word' }}
+              style={{ overflowWrap: 'break-word', whiteSpace: 'pre' }}
               >
                 {text}
               </p>

--- a/pkg/interface/src/views/apps/dojo/subscription.js
+++ b/pkg/interface/src/views/apps/dojo/subscription.js
@@ -19,9 +19,11 @@ export default class Subscription {
 
   setupSlog() {
     const slog = new EventSource('/~/slog', { withCredentials: true });
+    let available = false;
 
     slog.onopen = e => {
       console.log('slog: opened stream');
+      available = true;
     }
 
     slog.onmessage = e => {
@@ -30,11 +32,13 @@ export default class Subscription {
 
     slog.onerror = e => {
       console.error('slog: eventsource error:', e);
-      window.setTimeout(() => {
-        if (slog.readyState !== EventSource.CLOSED) return;
-        console.log('slog: reconnecting...');
-        this.setupSlog();
-      }, 10000);
+      if (available) {
+        window.setTimeout(() => {
+          if (slog.readyState !== EventSource.CLOSED) return;
+          console.log('slog: reconnecting...');
+          this.setupSlog();
+        }, 10000);
+      }
     }
   }
 

--- a/pkg/interface/src/views/apps/dojo/subscription.js
+++ b/pkg/interface/src/views/apps/dojo/subscription.js
@@ -19,11 +19,9 @@ export default class Subscription {
 
   setupSlog() {
     const slog = new EventSource('/~/slog', { withCredentials: true });
-    let available = false;
 
     slog.onopen = e => {
       console.log('slog: opened stream');
-      available = true;
     }
 
     slog.onmessage = e => {
@@ -32,17 +30,11 @@ export default class Subscription {
 
     slog.onerror = e => {
       console.error('slog: eventsource error:', e);
-      if (!available) {
-        this.handleEvent({ txt:
-          'landscape: no printf stream. bad connection or old binary.'
-        });
-      } else {
-        window.setTimeout(() => {
-          if (slog.readyState !== EventSource.CLOSED) return;
-          console.log('slog: reconnecting...');
-          this.setupSlog();
-        }, 10000);
-      }
+      window.setTimeout(() => {
+        if (slog.readyState !== EventSource.CLOSED) return;
+        console.log('slog: reconnecting...');
+        this.setupSlog();
+      }, 10000);
     }
   }
 

--- a/pkg/interface/src/views/apps/dojo/subscription.js
+++ b/pkg/interface/src/views/apps/dojo/subscription.js
@@ -18,8 +18,8 @@ export default class Subscription {
   }
 
   setupSlog() {
-    const slog = new EventSource('/~/slog', { withCredentials: true });
     let available = false;
+    const slog = new EventSource('/~_~/slog', { withCredentials: true });
 
     slog.onopen = e => {
       console.log('slog: opened stream');


### PR DESCRIPTION
Connects to the SSE stream on `/~/slog` to receive printf output from the
runtime, and pretends those are incoming `%txt` effects.

Depends on #3557, which introduces the endpoint used here. Probably shouldn't be merged until that has gone out in a vere release? But this fails gracefully, so maybe we can pass on juggling pending PRs.