### PR TITLE
Restore thread and Indigo import fix

### DIFF
--- a/pkg/arvo/ted/graph/restore.hoon
+++ b/pkg/arvo/ted/graph/restore.hoon
@@ -1,0 +1,37 @@
+/-  spider, graph=graph-store, *metadata-store, *group, group-store
+/+  strandio, resource, graph-view
+=>
+|% 
+++  strand  strand:spider
+++  poke  poke:strandio
+++  poke-our   poke-our:strandio
+--
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<([rid=resource title=@t description=@t group=resource module=@t ~] arg)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+::  unarchive graph and share it
+;<  ~  bind:m
+  (poke-our %graph-store %graph-update !>([%0 now.bowl %unarchive-graph rid]))
+;<  ~  bind:m
+  (poke-our %graph-push-hook %push-hook-action !>([%add rid]))
+::
+::  Setup metadata
+::
+=/  =metadata
+  %*  .  *metadata
+    title         title
+    description   description
+    date-created  now.bowl
+    creator       our.bowl
+    module        module
+  ==
+=/  act=metadata-action
+  [%add (en-path:resource group) graph+(en-path:resource rid) metadata]
+;<  ~  bind:m  (poke-our %metadata-hook %metadata-action !>(act))
+;<  ~  bind:m
+  (poke-our %metadata-hook %metadata-hook-action !>([%add-owned (en-path:resource group)]))
+(pure:m !>(~))

--- a/pkg/interface/src/views/apps/links/components/new.tsx
+++ b/pkg/interface/src/views/apps/links/components/new.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { Box, Input, Col } from "@tlon/indigo-react";
+import { Box, ManagedTextInputField as Input, Col } from "@tlon/indigo-react";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 
@@ -69,7 +69,7 @@ export function NewScreen(props: object) {
           <Box
             display="grid"
             gridTemplateRows="auto"
-            gridRowGap={2}
+            gridRowGap={4}
             gridTemplateColumns="300px">
             <Input
               id="name"


### PR DESCRIPTION
Adds a thread to restore an archived graph to full functioning, and fixes imports that broke in the indigo 1.2 upgrade