### PR TITLE
eyre: send 'no content' headers with no content

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -843,7 +843,7 @@
       ?~  redirect
         %-  handle-response
         :*  %start
-            :-  status-code=200
+            :-  status-code=204
             ^=  headers
               :~  ['set-cookie' cookie-line]
               ==
@@ -1282,7 +1282,7 @@
         =^  http-moves  state
           %-  handle-response
           :*  %start
-              [status-code=200 headers=~]
+              [status-code=204 headers=~]
               data=~
               complete=%.y
           ==

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -996,7 +996,7 @@
                 %give
                 %response
                 %start
-                :-  204
+                :-  200
                 :~  ['content-type' 'text/event-stream']
                     ['cache-control' 'no-cache']
                     ['connection' 'keep-alive']

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -996,7 +996,7 @@
                 %give
                 %response
                 %start
-                :-  200
+                :-  204
                 :~  ['content-type' 'text/event-stream']
                     ['cache-control' 'no-cache']
                     ['connection' 'keep-alive']
@@ -1110,7 +1110,7 @@
             card.i.moves
         ::
           %+  expect-eq
-            !>  put-200-response
+            !>  put-204-response
             !>  i.t.moves
         ::
           %+  expect-eq
@@ -1210,7 +1210,7 @@
             card.i.moves
         ::
           %+  expect-eq
-            !>  put-200-response
+            !>  put-204-response
             !>  i.t.moves
         ::
           %+  expect-eq
@@ -1313,7 +1313,7 @@
             card.i.moves
         ::
           %+  expect-eq
-            !>  put-200-response
+            !>  put-204-response
             !>  i.t.moves
         ::
           %+  expect-eq
@@ -1463,7 +1463,7 @@
             card.i.moves
         ::
           %+  expect-eq
-            !>  put-200-response
+            !>  put-204-response
             !>  i.t.moves
     ==  ==
   ::  gall responds on the second subscription.
@@ -1682,7 +1682,7 @@
           [%leaf "wrong number of moves: {<(lent moves)>}"]~
         ::
         %+  expect-eq
-          !>  put-200-response
+          !>  put-204-response
           !>  i.moves
     ==
   ::  the client connection is detected to be broken
@@ -2206,7 +2206,7 @@
             card.i.t.moves
         ::
           %+  expect-eq
-            !>  put-200-response
+            !>  put-204-response
             !>  i.t.t.moves
         ::
           %+  expect-eq
@@ -2243,14 +2243,14 @@
   ?~  data  headers
   %+  weld  headers
   ['content-length' (crip ((d-co:co 1) p.u.data))]~
-::  produce the 200 response to a put request
+::  produce the 204 response to a put request
 ::
-++  put-200-response
+++  put-204-response
   :*  ~[/http-put-request]
       %give
       %response
       %start
-      [200 ['set-cookie' cookie-string]~]
+      [204 ['set-cookie' cookie-string]~]
       ~
       %.y
   ==


### PR DESCRIPTION
Take 2!

Ok, full disclosure I didn't test this. But I know so little about this system I figured I should just run it all by you and tell you why.

I'm tired of seeing this in the console and it suggests an error:
```
XML Parsing Error: no root element found
Location: http://localhost:1701/~/channel/1601004556-791863
Line Number 1, Column 1:
```

So, in `eyre.hoon` wherever I saw `data=~` and `status-code=200` I changed it to 204, as per [the spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)

?