### PR TITLE
dojo: parse %as in ++parse-value instead of ++parse-build

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -218,7 +218,6 @@
         ;~(plug (cold %ur lus) parse-url)
         ;~(plug (cold %ge lus) parse-model)
         ;~(plug (cold %te hep) sym (star ;~(pfix ace parse-source)))
-        ;~(plug (cold %as pad) sym ;~(pfix ace parse-source))
         ;~(plug (cold %do cab) parse-hoon ;~(pfix ace parse-source))
         parse-value
       ==
@@ -284,6 +283,7 @@
     ==
   ++  parse-value
     ;~  pose
+      ;~(plug (cold %as pad) sym ;~(pfix ace parse-source))
       (stag %sa ;~(pfix tar pad sym))
       (stag %ex parse-hoon)
       (stag %tu (ifix [lac rac] (most ace parse-source)))


### PR DESCRIPTION
Allows things like `+hello &helm-hi 'hi'`. Fixes #1476.