### PR TITLE
King Haskell terminal fixes

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/King/API.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/API.hs
@@ -18,7 +18,6 @@ import Urbit.Prelude
 
 import Network.Socket (Socket)
 import Prelude        (read)
-import Urbit.Arvo     (Belt)
 import Urbit.King.App (HasPierPath(..))
 
 import qualified Network.HTTP.Types             as H
@@ -32,7 +31,7 @@ import qualified Urbit.Vere.Term.API            as Term
 
 -- Types -----------------------------------------------------------------------
 
-type TermConn = NounServ.Conn Belt [Term.Ev]
+type TermConn = NounServ.Conn Term.ClientTake [Term.Ev]
 
 type TermConnAPI = TVar (Maybe (TermConn -> STM ()))
 

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -175,10 +175,10 @@ logStderr action = do
   logFunc <- view stderrLogFuncL
   runRIO logFunc action
 
-logSlogs :: HasStderrLogFunc e => RIO e (TVar (Text -> IO ()))
+logSlogs :: HasStderrLogFunc e => RIO e (TVar ((Atom, Tank) -> IO ()))
 logSlogs = logStderr $ do
   env <- ask
-  newTVarIO (runRIO env . logOther "serf" . display . T.strip)
+  newTVarIO (runRIO env . logOther "serf" . display . T.strip . tankToText . snd)
 
 tryBootFromPill
   :: Bool
@@ -200,7 +200,7 @@ tryBootFromPill oExit pill lite ship boot = do
     pure sls
 
 runOrExitImmediately
-  :: TVar (Text -> IO ())
+  :: TVar ((Atom, Tank) -> IO ())
   -> RAcquire PierEnv (Serf, Log.EventLog)
   -> Bool
   -> MVar ()
@@ -240,7 +240,8 @@ tryPlayShip exitImmediately fullReplay playFrom mStart = do
   north shipPath = shipPath <> "/.urb/chk/north.bin"
   south shipPath = shipPath <> "/.urb/chk/south.bin"
 
-  resumeShip :: TVar (Text -> IO ()) -> RAcquire PierEnv (Serf, Log.EventLog)
+  resumeShip :: TVar ((Atom, Tank) -> IO ())
+             -> RAcquire PierEnv (Serf, Log.EventLog)
   resumeShip vSlog = do
     view pierPathL >>= lockFile
     rio $ logInfo "RESUMING SHIP"

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
@@ -126,7 +126,7 @@ runSerf vSlog pax = do
     { scSerf = env ^. pierConfigL . pcSerfExe . to (maybe serfProg unpack)
     , scPier = pax
     , scFlag = env ^. pierConfigL . pcSerfFlags
-    , scSlog = slog   -- printTank slog pri tank
+    , scSlog = slog
     , scStdr = \txt -> slog (0, (textToTank txt))
     , scDead = pure () -- TODO: What can be done?
     }
@@ -353,7 +353,6 @@ pier (serf, log) vSlog startedSig = do
 
   let slog :: Text -> IO ()
       slog txt = do
-        -- TODO: What is this and is it right?
         fn <- atomically (readTVar vSlog)
         fn (0, textToTank txt)
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
@@ -282,8 +282,8 @@ localClient doneSignal = fst <$> mkRAcquire start stop
             putStr "\r"
             T.clearLine
             TermSize width _ <- atomically $ readTVar termSizeVar
-            -- TODO: Ignoring priority for now.
-            putStr (tshow width <> "\r\n")
+            -- TODO: Ignoring priority for now. Priority changes the color of,
+            -- and adds a prefix of '>' to, the output.
             let lines = fmap unTape $ wash (WashCfg 0 width) $ tankTree $ snd slog
             forM lines $ \line -> putStr (line <> "\r\n")
             termRefreshLine ls

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term/API.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term/API.hs
@@ -1,7 +1,12 @@
 {-|
     Interface Terminal API.
 -}
-module Urbit.Vere.Term.API (Ev(..), Client(..), trace, spin, stopSpin) where
+module Urbit.Vere.Term.API (Ev(..),
+                            Client(..),
+                            trace,
+                            slog,
+                            spin,
+                            stopSpin) where
 
 import Urbit.Prelude hiding (trace)
 
@@ -15,11 +20,13 @@ import Urbit.Arvo (Belt, Blit)
 
     %blits -- list of blits from arvo.
     %trace -- stderr line from runtime.
+    %slog  -- nock worker logging with priority
     %blank -- print a blank line
     %spinr -- Start or stop the spinner
 -}
 data Ev = Blits [Blit]
         | Trace Cord
+        | Slog (Atom, Tank)
         | Blank
         | Spinr (Maybe (Maybe Cord))
   deriving (Show)
@@ -36,6 +43,9 @@ deriveNoun ''Ev
 
 trace :: Client -> Text -> STM ()
 trace ts = give ts . singleton . Trace . Cord
+
+slog :: Client -> (Atom, Tank) -> STM ()
+slog ts = give ts . singleton . Slog
 
 spin :: Client -> Maybe Text -> STM ()
 spin ts = give ts . singleton . Spinr . Just . fmap Cord

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Demux.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Demux.hs
@@ -4,12 +4,15 @@
     given full event history since the creation of the demuxer.
 -}
 
-module Urbit.Vere.Term.Demux (Demux, mkDemux, addDemux, useDemux) where
+module Urbit.Vere.Term.Demux (Demux,
+                              mkDemux,
+                              addDemux,
+                              useDemux,
+                              curDemuxSize) where
 
 import Urbit.Prelude
-
-import Urbit.Arvo          (Belt)
-import Urbit.Vere.Term.API (Client(Client))
+import Urbit.TermSize
+import Urbit.Vere.Term.API (Client(Client), ClientTake(..))
 
 import qualified Urbit.Vere.Term.API   as Term
 import qualified Urbit.Vere.Term.Logic as Logic
@@ -42,11 +45,17 @@ ksDelete k (KeyedSet t n) = KeyedSet (deleteMap k t) n
 
 data Demux = Demux
     { dConns :: TVar (KeyedSet Client)
+    , dSizes :: TVar (IntMap TermSize)
     , dStash :: TVar Logic.St
+    , dMinSize :: TVar TermSize
     }
 
-mkDemux :: STM Demux
-mkDemux = Demux <$> newTVar mempty <*> newTVar Logic.init
+mkDemux :: TermSize -> STM Demux
+mkDemux ts = Demux <$>
+  newTVar mempty <*>
+  newTVar mempty <*>
+  newTVar Logic.init <*>
+  newTVar ts
 
 addDemux :: Client -> Demux -> STM ()
 addDemux conn Demux{..} = do
@@ -57,6 +66,8 @@ addDemux conn Demux{..} = do
 useDemux :: Demux -> Client
 useDemux d = Client { give = dGive d, take = dTake d }
 
+curDemuxSize :: Demux -> STM TermSize
+curDemuxSize Demux{..} = readTVar dMinSize
 
 -- Internal --------------------------------------------------------------------
 
@@ -77,16 +88,45 @@ dGive Demux{..} evs = do
     If there are no attached clients, this will not return until one
     is attached.
 -}
-dTake :: Demux -> STM (Maybe Belt)
+dTake :: Demux -> STM (Maybe ClientTake)
 dTake Demux{..} = do
     conns <- readTVar dConns
-    waitForBelt conns >>= \case
-        (_, Just b ) -> pure (Just b)
-        (k, Nothing) -> do writeTVar dConns (ksDelete k conns)
-                           pure Nothing
+    waitForTake conns >>= \case
+        (_, Just (ClientTakeBelt b)) -> pure (Just (ClientTakeBelt b))
+
+        (k, Just (ClientTakeSize s)) -> do
+          newSizeTree <- modifyAndReturnTVar dSizes (insertMap k s)
+          maybeUpdateTerminalSize newSizeTree
+
+        (k, Nothing) -> do
+          writeTVar dConns (ksDelete k conns)
+          newSizeTree <- modifyAndReturnTVar dSizes (deleteMap k)
+          maybeUpdateTerminalSize newSizeTree
+
   where
-    waitForBelt :: KeyedSet Client -> STM (Int, Maybe Belt)
-    waitForBelt ks = asum
+    waitForTake :: KeyedSet Client -> STM (Int, Maybe ClientTake)
+    waitForTake ks = asum
                    $ fmap (\(k,c) -> (k,) <$> Term.take c)
                    $ mapToList
                    $ _ksTable ks
+
+    maybeUpdateTerminalSize :: IntMap TermSize -> STM (Maybe ClientTake)
+    maybeUpdateTerminalSize newSizeTree = do
+      let termSize = foldr minTermSize (TermSize 1024 1024) newSizeTree
+      curSize <- readTVar dMinSize
+      if curSize == termSize
+        then pure Nothing
+        else do
+          writeTVar dMinSize termSize
+          pure $ Just (ClientTakeSize termSize)
+
+    modifyAndReturnTVar :: TVar a -> (a -> a) -> STM a
+    modifyAndReturnTVar var fun = do
+      pre <- readTVar var
+      let post = fun pre
+      writeTVar var post
+      pure post
+
+    minTermSize :: TermSize -> TermSize -> TermSize
+    minTermSize (TermSize wa ha) (TermSize wb hb) =
+      TermSize (min wa wb) (min ha hb)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Demux.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Demux.hs
@@ -95,12 +95,12 @@ dTake Demux{..} = do
         (_, Just (ClientTakeBelt b)) -> pure (Just (ClientTakeBelt b))
 
         (k, Just (ClientTakeSize s)) -> do
-          newSizeTree <- modifyAndReturnTVar dSizes (insertMap k s)
+          newSizeTree <- modifyAndReadTVar' dSizes (insertMap k s)
           maybeUpdateTerminalSize newSizeTree
 
         (k, Nothing) -> do
           writeTVar dConns (ksDelete k conns)
-          newSizeTree <- modifyAndReturnTVar dSizes (deleteMap k)
+          newSizeTree <- modifyAndReadTVar' dSizes (deleteMap k)
           maybeUpdateTerminalSize newSizeTree
 
   where
@@ -120,10 +120,10 @@ dTake Demux{..} = do
           writeTVar dMinSize termSize
           pure $ Just (ClientTakeSize termSize)
 
-    modifyAndReturnTVar :: TVar a -> (a -> a) -> STM a
-    modifyAndReturnTVar var fun = do
+    modifyAndReadTVar' :: TVar a -> (a -> a) -> STM a
+    modifyAndReadTVar' var fun = do
       pre <- readTVar var
-      let post = fun pre
+      let !post = fun pre
       writeTVar var post
       pure post
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Logic.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Logic.hs
@@ -37,6 +37,7 @@ type SpinnerState = Maybe SpinnerCause
 -}
 data Ev
     = EvLine Text
+    | EvSlog (Atom, Tank)
     | EvSpin SpinnerState
     | EvMove Word
     | EvBell
@@ -53,8 +54,13 @@ data Ef
     | EfSpin SpinnerState
   deriving (Show)
 
+data History
+    = HistoryText Text
+    | HistorySlog (Atom, Tank)
+  deriving (Show)
+
 data St = St
-    { sHistory :: Seq Text
+    { sHistory :: Seq History
     , sLine    :: Text
     , sCurPos  :: Word
     , sSpinner :: SpinnerState
@@ -74,19 +80,27 @@ init = St mempty "" 0 Nothing
 -}
 step :: St -> Ev -> St
 step st@St{..} = \case
-    EvLine t -> st & record t
+    EvLine t -> st & recordText t
+    EvSlog s -> st & recordSlog s
     EvSpin s -> st { sSpinner = s }
     EvMove w -> st { sCurPos = min w (word $ length sLine) }
     EvEdit t -> st { sLine = t, sCurPos = word (length t) }
-    EvMore   -> st { sLine = "", sCurPos = 0 } & record (sLine <> "\n")
+    EvMore   -> st { sLine = "", sCurPos = 0 } & recordText (sLine <> "\n")
     EvBell   -> st
     EvDraw   -> st
   where
     word :: Integral i => i -> Word
     word = fromIntegral
 
-    record :: Text -> St -> St
-    record t st@St{..} = st { sHistory = trim (sHistory |> t) }
+    recordText :: Text -> St -> St
+    recordText t st@St{..} = st {
+      sHistory = trim (sHistory |> (HistoryText t))
+      }
+
+    recordSlog :: (Atom, Tank) -> St -> St
+    recordSlog t st@St{..} = st {
+      sHistory = trim (sHistory |> (HistorySlog t))
+      }
 
     trim :: Seq a -> Seq a
     trim s | length s < 20 = s
@@ -96,10 +110,13 @@ step st@St{..} = \case
 drawState :: St -> [Ev]
 drawState St{..} = hist <> out <> cur <> spin
   where
-    hist = EvLine <$> toList sHistory
+    hist = fmap drawHistory $ toList sHistory
     out  = if null sLine   then [] else [EvEdit sLine]
     cur  = if 0 == sCurPos then [] else [EvMove $ fromIntegral $ sCurPos]
     spin = maybe [] (singleton . EvSpin . Just) sSpinner
+
+    drawHistory (HistoryText t) = EvLine t
+    drawHistory (HistorySlog s) = EvSlog s
 
 
 -- Conversion ------------------------------------------------------------------
@@ -127,11 +144,13 @@ fromTermEv = \case
     Term.Trace t  -> [EvLine $ unCord t]
     Term.Blank    -> [EvLine ""]
     Term.Spinr s  -> [EvSpin $ toCause <$> s]
+    Term.Slog s   -> [EvSlog s]
 
 toTermEv :: Ev -> Term.Ev
 toTermEv = \case
     EvLine "" -> Term.Blank
     EvLine t  -> Term.Trace (Cord t)
+    EvSlog s  -> Term.Slog s
     EvSpin s  -> Term.Spinr (fromCause <$> s)
     EvMove w  -> Term.Blits [Arvo.Hop $ fromIntegral w]
     EvBell    -> Term.Blits [Arvo.Bel ()]

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Logic.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term/Logic.hs
@@ -110,7 +110,7 @@ step st@St{..} = \case
 drawState :: St -> [Ev]
 drawState St{..} = hist <> out <> cur <> spin
   where
-    hist = fmap drawHistory $ toList sHistory
+    hist = drawHistory <$> toList sHistory
     out  = if null sLine   then [] else [EvEdit sLine]
     cur  = if 0 == sCurPos then [] else [EvMove $ fromIntegral $ sCurPos]
     spin = maybe [] (singleton . EvSpin . Just) sSpinner

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Tank.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Tank.hs
@@ -85,6 +85,12 @@ ram = \case
         loop [x]    = ram x <> r
         loop (x:xs) = ram x <> p <> loop xs
 
+tankToText :: Tank -> Text
+tankToText (Tank t) = unlines $ fmap unTape $ wash (WashCfg 0 80) t
+
+textToTank :: Text -> Tank
+textToTank = Tank . Leaf . Tape
+
 {-
   ++  win
     |=  {tab/@ edg/@}

--- a/pkg/hs/urbit-termsize/lib/Urbit/TermSize.hs
+++ b/pkg/hs/urbit-termsize/lib/Urbit/TermSize.hs
@@ -37,4 +37,6 @@ termSize = size <&> \case
 liveTermSize :: (TermSize -> IO ()) -> IO TermSize
 liveTermSize cb = do
   Sys.installHandler Sys.sigWINCH (Sys.Catch (termSize >>= cb)) Nothing
-  termSize
+  ts <- termSize
+  cb ts
+  pure ts


### PR DESCRIPTION
This fixes two, related problems with terminal handling in KH:

- slog (`~&`) and urbit-worker stderr output wouldn't display in mulitplexed terminals, because they were hardcoded to go to the stderr of the terminal that king haskell was attached to.

- Terminal sizing was wrong, in part because of multiplexed terminals.

These two commits can be reviewed individually.