### PR TITLE
zuse: adds |base16 en/decoding core

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6eaa8eba3b5170da4162feadcdc7804fa72db9b3746927d4a895fa192b0a6483
-size 6316916
+oid sha256:2291d9c0febd6ccd7538571ab1e41409f6808b12e5b3d3b0cb3e0fbf8c1bc8aa
+size 6319141

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6055,48 +6055,19 @@
       |%
       ++  en
         ~/  %en
-        |=  a=(pair @ud @)  ::  $octs, but safe
-        ^-  cord
-        ::  trailing zero bytes, possible truncated input
-        ::
-        =/  [pad=@ud dat=@]
-          =/  wid  (met 3 q.a)
-          ?:  (gte p.a wid)
-            [(sub p.a wid) q.a]
-          =/  dat  (cut 3 [0 p.a] q.a)
-          =.  wid  (met 3 dat)
-          [(sub p.a wid) dat]
-        ::
-        =/  dap  (add (mod (met 2 dat) 2) (mul 2 pad))
-        %+  rap  3
-        %+  weld  (reap dap '0')
-        %-  flop
-        %+  turn  (rip 2 dat)
-        |=  a=@C  ^-  cord
-        ?:  (lth a 10)
-          (add '0' a)
-        (add 'a' (sub a 10))
+        |=  a=octs  ^-  cord
+        (crip ((x-co:co (mul p.a 2)) (end 3 p.a q.a)))
       ::
       ++  de
         ~/  %de
-        |=  a=cord
-        ^-  (unit (pair @ud @))  ::  $octs, but safe
+        |=  a=cord  ^-  (unit octs)
         (rush a rule)
       ::
       ++  rule
-        |^  (bass 3 16 (star hit))
-        ::
-        ::  shadowed for bloq-length capture
-        ::
-        ++  bass
-          |*  [boq=@u wuc=@u tyd=^rule]
-          %+  cook
-            |=  waq=(list @)
-            =/  wid  (mul (lent waq) (dec (xeb wuc)))
-            :-  (rsh 0 boq (add wid (dec (bex boq))))
-            (roll waq |=([p=@ q=@] (add (end 0 wuc p) (mul wuc q))))
-          tyd
-        --
+        %+  cook
+          |=  a=(list @)  ^-  octs
+          [(add (dvr (lent a) 2)) (repn 4 (flop a))]
+        (star hit)
       --
     ::                                                  ::  ++en-base64:mimes:
     ++  en-base64                                       ::  encode base64

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6029,6 +6029,7 @@
   ::::                    ++mimes:html                  ::  (2e1) MIME
     ::                                                  ::::
   ++  mimes  ^?
+    ~%  %mimes  ..is  ~
     |%
     ::                                                  ::  ++as-octs:mimes:html
     ++  as-octs                                         ::  atom to octstream
@@ -6046,6 +6047,57 @@
       ?~  myn  ~
       ?:  =(~ t.myn)  (trip i.myn)
       (weld (trip i.myn) `tape`['/' $(myn t.myn)])
+    ::
+    ::  |base16: en/decode arbitrary MSB-first hex strings
+    ::
+    ++  base16
+      ~%  %base16  +  ~
+      |%
+      ++  en
+        ~/  %en
+        |=  a=(pair @ud @)  ::  $octs, but safe
+        ^-  cord
+        ::  trailing zero bytes, possible truncated input
+        ::
+        =/  [pad=@ud dat=@]
+          =/  wid  (met 3 q.a)
+          ?:  (gte p.a wid)
+            [(sub p.a wid) q.a]
+          =/  dat  (cut 3 [0 p.a] q.a)
+          =.  wid  (met 3 dat)
+          [(sub p.a wid) dat]
+        ::
+        =/  dap  (add (mod (met 2 dat) 2) (mul 2 pad))
+        %+  rap  3
+        %+  weld  (reap dap '0')
+        %-  flop
+        %+  turn  (rip 2 dat)
+        |=  a=@C  ^-  cord
+        ?:  (lth a 10)
+          (add '0' a)
+        (add 'a' (sub a 10))
+      ::
+      ++  de
+        ~/  %de
+        |=  a=cord
+        ^-  (unit (pair @ud @))  ::  $octs, but safe
+        (rush a rule)
+      ::
+      ++  rule
+        |^  (bass 3 16 (star hit))
+        ::
+        ::  shadowed for bloq-length capture
+        ::
+        ++  bass
+          |*  [boq=@u wuc=@u tyd=^rule]
+          %+  cook
+            |=  waq=(list @)
+            =/  wid  (mul (lent waq) (dec (xeb wuc)))
+            :-  (rsh 0 boq (add wid (dec (bex boq))))
+            (roll waq |=([p=@ q=@] (add (end 0 wuc p) (mul wuc q))))
+          tyd
+        --
+      --
     ::                                                  ::  ++en-base64:mimes:
     ++  en-base64                                       ::  encode base64
       |=  tig/@

--- a/pkg/arvo/tests/sys/zuse/mimes.hoon
+++ b/pkg/arvo/tests/sys/zuse/mimes.hoon
@@ -1,0 +1,64 @@
+::  tests for |mimes:html
+::
+/+  *test
+=,  mimes:html
+|%
+++  test-en-base16
+  ;:  weld
+    %+  expect-eq
+      !>  'aa'
+      !>  (en:base16 (as-octs 0xaa))
+  ::
+    %+  expect-eq
+      !>  '1234'
+      !>  (en:base16 (as-octs 0x1234))
+  ::
+    %+  expect-eq
+      !>  'f012'
+      !>  (en:base16 (as-octs 0xf012))
+  ::
+    %+  expect-eq
+      !>  '010b'
+      !>  (en:base16 (as-octs 0x10b))
+  ::
+    %+  expect-eq
+      !>  '001234'
+      !>  (en:base16 3 0x1234)
+  ::
+    %+  expect-eq
+      !>  '34'
+      !>  (en:base16 1 0x1234)
+  ==
+::
+++  test-de-base16
+  ;:  weld
+    %+  expect-eq
+      !>  `[1 0xaa]
+      !>  ^-  (unit [@ud @ux])
+          (de:base16 'aa')
+  ::
+    %+  expect-eq
+      !>  `[2 0x1234]
+      !>  `(unit [@ud @ux])`(de:base16 '1234')
+  ::
+    %+  expect-eq
+      !>  `[2 `@`0xf012]
+      !>  ^-  (unit [@ud @ux])
+          (de:base16 'f012')
+  ::
+    %+  expect-eq
+      !>  lz=`[2 0x10b]
+      !>  ^-  (unit [@ud @ux])
+          (de:base16 '010b')
+  ::
+    %+  expect-eq
+      !>  nlz=`[2 0x10b]
+      !>  ^-  (unit [@ud @ux])
+          (de:base16 '10b')
+  ::
+    %+  expect-eq
+      !>  `[3 0x1234]
+      !>  ^-  (unit [@ud @ux])
+          (de:base16 '001234')
+  ==
+--


### PR DESCRIPTION
Motivated by #1892, jets incoming. This is just typical MSB-first hex; the only remotely interesting part is the careful handling of input length to account for leading zeros. (The input will be `$octs` once #3554 is in.)

The API is (mostly) taken from `lib/base64`, which I intend to clean up and move into %zuse (and jet) in a similar manner.