### PR TITLE
interface: open dev server to network

### DIFF
--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -44,6 +44,8 @@ let devServer = {
   contentBase: path.join(__dirname, '../dist'),
   hot: true,
   port: 9000,
+  host: '0.0.0.0',
+  disableHostCheck: true,
   historyApiFallback: true
 };
 


### PR DESCRIPTION
This opens up the dev server to network connections, for instance on a mobile device on the same wifi network.