### PR TITLE
shoe: don't auto-run discontinuous inputs

### DIFF
--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -243,7 +243,10 @@
         %+  rose  (tufa buf.cli-state)
         (command-parser:og sole-id)
       ?:  ?=(%& -.res)
-        ?.  &(?=(^ p.res) run.u.p.res)
+        ::  only auto-run eligible commands if they were typed out
+        ::  (that is, not retrieved from command history)
+        ::
+        ?.  &(?=(^ p.res) run.u.p.res !?=(%set -.ted.sole-change))
           [[~ cli-state] shoe]
         (run-command cmd.u.p.res)
       :_  shoe


### PR DESCRIPTION
Previously, up-arrowing into (or otherwise retrieving) a command from history
that automatically runs on-input would directly run the command again,
preventing the user from up-arrowing past the auto-run command into further
history.

With this change, shoe detects discontinuous inputs (sole's `%set` edit), and
refuses to auto-run the parsed command in those cases.

Wrote an alternative fix here: 4267761, but ultimately decided against leaving auto-run commands out of history entirely. I imagine the behavior here fits user expectations better. Maybe this needs to be configurable, but I'm be hesitant to make that change without clear demand for it.