### PR TITLE
Implement stateless forwarding in the king

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/King/App.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/App.hs
@@ -190,9 +190,9 @@ runHostEnv multi ports action = do
     king <- ask
 
     let hostEnv = HostEnv { _hostEnvKingEnv        = king
-                                , _hostEnvMultiEyreApi   = multi
-                                , _hostEnvPortControlApi = ports
-                                }
+                          , _hostEnvMultiEyreApi   = multi
+                          , _hostEnvPortControlApi = ports
+                          }
 
     io (runRIO hostEnv action)
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -9,13 +9,18 @@ import Urbit.Prelude
 import Network.Socket              hiding (recvFrom, sendTo)
 import Urbit.Arvo                  hiding (Fake)
 import Urbit.King.Config
+import Urbit.Vere.Ames.LaneCache
+import Urbit.Vere.Ames.Packet
 import Urbit.Vere.Pier.Types
 import Urbit.Vere.Ports
 
+import Data.Serialize      (decode, encode)
 import Urbit.King.App      (HasKingId(..), HasPierEnv(..))
 import Urbit.Vere.Ames.DNS (NetworkMode(..), ResolvServ(..))
 import Urbit.Vere.Ames.DNS (galaxyPort, resolvServ)
 import Urbit.Vere.Ames.UDP (UdpServ(..), fakeUdpServ, realUdpServ)
+
+import qualified Urbit.Noun.Time as Time
 
 
 -- Constants -------------------------------------------------------------------
@@ -33,11 +38,15 @@ packetsDroppedPerComplaint = 1000
 
 -- Types -----------------------------------------------------------------------
 
+type Version = Word8
+
 data AmesDrv = AmesDrv
   { aTurfs    :: TVar (Maybe [Turf])
   , aDropped  :: TVar Word
+  , aVersion  :: TVar (Maybe Version)
   , aUdpServ  :: UdpServ
   , aResolvr  :: ResolvServ
+  , aVersTid  :: Async ()
   , aRecvTid  :: Async ()
   }
 
@@ -82,9 +91,10 @@ bornEv inst = EvBlip $ BlipEvNewt $ NewtEvBorn (fromIntegral inst, ()) ()
 
 hearEv :: PortNumber -> HostAddress -> ByteString -> Ev
 hearEv p a bs =
-  EvBlip $ BlipEvAmes $ AmesEvHear () dest (MkBytes bs)
- where
-  dest = EachNo $ Jammed $ AAIpv4 (Ipv4 a) (fromIntegral p)
+  EvBlip $ BlipEvAmes $ AmesEvHear () (ipDest p a) (MkBytes bs)
+
+ipDest :: PortNumber -> HostAddress -> AmesDest
+ipDest p a = EachNo $ Jammed $ AAIpv4 (Ipv4 a) (fromIntegral p)
 
 
 --------------------------------------------------------------------------------
@@ -125,9 +135,10 @@ ames'
   :: HasPierEnv e
   => Ship
   -> Bool
+  -> (Time.Wen -> Gang -> Path -> (Maybe (Term, Noun) -> IO ()) -> STM ())
   -> (Text -> RIO e ())
   -> RIO e ([Ev], RAcquire e (DriverApi NewtEf))
-ames' who isFake stderr = do
+ames' who isFake scry stderr = do
   -- Unfortunately, we cannot use TBQueue because the only behavior
   -- provided for when full is to block the writer. The implementation
   -- below uses materially the same data structures as TBQueue, however.
@@ -151,7 +162,7 @@ ames' who isFake stderr = do
       pure pM
 
   env <- ask
-  let (bornEvs, startDriver) = ames env who isFake enqueuePacket stderr
+  let (bornEvs, startDriver) = ames env who isFake scry enqueuePacket stderr
 
   let runDriver = do
         diOnEffect <- startDriver
@@ -178,10 +189,11 @@ ames
   => e
   -> Ship
   -> Bool
+  -> (Time.Wen -> Gang -> Path -> (Maybe (Term, Noun) -> IO ()) -> STM ())
   -> (EvErr -> STM PacketOutcome)
   -> (Text -> RIO e ())
   -> ([Ev], RAcquire e (NewtEf -> IO ()))
-ames env who isFake enqueueEv stderr = (initialEvents, runAmes)
+ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
  where
   king = fromIntegral (env ^. kingIdL)
 
@@ -194,36 +206,85 @@ ames env who isFake enqueueEv stderr = (initialEvents, runAmes)
     drv  <- mkRAcquire start stop
     pure (handleEffect drv mode)
 
-  start :: HasLogFunc e => RIO e AmesDrv
+  start :: RIO e AmesDrv
   start = do
+    mode <- rio (netMode isFake)
+    cache <- laneCache scryLane
+
     aTurfs   <- newTVarIO Nothing
     aDropped <- newTVarIO 0
+    aVersion <- newTVarIO Nothing
+    aVersTid <- trackVersionThread aVersion
     aUdpServ <- udpServ isFake who
-    aRecvTid <- queuePacketsThread aDropped aUdpServ
     aResolvr <- resolvServ aTurfs (usSend aUdpServ) stderr
+    aRecvTid <- queuePacketsThread
+      aDropped
+      aVersion
+      (byCache cache)
+      (send aUdpServ aResolvr mode)
+      aUdpServ
+
     pure (AmesDrv { .. })
 
   hearFailed _ = pure ()
 
-  queuePacketsThread :: HasLogFunc e => TVar Word -> UdpServ -> RIO e (Async ())
-  queuePacketsThread dropCtr UdpServ {..} = async $ forever $ do
-    outcome <- atomically $ do
-      (p, a, b) <- usRecv
-      enqueueEv (EvErr (hearEv p a b) hearFailed)
-    case outcome of
-      Intake -> pure ()
-      Ouster -> do
-        d <- atomically $ do
-          d <- readTVar dropCtr
-          writeTVar dropCtr (d + 1)
-          pure d
-        when (d `rem` packetsDroppedPerComplaint == 0) $
-          logWarn "ames: queue full; dropping inbound packets"
+  trackVersionThread :: HasLogFunc e => TVar (Maybe Version) -> RIO e (Async ())
+  trackVersionThread versSlot = async $ forever do
+    env <- ask
 
-  stop :: AmesDrv -> RIO e ()
+    scryVersion \v -> do
+      v0 <- readTVarIO versSlot
+      atomically $ writeTVar versSlot (Just v)
+      if (v0 == Just v)
+        then logInfo $ displayShow ("ames: proto version unchanged at", v)
+        else stderr ("ames: protocol version now " <> tshow v)
+
+    threadDelay (10 * 60 * 1_000_000)  -- 10m
+
+  queuePacketsThread :: HasLogFunc e
+                     => TVar Word
+                     -> TVar (Maybe Version)
+                     -> (Ship -> (Maybe [AmesDest] -> RIO e ()) -> RIO e ())
+                     -> (AmesDest -> ByteString -> RIO e ())
+                     -> UdpServ
+                     -> RIO e (Async ())
+  queuePacketsThread dropCtr vers lan forward UdpServ{..} = async $ forever $ do
+      -- port number, host address, bytestring
+    (p, a, b) <- atomically usRecv
+    ver <- readTVarIO vers
+
+    case decode b of
+      Right (pkt@Packet {..}) | ver == Nothing || ver == Just pktVersion -> do
+        logDebug $ displayShow ("ames: bon packet", pkt, showUD $ bytesAtom b)
+
+        if pktRcvr == who
+          then serf'sUp p a b
+          else lan pktRcvr $ \case
+            Just (dest:_) -> forward dest $ encode pkt
+              { pktOrigin = pktOrigin <|> Just (ipDest p a) }
+            _ -> logInfo $ displayShow ("ames: dropping unroutable", pkt)
+
+      Right pkt -> logInfo $ displayShow ("ames: dropping ill-versed", pkt, ver)
+
+      Left e -> logInfo $ displayShow ("ames: dropping malformed", e)
+
+    where
+      serf'sUp p a b =
+        atomically (enqueueEv (EvErr (hearEv p a b) hearFailed)) >>= \case
+          Intake -> pure ()
+          Ouster -> do
+            d <- atomically $ do
+              d <- readTVar dropCtr
+              writeTVar dropCtr (d + 1)
+              pure d
+            when (d `rem` packetsDroppedPerComplaint == 0) $
+              logWarn "ames: queue full; dropping inbound packets"
+
+  stop :: forall e. AmesDrv -> RIO e ()
   stop AmesDrv {..} = io $ do
     usKill aUdpServ
     rsKill aResolvr
+    cancel aVersTid
     cancel aRecvTid
 
   handleEffect :: AmesDrv -> NetworkMode -> NewtEf -> IO ()
@@ -234,19 +295,53 @@ ames env who isFake enqueueEv stderr = (initialEvents, runAmes)
     NewtEfSend (_id, ()) dest (MkBytes bs) -> do
       atomically (readTVar aTurfs) >>= \case
         Nothing    -> stderr "ames: send before turfs" >> pure ()
-        Just turfs -> sendPacket drv mode dest bs
+        Just turfs -> send aUdpServ aResolvr mode dest bs
 
-  sendPacket :: AmesDrv -> NetworkMode -> AmesDest -> ByteString -> RIO e ()
-  sendPacket AmesDrv {..} mode dest byt = do
-    let to adr = io (usSend aUdpServ adr byt)
+  send :: UdpServ
+       -> ResolvServ
+       -> NetworkMode
+       -> AmesDest
+       -> ByteString
+       -> RIO e ()
+  send udpServ resolvr mode dest byt = do
+    let to adr = io (usSend udpServ adr byt)
 
     case (mode, dest) of
       (NoNetwork, _ ) -> pure ()
       (Fake     , _ ) -> when (okFakeAddr dest) $ to (localAddr Fake dest)
       (Localhost, _ ) -> to (localAddr Localhost dest)
       (Real     , ra) -> ra & \case
-        EachYes gala -> io (rsSend aResolvr gala byt)
+        EachYes gala -> io (rsSend resolvr gala byt)
         EachNo  addr -> to (ipv4Addr addr)
+
+  scryVersion :: HasLogFunc e => (Version -> RIO e ()) -> RIO e ()
+  scryVersion = scry' ["protocol", "version"]
+              . maybe (logError "ames: could not scry for version")
+
+  scryLane :: HasLogFunc e
+           => Ship
+           -> (Maybe [AmesDest] -> RIO e ())
+           -> RIO e ()
+  scryLane ship = scry' ["peers", MkKnot $ tshow ship, "forward-lane"]
+
+  scry' :: forall e n
+         . (HasLogFunc e, FromNoun n)
+        => [Knot]
+        -> (Maybe n -> RIO e ())
+        -> RIO e ()
+  scry' p k = do
+    env <- ask
+    wen <- io Time.now
+    let nkt = MkKnot $ tshow $ Time.MkDate wen
+    let pax = Path $ "ax" : MkKnot (tshow who) : "" : nkt : p
+    putStrLn ("scrying for " <> tshow pax)
+    let kon = runRIO env . \case
+          Just (_, fromNoun @n -> Just v) -> k (Just v)
+          Just (_, n) -> do
+            logError $ displayShow ("ames: uncanny scry result", pax, n)
+            k Nothing
+          Nothing -> k Nothing
+    atomically $ scry wen Nothing pax kon
 
   ipv4Addr (Jammed (AAVoid v  )) = absurd v
   ipv4Addr (Jammed (AAIpv4 a p)) = SockAddrInet (fromIntegral p) (unIpv4 a)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -235,11 +235,12 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
     scryVersion \v -> do
       v0 <- readTVarIO versSlot
       atomically $ writeTVar versSlot (Just v)
+      putStrLn "wow"
       if (v0 == Just v)
         then logInfo $ displayShow ("ames: proto version unchanged at", v)
         else stderr ("ames: protocol version now " <> tshow v)
 
-    threadDelay (10 * 60 * 1_000_000)  -- 10m
+    threadDelay (1_000_000)  -- 10m
 
   queuePacketsThread :: HasLogFunc e
                      => TVar Word
@@ -258,7 +259,7 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
         logDebug $ displayShow ("ames: bon packet", pkt, showUD $ bytesAtom b)
 
         if pktRcvr == who
-          then serf'sUp p a b
+          then serfsUp p a b
           else lan pktRcvr $ \case
             Just (dest:_) -> forward dest $ encode pkt
               { pktOrigin = pktOrigin <|> Just (ipDest p a) }
@@ -269,7 +270,7 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
       Left e -> logInfo $ displayShow ("ames: dropping malformed", e)
 
     where
-      serf'sUp p a b =
+      serfsUp p a b =
         atomically (enqueueEv (EvErr (hearEv p a b) hearFailed)) >>= \case
           Intake -> pure ()
           Ouster -> do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -235,12 +235,11 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
     scryVersion \v -> do
       v0 <- readTVarIO versSlot
       atomically $ writeTVar versSlot (Just v)
-      putStrLn "wow"
       if (v0 == Just v)
         then logInfo $ displayShow ("ames: proto version unchanged at", v)
         else stderr ("ames: protocol version now " <> tshow v)
 
-    threadDelay (1_000_000)  -- 10m
+    threadDelay (10 * 60 * 1_000_000)  -- 10m
 
   queuePacketsThread :: HasLogFunc e
                      => TVar Word
@@ -335,7 +334,6 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
     wen <- io Time.now
     let nkt = MkKnot $ tshow $ Time.MkDate wen
     let pax = Path $ "ax" : MkKnot (tshow who) : "" : nkt : p
-    putStrLn ("scrying for " <> tshow pax)
     let kon = runRIO env . \case
           Just (_, fromNoun @n -> Just v) -> k (Just v)
           Just (_, n) -> do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -267,6 +267,21 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
 
       Right pkt -> logInfo $ displayShow ("ames: dropping ill-versed", pkt, ver)
 
+      -- XX better handle misversioned or illegible packets.
+      -- Remarks from 67f06ce5, pkg/urbit/vere/io/ames.c, L1010:
+      --
+      -- [There are] two protocol-change scenarios [which we must think about]:
+      --
+      --  - packets using old protocol versions from our sponsees
+      --    these must be let through, and this is a transitive condition;
+      --    they must also be forwarded where appropriate
+      --    they can be validated, as we know their semantics
+      --
+      --  - packets using newer protocol versions
+      --    these should probably be let through, or at least
+      --    trigger printfs suggesting upgrade.
+      --    they cannot be filtered, as we do not know their semantics
+      --
       Left e -> logInfo $ displayShow ("ames: dropping malformed", e)
 
     where

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames.hs
@@ -261,8 +261,13 @@ ames env who isFake scry enqueueEv stderr = (initialEvents, runAmes)
         if pktRcvr == who
           then serfsUp p a b
           else lan pktRcvr >>= \case
-            Just (dest:_) -> forward dest $ encode pkt
-              { pktOrigin = pktOrigin <|> Just (ipDest p a) }
+            Just ls
+              |  dest:_ <- filter notSelf ls
+              -> forward dest $ encode pkt
+                { pktOrigin = pktOrigin <|> Just (ipDest p a) }
+              where
+                notSelf (EachYes g) = who /= Ship (fromIntegral g)
+                notSelf (EachNo  _) = True
             _ -> logInfo $ displayShow ("ames: dropping unroutable", pkt)
 
       Right pkt -> logInfo $ displayShow ("ames: dropping ill-versed", pkt, ver)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/LaneCache.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/LaneCache.hs
@@ -1,0 +1,34 @@
+module Urbit.Vere.Ames.LaneCache (LaneCache, laneCache, byCache) where
+
+import Urbit.Prelude
+
+import Urbit.Noun.Time
+
+expiry :: Gap
+expiry = (2 * 60) ^. from secs
+
+data LaneCache m a b = LaneCache
+  { lcCache    :: TVar (Map a (Wen, b))
+  , lcAction   :: a -> (b -> m ()) -> m ()
+  }
+
+laneCache :: (Ord a, MonadIO n)
+          => (a -> (b -> m ()) -> m ())
+          -> n (LaneCache m a b)
+laneCache act = LaneCache <$> newTVarIO mempty <*> pure act
+
+byCache :: (Ord a, MonadIO m)
+        => LaneCache m a b
+        -> a -> (b -> m ()) -> m ()
+byCache LaneCache {..} x f = lookup x <$> readTVarIO lcCache >>= \case
+  Nothing -> go
+  Just (t, v) -> do
+    t' <- io now
+    if gap t' t > expiry
+      then go
+      else f v
+  where
+    go = lcAction x $ \v -> do
+      t <- io now
+      atomically $ modifyTVar' lcCache (insertMap x (t, v))
+      f v

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
@@ -22,6 +22,7 @@ data Packet = Packet
   , pktOrigin     :: Maybe AmesDest
   , pktContent    :: Bytes
   }
+  deriving Eq
 
 instance Show Packet where
   show Packet {..}

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
@@ -1,0 +1,102 @@
+{-|
+  Parsing of Ames packets
+-}
+
+module Urbit.Vere.Ames.Packet where
+
+import Urbit.Prelude
+
+import Data.Bits
+import Data.LargeWord
+import Data.Serialize
+
+import Urbit.Arvo (AmesDest)
+import Urbit.Noun.Tree (mug)
+
+data Packet = Packet
+  { pktVersion    :: Word8
+  , pktEncrypted  :: Bool
+  --
+  , pktSndr       :: Ship
+  , pktRcvr       :: Ship
+  , pktOrigin     :: Maybe AmesDest
+  , pktContent    :: Bytes
+  }
+
+instance Show Packet where
+  show Packet {..}
+    = "Packet {pktVersion = "
+   <> show pktVersion
+   <> ", pktEncrypted = "
+   <> show pktEncrypted
+   <> ", pktSndr = "
+   <> show pktSndr
+   <> ", pktRcvr = "
+   <> show pktRcvr
+   <> ", pktOrigin = "
+   <> show pktOrigin
+   <> ", pktContent = "
+   <> showUD (bytesAtom $ unBytes pktContent)
+   <> "}"
+
+instance Serialize Packet where
+  get = do
+    -- header
+    head <- getWord32le
+    let pktVersion   =         head    .&. 0b111        & fromIntegral
+    let checksum     = shiftR  head  3 .&. (2 ^ 20 - 1)
+    let sndrRank     = shiftR  head 23 .&. 0b11
+    let rcvrRank     = shiftR  head 25 .&. 0b11
+    let pktEncrypted = testBit head 27  &  not  -- loobean
+    -- verify checksum
+    lookAhead $ do
+      len  <- remaining
+      body <- getBytes len
+      -- XX mug (marked "TODO") is implemented as "slowMug" in U.N.Tree. Ominous
+      -- Also, toNoun will copy the bytes into an atom. We probably want a mugBS
+      let chk = fromIntegral (mug $ toNoun $ MkBytes body) .&. (2 ^ 20 - 1)
+      when (checksum /= chk) $
+        fail ("checksum mismatch: expected " <> show checksum
+           <> "; got " <> show chk)
+    -- body
+    pktSndr <- getShip sndrRank
+    pktRcvr <- getShip rcvrRank
+    len     <- remaining
+    payload <- getBytes len
+    -- data ("payload")
+    (pktOrigin, pktContent) <- case cueBS payload of
+          Left  e -> fail (show e)
+          Right n -> case fromNounErr n of
+            Left  e -> fail (show e)
+            Right c -> pure c
+    pure Packet {..}
+    where
+      getShip = fmap Ship . \case
+        0 -> fromIntegral <$> getWord16le              -- galaxy / star
+        1 -> fromIntegral <$> getWord32le              -- planet
+        2 -> fromIntegral <$> getWord64le              -- moon
+        3 -> LargeKey <$> getWord64le <*> getWord64le  -- comet
+        _ -> fail "impossibiru"
+
+  put Packet {..} = do
+    let load = jamBS $ toNoun (pktOrigin, pktContent)
+    let (sndR, putSndr) = putShipGetRank pktSndr
+    let (rcvR, putRcvr) = putShipGetRank pktRcvr
+    let body = runPut (putSndr <> putRcvr <> putByteString load)
+    -- XX again maybe mug can be made better here
+    let chek = fromIntegral (mug $ toNoun $ MkBytes body) .&. (2 ^ 20 - 1)
+    let encr = pktEncrypted
+    let vers = fromIntegral pktVersion .&. 0b111
+    let head =        vers
+           .|. shiftL chek                  3
+           .|. shiftL sndR                 23
+           .|. shiftL rcvR                 25
+           .|. if     encr then 0 else bit 27
+    putWord32le head
+    putByteString body  -- XX can we avoid copy?
+    where
+      putShipGetRank s@(Ship (LargeKey p q)) = case () of
+        _ | s < 2 ^ 16 -> (0, putWord16le $ fromIntegral s)    -- gar
+          | s < 2 ^ 32 -> (1, putWord32le $ fromIntegral s)    -- pan
+          | s < 2 ^ 64 -> (2, putWord64le $ fromIntegral s)    -- mon
+          | otherwise  -> (3, putWord64le p >> putWord64le q)  -- com

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
@@ -250,8 +250,8 @@ recvPeek :: Serf -> IO (Maybe (Term, Noun))
 recvPeek serf = do
   recvPleaHandlingSlog serf >>= \case
     PPeek (SDone peek) -> pure peek
-    -- XX produce error
-    PPeek (SBail dud)  -> throwIO (PeekBail dud)
+    -- XX surface error content
+    PPeek (SBail dud)  -> pure Nothing
     plea               -> throwIO (UnexpectedPlea (toNoun plea) "expecting %peek")
 
 

--- a/pkg/hs/urbit-king/package.yaml
+++ b/pkg/hs/urbit-king/package.yaml
@@ -31,6 +31,7 @@ dependencies:
   - binary
   - bytestring
   - case-insensitive
+  - cereal
   - classy-prelude
   - conduit
   - containers
@@ -119,6 +120,7 @@ dependencies:
 default-extensions:
   - ApplicativeDo
   - BangPatterns
+  - BinaryLiterals
   - BlockArguments
   - ConstraintKinds
   - DataKinds
@@ -145,6 +147,7 @@ default-extensions:
   - OverloadedStrings
   - PackageImports
   - PartialTypeSignatures
+  - PatternGuards
   - PatternSynonyms
   - QuasiQuotes
   - Rank2Types

--- a/pkg/hs/urbit-noun/package.yaml
+++ b/pkg/hs/urbit-noun/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - text
   - time
   - urbit-atom
+  - urbit-hob
   - urbit-noun-core
 
 default-extensions:


### PR DESCRIPTION
Our version of #3174 and #3405.

When the king receives a packet, he parses it and determines if it is for a ship other than himself. If so, he forwards it without involving the serf, except that he from time to time scries the serf for information on the routes ("lanes"/"AmesDests") stored for ships he wishes to forward to. Additionally, he drops packets that are malformed, have the wrong version number, or which are bound for ships that we don't have a route to.

Test plan.

Change the logDebug to a logInfo on L258 and add the following code at L259 of Ames.hs:
```
if encode pkt == b
  then logInfo $ displayShow ("ames: packet match")
  else logInfo $ displayShow ("ames: packet mismatch", encode pkt, b)
```
Throughout, verify that we have only "packet match" messages.

1. Run your own ship with this version of king haskell. Make sure everything looks good and we have no packet parsing errors.

2. Run the following transcript
```
$ ./urbit-king new -F zod
$ ./urbit-king new -F marzod
$ ./urbit-king new -F panzod
zod> |hi ~marzod
marzod> |hi ~zod
panzod> |hi ~zod
panzod> |hi ~marzod
```
Look to see that all the printouts look good. In particular, for the hi from panzod to marzod, we should see a packet arrive at zod with sndr panzod, rcvr marzod, and origin Nothing, and we should subsequently see a packet arrive at marzod with sndr panzod, rcvr marzod, and origin Just <stuff>.

3. [testing the cache system]. Modify LaneCache.hs to have an expiry of only 3 seconds. Add putStrLns to each of the three possible outcomes of `byCache`. To the start function in Ames.hs add code which spawns a thread that, every .5s scries for the route to marzod (Ship 256). Start the zod from part 2 of this test plan and watch the printouts. You should see first that there is a cache miss, then that there are a bunch of cache hits, then a cache expiry.