### PR TITLE
zuse: improve url extension parsing

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a5ffa86349b0f418d7d5a5f69a773d29b1d48d80d657058ff5abb0572f5187f
-size 6409970
+oid sha256:b4e0acf6459d5d17f2dff4de71e9ddd0732148f00bd13d0c092fdfa14774a015
+size 6332407

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6563,8 +6563,13 @@
       ?^  t.rax
         [p.pok [ire q.pok]]:[pok=$(rax t.rax) ire=i.rax]
       =/  raf/(like term)
-          =>  |=(a/@ ((sand %tas) (crip (flop (trip a)))))
-          (;~(sfix (sear . sym) dot) [1^1 (flop (trip i.rax))])
+        %-  ;~  sfix
+              %+  sear
+                |=(a/@ ((sand %ta) (crip (flop (trip a)))))
+              (cook |=(a/tape (rap 3 ^-((list @) a))) (star aln))
+              dot
+            ==
+        [1^1 (flop (trip i.rax))]
       ?~  q.raf
         [~ [i.rax ~]]
       =+  `{ext/term {@ @} fyl/tape}`u.q.raf


### PR DESCRIPTION
Previously extensions ending with numbers such as `.woff2` were not recognized.

Observe:
```
(rash '/~landscape/fonts/inter.woff2' apat:de-purl:html)
[p=~ q=<|~landscape fonts inter.woff2|>]
```

Now: 
```
(rash '/~landscape/fonts/inter.woff2' apat:de-purl:html)
[p=[~ ~.woff2] q=<|~landscape fonts inter|>]
```