### PR TITLE
landscape: increase z-index of dropdown search

### DIFF
--- a/pkg/interface/src/views/components/DropdownSearch.tsx
+++ b/pkg/interface/src/views/components/DropdownSearch.tsx
@@ -128,7 +128,7 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>) {
   );
 
   return (
-    <Box position="relative">
+    <Box position="relative" zIndex={9}>
       <Label htmlFor={props.id}>{props.label}</Label>
       {caption ? <Label mt="2" gray>{caption}</Label> : null}
       {!props.disabled && (


### PR DESCRIPTION
fixes #3583

I figure this is safe because in general you want dropdowns to be above other things. LMK if there's a better pattern to use here.