### PR TITLE
landscape: delay uploading briefly to account for browser inconsistencies

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/lib/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/lib/ChatInput.tsx
@@ -162,12 +162,9 @@ export default class ChatInput extends Component<ChatInputProps, ChatInputState>
     }
     if (!this.s3Uploader.current || !this.s3Uploader.current.inputRef.current) return;
     this.s3Uploader.current.inputRef.current.files = files;
-    setTimeout(() => {
-      if (this.s3Uploader.current.state.isUploading) return;
-      const fire = document.createEvent("HTMLEvents");
-      fire.initEvent("change", true, true);
-      this.s3Uploader.current?.inputRef.current?.dispatchEvent(fire);
-    }, 200);
+    const fire = document.createEvent("HTMLEvents");
+    fire.initEvent("change", true, true);
+    this.s3Uploader.current?.inputRef.current?.dispatchEvent(fire);
   }
 
   render() {

--- a/pkg/interface/src/views/components/s3-upload.tsx
+++ b/pkg/interface/src/views/components/s3-upload.tsx
@@ -99,22 +99,25 @@ export class S3Upload extends Component<S3UploadProps, S3UploadState> {
     const timestamp = deSig(dateToDa(new Date()));
     let bucket = props.configuration.currentBucket;
 
-    this.setState({ isUploading: true });
+    setTimeout(() => {
+      if (this.state.isUploading) return;
+      this.setState({ isUploading: true });
+      this.s3.upload(bucket, `${window.ship}/${timestamp}-${fileName}.${fileExtension}`, file)
+        .then((data) => {
+          if (!data || !('Location' in data)) {
+            return;
+          }
+          this.props.uploadSuccess(data.Location);
+        })
+        .catch((err) => {
+          console.error(err);
+          this.props.uploadError(err);
+        })
+        .finally(() => {
+          this.setState({ isUploading: false });
+        });
+    }, 200);
 
-    this.s3.upload(bucket, `${window.ship}/${timestamp}-${fileName}.${fileExtension}`, file)
-      .then((data) => {
-        if (!data || !('Location' in data)) {
-          return;
-        }
-        this.props.uploadSuccess(data.Location);
-      })
-      .catch((err) => {
-        console.error(err);
-        this.props.uploadError(err);
-      })
-      .finally(() => {
-        this.setState({ isUploading: false });
-      });
   }
 
   onClick() {


### PR DESCRIPTION
fixes #3589

Due to inconsistencies in how browsers handle "change" events, it is necessary to make a brief delay on S3 uploader to prevent double-uploading