### PR TITLE
leap: use indigo-react icons

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -68,7 +68,7 @@ const appIndex = function (apps) {
     });
   // add groups separately
   applications.push(
-    result('Groups', '/~groups', 'groups', null)
+    result('Groups', '/~groups', 'Groups', null)
   );
   return applications;
 };

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -26,43 +26,20 @@ export class OmniboxResult extends Component {
   }
 
   getIcon(icon, dark, selected, link) {
-    // graphicStyle is only necessary for pngs
-    //
-    //TODO can be removed after indigo-react 1.2
-    //which includes icons for apps
-    let graphicStyle = {};
-
-    if (icon.toLowerCase() !== 'dojo') {
-      graphicStyle = (!dark && this.state.hovered) ||
-        selected === link ||
-        (dark && !(this.state.hovered || selected === link))
-        ? { filter: 'invert(1)' }
-        : { filter: 'invert(0)' };
-    } else {
-      graphicStyle =
-        (!dark && this.state.hovered) ||
-          selected === link ||
-          (dark && !(this.state.hovered || selected === link))
-          ? { filter: 'invert(0)' }
-          : { filter: 'invert(1)' };
-    }
-
-    const iconFill = this.state.hovered || selected === link ? 'white' : 'black';
-    const sigilFill = this.state.hovered || selected === link ? '#3a8ff7' : '#ffffff';
+    const iconFill = (this.state.hovered || (selected === link)) ? 'white' : 'black';
+    const sigilFill = (this.state.hovered || (selected === link)) ? '#3a8ff7' : '#ffffff';
 
     let graphic = <div />;
     if (defaultApps.includes(icon.toLowerCase()) || icon.toLowerCase() === 'links') {
-      graphic =
-        <img className="mr2 v-mid dib" height="16"
-          width="16" src={`/~landscape/img/${icon.toLowerCase()}.png`}
-          style={graphicStyle}
-        />;
+      icon = (icon === 'Dojo') ? 'ChevronEast' : icon;
+      icon = (icon === 'Link') ? 'Links' : icon;
+      graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'logout') {
-      graphic = <Icon display="inline-block" verticalAlign="middle" icon='ArrowWest' mr='2' size='16px' fill={iconFill} />;
+      graphic = <Icon display="inline-block" verticalAlign="middle" icon='ArrowWest' mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'profile') {
       graphic = <Sigil color={sigilFill} classes='dib v-mid mr2' ship={window.ship} size={16} />;
     } else {
-      graphic = <Icon verticalAlign="middle" mr='2' size="16px" fill={iconFill} />;
+      graphic = <Icon verticalAlign="middle" mr='2' size="16px" color={iconFill} />;
     }
 
     return graphic;
@@ -78,68 +55,40 @@ export class OmniboxResult extends Component {
     const graphic = this.getIcon(icon, dark, selected, link);
 
     return (
-        <Row
-          py='2'
-          px='2'
-          display='flex'
-          flexDirection='row'
-          style={{ cursor: 'pointer' }}
-          onMouseEnter={() => this.setHover(true)}
-          onMouseLeave={() => this.setHover(false)}
-          backgroundColor={
-            this.state.hovered || selected === link ? 'blue' : 'white'
-          }
-          onClick={navigate}
-          width="100%"
-          ref={this.result}
+      <Row
+      py='2'
+      px='2'
+      cursor='pointer'
+      onMouseEnter={() => this.setHover(true)}
+      onMouseLeave={() => this.setHover(false)}
+      backgroundColor={
+        this.state.hovered || selected === link ? 'blue' : 'white'
+      }
+      onClick={navigate}
+      width="100%"
+      ref={this.result}
+      >
+        {graphic}
+        <Text
+        display="inline-block"
+        verticalAlign="middle"
+        color={this.state.hovered || selected === link ? 'white' : 'black'}
+        maxWidth="60%"
+        style={{ flexShrink: 0 }}
+        mr='1'
         >
-          {this.state.hovered || selected === link ? (
-            <>
-            {graphic}
-              <Text
-                display="inline-block"
-                verticalAlign="middle"
-                color='white'
-                maxWidth="60%"
-                style={{ flexShrink: 0 }}
-                mr='1'>
-                {text}
-              </Text>
-            <Text pr='2'
-            display="inline-block"
-            verticalAlign="middle"
-            color='white'
-            width='100%'
-            textAlign='right'
-            >
-                {subtext}
-              </Text>
-            </>
-          ) : (
-            <>
-            {graphic}
-              <Text
-                mr='1'
-                display="inline-block"
-                verticalAlign="middle"
-                maxWidth="60%"
-                style={{ flexShrink: 0 }}
-              >
-              {text}
-            </Text>
-              <Text
-                pr='2'
-                display="inline-block"
-                verticalAlign="middle"
-                gray
-                width='100%'
-                textAlign='right'
-              >
-                {subtext}
-              </Text>
-            </>
-          )}
-        </Row>
+          {text}
+        </Text>
+        <Text pr='2'
+        display="inline-block"
+        verticalAlign="middle"
+        color={this.state.hovered || selected === link ? 'white' : 'black'}
+        width='100%'
+        textAlign='right'
+        >
+          {subtext}
+        </Text>
+      </Row>
     );
   }
 }

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -33,7 +33,7 @@ export class OmniboxResult extends Component {
     if (defaultApps.includes(icon.toLowerCase()) || icon.toLowerCase() === 'links') {
       icon = (icon === 'Dojo') ? 'ChevronEast' : icon;
       icon = (icon === 'Link') ? 'Links' : icon;
-      graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color={iconFill} />;
+      graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color='transparent' stroke={iconFill} />;
     } else if (icon === 'logout') {
       graphic = <Icon display="inline-block" verticalAlign="middle" icon='ArrowWest' mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'profile') {


### PR DESCRIPTION
- Removes all the image logic gunk and just uses indigo-react icons for Leap results. (One step closer to getting PNGs out of Landscape.)
- Trims up OmniboxResult of some unnecessary duplicate logic for essentially a single color ternary.

cc @urcades @g-a-v-i-n 

<img width="660" alt="Screen Shot 2020-09-28 at 9 13 01 PM" src="https://user-images.githubusercontent.com/20846414/94501271-79e76d00-01cf-11eb-9f51-2ae7464923b1.png">
<img width="682" alt="Screen Shot 2020-09-28 at 9 12 48 PM" src="https://user-images.githubusercontent.com/20846414/94501273-7b189a00-01cf-11eb-9f05-a4f3c1b1b845.png">
