### PR TITLE
links: access contact metadata properly

### DIFF
--- a/pkg/interface/src/views/apps/links/components/link-detail.js
+++ b/pkg/interface/src/views/apps/links/components/link-detail.js
@@ -1,13 +1,13 @@
-import React, { Component, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { TabBar } from '~/views/components/chat-link-tabbar';
 import { LinkPreview } from './lib/link-preview';
-import { LinkSubmit } from './lib/link-submit';
 import { CommentSubmit } from './lib/comment-submit';
 import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
 import { Link } from 'react-router-dom';
 import { Comments } from './lib/comments';
 import { getContactDetails } from '~/logic/lib/util';
 
+import { Box } from '@tlon/indigo-react';
 
 export const LinkDetail = (props) => {
   if (!props.node && props.graphResource) {
@@ -35,24 +35,30 @@ export const LinkDetail = (props) => {
 
   return (
     <div className="h-100 w-100 overflow-hidden flex flex-column">
-      <div
-        className={
-          'pl4 pt2 flex relative overflow-x-scroll ' +
-          'overflow-x-auto-l overflow-x-auto-xl flex-shrink-0 ' +
-          'bb bn-m bn-l bn-xl b--gray4'
-        }
-        style={{ height: 48 }}>
+      <Box
+        pl='12px'
+        pt='2'
+        display='flex'
+        position='relative'
+        overflowX={['scroll', 'auto']}
+        flexShrink='0'
+        borderBottom='1px solid'
+        borderColor='washedGray'
+        height='48px'
+      >
         <SidebarSwitcher
           sidebarShown={props.sidebarShown}
           popout={props.popout}
           api={props.api}
         />
         <Link className="dib f9 fw4 pt2 gray2 lh-solid"
-              to={`/~link/${resourcePath}`}>
+              to={`/~link/${resourcePath}`}
+        >
           <h2
             className="dib f9 fw4 lh-solid v-top black white-d"
-            style={{ width: 'max-content' }}>
-            {`<- ${title}`}
+            style={{ width: 'max-content' }}
+          >
+            {`${title}`}
           </h2>
         </Link>
         <TabBar
@@ -61,7 +67,7 @@ export const LinkDetail = (props) => {
           popoutHref={`/~link/popout/${resourcePath}/${props.match.params.index}`}
           settings={`/~link/${resourcePath}/settings`}
         />
-      </div>
+      </Box>
       <div className="w-100 mt2 flex justify-center overflow-y-scroll ph4 pb4">
         <div className="w-100 mw7">
           <LinkPreview
@@ -77,7 +83,8 @@ export const LinkDetail = (props) => {
               name={props.name}
               ship={props.ship}
               api={props.api}
-              parentIndex={props.node.post.index} />
+              parentIndex={props.node.post.index}
+            />
           </div>
           <Comments
             comments={props.node.children}
@@ -87,10 +94,11 @@ export const LinkDetail = (props) => {
             api={props.api}
             hideAvatars={props.hideAvatars}
             hideNicknames={props.hideNicknames}
-            remoteContentPolicy={props.remoteContentPolicy} />
+            remoteContentPolicy={props.remoteContentPolicy}
+          />
         </div>
       </div>
     </div>
   );
-}
+};
 

--- a/pkg/interface/src/views/apps/links/components/link-detail.js
+++ b/pkg/interface/src/views/apps/links/components/link-detail.js
@@ -29,8 +29,7 @@ export const LinkDetail = (props) => {
     );
   }
 
-  const { nickname } = getContactDetails(props.contacts[ship]);
-  const our = getContactDetails(props.contacts[window.ship]);
+  const { nickname } = getContactDetails(props.contacts[props.node?.post?.author]);
   const resourcePath = `${props.ship}/${props.name}`;
   const title = props.resource.metadata.title || resourcePath;
 

--- a/pkg/interface/src/views/apps/links/components/link-list.js
+++ b/pkg/interface/src/views/apps/links/components/link-list.js
@@ -5,6 +5,7 @@ import { SidebarSwitcher } from '~/views/components/SidebarSwitch';
 import { Link } from 'react-router-dom';
 import { LinkItem } from './lib/link-item';
 import LinkSubmit from './lib/link-submit';
+import { Box } from '@tlon/indigo-react';
 
 import { getContactDetails } from '~/logic/lib/util';
 
@@ -38,12 +39,16 @@ export const LinkList = (props) => {
         style={{ height: '1rem' }}>
        <Link to="/~link">{'⟵ All Channels'}</Link>
       </div>
-      <div className={
-             'pl4 pt2 flex relative overflow-x-scroll' +
-             'overflow-x-auto-l overflow-x-auto-xl flex-shrink-0' +
-             'bb b--gray4 b--gray1-d bg-gray0-d'
-           }
-           style={{ height: 48 }}>
+      <Box
+        pl='12px'
+        pt='2'
+        display='flex'
+        position='relative'
+        overflowX={['scroll', 'auto']}
+        flexShrink='0'
+        borderBottom='1px solid'
+        borderColor='washedGray'
+        height='48px'>
         <SidebarSwitcher
           sidebarShown={props.sidebarShown}
           popout={props.popout}
@@ -59,7 +64,7 @@ export const LinkList = (props) => {
           popoutHref={`/~link/popout/${resource}`}
           settings={`/~link/${resource}/settings`}
         />
-      </div>
+      </Box>
       <div className="w-100 mt6 flex justify-center overflow-y-scroll ph4 pb4">
         <div className="w-100 mw7">
           <div className="flex">

--- a/pkg/interface/src/views/apps/links/components/link-list.js
+++ b/pkg/interface/src/views/apps/links/components/link-list.js
@@ -40,7 +40,7 @@ export const LinkList = (props) => {
       </div>
       <div className={
              'pl4 pt2 flex relative overflow-x-scroll' +
-             'overflow-x-auto-l overflow-x-auto-xl flex-shrink-0' + 
+             'overflow-x-auto-l overflow-x-auto-xl flex-shrink-0' +
              'bb b--gray4 b--gray1-d bg-gray0-d'
            }
            style={{ height: 48 }}>
@@ -71,10 +71,10 @@ export const LinkList = (props) => {
           </div>
           { Array.from(props.graph).map(([date, node]) => {
               const { nickname, color, avatar } =
-                getContactDetails(props.contacts[ship]);
-
+                getContactDetails(props.contacts[node?.post?.author]);
               return (
                 <LinkItem
+                  key={date}
                   resource={resource}
                   node={node}
                   nickname={nickname}

--- a/pkg/interface/src/views/apps/links/components/settings.js
+++ b/pkg/interface/src/views/apps/links/components/settings.js
@@ -7,6 +7,8 @@ import { Spinner } from '~/views/components/Spinner';
 import { TabBar } from '~/views/components/chat-link-tabbar';
 import SidebarSwitcher from '~/views/components/SidebarSwitch';
 
+import { Box } from '@tlon/indigo-react';
+
 import { MetadataSettings } from '~/views/components/metadata/settings';
 
 export class SettingsScreen extends Component {
@@ -132,12 +134,16 @@ export class SettingsScreen extends Component {
              style={{ height: '1rem' }}>
           <Link to="/~link">{'⟵ All Collections'}</Link>
         </div>
-        <div
-          className={
-            "pl4 pt2 bb b--gray4 b--gray1-d flex relative overflow-x-scroll " +
-            "overflow-x-auto-l overflow-x-auto-xl flex-shrink-0"
-          }
-          style={{ height: 48 }}>
+        <Box
+          pl='12px'
+          pt='2'
+          display='flex'
+          position='relative'
+          overflowX={['scroll', 'auto']}
+          flexShrink='0'
+          borderBottom='1px solid'
+          borderColor='washedGray'
+          height='48px'>
           <SidebarSwitcher
             sidebarShown={this.props.sidebarShown}
             popout={this.props.popout}
@@ -157,7 +163,7 @@ export class SettingsScreen extends Component {
             popoutHref={`/~link/popout/${props.resourcePath}/settings`}
             settings={`/~link/${props.resourcePath}/settings`}
           />
-          </div>
+          </Box>
         <div className="w-100 pl3 mt4 cf">
           <h2 className="f8 pb2">Collection Settings</h2>
           {this.renderRemove()}


### PR DESCRIPTION
- We were passing an undeclared `ship`, always blank and defaulting to our ship's info. We safely access the graph node's author.
- Also wraps the tab bar in a `Box` component — the graph-store rewrite apparently deleted some spaces in the quotes that were spacing atomic CSS classes, that prevented the tab bar from shrinking closed. When in doubt: always write the solution in indigo-react.