### PR TITLE
publish: disable cursor position reset on rerender

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/lib/MarkdownEditor.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/MarkdownEditor.tsx
@@ -63,6 +63,7 @@ export function MarkdownEditor(
       {...boxProps}
     >
       <CodeEditor
+        autoCursor={false}
         onBlur={onBlur}
         value={value}
         options={options}


### PR DESCRIPTION
Addresses #3593.

Due to the refactor in #3540 we now use `useCallback`, and this prompts a rerender every single time we make a keystroke, pushing the cursor to the end. `autoCursor={false}` tells CodeMirror to not reset the cursor on a value change. We are going to want to prevent the rerender entirely, but I am thus far unsure how to finagle hooks — initial tips point to adding a [useRef](https://stackoverflow.com/questions/55045566/react-hooks-usecallback-causes-child-to-re-render).

(h/t to @tylershuster for pointing out the obvious fix)