### PR TITLE
eyre: minimal CORS support

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b572ea1bc3bafc9ac7ff1a0fcecca16320bc2bbe6d6964cc76a2bc36f201975
-size 6299579
+oid sha256:7e4edc51f2f314a5236deb4a975d6364cca2164f104b6656446d52ba61ac3e45
+size 19166792

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -64,7 +64,7 @@
   =^  d  drum.state  (on-load:drum-core -.old drum.tup)
   =^  h  helm.state  (on-load:helm-core -.old helm.tup)
   =^  k  kiln.state  (on-load:kiln-core -.old kiln.tup)
-  [:(weld d h k) this]
+  [:(welp d h k) this]
 ::
 ++  on-poke
   |=  [=mark =vase]

--- a/pkg/arvo/gen/cors-registry.hoon
+++ b/pkg/arvo/gen/cors-registry.hoon
@@ -1,0 +1,6 @@
+::  eyre: give cors configuration
+::
+:-  %say
+|=  [[now=@da eny=@uvJ =beak] ~ ~]
+:-  %noun
+.^(cors-registry:eyre %ex /(scot %p p.beak)//(scot %da now)/cors)

--- a/pkg/arvo/gen/hood/cors-approve.hoon
+++ b/pkg/arvo/gen/hood/cors-approve.hoon
@@ -1,0 +1,5 @@
+::  eyre: allow cors requests from origin
+::
+:-  %say
+|=  [^ [=origin:eyre ~] ~]
+[%helm-cors-approve origin]

--- a/pkg/arvo/gen/hood/cors-reject.hoon
+++ b/pkg/arvo/gen/hood/cors-reject.hoon
@@ -1,0 +1,5 @@
+::  eyre: disallow cors requests from origin
+::
+:-  %say
+|=  [^ [=origin:eyre ~] ~]
+[%helm-cors-reject origin]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -219,6 +219,16 @@
   |=  [=binding:eyre =generator:eyre]  =<  abet
   (emit %pass /helm/serv %arvo %e %serve binding generator)
 ::
+++  poke-cors-approve
+  |=  =origin:eyre
+  =<  abet
+  (emit %pass /helm/cors/approve %arvo %e %approve-origin origin)
+::
+++  poke-cors-reject
+  |=  =origin:eyre
+  =<  abet
+  (emit %pass /helm/cors/reject %arvo %e %reject-origin origin)
+::
 ++  poke
   |=  [=mark =vase]
   ?+  mark  ~|([%poke-helm-bad-mark mark] !!)
@@ -229,6 +239,8 @@
     %helm-automass         =;(f (f !<(_+<.f vase)) poke-automass)
     %helm-cancel-automass  =;(f (f !<(_+<.f vase)) poke-cancel-automass)
     %helm-code             =;(f (f !<(_+<.f vase)) poke-code)
+    %helm-cors-approve     =;(f (f !<(_+<.f vase)) poke-cors-approve)
+    %helm-cors-reject      =;(f (f !<(_+<.f vase)) poke-cors-reject)
     %helm-hi               =;(f (f !<(_+<.f vase)) poke-hi)
     %helm-knob             =;(f (f !<(_+<.f vase)) poke-knob)
     %helm-mass             =;(f (f !<(_+<.f vase)) poke-mass)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1279,9 +1279,25 @@
           ::  notifies us that web login code changed
           ::
           [%code-changed ~]
+          ::  start responding positively to cors requests from origin
+          ::
+          [%approve-origin =origin]
+          ::  start responding negatively to cors requests from origin
+          ::
+          [%reject-origin =origin]
       ==
     ::
     --
+  ::  +origin: request origin as specified in an Origin header
+  ::
+  +$  origin  @torigin
+  ::  +cors-registry: origins categorized by approval status
+  ::
+  +$  cors-registry
+    $:  requests=(set origin)
+        approved=(set origin)
+        rejected=(set origin)
+    ==
   ::  +outstanding-connection: open http connections not fully complete:
   ::
   ::    This refers to outstanding connections where the connection to


### PR DESCRIPTION
Implement minimal CORS handling into Eyre, [as proposed on urbit-dev](https://groups.google.com/a/urbit.org/g/dev/c/bb82dwEJGzM/m/q2JjNSx5BwAJ).

Includes a `+cors-registry` generator for easily viewing the current CORS state, and `|cors-approve` and `|cors-reject` for allowing and denying origins access, respectively.

idk what's up with hood all of a sudden, but I needed b277b82 to get it to play nice and compile regardless of my other changes here.