### PR TITLE
eyre: add authentication checker scry endpoint

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2422,6 +2422,14 @@
         %approved  ``noun+!>((~(has in approved.cors-registry) u.origin))
         %rejected  ``noun+!>((~(has in rejected.cors-registry) u.origin))
       ==
+    ::
+        [%authenticated %cookie @ ~]
+      ?~  cookies=(slaw %t i.t.t.tyl)  [~ ~]
+      :^  ~  ~  %noun
+      !>  ^-  ?
+      %-  =<  request-is-logged-in:authentication
+          (per-server-event [our eny *duct now scry-gate] server-state.ax)
+      %*(. *request:http header-list ['cookie' u.cookies]~)
     ==
   ?.  ?=(%$ ren)
     [~ ~]


### PR DESCRIPTION
Lets you check whether a specific `Cookie` header value string constitutes an authenticated request.

eg: `/ex/=//=/authenticated/cookie/(scot %t 'cookie-string')`

Intended for use in the runtime, for example with #3557.