### PR TITLE
leap: error trapping, fixes icon bug

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -34,7 +34,7 @@ const commandIndex = function () {
 
       title = title.charAt(0).toUpperCase() + title.slice(1);
 
-      let obj = result(`${title}: Create`, `/~${e}/new`, e, null);
+      let obj = result(`${title}: Create`, `/~${e}/new`, title, null);
       commands.push(obj);
 
       if (title === 'Groups') {

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -17,6 +17,7 @@ import dark from './themes/old-dark';
 import { Content } from './components/Content';
 import StatusBar from './components/StatusBar';
 import Omnibox from './components/leap/Omnibox';
+import ErrorBoundary from '~/views/components/ErrorBoundary';
 
 import GlobalStore from '~/logic/store/store';
 import GlobalSubscription from '~/logic/subscription/global';
@@ -132,28 +133,34 @@ class App extends React.Component {
         </Helmet>
         <Root background={background} >
           <Router>
-            <StatusBarWithRouter
-              props={this.props}
-              associations={associations}
-              invites={this.state.invites}
-              api={this.api}
-              connection={this.state.connection}
-              subscription={this.subscription}
-              ship={this.ship}
-            />
-            <Omnibox
-              associations={state.associations}
-              apps={state.launch}
-              api={this.api}
-              dark={state.dark}
-              show={state.omniboxShown}
-            />
-          <Content
-            ship={this.ship}
-            api={this.api}
-            subscription={this.subscription}
-            {...state}
-          />
+            <ErrorBoundary>
+              <StatusBarWithRouter
+                props={this.props}
+                associations={associations}
+                invites={this.state.invites}
+                api={this.api}
+                connection={this.state.connection}
+                subscription={this.subscription}
+                ship={this.ship}
+              />
+            </ErrorBoundary>
+            <ErrorBoundary>
+              <Omnibox
+                associations={state.associations}
+                apps={state.launch}
+                api={this.api}
+                dark={state.dark}
+                show={state.omniboxShown}
+              />
+            </ErrorBoundary>
+            <ErrorBoundary>
+              <Content
+                ship={this.ship}
+                api={this.api}
+                subscription={this.subscription}
+                {...state}
+              />
+            </ErrorBoundary>
           </Router>
         </Root>
       </ThemeProvider>


### PR DESCRIPTION
This fixes an unfiled bug where any leap results including a command in them would crash the whole app because the lowercase app name would fail to be recognized as an icon, and leap was not contained in an error boundary.

For future error trapping it also wraps the main components of the app in error boundaries.