### PR TITLE
hoon: virtualize cue when parsing %blob coin literals

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2291d9c0febd6ccd7538571ab1e41409f6808b12e5b3d3b0cb3e0fbf8c1bc8aa
-size 6319141
+oid sha256:15a8b98d7eb45b168edfc1fe346bc79781a2e81a8d0b9fa7db87ef527b84c66b
+size 6319407

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6224,7 +6224,13 @@
   ++  twid
     ~+
     ;~  pose
-      (cook |=(a/@ [%blob (cue a)]) ;~(pfix (just '0') vum:ag))
+      %+  stag  %blob
+      %+  sear
+        ::  XX use +mole once available
+        ::
+        |=(a=@ `(unit)`=/(b (mule |.((cue a))) ?-(-.b %| ~, %& `p.b)))
+      ;~(pfix (just '0') vum:ag)
+    ::
       (stag %$ crub)
     ==
   ::


### PR DESCRIPTION
Fixes #1473.

<s>
Note that something is off with the type of (at least some of) the individual arms in the coin parser (`|so`). Invoking them directly works fine:

```
> (twid:so [1 1] "0sj1c9s1nmupjo1")
[p=[p=1 q=16] q=[~ u=[p=[%blob [7.303.014 7.496.034]] q=[p=[p=1 q=16] q=""]]]]
> (crub:so [1 1] "2012.1.1")
[p=[p=1 q=9] q=[~ u=[p=[p=~.da q=170.141.184.499.601.039.830.939.939.828.137.984.000] q=[p=[p=1 q=9] q=""]]]]
```

But we get a wet-gate type failure if we try to call them via `+scan`:

```
> (scan twid:so "0sj1c9s1nmupjo1")
mull-grow
-find.$.+2
> (scan crub:so "2012.1.1")
mull-grow
-find.$.+2
```

I discovered this behavior when testing the change in this PR, but it's a pre-existing issue, so I think it's out of scope here.
</s>

Update: I am an idiot, and had reversed the order of the arguments to `+scan`.