### PR TITLE
arvo: restore :time app

### DIFF
--- a/pkg/arvo/app/time.hoon
+++ b/pkg/arvo/app/time.hoon
@@ -1,0 +1,37 @@
+::
+/+  default-agent, verb
+::
+|%
+::
++$  card  card:agent:gall
+--
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+::
+++  on-init  [~ this]
+++  on-save  !>(~)
+++  on-load  _on-init
+++  on-poke
+  |=  [=mark =vase]
+  ?+    mark  !!
+      %noun  :_  this
+             [%pass /(scot %da now.bowl) %arvo %b %wait `@da`+(now.bowl)]~
+  ==
+::
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-arvo
+  |=  [=wire sign=sign-arvo]
+  ^-  (quip card _this)
+  ?+    wire  !!
+      [@ ~]
+    ?>  ?=(%wake +<.sign)
+    ~&  [%took `@dr`(sub now.bowl (slav %da i.wire))]
+    [~ this]
+  ==
+++  on-fail   on-fail:def
+--


### PR DESCRIPTION
This PR restores the `:time` app, which is a simple, low-resolution tool for timing a computation in the dojo (estimated via the elapsed time between the beginning of the computation, and the arrival of a subsequent timer event schedule for `+(now)`).

It's usefulness had been greatly reduced by the integration of `cc-release` (in v0.8.0), due to issues with event-timestamp granularity. It was removed with the integration of static-gall and spider, replaced by the `-time` thread. But the latter is less useful, as it doesn't support arbitrary expressions. And the event-timestamp issues have been resolved in `v0.10.8`.