### PR TITLE
eyre: prevent binding in reserved namespaces

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1772,6 +1772,12 @@
     |=  [=binding =action]
     ^-  [(list move) server-state]
     =^  success  bindings.state
+      ::  prevent binding in reserved namespaces
+      ::
+      ?:  ?|  ?=([%'~' *] path.binding)    ::  eyre
+              ?=([%'~_~' *] path.binding)  ::  runtime
+          ==
+        [| bindings.state]
       (insert-binding [binding duct action] bindings.state)
     :_  state
     [duct %give %bound success binding]~


### PR DESCRIPTION
Disallows registering bindings (through `%connect` and `%serve`) that would capture
traffic on paths starting with `/~` (Eyre's) or `/~_~` (runtime's, as of cc389c5).

Note that we don't touch `+insert-binding`, which is used by Eyre internally to
set up bindings in its own namespace.