### PR TITLE
publish: crashes and regressions

### DIFF
--- a/pkg/interface/src/logic/api/publish.ts
+++ b/pkg/interface/src/logic/api/publish.ts
@@ -187,8 +187,18 @@ export default class PublishApi extends BaseApi {
     });
   }
 
+  readNote(who: PatpNoSig, book: string, note: string) {
+    return this.publishAction({
+      read: {
+        who,
+        book,
+        note
+      }
+    });
+  }
+
   updateComment(who: PatpNoSig, book: string, note: string, comment: Path, body: string) {
-    return this.publishAction({ 
+    return this.publishAction({
       'edit-comment': {
         who,
         book,

--- a/pkg/interface/src/views/apps/publish/PublishResource.tsx
+++ b/pkg/interface/src/views/apps/publish/PublishResource.tsx
@@ -29,6 +29,7 @@ export function PublishResource(props: PublishResourceProps) {
         contacts={props.contacts}
         groups={props.groups}
         notebook={notebook}
+        associations={props.associations}
         notebookContacts={notebookContacts}
         rootUrl={baseUrl}
         baseUrl={`${baseUrl}/resource/publish/${ship}/${book}`}

--- a/pkg/interface/src/views/apps/publish/components/lib/Author.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/Author.tsx
@@ -18,7 +18,10 @@ interface AuthorProps {
 export function Author(props: AuthorProps) {
   const { contacts, ship = '', date, showImage } = props;
   const noSig = ship.slice(1);
-  const contact = noSig in contacts ? contacts[noSig] : null;
+  let contact = null;
+  if (contacts) {
+    contact = noSig in contacts ? contacts[noSig] : null;
+  }
   const color = contact?.color ? `#${uxToHex(contact?.color)}` : "#000000";
   const showAvatar = !props.hideAvatars && contact?.avatar;
   const showNickname = !props.hideNicknames && contact?.nickname;

--- a/pkg/interface/src/views/apps/publish/components/lib/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/Note.tsx
@@ -33,6 +33,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
   const [deleting, setDeleting] = useState(false);
   const { notebook, note, contacts, ship, book, noteId, api } = props;
   useEffect(() => {
+    api.publish.readNote(ship.slice(1), book, noteId);
     api.publish.fetchNote(ship, book, noteId);
   }, [ship, book, noteId]);
 

--- a/pkg/interface/src/views/apps/publish/components/lib/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/Notebook.tsx
@@ -70,7 +70,7 @@ export class Notebook extends PureComponent<
 
     const relativePath = (p: string) => this.props.baseUrl + p;
 
-    const contact = notebookContacts[ship];
+    const contact = notebookContacts?.[ship];
     const role = group ? roleForShip(group, window.ship) : undefined;
     const isOwn = `~${window.ship}` === ship;
     const isAdmin = role === "admin" || isOwn;

--- a/pkg/interface/src/views/apps/publish/components/lib/NotebookPosts.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/NotebookPosts.tsx
@@ -28,7 +28,7 @@ export function NotebookPosts(props: NotebookPostsProps) {
             host={props.host}
             book={props.book}
             note={note}
-            contact={props.contacts[note.author.substr(1)]}
+            contact={props?.contacts?.[note.author.substr(1)]}
             hideNicknames={props.hideNicknames}
             baseUrl={props.baseUrl}
           />

--- a/pkg/interface/src/views/components/DropdownSearch.tsx
+++ b/pkg/interface/src/views/components/DropdownSearch.tsx
@@ -118,7 +118,10 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>) {
 
   const dropdown = useMemo(() => {
     const first = props.isExact(query);
-    const opts = first ? [first, ...options] : options;
+    let opts = options;
+    if (first) {
+      opts = options.includes(first) ? opts : [first, ...options];
+    }
     return _.take(opts, 5).map((o, idx) =>
       props.renderCandidate(
         o,

--- a/pkg/interface/src/views/components/GroupSearch.tsx
+++ b/pkg/interface/src/views/components/GroupSearch.tsx
@@ -87,6 +87,7 @@ export function GroupSearch(props: InviteSearchProps) {
       id={props.id}
       caption={props.caption}
       candidates={groups}
+      isExact={() => undefined}
       renderCandidate={renderCandidate}
       disabled={value && value.length !== 0}
       search={(s: string, a: Association) =>


### PR DESCRIPTION
- Fix unmanaged notebooks (or any notebook in a group with no contacts) crashing
- Fix a crash in the groupify menu for notebooks
- Prevent duplicate results from showing when searching an exact patp
- Send 'read' actions when loading a note