### PR TITLE
publish: prevId -> nextId

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/lib/NoteNavigation.tsx
+++ b/pkg/interface/src/views/apps/publish/components/lib/NoteNavigation.tsx
@@ -54,7 +54,7 @@ export function NoteNavigation(props: NoteNavigationProps) {
   }
 
   if (next) {
-    nextUrl = `${props.prevId}`;
+    nextUrl = `${props.nextId}`;
     nextComponent = (
       <NavigationItem
         title={next.title}


### PR DESCRIPTION
`nextUrl` updated to the id of the next note rather than the previous note.

@matildepark @tylershuster 