### PR TITLE
u3: fixes jet memory leaks, mismatches in +div/+dvr/+sqt

### DIFF
--- a/pkg/urbit/jets/a/div.c
+++ b/pkg/urbit/jets/a/div.c
@@ -11,7 +11,7 @@
            u3_atom b)
   {
     if ( 0 == b ) {
-      return u3m_bail(c3__exit);
+      return u3m_error("divide-by-zero");
     }
     else {
       if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {

--- a/pkg/urbit/jets/c/dvr.c
+++ b/pkg/urbit/jets/c/dvr.c
@@ -10,8 +10,8 @@
   u3qc_dvr(u3_atom a,
            u3_atom b)
   {
-    if ( 0 == b) {
-      return u3m_bail(c3__exit);
+    if ( 0 == b ) {
+      return u3m_error("divide-by-zero");
     }
     else {
       if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {

--- a/pkg/urbit/jets/c/dvr.c
+++ b/pkg/urbit/jets/c/dvr.c
@@ -25,7 +25,7 @@
 
         mpz_tdiv_qr(a_mp, b_mp, a_mp, b_mp);
 
-        return u3nc(u3k(u3i_mp(a_mp)), u3k(u3i_mp(b_mp)));
+        return u3nc(u3i_mp(a_mp), u3i_mp(b_mp));
       }
     }
   }

--- a/pkg/urbit/jets/c/sqt.c
+++ b/pkg/urbit/jets/c/sqt.c
@@ -15,7 +15,7 @@
     mpz_init(b_mp);
     mpz_sqrtrem(a_mp, b_mp, a_mp);
 
-    return u3nc(u3k(u3i_mp(a_mp)), u3k(u3i_mp(b_mp)));
+    return u3nc(u3i_mp(a_mp), u3i_mp(b_mp));
   }
   u3_noun
   u3wc_sqt(u3_noun cor)


### PR DESCRIPTION
The `+dvr` and `+sqt` jets incorrectly double-counted references when copying GMP integers on the looom, and the `+div` and `+dvr` jets failed to push a `divide-by-zero` error message onto stack trace. (I found the former due to CI errors in #3636, and the latter in code review.)

Note that the `|fl` jets also appear to incorrectly double-count GMP integers. Those jets are much more complicated, and I'm much less familiar with them. I'll open a separate issue to track them.