### PR TITLE
u3: improve efficiency of list jets by cons'ing in-order

### DIFF
--- a/pkg/urbit/include/noun/imprison.h
+++ b/pkg/urbit/include/noun/imprison.h
@@ -111,6 +111,12 @@
           u3_noun
           u3i_cell(u3_noun a, u3_noun b);
 
+        /* u3i_defcons(): allocate cell for deferred construction.
+        **            NB: [hed] and [tel] pointers MUST be filled.
+        */
+          u3_cell
+          u3i_defcons(u3_noun** hed, u3_noun** tel);
+
         /* u3i_trel(): Produce the triple `[a b c]`.
         */
           u3_noun

--- a/pkg/urbit/jets/b/flop.c
+++ b/pkg/urbit/jets/b/flop.c
@@ -3,46 +3,29 @@
 */
 #include "all.h"
 
+u3_noun
+u3qb_flop(u3_noun a)
+{
+  u3_noun i, t = a, b = u3_nul;
 
-/* functions
-*/
-  u3_noun
-  u3qb_flop(u3_noun a)
-  {
-    u3_noun b = 0;
-
-    while ( 1 ) {
-      if ( u3_nul == a ) {
-        return b;
-      }
-      else if ( c3n == u3du(a) ) {
-        u3z(b);
-
-        return u3m_bail(c3__exit);
-      }
-      else {
-        b = u3nc(u3k(u3h(a)), b);
-        a = u3t(a);
-      }
-    }
-  }
-  u3_noun
-  u3wb_flop(u3_noun cor)
-  {
-    u3_noun a;
-
-    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_flop(a);
-    }
-  }
-  u3_noun
-  u3kb_flop(u3_noun a)
-  {
-    u3_noun b = u3qb_flop(a);
-
-    u3z(a);
-    return b;
+  while ( u3_nul != t ) {
+    u3x_cell(t, &i, &t);
+    b = u3nc(u3k(i), b);
   }
 
+  return b;
+}
+
+u3_noun
+u3wb_flop(u3_noun cor)
+{
+  return u3qb_flop(u3x_at(u3x_sam, cor));
+}
+
+u3_noun
+u3kb_flop(u3_noun a)
+{
+  u3_noun b = u3qb_flop(a);
+  u3z(a);
+  return b;
+}

--- a/pkg/urbit/jets/b/murn.c
+++ b/pkg/urbit/jets/b/murn.c
@@ -29,8 +29,9 @@ u3qb_murn(u3_noun a, u3_noun b)
 
         if ( u3_nul != res ) {
           *lit = u3i_defcons(&hed, &tel);
-          *hed = u3t(res);
+          *hed = u3k(u3t(res));
           lit  = tel;
+          u3z(res);
         }
       }
       while ( u3_nul != t );

--- a/pkg/urbit/jets/b/murn.c
+++ b/pkg/urbit/jets/b/murn.c
@@ -3,54 +3,50 @@
 */
 #include "all.h"
 
-  u3_noun
-  _murn_in(u3j_site* sit_u, u3_noun a)
-  {
-    if ( 0 == a ) {
-      return a;
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3m_bail(c3__exit);
-    }
-    else {
-      u3_noun one = u3j_gate_slam(sit_u, u3k(u3h(a)));
-      u3_noun two = _murn_in(sit_u, u3t(a));
-      u3_noun nex;
+u3_noun
+u3qb_murn(u3_noun a, u3_noun b)
+{
+  u3_noun pro = u3_nul;
 
-      switch ( u3ud(one) ) {
-        case c3y:  u3z(one);
-                   return two;
-        case c3n:  nex = u3nc(u3k(u3t(one)), two);
-                   u3z(one);
-                   return nex;
-        default:   u3z(one);
-                   u3z(two);
-                   return u3_none;
-      }
-    }
+  if ( u3_nul == a ) {
+    return u3_nul;
   }
-
-/* functions
-*/
-  u3_noun
-  u3qb_murn(u3_noun a, u3_noun b)
-  {
-    u3_noun pro;
+  else {
+    u3_noun    pro;
+    u3_noun*   lit = &pro;
     u3j_site sit_u;
+
     u3j_gate_prep(&sit_u, u3k(b));
-    pro = _murn_in(&sit_u, a);
+    {
+      u3_noun* hed;
+      u3_noun* tel;
+      u3_noun  res, i, t = a;
+
+      do {
+        u3x_cell(t, &i, &t);
+
+        res = u3j_gate_slam(&sit_u, u3k(i));
+
+        if ( u3_nul != res ) {
+          *lit = u3i_defcons(&hed, &tel);
+          *hed = u3t(res);
+          lit  = tel;
+        }
+      }
+      while ( u3_nul != t );
+    }
     u3j_gate_lose(&sit_u);
+
+    *lit = u3_nul;
+
     return pro;
   }
-  u3_noun
-  u3wb_murn(u3_noun cor)
-  {
-    u3_noun a, b;
+}
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_murn(a, b);
-    }
-  }
-
+u3_noun
+u3wb_murn(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_murn(a, b);
+}

--- a/pkg/urbit/jets/b/scag.c
+++ b/pkg/urbit/jets/b/scag.c
@@ -3,50 +3,49 @@
 */
 #include "all.h"
 
-
-/* functions
-*/
-  u3_noun
-  u3qb_scag(u3_atom a,
-            u3_noun b)
-  {
-    if ( u3_nul == b ) {
-      return u3_nul;
-    }
-    else if ( !_(u3a_is_cat(a)) ) {
-      return u3m_bail(c3__fail);
-    }
-    else {
-      u3_noun acc = u3_nul;
-      c3_w i_w = a;
-
-      if ( !i_w )
-        return u3_nul;
-
-      while ( i_w ) {
-        if ( c3n == u3du(b) ) {
-          return u3kb_flop(acc);
-        }
-        acc = u3nc(u3k(u3h(b)), acc);
-        b = u3t(b);
-        i_w--;
-      }
-
-      return u3kb_flop(acc);
-    }
+u3_noun
+u3qb_scag(u3_atom a, u3_noun b)
+{
+  if ( u3_nul == b ) {
+    return u3_nul;
   }
+  else if ( !_(u3a_is_cat(a)) ) {
+    return u3m_bail(c3__fail);
+  }
+  else {
+    u3_noun  pro;
+    u3_noun* lit = &pro;
 
-  u3_noun
-  u3wb_scag(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a) && u3_nul != b) )
     {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_scag(a, b);
+      c3_w   len_w = (c3_w)a;
+      u3_noun* hed;
+      u3_noun* tel;
+      u3_noun i, t = b;
+
+      while ( len_w-- && (u3_nul != t) ) {
+        u3x_cell(t, &i, &t);
+
+        *lit = u3i_defcons(&hed, &tel);
+        *hed = u3k(i);
+        lit  = tel;
+      }
     }
+
+    *lit = u3_nul;
+
+    return pro;
+  }
+}
+
+u3_noun
+u3wb_scag(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+
+  if ( (c3n == u3ud(a)) && (u3_nul != b) ) {
+    return u3m_bail(c3__exit);
   }
 
+  return u3qb_scag(a, b);
+}

--- a/pkg/urbit/jets/b/turn.c
+++ b/pkg/urbit/jets/b/turn.c
@@ -3,43 +3,46 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _turn_in(u3j_site* sit_u, u3_noun a)
-  {
-    u3_noun b = u3_nul;
+u3_noun
+u3qb_turn(u3_noun a, u3_noun b)
+{
+  u3_noun pro = u3_nul;
 
-    while ( u3_nul != a ) {
-      b = u3nc(u3j_gate_slam(sit_u, u3k(u3h(a))),
-               b);
-      a = u3t(a);
-    }
-
-    return u3kb_flop(b);
+  if ( u3_nul == a ) {
+    return u3_nul;
   }
-
-/* functions
-*/
-  u3_noun
-  u3qb_turn(u3_noun a, u3_noun b)
-  {
-    u3_noun  pro;
+  else {
+    u3_noun    pro;
+    u3_noun*   lit = &pro;
     u3j_site sit_u;
 
     u3j_gate_prep(&sit_u, u3k(b));
-    pro = _turn_in(&sit_u, a);
+    {
+      u3_noun* hed;
+      u3_noun* tel;
+      u3_noun i, t = a;
+
+      do {
+        u3x_cell(t, &i, &t);
+
+        *lit = u3i_defcons(&hed, &tel);
+        *hed = u3j_gate_slam(&sit_u, u3k(i));
+        lit  = tel;
+      }
+      while ( u3_nul != t );
+    }
     u3j_gate_lose(&sit_u);
+
+    *lit = u3_nul;
+
     return pro;
   }
+}
 
-  u3_noun
-  u3wb_turn(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_turn(a, b);
-    }
-  }
-
+u3_noun
+u3wb_turn(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_turn(a, b);
+}

--- a/pkg/urbit/jets/b/weld.c
+++ b/pkg/urbit/jets/b/weld.c
@@ -3,45 +3,43 @@
 */
 #include "all.h"
 
+u3_noun
+u3qb_weld(u3_noun a, u3_noun b)
+{
+  u3_noun  pro;
+  u3_noun* lit = &pro;
 
-/* functions
-*/
-  u3_noun
-  u3qb_weld(u3_noun a,
-            u3_noun b)
   {
-    u3_noun c = u3qb_flop(a);
-    u3_noun d = c;
+    u3_noun* hed;
+    u3_noun* tel;
+    u3_noun    i, t = a;
 
-    u3k(b);
+    while ( u3_nul != t ) {
+      u3x_cell(t, &i, &t);
 
-    while ( u3_nul != c ) {
-      b = u3nc(u3k(u3h(c)), b);
-      c = u3t(c);
-    }
-
-    u3z(d);
-
-    return b;
-  }
-  u3_noun
-  u3wb_weld(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_weld(a, b);
+      *lit = u3i_defcons(&hed, &tel);
+      *hed = u3k(i);
+      lit  = tel;
     }
   }
-  u3_noun
-  u3kb_weld(u3_noun a,
-            u3_noun b)
-  {
-    u3_noun c = u3qb_weld(a, b);
 
-    u3z(a); u3z(b);
-    return c;
-  }
+  *lit = u3k(b);
 
+  return pro;
+}
+
+u3_noun
+u3wb_weld(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_weld(a, b);
+}
+
+u3_noun
+u3kb_weld(u3_noun a, u3_noun b)
+{
+  u3_noun c = u3qb_weld(a, b);
+  u3z(a); u3z(b);
+  return c;
+}

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -789,6 +789,10 @@ u3a_cellblock(c3_w num_w)
 c3_w*
 u3a_celloc(void)
 {
+#ifdef U3_CPU_DEBUG
+  u3R->pro.cel_d++;
+#endif
+
 #ifdef U3_MEMORY_DEBUG
   if ( u3C.wag_w & u3o_debug_ram ) {
     return u3a_walloc(c3_wiseof(u3a_cell));

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -465,6 +465,37 @@ u3i_vint(u3_noun a)
   }
 }
 
+/* u3i_defcons(): allocate cell for deferred construction.
+**            NB: [hed] and [tel] pointers MUST be filled.
+*/
+u3_cell
+u3i_defcons(u3_noun** hed, u3_noun** tel)
+{
+  u3_noun pro;
+  u3t_on(mal_o);
+
+#ifdef U3_CPU_DEBUG
+  u3R->pro.cel_d++;
+#endif
+
+  {
+    c3_w*     nov_w = u3a_celloc();
+    u3a_cell* nov_u = (void *)nov_w;
+
+    nov_u->mug_w = 0;
+
+    //  XX zero-initialize head and tail?
+    //
+    *hed = &nov_u->hed;
+    *tel = &nov_u->tel;
+
+    pro = u3a_to_pom(u3a_outa(nov_w));
+  }
+
+  u3t_off(mal_o);
+  return pro;
+}
+
 /* u3i_cell(): Produce the cell `[a b]`.
 */
 u3_noun

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -480,8 +480,11 @@ u3i_defcons(u3_noun** hed, u3_noun** tel)
 
     nov_u->mug_w = 0;
 
-    //  XX zero-initialize head and tail?
-    //
+#ifdef U3_MEMORY_DEBUG
+    nov_u->hed = u3_none;
+    nov_u->tel = u3_none;
+#endif
+
     *hed = &nov_u->hed;
     *tel = &nov_u->tel;
 

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -472,12 +472,8 @@ u3_cell
 u3i_defcons(u3_noun** hed, u3_noun** tel)
 {
   u3_noun pro;
+
   u3t_on(mal_o);
-
-#ifdef U3_CPU_DEBUG
-  u3R->pro.cel_d++;
-#endif
-
   {
     c3_w*     nov_w = u3a_celloc();
     u3a_cell* nov_u = (void *)nov_w;
@@ -491,8 +487,8 @@ u3i_defcons(u3_noun** hed, u3_noun** tel)
 
     pro = u3a_to_pom(u3a_outa(nov_w));
   }
-
   u3t_off(mal_o);
+
   return pro;
 }
 
@@ -502,12 +498,8 @@ u3_noun
 u3i_cell(u3_noun a, u3_noun b)
 {
   u3_noun pro;
+
   u3t_on(mal_o);
-
-#ifdef U3_CPU_DEBUG
-  u3R->pro.cel_d++;
-#endif
-
   {
     c3_w*     nov_w = u3a_celloc();
     u3a_cell* nov_u = (void *)nov_w;
@@ -518,8 +510,8 @@ u3i_cell(u3_noun a, u3_noun b)
 
     pro = u3a_to_pom(u3a_outa(nov_w));
   }
-
   u3t_off(mal_o);
+
   return pro;
 }
 


### PR DESCRIPTION
This PR adds `u3i_defcons()`, a deferred cell constructor, and uses it in the list jets. This replaces a pattern of constructing lists in reverse order, and flopping them when complete, and therefore avoids an unnecessary round cell allocations in each. This optimization is often called [tail-recursion modulo cons](https://en.wikipedia.org/wiki/Tail_call#Tail_recursion_modulo_cons). We may want to consider adding it to the bytecode interpeter at some point in the future.