### PR TITLE
u3: replaces arbitrary-precision math in +lent and +wyt:in jets

### DIFF
--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -24,15 +24,18 @@
     */
 #     define u3a_bytes  (c3_w)((1 << (2 + u3a_bits)))
 
-    /* u3a_minimum: minimum number of words in a box.
-    **
-    **  wiseof(u3a_cell) + wiseof(u3a_box) + 1 (trailing siz_w)
+    /* u3a_cells: number of representable cells.
     */
-#ifdef U3_MEMORY_DEBUG
-#     define u3a_minimum   8
-#else
-#     define u3a_minimum   6
-#endif
+#     define u3a_cells  (c3_w)(u3a_words / u3a_minimum)
+
+    /* u3a_maximum: maximum loom object size (largest possible atom).
+    */
+#     define u3a_maximum   \
+        (c3_w)(u3a_words - (c3_wiseof(u3a_box) + c3_wiseof(u3a_atom)))
+
+    /* u3a_minimum: minimum loom object size (actual size of a cell).
+    */
+#     define u3a_minimum   (c3_w)(1 + c3_wiseof(u3a_box) + c3_wiseof(u3a_cell))
 
     /* u3a_fbox_no: number of free lists per size.
     */

--- a/pkg/urbit/jets/b/lent.c
+++ b/pkg/urbit/jets/b/lent.c
@@ -3,45 +3,56 @@
 */
 #include "all.h"
 
+u3_noun
+u3qb_lent(u3_noun a)
+{
+  if ( u3_nul == a ) {
+    return 0;
+  }
 
-/* functions
-*/
-  u3_noun
-  u3qb_lent(u3_noun a)
+  //  loop until we overflow [len_w]
+  //
   {
-    u3_noun len = 0;
+    c3_w len_w = 1;
+
+    do {
+      a = u3t(a);
+
+      if ( u3_nul == a ) {
+        return u3i_words(1, &len_w);
+      }
+    }
+    while ( ++len_w );
+  }
+
+  //  continue with arbitrary precision
+  //
+  {
+    u3_noun len = u3qc_bex(32);
 
     while ( 1 ) {
-      if ( 0 == a ) {
+      a = u3t(a);
+
+      if ( u3_nul == a ) {
         return len;
-      }
-      else if ( c3n == u3du(a) ) {
-        u3z(len);
-        return u3m_bail(c3__exit);
       }
       else {
         len = u3i_vint(len);
-        a = u3t(a);
       }
     }
   }
-  u3_noun
-  u3wb_lent(u3_noun cor)
-  {
-    u3_noun a;
+}
 
-    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_lent(a);
-    }
-  }
-  u3_noun
-  u3kb_lent(u3_noun a)
-  {
-    u3_noun b = u3qb_lent(a);
+u3_noun
+u3wb_lent(u3_noun cor)
+{
+  return u3qb_lent(u3x_at(u3x_sam, cor));
+}
 
-    u3z(a);
-    return b;
-  }
-
+u3_noun
+u3kb_lent(u3_noun a)
+{
+  u3_noun b = u3qb_lent(a);
+  u3z(a);
+  return b;
+}

--- a/pkg/urbit/jets/b/lent.c
+++ b/pkg/urbit/jets/b/lent.c
@@ -3,44 +3,20 @@
 */
 #include "all.h"
 
+STATIC_ASSERT( (UINT32_MAX > u3a_cells),
+               "length precision" );
+
 u3_noun
 u3qb_lent(u3_noun a)
 {
-  if ( u3_nul == a ) {
-    return 0;
+  c3_w len_w = 0;
+
+  while ( u3_nul != a ) {
+    a = u3t(a);
+    len_w++;
   }
 
-  //  loop until we overflow [len_w]
-  //
-  {
-    c3_w len_w = 1;
-
-    do {
-      a = u3t(a);
-
-      if ( u3_nul == a ) {
-        return u3i_words(1, &len_w);
-      }
-    }
-    while ( ++len_w );
-  }
-
-  //  continue with arbitrary precision
-  //
-  {
-    u3_noun len = u3qc_bex(32);
-
-    while ( 1 ) {
-      a = u3t(a);
-
-      if ( u3_nul == a ) {
-        return len;
-      }
-      else {
-        len = u3i_vint(len);
-      }
-    }
-  }
+  return u3i_word(len_w);
 }
 
 u3_noun

--- a/pkg/urbit/jets/d/in_wyt.c
+++ b/pkg/urbit/jets/d/in_wyt.c
@@ -3,26 +3,31 @@
 */
 #include "all.h"
 
-/* functions
-*/
-u3_noun
-u3qdi_wyt(u3_noun a)
+STATIC_ASSERT( (UINT32_MAX > u3a_cells),
+               "width precision" );
+
+static c3_w
+_wyt_in(u3_noun a)
 {
   if ( u3_nul == a ) {
     return 0;
   }
   else {
-    u3_noun n_a, l_a, r_a;
-    u3x_trel(a, &n_a, &l_a, &r_a);
+    u3_noun l_a, r_a;
+    u3x_trel(a, 0, &l_a, &r_a);
 
-    return u3i_vint(u3ka_add(u3qdi_wyt(l_a), u3qdi_wyt(r_a)));
+    return 1 + _wyt_in(l_a) + _wyt_in(r_a);
   }
+}
+
+u3_noun
+u3qdi_wyt(u3_noun a)
+{
+  return u3i_word(_wyt_in(a));
 }
 
 u3_noun
 u3wdi_wyt(u3_noun cor)
 {
-  u3_noun a;
-  u3x_mean(cor, u3x_con_2, &a, 0);
-  return u3qdi_wyt(a);
+  return u3qdi_wyt(u3x_at(u3x_con_2, cor));
 }


### PR DESCRIPTION
This PR removes what I argue is unnecessary arbitrary-precision in the `+lent` and `+wyt:in` jets.

First, it occurred to me that `+lent` need not unconditionally use arbitrary-precision increment (`u3i_vint()`); the counter starts at 0, so we know exactly when it no longer fits in a direct atom. I rewrote the `+lent` jet to iterate with a `c3_w` (uint32_t) counter until that overflows, then initialize an indirect atom and subsequently iterate with `u3i_vint()` (this is in 94a4dc5).

But then it occurred to me that we statically know the maximum number of cells we can represent on the loom, so use of arbitrary-precision in this jet is entirely unnecessary. Instead, we can simply increment a `c3_w` counter. The code is guarded by a compile-time assertion that the maximum number of cells (`u3a_cells`) is less than `UINT32_MAX` -- if the loom limits are increased beyond this point, the build will fail and that code can be switched to use a larger integer type (or arbitrary-precision), as necessary.

The same analysis applies to `+wyt:in`, which counts the number of nodes in a generic treap (`+tree`). Both GCC and clang can highly optimize that code (right branches become tail calls or jumps), since integer addition is commutative and associative (the compiler has no idea what `u3ka_add()` is).