### PR TITLE
launch: visual edits to tile borders and clock colors

### DIFF
--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -98,7 +98,7 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
             bg="white"
             border={1}
             borderRadius={2}
-            borderColor="lightGray"
+            borderColor="washedGray"
             p={2}
             fontSize={0}
           >

--- a/pkg/interface/src/views/apps/launch/components/tiles/clock.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/clock.js
@@ -278,7 +278,7 @@ class Clock extends React.Component {
         8,
         0,
         2 * Math.PI,
-        '#6792FF',
+        'rgba(0, 0, 0, 0.1)',
         1
       );
     } else {
@@ -300,7 +300,7 @@ class Clock extends React.Component {
         8,
         0,
         2 * Math.PI,
-        '#000000',
+        'rgba(0, 0, 0, 0.1)',
         1
       );
     }

--- a/pkg/interface/src/views/apps/launch/components/tiles/tile.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/tile.js
@@ -30,7 +30,7 @@ export default class Tile extends React.Component {
       <Box
         border={1}
         borderRadius={2}
-        borderColor="lightGray"
+        borderColor="washedGray"
         overflow="hidden"
         {...props}
       >


### PR DESCRIPTION
I made a few tiny edits to the colors used on the clock sun's outer border (to change it from blue to a low-opacity black), and lightened up the tile borders.