### PR TITLE
eyre: lower +channel-timeout

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15a8b98d7eb45b168edfc1fe346bc79781a2e81a8d0b9fa7db87ef527b84c66b
-size 6319407
+oid sha256:24459ded4f143fae9e942d5b4096ed05ff65db7fffc1f97bb69c6f1a3601a28b
+size 6328344

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -132,8 +132,16 @@
       [%delete ~]
   ==
 ::  channel-timeout: the delay before a channel should be reaped
+::  
+::    Channels are reaped after a period of channel-timeout passes
+::    from the associated eventstream being cancelled. Channels are
+::    reaped immediately when a %delete action is sent from the browser.
+::    The channel subsystem supports re-establishing a eventstream,
+::    however in practice this is not used to due to the general
+::    unreliability of communication to Earth. As such, we aggressively
+::    reap channels.
 ::
-++  channel-timeout  ~h12
+++  channel-timeout  ~m5
 ::  session-timeout: the delay before an idle session expires
 ::
 ++  session-timeout  ~d7


### PR DESCRIPTION
Eyre does not reap active channels with an associated eventstream.
+channel-timeout is only used when we lose the eventstream, to allow for
a client to re-establish a subscription without having to resend updates
that had already been received. However, this feature is unused in landscape
and the length of the timeout has been causing bail:memes as of late. As such,
this commit changes +channel-timeout to reap more often to avoid potential
memory pressure issues