### PR TITLE
channel.js: eagerly ack subscription updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 bin/* filter=lfs diff=lfs merge=lfs -text
 bin/*/* filter=lfs diff=lfs merge=lfs -text
-pkg/arvo/**/*.js binary
 pkg/arvo/**/*.css binary

--- a/pkg/arvo/app/landscape/js/channel.js
+++ b/pkg/arvo/app/landscape/js/channel.js
@@ -167,9 +167,11 @@ class Channel {
       //    The server side puts messages it sends us in a queue until we
       //    acknowledge that we received it.
       //
-      let x = JSON.stringify(
-        [{action: "ack", "event-id": parseInt(this.lastEventId)}, j]
-      );
+      let payload = [{action: "ack", "event-id": parseInt(this.lastEventId)}];
+      if(j) {
+        payload.push(j)
+      }
+      let x = JSON.stringify(payload);
       req.send(x);
 
       this.lastEventId = this.lastAcknowledgedEventId;
@@ -215,6 +217,8 @@ class Channel {
           funcs["subAck"](obj);
         }
       } else if (obj.response == "diff") {
+        // ack subscription
+        this.sendJSONToChannel();
         let funcs = subFuncs;
         funcs["event"](obj.json);
       } else if (obj.response == "quit") {

--- a/pkg/arvo/app/landscape/js/channel.js
+++ b/pkg/arvo/app/landscape/js/channel.js
@@ -66,7 +66,7 @@ class Channel {
   }
 
   deleteOnUnload() {
-    window.addEventListener("unload", (event) => {
+    window.addEventListener("beforeunload", (event) => {
       this.delete();
     });
   }


### PR DESCRIPTION
Changes channel.js to eagerly ack subscription updates. Also fires the delete action in beforeunload instead of unload, to buy us some more time. 