### PR TITLE
groups: remove remnant groups from recent

### DIFF
--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -43,7 +43,9 @@ function RecentGroups(props: { recent: string[]; associations: Associations }) {
       <Box fontSize={0} px={1} py={2} color="gray">
         Recent Groups
       </Box>
-      {props.recent.slice(1, 5).map((g) => {
+      {props.recent.filter((e) => {
+        return (e in associations?.contacts);
+      }).slice(1, 5).map((g) => {
         const assoc = associations.contacts[g];
         const color = uxToHex(assoc?.metadata?.color || "0x0");
         return (


### PR DESCRIPTION
- We get recent groups from localStorage, but this produces edge cases where we leave a group, but retain it in our recentGroups array
- We don't filter this array for what groups we're currently in before rendering it, so "empty" recents are rendered
- This just filters that array with a safety check'd call inside the `associations.contacts` object.