### PR TITLE
leap: add 'home' to leap index, default results

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -30,6 +30,7 @@ const commandIndex = function (currentGroup) {
 
 const otherIndex = function() {
   const other = [];
+  other.push(result('Home', '/~landscape/home', 'home', null));
   other.push(result('Profile and Settings', '/~profile/identity', 'profile', null));
   other.push(result('Log Out', '/~/logout', 'logout', null));
 

--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -120,7 +120,7 @@ export class Omnibox extends Component {
     const { props } = this;
     this.setState({ results: this.initialResults(), query: '' }, () => {
       props.api.local.setOmnibox();
-      if (defaultApps.includes(app.toLowerCase()) || app === 'profile' || app === 'Links') {
+      if (defaultApps.includes(app.toLowerCase()) || app === 'profile' || app === 'Links' || app === 'home') {
         props.history.push(link);
       } else {
         window.location.href = link;

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -39,6 +39,8 @@ export class OmniboxResult extends Component {
       graphic = <Icon display="inline-block" verticalAlign="middle" icon='ArrowWest' mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'profile') {
       graphic = <Sigil color={sigilFill} classes='dib v-mid mr2' ship={window.ship} size={16} />;
+    } else if (icon === 'home') {
+      graphic = <Icon display='inline-block' verticalAlign='middle' icon='Circle' mr='2' size='16px' color={iconFill} />;
     } else {
       graphic = <Icon verticalAlign="middle" mr='2' size="16px" color={iconFill} />;
     }


### PR DESCRIPTION
- Adds 'home' (our DM / personal space) to the leap index + default results when nothing is searched

cc @urcades @g-a-v-i-n — 

Design-wise I use "Circle" for the icon, not "Home", because we use "Circle" to denote the home space in the tile; and we use the "Home" icon to ...  bring us to the launch screen. I think this is gonna need smoothing at some point, but I just wanted to be consistent.

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/20846414/95499415-3c26d900-0973-11eb-83b2-313c8008a2fd.png">
