### PR TITLE
groups, leap: redirect unmanaged resources correctly

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -37,7 +37,7 @@ const otherIndex = function() {
   return other;
 };
 
-export default function index(associations, apps, currentGroup) {
+export default function index(associations, apps, currentGroup, groups) {
   // all metadata from all apps is indexed
   // into subscriptions and landscape
   const subscriptions = [];
@@ -75,9 +75,11 @@ export default function index(associations, apps, currentGroup) {
           landscape.push(obj);
         } else {
           const app = each.metadata.module || each['app-name'];
+          const group = (groups[each['group-path']]?.hidden)
+            ? '/home' : each['group-path'];
           const obj = result(
             title,
-            `/~landscape${each['group-path']}/join/${app}${each['app-path']}`,
+            `/~landscape${group}/join/${app}${each['app-path']}`,
             app.charAt(0).toUpperCase() + app.slice(1),
             (associations?.contacts?.[each['group-path']]?.metadata?.title || null)
           );

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -150,6 +150,7 @@ class App extends React.Component {
                 apps={state.launch}
                 api={this.api}
                 dark={state.dark}
+                groups={state.groups}
                 show={state.omniboxShown}
               />
             </ErrorBoundary>

--- a/pkg/interface/src/views/components/UnjoinedResource.tsx
+++ b/pkg/interface/src/views/components/UnjoinedResource.tsx
@@ -25,10 +25,10 @@ function isJoined(app: string, path: string) {
     props: Pick<UnjoinedResourceProps, "inbox" | "graphKeys" | "notebooks">
   ) {
     let ship, name;
+    const graphKey = path.substr(7);
     switch (app) {
       case "link":
-        [, , ship, name] = path.split("/");
-        return props.graphKeys.has(path);
+        return props.graphKeys.has(graphKey);
       case "publish":
         [, ship, name] = path.split("/");
         return !!props.notebooks[ship]?.[name];

--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -31,7 +31,7 @@ export class Omnibox extends Component {
       const { pathname } = this.props.location;
       const selectedGroup = pathname.startsWith('/~landscape/ship/') ? '/' + pathname.split('/').slice(2,5).join('/') : null;
 
-      this.setState({ index: index(this.props.associations, this.props.apps.tiles, selectedGroup) });
+      this.setState({ index: index(this.props.associations, this.props.apps.tiles, selectedGroup, this.props.groups) });
     }
 
     if (prevProps && (prevProps.apps !== this.props.apps) && (this.state.query === '')) {


### PR DESCRIPTION
- Leap didn't use `/home`, but the `group-path`, if the resource was unmanaged, emptying the sidebar when leaping to unmanaged resources
- The groups pane listened for the wrong key for Links inside `graphKeys` — it doesn't use `/ship/patp/resource`, but `sigless-patp/resource`, so we listen correctly now.