### PR TITLE
publish: fix 'notebook index' link

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -31,13 +31,11 @@ interface NoteProps {
 
 export function Note(props: NoteProps & RouteComponentProps) {
   const [deleting, setDeleting] = useState(false);
-  const { notebook, note, contacts, ship, book, noteId, api, baseUrl } = props;
+  const { notebook, note, contacts, ship, book, noteId, api, rootUrl } = props;
   useEffect(() => {
     api.publish.readNote(ship.slice(1), book, noteId);
     api.publish.fetchNote(ship, book, noteId);
   }, [ship, book, noteId]);
-
-  const rootUrl = props.baseUrl || '/~404';
 
   const deletePost = async () => {
     setDeleting(true);


### PR DESCRIPTION
- In `<Note>`, `baseUrl` is the Note's path; `rootUrl` is the notebook's path; thus the Notebook Index link was linking to itself. We just use `rootUrl` accordingly, instead of `baseUrl`.