### PR TITLE
LocalReducer: fix empty case of localStorage rehydration

### DIFF
--- a/pkg/interface/src/logic/reducers/local.ts
+++ b/pkg/interface/src/logic/reducers/local.ts
@@ -8,7 +8,7 @@ type LocalState = Pick<StoreState, 'sidebarShown' | 'omniboxShown' | 'baseHash' 
 export default class LocalReducer<S extends LocalState> {
     rehydrate(state: S) {
       try {
-        const json = JSON.parse(localStorage.getItem('localReducer') || '');
+        const json = JSON.parse(localStorage.getItem('localReducer') || '{}');
         _.forIn(json, (value, key) => {
           state[key] = value;
         });


### PR DESCRIPTION
This should fix the following warning that I get whenever I reload my landscape page:
```
Failed to rehydrate localStorage state SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at e.value (local.ts:11)
    at r.value (store.ts:39)
    at r.value (App.js:88)
    at as (react-dom.production.min.js:212)
    at fl (react-dom.production.min.js:255)
    at t.unstable_runWithPriority (scheduler.production.min.js:19)
    at Bi (react-dom.production.min.js:122)
    at hl (react-dom.production.min.js:248)
    at Qs (react-dom.production.min.js:239)
```

I believe this happened whenever localStorage was empty, because it would try to run `JSON.parse('')`, which produces that error.