### PR TITLE
links: key linkItems by date

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -71,10 +71,11 @@ export function LinkResource(props: LinkResourceProps) {
                 <Row width="100%" flexShrink='0'>
                   <LinkSubmit s3={s3} name={name} ship={ship.slice(1)} api={api} />
                 </Row>
-                {Array.from(graph.values()).map((node: GraphNode) => {
+                {Array.from(graph).map(([date, node]) => {
                   const contact = contactDetails[node.post.author];
                   return (
                     <LinkItem
+                      key={date}
                       resource={resourcePath}
                       node={node}
                       nickname={contact?.nickname}


### PR DESCRIPTION
Fixes a regression on next-userspace branch where, because we weren't keying by the graph's keys (dates), submitted links append to the bottom of the list, not pop up at the top of the list.