### PR TITLE
leap: restore app index, remove from default

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -4,6 +4,7 @@ import { cite } from '~/logic/lib/util';
     ['commands', []],
     ['subscriptions', []],
     ['groups', []],
+    ['apps', []],
     ['other', []]
   ]);
 
@@ -26,6 +27,29 @@ const commandIndex = function (currentGroup) {
   commands.push(result(`Channel: Create`, `/~landscape${workspace}/new`, 'Groups', null));
 
   return commands;
+};
+
+const appIndex = function (apps) {
+  // all apps are indexed from launch data
+  // indexed into 'apps'
+  const applications = [];
+  Object.keys(apps)
+    .filter((e) => {
+      return apps[e]?.type?.basic;
+    })
+    .sort((a, b) => {
+      return a.localeCompare(b);
+    })
+    .map((e) => {
+      const obj = result(
+        apps[e].type.basic.title,
+        apps[e].type.basic.linkedUrl,
+        apps[e].type.basic.title,
+        null
+      );
+      applications.push(obj);
+    });
+  return applications;
 };
 
 const otherIndex = function() {
@@ -91,6 +115,7 @@ export default function index(associations, apps, currentGroup, groups) {
   indexes.set('commands', commandIndex(currentGroup));
   indexes.set('subscriptions', subscriptions);
   indexes.set('groups', landscape);
+  indexes.set('apps', appIndex(apps));
   indexes.set('other', otherIndex());
 
   return indexes;

--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -55,7 +55,7 @@ export class Omnibox extends Component {
   }
 
   getSearchedCategories() {
-    return ['commands', 'groups', 'subscriptions', 'other'];
+    return ['commands', 'groups', 'subscriptions', 'apps', 'other'];
   }
 
   control(evt) {
@@ -105,9 +105,6 @@ export class Omnibox extends Component {
     return new Map(this.getSearchedCategories().map((category) => {
       if (!this.state) {
         return [category, []];
-      }
-      if (category === 'apps') {
-        return ['apps', this.state.index.get('apps')];
       }
       if (category === 'other') {
         return ['other', this.state.index.get('other')];

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -31,9 +31,7 @@ export class OmniboxResult extends Component {
 
     let graphic = <div />;
     if (defaultApps.includes(icon.toLowerCase()) || icon.toLowerCase() === 'links') {
-      icon = (icon === 'Dojo') ? 'ChevronEast' : icon;
       icon = (icon === 'Link') ? 'Links' : icon;
-
       graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'logout') {
       graphic = <Icon display="inline-block" verticalAlign="middle" icon='ArrowWest' mr='2' size='16px' color={iconFill} />;
@@ -42,7 +40,7 @@ export class OmniboxResult extends Component {
     } else if (icon === 'home') {
       graphic = <Icon display='inline-block' verticalAlign='middle' icon='Circle' mr='2' size='16px' color={iconFill} />;
     } else {
-      graphic = <Icon verticalAlign="middle" mr='2' size="16px" color={iconFill} />;
+      graphic = <Icon icon='NullIcon' verticalAlign="middle" mr='2' size="16px" color={iconFill} />;
     }
 
     return graphic;


### PR DESCRIPTION
Fixes a temporary regression where apps were no longer indexed in Leap; I believe it also fixes an unfiled bug where third party apps crash Landscape due to, what I can only assume, is new behaviour in indigo-react when no icon string is specified (it used to have a default?).

Doesn't list the apps in the default results list (we'll probably want "Recent Groups" here but requires some additional logic); also uses the new Dojo icon.