### PR TITLE
u3: run gc after each unit test suite

### DIFF
--- a/pkg/urbit/include/jets/k.h
+++ b/pkg/urbit/include/jets/k.h
@@ -5,6 +5,7 @@
   /** Tier 1.
   **/
     u3_noun u3ka_add(u3_noun a, u3_noun b);
+    u3_noun u3ka_dec(u3_atom a);
     u3_noun u3ka_sub(u3_noun a, u3_noun b);
     u3_noun u3ka_mul(u3_noun a, u3_noun b);
     u3_noun u3ka_gth(u3_noun a, u3_noun b);

--- a/pkg/urbit/jets/a/dec.c
+++ b/pkg/urbit/jets/a/dec.c
@@ -45,3 +45,11 @@
       return u3qa_dec(a);
     }
   }
+
+  u3_noun
+  u3ka_dec(u3_atom a)
+  {
+    u3_noun b = u3qa_dec(a);
+    u3z(a);
+    return b;
+  }

--- a/pkg/urbit/tests/ames_tests.c
+++ b/pkg/urbit/tests/ames_tests.c
@@ -39,6 +39,10 @@ main(int argc, char* argv[])
 
   _test_ames();
 
+  //  GC
+  //
+  u3m_grab(u3_none);
+
   fprintf(stderr, "ames okeedokee\n");
   return 0;
 }

--- a/pkg/urbit/tests/hashtable_tests.c
+++ b/pkg/urbit/tests/hashtable_tests.c
@@ -14,41 +14,51 @@ _setup(void)
 
 /* _test_bit_manipulation():
 */
-static void
+static c3_i
 _test_bit_manipulation()
 {
-  if ( sizeof(u3_noun) != sizeof(u3h_slot) ){
-    c3_assert(!"wrong size\n");
+  c3_i ret_i = 1;
+
+  if ( sizeof(u3_noun) != sizeof(u3h_slot) ) {
+    fprintf(stderr, "bit manipulation: wrong size\r\n");
+    ret_i = 0;
   }
 
   u3h_slot a = 0;
 
-  if (u3h_slot_is_null(a) != c3y){
-    c3_assert(!"nullity\n");
+  if (u3h_slot_is_null(a) != c3y) {
+    fprintf(stderr, "bit manipulation: nullity\r\n");
+    ret_i = 0;
   }
 
   a = u3h_noun_be_warm(a);
-  if (u3h_slot_is_warm(a) != c3y){
-    c3_assert(!"warmth\n");
+  if (u3h_slot_is_warm(a) != c3y) {
+    fprintf(stderr, "bit manipulation: warmth\r\n");
+    ret_i = 0;
   }
 
-  if (u3h_slot_is_null(a) != c3n){
-    c3_assert(!"nullity 2\n");
+  if (u3h_slot_is_null(a) != c3n) {
+    fprintf(stderr, "bit manipulation: nullity 2\r\n");
+    ret_i = 0;
   }
 
   a = u3h_noun_be_cold(a);
-  if (u3h_slot_is_warm(a) != c3n){
-    c3_assert(!"coldness\n");
+  if (u3h_slot_is_warm(a) != c3n) {
+    fprintf(stderr, "bit manipulation: coldness\r\n");
+    ret_i = 0;
   }
+
+  return ret_i;
 }
 
 /* _test_no_cache(): test a hashtable without caching.
 */
-static void
+static c3_i
 _test_no_cache(void)
 {
-  c3_w i_w;
+  c3_i ret_i = 1;
   c3_w max_w = 1000;
+  c3_w   i_w;
 
   u3p(u3h_root) har_p = u3h_new();
 
@@ -57,52 +67,77 @@ _test_no_cache(void)
   }
 
   for ( i_w = 0; i_w < max_w; i_w++ ) {
-    c3_assert(i_w + max_w == u3h_get(har_p, i_w));
+    if ( (i_w + max_w) != u3h_get(har_p, i_w) ) {
+      fprintf(stderr, "bit test_no_cache: get failed\r\n");
+      ret_i = 0;
+    }
   }
-  printf("test_no_cache: ok\n");
+
+  u3h_free(har_p);
+  return ret_i;
 }
 
 /* _test_skip_slot():
 */
-static void
+static c3_i
 _test_skip_slot(void)
 {
+  c3_i ret_i = 1;
+
   //  root table
   {
     c3_w mug_w = 0x17 << 25;
     c3_w res_w = _ch_skip_slot(mug_w, 25);
-    c3_assert((0x18 << 25) == res_w);
+
+    if ( (0x18 << 25) != res_w ) {
+      fprintf(stderr, "bit skip_slot (a): failed\r\n");
+      ret_i = 0;
+    }
   }
 
   {
     c3_w mug_w = 63 << 25; //  6 bits, all ones
     c3_w res_w = _ch_skip_slot(mug_w, 25);
-    c3_assert(0 == res_w);
+
+    if ( 0 != res_w ) {
+      fprintf(stderr, "bit skip_slot (b): failed\r\n");
+      ret_i = 0;
+    }
   }
 
   //  child nodes
   {
     c3_w mug_w = 17 << 20;
     c3_w res_w = _ch_skip_slot(mug_w, 20);
-    c3_assert((18 << 20) == res_w);
+
+    if ( (18 << 20) != res_w ) {
+      fprintf(stderr, "bit skip_slot (c): failed\r\n");
+      ret_i = 0;
+    }
   }
 
   {
     c3_w mug_w = 31 << 20; //  5 bits, all ones
     c3_w res_w = _ch_skip_slot(mug_w, 20);
     c3_assert((1 << 25) == res_w);
+
+    if ( (1 << 25) != res_w ) {
+      fprintf(stderr, "bit skip_slot (d): failed\r\n");
+      ret_i = 0;
+    }
   }
 
-  fprintf(stderr, "test_skip_slot: ok\n");
+  return ret_i;
 }
 
 /* _test_cache_trimming(): ensure a caching hashtable removes stale items.
 */
-static void
+static c3_i
 _test_cache_trimming(void)
 {
+  c3_i ret_i = 1;
   c3_w max_w = 620;
-  c3_w i_w;
+  c3_w   i_w;
 
   //u3p(u3h_root) har_p = u3h_new_cache(max_w / 2);
   u3p(u3h_root) har_p = u3h_new_cache(max_w / 10 );
@@ -113,23 +148,26 @@ _test_cache_trimming(void)
   }
 
   if ( ( max_w + max_w - 1) != u3h_get(har_p, max_w - 1) ) {
-    fprintf(stderr, "fail\r\n");
-    exit(1);
+    fprintf(stderr, "cache_trimming (a): fail\r\n");
+    ret_i = 0;
   }
   if ( ( max_w / 10 ) != har_u->use_w ) {
-    fprintf(stderr, "fail\r\n");
-    exit(1);
+    fprintf(stderr, "cache_trimming (b): fail\r\n");
+    ret_i = 0;
   }
-  fprintf(stderr, "test_cache_trimming: ok\n");
+
+  u3h_free(har_p);
+  return ret_i;
 }
 
 /* _test_cache_replace_value():
 */
-static void
+static c3_i
 _test_cache_replace_value(void)
 {
+  c3_i ret_i = 1;
   c3_w max_w = 100;
-  c3_w i_w;
+  c3_w   i_w;
 
   u3p(u3h_root) har_p = u3h_new_cache(max_w);
   u3h_root*     har_u = u3to(u3h_root, har_p);
@@ -143,14 +181,30 @@ _test_cache_replace_value(void)
   }
 
   if ( (2 * max_w) != u3h_get(har_p, max_w - 1) ) {
-    fprintf(stderr, "fail\r\n");
-    exit(1);
+    fprintf(stderr, "cache_replace (a): fail\r\n");
+    ret_i = 0;
   }
   if ( max_w != har_u->use_w ) {
-    fprintf(stderr, "fail\r\n");
-    exit(1);
+    fprintf(stderr, "cache_replace (b): fail\r\n");
+    ret_i = 0;
   }
-  fprintf(stderr, "test_cache_replace_value: ok\r\n");
+
+  u3h_free(har_p);
+  return ret_i;
+}
+
+static c3_i
+_test_hashtable(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _test_bit_manipulation();
+  ret_i &= _test_no_cache();
+  ret_i &= _test_skip_slot();
+  ret_i &= _test_cache_trimming();
+  ret_i &= _test_cache_replace_value();
+
+  return ret_i;
 }
 
 /* main(): run all test cases.
@@ -160,11 +214,14 @@ main(int argc, char* argv[])
 {
   _setup();
 
-  _test_bit_manipulation();
-  _test_no_cache();
-  _test_skip_slot();
-  _test_cache_trimming();
-  _test_cache_replace_value();
+  if ( !_test_hashtable() ) {
+    fprintf(stderr, "test_hashtable: failed\r\n");
+    exit(1);
+  }
+
+  //  GC
+  //
+  u3m_grab(u3_none);
 
   fprintf(stderr, "test_hashtable: ok\r\n");
 

--- a/pkg/urbit/tests/jam_tests.c
+++ b/pkg/urbit/tests/jam_tests.c
@@ -10,291 +10,6 @@ _setup(void)
   u3m_pave(c3y, c3n);
 }
 
-/* _test_jam_spot_a(): spot check jam/cue
-*/
-static c3_i
-_test_jam_spot_a(void)
-{
-  c3_i ret_i = 1;
-
-  if ( 0xc != u3qe_jam(1) ) {
-    fprintf(stderr, "jam: fail (a)\r\n");
-    ret_i = 0;
-  }
-
-  if ( 1 != u3ke_cue(u3qe_jam(1)) ) {
-    fprintf(stderr, "jam: fail (b)\r\n");
-    ret_i = 0;
-  }
-
-  {
-    u3_noun a = u3nc(1, 2);
-
-    if ( 0x1231 != u3qe_jam(a) ) {
-      fprintf(stderr, "jam: fail (c)\r\n");
-      ret_i = 0;
-    }
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (d)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  {
-    u3_noun a = u3nt(1, 2, 3);
-
-    if ( 0x344871 != u3qe_jam(a) ) {
-      fprintf(stderr, "jam: fail (e)\r\n");
-      ret_i = 0;
-    }
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (f)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  {
-    u3_noun a = u3nc(u3nc(1, 2), 3);
-
-    if ( 0x3448c5 != u3qe_jam(a) ) {
-      fprintf(stderr, "jam: fail (g)\r\n");
-      ret_i = 0;
-    }
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (h)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  {
-    u3_noun b = u3nc(1, 2);
-    u3_noun a = u3nt(b, b, b);
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (j)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  {
-    u3_noun b = u3i_string("abcdefjhijklmnopqrstuvwxyz");
-    u3_noun a = u3nq(b, 2, 3, b);
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (k)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  {
-    u3_noun a = u3nc(u3nc(u3nc(1, u3nc(u3nc(2, u3nc(u3nc(3, u3nc(u3nc(4, u3nc(u3nt(5, 6, u3nc(7, u3nc(u3nc(8, 0), 0))), 0)), 0)), 0)), 0)), 0), 0);
-
-    if ( c3y != u3r_sing(a, u3ke_cue(u3qe_jam(a))) ) {
-      fprintf(stderr, "jam: fail (l)\r\n");
-      ret_i = 0;
-    }
-  }
-
-  return ret_i;
-}
-
-/* _test_jam_spot_b(): more jam/cue spot-checking, ported from the 64-bit effort
-*/
-static c3_i
-_test_jam_spot_b()
-{
-  c3_i ret_i = 1;
-
-  // the boot msg from the worker
-  {
-    u3_noun dat = u3_nul;
-    u3_noun in_1 = u3nc(c3__play, dat);
-    u3_atom jam_1 = u3ke_jam(in_1);
-
-    u3_noun out_1 = u3ke_cue(jam_1);
-    u3_noun head_out =    u3h(out_1);
-    u3_noun tail_out =    u3t(out_1);
-
-    if (c3__play != head_out){
-      fprintf(stderr, "*** cue_jam 0 out head\r\n");
-      ret_i = 0;
-    }
-
-    if (u3_nul != tail_out){
-      fprintf(stderr, "*** cue_jam 0 out tail\r\n");
-      ret_i = 0;
-    }
-  }
-
-  // the boot msg from the worker, again,
-  // but this time torn apart into bytes and rebuilt
-  {
-    u3_noun dat = u3_nul;
-    u3_noun in_1 = u3nc(c3__play, dat);
-    u3_atom jam_1 = u3ke_jam(in_1);
-
-    c3_y buf_y[1024];
-    memset(buf_y, 0, 1024);
-    c3_w len_w = u3r_met(3, jam_1);
-
-    u3r_bytes(0,       // start byte
-              len_w,   // len
-              buf_y,   // buffer
-              jam_1 ); // input noun
-
-    /// zip ....zap ... communicate between serf and king
-
-    u3_noun jam_2 = u3i_bytes(len_w, buf_y);
-
-    if ( c3n == u3r_sing(jam_1, jam_2) ) {
-      fprintf(stderr, "*** error in 6 byte message\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun out_1 = u3ke_cue(jam_2);
-
-    u3_noun head_out =    u3h(out_1);
-    u3_noun tail_out =    u3t(out_1);
-
-    if (c3__play != head_out){
-      fprintf(stderr, "*** cue_jam 0 out head\r\n");
-      ret_i = 0;
-    }
-
-    if (u3_nul != tail_out){
-      fprintf(stderr, "*** cue_jam 0 out tail\r\n");
-      ret_i = 0;
-    }
-  }
-
-  // 1
-  {
-
-    u3_atom in_1 = 1;
-    u3_atom jam_1 = u3ke_jam(in_1);
-
-    if (12 != jam_1){
-      fprintf(stderr, "*** cue_jam 1a\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun out_1 = u3ke_cue(jam_1);
-
-    if (1 != out_1){
-      fprintf(stderr, "*** cue_jam 1b\r\n");
-      ret_i = 0;
-    }
-  }
-
-  // [ 1 1 ]
-  {
-
-    u3_noun in_1 = u3i_cell(1, 1);
-    u3_atom jam_1 = u3ke_jam(in_1);
-
-    if (817 != jam_1){
-      fprintf(stderr, "*** cue_jam 2 in\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun out_1 = u3ke_cue(jam_1);
-
-
-    u3_noun head_out =    u3h(out_1);
-    u3_noun tail_out =    u3t(out_1);
-
-    if (1 != head_out){
-      fprintf(stderr, "*** cue_jam 2 out head\r\n");
-      ret_i = 0;
-    }
-
-    if (1 != tail_out){
-      fprintf(stderr, "*** cue_jam 2 out tail\r\n");
-      ret_i = 0;
-    }
-  }
-
-  // [ 1 2 ]
-  {
-
-    u3_noun in_1 = u3i_cell(1, 2);
-    u3_atom jam_1 = u3ke_jam(in_1);
-
-    if (4657 != jam_1){
-      fprintf(stderr, "*** cue_jam 2 in\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun out_1 = u3ke_cue(jam_1);
-
-    u3_noun head_out =    u3h(out_1);
-    u3_noun tail_out =    u3t(out_1);
-
-    if (1 != head_out){
-      fprintf(stderr, "*** cue_jam 2 out head\r\n");
-      ret_i = 0;
-    }
-
-    if (2 != tail_out){
-      fprintf(stderr, "*** cue_jam 2 out tail\r\n");
-      ret_i = 0;
-    }
-  }
-
-  // medium complicated cell
-  //    q
-  //   / \
-  //  a1  r
-  //     / \
-  //    b2  s
-  //       / \
-  //      c3  d4
-  {
-    u3_noun a = (u3_noun) 0x1;
-    u3_noun b = (u3_noun) 0x2;
-    u3_noun c = (u3_noun) 0x3;
-    u3_noun d = (u3_noun) 0x4;
-
-    u3_noun s = u3i_cell(c, d);
-    u3_noun r = u3i_cell(b, s);
-    u3_noun q = u3i_cell(a, r);
-
-    u3_atom jam_1 = u3ke_jam(q);
-    u3_noun out_1 = u3ke_cue(jam_1);
-
-    u3_noun a2 = u3h(out_1);
-    u3_noun r2 = u3t(out_1);
-    if (a2 != a){
-      fprintf(stderr, "*** _cue_jam: complicated a\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun b2 = u3h(r2);
-    u3_noun s2 = u3t(r2);
-    if (b2 != b){
-      fprintf(stderr, "*** _cue_jam: complicated b\r\n");
-      ret_i = 0;
-    }
-
-    u3_noun c2 = u3h(s2);
-    u3_noun d2 = u3t(s2);
-    if (c2 != c){
-      fprintf(stderr, "*** _cue_jam: complicated c\r\n");
-      ret_i = 0;
-    }
-
-    if (d2 != d){
-      fprintf(stderr, "*** _cue_jam: complicated d\r\n");
-      ret_i = 0;
-    }
-  }
-
-  return 1;
-}
-
 static void
 _byte_print(c3_d        out_d,
             c3_y*       out_y,
@@ -454,6 +169,11 @@ _test_jam_roundtrip(void)
   }
 
   {
+    c3_y res_y[2] = { 0x31, 0x12 };
+    TEST_CASE("[1 2]", u3nc(1, 2));
+  }
+
+  {
     c3_y res_y[2] = { 0x21, 0xd1 };
     TEST_CASE("[2 3]", u3nc(2, 3));
   }
@@ -464,13 +184,28 @@ _test_jam_roundtrip(void)
   }
 
   {
-    c3_y res_y[2] = {  0x71, 0xcc };
+    c3_y res_y[2] = { 0x71, 0xcc };
     TEST_CASE("[1 1 1]", u3nc(1, u3nc(1, 1)));
+  }
+
+  {
+    c3_y res_y[3] = { 0x71, 0x48, 0x34 };
+    TEST_CASE("[1 2 3]", u3nt(1, 2, 3));
   }
 
   {
     c3_y res_y[12] = { 0x1, 0xdf, 0x2c, 0x6c, 0x8e, 0x1e, 0xf0, 0xcd, 0xea, 0xd8, 0xd8, 0x93 };
     TEST_CASE("[%fast %full %fast]", u3nc(c3__fast, u3nc(c3__full, c3__fast)));
+  }
+
+  {
+    c3_y res_y[3] = { 0xc5, 0x48, 0x34 };
+    TEST_CASE("[[1 2] 3]", u3nc(u3nc(1, 2), 3));
+  }
+
+  {
+    c3_y res_y[5] = { 0xc5, 0xc8, 0x26, 0x27, 0x1 };
+    TEST_CASE("[[1 2] [1 2] 1 2]", u3nt(u3nc(1, 2), u3nc(1, 2), u3nc(1, 2)));
   }
 
   {
@@ -495,27 +230,14 @@ _test_jam_roundtrip(void)
     TEST_CASE("date", u3i_bytes(sizeof(inp_y), inp_y));
   }
 
-  return ret_i;
-}
-
-static c3_i
-_test_jam(void)
-{
-  c3_i ret_i = 1;
-
-  if ( !_test_jam_spot_a() ) {
-    fprintf(stderr, "test jam: spot a: failed\r\n");
-    ret_i = 0;
-  }
-
-  if ( !_test_jam_spot_b() ) {
-    fprintf(stderr, "test jam: spot b: failed\r\n");
-    ret_i = 0;
-  }
-
-  if ( !_test_jam_roundtrip() ) {
-    fprintf(stderr, "test jam: roundtrip: failed\r\n");
-    ret_i = 0;
+  {
+    u3_noun a = u3i_string("abcdefjhijklmnopqrstuvwxyz");
+    c3_y res_y[32] = {
+       0x1, 0xf8,  0xc, 0x13, 0x1b, 0x23, 0x2b, 0x33, 0x53, 0x43, 0x4b,
+      0x53, 0x5b, 0x63, 0x6b, 0x73, 0x7b, 0x83, 0x8b, 0x93, 0x9b, 0xa3,
+      0xab, 0xb3, 0xbb, 0xc3, 0xcb, 0xd3, 0x87,  0xc, 0x3d,  0x9
+    };
+    TEST_CASE("alpha", u3nq(u3k(a), 2, 3, a));
   }
 
   return ret_i;
@@ -528,10 +250,14 @@ main(int argc, char* argv[])
 {
   _setup();
 
-  if ( !_test_jam() ) {
+  if ( !_test_jam_roundtrip() ) {
     fprintf(stderr, "test jam: failed\r\n");
     exit(1);
   }
+
+  //  GC
+  //
+  u3m_grab(u3_none);
 
   fprintf(stderr, "test jam: ok\r\n");
   return 0;

--- a/pkg/urbit/tests/mug_tests.c
+++ b/pkg/urbit/tests/mug_tests.c
@@ -11,47 +11,73 @@ _setup(void)
 
 /* _test_mug(): spot check u3r_mug hashes.
 */
-static void
+static c3_i
 _test_mug(void)
 {
+  c3_i ret_i = 1;
+
   if ( 0x4d441035 != u3r_mug_string("Hello, world!") ) {
     fprintf(stderr, "fail (a)\r\n");
-    exit(1);
+    ret_i = 0;
   }
 
-  if ( 0x4d441035 != u3r_mug(u3i_string("Hello, world!")) ) {
-    fprintf(stderr, "fail (b)\r\n");
-    exit(1);
+  {
+    u3_noun a = u3i_string("Hello, world!");
+
+    if ( 0x4d441035 != u3r_mug(a) ) {
+      fprintf(stderr, "fail (b)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(a);
   }
 
   if ( 0x79ff04e8 != u3r_mug_bytes(0, 0) ) {
     fprintf(stderr, "fail (c)\r\n");
-    exit(1);
+    ret_i = 0;
   }
 
-  if ( 0x64dfda5c != u3r_mug(u3i_string("xxxxxxxxxxxxxxxxxxxxxxxxxxxx")) ) {
-    fprintf(stderr, "fail (d)\r\n");
-    exit(1);
+  {
+    u3_noun a = u3i_string("xxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+
+    if ( 0x64dfda5c != u3r_mug(a) ) {
+      fprintf(stderr, "fail (d)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(a);
   }
 
   if ( 0x389ca03a != u3r_mug_cell(0, 0) ) {
     fprintf(stderr, "fail (e)\r\n");
-    exit(1);
+    ret_i = 0;
   }
 
   if ( 0x389ca03a != u3r_mug_cell(1, 1) ) {
     fprintf(stderr, "fail (f)\r\n");
-    exit(1);
+    ret_i = 0;
   }
 
-  if ( 0x5258a6c0 != u3r_mug_cell(0, u3qc_bex(32)) ) {
-    fprintf(stderr, "fail (g)\r\n");
-    exit(1);
+  {
+    u3_noun a = u3qc_bex(32);
+
+    if ( 0x5258a6c0 != u3r_mug_cell(0, a) ) {
+      fprintf(stderr, "fail (g)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(a);
   }
 
-  if ( 0x2ad39968 != u3r_mug_cell(u3qa_dec(u3qc_bex(128)), 1) ) {
-    fprintf(stderr, "fail (h)\r\n");
-    exit(1);
+  {
+    u3_noun a = u3ka_dec(u3qc_bex(128));
+
+    if ( 0x2ad39968 != u3r_mug_cell(a, 1) ) {
+      fprintf(stderr, "fail (h)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(a);
   }
 
   {
@@ -75,107 +101,95 @@ _test_mug(void)
 
     if ( 0x34d08717 != u3r_mug(str) ) {
       fprintf(stderr, "fail (i) (1) \r\n");
-      exit(1);
+      ret_i = 0;
     }
     if ( 0x34d08717 != u3r_mug_bytes(str_y, byt_w) ) {
       fprintf(stderr, "fail (i) (2)\r\n");
-      exit(1);
+      ret_i = 0;
     }
     if ( 0x34d08717 != u3r_mug_words(str_w, wor_w) ) {
       fprintf(stderr, "fail (i) (3)\r\n");
-      exit(1);
+      ret_i = 0;
     }
     if ( u3r_mug_words(str_w, 2) != u3r_mug_chub(str_d) ) {
       fprintf(stderr, "fail (i) (4)\r\n");
-      exit(1);
+      ret_i = 0;
     }
 
     c3_free(str_y);
     c3_free(str_w);
+    u3z(str);
   }
 
   {
-    c3_w  som_w[4];
-    u3_noun som;
+    c3_w  som_w[4] = { 0, 0, 0, 1 };
+    u3_noun som    = u3i_words(4, som_w);
 
-    {
-      som_w[0] = 0;
-      som_w[1] = 0;
-      som_w[2] = 0;
-      som_w[3] = 1;
-      som      = u3i_words(4, som_w);
-
-      if ( 0x519bd45c != u3r_mug(som) ) {
-        fprintf(stderr, "fail (j) (1)\r\n");
-        exit(1);
-      }
-
-      if ( 0x519bd45c != u3r_mug_words(som_w, 4) ) {
-        fprintf(stderr, "fail (j) (2)\r\n");
-        exit(1);
-      }
-      u3z(som);
+    if ( 0x519bd45c != u3r_mug(som) ) {
+      fprintf(stderr, "fail (j) (1)\r\n");
+      ret_i = 0;
     }
 
-    {
-      som_w[0] = 0;
-      som_w[1] = 1;
-      som_w[2] = 0;
-      som_w[3] = 1;
-      som      = u3i_words(4, som_w);
-
-      if ( 0x540eb8a9 != u3r_mug(som) ) {
-        fprintf(stderr, "fail (k) (1)\r\n");
-        exit(1);
-      }
-
-      if ( 0x540eb8a9 != u3r_mug_words(som_w, 4) ) {
-        fprintf(stderr, "fail (k) (2)\r\n");
-        exit(1);
-      }
-      u3z(som);
+    if ( 0x519bd45c != u3r_mug_words(som_w, 4) ) {
+      fprintf(stderr, "fail (j) (2)\r\n");
+      ret_i = 0;
     }
 
-    {
-      som_w[0] = 1;
-      som_w[1] = 1;
-      som_w[2] = 0;
-      som_w[3] = 1;
-      som      = u3i_words(4, som_w);
-
-      if ( 0x319d28f9 != u3r_mug(som) ) {
-        fprintf(stderr, "fail (l) (1)\r\n");
-        exit(1);
-      }
-
-      if ( 0x319d28f9 != u3r_mug_words(som_w, 4) ) {
-        fprintf(stderr, "fail (l) (2)\r\n");
-        exit(1);
-      }
-      u3z(som);
-    }
-
-    {
-      som_w[0] = 0;
-      som_w[1] = 0;
-      som_w[2] = 0;
-      som_w[3] = 0xffff;
-      som      = u3i_words(4, som_w);
-
-      if ( 0x5230a260 != u3r_mug(som) ) {
-        fprintf(stderr, "fail (m) (1)\r\n");
-        exit(1);
-      }
-
-      if ( 0x5230a260 != u3r_mug_words(som_w, 4) ) {
-        fprintf(stderr, "fail (m) (2)\r\n");
-        exit(1);
-      }
-      u3z(som);
-    }
+    u3z(som);
   }
 
-  fprintf(stderr, "test_mug: ok\n");
+  {
+    c3_w  som_w[4] = { 0, 1, 0, 1 };
+    u3_noun som    = u3i_words(4, som_w);
+
+    if ( 0x540eb8a9 != u3r_mug(som) ) {
+      fprintf(stderr, "fail (k) (1)\r\n");
+      ret_i = 0;
+    }
+
+    if ( 0x540eb8a9 != u3r_mug_words(som_w, 4) ) {
+      fprintf(stderr, "fail (k) (2)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(som);
+  }
+
+  {
+    c3_w  som_w[4] = { 1, 1, 0, 1 };
+    u3_noun som    = u3i_words(4, som_w);
+
+    if ( 0x319d28f9 != u3r_mug(som) ) {
+      fprintf(stderr, "fail (l) (1)\r\n");
+      ret_i = 0;
+    }
+
+    if ( 0x319d28f9 != u3r_mug_words(som_w, 4) ) {
+      fprintf(stderr, "fail (l) (2)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(som);
+  }
+
+  {
+    c3_w  som_w[4] = { 0, 0, 0, 0xffff };
+    u3_noun som    = u3i_words(4, som_w);
+
+    if ( 0x5230a260 != u3r_mug(som) ) {
+      fprintf(stderr, "fail (m) (1)\r\n");
+      ret_i = 0;
+    }
+
+    if ( 0x5230a260 != u3r_mug_words(som_w, 4) ) {
+      fprintf(stderr, "fail (m) (2)\r\n");
+      ret_i = 0;
+    }
+
+    u3z(som);
+  }
+
+  return ret_i;
 }
 
 /* main(): run all test cases.
@@ -185,7 +199,16 @@ main(int argc, char* argv[])
 {
   _setup();
 
-  _test_mug();
+  if ( !_test_mug() ) {
+    fprintf(stderr, "test_mug: failed\r\n");
+    exit(1);
+  }
+
+  //  GC
+  //
+  u3m_grab(u3_none);
+
+  fprintf(stderr, "test_mug: ok\n");
 
   return 0;
 }

--- a/pkg/urbit/tests/newt_tests.c
+++ b/pkg/urbit/tests/newt_tests.c
@@ -343,6 +343,10 @@ main(int argc, char* argv[])
   _test_newt_smol();
   _test_newt_vast();
 
+  //  GC
+  //
+  u3m_grab(u3_none);
+
   fprintf(stderr, "test_newt: ok\n");
 
   return 0;


### PR DESCRIPTION
This PR enables garbage-collection in all of our runtime unit suites (except for `noun_tests`, which would need a ton of cleanup). It also removes redundant tests, uses a more consistent testing protocol (continue testing after failure, return results), and generally cleans things up.