### PR TITLE
hoon: adds product cast to +murn

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -625,12 +625,12 @@
 ++  murn                                                ::  maybe transform
   ~/  %murn
   |*  {a/(list) b/$-(* (unit))}
-  |-
+  =>  .(a (homo a))
+  |-  ^-  (list _?>(?=(^ a) (need (b i.a))))
   ?~  a  ~
-  =+  c=(b i.a)
-  ?~  c
-    $(a t.a)
-  [i=u.c t=$(a t.a)]
+  =/  c  (b i.a)
+  ?~  c  $(a t.a)
+  [+.c $(a t.a)]
 ::
 ++  oust                                                ::  remove
   ~/  %oust


### PR DESCRIPTION
`+murn` was missing both a typecast of its product and list sample homogenization (compare with `+turn`). It also required the provided gate to cast to `(unit)` or manually add the relevant `u` face: ``(murn `(list @)`[1 2 3 ~] |=(a=@ `a))`` would nest-fail in `+mull`, but ``(murn `(list @)`[1 2 3 ~] |=(a=@ (some a)))`` would succeed.