### PR TITLE
u3: improve efficiency of more list jets

### DIFF
--- a/pkg/urbit/jets/b/murn.c
+++ b/pkg/urbit/jets/b/murn.c
@@ -6,42 +6,37 @@
 u3_noun
 u3qb_murn(u3_noun a, u3_noun b)
 {
-  u3_noun pro = u3_nul;
+  u3_noun  pro;
+  u3_noun* lit = &pro;
 
-  if ( u3_nul == a ) {
-    return u3_nul;
-  }
-  else {
-    u3_noun    pro;
-    u3_noun*   lit = &pro;
+  if ( u3_nul != a ) {
+    u3_noun*   hed;
+    u3_noun*   tel;
+    u3_noun res, i, t = a;
     u3j_site sit_u;
 
     u3j_gate_prep(&sit_u, u3k(b));
-    {
-      u3_noun* hed;
-      u3_noun* tel;
-      u3_noun  res, i, t = a;
 
-      do {
-        u3x_cell(t, &i, &t);
+    do {
+      u3x_cell(t, &i, &t);
 
-        res = u3j_gate_slam(&sit_u, u3k(i));
+      res = u3j_gate_slam(&sit_u, u3k(i));
 
-        if ( u3_nul != res ) {
-          *lit = u3i_defcons(&hed, &tel);
-          *hed = u3k(u3t(res));
-          lit  = tel;
-          u3z(res);
-        }
+      if ( u3_nul != res ) {
+        *lit = u3i_defcons(&hed, &tel);
+        *hed = u3k(u3t(res));
+        lit  = tel;
+        u3z(res);
       }
-      while ( u3_nul != t );
     }
+    while ( u3_nul != t );
+
     u3j_gate_lose(&sit_u);
-
-    *lit = u3_nul;
-
-    return pro;
   }
+
+  *lit = u3_nul;
+
+  return pro;
 }
 
 u3_noun

--- a/pkg/urbit/jets/b/skid.c
+++ b/pkg/urbit/jets/b/skid.c
@@ -3,53 +3,54 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _skid_in(u3j_site* sit_u, u3_noun a)
-  {
-    if ( 0 == a ) {
-      return u3nc(u3_nul, u3_nul);
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      u3_noun acc = _skid_in(sit_u, u3t(a));
-      u3_noun hoz = u3j_gate_slam(sit_u, u3k(u3h(a)));
-      u3_noun nex;
+u3_noun
+u3qb_skid(u3_noun a, u3_noun b)
+{
+  u3_noun l, r;
+  u3_noun* lef = &l;
+  u3_noun* rig = &r;
 
-      if ( c3y == hoz ) {
-        nex = u3nc(u3nc(u3k(u3h(a)), u3k(u3h(acc))), u3k(u3t(acc)));
-      }
-      else {
-        nex = u3nc(u3k(u3h(acc)), u3nc(u3k(u3h(a)), u3k(u3t(acc))));
-      }
-      u3z(hoz);
-      u3z(acc);
-
-      return nex;
-    }
-  }
-
-/* functions
-*/
-  u3_noun
-  u3qb_skid(u3_noun a,
-            u3_noun b)
-  {
-    u3_noun  pro;
+  if ( u3_nul != a) {
+    u3_noun   i, t = a;
+    u3_noun*   hed;
+    u3_noun*   tel;
     u3j_site sit_u;
     u3j_gate_prep(&sit_u, u3k(b));
-    pro = _skid_in(&sit_u, a);
-    u3j_gate_lose(&sit_u);
-    return pro;
-  }
-  u3_noun
-  u3wb_skid(u3_noun cor)
-  {
-    u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_skid(a, b);
+    do {
+      u3x_cell(t, &i, &t);
+
+      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
+        case c3y: {
+          *lef = u3i_defcons(&hed, &tel);
+          *hed = u3k(i);
+          lef  = tel;
+        } break;
+
+        case c3n: {
+          *rig = u3i_defcons(&hed, &tel);
+          *hed = u3k(i);
+          rig  = tel;
+        } break;
+
+        default: u3m_bail(c3__exit);
+      }
     }
+    while ( u3_nul != t );
+
+    u3j_gate_lose(&sit_u);
   }
+
+  *lef = u3_nul;
+  *rig = u3_nul;
+
+  return u3nc(l, r);
+}
+
+u3_noun
+u3wb_skid(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_skid(a, b);
+}

--- a/pkg/urbit/jets/b/skim.c
+++ b/pkg/urbit/jets/b/skim.c
@@ -3,50 +3,48 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _skim_in(u3j_site* sit_u, u3_noun a)
-  {
-    if ( 0 == a ) {
-      return a;
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      u3_noun hoz = u3j_gate_slam(sit_u, u3k(u3h(a)));
-      u3_noun vyr = _skim_in(sit_u, u3t(a));
+u3_noun
+u3qb_skim(u3_noun a, u3_noun b)
+{
+  u3_noun  pro;
+  u3_noun* lit = &pro;
 
-      switch ( hoz ) {
-        case c3y:  return u3nc(u3k(u3h(a)), vyr);
-        case c3n:  return vyr;
-        default:   u3z(hoz);
-                   u3z(vyr);
-                   return u3m_bail(c3__exit);
-      }
-    }
-  }
-
-/* functions
-*/
-  u3_noun
-  u3qb_skim(u3_noun a,
-            u3_noun b)
-  {
-    u3_noun pro;
+  if ( u3_nul != a) {
+    u3_noun   i, t = a;
+    u3_noun*   hed;
+    u3_noun*   tel;
     u3j_site sit_u;
     u3j_gate_prep(&sit_u, u3k(b));
-    pro = _skim_in(&sit_u, a);
-    u3j_gate_lose(&sit_u);
-    return pro;
-  }
-  u3_noun
-  u3wb_skim(u3_noun cor)
-  {
-    u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qb_skim(a, b);
+    do {
+      u3x_cell(t, &i, &t);
+
+      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
+        case c3y: {
+          *lit = u3i_defcons(&hed, &tel);
+          *hed = u3k(i);
+          lit  = tel;
+        } break;
+
+        case c3n: break;
+
+        default: u3m_bail(c3__exit);
+      }
     }
+    while ( u3_nul != t );
+
+    u3j_gate_lose(&sit_u);
   }
 
+  *lit = u3_nul;
+
+  return pro;
+}
+
+u3_noun
+u3wb_skim(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_skim(a, b);
+}

--- a/pkg/urbit/jets/b/skip.c
+++ b/pkg/urbit/jets/b/skip.c
@@ -3,50 +3,48 @@
 */
 #include "all.h"
 
-  static u3_noun
-  _skip_in(u3j_site* sit_u, u3_noun a)
-  {
-    if ( 0 == a ) {
-      return a;
-    }
-    else if ( c3n == u3du(a) ) {
-      return u3_none;
-    } else {
-      u3_noun hoz = u3j_gate_slam(sit_u, u3k(u3h(a)));
-      u3_noun vyr = _skip_in(sit_u, u3t(a));
+u3_noun
+u3qb_skip(u3_noun a, u3_noun b)
+{
+  u3_noun  pro;
+  u3_noun* lit = &pro;
 
-      switch ( hoz ) {
-        case c3y:  return vyr;
-        case c3n:  return u3nc(u3k(u3h(a)), vyr);
-        default:   u3z(hoz);
-                   u3z(vyr);
-                   return u3_none;
+  if ( u3_nul != a) {
+    u3_noun   i, t = a;
+    u3_noun*   hed;
+    u3_noun*   tel;
+    u3j_site sit_u;
+    u3j_gate_prep(&sit_u, u3k(b));
+
+    do {
+      u3x_cell(t, &i, &t);
+
+      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
+        case c3y: break;
+
+        case c3n: {
+          *lit = u3i_defcons(&hed, &tel);
+          *hed = u3k(i);
+          lit  = tel;
+        } break;
+
+        default: u3m_bail(c3__exit);
       }
     }
-  }
+    while ( u3_nul != t );
 
-/* functions
-*/
-  u3_noun
-  u3qb_skip(u3_noun a,
-            u3_noun b)
-  {
-    u3j_site sit_u;
-    u3_noun  pro;
-    u3j_gate_prep(&sit_u, u3k(b));
-    pro = _skip_in(&sit_u, a);
     u3j_gate_lose(&sit_u);
-    return pro;
-  }
-  u3_noun
-  u3wb_skip(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ) {
-      return u3_none;
-    } else {
-      return u3qb_skip(a, b);
-    }
   }
 
+  *lit = u3_nul;
+
+  return pro;
+}
+
+u3_noun
+u3wb_skip(u3_noun cor)
+{
+  u3_noun a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qb_skip(a, b);
+}

--- a/pkg/urbit/jets/b/turn.c
+++ b/pkg/urbit/jets/b/turn.c
@@ -6,37 +6,32 @@
 u3_noun
 u3qb_turn(u3_noun a, u3_noun b)
 {
-  u3_noun pro = u3_nul;
+  u3_noun  pro;
+  u3_noun* lit = &pro;
 
-  if ( u3_nul == a ) {
-    return u3_nul;
-  }
-  else {
-    u3_noun    pro;
-    u3_noun*   lit = &pro;
+  if ( u3_nul != a ) {
+    u3_noun*   hed;
+    u3_noun*   tel;
+    u3_noun   i, t = a;
     u3j_site sit_u;
 
     u3j_gate_prep(&sit_u, u3k(b));
-    {
-      u3_noun* hed;
-      u3_noun* tel;
-      u3_noun i, t = a;
 
-      do {
-        u3x_cell(t, &i, &t);
+    do {
+      u3x_cell(t, &i, &t);
 
-        *lit = u3i_defcons(&hed, &tel);
-        *hed = u3j_gate_slam(&sit_u, u3k(i));
-        lit  = tel;
-      }
-      while ( u3_nul != t );
+      *lit = u3i_defcons(&hed, &tel);
+      *hed = u3j_gate_slam(&sit_u, u3k(i));
+      lit  = tel;
     }
+    while ( u3_nul != t );
+
     u3j_gate_lose(&sit_u);
-
-    *lit = u3_nul;
-
-    return pro;
   }
+
+  *lit = u3_nul;
+
+  return pro;
 }
 
 u3_noun


### PR DESCRIPTION
This PR builds on #3658, applying the same optimizations to the `+skim`, `+skip`, and `+skid` jets. Each of these were implemented with unbounded recursion, and would overflow the stack on large inputs. All three have been converted to loops, and unnecessary intermediate cell allocation and deconstruction in `+skid` has been removed.