### PR TITLE
interface: multi ship devserver

### DIFF
--- a/pkg/interface/CONTRIBUTING.md
+++ b/pkg/interface/CONTRIBUTING.md
@@ -39,6 +39,31 @@ npm run start
 The dev server will start at `http://localhost:9000`. Sign in as you would
 normally. Landscape will refresh automatically as you make changes.
 
+#### Multi ship environments
+
+If you are testing across multiple ships at once, and you would like to be able
+to run the development server against all of the ships simulataneously, then do
+the following.
+
+Add an object under the `FLEET` key to your urbitrc.
+```javascript
+module.exports = {
+  URL: 'http://localhost:80',
+  FLEET: {
+    'zod': 'http://localhost:8080',
+    'bus': 'http://localhost:8081',
+    'nus': 'http://localhost:8082'
+  }
+};
+
+```
+
+The dev environment will attempt to match the subdomain against the keys of this
+object, and if matched will proxy to the corresponding URL. For example, the 
+above config will proxy `zod.localhost:9000` to `http://localhost:8080`,
+`bus.localhost:9000` to `http://localhost:8081` and so on and so forth. If no
+match is found, then it will fallback to the `URL` property.
+
 ## Linting
 
 The Urbit interface uses Eslint to lint the JavaScript code. To install the

--- a/pkg/interface/config/urbitrc-sample
+++ b/pkg/interface/config/urbitrc-sample
@@ -3,5 +3,9 @@ module.exports = {
     "/Users/user/ships/zod/home",
   ],
   herb: false,
-  URL: 'http://localhost:80'
+  URL: 'http://localhost:80',
+  /*  FLEET: {
+    'zod': "http://localhost:8080',
+    'bus': 'http://localhost:8081'
+  } */
 };

--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -4,6 +4,7 @@ const path = require('path');
 const urbitrc = require('./urbitrc');
 const fs = require('fs');
 const util = require('util');
+const _ = require('lodash');
 const exec = util.promisify(require('child_process').exec);
 
 function copyFile(src,dest) {
@@ -49,6 +50,8 @@ let devServer = {
   historyApiFallback: true
 };
 
+const router =  _.mapKeys(urbitrc.FLEET || {}, (value, key) => `${key}.localhost:9000`);
+
 if(urbitrc.URL) {
   devServer = {
     ...devServer,
@@ -56,13 +59,17 @@ if(urbitrc.URL) {
     proxy: {
       '/~landscape/js/bundle/index.*.js': {
         target: 'http://localhost:9000',
-        pathRewrite: (req, path) => '/index.js'
+        pathRewrite: (req, path) => {
+          return '/index.js'
+        }
       },
       '**': {
+        changeOrigin: true,
         target: urbitrc.URL,
+        router,
         // ensure proxy doesn't timeout channels
-        proxyTimeout: 0
-      }
+        proxyTimeout: 0,
+     }
     }
   };
 }


### PR DESCRIPTION
Allows to dynamically switch between ships depending on the localhost subdomain. e.g. 
```
module.exports = {
  URL: 'https://hastuc-dibtux.arvo.network',
  FLEET: {
    'zod': 'http://localhost:80',
    'bus': 'http://localhost:8080',
    'nus': 'http://localhost:8081'
}
```

in one's urbitrc will proxy `zod.localhost:9000` to `http://localhost:80`,  `bus.localhost:9000` to `http://localhost:8080`  and  `nus.localhost:9000` to `http://localhost:8081`. It will fall back to `https://hastuc-dibtux.arvo.network` when no subdomain is found.