### PR TITLE
u3: re-re-enable +repn jet

### DIFF
--- a/pkg/urbit/include/jets/w.h
+++ b/pkg/urbit/include/jets/w.h
@@ -66,6 +66,7 @@
     u3_noun u3wc_rep(u3_noun);
     u3_noun u3wc_rev(u3_noun);
     u3_noun u3wc_rip(u3_noun);
+    u3_noun u3wc_repn(u3_noun);
     u3_noun u3wc_ripn(u3_noun);
     u3_noun u3wc_rsh(u3_noun);
     u3_noun u3wc_swp(u3_noun);

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -1496,6 +1496,10 @@ static c3_c* _141_two_rip_ha[] = {
   "e8e0b834aded0d2738bcf38a93bf373d412a51e0cee7f274277a6393e634a65e",
   0
 };
+static u3j_harm _141_two_repn_a[] = {{".2", u3wc_repn, c3y}, {}};
+static c3_c* _141_two_repn_ha[] = {
+  0
+};
 static u3j_harm _141_two_ripn_a[] = {{".2", u3wc_ripn, c3y}, {}};
 static c3_c* _141_two_ripn_ha[] = {
   "2759a6931e9ef9a52c8eee43108843d94d3932a6b04f86cb6ba1555343293a28",
@@ -1732,6 +1736,7 @@ static u3j_core _141_two_d[] =
   { "rep", 7, _141_two_rep_a, 0, _141_two_rep_ha },
   { "rev", 7, _141_two_rev_a, 0, _141_two_rev_ha },
   { "rip", 7, _141_two_rip_a, 0, _141_two_rip_ha },
+  { "repn", 7, _141_two_repn_a, 0, _141_two_repn_ha },
   { "ripn", 7, _141_two_ripn_a, 0, _141_two_ripn_ha },
   { "rsh", 7, _141_two_rsh_a, 0, _141_two_rsh_ha },
   { "swp", 7, _141_two_swp_a, 0, _141_two_swp_ha },


### PR DESCRIPTION
This just backports #2899 from `na-release/next-vere`.