### PR TITLE
chat-hook: hack to move scry to a new event to fix +on-load

### DIFF
--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -93,68 +93,15 @@
       [cards this(state old)]
     ?:  ?=(%9 -.old)
       =.  cards
-        %+  weld  cards
-        ^-  (list card)
-        %+  roll  ~(tap in ~(key by wex.bol))
-        |=  [[=wire =ship =term] out=(list card)]
-        ?>  ?=([@ *] wire)
-        ?.  ?&(=(ship our.bol) =(term %chat-hook))
-          out
-        :_  out
-        =-  [%pass / %agent [our.bol %chat-hook] %poke %chat-hook-action !>(-)]
-        [%remove t.wire]
-      =/  chat-keys=(set path)  (scry-for (set path) %chat-store [%keys ~])
-      =.  cards
-        %+  weld  cards
-        ^-  (list card)
-        %+  turn  ~(tap in chat-keys)
-        |=  =app=path
-        ^-  card
-        ?>  ?=([@ @ ~] app-path)
-        =/  =ship  (slav %p i.app-path)
-        ?:  =(ship our.bol)
-          (add-owned app-path %.y)
-        (add-synced ship app-path)
-      ::       
-      =/  list-paths=(list path)
-        %+  murn  ~(tap in ~(key by synced.old))
-        |=  =app=path
-        ^-  (unit path)
-        ?~  (groups-of-chat:cc app-path)
-          `app-path
-        ~
-      |-
-      ?~  list-paths
-        ^$(-.old %10)
-      =.  synced.old  (~(del by synced.old) i.list-paths)
-      $(list-paths t.list-paths)
+        :_  cards
+        [%pass /self-poke %agent [our.bol %chat-hook] %poke %noun !>(%run-upg9)]
+      $(-.old %10)
     ?:  ?=(%8 -.old)
       $(-.old %9)
     ?:  ?=(%7 -.old)
-      =/  subscribers=(jug path ship)
-        %+  roll  ~(val by sup.bol)
-        |=  [[=ship =path] out=(jug path ship)]
-        ::  /(mailbox|backlog)/~ship/resource.name
-        ::
-        ?.  ?=([@ @ @ *] path)  out
-        =/  pax=^path  [i.t.path i.t.t.path ~]
-        (~(put ju out) pax ship)
-      =/  group  ~(. grpl bol)
       =.  cards
-        %+  weld  cards
-        ^-  (list card)
-        %+  murn  ~(tap in ~(key by synced.old))
-        |=  =path
-        ^-  (unit card)
-        ?>  ?=([@ @ ~] path)
-        =/  group-paths  (groups-of-chat:cc path)
-        ?~  group-paths  ~
-        =/  members     (members-from-path:group i.group-paths)
-        ?:  (is-managed-path:group i.group-paths)  ~
-        =/  ships=(set ship)  (~(get ju subscribers) path)
-        %-  some
-        =+  [%invite path (~(dif in members) ships)]
-        [%pass /inv %agent [our.bol %chat-view] %poke %chat-view-action !>(-)]
+        :_  cards
+        [%pass /self-poke %agent [our.bol %chat-hook] %poke %noun !>(%run-upg7)]
       $(-.old %8)
     ?:  ?=(%6 -.old)
       =.  cards
@@ -417,7 +364,8 @@
       ?+  mark  (on-poke:def mark vase)
           %json         (poke-json:cc !<(json vase))
           %chat-action  (poke-chat-action:cc !<(action:store vase))
-          %noun         (poke-noun:cc !<(?(%fix-dm %fix-out-of-sync) vase))
+          %noun
+        (poke-noun:cc !<(?(%fix-dm %fix-out-of-sync %run-upg7 %run-upg9) vase))
       ::
           %chat-hook-action
         (poke-chat-hook-action:cc !<(action:hook vase))
@@ -480,14 +428,99 @@
 ++  grp  ~(. grpl bol)
 ::
 ++  poke-noun
-  |=  a=?(%fix-dm %fix-out-of-sync)
+  |=  a=?(%fix-dm %fix-out-of-sync %run-upg7 %run-upg9)
   ^-  (quip card _state)
   |^
-  :_  state
   ?-  a
-      %fix-dm    (fix-dm %fix-dm)
-      %fix-out-of-sync  (fix-out-of-sync %fix-out-of-sync)
+      %fix-dm    [(fix-dm %fix-dm) state]
+      %fix-out-of-sync  [(fix-out-of-sync %fix-out-of-sync) state]
+      %run-upg7    run-7-to-8
+      %run-upg9   run-9-to-10
   ==
+  ::
+  ++  scry-for
+    |*  [=mold app=term =path]
+    .^  mold
+      %gx
+      (scot %p our.bol)
+      app
+      (scot %da now.bol)
+      (snoc `^path`path %noun)
+    ==
+  ::
+  ++  add-synced
+    |=  [=ship =path]
+    ^-  card
+    =-  [%pass / %agent [our.bol %chat-hook] %poke %chat-hook-action -]
+    !>(`action:hook`[%add-synced ship path %.y])
+  ::
+  ++  add-owned
+    |=  [=path history=?]
+    ^-  card
+    =-  [%pass / %agent [our.bol %chat-hook] %poke %chat-hook-action -]
+    !>(`action:hook`[%add-owned path history])
+  ::
+  ++  run-7-to-8
+    ^-  (quip card _state)
+    :_  state
+    =/  subscribers=(jug path ship)
+      %+  roll  ~(val by sup.bol)
+      |=  [[=ship =path] out=(jug path ship)]
+      ::  /(mailbox|backlog)/~ship/resource.name
+      ::
+      ?.  ?=([@ @ @ *] path)  out
+      =/  pax=^path  [i.t.path i.t.t.path ~]
+      (~(put ju out) pax ship)
+    =/  group  ~(. grpl bol)
+    ^-  (list card)
+    %+  murn  ~(tap in ~(key by synced.state))
+    |=  =path
+    ^-  (unit card)
+    ?>  ?=([@ @ ~] path)
+    =/  group-paths  (groups-of-chat path)
+    ?~  group-paths  ~
+    =/  members     (members-from-path:group i.group-paths)
+    ?:  (is-managed-path:group i.group-paths)  ~
+    =/  ships=(set ship)  (~(get ju subscribers) path)
+    %-  some
+    =+  [%invite path (~(dif in members) ships)]
+    [%pass /inv %agent [our.bol %chat-view] %poke %chat-view-action !>(-)]
+  ::
+  ++  run-9-to-10
+    ^-  (quip card _state)
+    :_
+      =/  list-paths=(list path)
+        %+  murn  ~(tap in ~(key by synced.state))
+        |=  =app=path
+        ^-  (unit path)
+        ?~  (groups-of-chat app-path)
+          `app-path
+        ~
+      |-
+      ?~  list-paths
+        state
+      =.  synced.state  (~(del by synced.state) i.list-paths)
+      $(list-paths t.list-paths)
+    %+  weld
+      ^-  (list card)
+      %+  roll  ~(tap in ~(key by wex.bol))
+      |=  [[=wire =ship =term] out=(list card)]
+      ?>  ?=([@ *] wire)
+      ?.  ?&(=(ship our.bol) =(term %chat-hook))
+        out
+      :_  out
+      =-  [%pass / %agent [our.bol %chat-hook] %poke %chat-hook-action !>(-)]
+      [%remove t.wire]
+    =/  chat-keys=(set path)  (scry-for (set path) %chat-store [%keys ~])
+    ^-  (list card)
+    %+  turn  ~(tap in chat-keys)
+    |=  =app=path
+    ^-  card
+    ?>  ?=([@ @ ~] app-path)
+    =/  =ship  (slav %p i.app-path)
+    ?:  =(ship our.bol)
+      (add-owned app-path %.y)
+    (add-synced ship app-path)
   ::
   ++  fix-out-of-sync
     |=  b=%fix-out-of-sync


### PR DESCRIPTION
Fixes #3710. Really straightforward, moved logic from +on-load to +poke-noun so as not to be caught in %gall's molting phase. I have tested on a fakezod upgrading from state-7 to state-10 and can confirm that it runs successfully.

This hack is extremely ugly, but we plan on deprecating %chat-hook as soon as next week, so this seems acceptable.