### PR TITLE
interface: design feedback tweaks

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -7,6 +7,7 @@ import tokenizeMessage, { isUrl } from '~/logic/lib/tokenizeMessage';
 import GlobalApi from '~/logic/api/global';
 import { Envelope } from '~/types/chat-update';
 import { Contacts, S3Configuration } from '~/types';
+import { Row } from '@tlon/indigo-react';
 
 interface ChatInputProps {
   api: GlobalApi;
@@ -187,12 +188,16 @@ export default class ChatInput extends Component<ChatInputProps, ChatInputState>
         />;
 
     return (
-      <div className={
-             "cf items-center flex black white-d bt b--gray4 b--gray1-d bg-white"  +
-             "bg-gray0-d relative"
-           }
-           style={{ flexGrow: 1 }}
-           >
+      <Row
+        alignItems='center'
+        position='relative'
+        flexGrow='1'
+        flexShrink='0'
+        borderTop='1'
+        borderTopColor='washedGray'
+        backgroundColor='white'
+        className='cf'
+      >
         <div className="pa2 flex items-center">
           {avatar}
         </div>
@@ -241,7 +246,7 @@ export default class ChatInput extends Component<ChatInputProps, ChatInputState>
             src="/~landscape/img/CodeEval.png"
             className="contrast-10-d bg-white bg-none-d ba b--gray1-d br1" />
         </div>
-      </div>
+      </Row>
     );
   }
 }

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -243,7 +243,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
               }}
               title={`~${msg.author}`}
             >{name}</Text>
-            <Text gray mono className="v-mid">{timestamp}</Text>
+            <Text flexShrink='0' gray mono className="v-mid">{timestamp}</Text>
             <Text gray mono ml={2} className="v-mid child dn-s">{datestamp}</Text>
           </Box>
           <Box fontSize='14px'><MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure} /></Box>

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -223,7 +223,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
           api={api}
           className="fl pr3 v-top bg-white bg-gray0-d pt1"
         />
-        <div className="clamp-message" style={{ flexGrow: 1 }}>
+        <Box flexGrow='1' display='block' className="clamp-message">
           <Box
             className="hide-child"
             pt={1}
@@ -247,7 +247,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
             <Text gray mono ml={2} className="v-mid child dn-s">{datestamp}</Text>
           </Box>
           <Box fontSize='14px'><MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure} /></Box>
-        </div>
+        </Box>
       </>
     );
   }
@@ -256,7 +256,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
 export const MessageWithoutSigil = ({ timestamp, msg, remoteContentPolicy, measure }) => (
   <>
     <p className="child pr1 mono f9 gray2 dib">{timestamp}</p>
-    <Box fontSize={0} className="clamp-message" style={{ flexGrow: 1 }}>
+    <Box fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
       <MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure}/>
     </Box>
   </>
@@ -267,7 +267,7 @@ export const MessageContent = ({ content, remoteContentPolicy, measure }) => {
     return <CodeContent content={content} />;
   } else if ('url' in content) {
     return (
-      <Text fontSize='14px' lineHeight="tall" color='gray'>
+      <Text fontSize='14px' lineHeight="tall" color='black'>
         <RemoteContent
           url={content.url}
           remoteContentPolicy={remoteContentPolicy}
@@ -283,9 +283,9 @@ export const MessageContent = ({ content, remoteContentPolicy, measure }) => {
     );
   } else if ('me' in content) {
     return (
-      <p className='f9 i lh-copy v-top'>
+      <Text fontStyle='italic' fontSize='14px' lineHeight='tall' color='black'>
         {content.me}
-      </p>
+      </Text>
     );
   }
   else if ('text' in content) {

--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -3,6 +3,8 @@ import { UnControlled as CodeEditor } from 'react-codemirror2';
 import { MOBILE_BROWSER_REGEX } from "~/logic/lib/util";
 import CodeMirror from 'codemirror';
 
+import { Row } from '@tlon/indigo-react';
+
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/addon/display/placeholder';
 
@@ -131,12 +133,16 @@ export default class ChatEditor extends Component {
     };
 
     return (
-      <div
-        className={
-          'chat fr flex h-100 bg-gray0-d lh-copy w-100 items-center ' +
-          (inCodeMode ? ' code' : '')
-        }
-        style={{ flexGrow: 1, paddingTop: '8px', maxHeight: '224px', width: 'calc(100% - 88px)' }}>
+      <Row
+        backgroundColor='white'
+        alignItems='center'
+        flexGrow='1'
+        height='100%'
+        maxHeight='224px'
+        paddingTop='8px'
+        width='calc(100% - 88px)'
+        className={inCodeMode ? 'chat code' : 'chat'}
+      >
         <CodeEditor
           value={message}
           options={options}
@@ -149,7 +155,7 @@ export default class ChatEditor extends Component {
           }}
           {...props}
         />
-      </div>
+      </Row>
     );
   }
 }

--- a/pkg/interface/src/views/apps/chat/components/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/content/code.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
-
+import { Box, Text } from '@tlon/indigo-react';
 
 export default class CodeContent extends Component {
-
   render() {
     const { props } = this;
     const content = props.content;
@@ -11,18 +10,37 @@ export default class CodeContent extends Component {
       (Boolean(content.code.output) &&
        content.code.output.length && content.code.output.length > 0) ?
       (
-        <pre className={`code f9 clamp-attachment pa1 mt0 mb0`}>
+        <Text
+          display='block'
+          mono
+          p='1'
+          my='0'
+          fontSize='14px'
+          overflow='auto'
+          maxHeight='10em'
+          maxWidth='100%'
+          backgroundColor='scales.black10'
+        >
           {content.code.output[0].join('\n')}
-        </pre>
+        </Text>
       ) : null;
 
     return (
-      <div className="mv2">
-        <pre className={`code f9 clamp-attachment pa1 mt0 mb0`}>
+      <Box my='2'>
+        <Text
+          display='block'
+          mono
+          my='0'
+          p='1'
+          fontSize='14px'
+          overflow='auto'
+          maxHeight='10em'
+          maxWidth='100%'
+        >
           {content.code.expression}
-        </pre>
+        </Text>
         {outputElement}
-      </div>
+      </Box>
     );
   }
 }

--- a/pkg/interface/src/views/apps/chat/components/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/content/text.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
 import urbitOb from 'urbit-ob';
-import { Box, Text } from '@tlon/indigo-react';
+import { Text } from '@tlon/indigo-react';
 
 const DISABLED_BLOCK_TOKENS = [
   'indentedCode',
@@ -63,7 +63,7 @@ export default class TextContent extends Component {
       && (urbitOb.isValidPatp(group[2]) // valid patp?
       && (group[0] === content.text))) { // entire message is room name?
       return (
-        <Text fontSize='14px' color='gray' lineHeight="tall">
+        <Text fontSize='14px' color='black' lineHeight="tall">
           <Link
             className="bb b--black b--white-d mono"
             to={'/~landscape/join/' + group.input}>
@@ -73,7 +73,7 @@ export default class TextContent extends Component {
       );
     } else {
       return (
-        <Text color='gray' fontSize='14px' lineHeight="tall" style={{ overflowWrap: 'break-word' }}>
+        <Text color='black' fontSize='14px' lineHeight="tall" style={{ overflowWrap: 'break-word' }}>
           <MessageMarkdown source={content.text} />
         </Text>
       );

--- a/pkg/interface/src/views/apps/chat/components/profile-overlay.js
+++ b/pkg/interface/src/views/apps/chat/components/profile-overlay.js
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
-import { Link } from 'react-router-dom';
 import { cite } from '~/logic/lib/util';
 import { Sigil } from '~/logic/lib/sigil';
 
-import { Center, Button } from "@tlon/indigo-react";
+import { Box, Col, Button, Text } from "@tlon/indigo-react";
 
 export const OVERLAY_HEIGHT = 250;
 
@@ -107,19 +106,31 @@ export class ProfileOverlay extends PureComponent {
     const isHidden = group.hidden;
 
     return (
-      <div
+      <Col
         ref={this.popoverRef}
+        boxShadow="2px 4px 20px rgba(0, 0, 0, 0.25)"
+        position='absolute'
+        backgroundColor='white'
+        zIndex='3'
+        fontSize='0'
         style={containerStyle}
-        className="flex-col shadow-6 br2 bg-white bg-gray0-d inter absolute z-1 f9 lh-solid"
       >
-        <div style={{ height: '160px', width: '160px' }}>
+        <Box height='160px' width='160px'>
           {img}
-        </div>
-        <div className="pv3 pl3 pr3">
+        </Box>
+        <Box p='3'>
           {showNickname && (
-            <div className="b white-d truncate">{contact.nickname}</div>
+            <Text
+              fontWeight='600'
+              display='block'
+              textOverflow='ellipsis'
+              overflow='hidden'
+              whiteSpace='pre'
+            >
+              {contact.nickname}
+            </Text>
           )}
-          <div className="mono gray2">{cite(`~${ship}`)}</div>
+          <Text mono gray>{cite(`~${ship}`)}</Text>
           {!isOwn && (
             <Button mt={2} width="100%" style={{ cursor: 'pointer' }} onClick={this.createAndRedirectToDM}>
               Send Message
@@ -135,8 +146,8 @@ export class ProfileOverlay extends PureComponent {
               Edit Identity
             </Button>
           ) : <div />}
-        </div>
-      </div>
+        </Box>
+      </Col>
     );
   }
 }

--- a/pkg/interface/src/views/apps/chat/components/unread-notice.js
+++ b/pkg/interface/src/views/apps/chat/components/unread-notice.js
@@ -17,7 +17,7 @@ export const UnreadNotice = (props) => {
   }
 
   return (
-    <Box style={{ left: '0px' }}
+    <Box style={{ left: '0px', top: '0px' }}
       p='4'
       width='100%'
       position='absolute'
@@ -34,7 +34,7 @@ export const UnreadNotice = (props) => {
         borderRadius='1'
         border='1'
         borderColor='blue'>
-        <Text flexShrink='0' display='block' cursor='pointer' onClick={onClick}>
+        <Text flexShrink='1' textOverflow='ellipsis' whiteSpace='pre' overflow='hidden' display='block' cursor='pointer' onClick={onClick}>
           {unreadCount} new messages since{' '}
           {datestamp && (
             <>
@@ -48,6 +48,7 @@ export const UnreadNotice = (props) => {
           color='blue'
           cursor='pointer'
           textAlign='right'
+          flexShrink='0'
           onClick={dismissUnread}>
           Mark as Read
         </Text>

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -63,26 +63,12 @@ h2 {
   max-width: calc(100% - 36px - 1.5rem);
 }
 
-.clamp-attachment {
-  overflow: auto;
-  max-height: 10em;
-  max-width: 100%;
-}
-
-.lh-16 {
-  line-height: 16px;
-}
-
 .mono {
   font-family: "Source Code Pro", monospace;
 }
 
 .bg-welcome-green {
   background-color: #ECF6F2;
-}
-
-.list-ship {
-  line-height: 2.2;
 }
 
 .c-default {

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -387,7 +387,6 @@ pre.CodeMirror-placeholder.CodeMirror-line-like { color: var(--gray); }
   /* codemirror */
   .chat .cm-s-tlon.CodeMirror {
     color: #fff;
-    font-size: 14px;
   }
 
   .chat .cm-s-tlon span.cm-def {

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -11,36 +11,11 @@ interface GroupsProps {
   associations: Associations;
 }
 
-// Sort by recent, then by channel size? Should probably sort
-// by num unreads when notif-store drops
-const sortGroupsRecent = (recent: string[]) => (
-  a: Association,
-  b: Association
-) => {
-  //
-  const aRecency = recent.findIndex((r) => a["group-path"] === r);
-  const bRecency = recent.findIndex((r) => b["group-path"] === r);
-  if(aRecency === -1) {
-    if(bRecency === -1) {
-      return 0;
-    }
-    return 1;
-  }
-  if(bRecency === -1) {
-    return -1;
-  }
-  return Math.max(0, aRecency) - Math.max(0,bRecency);
-};
-
 const sortGroupsAlph = (a: Association, b: Association) =>
   alphabeticalOrder(a.metadata.title, b.metadata.title);
 
 export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
   const { associations, invites, api, ...boxProps } = props;
-  const [recentGroups, setRecentGroups] = useLocalStorageState<string[]>(
-    "recent-groups",
-    []
-  );
 
   const incomingGroups = Object.values(invites?.['/contacts'] || {});
   const getKeyByValue = (object, value) => {
@@ -48,8 +23,7 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
   }
 
   const groups = Object.values(associations?.contacts || {})
-    .sort(sortGroupsAlph)
-    .sort(sortGroupsRecent(recentGroups))
+    .sort(sortGroupsAlph);
 
   const acceptInvite = (invite) => {
     const [, , ship, name] = invite.path.split('/');

--- a/pkg/interface/src/views/apps/launch/components/tiles/tile.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/tile.js
@@ -30,7 +30,8 @@ export default class Tile extends React.Component {
         borderRadius={2}
         overflow="hidden"
         bg={bg || "white"}
-        boxShadow={boxShadow || '0 0 0px 1px rgba(0, 0, 0, 0.1) inset'}
+        color='washedGray'
+        boxShadow={boxShadow || '0 0 0px 1px inset'}
         {...props}
       >
         <Box

--- a/pkg/interface/src/views/landscape/components/ChannelMenu.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelMenu.tsx
@@ -83,15 +83,15 @@ export function ChannelMenu(props: ChannelMenuProps) {
   return (
     <Dropdown
       options={
-        <Col bg="white" border={1} borderRadius={1} borderColor="lightGray">
+        <Col backgroundColor="white" border={1} borderRadius={1} borderColor="lightGray">
           {isOurs ? (
             <>
               <ChannelMenuItem color="red" icon="TrashCan">
-                <Action m="2" destructive onClick={onDelete}>
+                <Action m="2" backgroundColor='white' destructive onClick={onDelete}>
                   Delete Channel
                 </Action>
               </ChannelMenuItem>
-              <ChannelMenuItem bottom icon="Gear">
+              <ChannelMenuItem bottom icon="Gear" color='black'>
                 <Link to={`${baseUrl}/settings`}>
                   <Box fontSize={0} p="2">
                     Channel Settings

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -194,7 +194,7 @@ export function GroupsPane(props: GroupsPaneProps) {
                 alignItems="center"
                 justifyContent="center"
                 display={["none", "flex"]}
-                p='2'
+                p='4'
               >
                 <Box><Text fontSize="0" color='gray'>
                   {description}

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -194,6 +194,7 @@ export function GroupsPane(props: GroupsPaneProps) {
                 alignItems="center"
                 justifyContent="center"
                 display={["none", "flex"]}
+                p='2'
               >
                 <Box><Text fontSize="0" color='gray'>
                   {description}

--- a/pkg/interface/src/views/landscape/components/InvitePopover.tsx
+++ b/pkg/interface/src/views/landscape/components/InvitePopover.tsx
@@ -71,7 +71,7 @@ export function InvitePopover(props: InvitePopoverProps) {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          bg="gray"
+          bg="scales.black30"
           left="0px"
           top="0px"
           width="100vw"
@@ -106,13 +106,13 @@ export function InvitePopover(props: InvitePopoverProps) {
                     label=""
                   />
                   <FormError message="Failed to invite" />
-                  <ChipInput
+                  {/* <ChipInput
                     id="emails"
                     label="Invite via Email"
                     caption="Send an Urbit ID and invite them to this group"
                     placeholder="name@example.com"
                     breakOnSpace
-                  />
+                  /> */}
                 </Col>
                 <Row
                   borderTop={1}

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -337,11 +337,6 @@ function Participant(props: {
               gapY={2}
               p={2}
             >
-              <Action bg="transparent">
-                <Link to={`/~chat/new/dm/${contact.patp}`}>
-                  <Text color="green">Send Message</Text>
-                </Link>
-              </Action>
               {props.role === "admin" && (
                 <>
                   {!isInvite && (


### PR DESCRIPTION
- Fixes the chat input top border being cut off on dark mode Safari; rewrites the containers in indigo-react.
- Properly pins the unread notice; truncates the text for small browsers (urbit/landscape#106).
<img width="322" alt="Screen Shot 2020-10-14 at 6 05 54 PM" src="https://user-images.githubusercontent.com/20846414/96051823-51f03e80-0e4a-11eb-9331-25795cbb2865.png">

- Because we don't have a new DM route to handle the logic, just removes 'send message' from Participants view for now. (We need a utility to redirect and/or create a DM.)
- Stubs out the email invite prompt as per @vvisigoth.
- Fixes the styling of the channel dropdown in dark mode (urbit/landscape#109).
- Removes the secondary, 'recent groups' sort from the launch screen (urbit/landscape#111).
- Fixes an unfiled bug where the box-shadow was set to `rgba(0,0,0,0.1)` producing a weird, dark border in dark mode. We just pass the theme colour and inherit it, as we do elsewhere.

cc @urcades 