### PR TITLE
launch: pass tile props to child

### DIFF
--- a/pkg/interface/src/views/apps/launch/components/tiles/tile.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/tile.js
@@ -32,9 +32,9 @@ export default class Tile extends React.Component {
         bg={bg || "white"}
         color='washedGray'
         boxShadow={boxShadow || '0 0 0px 1px inset'}
-        {...props}
       >
         <Box
+          {...props}
           height="100%"
           width="100%"
         >


### PR DESCRIPTION
Dropped this in the last PR — because we get boxShadow colour from inheriting it, Weather passing 'color' as a prop overwrite both the text and shadow, making them bright white. Tile props should be passed to their children, not necessarily their wrapper, so this moves the spread a layer down.