### PR TITLE
invite-store/hook: modernize the code style to match other new apps

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -724,10 +724,10 @@
         ::
           !>
           ^-  invite-action
-          :^  %invite  /chat
+          :^  %invite  %chat
             (shax (jam [our-self where] who))
           ^-  invite
-          [our-self %chat-hook where who '']
+          [our-self %chat-hook (de-path:resource where) who '']
       ==
     ::  +set-target: set audience, update prompt
     ::
@@ -1134,9 +1134,7 @@
   ++  show-invite
     |=  invite
     ^-  card
-    %-  note
-    %+  weld  "invited to: "
-    ~(phat tr (path-to-target path))
+    (note "invited to: {(scow %p entity.resource)} {(trip name.resource)}")
   --
 ::
 ::  +tr: render targets

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -10,7 +10,7 @@
 ::    and trust it to take care of the rest.
 ::
 /-  view=chat-view, hook=chat-hook,  *group,
-    *permission-store, *group-store, *invite-store,
+    *permission-store, *group-store, inv=invite-store,
     sole
 /+  shoe, default-agent, verb, dbug, store=chat-store,
     group-store, grpl=group, resource
@@ -27,7 +27,7 @@
 +$  state-2
   $:  %2
       grams=(list mail)                             ::  all messages
-      known=(set [target serial])                   ::  known message lookup
+      known=(set [target serial:store])             ::  known message lookup
       count=@ud                                     ::  (lent grams)
       bound=(map target glyph)                      ::  bound circle glyphs
       binds=(jug glyph target)                      ::  circle glyph lookup
@@ -54,7 +54,7 @@
 ::
 +$  state-0
   $:  grams=(list [[=ship =path] envelope:store])   ::  all messages
-      known=(set [[=ship =path] serial])            ::  known message lookup
+      known=(set [[=ship =path] serial:store])      ::  known message lookup
       count=@ud                                     ::  (lent grams)
       bound=(map [=ship =path] glyph)               ::  bound circle glyphs
       binds=(jug glyph [=ship =path])               ::  circle glyph lookup
@@ -161,7 +161,7 @@
           %fact
         ?+  p.cage.sign  ~|([%chat-cli-bad-sub-mark wire p.cage.sign] !!)
           %chat-update    (diff-chat-update:tc wire !<(update:store q.cage.sign))
-          %invite-update  (handle-invite-update:tc !<(invite-update q.cage.sign))
+          %invite-update  (handle-invite-update:tc !<(update:inv q.cage.sign))
         ==
       ==
     [cards this]
@@ -224,9 +224,9 @@
       grams  ~  ::NOTE  this only impacts historic message lookup in chat-cli
     ::
         known
-      ^-  (set [target serial])
+      ^-  (set [target serial:store])
       %-  ~(run in known.u.old)
-      |=  [t=[ship path] s=serial]
+      |=  [t=[ship path] s=serial:store]
       [`target`[| t] s]
     ::
         bound
@@ -324,7 +324,7 @@
 ::  +handle-invite-update: get new invites
 ::
 ++  handle-invite-update
-  |=  upd=invite-update
+  |=  upd=update:inv
   ^-  (quip card _state)
   ?+  -.upd  [~ state]
     %invite  [[(show-invite:sh-out invite.upd) ~] state]
@@ -722,11 +722,10 @@
           %poke
           %invite-action
         ::
-          !>
-          ^-  invite-action
+          !>  ^-  action:inv
           :^  %invite  %chat
             (shax (jam [our-self where] who))
-          ^-  invite
+          ^-  invite:inv
           [our-self %chat-hook (de-path:resource where) who '']
       ==
     ::  +set-target: set audience, update prompt
@@ -865,7 +864,7 @@
       |=  =letter:store
       ^-  (quip card _state)
       ~!  bowl
-      =/  =serial  (shaf %msg-uid eny.bowl)
+      =/  =serial:store  (shaf %msg-uid eny.bowl)
       :_  state
       ^-  (list card)
       %+  turn  ~(tap in audience)
@@ -1132,7 +1131,7 @@
   ::  +show-invite: print incoming invite notification
   ::
   ++  show-invite
-    |=  invite
+    |=  invite:inv
     ^-  card
     (note "invited to: {(scow %p entity.resource)} {(trip name.resource)}")
   --

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -77,7 +77,7 @@
   ++  on-init
     ^-  (quip card _this)
     :_  this(invite-created %.y)
-    :~  (invite-poke:cc [%create /chat])
+    :~  (invite-poke:cc [%create %chat])
         [%pass /invites %agent [our.bol %invite-store] %watch /invitatory/chat]
         watch-groups:cc
     ==
@@ -691,10 +691,13 @@
   :_  state
   ?+  -.fact  ~
       %accepted
-    =/  ask-history  ?~((chat-scry path.invite.fact) %.y %.n)
-    =*  shp       ship.invite.fact
-    =*  app-path  path.invite.fact
-    ~[(chat-view-poke [%join shp app-path ask-history])]
+    =*  resource  resource.invite.fact
+    =/  =path  [(scot %p entity.resource) name.resource ~]
+    :_  ~
+    %-  chat-view-poke
+    :^  %join  ship.invite.fact
+      path
+    ?=(~ (chat-scry path))
 ==
 ::
 ++  fact-group-update

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -2,7 +2,7 @@
 ::  mirror chat data from foreign to local based on read permissions
 ::  allow sending chat messages to foreign paths based on write perms
 ::
-/-  *permission-store, *invite-store, *metadata-store,
+/-  *permission-store, inv=invite-store, *metadata-store,
     *permission-hook, *group-store, *permission-group-hook,  ::TMP  for upgrade
     hook=chat-hook,
     view=chat-view,
@@ -52,7 +52,7 @@
 +$  poke
   $%  [%chat-action action:store]
       [%permission-action permission-action]
-      [%invite-action invite-action]
+      [%invite-action action:inv]
       [%chat-view-action action:view]
   ==
 ::
@@ -458,7 +458,7 @@
       ::
           %invite-update
         =^  cards  state
-          (fact-invite-update:cc wire !<(invite-update q.cage.sign))
+          (fact-invite-update:cc wire !<(update:inv q.cage.sign))
         [cards this]
       ::
           %group-update
@@ -686,7 +686,7 @@
   ==
 ::
 ++  fact-invite-update
-  |=  [wir=wire fact=invite-update]
+  |=  [wir=wire fact=update:inv]
   ^-  (quip card _state)
   :_  state
   ?+  -.fact  ~
@@ -889,9 +889,9 @@
   [%pass / %agent [our.bol %chat-view] %poke %chat-view-action !>(act)]
 ::
 ++  invite-poke
-  |=  act=invite-action
+  |=  =action:inv
   ^-  card
-  [%pass / %agent [our.bol %invite-store] %poke %invite-action !>(act)]
+  [%pass / %agent [our.bol %invite-store] %poke %invite-action !>(action)]
 ::
 ++  sec-to-perm
   |=  [pax=path =kind]
@@ -906,9 +906,9 @@
   [%mailbox pax]
 ::
 ++  invite-scry
-  |=  uid=serial
-  ^-  (unit invite)
-  %^  scry  (unit invite)
+  |=  uid=serial:inv
+  ^-  (unit invite:inv)
+  %^  scry  (unit invite:inv)
     %invite-store
   /invite/chat/(scot %uv uid)
 ::

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -410,7 +410,7 @@
     =/  =invite
       :*  our.bol
           ?:(managed %contact-hook %chat-hook)
-          (de-path:resource ?:(managed group-path app-path))
+          (de-path:resource ?:(managed group-path ship+app-path))
           ship  ''
       ==
     =/  act=invite-action

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -410,10 +410,11 @@
     =/  =invite
       :*  our.bol
           ?:(managed %contact-hook %chat-hook)
-          ?:(managed group-path app-path)
+          (de-path:resource ?:(managed group-path app-path))
           ship  ''
       ==
-    =/  act=invite-action  [%invite ?:(managed /contacts /chat) (shaf %msg-uid eny.bol) invite]
+    =/  act=invite-action
+      [%invite ?:(managed %contacts %chat) (shaf %msg-uid eny.bol) invite]
     [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
   ::
   ++  chat-scry

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -6,7 +6,7 @@
 /-  *permission-store,
     *permission-hook,
     *group,
-    *invite-store,
+    inv=invite-store,
     *metadata-store,
     group-hook,
     *permission-group-hook,
@@ -407,13 +407,13 @@
     ^-  card
     =/  managed=?
       !=(ship+app-path group-path)
-    =/  =invite
+    =/  =invite:inv
       :*  our.bol
           ?:(managed %contact-hook %chat-hook)
           (de-path:resource ?:(managed group-path ship+app-path))
           ship  ''
       ==
-    =/  act=invite-action
+    =/  act=action:inv
       [%invite ?:(managed %contacts %chat) (shaf %msg-uid eny.bol) invite]
     [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
   ::

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -44,7 +44,7 @@
   ++  on-init
     ^-  (quip card _this)
     :_  this(invite-created %.y)
-    :~  (invite-poke:cc [%create /contacts])
+    :~  (invite-poke:cc [%create %contacts])
         [%pass /inv %agent [our.bol %invite-store] %watch /invitatory/contacts]
         [%pass /group %agent [our.bol %group-store] %watch /groups]
     ==
@@ -467,16 +467,6 @@
           (contact-poke [%delete path])
         (contact-poke [%remove path ship])
     ==
-  ::
-  ++  send-invite-poke
-    |=  [=path =ship]
-    ^-  card
-    =/  =invite
-      :*  our.bol  %contact-hook
-          path  ship  ''
-      ==
-    =/  act=invite-action  [%invite /contacts (shaf %msg-uid eny.bol) invite]
-    [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
   --
 ::
 ++  invite-poke

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -4,7 +4,7 @@
 /-  group-hook,
     *contact-hook,
     *contact-view,
-    *invite-store,
+    inv=invite-store,
     *metadata-hook,
     *metadata-store,
     *group
@@ -470,7 +470,7 @@
   --
 ::
 ++  invite-poke
-  |=  act=invite-action
+  |=  act=action:inv
   ^-  card
   [%pass / %agent [our.bol %invite-store] %poke %invite-action !>(act)]
 ::

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -161,27 +161,22 @@
       %+  turn
         ~(tap in pending.policy.act)
       |=  =ship
-      (send-invite our.bol %contacts path ship '')
+      (send-invite our.bol %contacts rid ship '')
     ==
   ::
       %join
-    =/  =path
-      (en-path:resource resource.act)
     =/  =cage
       :-  %group-update
       !>  ^-  update:group-store
       [%add-members resource.act (sy our.bol ~)]
     =/  =wire
-      [%join-group path]
+      [%join-group (en-path:resource resource.act)]
     [%pass wire %agent [entity.resource.act %group-push-hook] %poke cage]~
   ::
       %invite
     =*  rid  resource.act
-    =/  =path
-      (en-path:resource rid)
-    =/  =group
-      (need (scry-group:grp rid))
-    :-  (send-invite entity.rid %contacts path ship.act text.act)
+    =/  =group  (need (scry-group:grp rid))
+    :-  (send-invite entity.rid %contacts rid ship.act text.act)
     ?.  ?=(%invite -.policy.group)  ~
     ~[(add-pending rid ship.act)]
   ::
@@ -281,7 +276,7 @@
   =/  =cage
     :-  %invite-action
     !>  ^-  invite-action
-    [%invite /contacts (shaf %invite-uid eny.bol) invite]
+    [%invite %contacts (shaf %invite-uid eny.bol) invite]
   [%pass / %agent [recipient.invite %invite-hook] %poke cage]
 ::
 ++  contact-poke

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -5,7 +5,7 @@
 ::
 /-
     group-hook,
-    *invite-store,
+    inv=invite-store,
     *contact-hook,
     *metadata-store,
     *metadata-hook,
@@ -271,11 +271,11 @@
   [%pass / %agent [entity.rid app] %poke cage]
 ::
 ++  send-invite
-  |=  =invite
+  |=  =invite:inv
   ^-  card
   =/  =cage
     :-  %invite-action
-    !>  ^-  invite-action
+    !>  ^-  action:inv
     [%invite %contacts (shaf %invite-uid eny.bol) invite]
   [%pass / %agent [recipient.invite %invite-hook] %poke cage]
 ::

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -37,16 +37,16 @@
       %invite-action
     =/  act=invite-action  !<(invite-action vase)
     ?.  ?=(%invite -.act)  ~
-    ?:  (team:title our.bowl src.bowl)
+    ?:  (team:title [our src]:bowl)
       ::  outgoing. we must be inviting another ship. send them the invite.
       ::
       ?<  (team:title our.bowl recipient.invite.act)
       [(invite-hook-poke recipient.invite.act act)]~
     ::  else incoming. ensure invitatory exists and invite is not a duplicate.
     ::
-    ?>  ?=(^ (invitatory-scry path.act))
-    ?>  ?=(~ (invite-scry path.act uid.act))
-    [(invite-poke path.act act)]~
+    ?>  ?=(^ (invitatory-scry term.act))
+    ?>  ?=(~ (invite-scry term.act uid.act))
+    [(invite-poke term.act act)]~
   ==
   ::
   ++  invite-hook-poke
@@ -62,10 +62,10 @@
     ==
   ::
   ++  invite-poke
-    |=  [=path action=invite-action]
+    |=  [=term action=invite-action]
     ^-  card
     :*  %pass
-        path
+        /[term]
         %agent
         [our.bowl %invite-store]
         %poke
@@ -74,26 +74,22 @@
     ==
   ::
   ++  invitatory-scry
-    |=  pax=path
-    ^-  (unit invitatory)
-    =.  pax
-      ;:  weld
-        /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invitatory
-        pax
-        /noun
-      ==
-    .^((unit invitatory) %gx pax)
+    |=  =term
+    .^  (unit invitatory)
+        %gx
+        %+  weld
+          /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invitatory
+        /[term]/noun
+    ==
   ::
   ++  invite-scry
-    |=  [pax=path uid=serial]
-    ^-  (unit invite)
-    =.  pax
-      ;:  weld
-        /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invite
-        pax
-        /(scot %uv uid)/noun
-      ==
-    .^((unit invite) %gx pax)
+    |=  [=term uid=serial]
+    .^  (unit invite)
+        %gx
+        %+  weld
+          /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invite
+        /[term]/(scot %uv uid)/noun
+    ==
   --
 ::
 ++  on-peek   on-peek:def

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -1,123 +1,105 @@
-::  invite-hook [landscape]:
+::  invite-hook [landscape]: receive invites from any source
 ::
-::  receive invites from any source
+::    only handles %invite actions:
+::    - can be poked by the host team to send an invite out to someone.
+::    - can be poked by foreign ships to send an invite to us.
 ::
-::    only handles %invite actions. accepts json, but only from the host team.
-::    can be poked by the host team to send an invite out to someone.
-::    can be poked by foreign ships to send an invite to us.
-::
-/+  *invite-json, default-agent, verb, dbug
+/-  *invite-store
+/+  default-agent, dbug
 ::
 |%
 +$  state-0  [%0 ~]
-::
 +$  card  card:agent:gall
 --
 ::
 =|  state-0
 =*  state  -
-::
-%+  verb  |
 %-  agent:dbug
 ^-  agent:gall
-=<
-  |_  =bowl:gall
-  +*  this  .
-      do    ~(. +> bowl)
-      def   ~(. (default-agent this %|) bowl)
-  ::
-  ++  on-init
-    ^-  (quip card _this)
-    [~ this]
-  ::
-  ++  on-save  !>(state)
-  ++  on-load
-    |=  old=vase
-    ^-  (quip card _this)
-    [~ this(state !<(state-0 old))]
-  ::
-  ++  on-poke
-    |=  [=mark =vase]
-    ^-  (quip card _this)
-    :_  this
-    ?+  mark  (on-poke:def mark vase)
-        %json
-      ::  only accept json from ourselves.
-      ::
-      ?>  (team:title our.bowl src.bowl)
-      =/  act  (json-to-action !<(json vase))
-      ?>  ?=(%invite -.act)
-      [(invite-hook-poke:do recipient.invite.act act)]~
-    ::
-        %invite-action
-      =/  act=invite-action  !<(invite-action vase)
-      ?.  ?=(%invite -.act)  ~
-      ?:  (team:title our.bowl src.bowl)
-        ::  outgoing. we must be inviting another ship. send them the invite.
-        ::
-        ?<  (team:title our.bowl recipient.invite.act)
-        [(invite-hook-poke:do recipient.invite.act act)]~
-      ::  else incoming. ensure invitatory exists and invite is not a duplicate.
-      ::
-      ?>  ?=(^ (invitatory-scry:do path.act))
-      ?>  ?=(~ (invite-scry:do path.act uid.act))
-      [(invite-poke:do path.act act)]~
-    ==
-  ::
-  ++  on-peek   on-peek:def
-  ++  on-watch  on-watch:def
-  ++  on-leave  on-leave:def
-  ++  on-agent  on-agent:def
-  ++  on-arvo   on-arvo:def
-  ++  on-fail   on-fail:def
-  --
 ::
 |_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
 ::
-++  invite-hook-poke
-  |=  [=ship action=invite-action]
-  ^-  card
-  :*  %pass
-      /invite-hook
-      %agent
-      [ship %invite-hook]
-      %poke
+++  on-init  [~ this]
+++  on-save  !>(state)
+++  on-load
+  |=  old=vase
+  ^-  (quip card _this)
+  [~ this(state !<(state-0 old))]
+::
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  |^
+  :_  this
+  ?+  mark  (on-poke:def mark vase)
       %invite-action
-      !>(action)
+    =/  act=invite-action  !<(invite-action vase)
+    ?.  ?=(%invite -.act)  ~
+    ?:  (team:title our.bowl src.bowl)
+      ::  outgoing. we must be inviting another ship. send them the invite.
+      ::
+      ?<  (team:title our.bowl recipient.invite.act)
+      [(invite-hook-poke recipient.invite.act act)]~
+    ::  else incoming. ensure invitatory exists and invite is not a duplicate.
+    ::
+    ?>  ?=(^ (invitatory-scry path.act))
+    ?>  ?=(~ (invite-scry path.act uid.act))
+    [(invite-poke path.act act)]~
   ==
-::
-++  invite-poke
-  |=  [=path action=invite-action]
-  ^-  card
-  :*  %pass
-      path
-      %agent
-      [our.bowl %invite-store]
-      %poke
-      %invite-action
-      !>(action)
-  ==
-::
-++  invitatory-scry
-  |=  pax=path
-  ^-  (unit invitatory)
-  =.  pax
-    ;:  weld
-      /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invitatory
-      pax
-      /noun
+  ::
+  ++  invite-hook-poke
+    |=  [=ship action=invite-action]
+    ^-  card
+    :*  %pass
+        /invite-hook
+        %agent
+        [ship %invite-hook]
+        %poke
+        %invite-action
+        !>(action)
     ==
-  .^((unit invitatory) %gx pax)
-::
-++  invite-scry
-  |=  [pax=path uid=serial]
-  ^-  (unit invite)
-  =.  pax
-    ;:  weld
-      /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invite
-      pax
-      /(scot %uv uid)/noun
+  ::
+  ++  invite-poke
+    |=  [=path action=invite-action]
+    ^-  card
+    :*  %pass
+        path
+        %agent
+        [our.bowl %invite-store]
+        %poke
+        %invite-action
+        !>(action)
     ==
-  .^((unit invite) %gx pax)
+  ::
+  ++  invitatory-scry
+    |=  pax=path
+    ^-  (unit invitatory)
+    =.  pax
+      ;:  weld
+        /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invitatory
+        pax
+        /noun
+      ==
+    .^((unit invitatory) %gx pax)
+  ::
+  ++  invite-scry
+    |=  [pax=path uid=serial]
+    ^-  (unit invite)
+    =.  pax
+      ;:  weld
+        /(scot %p our.bowl)/invite-store/(scot %da now.bowl)/invite
+        pax
+        /(scot %uv uid)/noun
+      ==
+    .^((unit invite) %gx pax)
+  --
+::
+++  on-peek   on-peek:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-agent  on-agent:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
 --
-

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -46,9 +46,7 @@
       ^-  card
       ?<  (team:title our.bowl recipient)
       %+  invite-hook-poke  recipient
-      :^  %invite 
-          term.act
-        uid.act
+      :^  %invite  term.act  uid.act
       ^-  invite
       :*  ship.invites.act
           app.invites.act

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -35,22 +35,44 @@
   :_  this
   ?+  mark  (on-poke:def mark vase)
       %invite-action
-    =/  act=invite-action  !<(invite-action vase)
-    ?.  ?=(%invite -.act)  ~
-    ?:  (team:title [our src]:bowl)
-      ::  outgoing. we must be inviting another ship. send them the invite.
+    =/  act=action  !<(action vase)
+    ?+  -.act     ~
+        %invites
+      ?.  (team:title [our src]:bowl)  ~
+      ::  outgoing. we must be inviting other ships. send them each an invite
       ::
-      ?<  (team:title our.bowl recipient.invite.act)
-      [(invite-hook-poke recipient.invite.act act)]~
-    ::  else incoming. ensure invitatory exists and invite is not a duplicate.
+      %+  turn  ~(tap in recipients.invites.act)
+      |=  recipient=ship
+      ^-  card
+      ?<  (team:title our.bowl recipient)
+      %+  invite-hook-poke  recipient
+      :^  %invite 
+          term.act
+        uid.act
+      ^-  invite
+      :*  ship.invites.act
+          app.invites.act
+          resource.invites.act
+          recipient
+          text.invites.act
+      ==
     ::
-    ?>  ?=(^ (invitatory-scry term.act))
-    ?>  ?=(~ (invite-scry term.act uid.act))
-    [(invite-poke term.act act)]~
+        %invite
+      ?:  (team:title [our src]:bowl)
+        ::  outgoing. we must be inviting another ship. send them the invite.
+        ::
+        ?<  (team:title our.bowl recipient.invite.act)
+        [(invite-hook-poke recipient.invite.act act)]~
+      ::  else incoming. ensure invitatory exists and invite is not a duplicate.
+      ::
+      ?>  ?=(^ (invitatory-scry term.act))
+      ?>  ?=(~ (invite-scry term.act uid.act))
+      [(invite-poke term.act act)]~
+    ==
   ==
   ::
   ++  invite-hook-poke
-    |=  [=ship action=invite-action]
+    |=  [=ship =action]
     ^-  card
     :*  %pass
         /invite-hook
@@ -62,7 +84,7 @@
     ==
   ::
   ++  invite-poke
-    |=  [=term action=invite-action]
+    |=  [=term =action]
     ^-  card
     :*  %pass
         /[term]

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -1,184 +1,172 @@
 ::  invite-store [landscape]
-/+  *invite-json, default-agent, dbug
+/-  *invite-store
+/+  default-agent, dbug
 |%
 +$  card  card:agent:gall
-::
 +$  versioned-state
-  $%  state-zero
+  $%  state-0
   ==
 ::
-+$  state-zero
-  $:  %0
-      =invites
-  ==
++$  state-0  [%0 =invites]
 --
 ::
-=|  state-zero
+=|  state-0
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
-=<
-  |_  bol=bowl:gall
-  +*  this      .
-      inv-core  +>
-      ic        ~(. inv-core bol)
-      def       ~(. (default-agent this %|) bol)
-  ++  on-init   on-init:def
-  ++  on-save   !>(state)
-  ++  on-load
-    |=  old=vase
-    `this(state !<(state-zero old))
+::
+|_  =bowl:gall
++*  this      .
+    def       ~(. (default-agent this %|) bowl)
+++  on-init   on-init:def
+++  on-save   !>(state)
+++  on-load
+  |=  old=vase
+  `this(state !<(state-0 old))
+::
+++  on-agent  on-agent:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+::
+++  on-watch
+  |=  =path
+  ^-  (quip card _this)
+  =/  cards=(list card)
+    ?+    path  (on-watch:def path)
+        [%all ~]      [%give %fact ~ %invite-update !>([%initial invites])]~
+        [%updates ~]  ~
+        [%invitatory *]
+      =/  inv=invitatory  (~(got by invites) t.path)
+      [%give %fact ~ %invite-update !>([%invitatory inv])]~
+    ==
+  [cards this]
+::
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  |^
+  ?>  (team:title our.bowl src.bowl)
+  =^  cards  state
+    ?+  mark  (on-poke:def mark vase)
+      %invite-action  (poke-invite-action !<(invite-action vase))
+    ==
+  [cards this]
   ::
-  ++  on-poke
-    |=  [=mark =vase]
-    ^-  (quip card _this)
-    ?>  (team:title our.bol src.bol)
-    =^  cards  state
-      ?+  mark  (on-poke:def mark vase)
-        %json           (poke-invite-action:ic (json-to-action !<(json vase)))
-        %invite-action  (poke-invite-action:ic !<(invite-action vase))
-      ==
-    [cards this]
-  ::
-  ++  on-watch
-    |=  =path
-    ^-  (quip card _this)
-    =/  cards=(list card)
-      ?+    path  (on-watch:def path)
-          [%all ~]      [%give %fact ~ %invite-update !>([%initial invites])]~
-          [%updates ~]  ~
-          [%invitatory *]
-        =/  inv=invitatory  (~(got by invites) t.path)
-        [%give %fact ~ %invite-update !>([%invitatory inv])]~
-      ==
-    [cards this]
-  ::
-  ++  on-leave  on-leave:def
-  ++  on-peek
-    |=  =path
-    ^-  (unit (unit cage))
-    ?+  path  (on-peek:def path)
-      [%x %all ~]         (peek-x-all:ic t.t.path)
-      [%x %invitatory *]  (peek-x-invitatory:ic t.t.path)
-      [%x %invite *]      (peek-x-invite:ic t.t.path)
+  ++  poke-invite-action
+    |=  action=invite-action
+    ^-  (quip card _state)
+    ?-  -.action
+        %create   (handle-create action)
+        %delete   (handle-delete action)
+        %invite   (handle-invite action)
+        %accept   (handle-accept action)
+        %decline  (handle-decline action)
     ==
   ::
-  ++  on-agent  on-agent:def
-  ++  on-arvo   on-arvo:def
-  ++  on-fail   on-fail:def
+  ++  handle-create
+    |=  act=invite-action
+    ^-  (quip card _state)
+    ?>  ?=(%create -.act)
+    ?:  (~(has by invites) path.act)
+      [~ state]
+    :-  (send-diff path.act act)
+    state(invites (~(put by invites) path.act *invitatory))
+  ::
+  ++  handle-delete
+    |=  act=invite-action
+    ^-  (quip card _state)
+    ?>  ?=(%delete -.act)
+    ?.  (~(has by invites) path.act)
+      [~ state]
+    :-  (send-diff path.act act)
+    state(invites (~(del by invites) path.act))
+  ::
+  ++  handle-invite
+    |=  act=invite-action
+    ^-  (quip card _state)
+    ?>  ?=(%invite -.act)
+    ?.  (~(has by invites) path.act)
+      [~ state]
+    =/  container  (~(got by invites) path.act)
+    =.  uid.act  (sham eny.bowl)
+    =.  container  (~(put by container) uid.act invite.act)
+    :-  (send-diff path.act act)
+    state(invites (~(put by invites) path.act container))
+  ::
+  ++  handle-accept
+    |=  act=invite-action
+    ^-  (quip card _state)
+    ?>  ?=(%accept -.act)
+    ?.  (~(has by invites) path.act)
+      [~ state]
+    =/  container  (~(got by invites) path.act)
+    =/  invite  (~(get by container) uid.act)
+    ?~  invite
+      [~ state]
+    =.  container  (~(del by container) uid.act)
+    :-  (send-diff path.act [%accepted path.act uid.act u.invite])
+    state(invites (~(put by invites) path.act container))
+  ::
+  ++  handle-decline
+    |=  act=invite-action
+    ^-  (quip card _state)
+    ?>  ?=(%decline -.act)
+    ?.  (~(has by invites) path.act)
+      [~ state]
+    =/  container  (~(got by invites) path.act)
+    =/  invite  (~(get by container) uid.act)
+    ?~  invite
+      [~ state]
+    =.  container  (~(del by container) uid.act)
+    :-  (send-diff path.act act)
+    state(invites (~(put by invites) path.act container))
+  ::
+  ++  update-subscribers
+    |=  [pax=path upd=invite-update]
+    ^-  card
+    [%give %fact ~[pax] %invite-update !>(upd)]
+  ::
+  ++  send-diff
+    |=  [pax=path upd=invite-update]
+    ^-  (list card)
+    :~  (update-subscribers /all upd)
+        (update-subscribers /updates upd)
+        (update-subscribers [%invitatory pax] upd)
+    ==
   --
 ::
-|_  bol=bowl:gall
-::
-++  peek-x-all
-  |=  pax=path
+++  on-leave  on-leave:def
+++  on-peek
+  |=  =path
   ^-  (unit (unit cage))
-  [~ ~ %noun !>(invites)]
-::
-++  peek-x-invitatory
-  |=  pax=path
-  ^-  (unit (unit cage))
-  ?~  pax
-    ~
-  =/  invitatory=(unit invitatory)  (~(get by invites) pax)
-  [~ ~ %noun !>(invitatory)]
-::
-++  peek-x-invite
-  |=  pax=path
-  ^-  (unit (unit cage))
-  ::  /:path/:uid
-  =/  pas  (flop pax)
-  ?~  pas
-    ~
-  =/  uid=serial  (slav %uv i.pas)
-  =.  pax  (scag (dec (lent pax)) `(list @ta)`pax)
-  =/  invitatory=(unit invitatory)  (~(get by invites) pax)
-  ?~  invitatory
-    ~
-  =/  invite=(unit invite)  (~(get by u.invitatory) uid)
-  [~ ~ %noun !>(invite)]
-::
-++  poke-invite-action
-  |=  action=invite-action
-  ^-  (quip card _state)
-  ?>  (team:title our.bol src.bol)
-  ?-  -.action
-      %create   (handle-create action)
-      %delete   (handle-delete action)
-      %invite   (handle-invite action)
-      %accept   (handle-accept action)
-      %decline  (handle-decline action)
+  |^
+  ?+  path  (on-peek:def path)
+    [%x %all ~]         [~ ~ %noun !>(invites)]
+    [%x %invitatory *]  (peek-x-invitatory t.t.path)
+    [%x %invite *]      (peek-x-invite t.t.path)
   ==
-::
-++  handle-create
-  |=  act=invite-action
-  ^-  (quip card _state)
-  ?>  ?=(%create -.act)
-  ?:  (~(has by invites) path.act)
-    [~ state]
-  :-  (send-diff path.act act)
-  state(invites (~(put by invites) path.act *invitatory))
-::
-++  handle-delete
-  |=  act=invite-action
-  ^-  (quip card _state)
-  ?>  ?=(%delete -.act)
-  ?.  (~(has by invites) path.act)
-    [~ state]
-  :-  (send-diff path.act act)
-  state(invites (~(del by invites) path.act))
-::
-++  handle-invite
-  |=  act=invite-action
-  ^-  (quip card _state)
-  ?>  ?=(%invite -.act)
-  ?.  (~(has by invites) path.act)
-    [~ state]
-  =/  container  (~(got by invites) path.act)
-  =.  uid.act  (sham eny.bol)
-  =.  container  (~(put by container) uid.act invite.act)
-  :-  (send-diff path.act act)
-  state(invites (~(put by invites) path.act container))
-::
-++  handle-accept
-  |=  act=invite-action
-  ^-  (quip card _state)
-  ?>  ?=(%accept -.act)
-  ?.  (~(has by invites) path.act)
-    [~ state]
-  =/  container  (~(got by invites) path.act)
-  =/  invite  (~(get by container) uid.act)
-  ?~  invite
-    [~ state]
-  =.  container  (~(del by container) uid.act)
-  :-  (send-diff path.act [%accepted path.act uid.act u.invite])
-  state(invites (~(put by invites) path.act container))
-::
-++  handle-decline
-  |=  act=invite-action
-  ^-  (quip card _state)
-  ?>  ?=(%decline -.act)
-  ?.  (~(has by invites) path.act)
-    [~ state]
-  =/  container  (~(got by invites) path.act)
-  =/  invite  (~(get by container) uid.act)
-  ?~  invite
-    [~ state]
-  =.  container  (~(del by container) uid.act)
-  :-  (send-diff path.act act)
-  state(invites (~(put by invites) path.act container))
-::
-++  update-subscribers
-  |=  [pax=path upd=invite-update]
-  ^-  card
-  [%give %fact ~[pax] %invite-update !>(upd)]
-::
-++  send-diff
-  |=  [pax=path upd=invite-update]
-  ^-  (list card)
-  :~  (update-subscribers /all upd)
-      (update-subscribers /updates upd)
-      (update-subscribers [%invitatory pax] upd)
-  ==
-::
+  ::
+  ++  peek-x-invitatory
+    |=  pax=^path
+    ^-  (unit (unit cage))
+    ?~  pax
+      ~
+    =/  invitatory=(unit invitatory)  (~(get by invites) pax)
+    [~ ~ %noun !>(invitatory)]
+  ::
+  ++  peek-x-invite
+    |=  pax=^path
+    ^-  (unit (unit cage))
+    ::  /:path/:uid
+    =/  pas  (flop pax)
+    ?~  pas
+      ~
+    =/  uid=serial  (slav %uv i.pas)
+    =.  pax  (scag (dec (lent pax)) `(list @ta)`pax)
+    =/  invitatory=(unit invitatory)  (~(get by invites) pax)
+    ?~  invitatory
+      ~
+    =/  invite=(unit invite)  (~(get by u.invitatory) uid)
+    [~ ~ %noun !>(invite)]
+  --
 --

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -82,7 +82,7 @@
   ^-  (quip card _this)
   ?>  (team:title our.bowl src.bowl)
   =/  cards=(list card)
-    ?+  path  (on-watch:def path)
+    ?+    path  (on-watch:def path)
         [%all ~]      [%give %fact ~ %invite-update !>([%initial invites])]~
         [%updates ~]  ~
         [%invitatory @ ~]
@@ -106,12 +106,12 @@
     |=  =action:store
     ^-  (quip card _state)
     ?-  -.action
-        %create   (handle-create +.action)
-        %delete   (handle-delete +.action)
-        %invite   (handle-invite +.action)
-        %accept   (handle-accept +.action)
-        %decline  (handle-decline +.action)
-        %invites  ~|('only send this to %invite-hook' !!)
+      %create   (handle-create +.action)
+      %delete   (handle-delete +.action)
+      %invite   (handle-invite +.action)
+      %accept   (handle-accept +.action)
+      %decline  (handle-decline +.action)
+      %invites  ~|('only send this to %invite-hook' !!)
     ==
   ::
   ++  handle-create

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -59,14 +59,17 @@
     :-  ~
     :-  i.path
     %-  ~(gas by *invitatory:store)
-    %+  turn  ~(tap by invitatory-0)
+    %+  murn  ~(tap by invitatory-0)
     |=  [=serial:store =invite-0]
-    ^-  [serial:store invite:store]
+    ^-  (unit [serial:store invite:store])
+    =/  resource=(unit resource:res)  (de-path-soft:res path.invite-0)
+    ?~  resource  ~
+    :-  ~
     :-  serial
     ^-  invite:store
     :*  ship.invite-0
         app.invite-0
-        (de-path:res path.invite-0)
+        u.resource
         recipient.invite-0
         text.invite-0
     ==

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -27,8 +27,8 @@
 ^-  agent:gall
 ::
 |_  =bowl:gall
-+*  this      .
-    def       ~(. (default-agent this %|) bowl)
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
 ::
 ++  on-init   on-init:def
 ++  on-save   !>(state)
@@ -42,11 +42,12 @@
       state
     :-  %1
     %-  ~(gas by *^invites)
-    %+  turn  ~(tap by invites.old)
+    %+  murn  ~(tap by invites.old)
     |=  [=path =invitatory-0]
-    ^-  [resource invitatory]
-    ?>  ?=([@ @ ~] path)
-    :-  [(slav %p i.path) i.t.path]
+    ^-  (unit [term invitatory])
+    ?.  ?=([@ ~] path)  ~
+    :-  ~
+    :-  i.path
     %-  ~(gas by *invitatory)
     %+  turn  ~(tap by invitatory-0)
     |=  [uid=serial =invite-0]
@@ -73,8 +74,8 @@
     ?+    path  (on-watch:def path)
         [%all ~]      [%give %fact ~ %invite-update !>([%initial invites])]~
         [%updates ~]  ~
-        [%invitatory *]
-      =/  inv=invitatory  (~(got by invites) (de-path:res t.path))
+        [%invitatory @ ~]
+      =/  inv=invitatory  (~(got by invites) i.t.path)
       [%give %fact ~ %invite-update !>([%invitatory inv])]~
     ==
   [cards this]
@@ -102,57 +103,57 @@
     ==
   ::
   ++  handle-create
-    |=  =resource
+    |=  =term
     ^-  (quip card _state)
-    ?:  (~(has by invites) resource)
+    ?:  (~(has by invites) term)
       [~ state]
-    :-  (send-diff resource [%create resource])
-    state(invites (~(put by invites) resource *invitatory))
+    :-  (send-diff term [%create term])
+    state(invites (~(put by invites) term *invitatory))
   ::
   ++  handle-delete
-    |=  =resource
+    |=  =term
     ^-  (quip card _state)
-    ?.  (~(has by invites) resource)
+    ?.  (~(has by invites) term)
       [~ state]
-    :-  (send-diff resource [%delete resource])
-    state(invites (~(del by invites) resource))
+    :-  (send-diff term [%delete term])
+    state(invites (~(del by invites) term))
   ::
   ++  handle-invite
-    |=  [=resource uid=serial =invite]
+    |=  [=term uid=serial =invite]
     ^-  (quip card _state)
-    ?.  (~(has by invites) resource)
+    ?.  (~(has by invites) term)
       [~ state]
-    =/  container  (~(got by invites) resource)
+    =/  container  (~(got by invites) term)
     =.  uid  (sham eny.bowl)
     =.  container  (~(put by container) uid invite)
-    :-  (send-diff resource [%invite resource uid invite])
-    state(invites (~(put by invites) resource container))
+    :-  (send-diff term [%invite term uid invite])
+    state(invites (~(put by invites) term container))
   ::
   ++  handle-accept
-    |=  [=resource uid=serial]
+    |=  [=term uid=serial]
     ^-  (quip card _state)
-    ?.  (~(has by invites) resource)
+    ?.  (~(has by invites) term)
       [~ state]
-    =/  container  (~(got by invites) resource)
+    =/  container  (~(got by invites) term)
     =/  invite  (~(get by container) uid)
     ?~  invite
       [~ state]
     =.  container  (~(del by container) uid)
-    :-  (send-diff resource [%accepted resource uid u.invite])
-    state(invites (~(put by invites) resource container))
+    :-  (send-diff term [%accepted term uid u.invite])
+    state(invites (~(put by invites) term container))
   ::
   ++  handle-decline
-    |=  [=resource uid=serial]
+    |=  [=term uid=serial]
     ^-  (quip card _state)
-    ?.  (~(has by invites) resource)
+    ?.  (~(has by invites) term)
       [~ state]
-    =/  container  (~(got by invites) resource)
+    =/  container  (~(got by invites) term)
     =/  invite  (~(get by container) uid)
     ?~  invite
       [~ state]
     =.  container  (~(del by container) uid)
-    :-  (send-diff resource [%decline resource uid])
-    state(invites (~(put by invites) resource container))
+    :-  (send-diff term [%decline term uid])
+    state(invites (~(put by invites) term container))
   ::
   ++  update-subscribers
     |=  [=path upd=invite-update]
@@ -160,47 +161,34 @@
     [%give %fact ~[path] %invite-update !>(upd)]
   ::
   ++  send-diff
-    |=  [=resource upd=invite-update]
+    |=  [=term upd=invite-update]
     ^-  (list card)
     :~  (update-subscribers /all upd)
         (update-subscribers /updates upd)
-        (update-subscribers [%invitatory (en-path:res resource)] upd)
+        (update-subscribers /invitatory/[term] upd)
     ==
   --
 ::
 ++  on-peek
   |=  =path
   ^-  (unit (unit cage))
-  |^
   ?+  path  (on-peek:def path)
-    [%x %all ~]         [~ ~ %noun !>(invites)]
-    [%x %invitatory *]  (peek-x-invitatory t.t.path)
-    [%x %invite *]      (peek-x-invite t.t.path)
+      [%x %all ~]
+    ``noun+!>(invites)
+  ::
+      [%x %invitatory @ ~]
+    :^  ~  ~  %noun
+    !>  ^-  (unit invitatory)
+    (~(get by invites) i.t.t.path)
+  ::
+      [%x %invite @ @ ~]
+    =*  term  i.t.t.path
+    =/  uid=serial  (slav %uv i.t.t.t.path)
+    ?.  (~(has by invites) term)
+      ~
+    =/  =invitatory  (~(got by invites) term)
+    :^  ~  ~  %noun
+    !>  ^-  (unit invite)
+    (~(get by invitatory) uid)
   ==
-  ::
-  ++  peek-x-invitatory
-    |=  pax=^path
-    ^-  (unit (unit cage))
-    ?~  pax
-      ~
-    =/  invitatory=(unit invitatory)
-      (~(get by invites) (de-path:res pax))
-    [~ ~ %noun !>(invitatory)]
-  ::
-  ++  peek-x-invite
-    |=  pax=^path
-    ^-  (unit (unit cage))
-    ::  /:path/:uid
-    =/  pas  (flop pax)
-    ?~  pas
-      ~
-    =/  uid=serial  (slav %uv i.pas)
-    =.  pax  (scag (dec (lent pax)) `(list @ta)`pax)
-    =/  invitatory=(unit invitatory)
-      (~(get by invites) (de-path:res pax))
-    ?~  invitatory
-      ~
-    =/  invite=(unit invite)  (~(get by u.invitatory) uid)
-    [~ ~ %noun !>(invite)]
-  --
 --

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -30,7 +30,15 @@
 +*  this  .
     def   ~(. (default-agent this %|) bowl)
 ::
-++  on-init   on-init:def
+++  on-init
+  ^-  (quip card _this)
+  :-  ~
+  %_  this
+      invites.state
+    %-  ~(gas by *invites:store)
+    [%graph *invitatory:store]~
+  ==
+::
 ++  on-save   !>(state)
 ++  on-load
   |=  old-vase=vase

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -8,7 +8,7 @@
 /-  *permission-hook
 /-  *permission-group-hook
 /-  *permission-store
-/-  *invite-store
+/-  inv=invite-store
 /-  *metadata-store
 /-  *metadata-hook
 /-  contact-view
@@ -136,10 +136,10 @@
       =+  ^-  [kick-cards=(list card) old-subs=(jug @tas @p)]  kick-subs
       =/  inv-scry-pax
         /(scot %p our.bol)/invite-store/(scot %da now.bol)/invitatory/publish/noun
-      =/  inv=(unit invitatory)  .^((unit invitatory) %gx inv-scry-pax)
+      =/  invi=(unit invitatory:inv)  .^((unit invitatory:inv) %gx inv-scry-pax)
       =|  new-state=state-two
-      =?  tile-num.new-state  ?=(^ inv)
-        ~(wyt by u.inv)
+      =?  tile-num.new-state  ?=(^ invi)
+        ~(wyt by u.invi)
       %=  $
           old-state  [%& %2 new-state]
       ::
@@ -312,12 +312,12 @@
       |=  who=@p
       ^-  card
       =/  uid  (sham %publish who book eny.bol)
-      =/  inv=invite
+      =/  =invite:inv
         :*  our.bol  %publish  [our.bol book]  who
             (crip "invite for notebook {<our.bol>}/{(trip book)}")
         ==
-      =/  act=invite-action  [%invite %publish uid inv]
-      [%pass /invite %agent [who %invite-hook] %poke %invite-action !>(act)]
+      =/  =action:inv  [%invite %publish uid invite]
+      [%pass /invite %agent [who %invite-hook] %poke %invite-action !>(action)]
     ::
     ++  move-files
       |=  old-subs=(jug @tas @p)
@@ -545,7 +545,7 @@
       ::
           [%invites ~]
         =^  cards  state
-          (handle-invite-update:main !<(invite-update q.cage.sin))
+          (handle-invite-update:main !<(update:inv q.cage.sin))
         [cards this]
       ::
           [%collection *]
@@ -1042,27 +1042,20 @@
   ?:  ?|(?=(%remove-members -.update) (is-managed-path:grup path))
     ~
   =/  uid  (sham %publish who u.book eny.bol)
-  =/  inv=invite
+  =/  =invite:inv
     :*  our.bol  %publish  [our.bol u.book]  who
         (crip "invite for notebook {<our.bol>}/{(trip u.book)}")
     ==
-  =/  act=invite-action  [%invite %publish uid inv]
+  =/  act=action:inv  [%invite %publish uid invite]
   [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]~
 ::
 ++  handle-invite-update
-  |=  upd=invite-update
+  |=  upd=update:inv
   ^-  (quip card _state)
-  ?+    -.upd
-    [~ state]
-  ::
-      %delete
-    [~ state]
-  ::
-      %invite
-    [~ state]
-  ::
-      %decline
-    [~ state]
+  ?+    -.upd   [~ state]
+      %delete   [~ state]
+      %invite   [~ state]
+      %decline  [~ state]
   ::
       %accepted
     =*  rid  resource.invite.upd
@@ -1229,7 +1222,7 @@
   ==
 ::
 ++  invite-poke
-  |=  act=invite-action
+  |=  act=action:inv
   ^-  card
   [%pass / %agent [our.bol %invite-store] %poke %invite-action !>(act)]
 ::
@@ -1251,11 +1244,11 @@
   %+  turn  ~(tap in invitees)
   |=  who=ship
   =/  uid  (sham %publish who book eny.bol)
-  =/  inv=invite
+  =/  =invite:inv
     :*  our.bol  %publish  [our.bol book]  who
         (crip "invite for notebook {<our.bol>}/{(trip book)}")
     ==
-  =/  act=invite-action  [%invite %publish uid inv]
+  =/  act=action:inv  [%invite %publish uid invite]
   [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
 ::
 ++  make-groups
@@ -1938,13 +1931,13 @@
         %+  turn
           ~(tap in ships)
         |=  =ship
-        =/  =invite
+        =/  =invite:inv
           :*  our.bol
               %contact-hook
               rid
               ship  ''
           ==
-        =/  act=invite-action
+        =/  act=action:inv
           [%invite %contacts (shaf %msg-uid eny.bol) invite]
         [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
     ==

--- a/pkg/arvo/app/publish.hoon
+++ b/pkg/arvo/app/publish.hoon
@@ -91,7 +91,7 @@
     :_  this
     :~  [%pass /view-bind %arvo %e %connect [~ /'publish-view'] %publish]
         [%pass /read/paths %arvo %c %warp our.bol q.byk.bol `rav]
-        (invite-poke:main [%create /publish])
+        (invite-poke:main [%create %publish])
         :*  %pass  /invites  %agent  [our.bol %invite-store]  %watch
             /invitatory/publish
         ==
@@ -122,7 +122,7 @@
             :*  %pass  /permissions  %agent  [our.bol %permission-store]  %watch
                 /updates
             ==
-            (invite-poke:main [%create /publish])
+            (invite-poke:main [%create %publish])
             :*  %pass  /invites  %agent  [our.bol %invite-store]  %watch
                 /invitatory/publish
             ==
@@ -313,10 +313,10 @@
       ^-  card
       =/  uid  (sham %publish who book eny.bol)
       =/  inv=invite
-        :*  our.bol  %publish  /notebook/[book]  who
+        :*  our.bol  %publish  [our.bol book]  who
             (crip "invite for notebook {<our.bol>}/{(trip book)}")
         ==
-      =/  act=invite-action  [%invite /publish uid inv]
+      =/  act=invite-action  [%invite %publish uid inv]
       [%pass /invite %agent [who %invite-hook] %poke %invite-action !>(act)]
     ::
     ++  move-files
@@ -1043,10 +1043,10 @@
     ~
   =/  uid  (sham %publish who u.book eny.bol)
   =/  inv=invite
-    :*  our.bol  %publish  /notebook/[u.book]  who
+    :*  our.bol  %publish  [our.bol u.book]  who
         (crip "invite for notebook {<our.bol>}/{(trip u.book)}")
     ==
-  =/  act=invite-action  [%invite /publish uid inv]
+  =/  act=invite-action  [%invite %publish uid inv]
   [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]~
 ::
 ++  handle-invite-update
@@ -1065,16 +1065,13 @@
     [~ state]
   ::
       %accepted
-    ?>  ?=([@ @ *] path.invite.upd)
-    =/  book  i.t.path.invite.upd
+    =*  rid  resource.invite.upd
     =/  group
-      (group-from-book notebook+book^~)
+      (group-from-book notebook+name.rid^~)
     ?^  group
-      (subscribe-notebook ship.invite.upd book)
-    =/  rid=resource
-      (de-path:resource ship+path.invite.upd)
+      (subscribe-notebook ship.invite.upd name.rid)
     =/  join-wire=wire
-      /join-group/[(scot %p ship.invite.upd)]/[book]
+      /join-group/[(scot %p ship.invite.upd)]/[name.rid]
     =/  =cage
       :-  %group-update
       !>  ^-  action:group-store
@@ -1255,10 +1252,10 @@
   |=  who=ship
   =/  uid  (sham %publish who book eny.bol)
   =/  inv=invite
-    :*  our.bol  %publish  /(scot %p our.bol)/[book]  who
+    :*  our.bol  %publish  [our.bol book]  who
         (crip "invite for notebook {<our.bol>}/{(trip book)}")
     ==
-  =/  act=invite-action  [%invite /publish uid inv]
+  =/  act=invite-action  [%invite %publish uid inv]
   [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
 ::
 ++  make-groups
@@ -1944,10 +1941,11 @@
         =/  =invite
           :*  our.bol
               %contact-hook
-              group-path
+              rid
               ship  ''
           ==
-        =/  act=invite-action  [%invite /contacts (shaf %msg-uid eny.bol) invite]
+        =/  act=invite-action
+          [%invite %contacts (shaf %msg-uid eny.bol) invite]
         [%pass / %agent [our.bol %invite-hook] %poke %invite-action !>(act)]
     ==
   ==

--- a/pkg/arvo/lib/invite-json.hoon
+++ b/pkg/arvo/lib/invite-json.hoon
@@ -40,7 +40,7 @@
   ==
 ::
 ++  update-to-json
-  |=  upd=invite-update
+  |=  upd=update
   =,  enjs:format
   ^-  json
   %+  frond  %invite-update
@@ -89,7 +89,7 @@
 ::
 ++  json-to-action
   |=  jon=json
-  ^-  invite-action
+  ^-  action
   =,  dejs:format
   =<  (parse-json jon)
   |%
@@ -131,4 +131,3 @@
     ==
   --
 --
-

--- a/pkg/arvo/lib/invite-json.hoon
+++ b/pkg/arvo/lib/invite-json.hoon
@@ -1,4 +1,5 @@
 /-  *invite-store
+/+  resource
 |%
 ++  slan  |=(mod/@tas |=(txt/@ta (need (slaw mod txt))))
 ::
@@ -12,9 +13,9 @@
   ^-  json
   %-  pairs:enjs:format
   %+  turn  ~(tap by inv)
-  |=  [=path =invitatory]
+  |=  [=term =invitatory]
   ^-  [cord json]
-  [(spat path) (invitatory-to-json invitatory)]
+  [term (invitatory-to-json invitatory)]
 ::
 ++  invitatory-to-json
   |=  =invitatory
@@ -33,7 +34,7 @@
   %-  pairs
   :~  [%ship (ship ship.invite)]
       [%app [%s app.invite]]
-      [%path (path path.invite)]
+      [%resource (enjs:resource resource.invite)]
       [%recipient (ship recipient.invite)]
       [%text [%s text.invite]]
   ==
@@ -50,15 +51,15 @@
       [%initial (invites-to-json invites.upd)]
     ?:  =(%create -.upd)
       ?>  ?=(%create -.upd)
-      [%create (pairs [%path (path path.upd)]~)]
+      [%create (pairs [%term s+term.upd]~)]
     ?:  =(%delete -.upd)
       ?>  ?=(%delete -.upd)
-      [%delete (pairs [%path (path path.upd)]~)]
+      [%delete (pairs [%term s+term.upd]~)]
     ?:  =(%accepted -.upd)
       ?>  ?=(%accepted -.upd)
       :-  %accepted
       %-  pairs
-      :~  [%path (path path.upd)]
+      :~  [%term s+term.upd]
           [%uid s+(scot %uv uid.upd)]
           [%invite (invite-to-json invite.upd)]
       ==
@@ -66,14 +67,14 @@
       ?>  ?=(%decline -.upd)
       :-  %decline
       %-  pairs
-      :~  [%path (path path.upd)]
+      :~  [%term s+term.upd]
           [%uid s+(scot %uv uid.upd)]
       ==
     ?:  =(%invite -.upd)
       ?>  ?=(%invite -.upd)
       :-  %invite
       %-  pairs
-      :~  [%path (path path.upd)]
+      :~  [%term s+term.upd]
           [%uid s+(scot %uv uid.upd)]
           [%invite (invite-to-json invite.upd)]
       ==
@@ -94,44 +95,37 @@
   |%
   ++  parse-json
     %-  of
-    :~  [%create create]
-        [%delete delete]
+    :~  [%create so]
+        [%delete so]
         [%invite invite]
         [%accept accept]
         [%decline decline]
     ==
   ::
-  ++  create
-    (ot [%path pa]~)
-  ::
-  ++  delete
-    (ot [%path pa]~)
-  ::
-
   ++  invite
     %-  ot
-    :~  [%path pa]
+    :~  [%term so]
         [%uid seri]
         [%invite invi]
     ==
   ::
   ++  accept
     %-  ot
-    :~  [%path pa]
+    :~  [%term so]
         [%uid seri]
     ==
   ::
   ++  decline
     %-  ot
-    :~  [%path pa]
+    :~  [%term so]
         [%uid seri]
     ==
   ::
   ++  invi
     %-  ot
     :~  [%ship (su ;~(pfix sig fed:ag))]
-        [%app (se %tas)]
-        [%path pa]
+        [%app so]
+        [%resource dejs:resource]
         [%recipient (su ;~(pfix sig fed:ag))]
         [%text so]
     ==

--- a/pkg/arvo/mar/invite/action.hoon
+++ b/pkg/arvo/mar/invite/action.hoon
@@ -1,6 +1,6 @@
 /+  *invite-json
 =,  dejs:format
-|_  act=invite-action
+|_  act=action
 ++  grad  %noun
 ++  grow
   |%
@@ -8,7 +8,7 @@
   --
 ++  grab
   |%
-  ++  noun  invite-action
+  ++  noun  action
   ++  json
     |=  jon=^json
     (json-to-action jon)

--- a/pkg/arvo/mar/invite/update.hoon
+++ b/pkg/arvo/mar/invite/update.hoon
@@ -4,7 +4,7 @@
 ++  grad  %noun
 ++  grow
   |%
-  ++  noun  upd
+  ++  noun  update
   ++  json  (update-to-json update)
   --
 ::

--- a/pkg/arvo/mar/invite/update.hoon
+++ b/pkg/arvo/mar/invite/update.hoon
@@ -1,15 +1,15 @@
+/-  store=invite-store
 /+  *invite-json
-|_  upd=invite-update
+|_  =update:store
 ++  grad  %noun
 ++  grow
   |%
   ++  noun  upd
-  ++  json  (update-to-json upd)
+  ++  json  (update-to-json update)
   --
 ::
 ++  grab
   |%
-  ++  noun  invite-update
+  ++  noun  update:store
   --
-::
 --

--- a/pkg/arvo/sur/invite-store.hoon
+++ b/pkg/arvo/sur/invite-store.hoon
@@ -14,27 +14,27 @@
 ::  contains a map of serial to invite. this allows it to only receive
 ::  invites that it is concerned with
 ::
-+$  invites  (map resource invitatory)   ::  main data structure
++$  invites     (map term invitatory)   ::  main data structure
 ::
 +$  invitatory  (map serial invite)  ::  containing or conveying an invitation
 ::
 +$  invite-base
-  $%  [%create =resource]                     ::  create a resource
-      [%delete =resource]                     ::  delete a resource
-      [%invite =resource uid=serial =invite]  ::  receive an invite at res/uid
-      [%decline =resource uid=serial]         ::  decline an invite at res/uid
+  $%  [%create =term]                     ::  create a resource
+      [%delete =term]                     ::  delete a resource
+      [%invite =term uid=serial =invite]  ::  receive an invite at term/uid
+      [%decline =term uid=serial]         ::  decline an invite at term/uid
   ==
 ::
 +$  invite-action
   $%  invite-base
-      [%accept =resource uid=serial]            ::  accept an invite at res/uid
+      [%accept =term uid=serial]            ::  accept an invite at term/uid
   ==
 ::
 +$  invite-update
   $%  invite-base
       [%initial =invites]
       [%invitatory =invitatory]                 ::  receive invitatory
-      [%accepted =resource uid=serial =invite]  ::  an invite has been accepted
+      [%accepted =term uid=serial =invite]  ::  an invite has been accepted
   ==
 --
 

--- a/pkg/arvo/sur/invite-store.hoon
+++ b/pkg/arvo/sur/invite-store.hoon
@@ -1,45 +1,40 @@
+/-  *resource
 |%
 ++  serial  @uvH
 ::
 +$  invite
   $:  =ship           ::  ship to subscribe to upon accepting invite
       app=@tas        ::  app to subscribe to upon accepting invite
-      =path           ::  path to subscribe to upon accepting invite
+      =resource       ::  path to subscribe to upon accepting invite
       recipient=ship  ::  recipient to receive invite
       text=cord       ::  text to describe the invite
   ==
 ::
-::  +invites: each application using invites creates its own path that
+::  +invites: each application using invites creates its own resource that
 ::  contains a map of serial to invite. this allows it to only receive
 ::  invites that it is concerned with
 ::
-+$  invites  (map path invitatory)   ::  main data structure
++$  invites  (map resource invitatory)   ::  main data structure
 ::
 +$  invitatory  (map serial invite)  ::  containing or conveying an invitation
 ::
-::
 +$  invite-base
-  $%  [%create =path]                       ::  create a path
-      [%delete =path]                       ::  delete a path
-      [%invite =path uid=serial =invite]    ::  receive an invite at path/uid
-      [%decline =path uid=serial]           ::  decline an invite at path/uid
+  $%  [%create =resource]                     ::  create a resource
+      [%delete =resource]                     ::  delete a resource
+      [%invite =resource uid=serial =invite]  ::  receive an invite at res/uid
+      [%decline =resource uid=serial]         ::  decline an invite at res/uid
   ==
 ::
 +$  invite-action
   $%  invite-base
-      [%accept =path uid=serial]            ::  accept an invite at path/uid
+      [%accept =resource uid=serial]            ::  accept an invite at res/uid
   ==
 ::
 +$  invite-update
   $%  invite-base
       [%initial =invites]
-      [%invitatory =invitatory]             ::  receive invitatory
-      [%accepted =path uid=serial =invite]  ::  an invite has been accepted
-  ==
-::
-+$  invite-diff
-  $%  [%invite-initial invites]
-      [%invite-update invite-update]
+      [%invitatory =invitatory]                 ::  receive invitatory
+      [%accepted =resource uid=serial =invite]  ::  an invite has been accepted
   ==
 --
 

--- a/pkg/arvo/sur/invite-store.hoon
+++ b/pkg/arvo/sur/invite-store.hoon
@@ -5,7 +5,7 @@
 +$  invite
   $:  =ship           ::  ship to subscribe to upon accepting invite
       app=@tas        ::  app to subscribe to upon accepting invite
-      =resource       ::  path to subscribe to upon accepting invite
+      =resource       ::  resource to subscribe to upon accepting invite
       recipient=ship  ::  recipient to receive invite
       text=cord       ::  text to describe the invite
   ==
@@ -13,7 +13,7 @@
 +$  multi-invite
   $:  =ship                  ::  ship to subscribe to upon accepting invite
       app=@tas               ::  app to subscribe to upon accepting invite
-      =resource              ::  path to subscribe to upon accepting invite
+      =resource              ::  resource to subscribe to upon accepting invite
       recipients=(set ship)  ::  recipient to receive invite
       text=cord              ::  text to describe the invite
   ==
@@ -43,7 +43,7 @@
   $%  invite-base
       [%initial =invites]
       [%invitatory =invitatory]                 ::  receive invitatory
-      [%accepted =term uid=serial =invite]  ::  an invite has been accepted
+      [%accepted =term uid=serial =invite]      ::  an invite has been accepted
   ==
 --
 

--- a/pkg/arvo/sur/invite-store.hoon
+++ b/pkg/arvo/sur/invite-store.hoon
@@ -10,6 +10,14 @@
       text=cord       ::  text to describe the invite
   ==
 ::
++$  multi-invite
+  $:  =ship                  ::  ship to subscribe to upon accepting invite
+      app=@tas               ::  app to subscribe to upon accepting invite
+      =resource              ::  path to subscribe to upon accepting invite
+      recipients=(set ship)  ::  recipient to receive invite
+      text=cord              ::  text to describe the invite
+  ==
+::
 ::  +invites: each application using invites creates its own resource that
 ::  contains a map of serial to invite. this allows it to only receive
 ::  invites that it is concerned with
@@ -25,12 +33,13 @@
       [%decline =term uid=serial]         ::  decline an invite at term/uid
   ==
 ::
-+$  invite-action
++$  action
   $%  invite-base
       [%accept =term uid=serial]            ::  accept an invite at term/uid
+      [%invites =term uid=serial invites=multi-invite]
   ==
 ::
-+$  invite-update
++$  update
   $%  invite-base
       [%initial =invites]
       [%invitatory =invitatory]                 ::  receive invitatory

--- a/pkg/arvo/ted/graph/create.hoon
+++ b/pkg/arvo/ted/graph/create.hoon
@@ -72,7 +72,7 @@
 ::
 ?:  ?=(%group -.associated)
   (pure:m !>(~))
-?-  -.policy.associated.action
+?-    -.policy.associated.action
     %group  (pure:m !>(~))
     %invite
   =/  inv-action=action:inv

--- a/pkg/arvo/ted/graph/create.hoon
+++ b/pkg/arvo/ted/graph/create.hoon
@@ -1,4 +1,9 @@
-/-  spider, graph=graph-store, *metadata-store, *group, group-store
+/-  spider,
+    graph=graph-store,
+    *metadata-store,
+    *group,
+    group-store,
+    inv=invite-store
 /+  strandio, resource, graph-view
 =>
 |% 
@@ -27,6 +32,7 @@
 =+  !<(=action:graph-view arg)
 ?>  ?=(%create -.action)
 ;<  =bowl:spider  bind:m  get-bowl:strandio
+::
 ::  Add graph to graph-store
 ::
 ?.  =(our.bowl entity.rid.action)
@@ -37,12 +43,14 @@
   (poke-our %graph-store graph-update+!>(update))
 ;<  ~  bind:m
   (poke-our %graph-push-hook %push-hook-action !>([%add rid.action]))
+::
 ::  Add group, if graph is unmanaged
 ::
 ;<  group=resource  bind:m
   (handle-group rid.action associated.action)
 =/  group-path=path
   (en-path:resource group)
+::
 ::  Setup metadata
 ::
 =/  =metadata
@@ -53,9 +61,30 @@
     creator       our.bowl
     module        module.action
   ==
-=/  act=metadata-action
+=/  =metadata-action
   [%add group-path graph+(en-path:resource rid.action) metadata]
-;<  ~  bind:m  (poke-our %metadata-hook %metadata-action !>(act))
+;<  ~  bind:m
+  (poke-our %metadata-hook %metadata-action !>(metadata-action))
 ;<  ~  bind:m
   (poke-our %metadata-hook %metadata-hook-action !>([%add-owned group-path]))
-(pure:m !>(~))
+::
+::  Send invites
+::
+?:  ?=(%group -.associated)
+  (pure:m !>(~))
+?-  -.policy.associated.action
+    %group  (pure:m !>(~))
+    %invite
+  =/  inv-action=action:inv
+    :^  %invites  %graph  (shaf %graph-uid eny.bowl)
+    ^-  multi-invite:inv
+    :*  our.bowl
+        %graph-push-hook
+        rid.action
+        pending.policy.associated.action
+        description.action
+    ==
+  ;<  ~  bind:m
+    (poke-our %invite-hook %invite-action !>(inv-action))
+  (pure:m !>(~))
+==

--- a/pkg/interface/src/logic/api/invite.ts
+++ b/pkg/interface/src/logic/api/invite.ts
@@ -3,19 +3,19 @@ import { StoreState } from "../store/type";
 import { Serial, Path } from "~/types/noun";
 
 export default class InviteApi extends BaseApi<StoreState> {
-  accept(app: Path, uid: Serial) {
+  accept(app: string, uid: Serial) {
     return this.inviteAction({
       accept: {
-        path: app,
+        term: app,
         uid
       }
     });
   }
 
-  decline(app: Path, uid: Serial) {
+  decline(app: string, uid: Serial) {
     return this.inviteAction({
       decline: {
-        path: app,
+        term: app,
         uid
       }
     });

--- a/pkg/interface/src/logic/api/invite.ts
+++ b/pkg/interface/src/logic/api/invite.ts
@@ -22,6 +22,6 @@ export default class InviteApi extends BaseApi<StoreState> {
   }
 
   private inviteAction(action) {
-    return this.action('invite-store', 'json', action);
+    return this.action('invite-store', 'invite-action', action);
   }
 }

--- a/pkg/interface/src/logic/reducers/invite-update.ts
+++ b/pkg/interface/src/logic/reducers/invite-update.ts
@@ -29,35 +29,35 @@ export default class InviteReducer<S extends InviteState> {
   create(json: InviteUpdate, state: S) {
     const data = _.get(json, 'create', false);
     if (data) {
-      state.invites[data.path] = {};
+      state.invites[data] = {};
     }
   }
 
   delete(json: InviteUpdate, state: S) {
     const data = _.get(json, 'delete', false);
     if (data) {
-      delete state.invites[data.path];
+      delete state.invites[data];
     }
   }
 
   invite(json: InviteUpdate, state: S) {
     const data = _.get(json, 'invite', false);
     if (data) {
-      state.invites[data.path][data.uid] = data.invite;
+      state.invites[data.term][data.uid] = data.invite;
     }
   }
 
   accepted(json: InviteUpdate, state: S) {
     const data = _.get(json, 'accepted', false);
     if (data) {
-      delete state.invites[data.path][data.uid];
+      delete state.invites[data.term][data.uid];
     }
   }
 
   decline(json: InviteUpdate, state: S) {
     const data = _.get(json, 'decline', false);
     if (data) {
-      delete state.invites[data.path][data.uid];
+      delete state.invites[data.term][data.uid];
     }
   }
 }

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -17,7 +17,7 @@ const sortGroupsAlph = (a: Association, b: Association) =>
 export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
   const { associations, invites, api, ...boxProps } = props;
 
-  const incomingGroups = Object.values(invites?.['/contacts'] || {});
+  const incomingGroups = Object.values(invites?.['contacts'] || {});
   const getKeyByValue = (object, value) => {
     return Object.keys(object).find(key => object[key] === value);
   }
@@ -26,10 +26,12 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
     .sort(sortGroupsAlph);
 
   const acceptInvite = (invite) => {
-    const [, , ship, name] = invite.path.split('/');
-    const resource = { ship, name };
+    const resource = {
+      ship: `~${invite.resource.ship}`,
+      name: invite.resource.name
+    };
     return api.contacts.join(resource).then(() => {
-      api.invite.accept('/contacts', getKeyByValue(invites['/contacts'], invite));
+      api.invite.accept('contacts', getKeyByValue(invites['contacts'], invite));
     });
   };
 
@@ -54,10 +56,16 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
           borderRadius='2'
           borderColor='lightGray'
           p='2'
-          fontSize='0'
-        >
+          fontSize='0'>
           <Text display='block' pb='2' gray>You have been invited to:</Text>
-          <Text display='inline-block' overflow='hidden' maxWidth='100%' style={{ textOverflow: 'ellipsis', whiteSpace: 'pre' }} title={invite.path.slice(6)}>{invite.path.slice(6)}</Text>
+          <Text
+            display='inline-block'
+            overflow='hidden'
+            maxWidth='100%'
+            style={{ textOverflow: 'ellipsis', whiteSpace: 'pre' }}
+            title={`~${invite.resource.ship}/${invite.resource.name}`}>
+              {`~${invite.resource.ship}/${invite.resource.name}`}
+          </Text>
           <Box pt='5'>
             <Text
               onClick={() => acceptInvite(invite)}
@@ -68,7 +76,12 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
             </Text>
             <Text
               color='red'
-              onClick={() => api.invite.decline('/contacts', getKeyByValue(invites['/contacts'], invite))}
+              onClick={() =>
+                api.invite.decline(
+                  'contacts',
+                  getKeyByValue(invites['contacts'], invite)
+                )
+              }
               cursor='pointer'>
                 Reject
               </Text>

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarInvite.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarInvite.tsx
@@ -11,7 +11,7 @@ export class SidebarInvite extends Component<{invite: Invite, onAccept: Function
         <Box width='100%' verticalAlign='middle'>
           <Text display='block' pb='2' gray>You have been invited to:</Text>
           <Text display='inline-block'>
-            {props.invite.path.substr(1)}
+            {`~${props.invite.resource.ship}/${props.invite.resource.name}`}
           </Text>
         </Box>
         <Row>


### PR DESCRIPTION
No functionality or logic has been changed, just reorganized to be clearer and more in line with the modern style. We also no longer use the %json mark on the frontend to speak to %invite-store, instead relying on mark conversions.

Edit:

- The `%graph-create` thread should have been sending invites when it was handed an unmanaged resource with an invite policy, but it was not. It now is.