### PR TITLE
Simplify +code and implement it in KH.

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -1033,10 +1033,7 @@
     =/  who  (slaw %p i.tyl)
     ?~  who  [~ ~]
     =/  sec  (~(got by jaw.own.pki.lex) lyf.own.pki.lex)
-    =/  cub  (nol:nu:crub:crypto sec)
-    ::  XX use pac:ex:cub?
-    ::
-    ``[%noun !>((end 6 1 (shaf %pass (shax sec:ex:cub))))]
+    ``[%noun !>((end 6 1 (shaf %pass (shax sec))))]
   ::
       %life
     ?.  ?=([@ ~] tyl)  [~ ~]

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -491,6 +491,7 @@ newShip CLI.New{..} opts = do
       eny <- io $ Sys.randomIO
       let seed = mineComet (Set.fromList starList) eny
       putStrLn ("boot: found comet " ++ renderShip (sShip seed))
+      putStrLn ("code: " ++ (tshow $ deriveCode $ sRing seed))
       bootFromSeed pill seed
 
     CLI.BootFake name -> do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
@@ -477,10 +477,6 @@ shaf salt ruz = (mix a b)
 
 -- Given a ring, derives the network login code.
 --
--- The Urbit implementation of +code is just overly complicated. It first
--- takes the ring, then passes it into the encryption system, and then has
--- the encryption system spit the input ring back out.
---
 -- Note that the network code is a patp, not a patq: the bytes have been
 -- scrambled.
 deriveCode :: Ring -> Ob.Patp

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
@@ -10,6 +10,7 @@ module Urbit.Vere.Dawn ( dawnVent
                        , mix
                        , shas
                        , shaf
+                       , deriveCode
                        , cometFingerprintBS
                        , cometFingerprint
                        ) where
@@ -461,8 +462,11 @@ mix a b = BS.pack $ loop (BS.unpack a) (BS.unpack b)
     loop [] b          = b
     loop (x:xs) (y:ys) = (xor x y) : loop xs ys
 
+shax :: BS.ByteString -> BS.ByteString
+shax = SHA256.hash
+
 shas :: BS.ByteString -> BS.ByteString -> BS.ByteString
-shas salt = SHA256.hash . mix salt . SHA256.hash
+shas salt = shax . mix salt . shax
 
 shaf :: BS.ByteString -> BS.ByteString -> BS.ByteString
 shaf salt ruz = (mix a b)
@@ -470,6 +474,22 @@ shaf salt ruz = (mix a b)
     haz = shas salt ruz
     a = (take 16 haz)
     b = (drop 16 haz)
+
+-- Given a ring, derives the network login code.
+--
+-- The Urbit implementation of +code is just overly complicated. It first
+-- takes the ring, then passes it into the encryption system, and then has
+-- the encryption system spit the input ring back out.
+--
+-- Note that the network code is a patp, not a patq: the bytes have been
+-- scrambled.
+deriveCode :: Ring -> Ob.Patp
+deriveCode Ring {..} = Ob.patp $
+                       bytesAtom $
+                       take 8 $
+                       shaf (C.pack "pass") $
+                       shax $
+                       C.singleton 'B' <> ringSign <> ringCrypt
 
 cometFingerprintBS :: Pass -> ByteString
 cometFingerprintBS = (shaf $ C.pack "bfig") . passToBS


### PR DESCRIPTION
The derivation of `+code` in jael was more complicated than it had to be, I first simplified it, and then I implemented it in Haskell as part of the Dawn module so we could print the code on initial boot. (I want to say that vere used to do that.)