### PR TITLE
publish: prevent post input overflowing layout on safari

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
@@ -60,6 +60,7 @@ export function MarkdownEditor(
       border={1}
       borderColor="lightGray"
       borderRadius={2}
+      height={['calc(100% - 22vh)', '100%']}
       {...boxProps}
     >
       <CodeEditor

--- a/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
@@ -24,6 +24,7 @@ export const MarkdownField = ({
   return (
     <Box
       overflowY="hidden"
+      height='100%'
       width="100%"
       display="flex"
       flexDirection="column"

--- a/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
@@ -41,13 +41,13 @@ export function PostForm(props: PostFormProps) {
         onSubmit={onSubmit}
         validateOnBlur
       >
-        <Form style={{ display: "contents" }}>
-          <Row flexDirection={["column-reverse", "row"]} mb={4} gapX={4} justifyContent='space-between'>
-            <Input maxWidth='40rem' flexGrow={1} placeholder="Post Title" id="title" />
+        <Form style={{ display: "contents"}}>
+          <Row flexShrink='0' flexDirection={["column-reverse", "row"]} mb={4} gapX={4} justifyContent='space-between'>
+            <Input maxWidth='40rem' width='100%' flexShrink={[0, 1]} placeholder="Post Title" id="title" />
             <AsyncButton
               ml={[0,2]}
               mb={[4,0]}
-              flexShrink={1}
+              flexShrink={0}
               primary
               loadingText={loadingText}
             >


### PR DESCRIPTION
See urbit/landscape#117.

<img width="419" alt="image" src="https://user-images.githubusercontent.com/20846414/96283862-ccd06b00-0faa-11eb-8891-494fcbb65435.png">

Would appreciate a once-over on Firefox and the like, but seems to look fine on all sizes on Webkit.