### PR TITLE
eyre: kick busy subscriptions if client not acking

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f86fb4d082a41728b4b17a4c09dd0b718d3a83c2d20598fe2d5886742c330df
-size 6309399
+oid sha256:7b4927a8bf8f2c8f3e7677dba7c27054dfb59ec72a0f65d273a0f0b9068a599f
+size 6326384

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -385,9 +385,9 @@
         :-  'subscriptions'
         :-  %a
         %+  turn  ~(tap by subscriptions)
-        |=  [=wire [=^ship app=term =^path *]]
+        |=  [id=@ud [=^ship app=term =^path *]]
         %-  pairs
-        :~  'wire'^(^path wire)
+        :~  'id'^(numb id)
             'ship'^(^ship ship)
             'app'^s+app
             'path'^(^path path)

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -380,6 +380,7 @@
         'connected'^b+!-.state
         'expiry'^?-(-.state %& (time date.p.state), %| ~)
         'next-id'^(numb next-id)
+        'last-ack'^(time last-ack)
         'unacked'^a+(turn (sort (turn ~(tap in events) head) dor) numb)
       ::
         :-  'subscriptions'
@@ -391,6 +392,7 @@
             'ship'^(^ship ship)
             'app'^s+app
             'path'^(^path path)
+            'unacked'^(numb (~(gut by unacked) id 0))
         ==
     ==
   ==

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1392,6 +1392,11 @@
         ::  next-id: next sequence number to use
         ::
         next-id=@ud
+        ::  last-ack: time of last client ack
+        ::
+        ::    used for clog calculations, in combination with :unacked
+        ::
+        last-ack=@da
         ::  events: unacknowledged events
         ::
         ::    We keep track of all events where we haven't received a
@@ -1401,6 +1406,11 @@
         ::    can't assume it got received until we get an acknowledgment.
         ::
         events=(qeu [id=@ud request-id=@ud =channel-event])
+        ::  unacked: unacknowledged event counts by request-id
+        ::
+        ::    used for clog calculations, in combination with :last-ack
+        ::
+        unacked=(map @ud @ud)
         ::  subscriptions: gall subscriptions by request-id
         ::
         ::    We maintain a list of subscriptions so if a channel times out, we

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1401,12 +1401,12 @@
         ::    can't assume it got received until we get an acknowledgment.
         ::
         events=(qeu [id=@ud request-id=@ud =channel-event])
-        ::  subscriptions: gall subscriptions
+        ::  subscriptions: gall subscriptions by request-id
         ::
         ::    We maintain a list of subscriptions so if a channel times out, we
         ::    can cancel all the subscriptions we've made.
         ::
-        subscriptions=(map wire [ship=@p app=term =path duc=duct])
+        subscriptions=(map @ud [ship=@p app=term =path duc=duct])
         ::  heartbeat: sse heartbeat timer
         ::
         heartbeat=(unit timer)

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -1517,15 +1517,26 @@
 ::
 ++  test-prune-events
   =/  q=(qeu [id=@ud @ud channel-event:eyre])  ~
-  =.  q  (~(put to q) [0 *@ud *channel-event:eyre])
-  =.  q  (~(put to q) [1 *@ud *channel-event:eyre])
-  =.  q  (~(put to q) [2 *@ud *channel-event:eyre])
-  =.  q  (~(put to q) [3 *@ud *channel-event:eyre])
-  =.  q  (~(put to q) [4 *@ud *channel-event:eyre])
+  =.  q  (~(put to q) [0 0 *channel-event:eyre])
+  =.  q  (~(put to q) [1 0 *channel-event:eyre])
+  =.  q  (~(put to q) [2 0 *channel-event:eyre])
+  =.  q  (~(put to q) [3 1 *channel-event:eyre])
+  =.  q  (~(put to q) [4 1 *channel-event:eyre])
   ::
-  =.  q  (prune-events:eyre-gate q 3)
+  =^  a  q  (prune-events:eyre-gate q 3)
   ::
-  (expect-eq !>([~ [4 *@ud *channel-event:eyre]]) !>(~(top to q)))
+  %+  expect-eq
+    !>
+    :-  (~(gas by *(map @ud @ud)) ~[0^3 1^1])
+    [~ [4 1 *channel-event:eyre]]
+  !>([a ~(top to q)])
+::
+++  test-subtract-acked-events
+  =/  a  (~(gas by *(map @ud @ud)) ~[0^3 1^1])
+  =/  u  (~(gas by *(map @ud @ud)) ~[0^4 2^1])
+  =/  e  (~(gas by *(map @ud @ud)) ~[0^1 2^1])
+  =/  r  (subtract-acked-events:eyre-gate a u)
+  (expect-eq !>(e) !>(r))
 ::
 ++  test-channel-sends-unacknowledged-events-on-reconnection
   ::  common initialization
@@ -1795,6 +1806,123 @@
     results8
     results9
   ==
+::
+++  test-channel-subscription-clogged
+  ::  common initialization
+  ::
+  =^  tested-elsewhere  eyre-gate
+    (perform-init-start-channel eyre-gate *sley)
+  ::
+  =/  now=@da  :(add ~1111.1.2 clog-timeout:eyre-gate ~s1)
+  ::  subscription gets a success message
+  ::
+  =^  tested-elsewhere  eyre-gate
+    %:  eyre-take
+      eyre-gate
+      now
+      scry=scry-provides-code
+      ^=  take-args
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
+            ^-  (hypo sign:eyre-gate)
+            :-  *type
+            [%g %unto %watch-ack ~]
+         ==
+      moves=~
+    ==
+  ::  opens the http channel
+  ::
+  =^  tested-elsewhere  eyre-gate
+    %:  eyre-call
+      eyre-gate
+      now
+      scry=scry-provides-code
+      ^=  call-args
+      ^-  [duct * (hobo task:able:eyre-gate)]
+        :*  duct=~[/http-get-open]  ~
+            %request
+            %.n
+            [%ipv4 .192.168.1.1]
+            %'GET'
+            '/~/channel/0123456789abcdef'
+            ['cookie' cookie-value]~
+            ~
+        ==
+      ^=  expected-moves
+      ~  ::NOTE  tested elsewher
+    ==
+  ::  user gets sent multiple subscription results
+  ::
+  =/  max=@ud  (dec clog-threshold:eyre-gate)
+  =/  cur=@ud  0
+  |-  =*  loop-fact  $
+  ?.  =(cur max)
+    =^  tested-elsewhere  eyre-gate
+      %:  eyre-take
+        eyre-gate
+        now
+        scry=scry-provides-code
+        ^=  take-args
+          :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+              duct=~[/http-put-request]
+              ^-  (hypo sign:eyre-gate)
+              :-  *type
+              [%g %unto %fact %json !>(`json`[%a [%n '1'] ~])]
+          ==
+        ^=  moves
+        ~  ::NOTE  tested elsewhere
+      ==
+    loop-fact(cur +(cur))
+  ::  the next subscription result should trigger a clog
+  ::
+  =^  results  eyre-gate
+    %:  eyre-take
+      eyre-gate
+      now
+      scry=scry-provides-code
+      ^=  take-args
+        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
+            duct=~[/http-put-request]
+            ^-  (hypo sign:eyre-gate)
+            :-  *type
+            [%g %unto %fact %json !>(`json`[%a [%n '1'] ~])]
+        ==
+      ^=  moves
+        :~  :*  duct=~[/http-get-open]
+                %give
+                %response
+                %continue
+                :-  ~
+                %-  as-octt:mimes:html
+                """
+                id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
+                data: \{"id":1,"response":"quit"}
+
+
+                """
+                complete=%.n
+            ==
+            :*  duct=~[/http-put-request]  %pass
+              /channel/subscription/'0123456789abcdef'/'1'/~nul/two
+              %g  %deal  [~nul ~nul]  %two  %leave  ~
+            ==
+            :*  duct=~[/http-get-open]
+              %give
+              %response
+              %continue
+              :-  ~
+              %-  as-octt:mimes:html
+              """
+              id: {((d-co:co 1) clog-threshold:eyre-gate)}
+              data: \{"json":[1],"id":1,"response":"diff"}
+
+
+              """
+              complete=%.n
+            ==
+        ==
+    ==
+  results
 ::
 ++  test-born-sends-pending-cancels
   ::

--- a/pkg/interface/dbug/src/js/views/eyre.js
+++ b/pkg/interface/dbug/src/js/views/eyre.js
@@ -117,10 +117,10 @@ export class Eyre extends Component {
       </>);
       const subscriptionItems = c.subscriptions.map(s => {
         //NOTE jsx sorta copied from /components/subscriptions
-        return {key: `${s.wire} ${s.app} ${s.ship} ${s.path}`, jsx: (
+        return {key: `${s.id} ${s.app} ${s.ship} ${s.path}`, jsx: (
           <div class="flex">
             <div class="flex-auto" style={{maxWidth: '35%'}}>
-              {s.wire}
+              {s.id}
             </div>
             <div class="flex-auto" style={{maxWidth: '15%'}}>
               ~{s.ship}

--- a/pkg/interface/dbug/src/js/views/eyre.js
+++ b/pkg/interface/dbug/src/js/views/eyre.js
@@ -110,6 +110,10 @@ export class Eyre extends Component {
             <td>{c['next-id']}</td>
           </tr>
           <tr>
+            <td class="inter">last-ack</td>
+            <td>{c['last-ack']}</td>
+          </tr>
+          <tr>
             <td class="inter">unacked</td>
             <td>{c.unacked.reduce((a, b) => a + b + ', ', '')}</td>
           </tr>
@@ -119,17 +123,20 @@ export class Eyre extends Component {
         //NOTE jsx sorta copied from /components/subscriptions
         return {key: `${s.id} ${s.app} ${s.ship} ${s.path}`, jsx: (
           <div class="flex">
-            <div class="flex-auto" style={{maxWidth: '35%'}}>
+            <div class="flex-auto" style={{maxWidth: '15%'}}>
               {s.id}
             </div>
             <div class="flex-auto" style={{maxWidth: '15%'}}>
               ~{s.ship}
             </div>
-            <div class="flex-auto" style={{maxWidth: '15%'}}>
+            <div class="flex-auto" style={{maxWidth: '20%'}}>
               {s.app}
             </div>
             <div class="flex-auto" style={{maxWidth: '35%'}}>
               {s.path}
+            </div>
+            <div class="flex-auto" style={{maxWidth: '15%'}}>
+              {s.unacked}
             </div>
           </div>
         )};
@@ -137,7 +144,7 @@ export class Eyre extends Component {
       return {key: c.session, jsx: (
         <Summary summary={summary} details={(
           <SearchableList
-            placeholder="wire, app, ship, path"
+            placeholder="id, app, ship, path"
             items={subscriptionItems}
           />
         )} />


### PR DESCRIPTION
Intends to supersede #3680. This is the fancier implementation proposed therein.

Eyre keeps channel events in state until they get acked by a connected client, so that the client can catch up and resume operating after unexpected disconnects. Currently, Eyre does not react to rapid growth of those queues that might result from clients not sending acks.

This PR implements a mechanism for detecting such "[clogging](https://public-media.si-cdn.com/filer/1c/25/1c25dff1-03f2-4a64-8ef3-70721c533ca0/istock-177415966.jpg)", and proactively kicking subscriptions that are adding too many events to the queue.

If the client hasn't sent an ack for `~s30`, any subscription that accrues more than 50 unacked events gets closed to prevent further buildup.  
Upon reconnecting, the client will see `%kick` for the relevant subscriptions and can open a new subscription as appropriate.

Includes a simple test for this behavior, and updates `/app/dbug` to be able to display the newly tracked statistics.

Have tested the various flows here on a fake ship. Will boot a comet with this, see if it impacts "join chat" and similar cases at all, and report back with results.

I've observed that for the simple case of "send a chat message and watch it round-trip", Landscape sends five acks to Eyre. Hopefully, with these changes, we can tone that down a little bit.

Please do not hesitate to yell "refactor moar" at me if you think that's justified. Perhaps a restructuring could get us some clarity gains, but I need to step back for a little bit before I can judge that properly.

(Based off #3746 because I'd rather not deal with any conflicts here.)

cc @ everyone involved in prior discussion, I guess. Happy to take reviews/feedback from whoever.