### PR TITLE
[hoon co] Fix float printer overuse of scientific notation

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6024,17 +6024,17 @@
         |=  a/dn
         ?:  ?=({$i *} a)  (weld ?:(s.a "inf" "-inf") rep)
         ?:  ?=({$n *} a)  (weld "nan" rep)
-        =+  ^=  e  %+  ed-co  [10 1]
-          |=  {a/? b/@ c/tape}
-          ?:  a  [~(d ne b) '.' c]
-          [~(d ne b) c]
-        =+  ^=  f
-          =>(.(rep ~) (e a.a))
-        =.  e.a  (sum:si e.a (sun:si (dec +.f)))
-        =+  b=?:((syn:si e.a) "e" "e-")
-        =>  .(rep ?~(e.a rep (weld b ((d-co 1) (abs:si e.a)))))
-        =>  .(rep (weld -.f rep))
-        ?:(s.a rep ['-' rep])
+        =;  rep  ?:(s.a rep ['-' rep])
+        =/  f  ((d-co 1) a.a)
+        =^  e  e.a
+          =/  e=@s  (sun:si (lent f))
+          =/  sci  :(sum:si e.a e -1)
+          ?:  (syn:si (dif:si e.a --3))  [--1 sci]  :: 12000 -> 12e3 e>+2
+          ?:  !(syn:si (dif:si sci -2))  [--1 sci]  :: 0.001 -> 1e-3 e<-2
+          [(sum:si sci --1) --0] :: 1.234e2 -> '.'@3 -> 123 .4
+        =?  rep  !=(--0 e.a)
+          :(weld ?:((syn:si e.a) "e" "e-") ((d-co 1) (abs:si e.a)))
+        (weld (ed-co e f) rep)
       ::
       ++  s-co
         |=  esc/(list @)  ^-  tape
@@ -6064,20 +6064,13 @@
     ==
   ::
   ++  ed-co
-    |=  {{bas/@ min/@} par/$-({? @ tape} tape)}
-    =+  [fir=& cou=0]
-    |=  hol/@
-    ^-  {tape @}
-    ?:  &(=(0 hol) =(0 min))
-      [rep cou]
-    =+  [rad=(mod hol bas) dar=(div hol bas)]
-    %=  $
-      min  ?:(=(0 min) 0 (dec min))
-      hol  dar
-      rep  (par &(=(0 dar) !fir) rad rep)
-      fir  |
-      cou  +(cou)
-    ==
+    |=  [exp=@s int=tape]  ^-  tape
+    =/  [pos=? dig=@u]  [=(--1 (cmp:si exp --0)) (abs:si exp)]
+    ?.  pos
+      (into (weld (reap +(dig) '0') int) 1 '.')
+    =/  len  (lent int)
+    ?:  (lth dig len)  (into int dig '.')
+    (weld int (reap (sub dig len) '0'))
   ::
   ++  ox-co
     |=  {{bas/@ gop/@} dug/$-(@ @)}


### PR DESCRIPTION
I.e, print `.10` as `.10` not `.1e1`. Only use `e+-N` when it would be shorter.

Before:
```
> (turn (gulf 1 10) |=(a=@u (turn (gulf 0 9) |=(b=@u (grd:rs d/[& -5 (mul (pow 10 a) +((pow 10 b)))])))))
~[
  ~[.2e-3 .1.1e-3 .1.01e-2 .1.001e-1 .1.0001 .1.00001e1 .1.000001e2 .1.0000001e3 .1e4 .1e5]
  ~[.2e-2 .1.1e-2 .1.01e-1 .1.001 .1.0001e1 .1.00001e2 .1.000001e3 .1.0000001e4 .1e5 .1e6]
  ~[.2e-1 .1.1e-1 .1.01 .1.001e1 .1.0001e2 .1.00001e3 .1.000001e4 .1.0000001e5 .1e6 .1e7]
  ~[.2 .1.1 .1.01e1 .1.001e2 .1.0001e3 .1.00001e4 .1.000001e5 .1.0000001e6 .1e7 .1e8]
  ~[.2e1 .1.1e1 .1.01e2 .1.001e3 .1.0001e4 .1.00001e5 .1.000001e6 .1.0000001e7 .1e8 .1e9]
  ~[.2e2 .1.1e2 .1.01e3 .1.001e4 .1.0001e5 .1.00001e6 .1.000001e7 .1.0000001e8 .1e9 .1e10]
  ~[.2e3 .1.1e3 .1.01e4 .1.001e5 .1.0001e6 .1.00001e7 .1.00000096e8 .1.0000001e9 .1e10 .1e11]
  ~[.2e4 .1.1e4 .1.01e5 .1.001e6 .1.0001e7 .1.00001e8 .1.000001e9 .1.0000001e10 .1e11 .1e12]
  ~[.2e5 .1.1e5 .1.01e6 .1.001e7 .1.0001e8 .1.00001e9 .1.000001e10 .1.0000001e11 .1e12 .1e13]
  ~[.2e6 .1.1e6 .1.01e7 .1.001e8 .1.00009997e9 .1.00001e10 .1.000001e11 .1.0000001e12 .1e13 .1e14]
]
```

After:
```
> (turn (gulf 1 10) |=(a=@u (turn (gulf 0 9) |=(b=@u (grd:rs d/[& -5 (mul (pow 10 a) +((pow 10 b)))])))))
~[
  ~[.2e-4 .1.1e-3 .0.0101 .0.1001 .1.0001 .10.0001 .100.0001 .1000.0001 .1e4 .1e5]
  ~[.2e-3 .0.011 .0.101 .1.001 .10.001 .100.001 .1000.001 .10000.001 .1e5 .1e6]
  ~[.0.02 .0.11 .1.01 .10.01 .100.01 .1000.01 .10000.01 .100000.01 .1e6 .1e7]
  ~[.0.2 .1.1 .10.1 .100.1 .1000.1 .10000.1 .100000.1 .1000000.1 .1e7 .1e8]
  ~[.2 .11 .101 .1001 .10001 .100001 .1000001 .10000001 .1e8 .1e9]
  ~[.20 .110 .1010 .10010 .100010 .1000010 .10000010 .100000010 .1e9 .1e10]
  ~[.200 .1100 .10100 .100100 .1000100 .10000100 .100000096 .1000000100 .1e10 .1e11]
  ~[.2e3 .1.1e4 .1.01e5 .1.001e6 .1.0001e7 .1.00001e8 .1.000001e9 .1.0000001e10 .1e11 .1e12]
  ~[.2e4 .1.1e5 .1.01e6 .1.001e7 .1.0001e8 .1.00001e9 .1.000001e10 .1.0000001e11 .1e12 .1e13]
  ~[.2e5 .1.1e6 .1.01e7 .1.001e8 .1000099970 .1.00001e10 .1.000001e11 .1.0000001e12 .1e13 .1e14]
]
```