### PR TITLE
groups: new channel only shows ship search at home

### DIFF
--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -176,6 +176,7 @@ export function GroupsPane(props: GroupsPaneProps) {
                 groups={groups}
                 group={groupPath}
                 contacts={props.contacts}
+                workspace={workspace}
               />
               {popovers(routeProps, baseUrl)}
             </Skeleton>

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -45,7 +45,7 @@ interface NewChannelProps {
 
 
 export function NewChannel(props: NewChannelProps & RouteComponentProps) {
-  const { history, api, group } = props;
+  const { history, api, group, workspace } = props;
 
   const waiter = useWaitForProps(props, 5000);
 
@@ -146,12 +146,13 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
               caption="What's your channel about?"
               placeholder="Channel description"
             />
+            {(workspace?.type === 'home') &&
             <ShipSearch
               groups={props.groups}
               contacts={props.contacts}
               id="ships"
               label="Invitees"
-            />
+            />}
             <Box justifySelf="start">
               <AsyncButton
                 primary


### PR DESCRIPTION
- The 'ship search' prompt in the new channel menu shows in all workspaces; but it's only really necessary in the home workspace.
- In this PR we just hide it away when we're inside a group workspace, so inviting participants only happens from one place (the invite button in the sidebar)