### PR TITLE
groups: allow search to have sigs

### DIFF
--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -45,8 +45,9 @@ const searchParticipant = (search: string) => (p: Participant) => {
   if (search.length == 0) {
     return true;
   }
-  const s = search.toLowerCase();
-  return p.patp.includes(s) || p.nickname.toLowerCase().includes(search);
+  let s = search.toLowerCase();
+  s = (s.startsWith('~')) ? s.substr(1) : s;
+  return p.patp.includes(s) || p.nickname.toLowerCase().includes(s);
 };
 
 function getParticipants(cs: Contacts, group: Group) {


### PR DESCRIPTION
If you type `~haddef-sigwen` into the participant search, nothing shows up. If you type `haddef-sigwen`, I do indeed show up. 

In this PR we just trim off the query's sig if it starts with it.

(Also fixes an unfiled bug where the search was case sensitive by accident, because we were comparing the `nickname.toLowerCase()` against the raw, `search` query, not `s` which is `search` transformed to `lowercase` itself.)