### PR TITLE
chat: prevent crashes if join is interrupted

### DIFF
--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -25,8 +25,8 @@ export function ChatResource(props: ChatResourceProps) {
     return null;
   }
 
-  const { envelopes, config } = props.inbox[station];
-  const { read, length } = config;
+  const { envelopes, config } = (props.inbox?.[station]) ? props.inbox[station] : {envelopes: [], config: {}};
+  const { read, length } = (config) ? config : undefined;
 
   const groupPath = props.association["group-path"];
   const group = props.groups[groupPath];


### PR DESCRIPTION
Addresses #3748.

We destructure envelopes and config from the station inside our inbox unsafely; and if you navigate away mid-join, you can sidestep the join flow and see the view before the props are instantiated — causing a consistent crash when you navigate to the room, until the full backlog hits our ship and the messages load in on a subsequent refresh.

By safely instantiating (more elvis operators!) we can avoid the crash, which nicely enough shows the "Past messages are being restored" notice while we wait, which I haven't yet seen in nu-groups, so it seems to be functioning normally.