### PR TITLE
[hoon @r] add .0j1 complex float syntax

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -114,9 +114,10 @@
 ::  |parser-at: parsers for dojo expressions using :dir as working directory
 ::
 ++  parser-at
-  |=  [our=ship dir=beam]
+  |=  [our=ship dir=beam no-complex=?]
   |%
   ++  default-app         %hood
+  ++  vang                %*(. ^vang no-complex no-complex)
   ++  hoon-parser         (vang | (en-beam:format dir))
   ++  our                 p.dir
   ::
@@ -324,7 +325,9 @@
     dir(r [%da now.hid])
   ::
   ++  he-beak    `beak`[p q r]:he-beam
-  ++  he-parser  (parser-at our.hid he-beam)
+  ++  vang  %*(. ^vang no-complex !enable-complex-float)
+  ++  he-parser  (parser-at our.hid he-beam !enable-complex-float)
+  ++  enable-complex-float  (~(has by var) %enable-complex-float)
   ::
   ++  dy                                                ::  project work
     |_  dojo-project                                    ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2265,12 +2265,12 @@
   ::
 ::
 ++  fl                                                  ::  arb. precision fp
-  =/  {{p/@u v/@s w/@u} r/$?($n $u $d $z $a) d/$?($d $f $i)}
+  =/  {{p/@u v/@s w/@u} r/$?($u $d $z $a $n) d/$?($d $f $i)}
     [[113 -16.494 32.765] %n %d]
   ::  p=precision:     number of bits in arithmetic form; must be at least 2
   ::  v=min exponent:  minimum value of e
   ::  w=width:         max - min value of e, 0 is fixed point
-  ::  r=rounding mode: nearest (ties to even), up, down, to zero, away from zero
+  ::  r=rounding mode: up, down, to zero, away from zero, nearest (ties to even)
   ::  d=behavior:      return denormals, flush denormals to zero,
   ::                   infinite exponent range
   =>
@@ -2736,7 +2736,7 @@
   --
 ::
 ++  ff                                                  ::  ieee 754 format fp
-  |_  {{w/@u p/@u b/@s} r/$?($n $u $d $z $a)}
+  |_  {{w/@u p/@u b/@s} r/$?($u $d $z $a $n)}
   ::  this core has no use outside of the functionality
   ::  provided to ++rd, ++rs, ++rq, and ++rh
   ::
@@ -2847,8 +2847,8 @@
 ++  rd                                                  ::  double precision fp
   ^|
   ~%  %rd  +>  ~
-  |_  r/$?($n $u $d $z)
-  ::  round to nearest, round up, round down, round to zero
+  |_  r/$?($u $d $z $n)
+  ::  round up, round down, round to zero, round to nearest
   ::
   ++  ma
     %*(. ff w 11, p 52, b --1.023, r r)
@@ -2925,8 +2925,8 @@
 ++  rs                                                  ::  single precision fp
   ~%  %rs  +>  ~
   ^|
-  |_  r/$?($n $u $d $z)
-  ::  round to nearest, round up, round down, round to zero
+  |_  r/$?($u $d $z $n)
+  ::  round up, round down, round to zero, round to nearest
   ::
   ++  ma
     %*(. ff w 8, p 23, b --127, r r)
@@ -3004,8 +3004,8 @@
 ++  rq                                                  ::  quad precision fp
   ~%  %rq  +>  ~
   ^|
-  |_  r/$?($n $u $d $z)
-  ::  round to nearest, round up, round down, round to zero
+  |_  r/$?($u $d $z $n)
+  ::  round up, round down, round to zero, round to nearest
   ::
   ++  ma
     %*(. ff w 15, p 112, b --16.383, r r)
@@ -3083,8 +3083,8 @@
 ++  rh                                                  ::  half precision fp
   ~%  %rh  +>  ~
   ^|
-  |_  r/$?($n $u $d $z)
-  ::  round to nearest, round up, round down, round to zero
+  |_  r/$?($u $d $z $n)
+  ::  round up, round down, round to zero, round to nearest
   ::
   ++  ma
     %*(. ff w 5, p 10, b --15, r r)


### PR DESCRIPTION
Stores real then complex part in the obvious LSB manner: `=(.123j0 .123)`, `=(.3j-4 (cat 5 .3 .-4))`

Parsing feature-flagged as no support has been implemented in the math
cores, which will just ignore/truncate off the complex part.

In dojo,

    =enable-complex-float  &

to try out the syntax. (Or just go nuts with,
```
> ? (div:rs .15 .8)
  @rs
.1.875
> ? .~1
  @rd
.~1
> `@ux`(div:rs .15 .8)
0x3ff0.0000
> `@ux`.~1
0x3ff0.0000.0000.0000
> `@rs`.~1
.0j1.875
```
etc)

Steps to leave draft status:
- [ ] Figure out if we want a `@rsr` `@rdr` etc odor for "real, as in actually real", and implement that in the parser / otherwise resolve the TODO
- [ ] Update all the `ff` library functions and `++r[sdhq]` jet-variants to correctly calculate complex results, or to reject complex inputs per #3673 leaving correct implementations for future work; or at least figure out a more principled way to do the "opt into syntax that breaks all your math" flag.