### PR TITLE
hoon, sur/sole, dill, drum: Add 24-bit true color

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1972,7 +1972,9 @@
 +$  tile  ::  XX: ?@(knot (pair styl knot))
           ::
           cord
-+$  tint  ?($r $g $b $c $m $y $k $w $~)                 ::  text color
++$  tint
+  $@  ?($r $g $b $c $m $y $k $w $~)                     ::  text color
+  [r=@uxD g=@uxD b=@uxD]                                ::  24bit true color
 ::
 ::  A `plum` is the intermediate representation for the pretty-printer. It
 ::  encodes hoon-shaped data with the least amount of structured needed

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -211,7 +211,6 @@
               (bg ~)
               (fg ~)
           ==
-        ::
         ++  ef  |=(a/^deco (scap (deco a)))             ::  ANSI effect
         ::
         ++  fg  |=(a/^tint (scap (tint a)))             ::  ANSI foreground
@@ -219,13 +218,13 @@
         ++  bg                                          ::  ANSI background
           |=  a/^tint
           %-  scap
-          =>((tint a) [+(p) q])                         ::  (add 10 fg)
+          =>((tint a) [+(-) +])                         ::  (add 10 fg)
         ::
         ++  scap                                        ::  ANSI escape seq
-          |=  a/$@(@ (pair @ @))
+          |=  a/$@(@ (list @))
           %-  (list @c)
           :+  27  '['                                   ::  "\033[{a}m"
-          ?@(a :~(a 'm') :~(p.a q.a 'm'))
+          ?@(a :~(a 'm') (snoc a 'm'))
         ::
         ++  deco                                        ::  ANSI effects
           |=  a/^deco  ^-  @
@@ -238,19 +237,25 @@
         ::
         ++  tint                                        ::  ANSI colors (fg)
           |=  a/^tint
-          ^-  (pair @ @)
+          ^-  (list @)
           :-  '3'
-          ?-  a
-            $k  '0'
-            $r  '1'
-            $g  '2'
-            $y  '3'
-            $b  '4'
-            $m  '5'
-            $c  '6'
-            $w  '7'
-            ~  '9'
-           ==
+          ?@  a
+            :_  ~
+            ?-  a
+              $k  '0'
+              $r  '1'
+              $g  '2'
+              $y  '3'
+              $b  '4'
+              $m  '5'
+              $c  '6'
+              $w  '7'
+              ~  '9'
+             ==
+          =/  r  (~(sit fe 3) r.a)
+          =/  g  (~(sit fe 3) g.a)
+          =/  b  (~(sit fe 3) b.a)
+          "8;2;{<r>};{<g>};{<b>}"
         --
       ::  XX move
       ::


### PR DESCRIPTION
This commit adds 24bit true color capabilities to `sole-effect` for
those terminal supporting it (which most modern terminal does). As Urbit
does not do `termcap` detection, this also does not attempt that. But on
terminals that doesn't support true color (e.g. linux console), the
color would be truncated to the nearest achievable approximate.

The changes roughly follows what is done for normal 8-bit colors (`styx`
and related). The definition lives in `hoon`, the structural changes in
`sur/sole`, (in my case) passing the color structure through `drum` as
is, and coverting to escape sequences in `dill`.

Type/Arm names should be revised to fit Urbit/Hoon style.

cc related component maintainers: @pilfer-pandex @joemfb @philipcmonk 
