### PR TITLE
chat: timestamps are lined at top of messages

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -97,7 +97,7 @@ export default class ChatMessage extends Component<ChatMessageProps> {
 
     const containerClass = `${renderSigil
       ? `cf pt2 pl3 lh-copy`
-      : `items-center cf hide-child`} ${isPending ? 'o-40' : ''} ${className}`
+      : `items-top cf hide-child`} ${isPending ? 'o-40' : ''} ${className}`
 
     const timestamp = moment.unix(msg.when / 1000).format(renderSigil ? 'hh:mm a' : 'hh:mm');
 
@@ -255,7 +255,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
 
 export const MessageWithoutSigil = ({ timestamp, msg, remoteContentPolicy, measure }) => (
   <>
-    <p className="child pr1 mono f9 gray2 dib">{timestamp}</p>
+    <Text mono gray display='inline-block' pr='1' pt='2px' lineHeight='tall' className="child">{timestamp}</Text>
     <Box fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
       <MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure}/>
     </Box>


### PR DESCRIPTION
Before:

<img width="368" alt="image" src="https://user-images.githubusercontent.com/20846414/96645755-0978cb00-12f9-11eb-8ec2-55b43f9421f1.png">

After:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/20846414/96645689-f2d27400-12f8-11eb-925e-758393f6e184.png">

cc @tylershuster is there some reason we were using `items-center` on all these besides this timestamp?