### PR TITLE
vere: refactors ames i/o driver

### DIFF
--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -851,6 +851,22 @@ _ames_forward(u3_panc* pac_u, u3_noun las)
     u3l_log("ames: forwarded %" PRIu64 " total\n", sam_u->sat_u.fow_d);
   }
 
+  if ( u3C.wag_w & u3o_verbose ) {
+    u3_noun sen = u3dc("scot", 'p', u3i_chubs(2, pac_u->bod_u.sen_d));
+    u3_noun rec = u3dc("scot", 'p', u3i_chubs(2, pac_u->bod_u.rec_d));
+    c3_c* sen_c = u3r_string(sen);
+    c3_c* rec_c = u3r_string(rec);
+    c3_y* pip_y = (c3_y*)&pac_u->ore_u.pip_w;
+
+    u3l_log("ames: forwarding for %s to %s from %d.%d.%d.%d:%d\n",
+            sen_c, rec_c,
+            pip_y[0], pip_y[1], pip_y[2], pip_y[3],
+            pac_u->ore_u.por_s);
+
+    c3_free(sen_c); c3_free(rec_c);
+    u3z(sen); u3z(rec);
+  }
+
   {
     u3_noun los = las;
     u3_noun pac = _ames_serialize_packet(pac_u, c3y);

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -179,6 +179,35 @@ _ames_etch_head(u3_head* hed_u, c3_y buf_y[4])
   buf_y[3] = (hed_w >> 24) & 0xff;
 }
 
+/* _ames_chub_bytes(): c3_y[8] to c3_d
+** XX move
+*/
+static inline c3_d
+_ames_chub_bytes(c3_y byt_y[8])
+{
+  return (c3_d)byt_y[0]
+       | (c3_d)byt_y[1] << 8
+       | (c3_d)byt_y[2] << 16
+       | (c3_d)byt_y[3] << 24
+       | (c3_d)byt_y[4] << 32
+       | (c3_d)byt_y[5] << 40
+       | (c3_d)byt_y[6] << 48
+       | (c3_d)byt_y[7] << 56;
+}
+
+/* _ames_ship_to_chubs(): pack [len_y] bytes into c3_d[2]
+** XX move
+*/
+static inline void
+_ames_ship_to_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)
+{
+  c3_y sip_y[16] = {0};
+  memcpy(sip_y, buf_y, c3_min(16, len_y));
+
+  sip_d[0] = _ames_chub_bytes(sip_y);
+  sip_d[1] = _ames_chub_bytes(sip_y + 8);
+}
+
 /* _ames_send_cb(): send callback.
 */
 static void
@@ -839,11 +868,8 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   c3_y* con_y = NULL;
 
   if ( c3y == pas_o ) {
-    u3_noun sen = u3i_bytes(sen_y, bod_y);
-    u3_noun rec = u3i_bytes(rec_y, bod_y + sen_y);
-    u3r_chubs(0, 2, rec_d, rec);
-    u3r_chubs(0, 2, sen_d, sen);
-    u3z(sen); u3z(rec);
+    _ames_ship_to_chubs(sen_d, sen_y, bod_y);
+    _ames_ship_to_chubs(rec_d, rec_y, bod_y + sen_y);
 
     con_y = c3_malloc(con_w);
     memcpy(con_y, bod_y + sen_y + rec_y, con_w);

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -1392,14 +1392,22 @@ static void
 _ames_io_info(u3_auto* car_u)
 {
   u3_ames* sam_u = (u3_ames*)car_u;
-  u3l_log("               dropped: %" PRIu64 "\n", sam_u->sat_u.dop_d);
-  u3l_log("      forwards dropped: %" PRIu64 "\n", sam_u->sat_u.fod_d);
-  u3l_log("      forwards pending: %" PRIu64 "\n", sam_u->sat_u.foq_d);
-  u3l_log("             forwarded: %" PRIu64 "\n", sam_u->sat_u.fow_d);
-  u3l_log("        filtered (ver): %" PRIu64 "\n", sam_u->sat_u.vet_d);
-  u3l_log("        filtered (mug): %" PRIu64 "\n", sam_u->sat_u.mut_d);
-  u3l_log("               crashed: %" PRIu64 "\n", sam_u->sat_u.fal_d);
-  u3l_log("          cached lanes: %u\n", u3h_wyt(sam_u->lax_p));
+
+# define FLAG(a) ( (c3y == a) ? "&" : "|" )
+
+  u3l_log("      config:\n");
+  u3l_log("        filtering: %s\n", FLAG(sam_u->fig_u.fit_o));
+  u3l_log("         can send: %s\n", FLAG(sam_u->fig_u.net_o));
+  u3l_log("         can scry: %s\n", FLAG(sam_u->fig_u.see_o));
+  u3l_log("      counters:\n");
+  u3l_log("                 dropped: %" PRIu64 "\n", sam_u->sat_u.dop_d);
+  u3l_log("        forwards dropped: %" PRIu64 "\n", sam_u->sat_u.fod_d);
+  u3l_log("        forwards pending: %" PRIu64 "\n", sam_u->sat_u.foq_d);
+  u3l_log("               forwarded: %" PRIu64 "\n", sam_u->sat_u.fow_d);
+  u3l_log("          filtered (ver): %" PRIu64 "\n", sam_u->sat_u.vet_d);
+  u3l_log("          filtered (mug): %" PRIu64 "\n", sam_u->sat_u.mut_d);
+  u3l_log("                 crashed: %" PRIu64 "\n", sam_u->sat_u.fal_d);
+  u3l_log("            cached lanes: %u\n", u3h_wyt(sam_u->lax_p));
 }
 
 /* u3_ames_io_init(): initialize ames I/O.

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -1282,6 +1282,10 @@ _ames_io_talk(u3_auto* car_u)
 
   //  scry the protocol version out of arvo
   //
+  //    XX this should be re-triggered periodically,
+  //    or, better yet, %ames should emit a %turf
+  //    (or some other reconfig) effect when it is reset.
+  //
   u3_pier_peek_last(car_u->pir_u, u3_nul, c3__ax, u3_nul,
                     u3nt(u3i_string("protocol"), u3i_string("version"), u3_nul),
                     sam_u, _ames_prot_scry_cb);

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -53,8 +53,10 @@
       c3_d           dop_d;             //  drop count
       c3_d           fal_d;             //  crash count
       c3_d           saw_d;             //  successive scry failures
+      c3_d           hed_d;             //  failed to read header
       c3_d           vet_d;             //  version mismatches filtered
       c3_d           mut_d;             //  invalid mugs filtered
+      c3_d           bod_d;             //  failed to read body
       c3_d           foq_d;             //  forward queue size
       c3_d           fow_d;             //  forwarded count
       c3_d           fod_d;             //  forwards dropped count
@@ -1025,8 +1027,11 @@ _ames_hear(u3_ames* sam_u,
   if (  (4 > len_w)
      || (c3n == _ames_sift_head(&hed_u, hun_y)) )
   {
-    //  XX track stats
-    //
+    sam_u->sat_u.hed_d++;
+    if ( 0 == (sam_u->sat_u.hed_d % 100) ) {
+      u3l_log("ames: %" PRIu64 " dropped, failed to read header\n", sam_u->sat_u.hed_d);
+    }
+
     c3_free(hun_y);
     return;
   }
@@ -1068,8 +1073,11 @@ _ames_hear(u3_ames* sam_u,
     if (  (c3n == _ames_sift_body(&hed_u, &bod_u, bod_w, bod_y))
        || !ur_cue_test_with(sam_u->tes_u, bod_u.con_w, bod_u.con_y) )
     {
-      //  XX track stats
-      //
+      sam_u->sat_u.bod_d++;
+      if ( 0 == (sam_u->sat_u.bod_d % 100) ) {
+        u3l_log("ames: %" PRIu64 " dropped, failed to read body\n", sam_u->sat_u.bod_d);
+      }
+
       c3_free(hun_y);
       return;
     }
@@ -1424,8 +1432,10 @@ _ames_io_info(u3_auto* car_u)
   u3l_log("        forwards dropped: %" PRIu64 "\n", sam_u->sat_u.fod_d);
   u3l_log("        forwards pending: %" PRIu64 "\n", sam_u->sat_u.foq_d);
   u3l_log("               forwarded: %" PRIu64 "\n", sam_u->sat_u.fow_d);
+  u3l_log("          filtered (hed): %" PRIu64 "\n", sam_u->sat_u.hed_d);
   u3l_log("          filtered (ver): %" PRIu64 "\n", sam_u->sat_u.vet_d);
   u3l_log("          filtered (mug): %" PRIu64 "\n", sam_u->sat_u.mut_d);
+  u3l_log("          filtered (bod): %" PRIu64 "\n", sam_u->sat_u.bod_d);
   u3l_log("                 crashed: %" PRIu64 "\n", sam_u->sat_u.fal_d);
   u3l_log("            cached lanes: %u\n", u3h_wyt(sam_u->lax_p));
 }

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -668,7 +668,7 @@ _ames_czar(u3_pact* pac_u)
         u3z(nam);
       }
 
-      if ( 0 != sas_i ) {
+      if ( 255 <= sas_i ) {
         u3l_log("ames: czar: galaxy domain %s truncated\n", sam_u->dns_c);
         _ames_pact_free(pac_u);
         return;

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -190,7 +190,7 @@ _ames_etch_head(u3_head* hed_u, c3_y buf_y[4])
 }
 
 /* _ames_chub_bytes(): c3_y[8] to c3_d
-** XX move
+** XX factor out, deduplicate with other conversions
 */
 static inline c3_d
 _ames_chub_bytes(c3_y byt_y[8])
@@ -206,7 +206,6 @@ _ames_chub_bytes(c3_y byt_y[8])
 }
 
 /* _ames_ship_to_chubs(): pack [len_y] bytes into c3_d[2]
-** XX move
 */
 static inline void
 _ames_ship_to_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)
@@ -219,7 +218,7 @@ _ames_ship_to_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)
 }
 
 /* _ames_chub_bytes(): c3_d to c3_y[8]
-** XX move
+** XX factor out, deduplicate with other conversions
 */
 static inline void
 _ames_bytes_chub(c3_y byt_y[8], c3_d num_d)
@@ -235,7 +234,6 @@ _ames_bytes_chub(c3_y byt_y[8], c3_d num_d)
 }
 
 /* _ames_ship_of_chubs(): unpack c3_d[2] into [len_y] bytes.
-** XX move
 */
 static inline void
 _ames_ship_of_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -131,13 +131,11 @@ _ames_panc_free(u3_panc* pac_u) {
   c3_free(pac_u);
 }
 
-/* _ca_mug_body(): truncated mug hash of bytes
+/* _ames_mug_body(): truncated (20 least-significant bits) mug hash of bytes
 */
 static c3_l
-_ca_mug_body(c3_w len_w, c3_y* byt_y)
+_ames_mug_body(c3_w len_w, c3_y* byt_y)
 {
-  //  mask off ((1 << 20) - 1)
-  //
   return u3r_mug_bytes(byt_y, len_w) & 0xfffff;
 }
 
@@ -434,7 +432,7 @@ _ames_serialize_packet(u3_panc* pac_u, c3_o dop_o)
     //  if we updated the origin lane, we need to update the mug too
     //
     if ( c3y == nal_o ) {
-      pac_u->hed_u.mug_l = _ca_mug_body(sen_y + rec_y + bod_u->con_w,
+      pac_u->hed_u.mug_l = _ames_mug_body(sen_y + rec_y + bod_u->con_w,
                                         pac_y + 4);
     }
 
@@ -800,7 +798,7 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   //  ensure the mug is valid
   //
   if ( c3y == pas_o
-    && (hed_u.mug_l != _ca_mug_body(nrd_i - 4, bod_y)) )
+    && (hed_u.mug_l != _ames_mug_body(nrd_i - 4, bod_y)) )
   {
     pas_o = c3n;
 

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -208,6 +208,36 @@ _ames_ship_to_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)
   sip_d[1] = _ames_chub_bytes(sip_y + 8);
 }
 
+/* _ames_chub_bytes(): c3_d to c3_y[8]
+** XX move
+*/
+static inline void
+_ames_bytes_chub(c3_y byt_y[8], c3_d num_d)
+{
+  byt_y[0] = num_d & 0xff;
+  byt_y[1] = (num_d >>  8) & 0xff;
+  byt_y[2] = (num_d >> 16) & 0xff;
+  byt_y[3] = (num_d >> 24) & 0xff;
+  byt_y[4] = (num_d >> 32) & 0xff;
+  byt_y[5] = (num_d >> 40) & 0xff;
+  byt_y[6] = (num_d >> 48) & 0xff;
+  byt_y[7] = (num_d >> 56) & 0xff;
+}
+
+/* _ames_ship_of_chubs(): unpack c3_d[2] into [len_y] bytes.
+** XX move
+*/
+static inline void
+_ames_ship_of_chubs(c3_d sip_d[2], c3_y len_y, c3_y* buf_y)
+{
+  c3_y sip_y[16] = {0};
+
+  _ames_bytes_chub(sip_y, sip_d[0]);
+  _ames_bytes_chub(sip_y + 8, sip_d[1]);
+
+  memcpy(buf_y, sip_y, c3_min(16, len_y));
+}
+
 /* _ames_send_cb(): send callback.
 */
 static void
@@ -489,13 +519,10 @@ _ames_serialize_packet(u3_panc* pac_u, c3_o dop_o)
     //
     u3_body* bod_u = &pac_u->bod_u;
     c3_y*    pac_y = c3_malloc(4 + sen_y + rec_y + bod_u->con_w);
-    {
-      u3_atom sen = u3i_chubs(2, bod_u->sen_d);
-      u3_atom rec = u3i_chubs(2, bod_u->rec_d);
-      u3r_bytes(0, sen_y, pac_y + 4,         sen);
-      u3r_bytes(0, rec_y, pac_y + 4 + sen_y, rec);
-      u3z(sen); u3z(rec);
-    }
+
+    _ames_ship_of_chubs(bod_u->sen_d, sen_y, pac_y + 4);
+    _ames_ship_of_chubs(bod_u->rec_d, rec_y, pac_y + 4 + sen_y);
+
     memcpy(pac_y + 4 + sen_y + rec_y, bod_u->con_y, bod_u->con_w);
 
     //  if we updated the origin lane, we need to update the mug too

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -1007,6 +1007,19 @@ _ames_hear(u3_ames* sam_u,
   u3_head hed_u;
   u3_body bod_u;
 
+  //  XX packet filtering needs to revised for two protocol-change scenarios
+  //
+  //    - packets using old protocol versions from our sponsees
+  //      these must be let through, and this is a transitive condition;
+  //      they must also be forwarded where appropriate
+  //      they can be validated, as we know their semantics
+  //
+  //    - packets using newer protocol versions
+  //      these should probably be let through, or at least
+  //      trigger printfs suggesting upgrade.
+  //      they cannot be filtered, as we do not know their semantics
+  //
+
   //  unpack header, ensuring buffer is large enough
   //
   if (  (4 > len_w)
@@ -1020,7 +1033,7 @@ _ames_hear(u3_ames* sam_u,
 
   //  ensure the protocol version matches ours
   //
-  //    XX rethink
+  //    XX rethink use of [fit_o] here and elsewhere
   //
   if (  (c3y == sam_u->fig_u.fit_o)
      && (sam_u->ver_y != hed_u.ver_y) )
@@ -1243,6 +1256,9 @@ _ames_prot_scry_cb(void* vod_p, u3_noun nun)
     sam_u->ver_y = ver;
   }
 
+  //  XX revise: filtering should probably be disabled if
+  //  we get a protocol version above the latest one we know
+  //
   sam_u->fig_u.fit_o = c3y;
   u3z(nun);
 }

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -868,16 +868,46 @@ _ames_forward(u3_panc* pac_u, u3_noun las)
   }
 
   {
-    u3_noun los = las;
     u3_noun pac = _ames_serialize_packet(pac_u, c3y);
-    while ( u3_nul != las ) {
-      _ames_ef_send(sam_u, u3k(u3h(las)), u3k(pac));
-      las = u3t(las);
+    u3_noun tag, dat, lan, t = las;
+
+    while ( u3_nul != t ) {
+      u3x_cell(t, &lan, &t);
+
+      //  validate lane and skip self if galaxy
+      //
+      if ( c3n == u3r_cell(lan, &tag, &dat) ) {
+        u3l_log("ames: bogus lane\n");
+        u3m_p("lan", lan);
+      }
+      else {
+        c3_o sen_o = c3y;
+        c3_d who_d[2];
+
+        if ( c3y == tag ) {
+          u3r_chubs(0, 2, who_d, dat);
+
+          if (  (who_d[0] == sam_u->pir_u->who_d[0])
+             && (who_d[1] == sam_u->pir_u->who_d[1]) )
+          {
+            sen_o = c3n;
+            if ( u3C.wag_w & u3o_verbose ) {
+              u3l_log("ames: forward skipping self\n");
+            }
+          }
+        }
+
+        if ( c3y == sen_o ) {
+          _ames_ef_send(sam_u, u3k(lan), u3k(pac));
+        }
+      }
     }
-    u3z(los); u3z(pac);
+
+    u3z(pac);
   }
 
   _ames_panc_free(pac_u);
+  u3z(las);
 }
 
 /*  _ames_lane_scry_cb(): learn lane to forward packet on


### PR DESCRIPTION
With a focus on packet-parsing, stateless forwarding, and galaxy address resolution.

The packet parsing (original in `_ames_recv_cb()`) did not sufficiently protect against strange lengths, and could underflow the buffer-length (which was signed). The parsing logic was also mixed together with the forwarding logic. These things have been factored out from each other.

The packet parsing and serialization involved a bunch of unnecessary allocations and representation changes, these have been mostly replaced with direct implementations (but there's still a bunch of unnecessary allocations in the higher-level packet flows).

The protocol-version checking/enforcement is incomplete in various ways, this PR includes comments documenting various scenarios we need to support to varying degrees.

I have not tested these changes on the livenet -- I'll do so after source level issues are resolved.
