### PR TITLE
chat: hoon eval whitespace, unread marker padding

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import React, { Component, PureComponent } from "react";
 import moment from "moment";
 import _ from "lodash";
-import { Box, Row, Text } from "@tlon/indigo-react";
+import { Box, Row, Text, Rule } from "@tlon/indigo-react";
 
 import { OverlaySigil } from './overlay-sigil';
 import { uxToHex, cite, writeText } from '~/logic/lib/util';
@@ -14,15 +14,15 @@ import RemoteContent from '~/views/components/RemoteContent';
 export const DATESTAMP_FORMAT = '[~]YYYY.M.D';
 
 export const UnreadMarker = React.forwardRef(({ dayBreak, when }, ref) => (
-  <div ref={ref} style={{ color: "#219dff" }} className="flex items-center f9 absolute w-100 left-0 pv0">
-    <hr style={{ borderColor: "#219dff" }} className="dn-s ma0 w2 bt-0" />
-    <p className="mh4 z-2" style={{ whiteSpace: 'normal' }}>New messages below</p>
-    <hr style={{ borderColor: "#219dff" }} className="ma0 flex-grow-1 bt-0" />
+  <Row ref={ref} color='blue' alignItems='center' fontSize='0' position='absolute' width='100%' py='2'>
+    <Rule borderColor='blue' display={['none', 'block']} m='0' width='2rem' />
+    <Text flexShrink='0' display='block' zIndex='2' mx='4' color='blue'>New messages below</Text>
+    <Rule borderColor='blue' flexGrow='1' m='0'/>
     {dayBreak
-      ? <p className="gray2 mh4">{moment(when).calendar()}</p>
+      ? <Text display='block' gray mx='4'>{moment(when).calendar()}</Text>
       : null}
-    <hr style={{ width: "calc(50% - 48px)" }} style={{ borderColor: "#219dff" }} className="ma0 bt-0" />
-  </div>
+    <Rule style={{ width: "calc(50% - 48px)" }} borderColor='blue' m='0' />
+  </Row>
 ));
 
 export const DayBreak = ({ when }) => (
@@ -125,7 +125,7 @@ export default class ChatMessage extends Component<ChatMessageProps> {
     };
 
     const unreadContainerStyle = {
-      height: isLastRead ? '1.66em' : '0',
+      height: isLastRead ? '2rem' : '0',
     };
 
     return (

--- a/pkg/interface/src/views/apps/chat/components/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/content/code.js
@@ -19,6 +19,7 @@ export default class CodeContent extends Component {
           overflow='auto'
           maxHeight='10em'
           maxWidth='100%'
+          style={{ whiteSpace: 'pre' }}
           backgroundColor='scales.black10'
         >
           {content.code.output[0].join('\n')}
@@ -36,6 +37,7 @@ export default class CodeContent extends Component {
           overflow='auto'
           maxHeight='10em'
           maxWidth='100%'
+          style={{ whiteSpace: 'pre' }}
         >
           {content.code.expression}
         </Text>


### PR DESCRIPTION
1. Multi line hoon evaluations now have `white-space: pre` to preserve line breaks, etc.
2. Unread marker has a little bit more padding to even out its location in the log (was slightly too close to preceding messages). Still some weird cases when between authors but we may just have to equalise last message / next author padding amounts. (Also is rewritten in indigo-react.)

<img width="532" alt="image" src="https://user-images.githubusercontent.com/20846414/96770652-a0ec2580-13ae-11eb-8cbb-b21f4902a331.png">
