### PR TITLE
chat: create dm route, restore participants option

### DIFF
--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -114,7 +114,6 @@ export function ChatResource(props: ChatResourceProps) {
         group={group}
         ship={owner}
         station={station}
-        allStations={Object.keys(props.inbox)}
         api={props.api}
         hideNicknames={props.hideNicknames}
         hideAvatars={props.hideAvatars}

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -46,7 +46,6 @@ interface ChatMessageProps {
   className?: string;
   isPending: boolean;
   style?: any;
-  allStations: any;
   scrollWindow: HTMLDivElement;
   isLastMessage?: boolean;
   unreadMarkerRef: React.RefObject<HTMLDivElement>;
@@ -87,7 +86,6 @@ export default class ChatMessage extends Component<ChatMessageProps> {
       scrollWindow,
       isLastMessage,
       unreadMarkerRef,
-      allStations,
       history,
       api
     } = this.props;
@@ -118,7 +116,6 @@ export default class ChatMessage extends Component<ChatMessageProps> {
       style,
       containerClass,
       isPending,
-      allStations,
       history,
       api,
       scrollWindow
@@ -165,7 +162,6 @@ interface MessageProps {
   containerClass: string;
   isPending: boolean;
   style: any;
-  allStations: any;
   measure(element): void;
   scrollWindow: HTMLDivElement;
 };
@@ -182,7 +178,6 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
       hideAvatars,
       remoteContentPolicy,
       measure,
-      allStations,
       history,
       api,
       scrollWindow
@@ -218,7 +213,6 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
           hideAvatars={hideAvatars}
           hideNicknames={hideNicknames}
           scrollWindow={scrollWindow}
-          allStations={allStations}
           history={history}
           api={api}
           className="fl pr3 v-top bg-white bg-gray0-d pt1"

--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -39,7 +39,6 @@ type ChatWindowProps = RouteComponentProps<{
   group: Group;
   ship: Patp;
   station: any;
-  allStations: any;
   api: GlobalApi;
   hideNicknames: boolean;
   hideAvatars: boolean;
@@ -56,7 +55,7 @@ interface ChatWindowState {
 export default class ChatWindow extends Component<ChatWindowProps, ChatWindowState> {
   private virtualList: VirtualScroller | null;
   private unreadMarkerRef: React.RefObject<HTMLDivElement>;
-  
+
   INITIALIZATION_MAX_TIME = 1500;
 
   constructor(props) {
@@ -68,14 +67,14 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
       initialized: false,
       lastRead: props.unreadCount ? props.mailboxSize - props.unreadCount : Infinity,
     };
-    
+
     this.dismissUnread = this.dismissUnread.bind(this);
     this.scrollToUnread = this.scrollToUnread.bind(this);
     this.handleWindowBlur = this.handleWindowBlur.bind(this);
     this.handleWindowFocus = this.handleWindowFocus.bind(this);
     this.stayLockedIfActive = this.stayLockedIfActive.bind(this);
     this.dismissIfLineVisible = this.dismissIfLineVisible.bind(this);
-    
+
     this.virtualList = null;
     this.unreadMarkerRef = React.createRef();
   }
@@ -88,7 +87,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
       this.setState({ initialized: true });
     }, this.INITIALIZATION_MAX_TIME);
   }
-  
+
   componentWillUnmount() {
     window.removeEventListener('blur', this.handleWindowBlur);
     window.removeEventListener('focus', this.handleWindowFocus);
@@ -192,10 +191,10 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     }
 
     this.setState({ fetchPending: true });
-    
+
     start = Math.min(mailboxSize - start, mailboxSize);
     end = Math.max(mailboxSize - end, 0, start - MAX_BACKLOG_SIZE);
-    
+
     return api.chat
       .fetchMessages(end, start, station)
       .finally(() => {
@@ -224,7 +223,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
       this.dismissUnread();
     }
   }
-  
+
   render() {
     const {
       envelopes,
@@ -243,7 +242,6 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
       hideAvatars,
       hideNicknames,
       remoteContentPolicy,
-      allStations,
       history
     } = this.props;
 
@@ -251,7 +249,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
 
     const messages = new Map();
     let lastMessage = 0;
-    
+
     [...envelopes]
       .sort((a, b) => a.number - b.number)
       .forEach(message => {
@@ -267,8 +265,8 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
         lastMessage = mailboxSize + index;
       });
 
-    const messageProps = { association, group, contacts, hideAvatars, hideNicknames, remoteContentPolicy, unreadMarkerRef, allStations, history, api };
-    
+    const messageProps = { association, group, contacts, hideAvatars, hideNicknames, remoteContentPolicy, unreadMarkerRef, history, api };
+
     return (
       <>
         <UnreadNotice

--- a/pkg/interface/src/views/apps/chat/components/overlay-sigil.js
+++ b/pkg/interface/src/views/apps/chat/components/overlay-sigil.js
@@ -55,7 +55,7 @@ export class OverlaySigil extends PureComponent {
 
   render() {
     const { props, state } = this;
-    const { hideAvatars, allStations } = props;
+    const { hideAvatars } = props;
 
     const img = (props.contact && (props.contact.avatar !== null) && !hideAvatars)
       ? <img src={props.contact.avatar} height={16} width={16} className="dib" />
@@ -84,7 +84,6 @@ export class OverlaySigil extends PureComponent {
             association={props.association}
             group={props.group}
             onDismiss={this.profileHide}
-            allStations={allStations}
             hideAvatars={hideAvatars}
             hideNicknames={props.hideNicknames}
             history={props.history}

--- a/pkg/interface/src/views/apps/chat/components/profile-overlay.js
+++ b/pkg/interface/src/views/apps/chat/components/profile-overlay.js
@@ -12,7 +12,6 @@ export class ProfileOverlay extends PureComponent {
 
     this.popoverRef = React.createRef();
     this.onDocumentClick = this.onDocumentClick.bind(this);
-    this.createAndRedirectToDM = this.createAndRedirectToDM.bind(this);
   }
 
   componentDidMount() {
@@ -23,42 +22,6 @@ export class ProfileOverlay extends PureComponent {
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.onDocumentClick);
     document.removeEventListener('touchstart', this.onDocumentClick);
-  }
-
-  createAndRedirectToDM() {
-    const { api, ship, history, allStations } = this.props;
-    const station = `/~${window.ship}/dm--${ship}`;
-    const theirStation = `/~${ship}/dm--${window.ship}`;
-
-    if (allStations.indexOf(station) !== -1) {
-      history.push(`/~landscape/home/resource/chat${station}`);
-      return;
-    }
-
-    if (allStations.indexOf(theirStation) !== -1) {
-      history.push(`/~landscape/home/resource/chat${theirStation}`);
-      return;
-    }
-
-    const groupPath = `/ship/~${window.ship}/dm--${ship}`;
-    const aud = ship !== window.ship ? [`~${ship}`] : [];
-    const title = `${cite(window.ship)} <-> ${cite(ship)}`;
-
-    api.chat.create(
-      title,
-      '',
-      station,
-      groupPath,
-      { invite: { pending: aud } },
-      aud,
-      true,
-      false
-    );
-
-    //  TODO: make a pretty loading state
-    setTimeout(() => {
-      history.push(`/~landscape/home/resource/chat${station}`);
-    }, 5000);
   }
 
   onDocumentClick(event) {
@@ -72,7 +35,7 @@ export class ProfileOverlay extends PureComponent {
   }
 
   render() {
-    const { contact, ship, color, topSpace, bottomSpace, group, association, hideNicknames, hideAvatars, history } = this.props;
+    const { contact, ship, color, topSpace, bottomSpace, group, hideNicknames, hideAvatars, history } = this.props;
 
     let top, bottom;
     if (topSpace < OVERLAY_HEIGHT / 2) {
@@ -132,7 +95,7 @@ export class ProfileOverlay extends PureComponent {
           )}
           <Text mono gray>{cite(`~${ship}`)}</Text>
           {!isOwn && (
-            <Button mt={2} width="100%" style={{ cursor: 'pointer' }} onClick={this.createAndRedirectToDM}>
+            <Button mt={2} width="100%" style={{ cursor: 'pointer' }} onClick={() => history.push(`/~landscape/dm/${ship}`)}>
               Send Message
             </Button>
           )}

--- a/pkg/interface/src/views/components/DropdownSearch.tsx
+++ b/pkg/interface/src/views/components/DropdownSearch.tsx
@@ -22,7 +22,7 @@ interface RenderChoiceProps<C> {
 }
 
 interface DropdownSearchProps<C> {
-  label: string;
+  label?: string;
   id: string;
   // check if entry is exact match
   isExact: (s: string) => C | undefined;
@@ -118,7 +118,7 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>) {
 
   return (
     <Box position="relative" zIndex={9}>
-      <Label htmlFor={props.id}>{props.label}</Label>
+      {props.label && (<Label htmlFor={props.id}>{props.label}</Label>)}
       {caption ? <Label mt="2" gray>{caption}</Label> : null}
       {!props.disabled && (
         <Input

--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -13,11 +13,12 @@ import { HoverBox } from "./HoverBox";
 
 interface InviteSearchProps {
   disabled?: boolean;
-  label: string;
+  label?: string;
   caption?: string;
   id: string;
   contacts: Rolodex;
   groups: Groups;
+  hideSelection?: boolean;
 }
 
 const ClickableText = styled(Text)`
@@ -45,10 +46,11 @@ const Candidate = ({ title, detail, selected, onClick }) => (
 );
 
 export function ShipSearch(props: InviteSearchProps) {
-  const [{ value }, { error }, { setValue }] = useField<string[]>(props.id);
+  const [{ value }, { error }, { setValue, setTouched }] = useField<string[]>(props.id);
 
   const onSelect = useCallback(
     (s: string) => {
+      setTouched(true);
       setValue([...value, s]);
     },
     [setValue, value]
@@ -134,6 +136,7 @@ export function ShipSearch(props: InviteSearchProps) {
         value={undefined}
         error={error}
       />
+      {props.hideSelection && (
       <Row minHeight="34px" flexWrap="wrap">
         {value.map((s) => (
           <Box
@@ -153,7 +156,7 @@ export function ShipSearch(props: InviteSearchProps) {
             </ClickableText>
           </Box>
         ))}
-      </Row>
+      </Row>)}
     </Col>
   );
 }

--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -19,6 +19,7 @@ interface InviteSearchProps {
   contacts: Rolodex;
   groups: Groups;
   hideSelection?: boolean;
+  maxLength?: number;
 }
 
 const ClickableText = styled(Text)`
@@ -111,6 +112,8 @@ export function ShipSearch(props: InviteSearchProps) {
     [nicknames]
   );
 
+  const maxLength = props.maxLength
+
   return (
     <Col>
       <DropdownSearch<string>
@@ -125,7 +128,7 @@ export function ShipSearch(props: InviteSearchProps) {
         caption={props.caption}
         candidates={peers}
         renderCandidate={renderCandidate}
-        disabled={false}
+        disabled={props.maxLength ? value.length >= props.maxLength : false}
         search={(s: string, t: string) =>
           t.toLowerCase().startsWith(s.toLowerCase())
         }
@@ -136,7 +139,6 @@ export function ShipSearch(props: InviteSearchProps) {
         value={undefined}
         error={error}
       />
-      {props.hideSelection && (
       <Row minHeight="34px" flexWrap="wrap">
         {value.map((s) => (
           <Box
@@ -156,7 +158,7 @@ export function ShipSearch(props: InviteSearchProps) {
             </ClickableText>
           </Box>
         ))}
-      </Row>)}
+      </Row>
     </Col>
   );
 }

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -62,9 +62,8 @@ export function GroupsPane(props: GroupsPaneProps) {
   }
 
   const popovers = (routeProps: RouteComponentProps, baseUrl: string) =>
-    (groupPath && (
-      <>
-        <PopoverRoutes
+     ( <>
+        {groupPath && ( <PopoverRoutes
           contacts={groupContacts || {}}
           association={groupAssociation!}
           group={group!}
@@ -74,17 +73,17 @@ export function GroupsPane(props: GroupsPaneProps) {
           hideNicknames={props.hideNicknames}
           {...routeProps}
           baseUrl={baseUrl}
-        />
+        />)}
         <InvitePopover
           api={api}
           association={groupAssociation!}
           baseUrl={baseUrl}
           groups={props.groups}
           contacts={props.contacts}
+          workspace={workspace}
         />
       </>
-    )) ||
-    null;
+    ) 
 
   return (
     <Switch>

--- a/pkg/interface/src/views/landscape/components/InvitePopover.tsx
+++ b/pkg/interface/src/views/landscape/components/InvitePopover.tsx
@@ -11,7 +11,7 @@ import { useOutsideClick } from "~/logic/lib/useOutsideClick";
 import { FormError } from "~/views/components/FormError";
 import { resourceFromPath } from "~/logic/lib/group";
 import GlobalApi from "~/logic/api/global";
-import { Groups, Rolodex } from "~/types";
+import { Groups, Rolodex, Workspace } from "~/types";
 import { ChipInput } from "~/views/components/ChipInput";
 
 interface InvitePopoverProps {
@@ -20,6 +20,7 @@ interface InvitePopoverProps {
   groups: Groups;
   contacts: Rolodex;
   api: GlobalApi;
+  workspace: Workspace;
 }
 
 interface FormSchema {
@@ -46,6 +47,10 @@ export function InvitePopover(props: InvitePopoverProps) {
   useOutsideClick(innerRef, onOutsideClick);
 
   const onSubmit = async ({ ships, emails }: { ships: string[] }, actions) => {
+    if(props.workspace.type === 'home') {
+      history.push(`/~landscape/dm/${ships[0]}`);
+      return;
+    }
     //  TODO: how to invite via email?
     try {
       const resource = resourceFromPath(association["group-path"]);
@@ -97,13 +102,14 @@ export function InvitePopover(props: InvitePopoverProps) {
                 <Col gapY="3" p={3}>
                   <Box>
                     <Text>Invite to </Text>
-                    <Text fontWeight="800">{title}</Text>
+                    <Text fontWeight="800">{title || "DM"}</Text>
                   </Box>
                   <ShipSearch
                     groups={props.groups}
                     contacts={props.contacts}
                     id="ships"
                     label=""
+                    maxLength={props.workspace.type === 'home' ? 1 : undefined}
                   />
                   <FormError message="Failed to invite" />
                   {/* <ChipInput

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -1,38 +1,36 @@
-import React, { useCallback } from "react";
+import React, { useCallback } from 'react';
 import {
   Box,
   ManagedTextInputField as Input,
   Col,
   ManagedRadioButtonField as Radio,
-  Text,
-} from "@tlon/indigo-react";
-import { Formik, Form } from "formik";
-import * as Yup from "yup";
-import GlobalApi from "~/logic/api/global";
-import { AsyncButton } from "~/views/components/AsyncButton";
-import { FormError } from "~/views/components/FormError";
-import { RouteComponentProps } from "react-router-dom";
-import { stringToSymbol } from "~/logic/lib/util";
-import GroupSearch from "~/views/components/GroupSearch";
-import { Associations } from "~/types/metadata-update";
-import { useWaitForProps } from "~/logic/lib/useWaitForProps";
-import { Notebooks } from "~/types/publish-update";
-import { Groups } from "~/types/group-update";
-import { ShipSearch } from "~/views/components/ShipSearch";
-import { Rolodex } from "~/types";
+  Text
+} from '@tlon/indigo-react';
+import { Formik, Form } from 'formik';
+import * as Yup from 'yup';
+import GlobalApi from '~/logic/api/global';
+import { AsyncButton } from '~/views/components/AsyncButton';
+import { FormError } from '~/views/components/FormError';
+import { RouteComponentProps } from 'react-router-dom';
+import { stringToSymbol } from '~/logic/lib/util';
+import { Associations } from '~/types/metadata-update';
+import { useWaitForProps } from '~/logic/lib/useWaitForProps';
+import { Groups } from '~/types/group-update';
+import { ShipSearch } from '~/views/components/ShipSearch';
+import { Rolodex } from '~/types';
 
 interface FormSchema {
   name: string;
   description: string;
   ships: string[];
-  type: "chat" | "publish" | "links";
+  type: 'chat' | 'publish' | 'links';
 }
 
 const formSchema = Yup.object({
-  name: Yup.string().required("Channel must have a name"),
+  name: Yup.string().required('Channel must have a name'),
   description: Yup.string(),
   ships: Yup.array(Yup.string()),
-  type: Yup.string().required("Must choose channel type"),
+  type: Yup.string().required('Must choose channel type')
 });
 
 interface NewChannelProps {
@@ -42,7 +40,6 @@ interface NewChannelProps {
   groups: Groups;
   group?: string;
 }
-
 
 export function NewChannel(props: NewChannelProps & RouteComponentProps) {
   const { history, api, group, workspace } = props;
@@ -54,7 +51,7 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
     try {
       const { name, description, type, ships } = values;
       switch (type) {
-        case "chat":
+        case 'chat':
           const appPath = `/~${window.ship}/${resId}`;
           const groupPath = group || `/ship${appPath}`;
 
@@ -63,46 +60,46 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
             description,
             appPath,
             groupPath,
-            { invite: { pending: ships.map((s) => `~${s}`) } },
-            ships.map((s) => `~${s}`),
+            { invite: { pending: ships.map(s => `~${s}`) } },
+            ships.map(s => `~${s}`),
             true,
             false
           );
           break;
-        case "publish":
+        case 'publish':
           await props.api.publish.newBook(resId, name, description, group);
           break;
-        case "links":
+        case 'links':
           if (group) {
             await api.graph.createManagedGraph(
               resId,
               name,
               description,
               group,
-              "link"
+              'link'
             );
           } else {
             await api.graph.createUnmanagedGraph(
               resId,
               name,
               description,
-              { invite: { pending: ships.map((s) => `~${s}`) } },
-              "link"
+              { invite: { pending: ships.map(s => `~${s}`) } },
+              'link'
             );
           }
           break;
 
         default:
-          console.log("fallthrough");
+          console.log('fallthrough');
       }
 
       if (!group) {
-        await waiter((p) => !!p?.groups?.[`/ship/~${window.ship}/${resId}`]);
+        await waiter(p => Boolean(p?.groups?.[`/ship/~${window.ship}/${resId}`]));
       }
       actions.setStatus({ success: null });
     } catch (e) {
       console.error(e);
-      actions.setStatus({ error: "Channel creation failed" });
+      actions.setStatus({ error: 'Channel creation failed' });
     }
   };
   return (
@@ -113,11 +110,11 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
       <Formik
         validationSchema={formSchema}
         initialValues={{
-          type: "chat",
-          name: "",
-          description: "",
-          group: "",
-          ships: [],
+          type: 'chat',
+          name: '',
+          description: '',
+          group: '',
+          ships: []
         }}
         onSubmit={onSubmit}
       >

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -3,8 +3,8 @@ import React, {
   useMemo,
   useCallback,
   SyntheticEvent,
-  ChangeEvent,
-} from "react";
+  ChangeEvent
+} from 'react';
 import {
   Col,
   Box,
@@ -14,23 +14,23 @@ import {
   Center,
   Button,
   Action,
-  StatelessTextInput as Input,
-} from "@tlon/indigo-react";
-import _ from "lodash";
-import f from "lodash/fp";
-import VisibilitySensor from "react-visibility-sensor";
+  StatelessTextInput as Input
+} from '@tlon/indigo-react';
+import _ from 'lodash';
+import f from 'lodash/fp';
+import VisibilitySensor from 'react-visibility-sensor';
 
-import { Contact, Contacts } from "~/types/contact-update";
-import { Sigil } from "~/logic/lib/sigil";
-import { cite, uxToHex } from "~/logic/lib/util";
-import { Group, RoleTags } from "~/types/group-update";
-import { roleForShip, resourceFromPath } from "~/logic/lib/group";
-import { Association } from "~/types/metadata-update";
-import { useHistory, Link } from "react-router-dom";
-import { Dropdown } from "~/views/components/Dropdown";
-import GlobalApi from "~/logic/api/global";
-import { StatelessAsyncAction } from "~/views/components/StatelessAsyncAction";
-import styled from "styled-components";
+import { Contact, Contacts } from '~/types/contact-update';
+import { Sigil } from '~/logic/lib/sigil';
+import { cite, uxToHex } from '~/logic/lib/util';
+import { Group, RoleTags } from '~/types/group-update';
+import { roleForShip, resourceFromPath } from '~/logic/lib/group';
+import { Association } from '~/types/metadata-update';
+import { useHistory, Link } from 'react-router-dom';
+import { Dropdown } from '~/views/components/Dropdown';
+import GlobalApi from '~/logic/api/global';
+import { StatelessAsyncAction } from '~/views/components/StatelessAsyncAction';
+import styled from 'styled-components';
 
 const TruncText = styled(Box)`
   white-space: nowrap;
@@ -39,7 +39,7 @@ const TruncText = styled(Box)`
 `;
 
 type Participant = Contact & { patp: string; pending: boolean };
-type ParticipantsTabId = "total" | "pending" | "admin";
+type ParticipantsTabId = 'total' | 'pending' | 'admin';
 
 const searchParticipant = (search: string) => (p: Participant) => {
   if (search.length == 0) {
@@ -54,36 +54,36 @@ function getParticipants(cs: Contacts, group: Group) {
   const contacts: Participant[] = _.map(cs, (c, patp) => ({
     ...c,
     patp,
-    pending: false,
+    pending: false
   }));
-  const members: Participant[] = _.map(Array.from(group.members), (m) =>
+  const members: Participant[] = _.map(Array.from(group.members), m =>
     emptyContact(m, false)
   );
-  const allMembers = _.unionBy(contacts, members, "patp");
+  const allMembers = _.unionBy(contacts, members, 'patp');
   const pending: Participant[] =
-    "invite" in group.policy
-      ? _.map(Array.from(group.policy.invite.pending), (m) =>
+    'invite' in group.policy
+      ? _.map(Array.from(group.policy.invite.pending), m =>
           emptyContact(m, true)
         )
       : [];
 
   return [
-    _.unionBy(allMembers, pending, "patp"),
+    _.unionBy(allMembers, pending, 'patp'),
     pending.length,
-    allMembers.length,
+    allMembers.length
   ] as const;
 }
 
 const emptyContact = (patp: string, pending: boolean): Participant => ({
-  nickname: "",
-  email: "",
-  phone: "",
-  color: "",
+  nickname: '',
+  email: '',
+  phone: '',
+  color: '',
   avatar: null,
-  notes: "",
-  website: "",
+  notes: '',
+  website: '',
   patp,
-  pending,
+  pending
 });
 
 const Tab = ({ selected, id, label, setSelected }) => (
@@ -95,7 +95,7 @@ const Tab = ({ selected, id, label, setSelected }) => (
     cursor="pointer"
     onClick={() => setSelected(id)}
   >
-    <Text color={selected === id ? "black" : "gray"}>{label}</Text>
+    <Text color={selected === id ? 'black' : 'gray'}>{label}</Text>
   </Box>
 );
 
@@ -113,18 +113,18 @@ export function Participants(props: {
     (p: Participant) => boolean
   > = useMemo(
     () => ({
-      total: (p) => !p.pending,
-      pending: (p) => p.pending,
-      admin: (p) => props.group.tags?.role?.admin?.has(p.patp),
+      total: p => !p.pending,
+      pending: p => p.pending,
+      admin: p => props.group.tags?.role?.admin?.has(p.patp)
     }),
     [props.group]
   );
 
   const ourRole = roleForShip(props.group, window.ship);
 
-  const [filter, setFilter] = useState<ParticipantsTabId>("total");
+  const [filter, setFilter] = useState<ParticipantsTabId>('total');
 
-  const [search, _setSearch] = useState("");
+  const [search, _setSearch] = useState('');
   const setSearch = useMemo(() => _.debounce(_setSearch, 200), [_setSearch]);
   const onSearchChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -134,7 +134,7 @@ export function Participants(props: {
   );
 
   const adminCount = props.group.tags?.role?.admin?.size || 0;
-  const isInvite = "invite" in props.group.policy;
+  const isInvite = 'invite' in props.group.policy;
 
   const [participants, pendingCount, memberCount] = getParticipants(
     props.contacts,
@@ -156,7 +156,7 @@ export function Participants(props: {
   // TODO: remove when resolved
   const isSafari = useMemo(() => {
     const ua = window.navigator.userAgent;
-    return ua.includes("Safari") && !ua.includes("Chrome");
+    return ua.includes('Safari') && !ua.includes('Chrome');
   }, []);
 
   return (
@@ -166,7 +166,7 @@ export function Participants(props: {
         border={1}
         borderColor="washedGray"
         borderRadius={1}
-        position={isSafari ? "static" : "sticky"}
+        position={isSafari ? 'static' : 'sticky'}
         top="0px"
         mb={2}
         px={2}
@@ -192,7 +192,7 @@ export function Participants(props: {
             selected={filter}
             setSelected={setFilter}
             id="admin"
-            label={`${adminCount} Admin${adminCount > 1 ? "s" : ""}`}
+            label={`${adminCount} Admin${adminCount > 1 ? 's' : ''}`}
           />
         </Row>
       </Row>
@@ -210,8 +210,8 @@ export function Participants(props: {
         </Row>
         <Box
           display="grid"
-          gridAutoRows={["48px 48px 1px", "48px 1px"]}
-          gridTemplateColumns={["48px 1fr", "48px 2fr 1fr", "48px 3fr 1fr"]}
+          gridAutoRows={['48px 48px 1px', '48px 1px']}
+          gridTemplateColumns={['48px 1fr', '48px 2fr 1fr', '48px 3fr 1fr']}
           gridRowGap={2}
           alignItems="center"
         >
@@ -224,7 +224,7 @@ export function Participants(props: {
             >
               {({ isVisible }) =>
                 isVisible ? (
-                  cs.map((c) => (
+                  cs.map(c => (
                     <Participant
                       api={api}
                       key={c.patp}
@@ -261,37 +261,37 @@ function Participant(props: {
   const { title } = association.metadata;
 
   const color = uxToHex(contact.color);
-  const isInvite = "invite" in group.policy;
+  const isInvite = 'invite' in group.policy;
 
   const role = useMemo(
     () =>
       contact.pending
-        ? "pending"
-        : roleForShip(group, contact.patp) || "member",
+        ? 'pending'
+        : roleForShip(group, contact.patp) || 'member',
     [contact, group]
   );
 
   const onPromote = useCallback(async () => {
-    const resource = resourceFromPath(association["group-path"]);
-    await api.groups.addTag(resource, { tag: "admin" }, [`~${contact.patp}`]);
+    const resource = resourceFromPath(association['group-path']);
+    await api.groups.addTag(resource, { tag: 'admin' }, [`~${contact.patp}`]);
   }, [api, association]);
 
   const onDemote = useCallback(async () => {
-    const resource = resourceFromPath(association["group-path"]);
-    await api.groups.removeTag(resource, { tag: "admin" }, [
-      `~${contact.patp}`,
+    const resource = resourceFromPath(association['group-path']);
+    await api.groups.removeTag(resource, { tag: 'admin' }, [
+      `~${contact.patp}`
     ]);
   }, [api, association]);
 
   const onBan = useCallback(async () => {
-    const resource = resourceFromPath(association["group-path"]);
+    const resource = resourceFromPath(association['group-path']);
     await api.groups.changePolicy(resource, {
-      open: { banShips: [`~${contact.patp}`] },
+      open: { banShips: [`~${contact.patp}`] }
     });
   }, [api, association]);
 
   const onKick = useCallback(async () => {
-    const resource = resourceFromPath(association["group-path"]);
+    const resource = resourceFromPath(association['group-path']);
     await api.groups.remove(resource, [`~${contact.patp}`]);
   }, [api, association]);
 
@@ -319,7 +319,7 @@ function Participant(props: {
       </Col>
       <Row
         justifyContent="space-between"
-        gridColumn={["1 / 3", "auto"]}
+        gridColumn={['1 / 3', 'auto']}
         alignItems="center"
       >
         <Col>
@@ -340,7 +340,12 @@ function Participant(props: {
               gapY={2}
               p={2}
             >
-              {props.role === "admin" && (
+              <Action bg="transparent">
+                <Link to={`/~landscape/dm/${contact.patp}`}>
+                  <Text color="green">Send Message</Text>
+                </Link>
+              </Action>
+              {props.role === 'admin' && (
                 <>
                   {!isInvite && (
                     <>
@@ -352,7 +357,7 @@ function Participant(props: {
                     </StatelessAsyncAction>
                     </>
                   )}
-                  {role === "admin" ? (
+                  {role === 'admin' ? (
                     <StatelessAsyncAction onClick={onDemote} bg="transparent">
                       Demote from Admin
                     </StatelessAsyncAction>
@@ -372,7 +377,7 @@ function Participant(props: {
       <Box
         borderBottom={1}
         borderBottomColor="washedGray"
-        gridColumn={["1 / 3", "1 / 4"]}
+        gridColumn={['1 / 3', '1 / 4']}
       />
     </>
   );
@@ -382,7 +387,7 @@ function BlankParticipant({ length }) {
   return (
     <Box
       gridRow={[`auto / span ${3 * length}`, `auto / span ${2 * length}`]}
-      gridColumn={["1 / 3", "1 / 4"]}
+      gridColumn={['1 / 3', '1 / 4']}
       height="100%"
     />
   );

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -119,7 +119,7 @@ export function Sidebar(props: SidebarProps) {
         baseUrl={props.baseUrl}
         workspace={props.workspace}
       />
-      <SidebarListHeader initialValues={config} handleSubmit={setConfig} />
+      <SidebarListHeader initialValues={config} handleSubmit={setConfig} selected={selected || ""} workspace={workspace} />
       {sidebarInvites}
       <SidebarList
         config={config}

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -123,6 +123,7 @@ export function Sidebar(props: SidebarProps) {
       />
       <SidebarListHeader
         contacts={props.contacts} 
+        baseUrl={props.baseUrl}
         groups={props.groups}
         initialValues={config}
         handleSubmit={setConfig}

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Workspace,
   Groups,
   Invites,
+  Rolodex,
 } from "~/types";
 import { SidebarListHeader } from "./SidebarListHeader";
 import { useLocalStorageState } from "~/logic/lib/useLocalStorageState";
@@ -24,6 +25,7 @@ import { roleForShip } from "~/logic/lib/group";
 
 
 interface SidebarProps {
+  contacts: Rolodex;
   children: ReactNode;
   recentGroups: string[];
   invites: Invites ;
@@ -119,7 +121,13 @@ export function Sidebar(props: SidebarProps) {
         baseUrl={props.baseUrl}
         workspace={props.workspace}
       />
-      <SidebarListHeader initialValues={config} handleSubmit={setConfig} selected={selected || ""} workspace={workspace} />
+      <SidebarListHeader
+        contacts={props.contacts} 
+        groups={props.groups}
+        initialValues={config}
+        handleSubmit={setConfig}
+        selected={selected || ""} 
+        workspace={workspace} />
       {sidebarInvites}
       <SidebarList
         config={config}

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -63,18 +63,7 @@ export function SidebarListHeader(props: {
         mr='2'
         display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
       >
-      <Dropdown
-        flexShrink='0'
-        width="200px"
-        alignY="top"
-        alignX={["right", "left"]}
-        options={
-          <FormikOnBlur initialValues={{ ships: [] }} onSubmit={onDm}>
-              <ShipSearch hideSelection groups={props.groups} contacts={props.contacts} id="ships" label="" />
-          </FormikOnBlur>
-        }
-      >
-
+       <Link to="/~landscape/home/invites">
           <Text
             display='inline-block'
             verticalAlign='middle'
@@ -85,7 +74,7 @@ export function SidebarListHeader(props: {
             borderRadius='1'>
               + DM
             </Text>
-          </Dropdown>
+        </Link>
       </Box>
       <Dropdown
         flexShrink='0'

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -21,6 +21,7 @@ export function SidebarListHeader(props: {
   initialValues: SidebarListConfig;
   groups: Groups;
   contacts: Rolodex;
+  baseUrl: string;
   selected: string;
   workspace: Workspace;
   handleSubmit: (c: SidebarListConfig) => void;
@@ -35,14 +36,6 @@ export function SidebarListHeader(props: {
     [props.handleSubmit]
   );
 
-  const onDm = useCallback((values: { ships: string[]; }) => {
-    if(values.ships.length === 0) {
-      return;
-    }
-    const [ship] = values.ships;
-    history.push(`/~landscape/dm/${ship}`);
-  },[history]);
- 
   return (
     <Row
       flexShrink="0"
@@ -63,7 +56,7 @@ export function SidebarListHeader(props: {
         mr='2'
         display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
       >
-       <Link to="/~landscape/home/invites">
+       <Link to={`${props.baseUrl}/invites`}>
           <Text
             display='inline-block'
             verticalAlign='middle'

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -13,14 +13,20 @@ import { FormikOnBlur } from "~/views/components/FormikOnBlur";
 import { Dropdown } from "~/views/components/Dropdown";
 import { FormikHelpers } from "formik";
 import { SidebarListConfig, Workspace } from "./types";
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
+import {ShipSearch} from "~/views/components/ShipSearch";
+import {Groups, Rolodex} from "~/types";
 
 export function SidebarListHeader(props: {
   initialValues: SidebarListConfig;
+  groups: Groups;
+  contacts: Rolodex;
   selected: string;
   workspace: Workspace;
   handleSubmit: (c: SidebarListConfig) => void;
 }) {
+
+  const history = useHistory();
   const onSubmit = useCallback(
     (values: SidebarListConfig, actions: FormikHelpers<SidebarListConfig>) => {
       props.handleSubmit(values);
@@ -29,6 +35,14 @@ export function SidebarListHeader(props: {
     [props.handleSubmit]
   );
 
+  const onDm = useCallback((values: { ships: string[]; }) => {
+    if(values.ships.length === 0) {
+      return;
+    }
+    const [ship] = values.ships;
+    history.push(`/~landscape/dm/${ship}`);
+  },[history]);
+ 
   return (
     <Row
       flexShrink="0"
@@ -49,9 +63,18 @@ export function SidebarListHeader(props: {
         mr='2'
         display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
       >
-        <Link
-          to={`/~landscape/home${props.selected}/dm`}
-        >
+      <Dropdown
+        flexShrink='0'
+        width="200px"
+        alignY="top"
+        alignX={["right", "left"]}
+        options={
+          <FormikOnBlur initialValues={{ ships: [] }} onSubmit={onDm}>
+              <ShipSearch hideSelection groups={props.groups} contacts={props.contacts} id="ships" label="" />
+          </FormikOnBlur>
+        }
+      >
+
           <Text
             display='inline-block'
             verticalAlign='middle'
@@ -61,8 +84,8 @@ export function SidebarListHeader(props: {
             color='blue'
             borderRadius='1'>
               + DM
-          </Text>
-        </Link>
+            </Text>
+          </Dropdown>
       </Box>
       <Dropdown
         flexShrink='0'

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -12,10 +12,13 @@ import {
 import { FormikOnBlur } from "~/views/components/FormikOnBlur";
 import { Dropdown } from "~/views/components/Dropdown";
 import { FormikHelpers } from "formik";
-import { SidebarListConfig } from "./types";
+import { SidebarListConfig, Workspace } from "./types";
+import { Link } from 'react-router-dom';
 
 export function SidebarListHeader(props: {
   initialValues: SidebarListConfig;
+  selected: string;
+  workspace: Workspace;
   handleSubmit: (c: SidebarListConfig) => void;
 }) {
   const onSubmit = useCallback(
@@ -35,12 +38,34 @@ export function SidebarListHeader(props: {
       pr={2}
       pl={3}
     >
-      <Box>
+      <Box flexShrink='0'>
         <Text>
           {props.initialValues.hideUnjoined ? "Joined Channels" : "All Channels"}
         </Text>
       </Box>
+      <Box
+        width='100%'
+        textAlign='right'
+        mr='2'
+        display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
+      >
+        <Link
+          to={`/~landscape/home${props.selected}/dm`}
+        >
+          <Text
+            display='inline-block'
+            verticalAlign='middle'
+            py='1px'
+            px='3px'
+            backgroundColor='washedBlue'
+            color='blue'
+            borderRadius='1'>
+              + DM
+          </Text>
+        </Link>
+      </Box>
       <Dropdown
+        flexShrink='0'
         width="200px"
         alignY="top"
         alignX={["right", "left"]}

--- a/pkg/interface/src/views/landscape/components/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Skeleton.tsx
@@ -12,11 +12,12 @@ import { Path, AppName } from "~/types/noun";
 import { LinkCollections } from "~/types/link-update";
 import styled from "styled-components";
 import GlobalSubscription from "~/logic/subscription/global";
-import { Workspace, Groups, Graphs, Invites } from "~/types";
+import { Workspace, Groups, Graphs, Invites, Rolodex } from "~/types";
 import { useChat, usePublish, useLinks } from "./Sidebar/Apps";
 import { Body } from "~/views/components/Body";
 
 interface SkeletonProps {
+  contacts: Rolodex;
   children: ReactNode;
   recentGroups: string[];
   groups: Groups;
@@ -61,6 +62,7 @@ export function Skeleton(props: SkeletonProps) {
     >
       {!props.hideSidebar && (
         <Sidebar
+          contacts={props.contacts}
           api={props.api}
           recentGroups={props.recentGroups}
           selected={props.selected}

--- a/pkg/interface/src/views/landscape/index.tsx
+++ b/pkg/interface/src/views/landscape/index.tsx
@@ -1,20 +1,17 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { Box, Center } from '@tlon/indigo-react';
 
 import './css/custom.css';
 
-import { PatpNoSig, AppName } from '~/types/noun';
+import { PatpNoSig } from '~/types/noun';
 import GlobalApi from '~/logic/api/global';
 import { StoreState } from '~/logic/store/type';
-import GlobalSubscription from '~/logic/subscription/global';
-import { Resource } from '~/views/components/Resource';
-import { PopoverRoutes } from './components/PopoverRoutes';
-import { UnjoinedResource } from '~/views/components/UnjoinedResource';
 import { GroupsPane } from './components/GroupsPane';
 import { Workspace } from '~/types';
-import {NewGroup} from './components/NewGroup';
-import {JoinGroup} from './components/JoinGroup';
+import { NewGroup } from './components/NewGroup';
+import { JoinGroup } from './components/JoinGroup';
+
+import { cite } from '~/logic/lib/util';
 
 
 type LandscapeProps = StoreState & {
@@ -34,25 +31,46 @@ export default class Landscape extends Component<LandscapeProps, {}> {
     this.props.subscription.startApp('publish');
     this.props.subscription.startApp('graph');
     this.props.api.publish.fetchNotebooks();
-    
+  }
+
+  createandRedirectToDM(api, ship, history, allStations) {
+    const station = `/~${window.ship}/dm--${ship}`;
+    const theirStation = `/~${ship}/dm--${window.ship}`;
+
+    if (allStations.indexOf(station) !== -1) {
+      history.push(`/~landscape/home/resource/chat${station}`);
+      return;
+    }
+
+    if (allStations.indexOf(theirStation) !== -1) {
+      history.push(`/~landscape/home/resource/chat${theirStation}`);
+      return;
+    }
+
+    const groupPath = `/ship/~${window.ship}/dm--${ship}`;
+    const aud = ship !== window.ship ? [`~${ship}`] : [];
+    const title = `${cite(window.ship)} <-> ${cite(ship)}`;
+
+    api.chat.create(
+      title,
+      '',
+      station,
+      groupPath,
+      { invite: { pending: aud } },
+      aud,
+      true,
+      false
+    );
+
+    //  TODO: make a pretty loading state
+    setTimeout(() => {
+      history.push(`/~landscape/home/resource/chat${station}`);
+    }, 5000);
   }
 
   render() {
     const { props } = this;
-
-    const contacts = props.contacts || {};
-    const defaultContacts =
-      (Boolean(props.contacts) && '/~/default' in props.contacts) ?
-        props.contacts['/~/default'] : {};
-
-    const invites =
-      (Boolean(props.invites) && '/contacts' in props.invites) ?
-        props.invites['/contacts'] : {};
-    const s3 = props.s3 ? props.s3 : {};
-    const groups = props.groups || {};
-    const associations = props.associations || {};
-    const { api } = props;
-
+    const { api, inbox } = props;
 
     return (
       <Switch>
@@ -73,7 +91,6 @@ export default class Landscape extends Component<LandscapeProps, {}> {
         <Route path="/~landscape/home"
           render={routeProps => {
             const ws: Workspace = { type: 'home' };
-
             return (
               <GroupsPane workspace={ws} baseUrl="/~landscape/home" {...props} />
             );
@@ -85,21 +102,27 @@ export default class Landscape extends Component<LandscapeProps, {}> {
               <NewGroup
                 groups={props.groups}
                 contacts={props.contacts}
-                api={props.api} 
+                api={props.api}
                 {...routeProps}
               />
             );
           }}
+        />
+        <Route path='/~landscape/dm/:ship?'
+        render={routeProps => {
+          const { ship } = routeProps.match.params;
+          return this.createandRedirectToDM(api, ship, routeProps.history, Object.keys(inbox));
+        }}
         />
         <Route path="/~landscape/join/:ship?/:name?"
           render={routeProps=> {
             const { ship, name } = routeProps.match.params;
             const autojoin = ship && name ? `${ship}/${name}` : null;
             return (
-              <JoinGroup 
+              <JoinGroup
                 groups={props.groups}
                 contacts={props.contacts}
-                api={props.api} 
+                api={props.api}
                 autojoin={autojoin}
                 {...routeProps}
               />


### PR DESCRIPTION
- Places DM creation / redirection logic at `/~landscape/dm/:ship`.
- Pulls 'allStations' prop plumbing out of all the chat components, remove DM creation logic from profile overlay, just redirects to the DM route.
- Restores "Send Message" option in Participants list.

**Still to be done**:

- A general 'DM creation' prompt — part of me wondered if it would be easier to just weave in "Direct Message" instead of "Chat" when in NewChannel.tsx in the home workspace, but I don't know how to make Formik less aggressive about required values (much as it is with Publish).

That is, we want it to only prompt us to name the chat if there's multiple members in the direct message; if there's only one participant, we want to just ship it over to the "new / redirect DM" route.

I also thought we could write a Popover for inputting a ship? Unsure atm how we could most succinctly write a modal to take a single ship and redirect us.