### PR TITLE
clay: add %ce scry for static dais

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:808cc6a28842ab8cde540de14cf0663ef3c6e7cff7c4c5bf5bbb0bb43ec1894d
-size 6329173
+oid sha256:3e4c7cbdf0d3115c3e507a63a6c0a1a7c275c02eed71adb8395e3df9d82487aa
+size 19047616

--- a/pkg/arvo/mar/txt.hoon
+++ b/pkg/arvo/mar/txt.hoon
@@ -23,6 +23,7 @@
 ++  grad
   |%
   ++  form  %txt-diff
+  ++  dorm  (urge cord)
   ++  diff
     |=  tyt/wain
     ^-  (urge cord)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -611,6 +611,45 @@
         ^+  sam
         [p:bunt noun]
       --
+    ::  +get-says: get staticized mark definition
+    ::
+    ::  TODO: cache?
+    ::
+    ++  get-says
+      |=  mak=mark
+      ^-  [vase state]
+      =^  cor=vase  nub  (build-fit %mar mak)
+      =^  =dais  nub  (get-mark mak)
+      =/  sut  :(slop !>(day=dais) cor(p [%face %raw p.cor]) !>(..zuse))
+      =/  =hoon
+        :^  %tsnt  %typ  !,(*hoon noun:grab:raw)
+        :^  %tsnt  %dif  !,(*hoon dorm:grad:raw)
+        !,  *hoon
+        ^-  (says:clay typ dif)
+        |_  sam=typ
+        +*  d  ~(. day !>(sam))
+        ++  bunt  !<(typ bunt:d)
+        ++  diff  |=(typ !<(dif (diff:d !>(+<))))
+        ++  form  form:d
+        ++  join
+          |=  [a=dif b=dif]
+          ^-  (unit (unit dif))
+          =/  r  (join:d !>(a) !>(b))
+          ?~  r  ~
+          ?~  u.r  `~
+          ``!<(dif u.u.r)
+        ::
+        ++  mash
+          |=  [[=a=ship =a=desk a=dif] [=b=ship =b=desk b=dif]]
+          =/  r  (mash:d [a-ship a-desk !>(a)] [b-ship b-desk !>(b)])
+          ?~  r  ~
+          `!<(dif u.r)
+        ::
+        ++  pact  |=(dif !<(typ (pact:d !>(+<))))
+        ++  vale  |=(noun !<(typ (vale:d +<)))
+        ++  volt  |=(noun !<(typ (volt:d +<)))
+        --
+      [(slap sut hoon) nub]
     ::  +get-cast: produce a $tube mark conversion gate from .a to .b
     ::
     ++  get-cast
@@ -2743,6 +2782,7 @@
           $b  ~|  %i-guess-you-ought-to-build-your-own-marks  !!
           $c  ~|  %casts-should-be-compiled-on-your-own-ship  !!
           $d  ~|  %totally-temporary-error-please-replace-me  !!
+          $e  ~|  %even-static-dais-should-not-cross-network  !!
           $p  ~|  %requesting-foreign-permissions-is-invalid  !!
           $r  ~|  %no-cages-please-they-are-just-way-too-big  !!
           $s  ~|  %please-dont-get-your-takos-over-a-network  !!
@@ -3544,6 +3584,23 @@
         (get-cast:(ford:fusion static-ford-args) [i i.t]:path)
       :_(fod.dom [~ ~ %& %tube !>(tube)])
     ::
+    ++  read-e
+      !.
+      |=  [=aeon =path]
+      ^-  [(unit (unit (each cage lobe))) ford-cache]
+      ?.  =(aeon let.dom)
+        [~ fod.dom]
+      ?.  ?=([@ ~] path)
+        [[~ ~] fod.dom]
+      ::  TODO: cache?
+      ::  =/  cached=(unit [=tube *])  (~(get by casts.fod.dom) [i i.t]:path)
+      ::  ?^  cached
+      ::    :_(fod.dom [~ ~ %& %tube !>(tube.u.cached)])
+      =^  =vase  fod.dom
+        %-  wrap:fusion
+        (get-says:(ford:fusion static-ford-args) i.path)
+      :_(fod.dom [~ ~ %& %says vase])
+    ::
     ::  Gets the permissions that apply to a particular node.
     ::
     ::  If the node has no permissions of its own, we use its parent's.
@@ -3904,6 +3961,7 @@
         %a  (read-a yon path.mun)
         %b  (read-b yon path.mun)
         %c  (read-c yon path.mun)
+        %e  (read-e yon path.mun)
         %p  :_(fod (read-p path.mun))
         %r  :_(fod (bind (read-r yon path.mun) (lift |=(a=cage [%& a]))))
         %s  :_(fod (bind (read-s yon path.mun) (lift |=(a=cage [%& a]))))

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -883,7 +883,7 @@
     $:  face=(unit term)
         file-path=term
     ==
-  ++  care  ?($a $b $c $d $p $r $s $t $u $v $w $x $y $z)  ::  clay submode
+  ++  care  ?($a $b $c $d $e $p $r $s $t $u $v $w $x $y $z)  ::  clay submode
   ++  case                                              ::  ship desk case spur
     $%  {$da p/@da}                                     ::  date
         {$tas p/@tas}                                   ::  label
@@ -1046,6 +1046,23 @@
       |~  [a=[ship desk diff=vase] b=[ship desk diff=vase]]
       *(unit vase)
     ++  pact  |~(diff=vase sam)
+    ++  vale  |~(noun sam)
+    ++  volt  |~(noun sam)
+    --
+  ::  $says: static dais
+  ::
+  ++  says
+    |*  [typ=mold dif=mold]
+    $_  ^|
+    |_  sam=typ
+    ++  bunt  sam
+    ++  diff  |~(typ *dif)
+    ++  form  *mark
+    ++  join  |~([dif dif] *(unit (unit dif)))
+    ++  mash
+      |~  [a=[ship desk dif] b=[ship desk dif]]
+      *(unit dif)
+    ++  pact  |~(dif sam)
     ++  vale  |~(noun sam)
     ++  volt  |~(noun sam)
     --


### PR DESCRIPTION
If you know the type of a mark statically, then you can skip all the
vases and get a +says ("static dais").  This does not work if you don't
know the type at compile time since we don't polymorphize that way, so
in that case continue to use a +dais.

With this preamble:

```
=orig ~['line1' 'line2' 'line3']
=diff [%& 1] [%| ~['line2'] ~['newline2']] [%& 1] ~
```

With a dais, applying a diff looks like:

```
=/  dais  .^(dais:clay %cb %/txt)
!<(wain (~(pact dais !>(orig)) !>(diff)))

<|line1 newline2 line3|> 
```

And with a says:

```
=/  says  .^((says:clay wain (urge:clay cord)) %ce %/txt)
(~(pact says orig) diff)

<|line1 newline2 line3|> 
```