### PR TITLE
landscape: add 'admin only' check to groupify form

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/GroupifyForm.tsx
+++ b/pkg/interface/src/views/apps/publish/components/GroupifyForm.tsx
@@ -64,7 +64,9 @@ export function GroupifyForm(props: GroupifyFormProps) {
           id="group"
           label="Group"
           caption="What group should this notebook be added to? If blank, a new group will be made for the notebook"
+          groups={props.groups}
           associations={props.associations}
+          adminOnly
         />
         <AsyncButton loadingText="Groupifying..." border>
           Groupify

--- a/pkg/interface/src/views/components/GroupSearch.tsx
+++ b/pkg/interface/src/views/components/GroupSearch.tsx
@@ -4,11 +4,16 @@ import _ from "lodash";
 import { useField } from "formik";
 import styled from "styled-components";
 
+import { roleForShip } from "~/logic/lib/group";
+
 import { DropdownSearch } from "./DropdownSearch";
+import { Groups } from "~/types";
 import { Associations, Association } from "~/types/metadata-update";
 
 interface InviteSearchProps {
   disabled?: boolean;
+  adminOnly: boolean;
+  groups: Groups;
   associations: Associations;
   label: string;
   caption?: string;
@@ -59,7 +64,18 @@ function renderCandidate(
 
 export function GroupSearch(props: InviteSearchProps) {
   const groups = useMemo(
-    () => Object.values(props.associations?.contacts || {}),
+    () => {
+      return props.adminOnly
+        ? Object.values(
+          Object.keys(props.associations?.contacts)
+          .filter(e => roleForShip(props.groups[e], window.ship) === 'admin')
+          .reduce((obj, key) => {
+            obj[key] = props.associations?.contacts[key]
+            return obj;
+          }, {}) || {}
+        )
+        : Object.values(props.associations?.contacts || {});
+    },
     [props.associations?.contacts]
   );
 
@@ -97,7 +113,7 @@ export function GroupSearch(props: InviteSearchProps) {
       onSelect={onSelect}
       onRemove={onRemove}
       renderChoice={({ candidate, onRemove }) => (
-        <Box px={2} py={1} border={1} borderColor="washedGrey" color="black" fontSize={0}>
+        <Box cursor='default' px={2} py={1} border={1} borderColor="washedGrey" color="black" fontSize={0}>
           {candidate.metadata.title}
           <ClickableText ml={2} onClick={onRemove} color="black">
             x


### PR DESCRIPTION
Part of #3704 work — just only lists groups we admin in the groupify list if we pass `adminOnly` as a prop.

Side note: Currently only Publish has a groupify form at all, so might want to take a sec and add it to the other unmanaged settings pages again...