### PR TITLE
graph-js: normalize keys in reducer

### DIFF
--- a/pkg/interface/src/logic/reducers/graph-update.js
+++ b/pkg/interface/src/logic/reducers/graph-update.js
@@ -39,6 +39,7 @@ const addGraph = (json, state) => {
     //  is empty
     if (!node.children) {
       node.children = new OrderedMap();
+      node.post.originalIndex = node.post.index;
       node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
       return node;
     }
@@ -52,13 +53,17 @@ const addGraph = (json, state) => {
       });
 
       if (index.length === 0) { break; }
+
+      const normalKey = normalizeKey(index[index.length - 1]);
+      item[1].post.originalKey = index[index.length - 1];
       
       converted.set(
-        normalizeKey(index[index.length - 1]),
+        normalKey,
         _processNode(item[1])
       );
     }
     node.children = converted;
+    node.post.originalIndex = node.post.index;
     node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
     return node;
   };
@@ -81,7 +86,10 @@ const addGraph = (json, state) => {
       if (index.length === 0) { break; }
       
       let node = _processNode(item[1]);
-      state.graphs[resource].set(normalizeKey(index[index.length - 1]), node);
+
+      const normalKey = normalizeKey(index[index.length - 1])
+      node.post.originalKey = index[index.length - 1];
+      state.graphs[resource].set(normalKey, node);
     }
     state.graphKeys.add(resource);
   }
@@ -111,13 +119,17 @@ const addNodes = (json, state) => {
   const _addNode = (graph, index, node) => {
     //  set child of graph
     if (index.length === 1) {
+      node.post.originalIndex = node.post.index;
       node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
-      graph.set(normalizeKey(index[0]), node);
+
+      const normalKey = normalizeKey(index[0])
+      node.post.originalKey = index[0];
+      graph.set(normalKey, node);
       return graph;
     }
 
     // set parent of graph
-    let parNode = graph.get(index[0]);
+    let parNode = graph.get(normalizeKey(index[0]));
     if (!parNode) {
       console.error('parent node does not exist, cannot add child');
       return;
@@ -162,7 +174,7 @@ const removeNodes = (json, state) => {
     if (index.length === 1) {
         graph.delete(index[0]);
       } else {
-        const child = graph.get(index[0]);
+        const child = graph.get(normalizeKey(index[0]));
         _remove(child.children, index.slice(1));
         graph.set(normalizeKey(index[0]), child);
       }

--- a/pkg/interface/src/logic/reducers/graph-update.js
+++ b/pkg/interface/src/logic/reducers/graph-update.js
@@ -7,7 +7,7 @@ const normalizeKey = (key) => {
     // new links uses milliseconds since unix epoch
     // old (pre-graph-store) use @da
     // ported from +time:enjs:format in hoon.hoon
-    return (1000 * (9223372036854775 + (key - DA_UNIX_EPOCH))) / 18446744073709551616;
+    return Math.round((1000 * (9223372036854775 + (key - DA_UNIX_EPOCH))) / 18446744073709551616);
   }
   return key;
 }
@@ -39,6 +39,7 @@ const addGraph = (json, state) => {
     //  is empty
     if (!node.children) {
       node.children = new OrderedMap();
+      node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
       return node;
     }
 
@@ -58,6 +59,7 @@ const addGraph = (json, state) => {
       );
     }
     node.children = converted;
+    node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
     return node;
   };
 
@@ -109,6 +111,7 @@ const addNodes = (json, state) => {
   const _addNode = (graph, index, node) => {
     //  set child of graph
     if (index.length === 1) {
+      node.post.index = node.post.index.split('/').map(x => x.length === 0 ? '' : normalizeKey(parseInt(x, 10))).join('/');
       graph.set(normalizeKey(index[0]), node);
       return graph;
     }

--- a/pkg/interface/src/logic/reducers/graph-update.js
+++ b/pkg/interface/src/logic/reducers/graph-update.js
@@ -6,6 +6,7 @@ const normalizeKey = (key) => {
   if(key > DA_UNIX_EPOCH) {
     // new links uses milliseconds since unix epoch
     // old (pre-graph-store) use @da
+    // ported from +time:enjs:format in hoon.hoon
     return (1000 * (9223372036854775 + (key - DA_UNIX_EPOCH))) / 18446744073709551616;
   }
   return key;
@@ -14,7 +15,6 @@ const normalizeKey = (key) => {
 export const GraphReducer = (json, state) => {
   const data = _.get(json, 'graph-update', false);
   if (data) {
-    console.log(data);
     keys(data, state);
     addGraph(data, state);
     removeGraph(data, state);
@@ -143,7 +143,6 @@ const addNodes = (json, state) => {
 
       item[1].children = mapifyChildren(item[1].children || []);
 
-      console.log(index);
 
       
       state.graphs[resource] = _addNode(
@@ -167,13 +166,11 @@ const removeNodes = (json, state) => {
   };
   const data = _.get(json, 'remove-nodes', false);
   if (data) {
-    console.log(data);
     const { ship, name } = data.resource;
     const res = `${ship}/${name}`;
     if (!(res in state.graphs)) { return; }
 
     data.indices.forEach((index) => {
-      console.log(index);
       if (index.split('/').length === 0) { return; }
       let indexArr = index.split('/').slice(1).map((ind) => {
         return parseInt(ind, 10);

--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -124,7 +124,7 @@ export function LinkResource(props: LinkResourceProps) {
                     name={name}
                     ship={ship}
                     api={api}
-                    parentIndex={node.post.index}
+                    parentIndex={node.post.originalIndex}
                   />
                 </Row>
                 <Comments


### PR DESCRIPTION
Pre-graph-store links that were brought over use @da as their index,
however new links use a unix timestamp as their index. Pending a proper
fix, we instead just normalize all the indexes to be unix timestamps
inside the reducer.