### PR TITLE
ames: updates forward-lane scry-handling to prevent routing loops

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -785,23 +785,35 @@
       ~  ``noun+!>(u.peer)
     ::
         [%forward-lane ~]
-      ::  find lane for u.who, or their galaxy
+      ::
+      ::  this duplicates the routing hack from +send-blob:event-core
+      ::  so long as neither the peer nor the peer's sponsoring galaxy is us:
+      ::
+      ::    - no route to the peer: send to the peer's sponsoring galaxy
+      ::    - direct route to the peer: use that
+      ::    - indirect route to the peer: send to both that route and the
+      ::      the peer's sponsoring galaxy
       ::
       :^  ~  ~  %noun
       !>  ^-  (list lane)
-      =/  ship-state  (~(get by peers.ames-state) u.who)
-      ?.  ?=([~ %known *] ship-state)
+      ?.  ?&  ?=([~ %known *] peer)
+              !=(our u.who)
+          ==
         ~
-      =/  peer-state  +.u.ship-state
-      ?.  =(~ route.peer-state)  ::NOTE  avoid tmi
-        [lane:(need route.peer-state)]~
-      |-  ^-  (list lane)
-      ?:  ?=(%czar (clan:title sponsor.peer-state))
-        [%& sponsor.peer-state]~
-      =/  next  (~(get by peers.ames-state) sponsor.peer-state)
+      =;  zar=(trap (list lane))
+        ?~  route.u.peer  $:zar
+        =*  rot  u.route.u.peer
+        ?:(direct.rot [lane.rot ~] [lane.rot $:zar])
+      ::
+      |.  ^-  (list lane)
+      ?:  ?=(%czar (clan:title sponsor.u.peer))
+        ?:  =(our sponsor.u.peer)
+          ~
+        [%& sponsor.u.peer]~
+      =/  next  (~(get by peers.ames-state) sponsor.u.peer)
       ?.  ?=([~ %known *] next)
         ~
-      $(peer-state +.u.next)
+      $(peer next)
     ==
   ::
       [%bones @ ~]


### PR DESCRIPTION
To help avoid routing loops (see #3778), this PR updates the %ames' `/peer/<ship>/forward-lane` scry handler to exclude ourselves from possible routing targets. To precisely match the forwarding semantics in `+send-blob:event-core`, it also produces both the peer's and peer's sponsoring galaxy's routes, when the route to the peer is indirect.

