### PR TITLE
clock: always draw large arc

### DIFF
--- a/pkg/interface/src/views/apps/launch/components/tiles/clock.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/clock.js
@@ -107,7 +107,7 @@ const SvgArc = ({ start, end, ...rest }) => {
   const d = [
     'M', CX, CY,
     'L', x1, y1,
-    'A', RADIUS, RADIUS, '0', (isLarge ? '1' : '0'), '1', x2, y2, 'z'
+    'A', RADIUS, RADIUS, '0', '1', '1', x2, y2, 'z'
   ].join(' ');
 
   return <path d={d} {...rest} />;


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/110 (again)

SVG arc spec has a flag to draw "a large arc" which is what caused the bulbing out needing a mask. If we weren't masking, we'd want to be particular about when to draw a large arc and when not to. But if we don't draw a large arc, and we're supposed to, we get the emaciated behavior shown in the last comment on 110.

Normally you'd just get the distance of the arc and if it's greater than 180 you'd set the flag. But because we're dealing with angles that are greatly above 360 or below 0, instead of doing all the clamping and `Math.abs`ing, let's just always draw the large arc and mask out the overflow.

![tmyk](https://images2.minutemediacdn.com/image/upload/c_crop,h_1123,w_2000,x_0,y_111/v1554921495/shape/mentalfloss/550096-youtube_0.jpg?itok=ISWUTWlz)

> For with much wisdom comes much sorrow; the more knowledge, the more grief.