### PR TITLE
u3: remove timestamp printing in u3v_time()

### DIFF
--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -10,7 +10,7 @@
         c3_d    ent_d;                    //  event number
         u3_noun yot;                      //  cached gates
         u3_noun now;                      //  current time, as noun
-        u3_noun wen;                      //  current time, as text
+        u3_noun wen;                      //  current time, as text, XX remove
         u3_noun sev_l;                    //  instance number
         u3_noun sen;                      //  instance string
         u3_noun roc;                      //  kernel core

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1689,6 +1689,14 @@ u3m_boot(c3_c* dir_c)
     u3j_ream();
     u3n_ream();
 
+    //  XX unused, removed
+    //
+    //    u3z() temporarily preserved to avoid leaking
+    //    checkpointed values
+    //
+    u3z(u3A->wen);
+    u3A->wen = 0;
+
     return u3A->ent_d;
   }
   else {

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -164,14 +164,6 @@ u3v_time(u3_noun now)
 {
   u3z(u3A->now);
   u3A->now = now;
-
-  //  XX unused, removed
-  //
-  //    u3z() temporarily preserved to avoid leaking
-  //    checkpointed values
-  //
-  u3z(u3A->wen);
-  u3A->wen = 0;
 }
 
 /* u3v_numb(): set the instance number.

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -165,8 +165,13 @@ u3v_time(u3_noun now)
   u3z(u3A->now);
   u3A->now = now;
 
+  //  XX unused, removed
+  //
+  //    u3z() temporarily preserved to avoid leaking
+  //    checkpointed values
+  //
   u3z(u3A->wen);
-  u3A->wen = _cv_scot(u3nc(c3__da, u3k(u3A->now)));
+  u3A->wen = 0;
 }
 
 /* u3v_numb(): set the instance number.


### PR DESCRIPTION
This PR is a substantial performance improvement for the vere king.

On every turn of the libuv event loop, we update a global `@da` timestamp, so that all i/o drivers can have a consistent view of time. The function that we use to do so (`u3v_time()`) was also formatting that same timestamp, through a nock call to hoon's atom (`$coin`) printer. That's an expensive call, with no relevant high level jets (at the moment, see #2853). But, even worse, that formatted timestamp was never read or used anywhere.

I discovered this issue while debugging the network forwarding loop reported in #3778. So I used the loop as a simple performance test. As the following flame graph makes clear, samples were dominated by `u3v_time()`.

<img width="1207" alt="before" src="https://user-images.githubusercontent.com/702304/97052728-66ad9000-1536-11eb-92df-c37cccd137f4.png">

Those samples were taken roughly every millisecond, for around 90 seconds. In that time, my fake ~zod forwarded over 400K packets.

Compare with timestamp printing removed:

<img width="1193" alt="after" src="https://user-images.githubusercontent.com/702304/97052717-63b29f80-1536-11eb-8392-d1bdff83fa37.png">

In those roughly 30 seconds, my fake ~zod forwarded over 2 million packets.

