### PR TITLE
leap: return 'other' first, lowercase groups

### DIFF
--- a/pkg/interface/src/views/components/leap/Omnibox.js
+++ b/pkg/interface/src/views/components/leap/Omnibox.js
@@ -55,7 +55,7 @@ export class Omnibox extends Component {
   }
 
   getSearchedCategories() {
-    return ['commands', 'groups', 'subscriptions', 'apps', 'other'];
+    return ['other', 'commands', 'groups', 'subscriptions', 'apps'];
   }
 
   control(evt) {
@@ -154,7 +154,7 @@ export class Omnibox extends Component {
             result.title.toLowerCase().includes(query) ||
             result.link.toLowerCase().includes(query) ||
             result.app.toLowerCase().includes(query) ||
-            (result.host !== null ? result.host.includes(query) : false)
+            (result.host !== null ? result.host.toLowerCase().includes(query) : false)
           );
         })
       );


### PR DESCRIPTION
- Return 'other' results first because "Home" was getting buried by channels when those types of results should be returned first (though exact results should also always be weighted, see #3705)
- Searching for group names was accidentally case sensitive; now it's not.