### PR TITLE
chat: indigo-react inline code

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/content/code.js
@@ -20,7 +20,7 @@ export default class CodeContent extends Component {
           maxHeight='10em'
           maxWidth='100%'
           style={{ whiteSpace: 'pre' }}
-          backgroundColor='scales.black10'
+          backgroundColor='washedGray'
         >
           {content.code.output[0].join('\n')}
         </Text>

--- a/pkg/interface/src/views/apps/chat/components/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/content/text.js
@@ -24,10 +24,30 @@ const DISABLED_INLINE_TOKENS = [
   'reference'
 ];
 
+const renderers = {
+  inlineCode: ({language, value}) => {
+    return <Text mono fontSize='14px' backgroundColor='washedGray' style={{ whiteSpace: 'preWrap'}}>{value}</Text>
+  },
+  code: ({language, value}) => {
+    return <Text
+              py='1'
+              className='clamp-message'
+              fontSize='14px'
+              display='block'
+              mono
+              backgroundColor='washedGray'
+              overflowX='scroll'
+              style={{ whiteSpace: 'pre'}}>
+              {value}
+            </Text>
+  }
+};
+
 const MessageMarkdown = React.memo(props => (
   <ReactMarkdown
     {...props}
     unwrapDisallowed={true}
+    renderers={renderers}
     allowNode={(node, index, parent) => {
       if (
         node.type === 'blockquote'

--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -225,16 +225,7 @@ blockquote {
   font-size: 14px;
 }
 
-pre, code {
-  background-color: var(--light-gray);
-}
-
-pre code {
-  background-color: transparent;
-  white-space: pre-wrap;
-}
-
-code, .code, .chat.code .react-codemirror2 .CodeMirror * {
+.chat.code .react-codemirror2 .CodeMirror * {
   font-family: 'Source Code Pro';
 }
 


### PR DESCRIPTION
Wraps inline / blocked code in indigo-react components to match our theme; rely less on custom CSS, etc. See urbit/landscape#124.

Kudos @tylershuster (and yes, I did test to avoid overflow regressions ...)

<img width="1032" alt="Screen Shot 2020-10-23 at 5 52 22 PM" src="https://user-images.githubusercontent.com/20846414/97057576-8dc98900-1559-11eb-9d03-f80e4b460ffa.png">
<img width="1015" alt="Screen Shot 2020-10-23 at 5 55 51 PM" src="https://user-images.githubusercontent.com/20846414/97057578-8e621f80-1559-11eb-9fa1-1baf99658596.png">
