### PR TITLE
eyre: produce moves in correct order

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1585,7 +1585,7 @@
         ==
       =?  next-id   kicking  +(next-id)
       ::
-      :-  moves
+      :-  (flop moves)
       %_    state
           session.channel-state
         %+  ~(put by session.channel-state.state)  channel-id

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -1849,7 +1849,7 @@
             ~
         ==
       ^=  expected-moves
-      ~  ::NOTE  tested elsewher
+      ~  ::NOTE  tested elsewhere
     ==
   ::  user gets sent multiple subscription results
   ::
@@ -1889,24 +1889,6 @@
         ==
       ^=  moves
         :~  :*  duct=~[/http-get-open]
-                %give
-                %response
-                %continue
-                :-  ~
-                %-  as-octt:mimes:html
-                """
-                id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
-                data: \{"id":1,"response":"quit"}
-
-
-                """
-                complete=%.n
-            ==
-            :*  duct=~[/http-put-request]  %pass
-              /channel/subscription/'0123456789abcdef'/'1'/~nul/two
-              %g  %deal  [~nul ~nul]  %two  %leave  ~
-            ==
-            :*  duct=~[/http-get-open]
               %give
               %response
               %continue
@@ -1919,6 +1901,24 @@
 
               """
               complete=%.n
+            ==
+            :*  duct=~[/http-put-request]  %pass
+              /channel/subscription/'0123456789abcdef'/'1'/~nul/two
+              %g  %deal  [~nul ~nul]  %two  %leave  ~
+            ==
+            :*  duct=~[/http-get-open]
+                %give
+                %response
+                %continue
+                :-  ~
+                %-  as-octt:mimes:html
+                """
+                id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
+                data: \{"id":1,"response":"quit"}
+
+
+                """
+                complete=%.n
             ==
         ==
     ==


### PR DESCRIPTION
I double-confused myself. The comment here made me think I was fine just storing the moves in reverse order, but of course I have to _produce_ them in the correct order. Also Arvo uses sane move order, so the test was wrong to begin with.

https://github.com/urbit/urbit/blob/235bfbbd2faf3184481558bad09108a8f69e91c3/pkg/arvo/sys/vane/eyre.hoon#L1050-L1052
