### PR TITLE
launch: filter out metadata for deleted groups

### DIFF
--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -76,7 +76,11 @@ export default class LaunchApp extends React.Component {
               weather={props.weather}
             />
           </Box>
-          <Groups associations={props.associations} invites={props.invites} api={props.api} />
+          <Groups
+            associations={props.associations}
+            groups={props.groups}
+            invites={props.invites}
+            api={props.api} />
         </Box>
         <Box
           position="absolute"

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { Box, Text } from "@tlon/indigo-react";
-import { Link } from "react-router-dom";
 
-import { useLocalStorageState } from "~/logic/lib/useLocalStorageState";
 import { Associations, Association } from "~/types";
 import { alphabeticalOrder } from "~/logic/lib/util";
 import Tile from '../components/tiles/tile';
@@ -23,6 +21,7 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
   }
 
   const groups = Object.values(associations?.contacts || {})
+    .filter(e => e['group-path'] in props.groups)
     .sort(sortGroupsAlph);
 
   const acceptInvite = (invite) => {


### PR DESCRIPTION
A front-end fix for #3800 until urbit/landscape#72 lands.

The launch screen iterates through `associations.contacts` to list group tiles; by using our metadata-store instead of the group-store, it inherits the "group metadata isn't deleted" bug in #2992. To the user, this is confusing — groups they're kicked out of and groups they delete alike will still persist on the launch screen (but groups they manually leave will correctly tell metadata-store to delete the data?), so it appears as though the group itself cannot be deleted.

This PR passes our groups into that logic and filters the metadata to verify we only list groups we currently actually have.