### PR TITLE
no more impostor comets

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1046,6 +1046,9 @@
   ++  on-hear-open
     |=  [=lane =packet ok=?]
     ^+  event-core
+    ::  assert the comet can't pretend to be a moon or other address
+    ::
+    ?>  (lth 64 (met 0 sndr.packet))
     ::  if we already know .sndr, ignore duplicate attestation
     ::
     =/  ship-state  (~(get by peers.ames-state) sndr.packet)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1048,7 +1048,7 @@
     ^+  event-core
     ::  assert the comet can't pretend to be a moon or other address
     ::
-    ?>  (lth 64 (met 0 sndr.packet))
+    ?>  ?=(%pawn (clan:title sndr.packet))
     ::  if we already know .sndr, ignore duplicate attestation
     ::
     =/  ship-state  (~(get by peers.ames-state) sndr.packet)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -9176,7 +9176,7 @@
     =/  who=ship  `@`fig:ex:cub
     ::  disallow 64-bit or smaller addresses
     ::
-    ?:  (gte 64 (met 0 sndr.packet))
+    ?.  ?=(%pawn (clan:title who))
       $(eny +(eny))
     ?:  (~(has in stars) (^sein:title who))
       [who 1 sec:ex:cub ~]

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -9174,6 +9174,10 @@
     |-  ^-  seed:able:jael
     =/  cub=acru:ames  (pit:nu:crub:crypto 512 eny)
     =/  who=ship  `@`fig:ex:cub
+    ::  disallow 64-bit or smaller addresses
+    ::
+    ?:  (gte 64 (met 0 sndr.packet))
+      $(eny +(eny))
     ?:  (~(has in stars) (^sein:title who))
       [who 1 sec:ex:cub ~]
     $(eny +(eny))


### PR DESCRIPTION
Only treat an address as a comet if it's bigger than 64 bits.  Otherwise, a comet could impersonate a different kind of ship, which posed security problems.  This PR changes comet generation in Zuse, and comet validation in Ames.  I'm not aware of other places where this validation would be necessary, but it's possible others exist.