### PR TITLE
king: cancel http servers immediately on shutdown.

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
@@ -344,9 +344,9 @@ eyre env who plan isFake stderr = (initialEvents, runHttpServer)
   kill :: HasLogFunc e => Serv -> RIO e ()
   kill Serv{..} = do
     atomically (leaveMultiEyre multi who)
-    atomically (saKil sLop)
-    atomically (saKil sIns)
-    for_ sSec (\sec -> atomically (saKil sec))
+    io (saKil sLop)
+    io (saKil sIns)
+    io $ for_ sSec (\sec -> (saKil sec))
     io (removePortsFile sPortsFile)
 
   restart :: Drv -> HttpServerConf -> RIO e Serv

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
@@ -45,7 +45,7 @@ data MultiEyreApi = MultiEyreApi
   , meaPlan :: TVar (Map Ship OnMultiReq)
   , meaCanc :: TVar (Map Ship OnMultiKil)
   , meaTlsC :: TVar (Map Ship (TlsConfig, Credential))
-  , meaKill :: STM ()
+  , meaKill :: IO ()
   }
 
 


### PR DESCRIPTION
This should fix the problem where shutting down urbit-king, and then immediately starting it up again changes the http port. I hit this all the time and it is super annoying.

Fixes #3822 