### PR TITLE
Revert "eyre: ignore facts directly after clog"

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1500,14 +1500,6 @@
       ?~  channel
         :_  state  :_  ~
         [duct %pass /flog %d %flog %crud %eyre-no-channel >id=channel-id< ~]
-      ::  it's possible that this is a fact emitted directly alongside a fact
-      ::  that triggered a clog & closed the subscription. in that case, just
-      ::  drop the fact.
-      ::
-      ?:  ?&  ?=(%fact -.sign)
-              !(~(has by subscriptions.u.channel) request-id)
-          ==
-        [~ state]
       ::  attempt to convert the sign to json.
       ::  if conversion succeeds, we *can* send it. if the client is actually
       ::  connected, we *will* send it immediately.

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -1875,7 +1875,7 @@
     loop-fact(cur +(cur))
   ::  the next subscription result should trigger a clog
   ::
-  =^  results1  eyre-gate
+  =^  results  eyre-gate
     %:  eyre-take
       eyre-gate
       now
@@ -1922,25 +1922,7 @@
             ==
         ==
     ==
-  ::  subsequent subscription updates, which might have gotten sent out during
-  ::  the same event in which a clog triggered, should be silently ignored
-  ::
-  =^  results2  eyre-gate
-    %:  eyre-take
-      eyre-gate
-      now
-      scry=scry-provides-code
-      ^=  take-args
-        :*  wire=/channel/subscription/'0123456789abcdef'/'1'/~nul/two
-            duct=~[/http-put-request]
-            ^-  (hypo sign:eyre-gate)
-            :-  *type
-            [%g %unto %fact %json !>(`json`[%a [%n '1'] ~])]
-        ==
-      ^=  moves
-        ~
-    ==
-  (weld results1 results2)
+  results
 ::
 ++  test-born-sends-pending-cancels
   ::


### PR DESCRIPTION
Reverts urbit/urbit#3799. It was accidentally merged into master, but should've targetted next-sys instead. Reverting to regain parity between master and livenet.