### PR TITLE
king: increase lmdb max mmap size for parity with vere

### DIFF
--- a/pkg/hs/urbit-eventlog-lmdb/lib/Urbit/EventLog/LMDB.hs
+++ b/pkg/hs/urbit-eventlog-lmdb/lib/Urbit/EventLog/LMDB.hs
@@ -100,7 +100,7 @@ rawOpen :: MonadIO m => FilePath -> m Env
 rawOpen dir = io $ do
     env <- mdb_env_create
     mdb_env_set_maxdbs env 3
-    mdb_env_set_mapsize env (100 * 1024 * 1024 * 1024)
+    mdb_env_set_mapsize env (1024 * 1024 * 1024 * 1024)
     mdb_env_open env dir []
     pure env
 


### PR DESCRIPTION
Previously, the mapsize was 10 GiB. This change increases it to 1 TiB, which should be the same that the c king uses.

When I tried to switch ~def over to kh for testing, I found that the ship would promptly crash because of this discrepancy.