### PR TITLE
landscape: fixes white background on scrollbars

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -43,7 +43,7 @@ const Root = styled.div`
 
   * {
     scrollbar-width: thin;
-    scrollbar-color: ${ p => p.theme.colors.gray } ${ p => p.theme.colors.white };
+    scrollbar-color: ${ p => p.theme.colors.gray } transparent;
   }
 
   /* Works on Chrome/Edge/Safari */


### PR DESCRIPTION
This puts firefox at parity with chrome — it's only a problem on the launch screen, but it should be this way anyway