### PR TITLE
publish: fixes #3859, fixes #3844

### DIFF
--- a/pkg/interface/src/logic/lib/publish.ts
+++ b/pkg/interface/src/logic/lib/publish.ts
@@ -87,7 +87,7 @@ export function getLatestRevision(node: GraphNode): [number, string, string, Pos
     return empty
   }
   const [title, body] = rev.post.contents as TextContent[];
-  return [revNum, title.text, body.text, rev.post];
+  return [revNum.toJSNumber(), title.text, body.text, rev.post];
 }
 
 export function getComments(node: GraphNode): GraphNode {


### PR DESCRIPTION
This is the same fix as https://github.com/urbit/urbit/pull/3856

@liam-fitzgerald does this have something to do with the work you mentioned on bigints earlier? `===` checks are failing because of a JS variable type and I haven't looked deeply into it but my intuition tells me a) that's the issue and b) you might know something about a holistic pass to remedy the issue rather than adding `valueOf()` piecemeal