### PR TITLE
Use new-style gate argument syntax in /mar

### DIFF
--- a/pkg/arvo/mar/css.hoon
+++ b/pkg/arvo/mar/css.hoon
@@ -14,7 +14,7 @@
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=({p/mite q/octs} (@t q.q))
+  ++  mime  |=([p=mite q=octs] (@t q.q))
   ++  noun  @t                                         ::  clam from %noun
   --
 ++  grad  %mime

--- a/pkg/arvo/mar/hoon.hoon
+++ b/pkg/arvo/mar/hoon.hoon
@@ -41,7 +41,7 @@
   --
 ++  grab
   |%                                            ::  convert from
-  ++  mime  |=({p/mite q/octs} q.q)
+  ++  mime  |=([p=mite q=octs] q.q)
   ++  noun  @t                                  ::  clam from %noun
   ++  txt   of-wain:format
   --

--- a/pkg/arvo/mar/html.hoon
+++ b/pkg/arvo/mar/html.hoon
@@ -17,7 +17,7 @@
 ++  grab  ^?
           |%                                            ::  convert from
           ++  noun  @t                                  ::  clam from %noun
-          ++  mime  |=({p/mite q/octs} q.q)             ::  retrieve form $mime
+          ++  mime  |=([p=mite q=octs] q.q)             ::  retrieve form $mime
           --
 ++  grad  %mime
 --

--- a/pkg/arvo/mar/js.hoon
+++ b/pkg/arvo/mar/js.hoon
@@ -15,7 +15,7 @@
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=({p/mite q/octs} (@t q.q))
+  ++  mime  |=([p=mite q=octs] (@t q.q))
   ++  noun  cord                                        ::  clam from %noun
   --
 ++  grad  %mime

--- a/pkg/arvo/mar/json.hoon
+++ b/pkg/arvo/mar/json.hoon
@@ -17,7 +17,7 @@
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=({p/mite q/octs} (fall (rush (@t q.q) apex:de-json) *json))
+  ++  mime  |=([p=mite q=octs] (fall (rush (@t q.q) apex:de-json) *json))
   ++  noun  json                                        ::  clam from %noun
   ++  numb  numb:enjs
   ++  time  time:enjs

--- a/pkg/arvo/mar/mime.hoon
+++ b/pkg/arvo/mar/mime.hoon
@@ -16,7 +16,7 @@
   |%
   +$  noun  mime                                  ::  clam from %noun
   ++  tape
-    |=(a/_"" [/application/x-urb-unknown (as-octt:mimes:html a)])
+    |=(a=^tape [/application/x-urb-unknown (as-octt:mimes:html a)])
   --
 ++  grad
   ^?

--- a/pkg/arvo/mar/png.hoon
+++ b/pkg/arvo/mar/png.hoon
@@ -5,7 +5,7 @@
   --
 ++  grab
   |%
-  ++  mime  |=({p/mite q/octs} q.q)
+  ++  mime  |=([p=mite q=octs] q.q)
   ++  noun  @t
   --
 ++  grad  %mime

--- a/pkg/arvo/mar/snip.hoon
+++ b/pkg/arvo/mar/snip.hoon
@@ -7,7 +7,7 @@
   ++  words  1
   ++  hedtal
     =|  met/marl
-    |=  a/marl  ^-  {hed/marl tal/marl}
+    |=  a=marl  ^-  {hed/marl tal/marl}
     ?~  a  [~ ~]
     ?.  ?=($h1 n.g.i.a)
       ?:  ?=($meta n.g.i.a)
@@ -18,7 +18,7 @@
     [c.i.a (weld (flop met) (limit words t.a))]
   ::
   ++  limit
-    |=  {lim/@u mal/marl}
+    |=  [lim=@u mal=marl]
     =<  res
     |-  ^-  {rem/@u res/marl}
     ?~  mal  [lim ~]
@@ -30,7 +30,7 @@
     [rem - res]:[hed $(lim lam, mal t.mal)]
   ::
   ++  deword
-    |=  {lim/@u tay/tape}  ^-  {lim/@u tay/tape}
+    |=  [lim=@u tay=tape]  ^-  {lim/@u tay/tape}
     ?~  tay  [lim tay]
     ?~  lim  [0 ~]
     =+  wer=(dot 1^1 tay)
@@ -58,5 +58,5 @@
   --
 ++  grab  |%                                            ::  convert from
           ++  noun  {marl marl}                         ::  clam from $noun
-          ++  elem  |=(a/manx (hedtal +.a))
+          ++  elem  |=(a=manx (hedtal +.a))
 --        --

--- a/pkg/arvo/mar/tang.hoon
+++ b/pkg/arvo/mar/tang.hoon
@@ -12,11 +12,11 @@
   ++  elem
     =-  ;pre:code:"{(of-wall -)}"
     ^-  wall  %-  zing  ^-  (list wall)
-    (turn (flop tan) |=(a/tank (wash 0^160 a)))
+    (turn (flop tan) |=(a=tank (wash 0^160 a)))
   --
 ++  grab                                                ::  convert from
   |%
   ++  noun  (list ^tank)                                ::  clam from %noun
-  ++  tank  |=(a/^tank [a]~)
+  ++  tank  |=(a=^tank [a]~)
   --
 --

--- a/pkg/arvo/mar/txt.hoon
+++ b/pkg/arvo/mar/txt.hoon
@@ -24,18 +24,18 @@
   |%
   ++  form  %txt-diff
   ++  diff
-    |=  tyt/wain
+    |=  tyt=wain
     ^-  (urge cord)
     (lusk txt tyt (loss txt tyt))
   ::
   ++  pact
-    |=  dif/(urge cord)
+    |=  dif=(urge cord)
     ~|  [%pacting dif]
     ^-  wain
     (lurk txt dif)
   ::
   ++  join
-    |=  {ali/(urge cord) bob/(urge cord)}
+    |=  [ali=(urge cord) bob=(urge cord)]
     ^-  (unit (urge cord))
     |^
     =.  ali  (clean ali)
@@ -49,20 +49,20 @@
           %&
         ?:  =(p.i.ali p.i.bob)
           %+  bind  $(ali t.ali, bob t.bob)
-          |=(cud/(urge cord) [i.ali cud])
+          |=(cud=(urge cord) [i.ali cud])
         ?:  (gth p.i.ali p.i.bob)
           %+  bind  $(p.i.ali (sub p.i.ali p.i.bob), bob t.bob)
-          |=(cud/(urge cord) [i.bob cud])
+          |=(cud=(urge cord) [i.bob cud])
         %+  bind  $(ali t.ali, p.i.bob (sub p.i.bob p.i.ali))
-        |=(cud/(urge cord) [i.ali cud])
+        |=(cud=(urge cord) [i.ali cud])
       ::
           %|
         ?:  =(p.i.ali (lent p.i.bob))
           %+  bind  $(ali t.ali, bob t.bob)
-          |=(cud/(urge cord) [i.bob cud])
+          |=(cud=(urge cord) [i.bob cud])
         ?:  (gth p.i.ali (lent p.i.bob))
           %+  bind  $(p.i.ali (sub p.i.ali (lent p.i.bob)), bob t.bob)
-          |=(cud/(urge cord) [i.bob cud])
+          |=(cud=(urge cord) [i.bob cud])
         ~
       ==
     ::
@@ -77,15 +77,15 @@
           %&
         ?:  =(p.i.bob (lent p.i.ali))
           %+  bind  $(ali t.ali, bob t.bob)
-          |=(cud/(urge cord) [i.ali cud])
+          |=(cud=(urge cord) [i.ali cud])
         ?:  (gth p.i.bob (lent p.i.ali))
           %+  bind  $(ali t.ali, p.i.bob (sub p.i.bob (lent p.i.ali)))
-          |=(cud/(urge cord) [i.ali cud])
+          |=(cud=(urge cord) [i.ali cud])
         ~
       ==
     ==
     ++  clean                                          ::  clean
-      |=  wig/(urge cord)
+      |=  wig=(urge cord)
       ^-  (urge cord)
       ?~  wig  ~
       ?~  t.wig  wig
@@ -179,7 +179,7 @@
       ~
     ::
     ++  clean                                          ::  clean
-      |=  wig/(urge cord)
+      |=  wig=(urge cord)
       ^-  (urge cord)
       ?~  wig  ~
       ?~  t.wig  wig
@@ -192,7 +192,7 @@
       [i.wig $(wig t.wig)]
     ::
     ++  resolve
-      |=  {ali/(urge cord) bob/(urge cord)}
+      |=  [ali=(urge cord) bob=(urge cord)]
       ^-  {fic/{%| p/(list cord) q/(list cord)} ali/(urge cord) bob/(urge cord)}
       =-  [[%| bac (annotate alc boc bac)] ali bob]
       |-  ^-  $:  $:  bac/(list cord)

--- a/pkg/arvo/mar/xml.hoon
+++ b/pkg/arvo/mar/xml.hoon
@@ -17,5 +17,5 @@
   --                                                    ::
 ++  grab  |%                                            ::  convert from
           ++  noun  @t                                  ::  clam from %noun
-          ++  mime  |=({p/mite q/octs} q.q)             ::  retrieve form $mime
+          ++  mime  |=([p=mite q=octs] q.q)             ::  retrieve form $mime
 --        --


### PR DESCRIPTION
Switch a bunch of .hoon files in /mar from using
the old `{}` syntax for specifying argument types, to the
newer `[argname=argtype]` syntax.