### PR TITLE
landscape: hide new channel container, daybreak in unread marker

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -18,9 +18,6 @@ export const UnreadMarker = React.forwardRef(({ dayBreak, when }, ref) => (
     <Rule borderColor='blue' display={['none', 'block']} m='0' width='2rem' />
     <Text flexShrink='0' display='block' zIndex='2' mx='4' color='blue'>New messages below</Text>
     <Rule borderColor='blue' flexGrow='1' m='0'/>
-    {dayBreak
-      ? <Text display='block' gray mx='4'>{moment(when).calendar(null, { sameElse: DATESTAMP_FORMAT })}</Text>
-      : null}
     <Rule style={{ width: "calc(50% - 48px)" }} borderColor='blue' m='0' />
   </Row>
 ));

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -97,10 +97,6 @@ export function Sidebar(props: SidebarProps) {
   const role = props.groups?.[groupPath] ? roleForShip(props.groups[groupPath], window.ship) : undefined;
   const isAdmin = (role === "admin") || (workspace?.type === 'home');
 
-  const newStyle = {
-    display: isAdmin ? "block" : "none"
-  };
-
   return (
     <Col
       display={display}
@@ -142,7 +138,7 @@ export function Sidebar(props: SidebarProps) {
       <SidebarStickySpacer flexShrink={0} />
       <Box
         flexShrink="0"
-        display="flex"
+        display={isAdmin ? "flex" : "none"}
         justifyContent="center"
         position="sticky"
         bottom={"8px"}
@@ -151,7 +147,6 @@ export function Sidebar(props: SidebarProps) {
         py="2"
       >
         <Link
-          style={newStyle}
           to={!!groupPath ? `/~landscape${groupPath}/new` : `/~landscape/home/new`}
         >
           <Box


### PR DESCRIPTION
- The new channel container had some padding leftover when its child was hidden, preventing users from clicking bottom channels; we hide the container itself now
- I was going to add `flex-shrink` to the daystamp in the unread marker, but it always provided useless data for its intended use case (eg. staggering the daybreak + unread marker instead of combining them, see below) so I just remove it.

<img width="858" alt="Screen Shot 2020-11-02 at 3 43 01 PM" src="https://user-images.githubusercontent.com/20846414/97919145-54490880-1d25-11eb-8456-e7436d3e1ca4.png">
