### PR TITLE
gall: fix crashed %fact handling not removing subscription from yoke

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a5ffa86349b0f418d7d5a5f69a773d29b1d48d80d657058ff5abb0572f5187f
-size 6409970
+oid sha256:9ead5c73510b0e764d0acdfd8c9dd40c599a065eaf43e8b313399ab3ba5147fe
+size 6338075

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1535,6 +1535,9 @@
       |=  [=wire =dock]
       ^+  ap-core
       ::
+      =.   outbound.watches.current-agent 
+        %-  ~(del by outbound.watches.current-agent)
+        [wire dock]
       =.  ap-core
         (ap-pass wire %agent dock %leave ~)
       =/  way  [%out (scot %p p.dock) q.dock wire]


### PR DESCRIPTION
If the handling of a %fact crashes in the gall agent, we kill the
subscription with +ap-kill-down. However, +ap-kill-down did not remove
the subscription from the yoke. This causes spurious %watch-not-unique
errors, as the bowl may contain subscriptions that have been killed by
crashed %fact handling.

Postscript: This is almost certainly the cause of publish's mysterious 'kicked for no reason' behaviour and the subsequent `%watch-not-unique` on resubscribe.