### PR TITLE
graph-pull-hook: only archive if we have graph

### DIFF
--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -20,6 +20,7 @@
 +*  this  .
     def   ~(. (default-agent this %|) bowl)
     dep   ~(. (default:pull-hook this config) bowl)
+    gra   ~(. graph bowl)
 ::
 ++  on-init       on-init:def
 ++  on-save       !>(~)
@@ -35,6 +36,7 @@
   |=  [=resource =tang]
   ^-  (quip card _this)
   :_  this
+  ?.  (~(has in get-keys:gra) resource)  ~
   =-  [%pass /pull-nack %agent [our.bowl %graph-store] %poke %graph-update -]~
   !>  ^-  update:store
   [%0 now.bowl [%archive-graph resource]]
@@ -42,7 +44,7 @@
 ++  on-pull-kick
   |=  =resource
   ^-  (unit path)
-  =/  maybe-time  (peek-update-log:graph resource)
+  =/  maybe-time  (peek-update-log:gra resource)
   ?~  maybe-time  `/
   `/(scot %da u.maybe-time)
 --

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -33,4 +33,12 @@
   ^-  update-log:store
   %+  scry-for  update-log:store
   /update-log-subset/(scot %p entity.res)/[name.res]/(scot %da start)/'~'
+::
+++  get-keys
+  ^-  resources
+  =+  %+  scry-for  ,=update:store
+      /keys
+  ?>  ?=(%0 -.update)
+  ?>  ?=(%keys -.q.update)
+  resources.q.update
 --


### PR DESCRIPTION
Scries to see if we already have the graph, and only then do we archive it. 
Unrelated, but how the hell does lib/graph work here if we aren't passing it the bowl?