### PR TITLE
verb: render printouts lazily

### DIFF
--- a/pkg/arvo/lib/verb.hoon
+++ b/pkg/arvo/lib/verb.hoon
@@ -12,26 +12,26 @@
 ::
 ++  on-init
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-init")
+  %-  (print bowl |.("{<dap.bowl>}: on-init"))
   =^  cards  agent  on-init:ag
   [[(emit-event %on-init ~) cards] this]
 ::
 ++  on-save
   ^-  vase
-  %-  (print bowl "{<dap.bowl>}: on-save")
+  %-  (print bowl |.("{<dap.bowl>}: on-save"))
   on-save:ag
 ::
 ++  on-load
   |=  old-state=vase
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-load")
+  %-  (print bowl |.("{<dap.bowl>}: on-load"))
   =^  cards  agent  (on-load:ag old-state)
   [[(emit-event %on-load ~) cards] this]
 ::
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-poke with mark {<mark>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-poke with mark {<mark>}"))
   ?:  ?=(%verb mark)
     ?-  !<(?(%loud %bowl) vase)
       %loud  `this(loud !loud)
@@ -43,7 +43,7 @@
 ++  on-watch
   |=  =path
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-watch on path {<path>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-watch on path {<path>}"))
   =^  cards  agent
     ?:  ?=([%verb %events ~] path)
       [~ agent]
@@ -53,7 +53,7 @@
 ++  on-leave
   |=  =path
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-leave on path {<path>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-leave on path {<path>}"))
   ?:  ?=([%verb %event ~] path)
     [~ this]
   =^  cards  agent  (on-leave:ag path)
@@ -62,39 +62,40 @@
 ++  on-peek
   |=  =path
   ^-  (unit (unit cage))
-  %-  (print bowl "{<dap.bowl>}: on-peek on path {<path>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-peek on path {<path>}"))
   (on-peek:ag path)
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-agent on wire {<wire>}, {<-.sign>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-agent on wire {<wire>}, {<-.sign>}"))
   =^  cards  agent  (on-agent:ag wire sign)
   [[(emit-event %on-agent wire -.sign) cards] this]
 ::
 ++  on-arvo
   |=  [=wire =sign-arvo]
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-arvo on wire {<wire>}, {<[- +<]:sign-arvo>}")
+  %-  %+  print  bowl  |.
+      "{<dap.bowl>}: on-arvo on wire {<wire>}, {<[- +<]:sign-arvo>}"
   =^  cards  agent  (on-arvo:ag wire sign-arvo)
   [[(emit-event %on-arvo wire [- +<]:sign-arvo) cards] this]
 ::
 ++  on-fail
   |=  [=term =tang]
   ^-  (quip card:agent:gall agent:gall)
-  %-  (print bowl "{<dap.bowl>}: on-fail with term {<term>}")
+  %-  (print bowl |.("{<dap.bowl>}: on-fail with term {<term>}"))
   =^  cards  agent  (on-fail:ag term tang)
   [[(emit-event %on-fail term) cards] this]
 --
 ::
 ++  print
-  |=  [=bowl:gall =tape]
+  |=  [=bowl:gall tape=_^?(|.(*tape))]
   ^+  same
   =?  .  bowl-print
     %-  (slog >bowl< ~)
     .
   ?.  loud  same
-  %-  (slog leaf+tape ~)
+  %-  (slog leaf+(tape) ~)
   same
 ::
 ++  emit-event

--- a/pkg/arvo/lib/verb.hoon
+++ b/pkg/arvo/lib/verb.hoon
@@ -89,13 +89,13 @@
 --
 ::
 ++  print
-  |=  [=bowl:gall tape=_^?(|.(*tape))]
+  |=  [=bowl:gall render=(trap tape)]
   ^+  same
   =?  .  bowl-print
     %-  (slog >bowl< ~)
     .
   ?.  loud  same
-  %-  (slog leaf+(tape) ~)
+  %-  (slog [%leaf $:render] ~)
   same
 ::
 ++  emit-event


### PR DESCRIPTION
Instead of passing in a tape to print in case we need in, pass in a trap that
can be called to generate the tape on-demand.

Eagerly rendering printouts was costing us a lot of time when we didn't actually
need them, because the pretty-printer is slow.