### PR TITLE
AsyncButton: protect against double submit

### DIFF
--- a/pkg/interface/src/views/components/AsyncButton.tsx
+++ b/pkg/interface/src/views/components/AsyncButton.tsx
@@ -29,7 +29,7 @@ export function AsyncButton({
   }, [status]);
 
   return (
-    <Button disabled={!isValid} type="submit" {...rest}>
+    <Button disabled={!isValid || isSubmitting} type="submit" {...rest}>
       {isSubmitting ? (
         <LoadingSpinner
           foreground={rest.primary ? "white" : 'black'}


### PR DESCRIPTION
Disables `AsyncButton` if the form is submitting, to prevent accidental double submits.

Design: it makes the new channel screen look this (note the different color of the button):
![Capture d’écran 2020-11-04 à 5 19 35 AM](https://user-images.githubusercontent.com/46801558/98031104-bd339c00-1e5d-11eb-8469-082dc95c8822.png)

cc: @urcades 