### PR TITLE
vere: save snapshot upon completed replay

### DIFF
--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -633,6 +633,9 @@ u3_disk_exit(u3_disk* log_u)
 
   //  cancel write thread
   //
+  //    XX can deadlock when called from signal handler
+  //    XX revise SIGTSTP handling
+  //
   if ( c3y == log_u->ted_o ) {
     c3_i sas_i;
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -725,6 +725,7 @@ _pier_play(u3_play* pay_u)
       u3_pier_cram(pir_u);
     }
     else if ( pay_u->eve_d == log_u->dun_d ) {
+      u3_lord_save(pir_u->god_u);
       _pier_work_init(pir_u);
     }
   }


### PR DESCRIPTION
The previous behavior was to simply wait for the next snapshot timer, but it's better to save eagerly.