### PR TITLE
dill: if styled prompt has no style, emit as plain

### DIFF
--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -186,6 +186,12 @@
           =.  see  [%lin p.bit]
           (done %blit [see [%hop pos] ~])
         ?:  ?=($pom -.bit)
+          ::NOTE  treat "styled prompt" without style as plain prompt,
+          ::      to allow rendering by older runtimes
+          ::TODO  remove me once v0.10.9+ has high/guaranteed adoption
+          ::
+          ?:  (levy p.bit (cork head |*(s=stye =(*stye s))))
+            $(bit [%pro (zing (turn p.bit tail))])
           =.  see  [%klr p.bit]
           (done %blit [see [%hop pos] ~])
         ?:  ?=($hop -.bit)


### PR DESCRIPTION
People using older runtimes might not support the `%klr` blit. It's not
uncommon for prompts without style to get passed in as `%pom` though, so
here we catch that case and turn it into a `%pro`, which gets rendered as
a traditional `%lin`.

With this, dojo and chat-cli remain usable under `next-dill`, even on `v0.10.8`. This allows us to consider pushing `next-dill` out more quickly after the release of `next-vere`, if we want. Note that old runtimes will still silently swallow _actually styled_ text. cc @vvisigoth 

(Arguably drum/sole should be more nuanced about this, but the code here sticks more closely to the original change location, which seems appropriate for a temporary, compatibility-oriented patch.)