### PR TITLE
vere: enable GC argument when running tests with debug binary

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -102,16 +102,8 @@ in localLib.dimension "system" systems (systemName: system:
         extension = tarball.meta.extension;
         contentType = "application/x-gtar";
       };
-
-      # Top-level pill attributes build and push-to-storage - only on linux.
-    } // lib.optionalAttrs (system == "x86_64-linux") {
-      pill = recurseIntoAttrs {
-        ivory = pushPill "ivory" dynamicPackages.ivory;
-        brass = pushPill "brass" dynamicPackages.brass;
-        solid = pushPill "solid" dynamicPackages.solid;
-      };
     };
-
+      
     # Filter derivations that have meta.platform missing the current system,
     # such as testFakeShip on darwin.
     platformFilter = localLib.platformFilterGeneric system;

--- a/nix/lib/boot-fake-ship.nix
+++ b/nix/lib/boot-fake-ship.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, cacert }:
+{ lib, stdenvNoCC, cacert }:
 
 { urbit, herb, arvo ? null, pill, ship }:
 
@@ -22,9 +22,13 @@ stdenvNoCC.mkDerivation {
     set -xeuo pipefail
 
     if [ -z "$ARVO" ]; then
-      urbit -d -F "$SHIP" -B "$PILL" ./pier
+      urbit ${
+        lib.concatStringsSep " " urbit.meta.arguments
+      } -d -F "$SHIP" -B "$PILL" ./pier
     else
-      urbit -d -F "$SHIP" -A "$ARVO" -B "$PILL" ./pier
+      urbit ${
+        lib.concatStringsSep " " urbit.meta.arguments
+      } -d -F "$SHIP" -A "$ARVO" -B "$PILL" ./pier
     fi
 
     cleanup () {

--- a/nix/lib/boot-fake-ship.nix
+++ b/nix/lib/boot-fake-ship.nix
@@ -1,8 +1,13 @@
 { lib, stdenvNoCC, cacert }:
 
-{ urbit, herb, arvo ? null, pill, ship }:
+{ urbit, herb, arvo ? null, pill, ship, arguments ? [ "-l" ] }:
 
-stdenvNoCC.mkDerivation {
+let
+
+  args = arguments ++ [ "-d" "-F" "${ship}" "-B" "${pill}" ]
+    ++ lib.optionals (arvo != null) [ "-A" "${arvo}" ];
+
+in stdenvNoCC.mkDerivation {
   name = "fake-${ship}";
 
   buildInputs = [ cacert urbit herb ];
@@ -15,21 +20,9 @@ stdenvNoCC.mkDerivation {
       exit 1
     fi
 
-    ARVO=${if arvo == null then "" else arvo}
-    PILL=${pill}
-    SHIP=${ship}
-
     set -xeuo pipefail
 
-    if [ -z "$ARVO" ]; then
-      urbit ${
-        lib.concatStringsSep " " urbit.meta.arguments
-      } -d -F "$SHIP" -B "$PILL" ./pier
-    else
-      urbit ${
-        lib.concatStringsSep " " urbit.meta.arguments
-      } -d -F "$SHIP" -A "$ARVO" -B "$PILL" ./pier
-    fi
+    urbit ${lib.concatStringsSep " " args} ./pier
 
     cleanup () {
       if [ -f ./pier/.vere.lock ]; then

--- a/nix/lib/test-fake-ship.nix
+++ b/nix/lib/test-fake-ship.nix
@@ -1,6 +1,7 @@
 { lib, stdenvNoCC, cacert, python3, bootFakeShip }:
 
-{ urbit, herb, arvo ? null, pill, ship ? "bus", doCheck ? true }:
+{ urbit, herb, arvo ? null, pill, ship ? "bus", arguments ? urbit.meta.arguments
+, doCheck ? true }:
 
 stdenvNoCC.mkDerivation {
   name = "test-${ship}";
@@ -19,9 +20,7 @@ stdenvNoCC.mkDerivation {
   buildPhase = ''
     set -x
 
-    urbit ${
-      lib.concatStringsSep " " urbit.meta.arguments
-    } -d ./pier 2> urbit-output
+    urbit ${lib.concatStringsSep " " arguments} -d ./pier 2> urbit-output
 
     # Sledge Hammer!
     # See: https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959

--- a/nix/lib/test-fake-ship.nix
+++ b/nix/lib/test-fake-ship.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, cacert, python3, bootFakeShip }:
+{ lib, stdenvNoCC, cacert, python3, bootFakeShip }:
 
 { urbit, herb, arvo ? null, pill, ship ? "bus", doCheck ? true }:
 
@@ -19,7 +19,9 @@ stdenvNoCC.mkDerivation {
   buildPhase = ''
     set -x
 
-    urbit -d ./pier 2> urbit-output
+    urbit ${
+      lib.concatStringsSep " " urbit.meta.arguments
+    } -d ./pier 2> urbit-output
 
     # Sledge Hammer!
     # See: https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -2,7 +2,7 @@
 , ed25519, ent, ge-additions, gmp, h2o, herb, ivory, libaes_siv, libscrypt
 , libsigsegv, libuv, lmdb, murmur3, openssl, secp256k1, softfloat3, zlib
 , enableStatic ? stdenv.hostPlatform.isStatic, enableDebug ? false
-, doCheck ? true, enableParallelBuilding ? true }:
+, doCheck ? true, enableParallelBuilding ? true, dontStrip ? true }:
 
 let
 
@@ -73,7 +73,7 @@ in stdenv.mkDerivation {
   # See https://github.com/NixOS/nixpkgs/issues/18995
   hardeningDisable = lib.optionals enableDebug [ "all" ];
 
-  inherit enableParallelBuilding doCheck;
+  inherit enableParallelBuilding doCheck dontStrip;
 
   meta = { debug = enableDebug; };
 }

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -75,5 +75,8 @@ in stdenv.mkDerivation {
 
   inherit enableParallelBuilding doCheck dontStrip;
 
-  meta = { debug = enableDebug; };
+  meta = {
+    debug = enableDebug;
+    arguments = lib.optionals enableDebug [ "-g" ];
+  };
 }

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -69,11 +69,11 @@
         %azimuth-tracker
         %ping
         %goad
+        %lens
     ==
   ?:  lit
     ~
   :~  %acme
-      %lens
       %clock
       %dojo
       %launch


### PR DESCRIPTION
Contains the following debug-related changes:

* Exposes `urbit.meta.arguments` which will contain `[ "-g" ]` when `enableDebug = true`.
* `lib/{boot,test}-fake-ship.nix` will now exec the `urbit` binary with any of the derivation's `urbit.meta.arguments`.
* `dontStrip = true` is now set by default.