### PR TITLE
vere: remove dependency on nix-store path for static darwin binary

### DIFF
--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -54,6 +54,12 @@ in stdenv.mkDerivation {
     mkdir -p $out/bin
     cp ./build/urbit $out/bin/urbit
     cp ./build/urbit-worker $out/bin/urbit-worker
+  '' + lib.optionalString (stdenv.isDarwin && enableStatic) ''
+    # Hack stolen from //nixpkgs/pkgs/stdenv/darwin/portable-libsystem.sh
+    find "$out/bin" -exec \
+      install_name_tool -change \
+        ${stdenv.cc.libc}/lib/libSystem.B.dylib \
+        /usr/lib/libSystem.B.dylib {} \;
   '';
 
   CFLAGS = [ (if enableDebug then "-O0" else "-O3") "-g" ]


### PR DESCRIPTION
Poached from @eglaysher's work in #3380.