### PR TITLE
publish: restore nicknames in note interface

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/Author.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Author.tsx
@@ -17,10 +17,9 @@ interface AuthorProps {
 
 export function Author(props: AuthorProps) {
   const { contacts, ship = '', date, showImage } = props;
-  const noSig = ship.slice(1);
   let contact = null;
   if (contacts) {
-    contact = noSig in contacts ? contacts[noSig] : null;
+    contact = ship in contacts ? contacts[ship] : null;
   }
   const color = contact?.color ? `#${uxToHex(contact?.color)}` : "#000000";
   const showAvatar = !props.hideAvatars && contact?.avatar;


### PR DESCRIPTION
Fixes an accidental regression — we were looking for `ship.slice(1)` in our contacts, but the `ship` prop had no sig anyway, so it always came up `false` in notes and comments.