### PR TITLE
lib-hooks: fix %kick bug

### DIFF
--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -20,6 +20,7 @@
 +*  this  .
     def   ~(. (default-agent this %|) bowl)
     dep   ~(. (default:pull-hook this config) bowl)
+    gra   ~(. graph bowl)
 ::
 ++  on-init       on-init:def
 ++  on-save       !>(~)
@@ -42,7 +43,7 @@
 ++  on-pull-kick
   |=  =resource
   ^-  (unit path)
-  =/  maybe-time  (peek-update-log:graph resource)
+  =/  maybe-time  (peek-update-log:gra resource)
   ?~  maybe-time  `/
   `/(scot %da u.maybe-time)
 --

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -334,9 +334,14 @@
     =/  rid=(unit resource)
       (resource-for-update:og vase)
     ?~  rid  ~
-    =/  =path
+    =/  prefix=path
       resource+(en-path:resource u.rid)
-    [%give %fact ~[path] update-mark.config vase]~
+    =/  paths=(list path)
+      %+  turn
+        (incoming-subscriptions prefix)
+      |=([ship pax=path] pax)
+    ?~  paths  ~
+    [%give %fact paths update-mark.config vase]~
   ::
   ++  forward-update
     |=  =vase

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -45,17 +45,24 @@
       pull-hook-name=term
   ==
 ::
-::  $state-0: state for the push hook
+::  $base-state-0: state for the push hook
 ::
 ::    .sharing: resources that the push hook is proxying
 ::    .inner-state: state given to internal door
 ::
-+$  state-0
-  $:  %0
-    sharing=(set resource)
-    inner-state=vase
++$  base-state-0
+  $:  sharing=(set resource)
+      inner-state=vase
   ==
 ::
++$  state-0  [%0 base-state-0]
+::
++$  state-1  [%1 base-state-0]
+::
++$  versioned-state
+  $%  state-0
+      state-1
+  ==
 ++  push-hook
   |*  =config
   $_  ^|
@@ -144,7 +151,7 @@
 ++  agent
   |*  =config
   |=  =(push-hook config)
-  =|  state-0
+  =|  state-1
   =*  state  -
   ^-  agent:gall
   =<
@@ -163,10 +170,39 @@
     ++  on-load
       |=  =old=vase
       =/  old
-        !<(state-0 old-vase)
-      =^  cards   push-hook
-        (on-load:og inner-state.old)
-      `this(state old)
+        !<(versioned-state old-vase)
+      =|  cards=(list card:agent:gall)
+      |^ 
+      ?-  -.old
+          %1  
+        =^  og-cards   push-hook
+          (on-load:og inner-state.old)
+        [(weld cards og-cards) this(state old)]
+        ::
+          %0
+        %_    $
+            -.old  %1
+          ::
+            cards
+          =/  paths=(list path)
+            kicked-watches
+          ?~  paths  cards
+          :_   cards
+          [%give %kick paths ~]
+        ==
+      ==
+      ::
+      ++  kicked-watches
+        ^-  (list path)
+        %~  tap  in
+        %+  roll
+          ~(val by sup.bowl)
+        |=  [[=ship =path] out=(set path)]
+        ?~  path   out
+        ?.  (lth 4 (lent path))
+          out
+        (~(put in out) path)
+      --
     ::
     ++  on-save
       =.  inner-state

--- a/pkg/arvo/ted/ph/lib-hooks.hoon
+++ b/pkg/arvo/ted/ph/lib-hooks.hoon
@@ -1,0 +1,65 @@
+/-  spider
+/+  *ph-io, *strandio
+=>
+|% 
+++  strand  strand:spider
+++  start-agents
+  |=  =ship
+  =/  m  (strand ,~)
+  ;<  ~  bind:m  (dojo ship "|start %graph-store")
+  ;<  ~  bind:m  (dojo ship "|start %graph-push-hook")
+  ;<  ~  bind:m  (dojo ship "|start %graph-pull-hook")
+  ;<  ~  bind:m  (dojo ship "|start %group-store")
+  ;<  ~  bind:m  (dojo ship "|start %group-push-hook")
+  ;<  ~  bind:m  (dojo ship "|start %group-pull-hook")
+  ;<  ~  bind:m  (dojo ship "|start %metadata-store")
+  ;<  ~  bind:m  (dojo ship "|start %metadata-hook")
+  ;<  ~  bind:m  (sleep `@dr`300)
+  (pure:m ~)
+::
+++  make-link
+  |=  [title=@t url=@t]
+  =/  m  (strand ,~)
+  ;<  ~  bind:m  (dojo ~bud ":graph-store|add-post [~bud %test] ~[[%text '{(trip title)}'] [%url '{(trip url)}']]") 
+  (pure:m ~)
+--
+
+^-  thread:spider
+|=  vase
+=/  m  (strand ,vase)
+;<  az=tid:spider
+  bind:m  start-azimuth
+;<  ~  bind:m  (spawn az ~bud)
+;<  ~  bind:m  (spawn az ~dev)
+;<  ~  bind:m  (real-ship az ~bud)
+;<  ~  bind:m  (real-ship az ~dev)
+;<  ~  bind:m  (start-agents ~bud)
+;<  ~  bind:m  (start-agents ~dev)
+;<  ~  bind:m  (send-hi ~bud ~dev)
+;<  ~  bind:m  (dojo ~bud "-graph-create [%create [~bud %test] 'test' '' `%graph-validator-link [%policy [%open ~ ~]] 'link']")
+;<  ~  bind:m  (sleep ~s5)
+;<  ~  bind:m  (dojo ~dev "-graph-join [%join [~bud %test] ~bud]")
+;<  ~  bind:m  (sleep ~s5)
+;<  ~  bind:m  (send-hi ~bud ~dev)
+;<  ~  bind:m  (poke-our %aqua noun+!>([%pause-events ~[~dev]]))
+;<  ~  bind:m  (make-link 'one' 'one')
+;<  ~  bind:m  (make-link 'two' 'one')
+;<  ~  bind:m  (make-link 'thre' 'one')
+;<  ~  bind:m  (make-link 'four' 'one')
+;<  ~  bind:m  (make-link 'five' 'one')
+;<  ~  bind:m  (make-link 'six' 'one')
+;<  ~  bind:m  (make-link 'seven' 'one')
+;<  ~  bind:m  (sleep ~s40)
+::  five unacked events is sufficent to cause a clog, and by extension a 
+::  %kick
+;<  ~  bind:m  (poke-our %aqua noun+!>([%unpause-events ~[~dev]]))
+;<  ~  bind:m  (sleep ~s10)
+;<  ~  bind:m  (make-link 'eight' 'one')
+;<  ~  bind:m  (make-link 'nine' 'one')
+;<  ~  bind:m  (sleep ~s10)
+;<  ~  bind:m  (dojo ~dev ":graph-pull-hook +dbug %bowl")
+;<  ~  bind:m  (dojo ~dev ":graph-store +dbug")
+;<  ~  bind:m  (dojo ~bud ":graph-push-hook +dbug %bowl")
+;<  ~  bind:m  (dojo ~bud ":graph-store +dbug")
+;<  ~  bind:m  end-azimuth
+(pure:m *vase)


### PR DESCRIPTION
- Fixes a bug where paths that had been kicked and rewatched would not receive new updates after receiving the backlog from the initial rewatch.
- Adds a ph test to validate that this rewatch-after-kick logic works correctly. 
- On migrate, kicks all rewatched paths so they can get the new updates

