### PR TITLE
vere/aes_siv: check claimed length

### DIFF
--- a/pkg/urbit/jets/e/aes_siv.c
+++ b/pkg/urbit/jets/e/aes_siv.c
@@ -327,7 +327,10 @@ u3qea_sivc_de(u3_atom key,
               u3_atom txt)
 {
   c3_y key_y[64];
-  if (u3r_met(3, key) > 64) {
+  if ( u3r_met(3, key) > 64 ) {
+    return u3_none;
+  }
+  if ( c3y == u3qa_gth(u3r_met(3, txt), len) ) {
     return u3_none;
   }
 

--- a/pkg/urbit/jets/e/aes_siv.c
+++ b/pkg/urbit/jets/e/aes_siv.c
@@ -104,6 +104,10 @@ static u3_noun _siv_de(c3_y* key_y,
     return u3_none;
   }
 
+  if ( c3y == u3qa_gth(u3r_met(3, txt), len) ) {
+    return u3_none;
+  }
+
   while (u3_nul != ads) {
     c3_w ad_w = u3r_met(3, u3h(ads));
     c3_y* ad_y = u3a_malloc(ad_w);
@@ -328,9 +332,6 @@ u3qea_sivc_de(u3_atom key,
 {
   c3_y key_y[64];
   if ( u3r_met(3, key) > 64 ) {
-    return u3_none;
-  }
-  if ( c3y == u3qa_gth(u3r_met(3, txt), len) ) {
     return u3_none;
   }
 


### PR DESCRIPTION
Along with https://github.com/urbit/urbit/pull/3894, closes a vulnerability when receiving Ames packets with a malicious `len` field.  I've tested this with single-packet and multi-packet messages.  I have not tested with malicious packets.