### PR TITLE
hark: follow individual indices 

### DIFF
--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -12,7 +12,7 @@
 ::
 +$  state-0
   $:  %0
-      watching=(set resource)
+      watching=(set [resource index:post])
       mentions=_&
       watch-on-self=_&
   ==
@@ -83,16 +83,16 @@
       %set-watch-on-self  (set-watch-on-self +.action)
     ==
     ++  listen
-      |=  graph=resource
+      |=  [graph=resource =index:post]
       ^-  (quip card _state)
-      :-  (give:ha ~[/updates] [%listen graph])
-      state(watching (~(put in watching) graph))
+      :-  (give:ha ~[/updates] [%listen graph index])
+      state(watching (~(put in watching) [graph index]))
     ::
     ++  ignore
-      |=  graph=resource
+      |=  [graph=resource =index:post]
       ^-  (quip card _state)
-      :-  (give:ha ~[/updates] [%ignore graph])
-      state(watching (~(del in watching) graph))
+      :-  (give:ha ~[/updates] [%ignore graph index])
+      state(watching (~(del in watching) [graph index]))
     ::
     ++  set-mentions
       |=  ment=?
@@ -127,10 +127,18 @@
       (graph-update !<(update:graph-store q.cage.sign))
     [cards this]
   ==
+  ++  add-graph
+    |=  rid=resource
+    ^-  (quip card _state)
+    ?.  &(watch-on-self =(our.bowl entity.rid))
+      [~ state]
+    `state(watching (~(put in watching) [rid ~]))
   ::
   ++  graph-update
     |=  =update:graph-store
     ^-  (quip card _state)
+    ?:  ?=(%add-graph -.q.update)
+      (add-graph resource.q.update)
     ?.  ?=(%add-nodes -.q.update)
       [~ state]
     =/  group=resource
@@ -187,15 +195,19 @@
           (self-post node)
         :_  state
         (weld child-cards self-cards)
-      =+  !<(notif-kind=(unit @t) (tube !>([0 post.node])))
+      =+  !<  notif-kind=(unit [name=@t parent-lent=@ud])
+          (tube !>([0 post.node]))
       ?~  notif-kind
         [child-cards state]
       =/  desc=@t
         ?:  (is-mention contents.post.node)
           %mention 
-        u.notif-kind
+        name.u.notif-kind
+      =/  parent=index:post
+        (scag parent-lent.u.notif-kind index.post.node)
+      ~&  parent
       ?.  ?|  =(desc %mention)
-              (~(has in watching) rid)
+              (~(has in watching) [rid parent])
           ==
         [child-cards state]
       =/  notif-index=index:store
@@ -222,7 +234,7 @@
       ^-  (quip card _state)
       ?.  ?=(%.y watch-on-self)
         [~ state]
-      `state(watching (~(put in watching) rid))
+      `state(watching (~(put in watching) [rid index.post.node]))
     ::
     ++  add-unread
       |=  [=index:store =notification:store]

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -221,7 +221,6 @@
         name.u.notif-kind
       =/  parent=index:post
         (scag parent-lent.u.notif-kind index.post.node)
-      ~&  parent
       ?.  ?|  =(desc %mention)
               (~(has in watching) [rid parent])
           ==

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -102,14 +102,12 @@
     ==
     ++  listen
       |=  [graph=resource =index:post]
-      ^-  (quip card _state)
-      :-  (give:ha ~[/updates] [%listen graph index])
+      ^+  state
       state(watching (~(put in watching) [graph index]))
     ::
     ++  ignore
       |=  [graph=resource =index:post]
-      ^-  (quip card _state)
-      :-  (give:ha ~[/updates] [%ignore graph index])
+      ^+  state
       state(watching (~(del in watching) [graph index]))
     ::
     ++  set-mentions

--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -52,6 +52,7 @@
   ++  index
     |=  i=^index
     ^-  json
+    ?:  =(~ i)  s+'/'
     =/  j=^tape  ""
     |-
     ?~  i  [%s (crip j)]

--- a/pkg/arvo/lib/hark/graph-hook.hoon
+++ b/pkg/arvo/lib/hark/graph-hook.hoon
@@ -1,4 +1,4 @@
-/-  sur=hark-graph-hook
+/-  sur=hark-graph-hook, post
 /+  graph-store, resource
 ^?
 =<  [. sur]
@@ -9,20 +9,20 @@
   =,  dejs:format
   |%
   ::
-  ++  graph-indices
-    %-  ot
-    :~  graph+dejs-path:resource
-        indices+(as graph-index)
-    ==
-  ::
-  ++  graph-index
+  ++  index
     ^-  $-(json index:graph-store)
     (su ;~(pfix net (more net dem)))
   ::
+  ++  graph-index
+    %-  ot
+    :~  graph+dejs-path:resource
+        index+index
+    ==
+  ::
   ++  action
     %-  of
-    :~  listen+dejs-path:resource
-        ignore+dejs-path:resource
+    :~  listen+graph-index
+        ignore+graph-index
         set-mentions+bo
         set-watch-on-self+bo
     ==
@@ -31,11 +31,11 @@
   =,  enjs:format
   |%
   ::
-  ++  graph-indices
-    |=  [graph=resource indices=(set index:graph-store)]
+  ++  graph-index
+    |=  [graph=resource =index:post]
     %-  pairs
     :~  graph+s+(enjs-path:resource graph)
-        indices+a+(turn ~(tap in indices) index:enjs:graph-store)
+        index+(index:enjs:graph-store index)
     ==
   ::
   ++  action
@@ -45,8 +45,10 @@
     ?-  -.act  
       %set-watch-on-self  b+watch-on-self.act
       %set-mentions  b+mentions.act
-      ?(%listen %ignore)   s+(enjs-path:resource graph.act)
+      ?(%listen %ignore)   (graph-index graph.act index.act)
     ==
+  ::
+  ::
   ::
   ++  update
     |=  upd=^update
@@ -57,7 +59,8 @@
     %-  pairs
     :~  'watchOnSelf'^b+watch-on-self.upd
         'mentions'^b+mentions.upd
-        watching+a+(turn ~(tap in watching.upd) |=(r=resource s+(enjs-path:resource r)))
+        :+  %watching  %a
+        (turn ~(tap in watching.upd) graph-index)
     ==
   --
 --

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -5,8 +5,8 @@
   ++  noun  i
   ++  notification-kind
     ?+  index.p.i  ~
-      [@ ~]    `%link
-      [@ @ ~]  `%comment
+      [@ ~]    `[%link 0]
+      [@ @ ~]  `[%comment 1]
     ==
   --
 ++  grab

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -8,8 +8,8 @@
   ::
   ++  notification-kind
     ?+  index.p.i   ~
-      [@ %1 @ ~]  `%note
-      [@ %2 @ ~]  `%comment
+      [@ %1 @ ~]  `[%note 0]
+      [@ %2 @ ~]  `[%comment 1]
     ==
   --
 ++  grab

--- a/pkg/arvo/sur/hark-graph-hook.hoon
+++ b/pkg/arvo/sur/hark-graph-hook.hoon
@@ -1,10 +1,10 @@
-/-  *resource, graph-store
+/-  *resource, graph-store, post
 ^?
 |%
 ::
 +$  action
   $%
-    [?(%listen %ignore) graph=resource]
+    [?(%listen %ignore) graph=resource =index:post]
     [%set-mentions mentions=?]
     [%set-watch-on-self watch-on-self=?]
   ==
@@ -13,7 +13,7 @@
   $% 
     action
     $:  %initial
-      watching=(set resource)
+      watching=(set [resource index:post])
       mentions=_&
       watch-on-self=_&
     ==

--- a/pkg/interface/src/logic/lib/notification.ts
+++ b/pkg/interface/src/logic/lib/notification.ts
@@ -1,0 +1,21 @@
+import { GraphNotifIndex, GraphNotificationContents } from "~/types";
+
+export function getParentIndex(
+  idx: GraphNotifIndex,
+  contents: GraphNotificationContents
+) {
+  const origIndex = contents[0].index.slice(1).split("/");
+  const ret = (i: string[]) => `/${i.join("/")}`;
+  switch (idx.description) {
+    case "link":
+      return "/";
+    case "comment":
+      return ret(origIndex.slice(0, 1));
+    case "note":
+      return "/";
+    case "mention":
+      return undefined;
+    default:
+      return undefined;
+  }
+}

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -97,7 +97,7 @@ function graphIgnore(json: any, state: HarkState) {
   const data = _.get(json, "ignore", false);
   if (data) {
     state.notificationsGraphConfig.watching = state.notificationsGraphConfig.watching.filter(
-      (n) => n !== data
+      ({ graph, index }) => !(graph === data.graph && index === data.index)
     );
   }
 }

--- a/pkg/interface/src/types/hark-update.ts
+++ b/pkg/interface/src/types/hark-update.ts
@@ -4,7 +4,7 @@ import { GroupUpdate } from "./group-update";
 import { BigIntOrderedMap } from "~/logic/lib/BigIntOrderedMap";
 import { Envelope } from './chat-update';
 
-type GraphNotifDescription = "link" | "comment";
+type GraphNotifDescription = "link" | "comment" | "note" | "mention";
 
 export interface GraphNotifIndex {
   graph: string;
@@ -39,7 +39,7 @@ export type NotificationContents =
   | { group: GroupNotificationContents }
   | { chat: ChatNotificationContents };
 
-interface Notification {
+export interface Notification {
   read: boolean;
   time: number;
   contents: NotificationContents;
@@ -57,7 +57,12 @@ export type Notifications = BigIntOrderedMap<Timebox>;
 export interface NotificationGraphConfig {
   watchOnSelf: boolean;
   mentions: boolean;
-  watching: string[];
+  watching: WatchedIndex[]
 }
 
+
+interface WatchedIndex {
+  graph: string;
+  index: string;
+}
 export type GroupNotificationsConfig = string[];

--- a/pkg/interface/src/views/landscape/components/ChannelMenu.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelMenu.tsx
@@ -51,19 +51,18 @@ export function ChannelMenu(props: ChannelMenuProps) {
   const isOurs = ship.slice(1) === window.ship;
 
   const isMuted = appIsGraph(app)
-    ? props.graphNotificationConfig.watching.findIndex((a) => a === appPath) ===
-      -1
+    ? props.graphNotificationConfig.watching.findIndex(
+        (a) => a.graph === appPath && a.index === "/"
+      ) === -1
     : props.chatNotificationConfig.findIndex((a) => a === appPath) === -1;
+
   const onChangeMute = async () => {
-    const func =
-      association["app-name"] === "chat"
-        ? isMuted
-          ? "listenChat"
-          : "ignoreChat"
-        : isMuted
-        ? "listenGraph"
-        : "ignoreGraph";
-    await api.hark[func](appPath);
+    if (association["app-name"] === "chat") {
+      const func = isMuted ? "listenChat" : "ignoreChat";
+      return api.hark[func](appPath);
+    }
+    const func = isMuted ? "listenGraph" : "ignoreGraph";
+    await api.hark[func](appPath, "/");
   };
   const onUnsubscribe = useCallback(async () => {
     const app = metadata.module || association["app-name"];


### PR DESCRIPTION
Follow individual indices in graph-store, and notify when an immediate child is created. In order to bypass potentially empty indices the notification-kind type is now `(unit [@t @ud])` where the `@ud` describes the length of the parent index. 