### PR TITLE
eyre: clog exclusively for %facts

### DIFF
--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -1853,7 +1853,7 @@
     ==
   ::  user gets sent multiple subscription results
   ::
-  =/  max=@ud  (dec clog-threshold:eyre-gate)
+  =/  max=@ud  clog-threshold:eyre-gate
   =/  cur=@ud  0
   |-  =*  loop-fact  $
   ?.  =(cur max)
@@ -1895,7 +1895,7 @@
               :-  ~
               %-  as-octt:mimes:html
               """
-              id: {((d-co:co 1) clog-threshold:eyre-gate)}
+              id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
               data: \{"json":[1],"id":1,"response":"diff"}
 
 
@@ -1913,7 +1913,7 @@
                 :-  ~
                 %-  as-octt:mimes:html
                 """
-                id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
+                id: {((d-co:co 1) (add 2 clog-threshold:eyre-gate))}
                 data: \{"id":1,"response":"quit"}
 
 


### PR DESCRIPTION
Eyre's clog logic was a tad inconsistent about "only facts" vs "not poke-acks". This makes it consistently say "only facts" when it comes to clog-related logic.

Yes, in theory this means `%watch-ack`s and `%kick`s can build up endlessly, but those should take up negligible space compared to %facts.

Should fix any oddball cases of crashes here that #3835 didn't already catch.