### PR TITLE
hark: pass remotecontentpolicy to chat notifications

### DIFF
--- a/pkg/interface/src/views/apps/notifications/chat.tsx
+++ b/pkg/interface/src/views/apps/notifications/chat.tsx
@@ -34,8 +34,9 @@ export function ChatNotification(props: {
   contacts: Rolodex;
   groups: Groups;
   api: GlobalApi;
+  remoteContentPolicy: any;
 }) {
-  const { index, contents, read, time, api, timebox } = props;
+  const { index, contents, read, time, api, timebox, remoteContentPolicy } = props;
   const authors = _.map(contents, "author");
 
   const { chat, mention } = index;
@@ -86,6 +87,7 @@ export function ChatNotification(props: {
                 contacts={groupContacts}
                 fontSize='0'
                 pt='2'
+                remoteContentPolicy={remoteContentPolicy}
               />
             </Link>
           );

--- a/pkg/interface/src/views/apps/notifications/header.tsx
+++ b/pkg/interface/src/views/apps/notifications/header.tsx
@@ -87,9 +87,9 @@ export function Header(props: {
       {!!moduleIcon && <Icon icon={moduleIcon as any} />}
       {!!channel && <Text fontWeight="500">{channelTitle}</Text>}
       <Rule vertical height="12px" />
-      {groupTitle && 
+      {groupTitle &&
          <>
-          <Text fontWeight="500">{groupTitle}</Text>}
+          <Text fontWeight="500">{groupTitle}</Text>
           <Rule vertical height="12px"/>
         </>
       }

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -134,6 +134,7 @@ export default function Inbox(props: {
           graphConfig={props.notificationsGraphConfig}
           groupConfig={props.notificationsGroupConfig}
           chatConfig={props.notificationsChatConfig}
+          remoteContentPolicy={props.remoteContentPolicy}
           api={api}
         />
       )}
@@ -153,6 +154,7 @@ export default function Inbox(props: {
               graphConfig={props.notificationsGraphConfig}
               groupConfig={props.notificationsGroupConfig}
               chatConfig={props.notificationsChatConfig}
+              remoteContentPolicy={props.remoteContentPolicy}
             />
           )
       )}
@@ -182,6 +184,7 @@ function DaySection({
   groupConfig,
   graphConfig,
   chatConfig,
+  remoteContentPolicy
 }) {
   const calendar = latest
     ? MOMENT_CALENDAR_DATE
@@ -216,6 +219,7 @@ function DaySection({
               contacts={contacts}
               groups={groups}
               time={date}
+              remoteContentPolicy={remoteContentPolicy}
             />
           </React.Fragment>
         ))

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -31,6 +31,7 @@ interface NotificationProps {
   graphConfig: NotificationGraphConfig;
   groupConfig: GroupNotificationsConfig;
   chatConfig: string[];
+  remoteContentPolicy: any;
 }
 
 function getMuted(
@@ -180,6 +181,7 @@ export function Notification(props: NotificationProps) {
           timebox={props.time}
           time={time}
           associations={associations}
+          remoteContentPolicy={props.remoteContentPolicy}
         />
       </Wrapper>
     );


### PR DESCRIPTION
Fixes an interface crash when receiving rich media in notifications.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/20846414/98943893-32d2e400-24be-11eb-857e-0e928db327f9.png">
