### PR TITLE
hoon: update glyph names (continued)

### DIFF
--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -534,7 +534,7 @@
     ::     ;~(pfix ace ;~(plug i.opt $(opt t.opt)))
     ::   --
     ::
-    ++  group  ;~((glue net) ship sym)
+    ++  group  ;~((glue fas) ship sym)
     ++  tag   |*(a=@tas (cold a (jest a)))  ::TODO  into stdlib
     ++  ship  ;~(pfix sig fed:ag)
     ++  path  ;~(pfix fas ;~(plug urs:ab (easy ~)))  ::NOTE  short only, tmp

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -218,7 +218,7 @@
         ;~(plug (cold %ur lus) parse-url)
         ;~(plug (cold %ge lus) parse-model)
         ;~(plug (cold %te hep) sym (star ;~(pfix ace parse-source)))
-        ;~(plug (cold %as pad) sym ;~(pfix ace parse-source))
+        ;~(plug (cold %as pam) sym ;~(pfix ace parse-source))
         ;~(plug (cold %do cab) parse-hoon ;~(pfix ace parse-source))
         parse-value
       ==

--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -295,7 +295,7 @@
           [%nodes nodes]
       ==
     ::
-    ++  nodes  (op ;~(pfix net (more net dem)) node)
+    ++  nodes  (op ;~(pfix fas (more fas dem)) node)
     ::
     ++  node
       %-  ot
@@ -366,7 +366,7 @@
           [%index index]          
       ==
     ::
-    ++  index  (su ;~(pfix net (more net dem)))
+    ++  index  (su ;~(pfix fas (more fas dem)))
     ::
     ++  add-tag
       %-  ot

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -11,7 +11,7 @@
     ::  parse optional /? and ignore
     ::
     ;~  pose
-      (cold ~ ;~(plug net wut gap dem gap))
+      (cold ~ ;~(plug fas wut gap dem gap))
       (easy ~)
     ==
   ::
@@ -20,7 +20,7 @@
         ;~  sfix
           %+  cook  |=((list (list taut)) (zing +<))
           %+  more  gap
-          ;~  pfix  ;~(plug net hep gap)
+          ;~  pfix  ;~(plug fas hep gap)
             (most ;~(plug com gaw) taut-rule)
           ==
           gap
@@ -32,7 +32,7 @@
         ;~  sfix
           %+  cook  |=((list (list taut)) (zing +<))
           %+  more  gap
-          ;~  pfix  ;~(plug net lus gap)
+          ;~  pfix  ;~(plug fas lus gap)
             (most ;~(plug com gaw) taut-rule)
           ==
           gap
@@ -44,9 +44,9 @@
         ;~  sfix
           %+  cook  |=((list [face=term =path]) +<)
           %+  more  gap
-          ;~  pfix  ;~(plug net tis gap)
+          ;~  pfix  ;~(plug fas tis gap)
             %+  cook  |=([term path] +<)
-            ;~(plug sym ;~(pfix ;~(plug gap net) (more net urs:ab)))
+            ;~(plug sym ;~(pfix ;~(plug gap fas) (more fas urs:ab)))
           ==
           gap
         ==
@@ -57,12 +57,12 @@
         ;~  sfix
           %+  cook  |=((list [face=term =mark =path]) +<)
           %+  more  gap
-          ;~  pfix  ;~(plug net tar gap)
+          ;~  pfix  ;~(plug fas tar gap)
             %+  cook  |=([term mark path] +<)
             ;~  plug
               sym
               ;~(pfix ;~(plug gap cen) sym)
-              ;~(pfix ;~(plug gap net) (more net urs:ab))
+              ;~(pfix ;~(plug gap fas) (more fas urs:ab))
             ==
           ==
           gap

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -811,7 +811,7 @@
         ::  parse optional /? and ignore
         ::
         ;~  pose
-          (cold ~ ;~(plug net wut gap dem gap))
+          (cold ~ ;~(plug fas wut gap dem gap))
           (easy ~)
         ==
       ::
@@ -820,7 +820,7 @@
             ;~  sfix
               %+  cook  |=((list (list taut)) (zing +<))
               %+  more  gap
-              ;~  pfix  ;~(plug net hep gap)
+              ;~  pfix  ;~(plug fas hep gap)
                 (most ;~(plug com gaw) taut-rule)
               ==
               gap
@@ -832,7 +832,7 @@
             ;~  sfix
               %+  cook  |=((list (list taut)) (zing +<))
               %+  more  gap
-              ;~  pfix  ;~(plug net lus gap)
+              ;~  pfix  ;~(plug fas lus gap)
                 (most ;~(plug com gaw) taut-rule)
               ==
               gap
@@ -844,9 +844,9 @@
             ;~  sfix
               %+  cook  |=((list [face=term =path]) +<)
               %+  more  gap
-              ;~  pfix  ;~(plug net tis gap)
+              ;~  pfix  ;~(plug fas tis gap)
                 %+  cook  |=([term path] +<)
-                ;~(plug sym ;~(pfix ;~(plug gap net) (more net urs:ab)))
+                ;~(plug sym ;~(pfix ;~(plug gap fas) (more fas urs:ab)))
               ==
               gap
             ==
@@ -857,12 +857,12 @@
             ;~  sfix
               %+  cook  |=((list [face=term =mark =path]) +<)
               %+  more  gap
-              ;~  pfix  ;~(plug net tar gap)
+              ;~  pfix  ;~(plug fas tar gap)
                 %+  cook  |=([term mark path] +<)
                 ;~  plug
                   sym
                   ;~(pfix ;~(plug gap cen) sym)
-                  ;~(pfix ;~(plug gap net) (more net urs:ab))
+                  ;~(pfix ;~(plug gap fas) (more fas urs:ab))
                 ==
               ==
               gap

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2050,7 +2050,7 @@
   ::
   %+  rush  u.for
   ;~  sfix
-    ;~(pose (stag %ipv4 ip4) (stag %ipv6 (ifix [lac rac] ip6)))
+    ;~(pose (stag %ipv4 ip4) (stag %ipv6 (ifix [sel ser] ip6)))
     ;~(pose ;~(pfix col dim:ag) (easy ~))
   ==
 ::

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -378,16 +378,16 @@
       ::NOTE  this is ptok:de-purl:html, but can't access that here
       %-  plus
       ;~  pose
-        aln  zap  hax  bus  cen  pad  say  tar  lus
-        hep  dot  ket  cab  tec  bar  sig
+        aln  zap  hax  buc  cen  pam  soq  tar  lus
+        hep  dot  ket  cab  tic  bar  sig
       ==
     ::
     ++  quoted-string                                 ::  7230 quoted string
       %+  cook  crip
-      %+  ifix  [. .]:;~(less (jest '\\"') yel)
+      %+  ifix  [. .]:;~(less (jest '\\"') doq)
       %-  star
       ;~  pose
-        ;~(pfix bat ;~(pose (just '\09') ace prn))
+        ;~(pfix bas ;~(pose (just '\09') ace prn))
         ;~(pose (just '\09') ;~(less (mask "\22\5c\7f") (shim 0x20 0xff)))
       ==
     --
@@ -6643,7 +6643,7 @@
       ;~(pose pure pesc pold fas wut col com)
     ::                                                  ::  ++pure:de-purl:html
     ++  pure                                            ::  2396 unreserved
-      ;~(pose aln hep cab dot zap sig tar say lit rit)
+      ;~(pose aln hep cab dot zap sig tar soq pal par)
     ::                                                  ::  ++psub:de-purl:html
     ++  psub                                            ::  3986 sub-delims
       ;~  pose


### PR DESCRIPTION
See: https://github.com/urbit/urbit/pull/3787

I tested by deleting the deprecated parsers in `hoon.hoon`, although that's not part of the PR.

I made a fakezod with this PR and the deletions.
```
urbit -A pkg/arvo -B bin/solid.pill -F zod
```

Then I made a new pill and made a fakezod from that too.
```
.fixup/pill +solid
^d

urbit -B zod/.urb/put/fixup.pill -F bus
```

This all worked.

I will start the conversion of `%bscl` to `%bccl`, etc.
I didn't commit a pill.
Is this the correct branch for this PR?
