### PR TITLE
hark: rework caching to allow for better unread counts, read all by index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -29,7 +29,7 @@
       ~
   ==
 ::
-++  orm  ((ordered-map @da timebox:store) lth)
+++  orm  ((ordered-map @da timebox:store) gth)
 --
 ::
 =|  inflated-state
@@ -55,6 +55,10 @@
   ^-  (quip card _this)
   =/  old
    !<(state-0 old-vase)
+  =.  notifications.old
+    (gas:orm *notifications:store (tap:orm notifications.old))
+  =.  archive.old
+    (gas:orm *notifications:store (tap:orm archive.old))
   `this(-.state old, +.state (inflate-cache old))
 ::
 ++  on-watch  
@@ -77,11 +81,11 @@
       [%count unread-count]
     %+  weld
       %+  turn
-         %+  scag  5
+         %+  scag  3
         (tap-nonempty:ha archive)
       (timebox-update &)
     %+  turn
-      %+  scag  5
+      %+  scag  3
       (tap-nonempty:ha notifications)
     (timebox-update |)
   ::

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -109,21 +109,24 @@
   ^-  (unit (unit cage))
   ?+  path  (on-peek:def path)
     ::
-      [%x %recent @ @ ~]
+      [%x %recent ?(%archive %inbox) @ @ ~]
+    =/  is-archive
+      =(%archive i.t.t.path)
     =/  offset=@ud
-      (slav %ud i.t.t.path)
-    =/  length=@ud
       (slav %ud i.t.t.t.path)
+    =/  length=@ud
+      (slav %ud i.t.t.t.t.path)
     :^  ~  ~  %hark-update
     !>  ^-  update:store
     :-  %more
     %+  turn
       %+  scag  length
       %+  slag  offset
-      (tap-nonempty:ha notifications)
+      %-  tap-nonempty:ha 
+      ?:(is-archive archive notifications)
     |=  [time=@da =timebox:store]
     ^-  update:store
-    :^  %timebox  time  %.n
+    :^  %timebox  time  is-archive
     ~(tap by timebox)
   ==
 ::

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -62,6 +62,7 @@
         read+notif-ref
         add+add
         set-dnd+bo
+        read-index+index
     ==
   --
 ::
@@ -78,21 +79,24 @@
         %timebox  (timebox +.upd)
         %set-dnd  b+dnd.upd
         %count    (numb count.upd)
-        %graph-unreads  (graph-unreads map.upd)
+        %unreads  (unreads unreads.upd)
         %more     (more +.upd)
         ::
           ?(%archive %read %unread)
         (notif-ref +.upd)
     ==
     ::
-    ++  graph-unreads
-      |=  =(map resource @ud)
+    ++  unreads
+      |=  l=(list [^index @ud]) 
       ^-  json 
+      :-  %a
+      ^-  (list json)
+      %+  turn  l
+      |=  [idx=^index unread=@ud]
       %-  pairs
-      %+  turn
-        ~(tap by map)
-      |=  [rid=resource unread=@ud]
-      (enjs-path:resource rid)^(numb unread)
+      :~  unread+(numb unread)
+          index+(index idx)
+      ==
     ::
     ++  added
       |=  [tim=@da idx=^index not=^notification]

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -26,7 +26,7 @@
   (map index notification)
 ::
 +$  notifications
-  ((mop @da timebox) lth)
+  ((mop @da timebox) gth)
 ::
 +$  action
   $%  [%add =index =notification]

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -32,6 +32,7 @@
   $%  [%add =index =notification]
       [%archive time=@da index]
       [%read time=@da index]
+      [%read-index index]
       [%unread time=@da index]
       [%set-dnd dnd=?]
       [%seen ~]
@@ -42,10 +43,10 @@
 ::  
 +$  update
   $%  action
-      [%more =(list update)]
+      [%more more=(list update)]
       [%added time=@da =index =notification]
       [%timebox time=@da archived=? =(list [index notification])]
       [%count count=@ud]
-      [%graph-unreads =(map resource @ud)]
+      [%unreads unreads=(list [index @ud])]
   ==
 --

--- a/pkg/interface/src/logic/api/hark.ts
+++ b/pkg/interface/src/logic/api/hark.ts
@@ -155,14 +155,17 @@ export class HarkApi extends BaseApi<StoreState> {
     });
   }
 
-  getMore() {
-    const offset = this.store.state.notifications.size;
-    const count = 10;
-    return this.getSubset(offset,count);
+  getMore(archive = false) {
+    const offset = this.store.state[
+      archive ? 'archivedNotifications' : 'notifications'
+    ].size;
+    const count = 3;
+    return this.getSubset(offset,count, archive);
   }
 
-  async getSubset(offset:number, count:number) {
-    const data = await this.scry("hark-store", `/recent/${offset}/${count}`);
+  async getSubset(offset:number, count:number, isArchive: boolean) {
+    const where = isArchive ? 'archive' : 'inbox';
+    const data = await this.scry("hark-store", `/recent/${where}/${offset}/${count}`);
     this.store.handleEvent({ data });
   }
 

--- a/pkg/interface/src/logic/api/hark.ts
+++ b/pkg/interface/src/logic/api/hark.ts
@@ -61,6 +61,12 @@ export class HarkApi extends BaseApi<StoreState> {
     return this.actOnNotification('read', time, index);
   }
 
+  readIndex(index: NotifIndex) {
+    return this.harkAction({
+      'read-index': index
+    });
+  }
+
   unread(time: BigInteger, index: NotifIndex) {
     return this.actOnNotification('unread', time, index);
   }

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -6,19 +6,21 @@ import {
 } from "~/types";
 import { makePatDa } from "~/logic/lib/util";
 import _ from "lodash";
+import {StoreState} from "../store/type";
 
-type HarkState = {
-  notifications: Notifications;
-  archivedNotifications: Notifications;
-  notificationsCount: number;
-  notificationsGraphConfig: NotificationGraphConfig;
-  notificationsGroupConfig: GroupNotificationsConfig;
-  notificationsChatConfig: string[];
-};
+type HarkState = Pick<StoreState,
+  "notificationsChatConfig"
+  | "notificationsGroupConfig" 
+  | "notificationsGraphConfig" 
+  | "notifications"
+  | "notificationsCount"
+  | "archivedNotifications"
+  | "unreads">;
 
 export const HarkReducer = (json: any, state: HarkState) => {
   const data = _.get(json, "harkUpdate", false);
   if (data) {
+    console.log(data);
     reduce(data, state);
   }
   const graphHookData = _.get(json, "hark-graph-hook-update", false);
@@ -139,16 +141,31 @@ function reduce(data: any, state: HarkState) {
   timebox(data, state);
   more(data, state);
   dnd(data, state);
-  count(data, state);
   added(data, state);
-  graphUnreads(data, state);
+  unreads(data, state);
 }
 
-function graphUnreads(json: any, state: HarkState) {
-  const data = _.get(json, 'graph-unreads');
+function unreads(json: any, state: HarkState) {
+  const data = _.get(json, 'unreads');
   if(data) {
-    state.graphUnreads =  data;
+    data.forEach(({ index, unread }) => {
+      updateUnreads(state, index, x => x + unread);
+    });
   }
+}
+
+function updateUnreads(state: HarkState, index: NotifIndex, f: (u: number) => number) {
+      state.notificationsCount = f(state.notificationsCount);
+      if('graph' in index) {
+        const curr = state.unreads.graph[index.graph.graph] || 0;
+        state.unreads.graph[index.graph.graph] = f(curr);
+      } else if('group' in index) {
+        const curr = state.unreads.group[index.group.group] || 0;
+        state.unreads.group[index.group.group] = f(curr);
+      } else if('chat' in index) {
+        const curr = state.unreads.chat[index.chat.chat] || 0
+        state.unreads.chat[index.chat.chat] = f(curr);
+      } 
 }
 
 function added(json: any, state: HarkState) {
@@ -157,27 +174,20 @@ function added(json: any, state: HarkState) {
     const { index, notification } = data;
     const time = makePatDa(data.time);
     const timebox = state.notifications.get(time) || [];
+
     const arrIdx = timebox.findIndex((idxNotif) =>
       notifIdxEqual(index, idxNotif.index)
     );
     if (arrIdx !== -1) {
+      if(timebox[arrIdx]?.notification?.read) {
+        updateUnreads(state, index, x => x+1);
+      }
       timebox[arrIdx] = { index, notification };
       state.notifications.set(time, timebox);
     } else {
+      updateUnreads(state, index, x => x+1);
       state.notifications.set(time, [...timebox, { index, notification }]);
-      state.notificationsCount++;
-      if('graph' in index) {
-        const curr = state.graphUnreads[index.graph.graph] || 0;
-        state.graphUnreads[index.graph.graph] = curr+1;
-      }
     }
-  }
-}
-
-function count(json: any, state: HarkState) {
-  const data = _.get(json, "count", false);
-  if (data !== false) {
-    state.notificationsCount = data;
   }
 }
 
@@ -254,12 +264,7 @@ function read(json: any, state: HarkState) {
   const data = _.get(json, "read", false);
   if (data) {
     const { time, index } = data;
-    state.notificationsCount--;
-    if('graph' in index) {
-      const curr = state.graphUnreads[index.graph.graph] || 0;
-      state.graphUnreads[index.graph.graph] = curr-1;
-    }
-
+    updateUnreads(state, index, x => x-1);
     setRead(time, index, true, state);
   }
 }
@@ -268,11 +273,7 @@ function unread(json: any, state: HarkState) {
   const data = _.get(json, "unread", false);
   if (data) {
     const { time, index } = data;
-    state.notificationsCount++;
-    if('graph' in index) {
-      const curr = state.graphUnreads[index.graph.graph] || 0;
-      state.graphUnreads[index.graph.graph] = curr+1;
-    }
+    updateUnreads(state, index, x => x+1);
     setRead(time, index, false, state);
   }
 }
@@ -292,9 +293,10 @@ function archive(json: any, state: HarkState) {
     );
     state.notifications.set(time, unarchived);
     const archiveBox = state.archivedNotifications.get(time) || [];
-    state.notificationsCount -= archived.filter(
+    const readCount = archived.filter(
       ({ notification }) => !notification.read
     ).length;
+    updateUnreads(state, index, x => x - readCount);
     state.archivedNotifications.set(time, [
       ...archiveBox,
       ...archived.map(({ notification, index }) => ({

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -6,7 +6,7 @@ import {
 } from "~/types";
 import { makePatDa } from "~/logic/lib/util";
 import _ from "lodash";
-import {StoreState} from "../store/type";
+import { StoreState } from "../store/type";
 
 type HarkState = Pick<StoreState,
   "notificationsChatConfig"
@@ -20,7 +20,6 @@ type HarkState = Pick<StoreState,
 export const HarkReducer = (json: any, state: HarkState) => {
   const data = _.get(json, "harkUpdate", false);
   if (data) {
-    console.log(data);
     reduce(data, state);
   }
   const graphHookData = _.get(json, "hark-graph-hook-update", false);
@@ -134,7 +133,6 @@ function graphWatchSelf(json: any, state: HarkState) {
 }
 
 function reduce(data: any, state: HarkState) {
-  console.log(data);
   unread(data, state);
   read(data, state);
   archive(data, state);

--- a/pkg/interface/src/logic/store/store.ts
+++ b/pkg/interface/src/logic/store/store.ts
@@ -107,7 +107,11 @@ export default class GlobalStore extends BaseStore<StoreState> {
         watching: [],
       },
       notificationsCount: 0,
-      graphUnreads: {}
+      unreads: {
+        graph: {},
+        group: {},
+        chat: {},
+      }
     };
   }
 

--- a/pkg/interface/src/logic/store/type.ts
+++ b/pkg/interface/src/logic/store/type.ts
@@ -14,7 +14,8 @@ import {
   NotificationGraphConfig, 
   GroupNotificationsConfig,
   LocalUpdateRemoteContentPolicy,
-  BackgroundConfig
+  BackgroundConfig,
+  Unreads
 } from "~/types";
 
 export interface StoreState {
@@ -59,11 +60,12 @@ export interface StoreState {
   inbox: Inbox;
   pendingMessages: Map<Path, Envelope[]>;
 
+  archivedNotifications: Notifications;
   notifications: Notifications;
   notificationsGraphConfig: NotificationGraphConfig;
   notificationsGroupConfig: GroupNotificationsConfig;
   notificationsChatConfig: string[];
   notificationsCount: number,
   doNotDisturb: boolean;
-  graphUnreads: Record<string, number>;
+  unreads: Unreads;
 }

--- a/pkg/interface/src/types/hark-update.ts
+++ b/pkg/interface/src/types/hark-update.ts
@@ -60,6 +60,11 @@ export interface NotificationGraphConfig {
   watching: WatchedIndex[]
 }
 
+export interface Unreads {
+  chat: Record<string, number>;
+  group: Record<string, number>;
+  graph: Record<string, number>;
+}
 
 interface WatchedIndex {
   graph: string;

--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -181,6 +181,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     if (this.state.fetchPending) return;
     if (this.props.unreadCount === 0) return;
     this.props.api.chat.read(this.props.station);
+    this.props.api.hark.readIndex({ chat: { chat: this.props.station, mention: false }});
   }
 
   fetchMessages(start, end, force = false): Promise<void> {

--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -63,7 +63,7 @@ export default class LaunchApp extends React.Component {
               weather={props.weather}
             />
             <Box display={["none", "block"]} width="100%" gridColumn="1 / -1"></Box>
-            <Groups groups={props.groups} associations={props.associations} />
+            <Groups unreads={props.unreads} groups={props.groups} associations={props.associations} />
           </Box>
         </ScrollbarLessBox>
         <Box

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -64,7 +64,7 @@ function Group(props: GroupProps) {
       <Col height="100%" justifyContent="space-between">
         <Text>{title}</Text>
         {unreads > 0 && 
-          (<Text gray>{unreads} unread{unreads !== 1 && 's'} </Text>)
+          (<Text color="blue" gray>{unreads} update{unreads !== 1 && 's'} </Text>)
         }
       </Col>
     </Tile>

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -63,7 +63,9 @@ function Group(props: GroupProps) {
     <Tile to={`/~landscape${path}`}>
       <Col height="100%" justifyContent="space-between">
         <Text>{title}</Text>
-        {unreads > 0 && <Text gray>{unreads} unread </Text>}
+        {unreads > 0 && 
+          (<Text gray>{unreads} unread{unreads !== 1 && 's'} </Text>)
+        }
       </Col>
     </Tile>
   );

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { Box, Text } from "@tlon/indigo-react";
+import { Box, Text, Col } from "@tlon/indigo-react";
+import f from "lodash/fp";
+import _ from "lodash";
 
-import { Associations, Association } from "~/types";
+import { Associations, Association, Unreads } from "~/types";
 import { alphabeticalOrder } from "~/logic/lib/util";
-import Tile from '../components/tiles/tile';
+import Tile from "../components/tiles/tile";
 
 interface GroupsProps {
   associations: Associations;
@@ -12,20 +14,57 @@ interface GroupsProps {
 const sortGroupsAlph = (a: Association, b: Association) =>
   alphabeticalOrder(a.metadata.title, b.metadata.title);
 
+const getKindUnreads = (associations: Associations) => (path: string) => (
+  kind: "chat" | "graph"
+): ((unreads: Unreads) => number) =>
+  f.flow(
+    (x) => x[kind],
+    f.pickBy((_v, key) => associations[kind]?.[key]["group-path"] === path),
+    f.values,
+    f.reduce(f.add, 0)
+  );
+
 export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
-  const { associations, ...boxProps } = props;
+  const { associations, unreads, ...boxProps } = props;
 
   const groups = Object.values(associations?.contacts || {})
-    .filter(e => e['group-path'] in props.groups)
+    .filter((e) => e["group-path"] in props.groups)
     .sort(sortGroupsAlph);
+  const getUnreads = getKindUnreads(associations || {});
 
   return (
     <>
-      {groups.map((group) => (
-        <Tile to={`/~landscape${group["group-path"]}`}>
-          <Text>{group.metadata.title}</Text>
-        </Tile>
-      ))}
+      {groups.map((group) => {
+        const path = group["group-path"];
+        const unreadCount = (["chat", "graph"] as const)
+          .map(getUnreads(path))
+          .map((f) => f(unreads))
+          .reduce(f.add, 0);
+        return (
+          <Group
+            unreads={unreadCount}
+            path={group["group-path"]}
+            title={group.metadata.title}
+          />
+        );
+      })}
     </>
+  );
+}
+
+interface GroupProps {
+  path: string;
+  title: string;
+  unreads: number;
+}
+function Group(props: GroupProps) {
+  const { path, title, unreads } = props;
+  return (
+    <Tile to={`/~landscape${path}`}>
+      <Col height="100%" justifyContent="space-between">
+        <Text>{title}</Text>
+        {unreads > 0 && <Text gray>{unreads} unread </Text>}
+      </Col>
+    </Tile>
   );
 }

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useCallback } from "react";
 import moment from "moment";
 import { Row, Box, Col, Text, Anchor, Icon, Action } from "@tlon/indigo-react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import _ from "lodash";
 import {
   Post,
@@ -83,10 +83,10 @@ const GraphNodeContent = ({ contents, mod, description, index }) => {
       return (
         <Col>
           <Box mb="2" fontWeight="500">
-            {header}
+            <Text>{header}</Text>
           </Box>
           <Box overflow="hidden" maxHeight="400px">
-            {snippet}
+            <Text lineHeight="tall">{snippet}</Text>
             <FilterBox
               width="100%"
               zIndex="1"
@@ -123,8 +123,11 @@ const GraphNode = ({
   index,
   graph,
   group,
+  read,
+  onRead
 }) => {
   author = deSig(author);
+  const history = useHistory();
 
   const img = (
     <Sigil
@@ -138,36 +141,41 @@ const GraphNode = ({
 
   const nodeUrl = getNodeUrl(mod, group, graph, index);
 
+  const onClick = useCallback(() => {
+    if(!read) {
+      onRead();
+    }
+    history.push(nodeUrl);
+  }, [read, onRead]);
+
   return (
-    <Link to={nodeUrl}>
-      <Row gapX="2" pt="2">
-        <Col>{img}</Col>
-        <Col alignItems="flex-start">
-          <Row
-            mb="2"
-            height="16px"
-            alignItems="center"
-            p="1"
-            backgroundColor="white"
-          >
-            <Text mono title={author}>
-              {cite(author)}
-            </Text>
-            <Text ml="2" gray>
-              {moment(time).format("HH:mm")}
-            </Text>
-          </Row>
-          <Row p="1">
-            <GraphNodeContent
-              contents={contents}
-              mod={mod}
-              description={description}
-              index={index}
-            />
-          </Row>
-        </Col>
-      </Row>
-    </Link>
+    <Row onClick={onClick} gapX="2" pt="2">
+      <Col>{img}</Col>
+      <Col alignItems="flex-start">
+        <Row
+          mb="2"
+          height="16px"
+          alignItems="center"
+          p="1"
+          backgroundColor="white"
+        >
+          <Text mono title={author}>
+            {cite(author)}
+          </Text>
+          <Text ml="2" gray>
+            {moment(time).format("HH:mm")}
+          </Text>
+        </Row>
+        <Row p="1">
+          <GraphNodeContent
+            contents={contents}
+            mod={mod}
+            description={description}
+            index={index}
+          />
+        </Row>
+      </Col>
+    </Row>
   );
 };
 
@@ -199,8 +207,9 @@ export function GraphNotification(props: {
   }, [api, timebox, index, read]);
 
   return (
-    <Col onClick={onClick} p="2">
+    <Col p="2">
       <Header
+        onClick={onClick}
         archived={props.archived}
         time={time}
         read={read}
@@ -223,6 +232,8 @@ export function GraphNotification(props: {
             index={content.index}
             graph={graph}
             group={group}
+            read={read}
+            onRead={onClick}
           />
         ))}
       </Col>

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -29,9 +29,9 @@ function getGraphModuleIcon(module: string) {
 
 const FilterBox = styled(Box)`
   background: linear-gradient(
-    ${(p) => p.theme.colors.scales.white10} 0%,
-    ${(p) => p.theme.colors.scales.white60} 40%,
-    ${(p) => p.theme.colors.scales.white100} 100%
+    to bottom,
+    transparent,
+    ${(p) => p.theme.colors.white}
   );
 `;
 
@@ -91,7 +91,7 @@ const GraphNodeContent = ({ contents, mod, description, index }) => {
               width="100%"
               zIndex="1"
               height="calc(100% - 2em)"
-              bottom="0px"
+              bottom="-4px"
               position="absolute"
             />
           </Box>

--- a/pkg/interface/src/views/apps/notifications/header.tsx
+++ b/pkg/interface/src/views/apps/notifications/header.tsx
@@ -37,7 +37,7 @@ export function Header(props: {
   read: boolean;
   associations: Associations;
   chat?: boolean;
-}) {
+} & PropFunc<typeof Row> ) {
   const { description, channel, group, moduleIcon, read } = props;
   const contacts = props.contacts[group] || {};
 
@@ -71,7 +71,7 @@ export function Header(props: {
     channel;
 
   return (
-    <Row p="2" flexWrap="wrap" gapX="1" alignItems="center">
+    <Row onClick={props.onClick} p="2" flexWrap="wrap" gapX="1" alignItems="center">
       {!props.archived && (
         <Icon
           display="block"

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -4,12 +4,15 @@ import _ from "lodash";
 import { Icon, Col, Row, Box, Text, Anchor } from "@tlon/indigo-react";
 import moment from "moment";
 import { Notifications, Rolodex, Timebox, IndexedNotification } from "~/types";
-import { MOMENT_CALENDAR_DATE, daToUnix } from "~/logic/lib/util";
+import { MOMENT_CALENDAR_DATE, daToUnix, resourceAsPath } from "~/logic/lib/util";
 import { BigInteger } from "big-integer";
 import GlobalApi from "~/logic/api/global";
 import { Notification } from "./notification";
 import { Associations } from "~/types";
 import { cite } from '~/logic/lib/util';
+import {useWaitForProps} from "~/logic/lib/useWaitForProps";
+import {useHistory} from "react-router-dom";
+import {StatelessAsyncAction} from "~/views/components/StatelessAsyncAction";
 
 type DatedTimebox = [BigInteger, Timebox];
 
@@ -43,6 +46,8 @@ export default function Inbox(props: {
   invites: any;
 }) {
   const { api, associations, invites } = props;
+  const waiter = useWaitForProps(props)
+  const history = useHistory();
   useEffect(() => {
     let seen = false;
     setTimeout(() => {
@@ -87,14 +92,17 @@ export default function Inbox(props: {
     return Object.keys(object).find(key => object[key] === value);
   };
 
-  const acceptInvite = (invite) => {
+  const acceptInvite = async (invite) => {
     const resource = {
       ship: `~${invite.resource.ship}`,
       name: invite.resource.name
     };
-    return api.contacts.join(resource).then(() => {
-      api.invite.accept('contacts', getKeyByValue(invites['contacts'], invite));
-    });
+    await api.contacts.join(resource);
+    await api.invite.accept('contacts', getKeyByValue(invites['contacts'], invite));
+    const path = resourceAsPath(invite.resource)
+    await waiter(p => path in p.associations?.contacts);
+
+    history.push(`/~landscape${path}`);
   };
 
   return (
@@ -104,26 +112,29 @@ export default function Inbox(props: {
           bg='white'
           p='3'
           fontSize='0'>
-          <Text display='block' pb='2' gray>{cite(invite.resource.ship)} invited you to <Text fontWeight='500'>{invite.resource.name}</Text></Text>
+          <Text display='block' pb='2' gray><Text mono>{cite(invite.resource.ship)}</Text> invited you to <Text fontWeight='500'>{invite.resource.name}</Text></Text>
           <Box pt='3'>
-            <Text
+            <StatelessAsyncAction 
+              name="accept"
+              bg="transparent"
               onClick={() => acceptInvite(invite)}
-            color='blue'
-            mr='2'
-            cursor='pointer'>
+              color='blue'
+              mr='2'
+            >
               Accept
-            </Text>
-            <Text
+            </StatelessAsyncAction>
+            <StatelessAsyncAction
+              name="decline"
+              bg="transparent"
               color='red'
               onClick={() =>
                 api.invite.decline(
                   'contacts',
                   getKeyByValue(invites['contacts'], invite)
                 )
-              }
-              cursor='pointer'>
+              }>
                 Reject
-              </Text>
+              </StatelessAsyncAction>
           </Box>
         </Box>
       ))}

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -69,12 +69,17 @@ export default function Inbox(props: {
     f.values
   )(notifications);
 
+  useEffect(() => {
+    api.hark.getMore(props.showArchive);
+  }, [props.showArchive]);
+
   const onScroll = useCallback((e) => {
     let container = e.target;
-    if(!props.showArchive && (container.scrollHeight - container.scrollTop === container.clientHeight)) {
-      api.hark.getMore();
+    const { scrollHeight, scrollTop, clientHeight } = container;
+    if((scrollHeight - scrollTop - clientHeight) < 20) {
+      api.hark.getMore(props.showArchive);
     }
-  }, [api]);
+  }, [props.showArchive]);
 
   const incomingGroups = Object.values(invites?.['contacts'] || {});
 
@@ -93,7 +98,7 @@ export default function Inbox(props: {
   };
 
   return (
-    <Col onScroll={onScroll} overflowY="auto" flexGrow="1" minHeight='0' flexShrink='0'>
+    <Col onScroll={onScroll} overflowY="auto" height="100%" minHeight='0'>
       {incomingGroups.map((invite) => (
         <Box
           bg='white'

--- a/pkg/interface/src/views/landscape/components/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Skeleton.tsx
@@ -43,7 +43,7 @@ interface SkeletonProps {
 
 export function Skeleton(props: SkeletonProps) {
   const chatConfig = useChat(props.inbox, props.chatSynced);
-  const graphConfig = useGraphModule(props.graphKeys, props.graphs, props.graphUnreads);
+  const graphConfig = useGraphModule(props.graphKeys, props.graphs, props.unreads.graph);
   const config = useMemo(
     () => ({
       graph: graphConfig,


### PR DESCRIPTION
Reworks the caching so that we keep a `(jug index @da)` as a cache of what indices have unread notifications in what timeboxes. Uses this cache to unify the unread handling and add a `%read-index` poke, which allows us to automatically read notifications when we mark a chat as read. Additionally, adds unread counts to group tiles as seen below.

Also includes assorted bugfixes:
- Cleans up UX of accepting a group invite from the invite (#3924 )
- Does not mark notifications as unread when their content is navigated to (#3920 )
- Fixes ordering and loading of notifications (#3929 )
- Fixes an issue where the color of the transparency on publish note notifications would not adjust with theme
- Enables scrollback on archived notifications

![Capture d’écran 2020-11-16 à 12 25 51 PM](https://user-images.githubusercontent.com/46801558/99206554-63d94e80-2807-11eb-8466-2d86d0a4fb15.png)
