### PR TITLE
interface: bump indigo to 1.2.14, adjust flexes

### DIFF
--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -1693,9 +1693,9 @@
       "integrity": "sha512-3OPSdf9cejP/TSzWXuBaYbzLtAfBzQnc75SlPLkoPfwpxnv1Bvy9hiWngLY0WnKRR6lMOldnkYQCCuNWeDibYQ=="
     },
     "@tlon/indigo-react": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@tlon/indigo-react/-/indigo-react-1.2.13.tgz",
-      "integrity": "sha512-6qYLjVcGZtDjI+BqS2PRrfAh9mUCDtYwDOHuYuPyV87mdVRAhduBlQ/3tDVlTNWICF9DeAhozeClxalACs5Ipw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@tlon/indigo-react/-/indigo-react-1.2.14.tgz",
+      "integrity": "sha512-iZFNW7GkR7xbAX9g965MvBd51gK8Gfk+UA8+FNjz30VSngjHE4CHweLSp+zkypzWYb5HHAd+7/vetNeZEev+1Q==",
       "requires": {
         "@reach/menu-button": "^0.10.5",
         "react": "^16.13.1",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -9,7 +9,7 @@
     "@reach/menu-button": "^0.10.5",
     "@reach/tabs": "^0.10.5",
     "@tlon/indigo-light": "^1.0.3",
-    "@tlon/indigo-react": "1.2.13",
+    "@tlon/indigo-react": "1.2.14",
     "@tlon/sigil-js": "^1.4.2",
     "aws-sdk": "^2.726.0",
     "big-integer": "^1.6.48",

--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -103,7 +103,7 @@ export function ChatResource(props: ChatResourceProps) {
   }, [station]);
 
   return (
-    <Col {...bind} height="100%" overflow="hidden" position="relative">
+    <Col {...bind} height="calc(100% - 33px)" overflow="hidden" position="relative">
       {dragging && <SubmitDragger />}
       <ChatWindow
         remoteContentPolicy={props.remoteContentPolicy}

--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -188,9 +188,7 @@ return;
     return (
       <Row
         alignItems='center'
-        position='relative'
-        flexGrow='1'
-        flexShrink='0'
+        flexGrow={1}
         borderTop='1'
         borderTopColor='washedGray'
         backgroundColor='white'
@@ -211,7 +209,6 @@ return;
         />
         <Box
           mx='2'
-          flexShrink='0'
           height='16px'
           width='16px'
           flexBasis='16px'
@@ -232,7 +229,6 @@ return;
         </Box>
         <Box
           mr='2'
-          flexShrink='0'
           height='16px'
           width='16px'
           flexBasis='16px'

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -16,9 +16,8 @@ export const DATESTAMP_FORMAT = '[~]YYYY.M.D';
 export const UnreadMarker = React.forwardRef(({ dayBreak, when }, ref) => (
   <Row ref={ref} color='blue' alignItems='center' fontSize='0' position='absolute' width='100%' py='2'>
     <Rule borderColor='blue' display={['none', 'block']} m='0' width='2rem' />
-    <Text flexShrink='0' display='block' zIndex='2' mx='4' color='blue'>New messages below</Text>
+    <Text display='block' zIndex='2' mx='4' color='blue'>New messages below</Text>
     <Rule borderColor='blue' flexGrow='1' m='0'/>
-    <Rule style={{ width: "calc(50% - 48px)" }} borderColor='blue' m='0' />
   </Row>
 ));
 
@@ -134,7 +133,6 @@ export default class ChatMessage extends Component<ChatMessageProps> {
         display='flex'
         flexWrap='wrap'
         pt={this.props.pt ? this.props.pt : renderSigil ? 3 : 0}
-        pr={3}
         pb={isLastMessage ? 3 : 0}
         ref={this.divRef}
         className={containerClass}
@@ -146,7 +144,7 @@ export default class ChatMessage extends Component<ChatMessageProps> {
         {renderSigil
           ? <MessageWithSigil {...messageProps} />
           : <MessageWithoutSigil {...messageProps} />}
-        <Box fontSize={0} position='relative' width='100%' overflow='visible' style={unreadContainerStyle}>{isLastRead
+        <Box overflow='hidden' fontSize={0} position='relative' width='100%' style={unreadContainerStyle}>{isLastRead
           ? <UnreadMarker dayBreak={dayBreak} when={msg.when} ref={unreadMarkerRef} />
           : null}</Box>
       </Box>
@@ -224,7 +222,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
           api={api}
           className="fl pr3 v-top pt1"
         />
-        <Box flexGrow='1' display='block' className="clamp-message">
+        <Box mr="3" flexGrow='1' display='block' className="clamp-message">
           <Box
             className="hide-child"
             pt={1}
@@ -245,7 +243,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
               }}
               title={`~${msg.author}`}
             >{name}</Text>
-            <Text flexShrink='0' gray mono className="v-mid">{timestamp}</Text>
+            <Text gray mono className="v-mid">{timestamp}</Text>
             <Text gray mono ml={2} className="v-mid child dn-s">{datestamp}</Text>
           </Box>
           <Box fontSize={fontSize ? fontSize : '14px'}><MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure} fontSize={fontSize} /></Box>
@@ -258,7 +256,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
 export const MessageWithoutSigil = ({ timestamp, msg, remoteContentPolicy, measure }) => (
   <>
     <Text mono gray display='inline-block' pt='2px' lineHeight='tall' className="child">{timestamp}</Text>
-    <Box fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
+    <Box mr="3" fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
       <MessageContent content={msg.letter} remoteContentPolicy={remoteContentPolicy} measure={measure}/>
     </Box>
   </>

--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -286,7 +286,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
         <VirtualScroller
           ref={list => {this.virtualList = list}}
           origin="bottom"
-          style={{ height: '100%' }}
+          style={{ height: 'calc(100% - 32px)' }}
           onStartReached={() => {
             this.setState({ idle: false });
             this.dismissUnread();

--- a/pkg/interface/src/views/apps/chat/components/unread-notice.js
+++ b/pkg/interface/src/views/apps/chat/components/unread-notice.js
@@ -34,7 +34,7 @@ export const UnreadNotice = (props) => {
         borderRadius='1'
         border='1'
         borderColor='blue'>
-        <Text flexShrink='1' textOverflow='ellipsis' whiteSpace='pre' overflow='hidden' display='block' cursor='pointer' onClick={onClick}>
+        <Text style={{ flexShrink: "1" }} textOverflow='ellipsis' whiteSpace='pre' overflow='hidden' display='block' cursor='pointer' onClick={onClick}>
           {unreadCount} new messages since{' '}
           {datestamp && (
             <>
@@ -48,7 +48,6 @@ export const UnreadNotice = (props) => {
           color='blue'
           cursor='pointer'
           textAlign='right'
-          flexShrink='0'
           onClick={dismissUnread}>
           Mark as Read
         </Text>

--- a/pkg/interface/src/views/apps/launch/components/tiles/weather.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/weather.js
@@ -166,7 +166,6 @@ export default class WeatherTile extends React.Component {
             backgroundColor='transparent'
             color='black'
             cursor='pointer'
-            flexShrink='0'
             pl='1'
             fontSize='0'
             border='0'

--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -69,7 +69,7 @@ export function LinkResource(props: LinkResourceProps) {
           render={(props) => {
             return (
               <Col width="100%" p={4} alignItems="center" maxWidth="768px">
-                <Col width="100%" flexShrink='0'>
+                <Col width="100%">
                   <LinkSubmit s3={s3} name={name} ship={ship.slice(1)} api={api} />
                 </Col>
                 {Array.from(graph).map(([date, node]) => {

--- a/pkg/interface/src/views/apps/links/components/link-item.js
+++ b/pkg/interface/src/views/apps/links/components/link-item.js
@@ -42,7 +42,7 @@ export const LinkItem = (props) => {
   const [ship, name] = resource.split('/');
 
   return (
-    <Row minWidth='0' flexShrink='0' width="100%" alignItems="center" py={3} bg="white">
+    <Row minWidth='0' width="100%" alignItems="center" py={3} bg="white">
       {img}
       <Col minWidth='0' height="100%" width='100%' justifyContent="space-between" ml={2}>
         <Anchor

--- a/pkg/interface/src/views/apps/links/components/link-submit.tsx
+++ b/pkg/interface/src/views/apps/links/components/link-submit.tsx
@@ -183,7 +183,6 @@ export class LinkSubmit extends Component<LinkSubmitProps, LinkSubmitState> {
     return (
       <>
       <Box
-        flexShrink='0'
         position='relative'
         border='1px solid'
         borderColor={this.state.submitFocus ? 'black' : 'washedGray'}
@@ -294,7 +293,6 @@ export class LinkSubmit extends Component<LinkSubmitProps, LinkSubmitState> {
       </Box>
       <Box mt='2' mb='4'>
         <Button
-          flexShrink='0'
           primary
           disabled={!this.state.linkValid || this.state.disabled}
           onClick={this.onClickPost.bind(this)}

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -94,7 +94,7 @@ export default function Inbox(props: {
   };
 
   return (
-    <Col onScroll={onScroll} overflowY="auto" flexGrow="1" minHeight='0' flexShrink='0'>
+    <Col onScroll={onScroll} overflowY="auto" flexGrow="1" minHeight='0'>
       {incomingGroups.map((invite) => (
         <Box
           bg='white'
@@ -206,7 +206,7 @@ function DaySection({
         _.map(nots.sort(sortIndexedNotification), (not, j: number) => (
           <React.Fragment key={j}>
             {(i !== 0 || j !== 0) && (
-              <Box flexShrink="0" height="4px" bg="scales.black05" />
+              <Box height="4px" bg="scales.black05" />
             )}
             <Notification
               graphConfig={graphConfig}

--- a/pkg/interface/src/views/apps/publish/PublishResource.tsx
+++ b/pkg/interface/src/views/apps/publish/PublishResource.tsx
@@ -20,7 +20,7 @@ export function PublishResource(props: PublishResourceProps) {
   const notebookContacts = props.contacts[association["group-path"]];
 
   return (
-    <Box height="100%" width="100%" overflowY="auto">
+    <Box height="calc(100% - 32px)" width="100%" overflowY="auto">
       <NotebookRoutes
         api={api}
         ship={ship}

--- a/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
@@ -42,12 +42,11 @@ export function PostForm(props: PostFormProps) {
         validateOnBlur
       >
         <Form style={{ display: "contents"}}>
-          <Row flexShrink='0' flexDirection={["column-reverse", "row"]} mb={4} gapX={4} justifyContent='space-between'>
+          <Row flexDirection={["column-reverse", "row"]} mb={4} gapX={4} justifyContent='space-between'>
             <Input maxWidth='40rem' width='100%' flexShrink={[0, 1]} placeholder="Post Title" id="title" />
             <AsyncButton
               ml={[0,2]}
               mb={[4,0]}
-              flexShrink={0}
               primary
               loadingText={loadingText}
             >

--- a/pkg/interface/src/views/components/ChipInput.tsx
+++ b/pkg/interface/src/views/components/ChipInput.tsx
@@ -115,7 +115,6 @@ export function ChipInput(props: ChipInputProps) {
         <Input
           width="auto"
           height="24px"
-          flexShrink="1"
           flexGrow="1"
           pl="0"
           ref={inputRef}

--- a/pkg/interface/src/views/components/Dropdown.tsx
+++ b/pkg/interface/src/views/components/Dropdown.tsx
@@ -11,6 +11,7 @@ import { Box, Col } from "@tlon/indigo-react";
 import { useOutsideClick } from "~/logic/lib/useOutsideClick";
 import { useLocation } from "react-router-dom";
 import { Portal } from "./Portal";
+import {PropFunc} from "~/types/util";
 
 type AlignY = "top" | "bottom";
 type AlignX = "left" | "right";
@@ -34,8 +35,8 @@ const DropdownOptions = styled(Box)`
   transition-timing-function: ease;
 `;
 
-export function Dropdown(props: DropdownProps) {
-  const { children, options } = props;
+export function Dropdown(props: DropdownProps & PropFunc<typeof Box>) {
+  const { children, options, alignX, alignY, width, ...rest } = props;
   const dropdownRef = useRef<HTMLElement>(null);
   const anchorRef = useRef<HTMLElement>(null);
   const { pathname } = useLocation();
@@ -51,12 +52,12 @@ export function Dropdown(props: DropdownProps) {
         bottom: document.documentElement.clientHeight - rect.bottom,
         right: document.documentElement.clientWidth - rect.right,
       };
-      const alignX = _.isArray(props.alignX) ? props.alignX : [props.alignX];
-      const alignY = _.isArray(props.alignY) ? props.alignY : [props.alignY];
+      const newAlignX = _.isArray(alignX) ? alignX : [alignX];
+      const newAlignY = _.isArray(alignY) ? alignY : [alignY];
 
       let newCoords = {
         ..._.reduce(
-          alignX,
+          newAlignY,
           (acc, a, idx) => ({
             ...acc,
             [a]: _.zipWith(
@@ -68,7 +69,7 @@ export function Dropdown(props: DropdownProps) {
           {}
         ),
         ..._.reduce(
-          alignY,
+          newAlignX,
           (acc, a, idx) => ({
             ...acc,
             [a]: _.zipWith(
@@ -111,14 +112,14 @@ export function Dropdown(props: DropdownProps) {
   });
 
   return (
-    <Box flexShrink={1} position={open ? "relative" : "static"} minWidth='0'>
+    <Box style={{ flexShrink:"1" }} position={open ? "relative" : "static"} minWidth='0'>
       <ClickBox width='100%' ref={anchorRef} onClick={onOpen}>
         {children}
       </ClickBox>
       {open && (
         <Portal>
           <DropdownOptions
-            width={props.width || "max-content"}
+            width={width || "max-content"}
             {...coords}
             ref={dropdownRef}
           >

--- a/pkg/interface/src/views/components/StatusBar.js
+++ b/pkg/interface/src/views/components/StatusBar.js
@@ -44,7 +44,7 @@ const StatusBar = (props) => {
         />
       </Row>
       <Row justifyContent="flex-end" collapse>
-        <StatusBarItem px={'2'} flexShrink='0' onClick={() => props.history.push('/~profile')}>
+        <StatusBarItem px={'2'} onClick={() => props.history.push('/~profile')}>
           <Sigil ship={props.ship} size={16} color='black' classes='mix-blend-diff' icon />
           <Text ml={2} display={["none", "inline"]} fontFamily="mono">~{props.ship}</Text>
         </StatusBarItem>

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -87,7 +87,6 @@ export class OmniboxResult extends Component {
         verticalAlign="middle"
         color={this.state.hovered || selected === link ? 'white' : 'black'}
         maxWidth="60%"
-        style={{ flexShrink: 0 }}
         mr='1'
         >
           {text}
@@ -96,7 +95,7 @@ export class OmniboxResult extends Component {
         display="inline-block"
         verticalAlign="middle"
         color={this.state.hovered || selected === link ? 'white' : 'black'}
-        width='100%'
+        flexGrow={1}
         textAlign='right'
         >
           {subtext}

--- a/pkg/interface/src/views/landscape/components/ChannelSettings.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelSettings.tsx
@@ -69,7 +69,7 @@ export function ChannelSettings(props: ChannelSettingsProps) {
     <Col gapY="6" overflowY="auto" p={4}>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form style={{ display: "contents" }}>
-          <Col flexShrink="0" maxWidth="512px" gapY="4">
+          <Col maxWidth="512px" gapY="4">
             <Col mb={3}>
               <Text fontWeight="bold">Channel Settings</Text>
               <Label gray mt="2">

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -60,7 +60,6 @@ function RecentGroups(props: { recent: string[]; associations: Associations }) {
               bg={`#${color}`}
               mr={2}
               display="block"
-              flexShrink='0'
             />
               <Text verticalAlign='top' maxWidth='100%' overflow='hidden' display='inline-block' style={{ textOverflow: 'ellipsis', whiteSpace: 'pre' }}>{assoc?.metadata?.title}</Text>
             </Row>
@@ -93,6 +92,7 @@ export function GroupSwitcher(props: {
           <Dropdown
             width="231px"
             alignY="top"
+            alignX="left"
             options={
               <Col
                 borderRadius={1}
@@ -165,12 +165,10 @@ export function GroupSwitcher(props: {
               </Col>
             }
           >
-            <Row p={2} alignItems="center" width='100%' minWidth='0'>
-              <Row alignItems="center" mr={1} flex='1' width='100%' minWidth='0'>
-                <Text overflow='hidden' display='inline-block' flexShrink='1' style={{ textOverflow: 'ellipsis', whiteSpace: 'pre'}}>{title}</Text>
+              <Row p="2" alignItems="center" mr={1} flex='1' flexGrow={1}>
+                <Text overflow='hidden' display='inline-block' style={{ flexShrink: "1", textOverflow: 'ellipsis', whiteSpace: 'pre'}}>{title}</Text>
                 <Icon size='12px' ml='1' mt="0px" display="inline-block" icon="ChevronSouth" />
               </Row>
-            </Row>
           </Dropdown>
           <Row pr={1} justifyContent="flex-end" alignItems="center">
             {(workspace.type === "group") && (

--- a/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
@@ -75,7 +75,7 @@ export function GroupifyForm(props: GroupifyFormProps) {
       onSubmit={onGroupify}
     >
       <Form>
-        <Col flexShrink="0" gapY="4" maxWidth="512px">
+        <Col gapY="4" maxWidth="512px">
           <Box>
             <Text fontWeight="500">Groupify this channel</Text>
           </Box>

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -171,9 +171,8 @@ export function Participants(props: {
         mb={2}
         px={2}
         zIndex={1}
-        flexShrink="0"
       >
-        <Row mr="4" flexShrink="0">
+        <Row mr="4">
           <Tab
             selected={filter}
             setSelected={setFilter}
@@ -196,7 +195,7 @@ export function Participants(props: {
           />
         </Row>
       </Row>
-      <Col flexShrink="0" width="100%" height="fit-content">
+      <Col width="100%" height="fit-content">
         <Row alignItems="center" bg="washedGray" borderRadius="1" px="2" my="2">
           <Icon color="gray" icon="MagnifyingGlass" />
           <Input

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -47,7 +47,6 @@ export function ResourceSkeleton(props: ResourceSkeletonProps) {
   return (
     <Col width="100%" height="100%" overflowY="hidden">
       <Box
-        flexShrink="0"
         py="2"
         px="2"
         display="flex"
@@ -85,9 +84,9 @@ export function ResourceSkeleton(props: ResourceSkeletonProps) {
               display={["none", "block"]}
               maxWidth="60%"
               verticalAlign="middle"
-              flexShrink={1}
               title={association?.metadata?.description}
               color="gray"
+              style={{ flexShrink: 1 }}
             >
               <RichText
                 color="gray"

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -143,9 +143,8 @@ export function Sidebar(props: SidebarProps) {
         apps={props.apps}
         baseUrl={props.baseUrl}
       />
-      <SidebarStickySpacer flexShrink={0} />
+      <SidebarStickySpacer />
       <Box
-        flexShrink="0"
         display={isAdmin ? "flex" : "none"}
         justifyContent="center"
         position="sticky"

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -103,7 +103,7 @@ export function SidebarItem(props: {
           color={color}
           icon={getAppIcon(appName, mod) as any}
         />
-        <Box width='100%' flexShrink={2} ml={2} display='flex' overflow='hidden'>
+        <Box width='100%' style={{ flexShrink: 2}} ml={2} display='flex' overflow='hidden'>
           <Text
             lineHeight="short"
             display='inline-block'

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -38,70 +38,64 @@ export function SidebarListHeader(props: {
 
   return (
     <Row
-      flexShrink="0"
       alignItems="center"
       justifyContent="space-between"
       py={2}
       pr={2}
       pl={3}
     >
-      <Box flexShrink='0'>
+      <Box>
         <Text>
           {props.initialValues.hideUnjoined ? "Joined Channels" : "All Channels"}
         </Text>
       </Box>
-      <Box
-        width='100%'
-        textAlign='right'
-        mr='2'
-        display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
-      >
-       <Link to={`${props.baseUrl}/invites`}>
-          <Text
-            display='inline-block'
-            verticalAlign='middle'
-            py='1px'
-            px='3px'
-            backgroundColor='washedBlue'
-            color='blue'
-            borderRadius='1'>
-              + DM
-            </Text>
+      <Row justifyContent="flex-end">
+        <Link
+          component={Text}
+          to={`${props.baseUrl}/invites`}
+          display={(props.workspace?.type === 'home') ? 'inline-block' : 'none'}
+          verticalAlign='middle'
+          mr="2"
+          py='1px'
+          px='3px'
+          backgroundColor='washedBlue'
+          color='blue'
+          borderRadius='1'>
+          + DM
         </Link>
-      </Box>
-      <Dropdown
-        flexShrink='0'
-        width="200px"
-        alignY="top"
-        alignX={["right", "left"]}
-        options={
-          <FormikOnBlur initialValues={props.initialValues} onSubmit={onSubmit}>
-            <Col bg="white" borderRadius={1} border={1} borderColor="lightGray">
-              <Col
-                gapY="2"
-                borderBottom={1}
-                borderBottomColor="washedGray"
-                p={2}
-              >
-                <Box>
-                  <Text color="gray">Sort Order</Text>
-                </Box>
-                <Radio mb="1" label="A -> Z" id="asc" name="sortBy" />
-                <Radio label="Last Updated" id="lastUpdated" name="sortBy" />
+        <Dropdown
+          width="200px"
+          alignY="top"
+          alignX={["right", "left"]}
+          options={
+            <FormikOnBlur initialValues={props.initialValues} onSubmit={onSubmit}>
+              <Col bg="white" borderRadius={1} border={1} borderColor="lightGray">
+                <Col
+                  gapY="2"
+                  borderBottom={1}
+                  borderBottomColor="washedGray"
+                  p={2}
+                >
+                  <Box>
+                    <Text color="gray">Sort Order</Text>
+                  </Box>
+                  <Radio mb="1" label="A -> Z" id="asc" name="sortBy" />
+                  <Radio label="Last Updated" id="lastUpdated" name="sortBy" />
+                </Col>
+                <Col px={2}>
+                  <Checkbox
+                    my={3}
+                    id="hideUnjoined"
+                    label="Hide Unsubscribed Channels"
+                  />
+                </Col>
               </Col>
-              <Col px={2}>
-                <Checkbox
-                  my={3}
-                  id="hideUnjoined"
-                  label="Hide Unsubscribed Channels"
-                />
-              </Col>
-            </Col>
-          </FormikOnBlur>
-        }
-      >
-        <Icon color="gray" icon="Adjust" />
-      </Dropdown>
+            </FormikOnBlur>
+          }
+        >
+          <Icon color="gray" icon="Adjust" />
+        </Dropdown>
+      </Row>
     </Row>
   );
 }


### PR DESCRIPTION
Bumps indigo to 1.2.14 and adjusts flexes to accomodate the `flex-shrink: 0` change. I realise this change might be slightly contentious, so I'd like to justify it in full.

### The problem with flex-shrink

With larger, layout-type components (think inputs in a form), you never want flex-shrink because you want it to scroll. Because of the unpredictable interaction of `min-{height,width}` and flex-shrink (behaviour differs very heavily on Safari, Chrome and FF), flex-shrink means that instead of having to test at a handful of screen width based on your media queries, the screen height is an important part of the equation, and layouts can break on only some combinations of screen dimensions. 

Furthermore, `flex-shrink: 1` (the user agent default as per the CSS spec), makes setting a percentage height/width ambiguous. In this PR there are some changes to heights to make containers size correctly. Setting `height="100%"` on a container that will *never* be the full height of its parent is ambiguous at best and downright confusing at worst. Instead, consider `flex-grow: 1` or a calculated height.

The number of deletions in this PR is also a decent argument for why flex-shrink should be off by default. 

cc: @tacryt-socryp @tylershuster 
