### PR TITLE
hoon: bscl to bccl, etc

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4e0acf6459d5d17f2dff4de71e9ddd0732148f00bd13d0c092fdfa14774a015
-size 6332407
+oid sha256:d18233ffa40c24e0e3d43b201788cf5d880ea4517fb33f12f6850af2b6a8100c
+size 6436148

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -897,7 +897,7 @@
     ++  dy-hoon-var
       =+  ^=  ope
           |=  gen/hoon  ^-  hoon
-          ?:  ?=(?($sgld $sgbn) -.gen)
+          ?:  ?=(?($sggl $sggr) -.gen)
             $(gen q.gen)
           =+  ~(open ap gen)
           ?.(=(gen -) $(gen -) gen)

--- a/pkg/arvo/gen/ivory.hoon
+++ b/pkg/arvo/gen/ivory.hoon
@@ -33,8 +33,8 @@
 ::    Parsed with a static path for reproducibility.
 ::
 =/  whole-hoon=hoon
-  :+  %tsbn  compiler-hoon
-  :+  %tsld  (rain /sys/arvo/hoon arvo-source)
+  :+  %tsgr  compiler-hoon
+  :+  %tsgl  (rain /sys/arvo/hoon arvo-source)
   [%$ 7]
 ::  compile the whole schmeer
 ::

--- a/pkg/arvo/gen/solid.hoon
+++ b/pkg/arvo/gen/solid.hoon
@@ -35,7 +35,7 @@
     ::  compile arvo against hoon, with our current compiler
     ::
     =/  whole-hoon=hoon
-      [%tsbn compiler-hoon [%tsbn [%$ 7] (rain arvo-path arvo-src)]]
+      [%tsgr compiler-hoon [%tsgr [%$ 7] (rain arvo-path arvo-src)]]
     ~&  %solid-parsed
     =/  whole-formula  q:(~(mint ut %noun) %noun whole-hoon)
     ~&  %solid-arvo

--- a/pkg/arvo/lib/language-server/complete.hoon
+++ b/pkg/arvo/lib/language-server/complete.hoon
@@ -144,7 +144,7 @@
       [^ *]      (both p.gen q.gen)
       [%ktcn *]  loop(gen p.gen)
       [%brcn *]  (grow q.gen)
-      [%brvt *]  (grow q.gen)
+      [%brpt *]  (grow q.gen)
       [%cnts *]
     |-  ^-  (unit [term type])
     =*  inner-loop  $
@@ -165,13 +165,13 @@
       [%hand *]  ~
       [%ktbr *]  loop(gen p.gen)
       [%ktls *]  (both p.gen q.gen)
-      [%ktpd *]  loop(gen p.gen)
+      [%ktpm *]  loop(gen p.gen)
       [%ktsg *]  loop(gen p.gen)
       [%ktwt *]  loop(gen p.gen)
       [%note *]  loop(gen q.gen)
       [%sgzp *]  (both p.gen q.gen)
-      [%sgbn *]  loop(gen q.gen)  ::  should check for hoon in p.gen
-      [%tsbn *]  (change p.gen q.gen)
+      [%sggr *]  loop(gen q.gen)  ::  should check for hoon in p.gen
+      [%tsgr *]  (change p.gen q.gen)
       [%tscm *]
     %+  replace
       loop(gen p.gen)
@@ -185,7 +185,7 @@
       [%lost *]  loop(gen p.gen)
       [%zpmc *]  (both p.gen q.gen)
       [%zpts *]  loop(gen p.gen)
-      [%zpvt *]  (both q.gen r.gen)
+      [%zppt *]  (both q.gen r.gen)
       [%zpzp *]  ~
       *
     =+  doz=~(open ap gen)

--- a/pkg/arvo/lib/language-server/easy-print.hoon
+++ b/pkg/arvo/lib/language-server/easy-print.hoon
@@ -17,7 +17,7 @@
           {$face p/term q/wine}
           {$list p/term q/wine}
           {$pear p/term q/@}
-          {$bswt p/(list wine)}
+          {$bcwt p/(list wine)}
           {$plot p/(list wine)}
           {$stop p/@ud}
           {$tree p/term q/wine}
@@ -122,7 +122,7 @@
       =^  cox  gid  $(q.ham q.q.ham)
       :_(gid [%rose [" " (weld (trip p.q.ham) "(") ")"] cox ~])
     ::
-        {$bswt *}
+        {$bcwt *}
       =^  coz  gid  (many p.q.ham)
       :_(gid [%rose [[' ' ~] ['?' '(' ~] [')' ~]] coz])
     ::
@@ -265,7 +265,7 @@
       ~
     [~ u.for u.aft]
   ::
-      {$bswt *}
+      {$bcwt *}
     |-  ^-  (unit tank)
     ?~  p.q.ham
       ~
@@ -354,7 +354,7 @@
   ^=  woz
   ^-  wine
   ?.  ?=({$stop *} q.ham)
-    ?:  ?&  ?=  {$bswt {$pear $n $0} {$plot {$pear $n $0} {$face *} ~} ~}
+    ?:  ?&  ?=  {$bcwt {$pear $n $0} {$plot {$pear $n $0} {$face *} ~} ~}
               q.ham
             =(1 (met 3 p.i.t.p.i.t.p.q.ham))
         ==
@@ -364,7 +364,7 @@
   ?~  may
     q.ham
   =+  nul=[%pear %n 0]
-  ?.  ?&  ?=({$bswt *} u.may)
+  ?.  ?&  ?=({$bcwt *} u.may)
           ?=({* * ~} p.u.may)
           |(=(nul i.p.u.may) =(nul i.t.p.u.may))
       ==
@@ -458,7 +458,7 @@
   ::
       {$fork *}
     =+  yed=(sort ~(tap in p.sut) aor)
-    =-  [p [%bswt q]]
+    =-  [p [%bcwt q]]
     |-  ^-  {p/{p/(map type @) q/(map @ wine)} q/(list wine)}
     ?~  yed
       [dex ~]

--- a/pkg/arvo/lib/pprint.hoon
+++ b/pkg/arvo/lib/pprint.hoon
@@ -340,7 +340,7 @@
       [%brsg *]  (rune '|~' ~ ~ (spec p.x) (hn q.x) ~)
       [%brtr *]  (rune '|*' ~ ~ (spec p.x) (hn q.x) ~)
       [%brts *]  (rune '|=' ~ ~ (spec p.x) (hn q.x) ~)
-      [%brvt *]  (chapter '|@' ~ q.x)                 ::  Ignoring p.x
+      [%brpt *]  (chapter '|@' ~ q.x)                 ::  Ignoring p.x
       [%brwt *]  (rune '|?' ~ ~ (hn p.x) ~)
       [%clcb *]  (rune ':_' ~ ~ (hoons ~[p q]:x))
       [%clkt *]  (rune ':^' ~ ~ (hoons ~[p q r s]:x))
@@ -370,7 +370,7 @@
       [%ktdt *]  (rune '^.' ~ ~ (hoons ~[p q]:x))
       [%ktls *]  (rune '^+' ~ ~ (hoons ~[p q]:x))
       [%kthp *]  (rune '^-' ~ ~ ~[(spec p.x) (hn q.x)])
-      [%ktpd *]  (rune '^&' ~ ~ (hoons ~[p]:x))
+      [%ktpm *]  (rune '^&' ~ ~ (hoons ~[p]:x))
       [%ktsg *]  (rune '^~' ~ ~ (hoons ~[p]:x))
       [%ktts *]  (rune '^=' ~ `['' '=' ''] ~[(skin p.x) (hn q.x)])
       [%ktwt *]  (rune '^?' ~ ~ (hoons ~[p]:x))
@@ -379,56 +379,58 @@
       [%sgbr *]  (rune '~|' ~ ~ (hoons ~[p q]:x))
       [%sgcb *]  (rune '~_' ~ ~ (hoons ~[p q]:x))
       [%sgcn *]  (rune '~%' ~ ~ (chum p.x) (hn q.x) (tyre r.x) (hn s.x) ~)
-      [%sgnt *]  (rune '~/' ~ ~ (chum p.x) (hn q.x) ~)
-      [%sgld *]  (rune '~<' ~ ~ (hint p.x) (hn q.x) ~)
-      [%sgbn *]  (rune '~>' ~ ~ (hint p.x) (hn q.x) ~)
-      [%sgbs *]  (rune '~$' ~ ~ p.x (hn q.x) ~)
+      [%sgfs *]  (rune '~/' ~ ~ (chum p.x) (hn q.x) ~)
+      [%sggl *]  (rune '~<' ~ ~ (hint p.x) (hn q.x) ~)
+      [%sggr *]  (rune '~>' ~ ~ (hint p.x) (hn q.x) ~)
+      [%sgbc *]  (rune '~$' ~ ~ p.x (hn q.x) ~)
       [%sgls *]  (rune '~+' ~ ~ (hn q.x) ~)           ::  Ignoring p.x
-      [%sgpd *]  (rune '~&' ~ ~ (hoons ~[q r]:x))     ::  Ignoring p.x
+      [%sgpm *]  (rune '~&' ~ ~ (hoons ~[q r]:x))     ::  Ignoring p.x
       [%sgts *]  (rune '~=' ~ ~ (hoons ~[p q]:x))
       [%sgwt *]  (rune '~?' ~ ~ (hoons ~[q r s]:x))   ::  Ignoring p.x
       [%sgzp *]  (rune '~!' ~ ~ (hoons ~[p q]:x))
       [%mcts *]  %ast-node-mcts
       [%mccl *]  (rune ';:' `'==' `[':(' spc ')'] (hoons [p q]:x))
-      [%mcnt *]  (rune ';/' ~ ~ (hoons ~[p]:x))
+      [%mcfs *]  (rune ';/' ~ ~ (hoons ~[p]:x))
       [%mcgl *]  (rune ';<' ~ ~ (spec p.x) (hoons ~[q r s]:x))
       [%mcsg *]  (rune ';~' `'==' ~ (hoons [p q]:x))
       [%mcmc *]  (rune ';;' ~ ~ ~[(spec p.x) (hn q.x)])
       [%tsbr *]  (rune '=|' ~ ~ ~[(spec p.x) (hn q.x)])
       [%tscl *]  (tiscol-to-plum p.x q.x)
-      [%tsnt *]  (rune '=/' ~ ~ (skin p.x) (hn q.x) (hn r.x) ~)
+      [%tsfs *]  (rune '=/' ~ ~ (skin p.x) (hn q.x) (hn r.x) ~)
       [%tsmc *]  (rune '=;' ~ ~ [(skin p.x) (hoons ~[q r]:x)])
       [%tsdt *]  (rune '=.' ~ ~ [(wing p.x) (hoons ~[q r]:x)])
       [%tswt *]  (rune '=?' ~ ~ [(wing p.x) (hoons ~[q r s]:x)])
-      [%tsld *]  (rune '=>' ~ `['' ':' ''] (hoons ~[p q]:x))
+::  XX %tsld to %tsgl, but should be %tsgr? (to match =>)
+      [%tsgl *]  (rune '=>' ~ `['' ':' ''] (hoons ~[p q]:x))
       [%tshp *]  (rune '=-' ~ ~ (hoons ~[p q]:x))
-      [%tsbn *]  (rune '=<' ~ ~ (hoons ~[p q]:x))
+::  XX %tsbn to %tsgr, but should be %tsgl? (to match =<)
+      [%tsgr *]  (rune '=<' ~ ~ (hoons ~[p q]:x))
       [%tskt *]  (rune '=^' ~ ~ [(skin p.x) (wing q.x) (hoons ~[r s]:x)])
       [%tsls *]  (rune '=+' ~ ~ (hoons ~[p q]:x))
       [%tssg *]  (rune '=~' `'==' ~ (hoons p:x))
       [%tstr *]  ?~  q.p.x
                    (rune '=*' ~ ~ p.p.x (hoons ~[q r]:x))
-                 (rune '=*' ~ ~ (spec [%bsts p.p.x u.q.p.x]) (hoons ~[q r]:x))
+                 (rune '=*' ~ ~ (spec [%bcts p.p.x u.q.p.x]) (hoons ~[q r]:x))
       [%tscm *]  (rune '=,' ~ ~ (hoons ~[p q]:x))
       [%wtbr *]  (rune '?|' `'--' `['|(' ' ' ')'] (hoons p:x))
       [%wthp *]  (rune '?-' `'==' ~ (wing p.x) (matches q.x))
       [%wtcl *]  (rune '?:' ~ ~ (hoons ~[p q r]:x))
       [%wtdt *]  (rune '?.' ~ ~ (hoons ~[p q r]:x))
       [%wtkt *]  (rune '?^' ~ ~ [(wing p.x) (hoons ~[q r]:x)])
-      [%wtld *]  (rune '?<' ~ ~ (hoons ~[p q]:x))
-      [%wtbn *]  (rune '?>' ~ ~ (hoons ~[p q]:x))
+      [%wtgl *]  (rune '?<' ~ ~ (hoons ~[p q]:x))
+      [%wtgr *]  (rune '?>' ~ ~ (hoons ~[p q]:x))
       [%wtls *]  (rune '?+' `'==' ~ (wing p.x) (hn q.x) (matches r.x))
-      [%wtpd *]  (rune '?&' `'==' `['&(' ' ' ')'] (hoons p:x))
-      [%wtvt *]  (rune '?@' ~ ~ (wing p.x) (hoons ~[q r]:x))
+      [%wtpm *]  (rune '?&' `'==' `['&(' ' ' ')'] (hoons p:x))
+      [%wtpt *]  (rune '?@' ~ ~ (wing p.x) (hoons ~[q r]:x))
       [%wtsg *]  (rune '?~' ~ ~ (wing p.x) (hoons ~[q r]:x))
       [%wthx *]  (rune '?#' ~ ~ (skin p.x) (wing q.x) ~)
       [%wtts *]  (rune '?=' ~ ~ (spec p.x) (wing q.x) ~)
       [%wtzp *]  (rune '?!' ~ `['!' '' ''] (hoons ~[p]:x))
       [%zpcm *]  (rune '!,' ~ ~ (hoons ~[p q]:x))
-      [%zpbn *]  (rune '!>' ~ ~ (hoons ~[p]:x))
+      [%zpgr *]  (rune '!>' ~ ~ (hoons ~[p]:x))
       [%zpmc *]  (rune '!;' ~ ~ (hoons ~[p q]:x))
       [%zpts *]  (rune '!=' ~ ~ (hoons ~[p]:x))
-      [%zpvt *]  (rune '!@' ~ ~ (wingseq p.x) (hoons ~[q r]:x))
+      [%zppt *]  (rune '!@' ~ ~ (wingseq p.x) (hoons ~[q r]:x))
       [%zpwt *]  (hn q.x)                             ::  Ignore p.x
       [%zpzp ~]  '!!'
     ==
@@ -642,37 +644,37 @@
                  ?:  =(- 3)  '%^'
                  ?:  =(- 2)  '%+'  '%-'
                [(dohoon p.spec) (turn q.spec ..$)]
-        %bsbs  (core-spec-to-plum '$$' p.spec q.spec)
-        %bsbr  (subtree (fixed '$|') $(spec p.spec) (dohoon q.spec) ~)
-        %bscb  (dohoon p.spec)
-        %bscl  :-  %sbrk
+        %bcbc  (core-spec-to-plum '$$' p.spec q.spec)
+        %bcbr  (subtree (fixed '$|') $(spec p.spec) (dohoon q.spec) ~)
+        %bccb  (dohoon p.spec)
+        %bccl  :-  %sbrk
                :+  %tree
                  [`[' ' `['[' ']']] `['$:' `['' '==']]]
                (turn `(list ^spec)`+.spec ..$)
-        %bscn  (subtree (varying '$%' '==') (turn `(list ^spec)`+.spec ..$))
-        %bsdt  (core-spec-to-plum '$.' p.spec q.spec)
-        %bsld  (subtree (fixed '$<') $(spec p.spec) $(spec q.spec) ~)
-        %bsbn  (subtree (fixed '$>') $(spec p.spec) $(spec q.spec) ~)
-        %bshp  (subtree (fixed '$-') $(spec p.spec) $(spec q.spec) ~)
-        %bskt  (subtree (fixed '$^') $(spec p.spec) $(spec q.spec) ~)
-        %bsls  (subtree (fixed '$+') (stud-to-plum p.spec) $(spec q.spec) ~)
-        %bsnt  (core-spec-to-plum '$/' p.spec q.spec)
-        %bsmc  (subtree (fixed '$;') (dohoon p.spec) ~)
-        %bspd  (subtree (fixed '$&') $(spec p.spec) (dohoon q.spec) ~)
-        %bssg  (subtree (fixed '$~') (dohoon p.spec) $(spec q.spec) ~)
-        %bstc  (core-spec-to-plum '$`' p.spec q.spec)
-        %bsts  :-  %sbrk
+        %bccn  (subtree (varying '$%' '==') (turn `(list ^spec)`+.spec ..$))
+        %bcdt  (core-spec-to-plum '$.' p.spec q.spec)
+        %bcgl  (subtree (fixed '$<') $(spec p.spec) $(spec q.spec) ~)
+        %bcgr  (subtree (fixed '$>') $(spec p.spec) $(spec q.spec) ~)
+        %bchp  (subtree (fixed '$-') $(spec p.spec) $(spec q.spec) ~)
+        %bckt  (subtree (fixed '$^') $(spec p.spec) $(spec q.spec) ~)
+        %bcls  (subtree (fixed '$+') (stud-to-plum p.spec) $(spec q.spec) ~)
+        %bcfs  (core-spec-to-plum '$/' p.spec q.spec)
+        %bcmc  (subtree (fixed '$;') (dohoon p.spec) ~)
+        %bcpm  (subtree (fixed '$&') $(spec p.spec) (dohoon q.spec) ~)
+        %bcsg  (subtree (fixed '$~') (dohoon p.spec) $(spec q.spec) ~)
+        %bctc  (core-spec-to-plum '$`' p.spec q.spec)
+        %bcts  :-  %sbrk
                :+  %tree
                  [`['=' ~] `['$=' ~]]
                :~  (skin-to-plum p.spec)
                    $(spec q.spec)
                ==
-        %bsvt  (subtree (fixed '$@') $(spec p.spec) $(spec q.spec) ~)
-        %bswt  :-  %sbrk
+        %bcpt  (subtree (fixed '$@') $(spec p.spec) $(spec q.spec) ~)
+        %bcwt  :-  %sbrk
                :+  %tree
                   [`[' ' `['?(' ')']] `['$?' `['' '==']]]
                (turn `(list ^spec)`+.spec ..$)
-        %bszp  (core-spec-to-plum '$.' p.spec q.spec)
+        %bczp  (core-spec-to-plum '$.' p.spec q.spec)
       ==
   ::
   ++  varying
@@ -850,7 +852,7 @@
     |=  [=sample=xkey =product=xkey]
     ^-  plum
     %-  spec-to-plum  :*
-      %bshp
+      %bchp
       (ximage-to-spec:libxray sample-xkey img)
       (ximage-to-spec:libxray product-xkey img)
     ==

--- a/pkg/arvo/lib/xray.hoon
+++ b/pkg/arvo/lib/xray.hoon
@@ -355,8 +355,8 @@
                =^  params=(list xkey)  st
                  |-  ^-  [(list xkey) xtable]
                  ?~  u.q.note  [~ st]
-                 =/  tsld  [%tsld [%limb %$] [%wing i.u.q.note]]
-                 =/  part  (~(play ut subject-of-note) tsld)
+                 =/  tsgl  [%tsgl [%limb %$] [%wing i.u.q.note]]
+                 =/  part  (~(play ut subject-of-note) tsgl)
                  =^  this  st  (main st part)
                  =^  more  st  $(u.q.note t.u.q.note)
                  [[this more] st]
@@ -1774,34 +1774,34 @@
              =/  tl  `spec`$(i tail.d)
              =/  both-basic  &(=([%base %noun] hd) =([%base %noun] tl))
              ?:  both-basic      [%base %cell]
-             ?:  ?=(%bscl -.tl)  [%bscl hd +.tl]
-             [%bscl hd tl ~]
+             ?:  ?=(%bccl -.tl)  [%bccl hd +.tl]
+             [%bccl hd tl ~]
       %core  =/  payld  $(i xray.d)
              =/  batt   ^-  (map term spec)
                         %-  ~(run by (flatten-battery batt.d))
                         |=  =xkey  ^$(i xkey)
              ?-  r.garb.d
-               %lead  [%bszp payld batt]
-               %gold  [%bsdt payld batt]
-               %zinc  [%bstc payld batt]
-               %iron  [%bsnt payld batt]
+               %lead  [%bczp payld batt]
+               %gold  [%bcdt payld batt]
+               %zinc  [%bctc payld batt]
+               %iron  [%bcfs payld batt]
              ==
       %pntr  !!
       %face  =/  =spec  $(i xray.d)
-             ?^(face.d spec [%bsts face.d spec])
+             ?^(face.d spec [%bcts face.d spec])
       %fork  =/  =xrole  (need xrole.x)
              |^  ?+  xrole
                      ~&  [%unexpected-fork-xrole xkey.x d xrole choices]
-                     [%bswt choices]
+                     [%bcwt choices]
                    %noun             [%base %noun]
                    %void             [%base %void]
-                   [%option *]       [%bswt choices]
-                   [%union *]        [%bscn choices]
-                   [%misjunction *]  [%bswt choices]
-                   [%junction *]     :+  %bsvt
+                   [%option *]       [%bcwt choices]
+                   [%union *]        [%bccn choices]
+                   [%misjunction *]  [%bcwt choices]
+                   [%junction *]     :+  %bcpt
                                        ^$(i flat.xrole)
                                      ^$(i deep.xrole)
-                   [%conjunction *]  :+  %bskt
+                   [%conjunction *]  :+  %bckt
                                        ^$(i wide.xrole)
                                      ^$(i tall.xrole)
                  ==
@@ -1821,7 +1821,7 @@
     ^-  spec
     ?.  (need loop.xr)  sp
     =/  nm  (synthetic xkey.xr)
-    [%bsbs [%loop nm] [[nm sp] ~ ~]]
+    [%bcbc [%loop nm] [[nm sp] ~ ~]]
   ::
   ::  If we have a `recipe`, we can generate much nicer output.
   ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2004,7 +2004,7 @@
 ::  A `wide` is a description of how to render a plum in a single
 ::  line. The nested (`kids`) sub-plums will be interleaved with `delimit`
 ::  strings, and, if `enclose` is set, then the output will be enclosed
-::  with `p.u.enclose` abnd `q.u.enclose`.
+::  with `p.u.enclose` and `q.u.enclose`.
 ::
 ::  For example, to build a plumfmt for string literals, we could write:
 ::
@@ -6653,26 +6653,26 @@
               {$name p/term q/spec}                     ::  annotate simple
               {$over p/wing q/spec}                     ::  relative to subject
           ::                                            ::
-              {$bsbn p/spec q/spec}                     ::  $>, filter: require
-              {$bsbs p/spec q/(map term spec)}          ::  $$, recursion
-              {$bsbr p/spec q/hoon}                     ::  $|, verify
-              {$bscb p/hoon}                            ::  $_, example
-              {$bscl p/{i/spec t/(list spec)}}          ::  $:, tuple
-              {$bscn p/{i/spec t/(list spec)}}          ::  $%, head pick
-              {$bsdt p/spec q/(map term spec)}          ::  $., read-write core
-              {$bsld p/spec q/spec}                     ::  $<, filter: exclude
-              {$bshp p/spec q/spec}                     ::  $-, function core
-              {$bskt p/spec q/spec}                     ::  $^, cons pick
-              {$bsls p/stud q/spec}                     ::  $+, standard
-              {$bsnt p/spec q/(map term spec)}          ::  $/, write-only core
-              {$bsmc p/hoon}                            ::  $;, manual
-              {$bspd p/spec q/hoon}                     ::  $&, repair
-              {$bssg p/hoon q/spec}                     ::  $~, default
-              {$bstc p/spec q/(map term spec)}          ::  $`, read-only core
-              {$bsts p/skin q/spec}                     ::  $=, name
-              {$bsvt p/spec q/spec}                     ::  $@, atom pick
-              {$bswt p/{i/spec t/(list spec)}}          ::  $?, full pick
-              {$bszp p/spec q/(map term spec)}          ::  $!, opaque core
+              {$bcgr p/spec q/spec}                     ::  $>, filter: require
+              {$bcbc p/spec q/(map term spec)}          ::  $$, recursion
+              {$bcbr p/spec q/hoon}                     ::  $|, verify
+              {$bccb p/hoon}                            ::  $_, example
+              {$bccl p/{i/spec t/(list spec)}}          ::  $:, tuple
+              {$bccn p/{i/spec t/(list spec)}}          ::  $%, head pick
+              {$bcdt p/spec q/(map term spec)}          ::  $., read-write core
+              {$bcgl p/spec q/spec}                     ::  $<, filter: exclude
+              {$bchp p/spec q/spec}                     ::  $-, function core
+              {$bckt p/spec q/spec}                     ::  $^, cons pick
+              {$bcls p/stud q/spec}                     ::  $+, standard
+              {$bcfs p/spec q/(map term spec)}          ::  $/, write-only core
+              {$bcmc p/hoon}                            ::  $;, manual
+              {$bcpm p/spec q/hoon}                     ::  $&, repair
+              {$bcsg p/hoon q/spec}                     ::  $~, default
+              {$bctc p/spec q/(map term spec)}          ::  $`, read-only core
+              {$bcts p/skin q/spec}                     ::  $=, name
+              {$bcpt p/spec q/spec}                     ::  $@, atom pick
+              {$bcwt p/{i/spec t/(list spec)}}          ::  $?, full pick
+              {$bczp p/spec q/(map term spec)}          ::  $!, opaque core
           ==                                            ::
 +$  tent                                                ::  model builder
           $%  {%| p/wing q/tent r/(list spec)}          ::  ~(p q r...)
@@ -6742,7 +6742,7 @@
     {$yell p/(list hoon)}                               ::  render as tank
     {$xray p/manx:hoot}                                 ::  ;foo; templating
   ::                                            ::::::  cores
-    {$brbs sample/(lest term) body/spec}                ::  |$
+    {$brbc sample/(lest term) body/spec}                ::  |$
     {$brcb p/spec q/alas r/(map term tome)}             ::  |_
     {$brcl p/hoon q/hoon}                               ::  |:
     {$brcn p/(unit term) q/(map term tome)}             ::  |%
@@ -6752,7 +6752,7 @@
     {$brsg p/spec q/hoon}                               ::  |~
     {$brtr p/spec q/hoon}                               ::  |*
     {$brts p/spec q/hoon}                               ::  |=
-    {$brvt p/(unit term) q/(map term tome)}             ::  |@
+    {$brpt p/(unit term) q/(map term tome)}             ::  |@
     {$brwt p/hoon}                                      ::  |?
   ::                                            ::::::  tuples
     {$clcb p/hoon q/hoon}                               ::  :_ [q p]
@@ -6783,7 +6783,7 @@
     {$ktdt p/hoon q/hoon}                               ::  ^.  self-cast
     {$ktls p/hoon q/hoon}                               ::  ^+  expression cast
     {$kthp p/spec q/hoon}                               ::  ^-  structure cast
-    {$ktpd p/hoon}                                      ::  ^&  covariant
+    {$ktpm p/hoon}                                      ::  ^&  covariant
     {$ktsg p/hoon}                                      ::  ^~  constant
     {$ktts p/skin q/hoon}                               ::  ^=  label
     {$ktwt p/hoon}                                      ::  ^?  bivariant
@@ -6793,32 +6793,32 @@
     {$sgbr p/hoon q/hoon}                               ::  ~|  sell on trace
     {$sgcb p/hoon q/hoon}                               ::  ~_  tank on trace
     {$sgcn p/chum q/hoon r/tyre s/hoon}                 ::  ~%  general jet hint
-    {$sgnt p/chum q/hoon}                               ::  ~/  function j-hint
-    {$sgld p/$@(term {p/term q/hoon}) q/hoon}           ::  ~<  backward hint
-    {$sgbn p/$@(term {p/term q/hoon}) q/hoon}           ::  ~>  forward hint
-    {$sgbs p/term q/hoon}                               ::  ~$  profiler hit
+    {$sgfs p/chum q/hoon}                               ::  ~/  function j-hint
+    {$sggl p/$@(term {p/term q/hoon}) q/hoon}           ::  ~<  backward hint
+    {$sggr p/$@(term {p/term q/hoon}) q/hoon}           ::  ~>  forward hint
+    {$sgbc p/term q/hoon}                               ::  ~$  profiler hit
     {$sgls p/@ q/hoon}                                  ::  ~+  cache/memoize
-    {$sgpd p/@ud q/hoon r/hoon}                         ::  ~&  printf/priority
+    {$sgpm p/@ud q/hoon r/hoon}                         ::  ~&  printf/priority
     {$sgts p/hoon q/hoon}                               ::  ~=  don't duplicate
     {$sgwt p/@ud q/hoon r/hoon s/hoon}                  ::  ~?  tested printf
     {$sgzp p/hoon q/hoon}                               ::  ~!  type on trace
   ::                                            ::::::  miscellaneous
     {$mcts p/marl:hoot}                                 ::  ;=  list templating
     {$mccl p/hoon q/(list hoon)}                        ::  ;:  binary to nary
-    {$mcnt p/hoon}                                      ::  ;/  [%$ [%$ p ~] ~]
+    {$mcfs p/hoon}                                      ::  ;/  [%$ [%$ p ~] ~]
     {$mcgl p/spec q/hoon r/hoon s/hoon}                 ::  ;<  bind
     {$mcsg p/hoon q/(list hoon)}                        ::  ;~  kleisli arrow
     {$mcmc p/spec q/hoon}                               ::  ;;  normalize
   ::                                            ::::::  compositions
     {$tsbr p/spec q/hoon}                               ::  =|  push bunt
     {$tscl p/(list (pair wing hoon)) q/hoon}            ::  =:  q w/ p changes
-    {$tsnt p/skin q/hoon r/hoon}                        ::  =/  typed variable
+    {$tsfs p/skin q/hoon r/hoon}                        ::  =/  typed variable
     {$tsmc p/skin q/hoon r/hoon}                        ::  =;  =/(q p r)
     {$tsdt p/wing q/hoon r/hoon}                        ::  =.  r with p as q
     {$tswt p/wing q/hoon r/hoon s/hoon}                 ::  =?  conditional =.
-    {$tsld p/hoon q/hoon}                               ::  =<  =>(q p)
+    {$tsgl p/hoon q/hoon}                               ::  =<  =>(q p)
     {$tshp p/hoon q/hoon}                               ::  =-  =+(q p)
-    {$tsbn p/hoon q/hoon}                               ::  =>  q w/subject p
+    {$tsgr p/hoon q/hoon}                               ::  =>  q w/subject p
     {$tskt p/skin q/wing r/hoon s/hoon}                 ::  =^  state machine
     {$tsls p/hoon q/hoon}                               ::  =+  q w/[p subject]
     {$tssg p/(list hoon)}                               ::  =~  hoon stack
@@ -6830,22 +6830,22 @@
     {$wtcl p/hoon q/hoon r/hoon}                        ::  ?:  if/then/else
     {$wtdt p/hoon q/hoon r/hoon}                        ::  ?.  ?:(p r q)
     {$wtkt p/wing q/hoon r/hoon}                        ::  ?^  if p is a cell
-    {$wtld p/hoon q/hoon}                               ::  ?<  ?:(p !! q)
-    {$wtbn p/hoon q/hoon}                               ::  ?>  ?:(p q !!)
+    {$wtgl p/hoon q/hoon}                               ::  ?<  ?:(p !! q)
+    {$wtgr p/hoon q/hoon}                               ::  ?>  ?:(p q !!)
     {$wtls p/wing q/hoon r/(list (pair spec hoon))}     ::  ?+  ?-  w/default
-    {$wtpd p/(list hoon)}                               ::  ?&  loobean and
-    {$wtvt p/wing q/hoon r/hoon}                        ::  ?@  if p is atom
+    {$wtpm p/(list hoon)}                               ::  ?&  loobean and
+    {$wtpt p/wing q/hoon r/hoon}                        ::  ?@  if p is atom
     {$wtsg p/wing q/hoon r/hoon}                        ::  ?~  if p is null
     {$wthx p/skin q/wing}                               ::  ?#  if q matches p
     {$wtts p/spec q/wing}                               ::  ?=  if q matches p
     {$wtzp p/hoon}                                      ::  ?!  loobean not
   ::                                            ::::::  special
     {$zpcm p/hoon q/hoon}                               ::  !,
-    {$zpbn p/hoon}                                      ::  !>
-    {$zpld p/spec q/hoon}                               ::  !<
+    {$zpgr p/hoon}                                      ::  !>
+    {$zpgl p/spec q/hoon}                               ::  !<
     {$zpmc p/hoon q/hoon}                               ::  !;
     {$zpts p/hoon}                                      ::  !=
-    {$zpvt p/(list wing) q/hoon r/hoon}                 ::  !@
+    {$zppt p/(list wing) q/hoon r/hoon}                 ::  !@
     {$zpwt p/$@(p/@ {p/@ q/@}) q/hoon}                  ::  !?
     {$zpzp ~}                                           ::  !!
   ==                                                    ::
@@ -7807,7 +7807,7 @@
     |=  gen/hoon
     ^-  hoon
     ?.  &(?=(%| -.tik) ?=(~ p.tik))  gen
-    [%tsbn [%$ 3] gen]
+    [%tsgr [%$ 3] gen]
   ::
   ++  teal
     |=  mod/spec
@@ -7843,7 +7843,7 @@
   ++  wtls  |=  {gen/hoon opt/(list (pair spec hoon))}
             %+  gray  %wtls
             [puce (blue gen) (turn opt |=({a/spec b/hoon} [a (blue b)]))]
-  ++  wtvt  |=({sic/hoon non/hoon} (gray [%wtvt puce (blue sic) (blue non)]))
+  ++  wtpt  |=({sic/hoon non/hoon} (gray [%wtpt puce (blue sic) (blue non)]))
   ++  wtsg  |=({sic/hoon non/hoon} (gray [%wtsg puce (blue sic) (blue non)]))
   ++  wthx  |=(syn/skin (gray [%wthx (tele syn) puce]))
   ++  wtts  |=(mod/spec (gray [%wtts (teal mod) puce]))
@@ -7880,26 +7880,26 @@
       $over  $(mod q.mod)
       $name  $(mod q.mod)
     ::
-      $bsbs  $(mod p.mod)
-      $bsbr  $(mod p.mod)
-      $bscb  ~(name ap p.mod)
-      $bscl  $(mod i.p.mod)
-      $bscn  $(mod i.p.mod)
-      $bsdt  ~
-      $bsld  $(mod q.mod)
-      $bsbn  $(mod q.mod)
-      $bshp  $(mod p.mod)
-      $bskt  $(mod q.mod)
-      $bsls  $(mod q.mod)
-      $bsnt  ~
-      $bsmc  ~(name ap p.mod)
-      $bspd  $(mod p.mod)
-      $bssg  $(mod q.mod)
-      $bstc  ~
-      $bsts  $(mod q.mod)
-      $bsvt  $(mod q.mod)
-      $bswt  $(mod i.p.mod)
-      $bszp  ~
+      $bcbc  $(mod p.mod)
+      $bcbr  $(mod p.mod)
+      $bccb  ~(name ap p.mod)
+      $bccl  $(mod i.p.mod)
+      $bccn  $(mod i.p.mod)
+      $bcdt  ~
+      $bcgl  $(mod q.mod)
+      $bcgr  $(mod q.mod)
+      $bchp  $(mod p.mod)
+      $bckt  $(mod q.mod)
+      $bcls  $(mod q.mod)
+      $bcfs  ~
+      $bcmc  ~(name ap p.mod)
+      $bcpm  $(mod p.mod)
+      $bcsg  $(mod q.mod)
+      $bctc  ~
+      $bcts  $(mod q.mod)
+      $bcpt  $(mod q.mod)
+      $bcwt  $(mod i.p.mod)
+      $bczp  ~
     ==
   ++  hint
     |=  not/note
@@ -7913,7 +7913,7 @@
     ^-  hoon
     ::  minimal context as subject
     ::
-    :+  %tsbn
+    :+  %tsgr
       ::  context is example of both specs
       ::
       [example:clear(mod fun) example:clear(mod arg)]
@@ -7936,11 +7936,11 @@
     =-  ?-  variance
           %gold  -
           %lead  [%ktwt -]
-          %zinc  [%ktpd -]
+          %zinc  [%ktpm -]
           %iron  [%ktbr -]
         ==
     ^-  hoon
-    :+  %tsbn  example:clear(mod payload)
+    :+  %tsgr  example:clear(mod payload)
     :+  %brcn  ~
     =-  [[%$ ~ -] ~ ~]
     %-  ~(gas by *(map term hoon))
@@ -7964,7 +7964,7 @@
           hay
         (weld hay `wing`[[%& dom] ~])
     ?~  -  gen
-    [%tsbn [%wing -] gen]
+    [%tsgr [%wing -] gen]
   ::
   ++  clear
     ::  clear annotations
@@ -8012,7 +8012,7 @@
   ++  unreel
     |=  [one/wing res/(list wing)]
     ^-  hoon
-    ?~(res [%wing one] [%tsld [%wing one] $(one i.res, res t.res)])
+    ?~(res [%wing one] [%tsgl [%wing one] $(one i.res, res t.res)])
   ::
   ++  descend
     ::  record an axis to original subject
@@ -8060,7 +8060,7 @@
     |-  ^-  hoon
     ?-  mod
       {$base *}  ?:(=(%void p.mod) [%rock %n 0] (basal p.mod))
-      {$bsbs *}  ::  track hygienic recursion points lexically
+      {$bcbc *}  ::  track hygienic recursion points lexically
                  ::
                  %=  $
                    mod  p.mod
@@ -8071,46 +8071,46 @@
       {$dbug *}  [%dbug p.mod $(mod q.mod)]
       {$leaf *}  [%rock p.mod q.mod]
       {$loop *}  ~|([%loop p.mod] $(mod (~(got by cox) p.mod)))
-      {$like *}  $(mod bsmc/(unreel p.mod q.mod))
+      {$like *}  $(mod bcmc/(unreel p.mod q.mod))
       {$made *}  $(mod q.mod)
-      {$make *}  $(mod bsmc/(unfold p.mod q.mod))
+      {$make *}  $(mod bcmc/(unfold p.mod q.mod))
       {$name *}  $(mod q.mod)
       {$over *}  $(hay p.mod, mod q.mod)
     ::
-      {$bsbr *}  $(mod p.mod)
-      {$bscb *}  [%rock %n 0]
-      {$bscl *}  |-  ^-  hoon
+      {$bcbr *}  $(mod p.mod)
+      {$bccb *}  [%rock %n 0]
+      {$bccl *}  |-  ^-  hoon
                  ?~  t.p.mod  ^$(mod i.p.mod)
                  :-  ^$(mod i.p.mod)
                  $(i.p.mod i.t.p.mod, t.p.mod t.t.p.mod)
-      {$bscn *}  ::  use last entry
+      {$bccn *}  ::  use last entry
                  ::
                  |-  ^-  hoon
                  ?~  t.p.mod  ^$(mod i.p.mod)
                  $(i.p.mod i.t.p.mod, t.p.mod t.t.p.mod)
-      {$bshp *}  ::  see under %bscb
+      {$bchp *}  ::  see under %bccb
                  ::
                  [%rock %n 0]
-      {$bsld *}  $(mod q.mod)
-      {$bsbn *}  $(mod q.mod)
-      {$bskt *}  $(mod q.mod)
-      {$bsls *}  $(mod q.mod)
-      {$bsmc *}  ::  borrow sample
+      {$bcgl *}  $(mod q.mod)
+      {$bcgr *}  $(mod q.mod)
+      {$bckt *}  $(mod q.mod)
+      {$bcls *}  $(mod q.mod)
+      {$bcmc *}  ::  borrow sample
                  ::
-                 [%tsld [%$ 6] p.mod]
-      {$bspd *}  $(mod p.mod)
-      {$bssg *}  [%kthp q.mod p.mod]
-      {$bsts *}  [%ktts p.mod $(mod q.mod)]
-      {$bsvt *}  $(mod p.mod)
-      {$bswt *}  ::  use last entry
+                 [%tsgl [%$ 6] p.mod]
+      {$bcpm *}  $(mod p.mod)
+      {$bcsg *}  [%kthp q.mod p.mod]
+      {$bcts *}  [%ktts p.mod $(mod q.mod)]
+      {$bcpt *}  $(mod p.mod)
+      {$bcwt *}  ::  use last entry
                  ::
                  |-  ^-  hoon
                  ?~  t.p.mod  ^$(mod i.p.mod)
                  $(i.p.mod i.t.p.mod, t.p.mod t.t.p.mod)
-      {$bsdt *}  [%rock %n 0]
-      {$bsnt *}  [%rock %n 0]
-      {$bstc *}  [%rock %n 0]
-      {$bszp *}  [%rock %n 0]
+      {$bcdt *}  [%rock %n 0]
+      {$bcfs *}  [%rock %n 0]
+      {$bctc *}  [%rock %n 0]
+      {$bczp *}  [%rock %n 0]
     ==
   ::
   ++  example
@@ -8128,29 +8128,29 @@
       {$base *}  (decorate (basal p.mod))
       {$dbug *}  example(mod q.mod, bug [p.mod bug])
       {$leaf *}  (decorate [%rock p.mod q.mod])
-      {$like *}  example(mod bsmc/(unreel p.mod q.mod))
+      {$like *}  example(mod bcmc/(unreel p.mod q.mod))
       {$loop *}  [%limb p.mod]
       {$made *}  example(mod q.mod, nut `made/[p.p.mod `(pieces q.p.mod)])
-      {$make *}  example(mod bsmc/(unfold p.mod q.mod))
+      {$make *}  example(mod bcmc/(unfold p.mod q.mod))
       {$name *}  example(mod q.mod, nut `made/[p.mod ~])
       {$over *}  example(hay p.mod, mod q.mod)
     ::
-      {$bscb *}  (decorate (home p.mod))
-      {$bscl *}  %-  decorate
+      {$bccb *}  (decorate (home p.mod))
+      {$bccl *}  %-  decorate
                  |-  ^-  hoon
                  ?~  t.p.mod
                    example:clear(mod i.p.mod)
                  :-  example:clear(mod i.p.mod)
                  example:clear(i.p.mod i.t.p.mod, t.p.mod t.t.p.mod)
-      {$bshp *}  (decorate (function:clear p.mod q.mod))
-      {$bsmc *}  (decorate (home [%tsld [%limb %$] p.mod]))
-      {$bssg *}  [%ktls example(mod q.mod) (home p.mod)]
-      {$bsls *}  (decorate example(mod q.mod))
-      {$bsts *}  (decorate [%ktts p.mod example:clear(mod q.mod)])
-      {$bsdt *}  (decorate (home (interface %gold p.mod q.mod)))
-      {$bsnt *}  (decorate (home (interface %iron p.mod q.mod)))
-      {$bszp *}  (decorate (home (interface %lead p.mod q.mod)))
-      {$bstc *}  (decorate (home (interface %zinc p.mod q.mod)))
+      {$bchp *}  (decorate (function:clear p.mod q.mod))
+      {$bcmc *}  (decorate (home [%tsgl [%limb %$] p.mod]))
+      {$bcsg *}  [%ktls example(mod q.mod) (home p.mod)]
+      {$bcls *}  (decorate example(mod q.mod))
+      {$bcts *}  (decorate [%ktts p.mod example:clear(mod q.mod)])
+      {$bcdt *}  (decorate (home (interface %gold p.mod q.mod)))
+      {$bcfs *}  (decorate (home (interface %iron p.mod q.mod)))
+      {$bczp *}  (decorate (home (interface %lead p.mod q.mod)))
+      {$bctc *}  (decorate (home (interface %zinc p.mod q.mod)))
     ==
   ::
   ++  factory
@@ -8160,17 +8160,17 @@
     ::  process annotations outside construct, to catch default
     ::
     ?:  ?=($dbug -.mod)  factory(mod q.mod, bug [p.mod bug])
-    ?:  ?=($bssg -.mod)  factory(mod q.mod, def `[%kthp q.mod p.mod])
+    ?:  ?=($bcsg -.mod)  factory(mod q.mod, def `[%kthp q.mod p.mod])
     ^-  hoon
     ::  if we recognize an indirection
     ::
-    ?:  &(=(~ def) ?=(?(%bsmc %like %loop %make) -.mod))
+    ?:  &(=(~ def) ?=(?(%bcmc %like %loop %make) -.mod))
       ::  then short-circuit it
       ::
       %-  decorate
       %-  home
       ?-  -.mod
-        %bsmc  p.mod
+        %bcmc  p.mod
         %like  (unreel p.mod q.mod)
         %loop  [%limb p.mod]
         %make  (unfold p.mod q.mod)
@@ -8195,10 +8195,10 @@
           {%atom *}
         :+  %ktls  example
         ^-  hoon
-        :^    %zpvt
+        :^    %zppt
             [[[%| 0 `%ruth] ~] ~]
           [%cnls [%limb %ruth] [%sand %ta p.bas] fetch]
-        [%wtvt fetch-wing fetch [%zpzp ~]]
+        [%wtpt fetch-wing fetch [%zpzp ~]]
       ::
           $cell
         :+  %ktls  example
@@ -8210,7 +8210,7 @@
         :^    %wtcl
             [%dtts [%rock %$ &] [%$ axe]]
           [%rock %f &]
-        :+  %wtbn
+        :+  %wtgr
           [%dtts [%rock %$ |] [%$ axe]]
         [%rock %f |]
       ::
@@ -8218,7 +8218,7 @@
         fetch
       ::
           $null
-        :+  %wtbn
+        :+  %wtgr
           [%dtts [%bust %noun] [%$ axe]]
         [%rock %n ~]
       :::
@@ -8286,7 +8286,7 @@
           ::  test if the head matches this wing
           ::
           :+  %fits
-            [%tsld [%$ 2] example:clear(mod one)]
+            [%tsgl [%$ 2] example:clear(mod one)]
           fetch-wing(axe (peg axe 2))
         ::  if so, use this form
         ::
@@ -8316,19 +8316,19 @@
       ::
           {$leaf *}
         %-  decorate
-        :+  %wtbn
+        :+  %wtgr
           [%dtts fetch [%rock %$ q.mod]]
         [%rock p.mod q.mod]
       ::
       ::  composite
       ::
           {$make *}
-        relative(mod bsmc/(unfold p.mod q.mod))
+        relative(mod bcmc/(unfold p.mod q.mod))
       ::
       ::  indirect
       ::
           {$like *}
-        relative(mod bsmc/(unreel p.mod q.mod))
+        relative(mod bcmc/(unreel p.mod q.mod))
       ::
       ::  loop
       ::
@@ -8352,7 +8352,7 @@
       ::
       ::  recursive, $$
       ::
-          {$bsbs *}
+          {$bcbc *}
         ::
         ::  apply semantically
         ::
@@ -8368,21 +8368,21 @@
       ::
       ::  normalize, $&
       ::
-          {$bspd *}
+          {$bcpm *}
         ::  push the raw result
         ::
         :+  %tsls  relative(mod p.mod)
         ::  push repair function
         ::
         :+  %tsls
-          [%tsbn $/3 q.mod]
+          [%tsgr $/3 q.mod]
         ::  push repaired product
         ::
         :+  %tsls
           [%cnhp $/2 $/6]
         ::  sanity-check repaired product
         ::
-        :+  %wtbn
+        :+  %wtgr
           ::  either
           ::
           :~  %wtbr
@@ -8397,7 +8397,7 @@
       ::
       ::  verify, $|
       ::
-          {$bsbr *}
+          {$bcbr *}
         ^-  hoon
         ::  push the raw product
         ::
@@ -8405,27 +8405,27 @@
         ^-  hoon
         ::  assert
         ::
-        :+  %wtbn
+        :+  %wtgr
           ::  run the verifier
           ::
-          [%cnhp [%tsbn $/3 q.mod] $/2]
+          [%cnhp [%tsgr $/3 q.mod] $/2]
         ::  produce verified product
         ::
         $/2
       ::
       ::  special, $_
       ::
-          {$bscb *}
+          {$bccb *}
         (decorate (home p.mod))
       ::
       ::  switch, $%
       ::
-          {$bscn *}
+          {$bccn *}
         (decorate (switch i.p.mod t.p.mod))
       ::
       ::  tuple, $:
       ::
-          {$bscl *}
+          {$bccl *}
         %-  decorate
         |-  ^-  hoon
         ?~  t.p.mod
@@ -8439,25 +8439,25 @@
       ::
       ::  exclude, $<
       ::
-          {$bsld *}
+          {$bcgl *}
         :+  %tsls
           relative:clear(mod q.mod)
-        :+  %wtld
+        :+  %wtgl
           [%wtts [%over ~[&/3] p.mod] ~[&/4]]
         $/2
       ::
       ::  require, $>
       ::
-          {$bsbn *}
+          {$bcgr *}
         :+  %tsls
           relative:clear(mod q.mod)
-        :+  %wtbn
+        :+  %wtgr
           [%wtts [%over ~[&/3] p.mod] ~[&/4]]
         $/2
       ::
       ::  function
       ::
-          {$bshp *}
+          {$bchp *}
         %-  decorate
         =/  fun  (function:clear p.mod q.mod)
         ?^  def
@@ -8466,7 +8466,7 @@
       ::
       ::  bridge, $^
       ::
-          {$bskt *}
+          {$bckt *}
         %-  decorate
         :^    %wtcl
             [%dtwt fetch(axe (peg axe 2))]
@@ -8475,38 +8475,38 @@
       ::
       ::  synthesis, $;
       ::
-          {$bsmc *}
+          {$bcmc *}
         (decorate [%cncl (home p.mod) fetch ~])
       ::
       ::  default
       ::
-          {$bssg *}
+          {$bcsg *}
         relative(mod q.mod, def `[%kthp q.mod p.mod])
       ::
       ::  choice, $?
       ::
-          {$bswt *}
+          {$bcwt *}
         (decorate (choice i.p.mod t.p.mod))
       ::
       ::  name, $=
       ::
-          {$bsts *}
+          {$bcts *}
         [%ktts p.mod relative(mod q.mod)]
       ::
       ::  branch, $@
       ::
-          {$bsvt *}
+          {$bcpt *}
         %-  decorate
         :^    %wtcl
             [%dtwt fetch]
           relative:clear(mod q.mod)
         relative:clear(mod p.mod)
       ::
-        {$bsls *}  relative(mod q.mod)
-        {$bsdt *}  (decorate (home (interface %gold p.mod q.mod)))
-        {$bsnt *}  (decorate (home (interface %iron p.mod q.mod)))
-        {$bszp *}  (decorate (home (interface %lead p.mod q.mod)))
-        {$bstc *}  (decorate (home (interface %zinc p.mod q.mod)))
+        {$bcls *}  relative(mod q.mod)
+        {$bcdt *}  (decorate (home (interface %gold p.mod q.mod)))
+        {$bcfs *}  (decorate (home (interface %iron p.mod q.mod)))
+        {$bczp *}  (decorate (home (interface %lead p.mod q.mod)))
+        {$bctc *}  (decorate (home (interface %zinc p.mod q.mod)))
       ==
     --
   --
@@ -8527,7 +8527,7 @@
     |-  ^-  hoon
     ?-    skin
         @
-      [%tsld [%tune skin] gen]
+      [%tsgl [%tune skin] gen]
         [%base *]
       ?:  ?=(%noun base.skin)
         gen
@@ -8553,7 +8553,7 @@
       [%note [%help help.skin] $(skin skin.skin)]
     ::
         [%name *]
-      [%tsld [%tune term.skin] $(skin skin.skin)]
+      [%tsgl [%tune term.skin] $(skin skin.skin)]
     ::
         [%over *]
       $(skin skin.skin, rel (weld wing.skin rel))
@@ -8564,7 +8564,7 @@
       $(skin skin.skin)
     ::
         [%wash *]
-      :+  %tsld
+      :+  %tsgl
         :-  %wing
         |-  ^-  wing
         ?:  =(0 depth.skin)  ~
@@ -8581,8 +8581,8 @@
                  `i.p.gen
       {$limb *}  `p.gen
       {$dbug *}  $(gen ~(open ap gen))
-      {$tsld *}  $(gen ~(open ap gen))
-      {$tsbn *}  $(gen q.gen)
+      {$tsgl *}  $(gen ~(open ap gen))
+      {$tsgr *}  $(gen q.gen)
     ==
   ::
   ++  feck
@@ -8636,7 +8636,7 @@
         [%cnts [@ ~] ~]
       `i.p.gen
     ::
-        [%tsbn *]
+        [%tsgr *]
       %+  biff  reek(gen p.gen)
       |=  =wing
       (bind ^$(gen q.gen) |=(=skin [%over wing skin]))
@@ -8682,7 +8682,7 @@
         {$eror *}  ~>(%slog.[0 leaf/p.gen] !!)
     ::
         {$knit *}                                       ::
-      :+  %tsbn  [%ktts %v %$ 1]                        ::  =>  v=.
+      :+  %tsgr  [%ktts %v %$ 1]                        ::  =>  v=.
       :-  %brhp                                         ::  |-
       :+  %ktls                                         ::  ^+
         :-  %brhp                                       ::  |-
@@ -8703,32 +8703,32 @@
               %a                                        ::  a
             :+  %ktls                                   ::  ^+
               [%limb %$]                                ::  $
-            [%tsbn [%limb %v] p.i.p.gen]                ::  =>(v {p.i.p.gen})
+            [%tsgr [%limb %v] p.i.p.gen]                ::  =>(v {p.i.p.gen})
         [%ktts %b res]                                  ::  b={res}
       ^-  hoon                                          ::
       :-  %brhp                                         ::  |-
-      :^    %wtvt                                       ::  ?@
+      :^    %wtpt                                       ::  ?@
           [%a ~]                                        ::  a
         [%limb %b]                                      ::  b
-      :-  [%tsld [%$ 2] [%limb %a]]                     ::  :-  -.a
+      :-  [%tsgl [%$ 2] [%limb %a]]                     ::  :-  -.a
       :+  %cnts                                         ::  %=
         [%$ ~]                                          ::  $
-      [[[%a ~] [%tsld [%$ 3] [%limb %a]]] ~]            ::  a  +.a
+      [[[%a ~] [%tsgl [%$ 3] [%limb %a]]] ~]            ::  a  +.a
     ::
         {$leaf *}  ~(factory ax fab `spec`gen)
         {$limb *}  [%cnts [p.gen ~] ~]
-        {$tell *}  [%cncl [%limb %noah] [%zpbn [%cltr p.gen]] ~]
+        {$tell *}  [%cncl [%limb %noah] [%zpgr [%cltr p.gen]] ~]
         {$wing *}  [%cnts p.gen ~]
-        {$yell *}  [%cncl [%limb %cain] [%zpbn [%cltr p.gen]] ~]
+        {$yell *}  [%cncl [%limb %cain] [%zpgr [%cltr p.gen]] ~]
         {$note *}  q.gen
     ::
-        {$brbs *}  =-  ?~  -  !!
-                       [%brtr [%bscl -] [%ktcl body.gen]]
+        {$brbc *}  =-  ?~  -  !!
+                       [%brtr [%bccl -] [%ktcl body.gen]]
                    %+  turn  `(list term)`sample.gen
                    |=  =term
                    ^-  spec
                    =/  tar  [%base %noun]
-                   [%bsts term [%bssg tar [%bshp tar tar]]]
+                   [%bcts term [%bcsg tar [%bchp tar tar]]]
         {$brcb *}  :+  %tsls  [%kttr p.gen]
                    :+  %brcn  ~
                    %-  ~(run by r.gen)
@@ -8742,7 +8742,7 @@
         {$brdt *}  :+  %brcn  ~
                    =-  [[%$ ~ -] ~ ~]
                    (~(put by *(map term hoon)) %$ p.gen)
-        {$brkt *}  :+  %tsld  [%limb %$]
+        {$brkt *}  :+  %tsgl  [%limb %$]
                    :+  %brcn  ~
                    =+  zil=(~(get by q.gen) %$)
                    ?~  zil
@@ -8750,10 +8750,10 @@
                      [*what [[%$ p.gen] ~ ~]]
                    %+  ~(put by q.gen)  %$
                    [p.u.zil (~(put by q.u.zil) %$ p.gen)]
-        {$brhp *}  [%tsld [%limb %$] [%brdt p.gen]]
+        {$brhp *}  [%tsgl [%limb %$] [%brdt p.gen]]
         {$brsg *}  [%ktbr [%brts p.gen q.gen]]
         {$brtr *}  :+  %tsls  [%kttr p.gen]
-                   :+  %brvt  ~
+                   :+  %brpt  ~
                    =-  [[%$ ~ -] ~ ~]
                    (~(put by *(map term hoon)) %$ q.gen)
         {$brts *}  :+  %brcb  p.gen
@@ -8804,28 +8804,28 @@
     ::
         {$cntr *}
       ?:  =(~ r.gen)
-        [%tsbn q.gen [%wing p.gen]]
+        [%tsgr q.gen [%wing p.gen]]
       :+  %tsls
         q.gen
       :+  %cnts
         (weld p.gen `wing`[[%& 2] ~])
-      (turn r.gen |=({p/wing q/hoon} [p [%tsbn [%$ 3] q]]))
+      (turn r.gen |=({p/wing q/hoon} [p [%tsgr [%$ 3] q]]))
     ::
         {$ktdt *}  [%ktls [%cncl p.gen q.gen ~] q.gen]
         {$kthp *}  [%ktls ~(example ax fab p.gen) q.gen]
         {$ktts *}  (grip(gen q.gen) p.gen)
     ::
         {$sgbr *}
-      :+  %sgbn
+      :+  %sggr
         :-  %mean
         =+  fek=~(feck ap p.gen)
         ?^  fek  [%rock %tas u.fek]
-        [%brdt [%cncl [%limb %cain] [%zpbn [%tsbn [%$ 3] p.gen]] ~]]
+        [%brdt [%cncl [%limb %cain] [%zpgr [%tsgr [%$ 3] p.gen]] ~]]
       q.gen
     ::
-        {$sgcb *}  [%sgbn [%mean [%brdt p.gen]] q.gen]
+        {$sgcb *}  [%sggr [%mean [%brdt p.gen]] q.gen]
         {$sgcn *}
-      :+  %sgld
+      :+  %sggl
         :-  %fast
         :-  %clls
         :+  [%rock %$ p.gen]
@@ -8838,21 +8838,21 @@
         [[[%rock %$ p.i.r.gen] [%zpts q.i.r.gen]] $(r.gen t.r.gen)]
       s.gen
     ::
-        {$sgnt *}  [%sgcn p.gen [%$ 7] ~ q.gen]
-        {$sgld *}  [%tsld [%sgbn p.gen [%$ 1]] q.gen]
-        {$sgbs *}  [%sgbn [%live [%rock %$ p.gen]] q.gen]
-        {$sgls *}  [%sgbn [%memo %rock %$ p.gen] q.gen]
-        {$sgpd *}
-      :+  %sgbn
-        [%slog [%sand %$ p.gen] [%cncl [%limb %cain] [%zpbn q.gen] ~]]
+        {$sgfs *}  [%sgcn p.gen [%$ 7] ~ q.gen]
+        {$sggl *}  [%tsgl [%sggr p.gen [%$ 1]] q.gen]
+        {$sgbc *}  [%sggr [%live [%rock %$ p.gen]] q.gen]
+        {$sgls *}  [%sggr [%memo %rock %$ p.gen] q.gen]
+        {$sgpm *}
+      :+  %sggr
+        [%slog [%sand %$ p.gen] [%cncl [%limb %cain] [%zpgr q.gen] ~]]
       r.gen
     ::
-        {$sgts *}  [%sgbn [%germ p.gen] q.gen]
+        {$sgts *}  [%sggr [%germ p.gen] q.gen]
         {$sgwt *}
       :+  %tsls  [%wtdt q.gen [%bust %null] [[%bust %null] r.gen]]
       :^  %wtsg  [%& 2]~
-        [%tsbn [%$ 3] s.gen]
-      [%sgpd p.gen [%$ 5] [%tsbn [%$ 3] s.gen]]
+        [%tsgr [%$ 3] s.gen]
+      [%sgpm p.gen [%$ 5] [%tsgr [%$ 3] s.gen]]
     ::
         {$mcts *}
       |-
@@ -8860,12 +8860,12 @@
       ?-  -.i.p.gen
         ^      [[%xray i.p.gen] $(p.gen t.p.gen)]
         $manx  [p.i.p.gen $(p.gen t.p.gen)]
-        $tape  [[%mcnt p.i.p.gen] $(p.gen t.p.gen)]
+        $tape  [[%mcfs p.i.p.gen] $(p.gen t.p.gen)]
         $call  [%cncl p.i.p.gen [$(p.gen t.p.gen)]~]
         $marl  =-  [%cndt [p.i.p.gen $(p.gen t.p.gen)] -]
                ^-  hoon
                :+  %tsbr  [%base %cell]
-               :+  %brvt  ~
+               :+  %brpt  ~
                ^-  (map term tome)
                =-  [[%$ ~ -] ~ ~]
                ^-  (map term hoon)
@@ -8887,13 +8887,13 @@
         =+  yex=`(list hoon)`q.gen
         |-  ^-  hoon
         ?-  yex
-          {* ~}  [%tsbn [%$ 3] i.yex]
-          {* ^}   [%cncl [%$ 2] [%tsbn [%$ 3] i.yex] $(yex t.yex) ~]
+          {* ~}  [%tsgr [%$ 3] i.yex]
+          {* ^}   [%cncl [%$ 2] [%tsgr [%$ 3] i.yex] $(yex t.yex) ~]
           ~      !!
         ==
       ==
     ::
-        {$mcnt *}  =+(zoy=[%rock %ta %$] [%clsg [zoy [%clsg [zoy p.gen] ~]] ~])
+        {$mcfs *}  =+(zoy=[%rock %ta %$] [%clsg [zoy [%clsg [zoy p.gen] ~]] ~])
         {$mcgl *}
       :^    %cnls
           :+  %cnhp
@@ -8909,21 +8909,21 @@
       ?-  q.gen
           ~      ~_(leaf+"open-mcsg" !!)
           ^
-        :+  %tsbn  [%ktts %v %$ 1]                      ::  =>  v=.
+        :+  %tsgr  [%ktts %v %$ 1]                      ::  =>  v=.
         |-  ^-  hoon                                    ::
         ?:  ?=(~ t.q.gen)                               ::
-          [%tsbn [%limb %v] i.q.gen]                    ::  =>(v {i.q.gen})
+          [%tsgr [%limb %v] i.q.gen]                    ::  =>(v {i.q.gen})
         :+  %tsls  [%ktts %a $(q.gen t.q.gen)]          ::  =+  ^=  a
         :+  %tsls                                       ::    {$(q.gen t.q.gen)}
-          [%ktts %b [%tsbn [%limb %v] i.q.gen]]         ::  =+  ^=  b
+          [%ktts %b [%tsgr [%limb %v] i.q.gen]]         ::  =+  ^=  b
         :+  %tsls                                       ::    =>(v {i.q.gen})
           :+  %ktts  %c                                 ::  =+  c=,.+6.b
-          :+  %tsld                                     ::
+          :+  %tsgl                                     ::
             [%wing [%| 0 ~] [%& 6] ~]                   ::
           [%limb %b]                                    ::
         :-  %brdt                                       ::  |.
         :^    %cnls                                     ::  %+
-            [%tsbn [%limb %v] p.gen]                    ::      =>(v {p.gen})
+            [%tsgr [%limb %v] p.gen]                    ::      =>(v {p.gen})
           [%cncl [%limb %b] [%limb %c] ~]               ::    (b c)
         :+  %cnts  [%a ~]                               ::  a(,.+6 c)
         [[[[%| 0 ~] [%& 6] ~] [%limb %c]] ~]            ::
@@ -8936,48 +8936,48 @@
       [%tsls ~(example ax fab p.gen) q.gen]
     ::
         {$tstr *}
-      :+  %tsld
+      :+  %tsgl
         r.gen
       [%tune [[p.p.gen ~ ?~(q.p.gen q.gen [%kthp u.q.p.gen q.gen])] ~ ~] ~]
     ::
         {$tscl *}
-      [%tsbn [%cncb [[%& 1] ~] p.gen] q.gen]
+      [%tsgr [%cncb [[%& 1] ~] p.gen] q.gen]
     ::
-        {$tsnt *}
+        {$tsfs *}
       [%tsls [%ktts p.gen q.gen] r.gen]
     ::
-        {$tsmc *}  [%tsnt p.gen r.gen q.gen]
+        {$tsmc *}  [%tsfs p.gen r.gen q.gen]
         {$tsdt *}
-      [%tsbn [%cncb [[%& 1] ~] [[p.gen q.gen] ~]] r.gen]
+      [%tsgr [%cncb [[%& 1] ~] [[p.gen q.gen] ~]] r.gen]
         {$tswt *}                                       ::                  =?
       [%tsdt p.gen [%wtcl q.gen r.gen [%wing p.gen]] s.gen]
     ::
         {$tskt *}                                       ::                  =^
       =+  wuy=(weld q.gen `wing`[%v ~])                 ::
-      :+  %tsbn  [%ktts %v %$ 1]                        ::  =>  v=.
-      :+  %tsls  [%ktts %a %tsbn [%limb %v] r.gen]      ::  =+  a==>(v \r.gen)
-      :^  %tsdt  wuy  [%tsld [%$ 3] [%limb %a]]
-      :+  %tsbn  :-  :+  %ktts  [%over [%v ~] p.gen]
-                     [%tsld [%$ 2] [%limb %a]]
+      :+  %tsgr  [%ktts %v %$ 1]                        ::  =>  v=.
+      :+  %tsls  [%ktts %a %tsgr [%limb %v] r.gen]      ::  =+  a==>(v \r.gen)
+      :^  %tsdt  wuy  [%tsgl [%$ 3] [%limb %a]]
+      :+  %tsgr  :-  :+  %ktts  [%over [%v ~] p.gen]
+                     [%tsgl [%$ 2] [%limb %a]]
                  [%limb %v]
       s.gen
     ::
-        {$tsld *}  [%tsbn q.gen p.gen]
-        {$tsls *}  [%tsbn [p.gen [%$ 1]] q.gen]
+        {$tsgl *}  [%tsgr q.gen p.gen]
+        {$tsls *}  [%tsgr [p.gen [%$ 1]] q.gen]
         {$tshp *}  [%tsls q.gen p.gen]
         {$tssg *}
       |-  ^-  hoon
       ?~  p.gen    [%$ 1]
       ?~  t.p.gen  i.p.gen
-      [%tsbn i.p.gen $(p.gen t.p.gen)]
+      [%tsgr i.p.gen $(p.gen t.p.gen)]
     ::
         {$wtbr *}
       |-
       ?~(p.gen [%rock %f 1] [%wtcl i.p.gen [%rock %f 0] $(p.gen t.p.gen)])
     ::
         {$wtdt *}   [%wtcl p.gen r.gen q.gen]
-        {$wtld *}   [%wtcl p.gen [%zpzp ~] q.gen]
-        {$wtbn *}   [%wtcl p.gen q.gen [%zpzp ~]]
+        {$wtgl *}   [%wtcl p.gen [%zpzp ~] q.gen]
+        {$wtgr *}   [%wtcl p.gen q.gen [%zpzp ~]]
         {$wtkt *}   [%wtcl [%wtts [%base %atom %$] p.gen] r.gen q.gen]
     ::
         {$wthp *}
@@ -8992,7 +8992,7 @@
         {$wtls *}
       [%wthp p.gen (weld r.gen `_r.gen`[[[%base %noun] q.gen] ~])]
     ::
-        {$wtpd *}
+        {$wtpm *}
       |-
       ?~(p.gen [%rock %f 0] [%wtcl i.p.gen $(p.gen t.p.gen) [%rock %f 1]])
     ::
@@ -9009,12 +9009,12 @@
         [(open-mane n) %knit v]
       --
     ::
-        {$wtvt *}   [%wtcl [%wtts [%base %atom %$] p.gen] q.gen r.gen]
+        {$wtpt *}   [%wtcl [%wtts [%base %atom %$] p.gen] q.gen r.gen]
         {$wtsg *}   [%wtcl [%wtts [%base %null] p.gen] q.gen r.gen]
         {$wtts *}   [%fits ~(example ax fab p.gen) q.gen]
         {$wtzp *}   [%wtcl p.gen [%rock %f 1] [%rock %f 0]]
-        {$zpbn *}
-      [%cncl [%limb %onan] [%zpmc [%kttr [%bsmc %limb %abel]] p.gen] ~]
+        {$zpgr *}
+      [%cncl [%limb %onan] [%zpmc [%kttr [%bcmc %limb %abel]] p.gen] ~]
     ::
         {$zpwt *}
       ?:  ?:  ?=(@ p.gen)
@@ -10200,7 +10200,7 @@
             -
         ~(gain ar - p.gen)
       ~(lose ar - p.gen)
-    ?:  ?&(how ?=({$wtpd *} gen))
+    ?:  ?&(how ?=({$wtpm *} gen))
       |-(?~(p.gen sut $(p.gen t.p.gen, sut ^$(gen i.p.gen))))
     ?:  ?&(!how ?=({$wtbr *} gen))
       |-(?~(p.gen sut $(p.gen t.p.gen, sut ^$(gen i.p.gen))))
@@ -10417,7 +10417,7 @@
     ::
         {$ktcn *}  $(fab |, gen p.gen)
         {$brcn *}  (grow %gold p.gen %dry [%$ 1] q.gen)
-        {$brvt *}  (grow %gold p.gen %wet [%$ 1] q.gen)
+        {$brpt *}  (grow %gold p.gen %wet [%$ 1] q.gen)
     ::
         {$cnts *}  (~(mint et p.gen q.gen) gol)
     ::
@@ -10443,7 +10443,7 @@
         {$ktls *}
       =+(hif=(nice (play p.gen)) [hif q:$(gen q.gen, gol hif)])
     ::
-        {$ktpd *}  =+(vat=$(gen p.gen) [(nice (wrap(sut p.vat) %zinc)) q.vat])
+        {$ktpm *}  =+(vat=$(gen p.gen) [(nice (wrap(sut p.vat) %zinc)) q.vat])
         {$ktsg *}  (blow gol p.gen)
         {$tune *}  [(face p.gen sut) [%0 %1]]
         {$ktwt *}  =+(vat=$(gen p.gen) [(nice (wrap(sut p.vat) %lead)) q.vat])
@@ -10453,7 +10453,7 @@
       [(hint [sut p.gen] p.hum) q.hum]
     ::
         {$sgzp *}  ~_(duck(sut (play p.gen)) $(gen q.gen))
-        {$sgbn *}
+        {$sggr *}
       =+  hum=$(gen q.gen)
       :: ?:  &(huz !?=(%|(@ [?(%sgcn %sgls) ^]) p.gen))
       ::  hum
@@ -10465,7 +10465,7 @@
         ==
       q.hum
     ::
-        {$tsbn *}
+        {$tsgr *}
       =+  fid=$(gen p.gen, gol %noun)
       =+  dov=$(sut p.fid, gen q.gen)
       [p.dov (comb q.fid q.dov)]
@@ -10523,7 +10523,7 @@
       =+  ref=p:$(gol %noun, gen p.gen)
       [(nice (cell ref p.vos)) (cons [%1 burp(sut p.vos)] q.vos)]
     ::
-        {$zpld *}
+        {$zpgl *}
       =/  typ  (nice (play [%kttr p.gen]))
       =/  val
         =<  q
@@ -10532,16 +10532,16 @@
             gen
           :^    %wtcl
               :+  %cncl  [%limb %levi]
-              :~  [%tsbn [%zpbn [%kttr p.gen]] [%$ 2]]
-                  [%tsbn q.gen [%$ 2]]
+              :~  [%tsgr [%zpgr [%kttr p.gen]] [%$ 2]]
+                  [%tsgr q.gen [%$ 2]]
               ==
-            [%tsbn q.gen [%$ 3]]
+            [%tsgr q.gen [%$ 3]]
           [%zpzp ~]
         ==
       [typ val]
     ::
         {$zpts *}   [(nice %noun) [%1 q:$(vet |, gen p.gen)]]
-        {$zpvt *}   ?:((feel p.gen) $(gen q.gen) $(gen r.gen))
+        {$zppt *}   ?:((feel p.gen) $(gen q.gen) $(gen r.gen))
     ::
         {$zpzp ~}  [%void [%0 0]]
         *
@@ -10596,7 +10596,7 @@
     ::
         {$ktcn *}  $(fab |, gen p.gen)
         {$brcn *}  (grow %gold p.gen %dry [%$ 1] q.gen)
-        {$brvt *}  (grow %gold p.gen %wet [%$ 1] q.gen)
+        {$brpt *}  (grow %gold p.gen %wet [%$ 1] q.gen)
         {$cnts *}  (~(mull et p.gen q.gen) gol dox)
         {$dtkt *}  =+($(gen q.gen, gol %noun) $(gen [%kttr p.gen]))
         {$dtls *}  =+($(gen p.gen, gol [%atom %$ ~]) (beth [%atom %$ ~]))
@@ -10618,7 +10618,7 @@
       =+  hif=[p=(nice (play p.gen)) q=(play(sut dox) p.gen)]
       =+($(gen q.gen, gol p.hif) hif)
     ::
-        {$ktpd *}
+        {$ktpm *}
       =+(vat=$(gen p.gen) [(wrap(sut p.vat) %zinc) (wrap(sut q.vat) %zinc)])
     ::
         {$tune *}
@@ -10633,8 +10633,8 @@
     ::
         {$ktsg *}  $(gen p.gen)
         {$sgzp *}  ~_(duck(sut (play p.gen)) $(gen q.gen))
-        {$sgbn *}  $(gen q.gen)
-        {$tsbn *}
+        {$sggr *}  $(gen q.gen)
+        {$tsgr *}
       =+  lem=$(gen p.gen, gol %noun)
       $(gen q.gen, sut p.lem, dox q.lem)
     ::
@@ -10702,11 +10702,11 @@
       =+  vos=$(gol %noun, gen q.gen)       ::  XX validate!
       [(nice (cell (play p.gen) p.vos)) (cell (play(sut dox) p.gen) q.vos)]
     ::
-        {$zpld *}
+        {$zpgl *}
       ::  XX is this right?
       (beth (play [%kttr p.gen]))
     ::
-        {$zpvt *}
+        {$zppt *}
       =+  [(feel p.gen) (feel(sut dox) p.gen)]
       ?.  =(-< ->)
         ~>(%mean.'mull-bonk-f' !!)
@@ -10971,7 +10971,7 @@
       {^ *}      (cell $(gen p.gen) $(gen q.gen))
       {$ktcn *}  $(fab |, gen p.gen)
       {$brcn *}  (core sut [p.gen %dry %gold] sut *seminoun q.gen)
-      {$brvt *}  (core sut [p.gen %wet %gold] sut *seminoun q.gen)
+      {$brpt *}  (core sut [p.gen %wet %gold] sut *seminoun q.gen)
       {$cnts *}  ~(play et p.gen q.gen)
       {$dtkt *}  $(gen [%kttr p.gen])
       {$dtls *}  [%atom %$ ~]
@@ -10990,13 +10990,13 @@
       {$hand *}  p.gen
       {$ktbr *}  (wrap(sut $(gen p.gen)) %iron)
       {$ktls *}  $(gen p.gen)
-      {$ktpd *}  (wrap(sut $(gen p.gen)) %zinc)
+      {$ktpm *}  (wrap(sut $(gen p.gen)) %zinc)
       {$ktsg *}  $(gen p.gen)
       {$ktwt *}  (wrap(sut $(gen p.gen)) %lead)
       {$note *}  (hint [sut p.gen] $(gen q.gen))
       {$sgzp *}  ~_(duck(sut ^$(gen p.gen)) $(gen q.gen))
-      {$sgbn *}  $(gen q.gen)
-      {$tsbn *}  $(gen q.gen, sut $(gen p.gen))
+      {$sggr *}  $(gen q.gen)
+      {$tsgr *}  $(gen q.gen, sut $(gen p.gen))
       {$tscm *}  $(gen q.gen, sut (busk p.gen))
       {$wtcl *}  =+  [fex=(gain p.gen) wux=(lose p.gen)]
                  %-  fork  :~
@@ -11009,9 +11009,9 @@
       {$zpcm *}  $(gen p.gen)
       {$lost *}  %void
       {$zpmc *}  (cell $(gen p.gen) $(gen q.gen))
-      {$zpld *}  (play [%kttr p.gen])
+      {$zpgl *}  (play [%kttr p.gen])
       {$zpts *}  %noun
-      {$zpvt *}  ?:((feel p.gen) $(gen q.gen) $(gen r.gen))
+      {$zppt *}  ?:((feel p.gen) $(gen q.gen) $(gen r.gen))
       {$zpzp *}  %void
       *          =+  doz=~(open ap gen)
                  ?:  =(doz gen)
@@ -11354,7 +11354,7 @@
                     {$face p/term q/wine}               ::
                     {$list p/term q/wine}               ::
                     {$pear p/term q/@}                  ::
-                    {$bswt p/(list wine)}               ::
+                    {$bcwt p/(list wine)}               ::
                     {$plot p/(list wine)}               ::
                     {$stop p/@ud}                       ::
                     {$tree p/term q/wine}               ::
@@ -11420,7 +11420,7 @@
         =^  cox  gid  $(q.ham q.q.ham)
         :_(gid [%rose [" " (weld (trip p.q.ham) "(") ")"] cox ~])
       ::
-          {$bswt *}
+          {$bcwt *}
         =^  coz  gid  (many p.q.ham)
         :_(gid [%rose [[' ' ~] ['?' '(' ~] [')' ~]] coz])
       ::
@@ -11560,7 +11560,7 @@
         ~
       [~ u.for u.aft]
     ::
-        {$bswt *}
+        {$bcwt *}
       |-  ^-  (unit tank)
       ?~  p.q.ham
         ~
@@ -11649,7 +11649,7 @@
     ^=  woz
     ^-  wine
     ?.  ?=({$stop *} q.ham)
-      ?:  ?&  ?=  {$bswt {$pear $n $0} {$plot {$pear $n $0} {$face *} ~} ~}
+      ?:  ?&  ?=  {$bcwt {$pear $n $0} {$plot {$pear $n $0} {$face *} ~} ~}
                 q.ham
               =(1 (met 3 p.i.t.p.i.t.p.q.ham))
           ==
@@ -11659,7 +11659,7 @@
     ?~  may
       q.ham
     =+  nul=[%pear %n 0]
-    ?.  ?&  ?=({$bswt *} u.may)
+    ?.  ?&  ?=({$bcwt *} u.may)
             ?=({* * ~} p.u.may)
             |(=(nul i.p.u.may) =(nul i.t.p.u.may))
         ==
@@ -11748,7 +11748,7 @@
     ::
         {$fork *}
       =+  yed=(sort ~(tap in p.sut) aor)
-      =-  [p [%bswt q]]
+      =-  [p [%bcwt q]]
       |-  ^-  {p/{p/(map type @) q/(map @ wine)} q/(list wine)}
       ?~  yed
         [dex ~]
@@ -12173,7 +12173,7 @@
   ?@  -.q.vax
     ^=  typ
     %-  ~(play ut p.vax)
-    [%wtbn [%wtts [%leaf %tas -.q.vax] [%& 2]~] [%$ 1]]
+    [%wtgr [%wtts [%leaf %tas -.q.vax] [%& 2]~] [%$ 1]]
   (~(fuse ut p.vax) [%cell %noun %noun])
 ::
 ::::  5d: parser
@@ -12342,7 +12342,7 @@
   ++  phax
     |=  ruw/(list (list woof))
     =+  [yun=*(list hoon) cah=*(list @)]
-    =+  wod=|=({a/tape b/(list hoon)} ^+(b ?~(a b [[%mcnt %knit (flop a)] b])))
+    =+  wod=|=({a/tape b/(list hoon)} ^+(b ?~(a b [[%mcfs %knit (flop a)] b])))
     |-  ^+  yun
     ?~  ruw
       (flop (wod cah yun))
@@ -13403,9 +13403,9 @@
     ^.  stet  ^.  limo
     :~
       :-  '_'
-        ;~(pfix cab (stag %bscb wide))
+        ;~(pfix cab (stag %bccb wide))
       :-  ','
-        ;~(pfix com (stag %bsmc wide))
+        ;~(pfix com (stag %bcmc wide))
       :-  '$'
         ;~  pose
           ;~  pfix  buc
@@ -13442,9 +13442,9 @@
       :-  '{'
         ::  XX deprecated
         ::
-        (stag %bscl (ifix [kel ker] (most ace wyde)))
+        (stag %bccl (ifix [kel ker] (most ace wyde)))
       :-  '['
-        (stag %bscl (ifix [sel ser] (most ace wyde)))
+        (stag %bccl (ifix [sel ser] (most ace wyde)))
       :-  '*'
         (cold [%base %noun] tar)
       :-  '/'
@@ -13453,7 +13453,7 @@
         ;~(pfix pat (stag %base (stag %atom mota)))
       :-  '?'
         ;~  pose
-          %+  stag  %bswt
+          %+  stag  %bcwt
           ;~(pfix wut (ifix [pal par] (most ace wyde)))
         ::
           (cold [%base %flag] wut)
@@ -13475,7 +13475,7 @@
               ~(autoname ax & spec)
             |=  =term
             =*  name  ?~(unit term (cat 3 u.unit (cat 3 '-' term)))
-            [%bsts name spec]
+            [%bcts name spec]
           ;~  pose
             ;~(plug (stag ~ ;~(sfix sym tis)) wyde)
             (stag ~ wyde)
@@ -13483,7 +13483,7 @@
         ==
       :-  ['a' 'z']
         ;~  pose
-          (stag %bsts ;~(plug sym ;~(pfix ;~(pose fas tis) wyde)))
+          (stag %bcts ;~(plug sym ;~(pfix ;~(pose fas tis) wyde)))
           (stag %like (most col rope))
         ==
     ==
@@ -13504,7 +13504,7 @@
           (stag %zpzp (cold ~ ;~(plug zap zap)))
         ==
       :-  '_'
-        ;~(pfix cab (stag %ktcl (stag %bscb wide)))
+        ;~(pfix cab (stag %ktcl (stag %bccb wide)))
       :-  '$'
         ;~  pose
           ;~  pfix  buc
@@ -13533,7 +13533,7 @@
       :-  '&'
         ;~  pose
           (cook |=(a/wing [%cnts a ~]) rope)
-          (stag %wtpd ;~(pfix pam (ifix [pal par] (most ace wide))))
+          (stag %wtpm ;~(pfix pam (ifix [pal par] (most ace wide))))
           ;~(plug (stag %rock (stag %f (cold & pam))) wede)
           (stag %sand (stag %f (cold & pam)))
         ==
@@ -13542,7 +13542,7 @@
       :-  '('
         (stag %cncl (ifix [pal par] (most ace wide)))
       :-  '{'
-        (stag %ktcl (stag %bscl (ifix [kel ker] (most ace wyde))))
+        (stag %ktcl (stag %bccl (ifix [kel ker] (most ace wyde))))
       :-  '*'
         ;~  pose
           (stag %kttr ;~(pfix tar wyde))
@@ -13556,7 +13556,7 @@
         ::
           %+  cook
             |=  a/(list (list woof))
-            :-  %mcnt
+            :-  %mcfs
             [%knit |-(^-((list woof) ?~(a ~ (weld i.a $(a t.a)))))]
           (most dog ;~(pfix lus soil))
         ::
@@ -13587,7 +13587,7 @@
         ;~  pfix  col
           ;~  pose
             (stag %mccl (ifix [pal par] (most ace wide)))
-            ;~(pfix fas (stag %mcnt wide))
+            ;~(pfix fas (stag %mcfs wide))
           ==
         ==
       :-  '='
@@ -13608,7 +13608,7 @@
       :-  '?'
         ;~  pose
           %+  stag  %ktcl
-          (stag %bswt ;~(pfix wut (ifix [pal par] (most ace wyde))))
+          (stag %bcwt ;~(pfix wut (ifix [pal par] (most ace wyde))))
         ::
           (cold [%base %flag] wut)
         ==
@@ -13706,20 +13706,20 @@
             ;~  pfix  buc
               %-  stew
               ^.  stet  ^.  limo
-              :~  [':' (rune col %bscl exqs)]
-                  ['%' (rune cen %bscn exqs)]
-                  ['<' (rune gal %bsld exqb)]
-                  ['>' (rune gar %bsbn exqb)]
-                  ['^' (rune ket %bskt exqb)]
-                  ['~' (rune sig %bssg exqd)]
-                  ['|' (rune bar %bsbr exqc)]
-                  ['&' (rune pam %bspd exqc)]
-                  ['@' (rune pat %bsvt exqb)]
-                  ['_' (rune cab %bscb expa)]
-                  ['-' (rune hep %bshp exqb)]
-                  ['=' (rune tis %bsts exqg)]
-                  ['?' (rune wut %bswt exqs)]
-                  [';' (rune mic %bsmc expa)]
+              :~  [':' (rune col %bccl exqs)]
+                  ['%' (rune cen %bccn exqs)]
+                  ['<' (rune gal %bcgl exqb)]
+                  ['>' (rune gar %bcgr exqb)]
+                  ['^' (rune ket %bckt exqb)]
+                  ['~' (rune sig %bcsg exqd)]
+                  ['|' (rune bar %bcbr exqc)]
+                  ['&' (rune pam %bcpm exqc)]
+                  ['@' (rune pat %bcpt exqb)]
+                  ['_' (rune cab %bccb expa)]
+                  ['-' (rune hep %bchp exqb)]
+                  ['=' (rune tis %bcts exqg)]
+                  ['?' (rune wut %bcwt exqs)]
+                  [';' (rune mic %bcmc expa)]
               ==
             ==
         :-  '%'
@@ -13761,7 +13761,7 @@
               ^.  stet  ^.  limo
               :~  ['_' (rune cab %brcb exqr)]
                   ['%' (runo cen %brcn ~ expe)]
-                  ['@' (runo pat %brvt ~ expe)]
+                  ['@' (runo pat %brpt ~ expe)]
                   [':' (rune col %brcl expb)]
                   ['.' (rune dot %brdt expa)]
                   ['-' (rune hep %brhp expa)]
@@ -13770,26 +13770,26 @@
                   ['*' (rune tar %brtr exqc)]
                   ['=' (rune tis %brts exqc)]
                   ['?' (rune wut %brwt expa)]
-                  ['$' (rune buc %brbs exqe)]
+                  ['$' (rune buc %brbc exqe)]
               ==
             ==
           :-  '$'
             ;~  pfix  buc
               %-  stew
               ^.  stet  ^.  limo
-              :~  ['@' (stag %ktcl (rune pat %bsvt exqb))]
-                  ['_' (stag %ktcl (rune cab %bscb expa))]
-                  [':' (stag %ktcl (rune col %bscl exqs))]
-                  ['%' (stag %ktcl (rune cen %bscn exqs))]
-                  ['<' (stag %ktcl (rune gal %bsld exqb))]
-                  ['>' (stag %ktcl (rune gar %bsbn exqb))]
-                  ['|' (stag %ktcl (rune bar %bsbr exqc))]
-                  ['&' (stag %ktcl (rune pam %bspd exqc))]
-                  ['^' (stag %ktcl (rune ket %bskt exqb))]
-                  ['~' (stag %ktcl (rune sig %bssg exqd))]
-                  ['-' (stag %ktcl (rune hep %bshp exqb))]
-                  ['=' (stag %ktcl (rune tis %bsts exqg))]
-                  ['?' (stag %ktcl (rune wut %bswt exqs))]
+              :~  ['@' (stag %ktcl (rune pat %bcpt exqb))]
+                  ['_' (stag %ktcl (rune cab %bccb expa))]
+                  [':' (stag %ktcl (rune col %bccl exqs))]
+                  ['%' (stag %ktcl (rune cen %bccn exqs))]
+                  ['<' (stag %ktcl (rune gal %bcgl exqb))]
+                  ['>' (stag %ktcl (rune gar %bcgr exqb))]
+                  ['|' (stag %ktcl (rune bar %bcbr exqc))]
+                  ['&' (stag %ktcl (rune pam %bcpm exqc))]
+                  ['^' (stag %ktcl (rune ket %bckt exqb))]
+                  ['~' (stag %ktcl (rune sig %bcsg exqd))]
+                  ['-' (stag %ktcl (rune hep %bchp exqb))]
+                  ['=' (stag %ktcl (rune tis %bcts exqg))]
+                  ['?' (stag %ktcl (rune wut %bcwt exqs))]
                   ['.' (rune dot %kttr exqa)]
                   [',' (rune com %ktcl exqa)]
               ==
@@ -13840,7 +13840,7 @@
                   ['.' (rune dot %ktdt expb)]
                   ['-' (rune hep %kthp exqc)]
                   ['+' (rune lus %ktls expb)]
-                  ['&' (rune pam %ktpd expa)]
+                  ['&' (rune pam %ktpm expa)]
                   ['~' (rune sig %ktsg expa)]
                   ['=' (rune tis %ktts expj)]
                   ['?' (rune wut %ktwt expa)]
@@ -13854,14 +13854,14 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  ['|' (rune bar %sgbr expb)]
-                  ['$' (rune buc %sgbs expf)]
+                  ['$' (rune buc %sgbc expf)]
                   ['_' (rune cab %sgcb expb)]
                   ['%' (rune cen %sgcn hind)]
-                  ['/' (rune fas %sgnt hine)]
-                  ['<' (rune gal %sgld hinb)]
-                  ['>' (rune gar %sgbn hinb)]
+                  ['/' (rune fas %sgfs hine)]
+                  ['<' (rune gal %sggl hinb)]
+                  ['>' (rune gar %sggr hinb)]
                   ['+' (rune lus %sgls hinc)]
-                  ['&' (rune pam %sgpd hinf)]
+                  ['&' (rune pam %sgpm hinf)]
                   ['?' (rune wut %sgwt hing)]
                   ['=' (rune tis %sgts expb)]
                   ['!' (rune zap %sgzp expb)]
@@ -13872,7 +13872,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
-                  ['/' (rune fas %mcnt expa)]
+                  ['/' (rune fas %mcfs expa)]
                   ['<' (rune gal %mcgl exp1)]
                   ['~' (rune sig %mcsg expi)]
                   [';' (rune mic %mcmc exqc)]
@@ -13887,10 +13887,10 @@
                   ['?' (rune wut %tswt expw)]
                   ['^' (rune ket %tskt expt)]
                   [':' (rune col %tscl expp)]
-                  ['/' (rune fas %tsnt expo)]
+                  ['/' (rune fas %tsfs expo)]
                   [';' (rune mic %tsmc expo)]
-                  ['<' (rune gal %tsld expb)]
-                  ['>' (rune gar %tsbn expb)]
+                  ['<' (rune gal %tsgl expb)]
+                  ['>' (rune gar %tsgr expb)]
                   ['-' (rune hep %tshp expb)]
                   ['*' (rune tar %tstr expg)]
                   [',' (rune com %tscm expb)]
@@ -13905,14 +13905,14 @@
               :~  ['|' (rune bar %wtbr exps)]
                   [':' (rune col %wtcl expc)]
                   ['.' (rune dot %wtdt expc)]
-                  ['<' (rune gal %wtld expb)]
-                  ['>' (rune gar %wtbn expb)]
+                  ['<' (rune gal %wtgl expb)]
+                  ['>' (rune gar %wtgr expb)]
                   ['-' ;~(pfix hep (toad txhp))]
                   ['^' ;~(pfix ket (toad tkkt))]
                   ['=' ;~(pfix tis (toad txts))]
                   ['#' ;~(pfix hax (toad txhx))]
                   ['+' ;~(pfix lus (toad txls))]
-                  ['&' (rune pam %wtpd exps)]
+                  ['&' (rune pam %wtpm exps)]
                   ['@' ;~(pfix pat (toad tkvt))]
                   ['~' ;~(pfix sig (toad tksg))]
                   ['!' (rune zap %wtzp expa)]
@@ -13926,9 +13926,9 @@
                   ['.' ;~(pfix dot (toad |.(loaf(bug |))))]
                   [',' (rune com %zpcm expb)]
                   [';' (rune mic %zpmc expb)]
-                  ['>' (rune gar %zpbn expa)]
-                  ['<' (rune gal %zpld exqc)]
-                  ['@' (rune pat %zpvt expy)]
+                  ['>' (rune gar %zpgr expa)]
+                  ['<' (rune gal %zpgl exqc)]
+                  ['@' (rune pat %zppt expy)]
                   ['=' (rune tis %zpts expa)]
                   ['?' (rune wut %zpwt hinh)]
               ==
@@ -13963,7 +13963,7 @@
           ^-  [term hoon]
           :-  b
           :+  %brtr
-            :-  %bscl
+            :-  %bccl
             =-  ?>(?=(^ -) -)
             ::  for each .term in .c, produce $=(term $~(* $-(* *)))
             ::  ie {term}=mold
@@ -13972,7 +13972,7 @@
             |=  =term
             ^-  spec
             =/  tar  [%base %noun]
-            [%bsts term [%bssg tar [%bshp tar tar]]]
+            [%bcts term [%bcsg tar [%bchp tar tar]]]
           [%ktcl [%made [b c] e]]
         ;~  pfix  (jest '+*')
           ;~  plug
@@ -14194,7 +14194,7 @@
                             (~(wtls ah a) b c)
                   (butt ;~(gunk teak loaf ruck))
     ++  tkvt  |.  %+  cook  |=  {a/tiki b/hoon c/hoon}
-                            (~(wtvt ah a) b c)
+                            (~(wtpt ah a) b c)
                   ;~(gunk teak loaf loaf)
     ++  tksg  |.  %+  cook  |=  {a/tiki b/hoon c/hoon}
                             (~(wtsg ah a) b c)
@@ -14270,7 +14270,7 @@
     |:  $:lang
     ^-  (unit hoon)
     ?-    -.vil
-      $col  ?:(=([%base %flag] ros) ~ [~ %tsld ros p.vil])
+      $col  ?:(=([%base %flag] ros) ~ [~ %tsgl ros p.vil])
       $lit  (bind ~(reek ap ros) |=(hyp/wing [%cnts hyp p.vil]))
       $ket  [~ ros p.vil]
       $tis  =+  rud=~(flay ap ros)
@@ -14546,7 +14546,7 @@
       ?@  q.vax    [%wtts [%base [%atom %$]] [%& 1]~]
       ?@  -.q.vax  [%wtts [%leaf %tas -.q.vax] [%& 2]~]
       [%wtts [%base %cell] [%& 1]~]
-    =^  typ  +>+<.$  (play p.vax [%wtbn gen [%$ 1]])
+    =^  typ  +>+<.$  (play p.vax [%wtgr gen [%$ 1]])
     [[typ q.vax] +>+<.$]
   ::
   ++  spot                                              ::  slot then sped

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -654,7 +654,7 @@
           (with-faces old+old sam+sam ~)
         :+  %sgzp  !,(*hoon old=old)
         :+  %sgzp  !,(*hoon sam=sam)
-        :+  %tsld  [%limb b]
+        :+  %tsgl  [%limb b]
         !,  *hoon
         ~(grow old sam)
       ::  try direct +grab
@@ -663,7 +663,7 @@
       =/  rab
         %-  mule  |.
         %+  slap  new
-        :+  %tsld  [%limb a]
+        :+  %tsgl  [%limb a]
         [%limb %grab]
       ?:  &(?=(%& -.rab) ?=(^ q.p.rab))
         :_(nub |=(sam=vase ~|([%grab a b] (slam p.rab sam))))
@@ -672,7 +672,7 @@
       =/  jum
         %-  mule  |.
         %+  slap  old
-        :+  %tsld  [%limb b]
+        :+  %tsgl  [%limb b]
         [%limb %jump]
       ?:  ?=(%& -.jum)
         (compose-casts a !<(mark p.jum) b)


### PR DESCRIPTION
### Issues

- I'm not sure how to create a bootable pill with these changes.

- `pkg/arvo/lib/pprint.hoon` may have a bug.
See these lines (403 and 406):
`XX %tsld to %tsgl, but should be %tsgr? (to match =>)`
`XX %tsbn to %tsgr, but should be %tsgl? (to match =<)`
