### PR TITLE
hark: handle "no chat metadata" errors

### DIFF
--- a/pkg/interface/src/views/apps/notifications/chat.tsx
+++ b/pkg/interface/src/views/apps/notifications/chat.tsx
@@ -40,11 +40,11 @@ export function ChatNotification(props: {
   const authors = _.map(contents, "author");
 
   const { chat, mention } = index;
-  const association = props.associations.chat[chat];
-  const groupPath = association["group-path"];
-  const appPath = association["app-path"];
+  const association = props?.associations?.chat?.[chat];
+  const groupPath = association?.["group-path"];
+  const appPath = index?.chat;
 
-  const group = props.groups[groupPath];
+  const group = props?.groups?.[groupPath];
 
   const desc = describeNotification(mention, contents.length);
   const groupContacts = props.contacts[groupPath] || {};
@@ -75,7 +75,10 @@ export function ChatNotification(props: {
       />
       <Col pb="3" pl="5">
         {_.map(_.take(contents, 5), (content, idx) => {
-          const workspace = group?.hidden ? '/home' : groupPath;
+          let workspace = groupPath;
+          if (workspace === undefined || group?.hidden) {
+            workspace = '/home';
+          }
           const to = `/~landscape${workspace}/resource/chat${appPath}?msg=${content.number}`;
           return (
             <Link key={idx} to={to}>


### PR DESCRIPTION
(Should) address urbit/landscape#161.

Chat notifications, unlike graph notifications, ask for metadata for render in a way that can lead to a crash if we don't have the metadata for whatever reason. This PR attempts to gracefully handle those errors:

- We look for the app path from the notification data itself, not from the association;
- We allow the groupPath to fall back to `undefined`;
- If our group path is `undefined` then the notification will redirect us to the chat inside of the home workspace (where the chat, if it has no group path, probably is anyway).