### PR TITLE
hark: fix automatically watching DMs 

### DIFF
--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -488,8 +488,8 @@
     (en-path:resource rid)
   ?>  ?=(^ path)
   :~  (group-pull-hook-poke %add ship rid)
-      (chat-hook-poke %add-synced ship t.path ask-history)
       (metadata-hook-poke %add-synced ship path)
+      (chat-hook-poke %add-synced ship t.path ask-history)
   ==
 ::
 ++  diff-chat-update

--- a/pkg/arvo/app/hark-chat-hook.hoon
+++ b/pkg/arvo/app/hark-chat-hook.hoon
@@ -51,7 +51,10 @@
 ++  on-load
   |=  old=vase
   ^-  (quip card _this)
-  `this(state !<(state-0 old))
+  :_  this(state !<(state-0 old))
+  ?:  (~(has by wex.bowl) [/chat our.bowl %chat-store])
+    ~
+  ~[watch-chat:ha]
 ::
 ++  on-watch  
   |=  =path


### PR DESCRIPTION
Fixes automatic watching of newly-joined DMs. Will rewatch DMs that were missed due to the bug. 