### PR TITLE
eth abi parsing, sur, lib, and mar codegen

### DIFF
--- a/pkg/arvo/lib/eth-abi-gen.hoon
+++ b/pkg/arvo/lib/eth-abi-gen.hoon
@@ -1,0 +1,635 @@
+/+  *eth-abi-parse
+|%
+::  TODO: for some reason u.name.petyp is null sometimes
+::  see petyp-to-bape hack
+  ++  damn-skim
+    |=  [es=(list event-input) b=?]
+    ^-  (list event-input)
+    %+  skim  es
+    |=  =event-input
+    =(indexed.event-input b)
+::
+  ++  get-all-functions-with-outputs
+    |=  =contract
+    ^-  (list function)
+    =/  writes=(list function)
+    %+  skim  ~(val by write-functions.contract)
+    |=  =function
+    ?~  outputs.function  |  &
+    (weld ~(val by read-functions.contract) writes)
+
+  ++  petyp-type-to-bape
+    |=  type=petyp-type
+    ^-  tape
+    ?+  type  !!
+        %address
+      "@ux"
+        %uint
+      "@ud"
+        %bool
+      "?"
+        %int :: doesn't work with decode lib yet
+      !!
+        %string
+      "tape"
+        %bytes
+      "octs"
+        [%bytes-n *]
+      "octs"
+        [%array *]
+      "(list {$(type t.type)})"
+        [%array-n *]
+      "(list {$(type t.type)})"
+        [%tuple *]
+      =-  :(weld "[" - "]")
+      %-  tape
+      %-  zing
+      %+  join  " "
+      %+  turn  t.type
+      petyp-to-bape
+    ==
+  ++  petyp-to-bape
+    |=  =petyp
+    =-
+    ?:  ?=(?(~ [~ ~]) name.petyp)  "{-}"
+    "{(trip u.name.petyp)}={-}"
+    (petyp-type-to-bape type.petyp)
+
+  ++  petyp-to-topic-sub
+    |=  =petyp
+    :: only support multiple on atoms, because otherwise hard to encode
+    :: need better types for topic formation
+    :: could do better than rpc with urbit-side filtering
+    =/  type=tape
+    =-  ?.  ?=(?(%uint %bool %int %address %bytes %real %ureal) type.petyp)  "{-}"
+        "?({-} (list {-}))"
+    ?:  ?=([?(%array %array-n %tuple %bytes-n %string) *] type.petyp)
+      "@ux"
+    (petyp-type-to-bape type.petyp)
+    ?~  name.petyp  type
+    "{(trip u.name.petyp)}={type}"
+    ::
+  ++  petyp-type-to-etape
+    |=  type=petyp-type
+    |-  ^-  tape
+    ?+  type  ~&  unexpected-type+type  !!
+      ?(%uint %bool %int %address %bytes %real %ureal %string)
+    "%{(trip type)}"
+      [%bytes-n *]
+    "[%bytes-n {(scow %ud n.type)}]"
+      [%array *]
+    "[%array {$(type t.type)}]"
+      [%tuple *]
+    =-  "[%tuple ~[{-}]]"
+    %-  zing
+    %+  join  " "
+    (turn t.type petyp-to-etape)
+    ==
+  ++  petyp-to-etape
+  ::  TODO: not working on arraysn or bytesn or tuples
+    |=  =petyp
+    ^-  tape
+    (petyp-type-to-etape type.petyp)
+::
+  ++  code-gen-diff-mark
+    |=  [sur-name=tape]
+    %-  crip
+    """
+    /+  *eth-contracts-{sur-name}
+    |_  dif=diff
+    ++  grow
+      |%
+      ++  json  (diff-to-json dif)
+      --
+    ++  grab
+      |%
+        ++  noun  diff
+        ++  eth-watcher-diff  decode-diff
+      --
+    --
+    """
+  ++  code-gen-esub-mark
+    |=  [sur-name=tape]
+    %-  crip
+    """
+    /+  *eth-contracts-{sur-name}
+    |_  zub=esub
+    ++  grow
+      |%
+      ++  eth-watcher-poke  (encode-esub zub)
+      --
+    ++  grab
+      |%
+        ++  noun  esub
+      --
+    --
+    """
+
+  ++  code-gen-call-mark
+    |=  [sur-name=tape]
+    %-  crip
+    """
+    /+  *eth-contracts-{sur-name}
+    |_  cal=call:methods
+    ++  grow
+      |%
+        ++  eth-call-data  (encode-call cal)
+      --
+    ++  grab
+      |%
+        ++  noun  call:methods
+      --
+    --
+    """
+  ++  code-gen-send-mark
+    |=  [sur-name=tape]
+    %-  crip
+    """
+    /+  *eth-contracts-{sur-name}
+    |_  sen=send:methods
+    ++  grow
+      |%
+        ++  eth-call-data  (encode-send sen)
+      --
+    ++  grab
+      |%
+        ++  noun  send:methods
+      --
+    --
+    """
+  ++  code-gen-res-mark
+    |=  [sur-name=tape]
+    %-  crip
+    """
+    /+  *eth-contracts-{sur-name}
+    |_  re=res
+    ++  grab
+      |%
+        ++  noun  res
+        ++  eth-call-result  decode-res
+      --
+    --
+    """
+
+  ++  code-gen-types
+    |=  [name=@tas =contract]  :: remove name since we're doing cages now
+    =/  read-functions=(list function)
+    ~(val by read-functions.contract)
+    =/  write-functions=(list function)
+    ~(val by write-functions.contract)
+    =/  functions-with-outputs=(list function)
+    (get-all-functions-with-outputs contract)
+    =/  events=(list event)
+    ~(val by events.contract)
+    |^
+      %-  crip
+      """
+      /-  eth-abi-magic
+      =,  able:jael
+      =,  builders=builders:eth-abi-magic
+      |%
+      {event-arms}
+      {res}
+      {methods}
+      --
+      """
+      ++  event-arms
+      ^-  tape
+      ?~  events  ""
+      """
+      {event-update}
+      {watch}
+      +$  diff  ::  gift
+          $%  [$history =loglist]
+              [$log =event-log]
+              [$disavow =id:block]
+          ==
+      +$  esub  ::  poke
+          $%  [$watch =path config=watch-config]
+              [$clear =path]
+          ==
+      +$  event-log  (event-log-config:builders event-update)
+      +$  watch-config
+          %-  watch-config:builders
+          watch
+      +$  loglist  (list event-log)
+      """
+      ++  methods
+      ^-  tape
+      ?.  ?!  |(?=(~ read-functions) ?=(~ write-functions))  ~
+      """
+      ++  methods
+        |%
+      {send}
+      {call}
+        --
+      """
+      ++  nl  (trip 10)
+      ++  call
+        ?~  read-functions  ""
+        """
+          ++  call
+              $%
+        {(function-calls read-functions)}
+              ==
+        """
+      ++  send
+        ?~  write-functions  ""
+        """
+          ++  send
+              $%
+        {(function-calls write-functions)}
+              ==
+        """
+      ++  res
+        ?~  functions-with-outputs  ""
+        """
+        +$  res
+            $%
+        {function-results}
+            ==
+        """
+      ++  event-update
+        ::  TODO: think no work for aren't anonymous functions
+        """
+        +$  event-update
+            $%
+        {event-bucs}
+            ==
+        """
+      ++  watch
+        """
+        +$  watch
+            $%
+        {event-indexed-bucs}
+            ==
+        """
+      ++  event-bucs
+        ^-  tape
+        %-  zing
+        %+  join  nl
+        %+  turn  events
+        |=  =event
+        :: =-  (zing ~["        [${(trip name.event)} {-}]" nl])
+        =-  "        [${(trip name.event)} {(zing -)}]"
+        %+  join  " "
+        %+  turn  inputs.event
+        |=  [=petyp ?]
+        (petyp-to-bape petyp)
+      ++  event-indexed-bucs
+        ^-  tape
+        %-  zing
+        %+  join  nl
+        %+  turn  events
+        |=  =event
+        =-  (zing ~["        [${(trip name.event)} " ?~(- "~]" "{(zing -)}]")])
+        %+  join  " "
+        %+  turn  (skim inputs.event |=([* i=?] i))
+        |=  [=petyp ?]
+        (petyp-to-topic-sub petyp)
+      ++  function-calls
+        |=  functions=(list function)
+        ^-  tape
+        %-  zing
+        ?~  functions  ~
+        %+  join  nl
+        %+  turn  functions
+        |=  =function
+        =-  (zing ~["        [${(trip name.function)}" ?~(- " ~]" " {(zing -)}]")])
+        %+  join  " "
+        %+  turn  inputs.function
+        petyp-to-bape
+      ++  function-results
+        :: |=  functions=(list function)
+        ^-  tape
+        %-  zing
+        ?~  read-functions  ~
+        %+  join  nl
+        %+  turn  functions-with-outputs
+        |=  =function
+        =-  "        [${(trip name.function)} {(zing -)}]"
+        %+  join  " "
+        %+  turn  outputs.function
+        petyp-to-bape
+    --
+::
+  ++  code-gen-lib
+    |=  [=contract sur-name=@tas]
+    ^-  cord
+    =/  read-functions=(list function)
+    (turn ~(tap by read-functions.contract) |=([* =function] function))
+    =/  write-functions=(list function)
+    (turn ~(tap by write-functions.contract) |=([* =function] function))
+    =/  functions-with-outputs=(list function)
+    (get-all-functions-with-outputs contract)
+    =/  events=(list event)
+    (turn ~(tap by events.contract) |=([* =event] event))
+    |^
+      %-  crip
+      """
+      /-  eth-watcher, *eth-contracts-{(trip sur-name)}
+      /+  eth-abi-magic
+      |%
+      :: ++  res-to-json
+      ::   |=  =res
+      ::   =,  enjs:format
+      {event-arms}
+      {encode-send}
+      {encode-call}
+      {decode-res}
+      --
+      """
+    ++  event-arms
+      ?~  events  ""
+      """
+      {decode-log}
+      {decode-diff}
+      {diff-to-json}
+      {event-log-to-json}
+      """
+    ++  diff-to-json
+    """
+    ++  diff-to-json
+    |=  =diff
+    =,  enjs:format
+    ^-  json
+    %+  frond  %{(trip sur-name)}
+    ?-  -.diff
+        %history
+      %+  frond  %history
+      [%a (turn loglist.diff event-log-to-json)]
+        %log
+      %+  frond  %log
+      (event-log-to-json event-log.diff)
+        %disavow
+      !!
+    ==
+    """
+    ++  event-log-to-json
+    """
+    ++  event-log-to-json
+      |=  [=event-log]
+      ^-  json
+      =,  enjs:format
+    {log-json-cases}
+    ++  encode-esub
+      |=  =esub
+      ^-  poke:eth-watcher
+      ?-  -.esub
+          %watch
+    {encode-esub-cases}
+          %clear
+        esub
+      ==
+    """
+    ++  decode-diff
+    """
+    ++  decode-diff
+      |=  =diff:eth-watcher
+      ^-  ^diff
+      ?-  -.diff
+          %history
+        :-  %history
+        %+  turn  loglist.diff  decode-log
+          %log
+        :-  %log  (decode-log event-log.diff)
+          %disavow
+        diff
+      ==
+    """
+    ++  decode-res
+    ?~  functions-with-outputs  ""
+    """
+    ++  decode-res
+      |=  [name=@tas result=@t]
+      ^-  res
+      ?+  name  ~|  "unexpected result in contract {(trip sur-name)}"  !!
+    {encode-result-cases}
+      ==
+    """
+    ++  encode-send
+    ?~  write-functions  ""
+    """
+    ++  encode-send
+      |=  =send:methods
+      ^-  call-data:rpc:ethereum
+      ?-  -.send
+    {(encode-method-cases write-functions.contract %send)}
+      ==
+    """
+    ++  decode-log
+    """
+    ++  decode-log
+      |=  [=event-log:rpc:ethereum]
+      ^-  ^event-log
+    {decode-log-cases}
+    ~|  "unexpected event in {(trip name.contract)}"  !!
+    """
+    ++  encode-call
+    ?~  read-functions  ""
+    """
+    ++  encode-call
+    |=  =call:methods
+    ^-  call-data:rpc:ethereum
+    ?-  -.call
+    {(encode-method-cases read-functions.contract %call)}
+    ==
+    """
+    ++  nl  (trip 10)
+    ++  encode-result-cases
+      :: |=  [functions=(map @tas function) face=@tas]
+      %-  zing
+      %+  join  nl
+      %+  turn  functions-with-outputs
+      |=  =function
+      =/  outputs=tape
+        %-  zing
+        %+  join  " "
+        (turn outputs.function |=(fo=func-output (petyp-to-etape petyp.fo)))
+      =-
+      """
+              %{(trip name.function)}
+            {-}
+      """
+      ?~  outputs  "[%{(trip name.function)} ~]"
+      "[%{(trip name.function)} (decode-results:decode:eth-abi-magic result ~[{outputs}])]"
+    ++  encode-method-cases
+      |=  [functions=(map @tas function) arm=@tas]
+      %-  zing
+      %+  join  nl
+      %+  turn  ~(tap by functions)
+      |=  [name=@tas =function]
+      =/  inputs=tape
+        %-  zing
+        %+  join  " "
+        (turn inputs.function |=(fi=func-input (petyp-to-etape petyp.fi)))
+      =-
+      """
+              %{(trip name)}
+            :-  '{(trip sel.function)}'
+            {-}
+      """
+      ?~  inputs  "~"
+      "(tuple-to-eth-data:eth-abi-magic ~[{inputs}] +.{(trip arm)})"
+    ++  decode-log-cases
+      %-  zing
+      %+  join  nl
+      %+  turn  ~(tap by events.contract)
+      |=  [hash=@ux =event]
+      ^-  tape
+      ?~  inputs.event
+      """
+        ?:  =(i.topics.event-log {(scow %ux hash)})
+          [%{(trip name.event)} ~]
+      """
+      |^
+      =/  topic-types=tape
+      %-  topics-to-etape  (damn-skim inputs.event &)
+      =/  data-types=tape
+      %-  topics-to-etape  (damn-skim inputs.event |)
+      =-
+      """
+        ?:  =(i.topics.event-log {(scow %ux hash)})
+          :*  mined.event-log
+              address.event-log
+      {-}
+          ==
+      """
+      ?~  topic-types
+        ?~  data-types
+          "        [%{(trip name.event)} ~]"
+        =-  "        [%{(trip name.event)} {-}]"
+        "(decode-results:decode:eth-abi-magic data.event-log ~[{data-types}])"
+      ?~  data-types
+        =-  "        [%{(trip name.event)} {-}]"
+        "(decode-topics:decode:eth-abi-magic t.topics.event-log ~[{topic-types}])"
+      """
+              :-  %{(trip name.event)}
+              %:        event-to-tuple:eth-abi-magic
+                      ~[{topic-types}]
+                    t.topics.event-log
+                ~[{data-types}]
+              data.event-log
+              ==
+      """
+      ++  topics-to-etape
+        |=  topics=(list event-input)
+        %-  zing
+        %+  join  " "
+        %+  turn  topics
+        |=  [=petyp *]
+        ^-  tape
+        (petyp-to-etape petyp)
+      --
+      ::
+    ++  encode-esub-cases
+      =-
+      """
+            =/  =topics:eth-watcher
+              ?-  -.topics.config.esub
+      {-}
+              ==
+            =/  =config:eth-watcher
+              :*  url=url.config.esub
+                  eager=eager.config.esub
+                  refresh-rate=refresh-rate.config.esub
+                  timeout-time=timeout-time.config.esub
+                  from=from.config.esub
+                  contracts=contracts.config.esub
+                  topics
+              ==
+            :*  %watch
+                path.esub
+                config
+            ==
+      """
+      %-  zing
+      %+  join  (trip `@t`10)
+      %+  turn  ~(tap by events.contract)
+      |=  [hash=@ux =event]
+      ^-  tape
+      =/  indexed=(list event-input)  (skim inputs.event |=(inp=event-input indexed.inp))
+      =-
+      ?~  indexed
+      """
+                  %{(trip name.event)}
+                [{(scow %ux hash)} ~]
+      """
+      """
+                  %{(trip name.event)}
+                :-  {(scow %ux hash)}
+                (encode-topics:eth-abi-magic ~[{-}] +.topics.config.esub)
+      """
+      %-  zing
+      %+  join  " "
+      %+  turn   indexed
+      |=  [inp=event-input]
+      :: ?.  indexed.i  ""
+      (petyp-to-etape petyp.inp)
+
+    ++  log-json-cases
+      =-
+      """
+            ?-  -.event-data.event-log
+      {-}
+            ==
+      """
+      %-  zing
+      %+  join  (trip `@t`10)
+      %+  turn  events
+      |=  =event
+      ^-  tape
+      =-
+      """
+                %{(trip name.event)}
+              %-  pairs
+              :*
+                [%type [%s %{(trip name.event)}]]
+                [%address [%s (crip (z-co:co address.event-log))]]
+                :-  %payload
+                %-  pairs
+                :~
+      {-}
+                ==
+                ?~  mined.event-log  ~
+                :~
+                :-  'txHash'
+                [%s (crip (z-co:co transaction-hash.u.mined.event-log))]
+                :-  'block'
+                [%s (crip ((d-co:co 1) block-number.u.mined.event-log))]
+                ==
+              ==
+      """
+      (inputs-json event)
+    ++  inputs-json
+      |=  =event
+      %-  zing
+      %+  turn  inputs.event
+      |=  inp=event-input
+      ?>  ?=([~ *] name.petyp.inp)
+      =-
+      (zing ~["          [%{(trip u.name.petyp.inp)} {-}]" nl])
+      (etyp-to-json (petyp-to-etyp petyp.inp) u.name.petyp.inp)
+    ++  etyp-to-json
+      :: TODO: tuple, array, etc
+      |=  [=etyp name=@tas]
+      ^-  tape
+      ?+  etyp  ~|(unimplemented-type+etyp !!)
+          %uint
+        "[%n (crip ((d-co:co 1) {(trip name)}.event-data.event-log))]"
+          %int
+        !!
+      :: "[%n (scot %sd {(trip name)}.event-data.event-log)]"
+          [%bytes-n *]
+        "[%s (crip (zing ~[\"0\" \"x\" (trip (en:base16:mimes:html {(trip name)}.event-data.event-log))]))]"
+          %string
+        "[%s (crip {(trip name)}.event-data.event-log)]"
+          %bytes
+        "[%s (crip (zing ~[\"0\" \"x\" (trip (en:base16:mimes:html {(trip name)}.event-data.event-log))]))]"
+          %address
+        "[%s (crip (z-co:co {(trip name)}.event-data.event-log))]"
+          %bool
+        "[%b {(trip name)}.event-data.event-log]"
+      ==
+  --
+--

--- a/pkg/arvo/lib/eth-abi-magic.hoon
+++ b/pkg/arvo/lib/eth-abi-magic.hoon
@@ -1,0 +1,254 @@
+/-  *eth-abi
+|%
+  ++  decode
+  |%
+  ++  decode-results
+    ::  rex:  string of hex bytes with leading 0x.
+    |*  [rex=@t tys=(list etyp)]
+    =-  (decode-arguments - tys)
+    %+  turn  (rip 9 (rsh 3 2 rex))
+    (curr rash hex)
+  ::
+  ++  decode-arguments
+    |*  [wos=(list @) tys=(list etyp)]
+    =/  wos=(list @)  wos  ::  get rid of tmi
+    =|  win=@ud
+    =<  (decode-from 0 tys)
+    |%
+    ++  decode-from
+      |*  [win=@ud tys=(list etyp)]
+      ?~  tys  !!
+      =-  ?~  t.tys  dat
+          [dat $(win nin, tys t.tys)]
+      (decode-one win ~[i.tys])
+    ::
+    ++  decode-one
+      ::NOTE  we take (list etyp) even though we only operate on
+      ::      a single etyp as a workaround for urbit/arvo#673
+      |*  [win=@ud tys=(list etyp)]
+      =-  [nin dat]=-  ::NOTE  ^= regular form broken
+      ?~  tys  !!
+      =*  typ  i.tys
+      =+  wor=(snag win wos)
+      ?+  typ
+        ~|  [%unsupported-type typ]
+        !!
+      ::
+          ?(%address %bool %uint)  ::  %int %real %ureal
+        :-  +(win)
+        ?-  typ
+          %address  `@ux`wor
+          %uint     `@ud`wor
+          %bool     =(1 wor)
+        ==
+      ::
+          %string
+        =+  $(tys ~[%bytes])
+        [nin (trip (swp 3 q.dat))]
+      ::
+          %bytes
+        :-  +(win)
+        ::  find the word index of the actual data.
+        =/  lic=@ud  (div wor 32)
+        ::  learn the bytelength of the data.
+        =/  len=@ud  (snag lic wos)
+        (decode-bytes-n +(lic) len)
+      ::
+          [%bytes-n *]
+        :-  (add win +((div (dec n.typ) 32)))
+        (decode-bytes-n win n.typ)
+      ::
+          [%array *]
+        :-  +(win)
+        ::  find the word index of the actual data.
+        =.  win  (div wor 32)
+        ::  read the elements from their location.
+        %-  tail
+        %^  decode-array-n  ~[t.typ]  +(win)
+        (snag win wos)
+      ::
+          [%array-n *]
+        (decode-array-n ~[t.typ] win n.typ)
+          [%tuple *]
+        (decode-tuple t.typ win)
+      ==
+    ::
+    ++  decode-bytes-n
+      |=  [fro=@ud bys=@ud]
+      ^-  octs
+      ::  parse {bys} bytes from {fro}.
+      :-  bys
+      ?~  bys  0
+      %^  rsh  3
+        =+  (mod bys 32)
+        ?:(=(0 -) - (sub 32 -))
+      %+  rep  8
+      %-  flop
+      =-  (swag [fro -] wos)
+      +((div (dec bys) 32))
+    ::
+    ++  decode-array-n
+      ::NOTE  we take (list etyp) even though we only operate on
+      ::      a single etyp as a workaround for urbit/arvo#673
+      ::NOTE  No longer typeless arrays as in zuse
+      |*  [tys=(list etyp) fro=@ud len=@ud]
+      ?~  tys  !!
+      =|  res=(list _dat:(decode-one fro ~[i.tys]))
+      |-  ^-  [@ud _res]
+      ?:  =(len 0)  [fro (flop res)]
+      =+  (decode-one fro ~[i.tys])  ::  [nin=@ud dat=*]
+      $(res ^+(res [dat res]), fro nin, len (dec len))
+    ++  decode-tuple
+      :: ::NOTE  we take (list etyp) even though we only operate on
+      :: ::      a single etyp as a workaround for urbit/arvo#673
+      :: ::NOTE  careful! produces lists without type info
+      ::  probably broken (shouldn't be list)
+      =|  res=(list)
+      |*  [tys=(list etyp) fro=@ud]
+      ^-  [@ud (list)]
+      ?~  tys  [fro (flop `(list)`res)]
+      =+  (decode-one fro ~[i.tys])  ::  [nin=@ud dat=*]
+      $(res ^+(res [dat res]), fro nin, tys t.tys)
+    --
+  --
+  ++  event-to-tuple
+    |*  [tt=(list etyp) topics=(list @) dt=(list etyp) data=@t]
+    |^
+    =+  tdata=(decode-arguments:decode topics tt)
+    =+  data=(decode-results:decode data dt)
+    (combine tt tdata data)
+  ++  combine
+    |*  [etyps=(list etyp) event-topics=* event-data=*]
+    |-
+    ?>  ?=(^ etyps)
+    ?~  t.etyps  [event-topics event-data]
+    ?>  ?=(^ event-topics)
+    :-  -.event-topics
+    $(event-topics +.event-topics, etyps t.etyps)
+  --
+
+  ++  tuple-to-eth-data  ::  n-tuple
+    |=  [etyps=(list etyp) data=*]
+    ^-  (list data:abi:ethereum)
+    =/  =data:abi:ethereum  (one-to-eth-data [%tuple etyps] data)
+    ?>  ?=([%tuple *] data)
+    p.data
+  ++  one-to-eth-data
+    |=  [=etyp data=*]
+    |-  ^-  data:abi:ethereum
+    :: TODO: missing bytes-n, and probably others
+    ?+  etyp  ~|("unimplemented etyp" !!)
+        %uint
+      ?>  ?=(@ud data)
+      [etyp data]
+        %address
+      ?>  ?=(@ux data)
+      [etyp data]
+        %bool
+      ?>  ?=(? data)
+      [etyp data]
+        %bytes
+      ?>  ?=(octs data)
+      [etyp data]
+        %string
+      :-  etyp
+      |-  ^-  tape
+      ?~  data  ~
+      ?>  ?=([@t *] data)
+      :_  ?:  ?=([@t ~] data)  ~
+          $(data +.data)
+      -.data
+        [%array-n *]
+      =/  index=@ud  0
+      :-  -.etyp
+      |-  ^-  (list data:abi:ethereum)
+      ?>  (lth index n.etyp)
+      :_  ?:  ?=([* ~] data)  ~
+          $(data +.data)
+      ^$(etyp t.etyp, data -.data)
+        [%array *]
+      :-  -.etyp
+      |-  ^-  (list data:abi:ethereum)
+      ?~  data  ~
+      :_  ?:  ?=([* ~] data)  ~
+          $(data +.data)
+      ^$(etyp t.etyp, data -.data)
+        [%tuple *]
+      :-  -.etyp
+      |-  ^-  (list data:abi:ethereum)
+      ?>  ?=(^ t.etyp)
+      ?~  t.t.etyp  [^$(etyp i.t.etyp) ~]
+      ?>  ?=(^ data)
+      [^$(etyp i.t.etyp, data -.data) $(t.etyp t.t.etyp, data +.data)]
+    ==
+    ++  encode-topics
+      ::  multiple topics with atom types only
+      |=  [types=(list etyp) topics=*]
+      |^  ^-  (list ?(@ux (list @ux)))
+      ?~  types  ~
+      ?+  i.types
+        ?~  t.types
+          ~[(encode i.types topics)]
+        :_  $(types t.types, topics +.topics)
+        (encode i.types -.topics)
+          ?(%address %bool %int %uint %real %ureal)
+        ?~  t.types
+          ?^  topics
+            ~[(turn-encode i.types topics)]
+          ~[(encode i.types topics)]
+        :_  $(types t.types, topics +.topics)
+        ?^  -.topics
+          (turn-encode i.types -.topics)
+        (encode i.types -.topics)
+      ==
+      ++  turn-encode
+        |=  [=etyp t=*]
+        |-  ^-  (list @ux)
+        ?^  t
+          [(encode etyp -.t) $(t +.t)]
+        ~
+      ++  encode
+        |=  [=etyp t=*]
+        ^-  @ux
+        (scan (encode-data:abi:ethereum (data:abi:ethereum [etyp t])) hex)
+      --
+  :: ++  encode-topics
+  ::   ::  multiple topics with atom types only
+  ::   |*  [types=(list etyp) topics=*]
+  ::   |^  ^-  (list (list @ux))
+  ::   ?~  types  ~
+  ::   ?+  i.types  !!
+  ::     :: ?~  t.types
+  ::     ::   ~[~[(decode i.types topics)]]
+  ::     :: :_  $(types t.types, topics +.topics)
+  ::     :: ~[(decode i.types -.topics)]
+  ::   ::
+  ::       ?(%address %bool %int %uint %real %ureal)
+  ::     ?~  t.types
+  ::       ?^  topics
+  ::       ^-  (list (list @ux))
+  ::         ~[~[(decode i.types topics)]]
+  ::         ^-  (list (list @ux))
+  ::       ~[(turn-decode i.types topics)]
+  ::     ^-  (list (list @ux))
+  ::     :_  ^-  (list (list @ux))
+  ::     $(types t.types, topics +.topics)
+  ::     ?^  -.topics
+  ::     ^-  (list @ux)
+  ::       (turn-decode i.types -.topics)
+  ::     ^-  (list @ux)
+  ::     ~[(decode i.types -.topics)]
+  ::   ==
+  ::   ++  turn-decode
+  ::     |*  [=etyp t=(list)]
+  ::     ^-  (list @ux)
+  ::     =+  typ=_?>(?=(^ t) -.t)
+  ::     %+  turn  `(list typ)`t
+  ::     |=  =typ
+  ::     (decode etyp typ)
+  ::   ++  decode
+  ::     |*  [=etyp t=*]
+  ::     ^-  @ux
+  ::     (scan (encode-data:abi:ethereum (data:abi:ethereum [etyp t])) hex)
+  ::   --
+--

--- a/pkg/arvo/lib/eth-abi-parse.hoon
+++ b/pkg/arvo/lib/eth-abi-parse.hoon
@@ -1,0 +1,206 @@
+/-  *eth-abi
+|%
+  ++  petyp-to-etyp
+    |=  =petyp
+    ^-  etyp
+    |^
+    (petyp-type-to-etyp type.petyp)
+    ++  petyp-type-to-etyp
+      |=  t=petyp-type
+      ^-  etyp
+      ?+  t  !!
+        [%tuple *]
+      [%tuple (turn t.t petyp-to-etyp)]
+        [%bytes-n *]
+      t
+        [%array *]
+      [%array $(t t.t)]
+        ?(%address %bool %int %uint %real %ureal %bytes %string)
+      t
+      ==
+    --
+  ::
+    ++  martianize-name
+      |=  =tape
+      ^-  ^tape
+      |^
+      |-
+      ?~  tape  tape
+      ?.  ?|  &((gte i.tape 'A') (lte i.tape 'Z'))
+              &((gte i.tape 'a') (lte i.tape 'z'))
+          ==
+        $(tape t.tape)
+      :_  martianize(tape t.tape)
+        ?.  (lth i.tape 91)  i.tape
+        (add i.tape 32)
+      ++  martianize
+        %-  zing
+        |-
+        ?~  tape  ~
+        ?:  (lth i.tape 91)
+          =.  i.tape  (add i.tape 32)
+          ["-" (trip i.tape) $(tape t.tape)]
+        [(trip i.tape) $(tape t.tape)]
+      --
+::
+  ++  parse-contract
+    |=  [jon=json name=@tas]
+    =/  entries=(list entry-raw)  (parse-abi jon)
+    =/  read-functions=(list function-raw)
+    %+  murn  entries
+    |=  =entry-raw
+    ?.  ?=([%function *] entry-raw)  ~
+    ?:  mut.entry-raw  ~
+    `+.entry-raw
+    =/  write-functions=(list function-raw)
+    %+  murn  entries
+    |=  =entry-raw
+    ?.  ?=([%function *] entry-raw)  ~
+    ?.  mut.entry-raw  ~
+    `+.entry-raw
+    =/  events=(list event-raw)
+    %+  murn  entries
+    |=  =entry-raw
+    ?.  ?=([%event *] entry-raw)  ~
+    `+.entry-raw
+    ^-  contract
+    :^    name
+        (parse-functions write-functions)
+      (parse-functions read-functions)
+    (parse-events events)
+::
+  ++  parse-abi
+    |=  jon=json
+    =,  dejs:format
+    ^-  (list entry-raw)
+    ?>  ?=([%a *] jon)
+    %+  murn  p.jon
+    |=  jan=json
+    ^-  (unit entry-raw)
+    ?~  jan  ~
+    ?>  ?=([%o *] jan)
+    =-  ?~  parse  ~  (some (u.parse jan))
+    ^-  parse=(unit $-(json entry-raw))
+    =/  typ  (so (~(got by p.jan) 'type'))
+    ?+    typ  ~
+        %function
+      :-  ~
+      |=  jun=json
+      :-  %function
+      ^-  function-raw
+      %.  jun
+      %-  ot
+      :~  [%name so]
+          [%inputs (ar (ou get-abi-type-raw))]
+          [%outputs (ar (ou get-abi-type-raw))]
+          :: should this be negated?
+          [%constant |=(jen=json !(bo jen))]
+          [%payable bo]
+      ==
+    ::
+        %event
+      :-  ~
+      |=  jun=json
+      :-  %event
+      ^-  event-raw
+      %.  jun
+      %-  ot
+      :~  [%name so]
+      ::
+          :-  %inputs
+          %-  ar
+          %-  ou
+          :*  [%indexed (un bo)]
+              get-abi-type-raw
+          ==
+      ==
+    ==
+  ++  get-abi-type-raw
+    =,  dejs:format
+    |^
+    :~  [%name (uf ~ (mu so))]
+        [%type (un so)]
+        [%components (uf ~ decode-components)]
+    ==
+    ++  decode-components
+        |=  =json
+        ^-  (list abi-type-raw)
+        %.  json
+        %-  ar  %-  ou  get-abi-type-raw
+  --
+
+  ++  parse-events
+    |=  events=(list event-raw)
+    ^-  (map @ux event)
+    %+  roll  events
+    |=  [e=event-raw es=(map @ux event)]
+    =/  =event
+      :-  (crip (martianize-name (trip name.e)))
+      %+  turn
+        inputs.e
+      |=  inp=event-input-raw
+      ^-  event-input
+      [(parse-type abi-type-raw.inp) indexed.inp]
+    =/  typs=(list @t)
+      %+  turn  inputs.e
+      |=  inp=event-input-raw
+      type.abi-type-raw.inp
+    %+  ~(put by es)
+      (get-hash name.e typs)
+      event
+
+  ++  parse-functions
+    |=  functions=(list function-raw)
+    %+  roll  functions
+    |=  [f=function-raw fs=(map @tas function)]
+    %+  ~(put by fs)  (crip (martianize-name (trip name.f)))
+    :*
+      (crip (martianize-name (trip name.f)))
+      (get-selector name.f (turn inputs.f |=(=func-input-raw type.abi-type-raw.func-input-raw)))
+      %+  turn  inputs.f  parse-type
+      %+  turn  outputs.f  parse-type
+    ==
+::
+  ++  parse-type
+    |=  item=abi-type-raw
+    ^-  petyp
+    =+  taype=(trip type.item)
+    =/  is-array=?
+    =([']' '[' ~] (scag 2 (flop taype)))
+    =.  taype  ?.  is-array  taype
+    (scag (sub (lent taype) 2) taype)
+    :: still need to handle dynamic type
+    =.  name.item
+    ?~  name.item  ~
+    `(crip (martianize-name (trip u.name.item)))
+    =-  ?.  is-array
+          [name.item -]
+        [name.item %array -]
+    ^-  petyp-type
+    ?+  (crip (scag 3 taype))  ~&  unimplemented-type+(crip taype)  !!
+      %add  %address
+      %boo  %bool
+      %int  %int
+      %uin  %uint
+      %byt
+    =/  ntape=tape  (slag 5 taype)
+    ?~  ntape  %bytes
+    [%bytes-n (scan ntape dem)]
+      %str  %string
+      %tup
+    :-  %tuple
+    %+  turn  comps.item  parse-type
+    ==
+::
+  ++  get-selector
+    |=  [name=@t inputs=(list @t)]
+    ^-  cord
+    =-  (crip "{(trip name)}({-})")
+    (zing (join "," (turn inputs trip)))
+::
+  ++  get-hash
+    |=  [name=@t inputs=(list @t)]
+    ^-  @ux
+    =/  sig  (get-selector name inputs)
+    (keccak-256:keccak:crypto (met 3 sig) sig)
+--

--- a/pkg/arvo/mar/eth-call-data.hoon
+++ b/pkg/arvo/mar/eth-call-data.hoon
@@ -1,0 +1,7 @@
+|_  dat=call-data:rpc:ethereum
+::
+++  grab
+  |%
+  ++  noun  call-data:rpc:ethereum
+  --
+--

--- a/pkg/arvo/mar/eth-watcher-diff.hoon
+++ b/pkg/arvo/mar/eth-watcher-diff.hoon
@@ -1,0 +1,8 @@
+/-  eth-watcher
+|_  dat=diff:eth-watcher
+::
+++  grab
+  |%
+  ++  noun  diff:eth-watcher
+  --
+--

--- a/pkg/arvo/mar/senate-store-poke.hoon
+++ b/pkg/arvo/mar/senate-store-poke.hoon
@@ -1,0 +1,7 @@
+/-  senate-store
+|_  =poke:senate-store
+  ++  grab
+    |%
+      ++  noun  poke:senate-store
+    --
+--

--- a/pkg/arvo/sur/eth-abi-magic.hoon
+++ b/pkg/arvo/sur/eth-abi-magic.hoon
@@ -1,0 +1,53 @@
+=,  able:jael
+|%
+  ++  call
+    $:  url=@ta
+        to=address:ethereum
+        action=cage
+    ==
+  ++  builders
+    |%
+      ++  watch-config
+        |$  [topics]
+        $:  url=@ta
+            eager=?
+            refresh-rate=@dr
+            timeout-time=@dr
+            from=number:block
+            contracts=(list address:ethereum)
+            =topics
+        ==
+      ++  send-tx
+        |$  [name action]
+        $:  url=@ta
+            nonce=@ud
+            gas-price=@ud
+            gas=@ud
+            to=address:ethereum
+            value=@ud
+            action=[name action]
+            chain-id=@ux
+        ==
+      ++  call
+        |$  [name action]
+        $:  url=@ta
+            to=address:ethereum
+            action=[name action]
+        ==
+      ++  event-log-config
+        |$  [event-data]
+        $:  ::  null for pending logs
+            $=  mined  %-  unit
+            $:  log-index=@ud
+                transaction-index=@ud
+                transaction-hash=@ux
+                block-number=@ud
+                block-hash=@ux
+                removed=?
+            ==
+          ::
+            address=@ux
+            =event-data
+        ==
+    --
+--

--- a/pkg/arvo/sur/eth-abi.hoon
+++ b/pkg/arvo/sur/eth-abi.hoon
@@ -1,0 +1,72 @@
+=>
+|%
+  +$  atr  [name=(unit @t) type=@t comps=(list atr)]
+--
+|%
++$  abi-type-raw    atr
++$  etyp  etyp:abi:ethereum
+:: ++  some-core
+::   |%
++$  petyp-type
+  $@  $?  ::  static
+          %address  %bool
+          %int      %uint
+          %real     %ureal
+          ::  dynamic
+          %bytes    %string
+      ==
+  $%  ::  static
+      [%bytes-n n=@ud]
+      ::  dynamic
+      [%array-n t=petyp-type n=@ud]
+      [%array t=petyp-type]
+      [%tuple t=(list petyp)]
+  ==
++$  petyp
+  $:  name=(unit term)
+      type=petyp-type
+  ==
++$  contract
+  $:  name=@tas
+      write-functions=(map @tas function)
+      read-functions=(map @tas function)
+      events=(map @ux event)
+  ==
++$  function
+  $:  name=@tas
+      sel=@t
+      inputs=(list func-input)
+      outputs=(list func-output)
+  ==
++$  event
+  $:  name=@tas
+      inputs=(list event-input)
+  ==
++$  event-input  [=petyp indexed=?]
++$  func-input  [=petyp]
++$  func-output  [=petyp]
+:: compos is ~ when ?!  ?=(?(_'tuple' _'tuple[]'')
+::  'tuple[]' should be turned into array<tuple>
+
++$  event-input-raw  [indexed=? =abi-type-raw]
++$  func-input-raw  [=abi-type-raw]
++$  func-output-raw  [=abi-type-raw]
++$  contract-raw
+  $:  entries=(list entry-raw)
+  ==
++$  entry-raw
+  $%  [%function function-raw]
+      [%event event-raw]
+  ==
++$  function-raw
+  $:  name=@t
+      inputs=(list func-input-raw)
+      outputs=(list func-output-raw)
+      mut=?
+      pay=?
+  ==
++$  event-raw
+  $:  name=@t
+      inputs=(list event-input-raw)
+  ==
+--

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -6374,7 +6374,7 @@
     ++  apex                                            ::  top level
       =+  spa=;~(pose comt whit)
       %+  knee  *manx  |.  ~+
-      %+  ifix  
+      %+  ifix
         [;~(plug (punt decl) (star spa)) (star spa)]
       ;~  pose
         %+  sear  |=({a/marx b/marl c/mane} ?.(=(c n.a) ~ (some [a b])))
@@ -8449,6 +8449,7 @@
               ::  dynamic
               [%array-n t=etyp n=@ud]
               [%array t=etyp]
+              [%tuple t=(list etyp)]
           ==
         ::
         ::  solidity-style typed data. integer bitsizes ignored
@@ -8462,9 +8463,9 @@
               [%ureal p=@urs]
               [%array-n p=(list data)]
               [%array p=(list data)]
+              [%tuple p=(list data)]
               [%bytes-n p=octs]  ::TODO  just @, because context knows length?
-              [%bytes p=octs]
-          ==
+              [%bytes p=octs]          ==
         --
     =,  mimes:html
     |%
@@ -8529,6 +8530,9 @@
         ~|  [%weird-ref-lent (lent ref)]
         ?>  =((lent ref) (lent hol))
         (weld nes ref)
+      ::
+          %tuple
+        $(dat [%array-n p.dat])
       ::
           %array  ::  where X has k elements (k is assumed to be of type uint256):
         ::  enc(X) = enc(k) enc([X[1], ..., X[k]])
@@ -8652,6 +8656,8 @@
         ::
             [%array-n *]
           (decode-array-n ~[t.typ] win n.typ)
+            [%tuple *]
+          (decode-tuple t.typ win)
         ==
       ::
       ++  decode-bytes-n
@@ -8678,6 +8684,16 @@
         ?:  =(len 0)  [fro (flop `(list)`res)]
         =+  (decode-one fro ~[i.tys])  ::  [nin=@ud dat=*]
         $(res ^+(res [dat res]), fro nin, len (dec len))
+      ++  decode-tuple
+        :: ::NOTE  we take (list etyp) even though we only operate on
+        :: ::      a single etyp as a workaround for urbit/arvo#673
+        :: ::NOTE  careful! produces lists without type info
+        =|  res=(list)
+        |*  [tys=(list etyp) fro=@ud]
+        ^-  [@ud (list)]
+        ?~  tys  [fro (flop `(list)`res)]
+        =+  (decode-one fro ~[i.tys])  ::  [nin=@ud dat=*]
+        $(res ^+(res [dat res]), fro nin, tys t.tys)
       --
     --
   ::

--- a/pkg/arvo/ted/eth/gen.hoon
+++ b/pkg/arvo/ted/eth/gen.hoon
@@ -1,0 +1,62 @@
+/-  spider
+/+  eth-abi=eth-abi-gen, strandio
+=,  strand=strand:spider
+=*  card  card:agent:gall
+|%
+++  write-eth-files
+  |=  [bol=bowl:spider act=[name=@tas =json]]
+  =*  card  card:agent:gall
+  ^-  (list card)
+  |^
+    =/  =contract:eth-abi  (parse-contract:eth-abi json.act name.act)
+    =|  cards=(list card)
+    =.  cards
+    :_  cards
+      %+  write-file  /sur/eth-contracts/[name.act]/hoon
+      [%hoon !>((code-gen-types:eth-abi name.act contract))]
+    =.  cards
+    :_  cards
+      %+  write-file  /lib/eth-contracts/[name.act]/hoon
+      [%hoon !>((code-gen-lib:eth-abi contract name.act))]
+    =.  cards
+    ?~  events.contract  cards
+    :_  cards
+      %+  write-file  /mar/[(crip (zing ~["eth-contracts-" (trip name.act) "-diff"]))]/hoon
+      [%hoon !>((code-gen-diff-mark:eth-abi (trip name.act)))]
+    =.  cards
+    ?~  events.contract  cards
+    :_  cards
+      %+  write-file  /mar/[(crip (zing ~["eth-contracts-" (trip name.act) "-esub"]))]/hoon
+      [%hoon !>((code-gen-esub-mark:eth-abi (trip name.act)))]
+    =.  cards
+    ?~  ~(val by write-functions.contract)  cards
+    :_  cards
+      %+  write-file  /mar/[(crip (zing ~["eth-contracts-" (trip name.act) "-send"]))]/hoon
+      [%hoon !>((code-gen-send-mark:eth-abi (trip name.act)))]
+    =.  cards
+    ?~  ~(val by read-functions.contract)  cards
+    :_  cards
+      %+  write-file  /mar/[(crip (zing ~["eth-contracts-" (trip name.act) "-call"]))]/hoon
+      [%hoon !>((code-gen-call-mark:eth-abi (trip name.act)))]
+    =.  cards
+    ?~  (get-all-functions-with-outputs:eth-abi contract)  cards
+    :_  cards
+      %+  write-file  /mar/[(crip (zing ~["eth-contracts-" (trip name.act) "-res"]))]/hoon
+      [%hoon !>((code-gen-res-mark:eth-abi (trip name.act)))]
+    cards
+  ++  our-beak  /(scot %p our.bol)/[q.byk.bol]/(scot %da now.bol)
+  ++  write-file
+    |=  [pax=path cay=cage]
+    ^-  card
+    =.  pax  (weld our-beak pax)
+    [%pass (weld /write pax) %arvo %c %info (foal:space:userlib pax cay)]
+  --
+--
+^-  thread:spider
+|=  args=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<([name=@tas =json $~] args)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+;<  ~  bind:m  (send-raw-cards:strandio (write-eth-files bowl [name json]))
+(pure:m !>(~))


### PR DESCRIPTION
This PR adds an eth ABI parser, and code generation of static types, marks, and encoding and decoding libraries for ethereum function calls and writes, event subscription and event updates.

lib/eth-abi does the parsing, lib/eth-abi-gen does the code generation, lib/eth-abi-magic has some extraneous methods and a modified version of abi:ethereum to do various noun manipulation and decoding that was not possible with existing zuse, which ends up being used by the generated libraries. The abi:ethereum code should probably be moved into zuse, but not the noun manipulation.

I have not exhaustively tested every ABI type yet, though have tested most. One thing in particular is I would like to get another pass on a decode-array-n that doesn't lose type information. I have one that works, but don't particularly like it. A similar thing ought to be done with the tuple case(which isn't present at all in zuse, but may be able to be reduced to an array-n case).

This probably deserves thorough unit tests in its own right, as we have for the zuse en/decoders.