### PR TITLE
landscape: preclude dropdown duplicates on exact match

### DIFF
--- a/pkg/interface/src/logic/lib/useDropdown.ts
+++ b/pkg/interface/src/logic/lib/useDropdown.ts
@@ -12,7 +12,7 @@ export function useDropdown<C>(
     (s: string) => {
       const exactMatch = isExact(s);
       const exact = exactMatch ? [exactMatch] : [];
-      const opts = [...exact,...candidates.filter((c) => searchPred(s, c))]
+      const opts = [...new Set([...exact, ...candidates.filter((c) => searchPred(s, c))])];
       setOptions(opts);
       if (selected) {
         const idx = opts.findIndex((c) => key(c) === key(selected));


### PR DESCRIPTION
Fixes #3954

Looks like somewhere along the way the dropdown started adding exact matches without checking to see if the match was also in the candidates. This should be fine across the board — if a candidate is also an exact match, we only show one of them.