### PR TITLE
gen: add +sponsor generator

### DIFF
--- a/pkg/arvo/gen/sponsor.hoon
+++ b/pkg/arvo/gen/sponsor.hoon
@@ -1,0 +1,5 @@
+::  Print the sponsor of this ship
+:-  %say
+|=  [[now=time @ our=ship ^] * ~]
+:-  %ship
+(sein:title our now our)


### PR DESCRIPTION
Add a new generator `+sponsor` that encapsulates the logic of invoking `(sein:title our now our)` to get the sponsor of the current ship. 