### PR TITLE
u3: adds |ut battery to jet cache keys

### DIFF
--- a/pkg/urbit/include/noun/zave.h
+++ b/pkg/urbit/include/noun/zave.h
@@ -18,6 +18,7 @@
       u3_noun u3z_key_2(c3_m, u3_noun, u3_noun);
       u3_noun u3z_key_3(c3_m, u3_noun, u3_noun, u3_noun);
       u3_noun u3z_key_4(c3_m, u3_noun, u3_noun, u3_noun, u3_noun);
+      u3_noun u3z_key_5(c3_m, u3_noun, u3_noun, u3_noun, u3_noun, u3_noun);
 
     /* u3z_find*(): find in memo cache. Arguments retained
     */

--- a/pkg/urbit/jets/f/ut_crop.c
+++ b/pkg/urbit/jets/f/ut_crop.c
@@ -6,16 +6,18 @@
 u3_noun
 u3wfu_crop(u3_noun cor)
 {
-  u3_noun sut, ref, van;
+  u3_noun bat, sut, ref, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__crop + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__crop + ((!!vet) << 8);
+    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_crop.c
+++ b/pkg/urbit/jets/f/ut_crop.c
@@ -17,7 +17,7 @@ u3wfu_crop(u3_noun cor)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__crop + ((!!vet) << 8);
-    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
+    u3_noun key = u3z_key_3(fun_m, sut, ref, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_fish.c
+++ b/pkg/urbit/jets/f/ut_fish.c
@@ -18,7 +18,7 @@ u3wfu_fish(u3_noun cor)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__fish + ((!!vet) << 8);
-    u3_noun key = u3z_key_3(fun_m, bat, sut, axe);
+    u3_noun key = u3z_key_3(fun_m, sut, axe, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_fish.c
+++ b/pkg/urbit/jets/f/ut_fish.c
@@ -6,17 +6,19 @@
 u3_noun
 u3wfu_fish(u3_noun cor)
 {
-  u3_noun sut, axe, van;
+  u3_noun bat, sut, axe, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &axe, u3x_con, &van, 0)) ||
-       (c3n == u3ud(axe)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (c3n == u3r_mean(cor, u3x_sam, &axe, u3x_con, &van, 0))
+     || (c3n == u3ud(axe))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__fish + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_2(fun_m, sut, axe);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__fish + ((!!vet) << 8);
+    u3_noun key = u3z_key_3(fun_m, bat, sut, axe);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_fuse.c
+++ b/pkg/urbit/jets/f/ut_fuse.c
@@ -6,16 +6,18 @@
 u3_noun
 u3wfu_fuse(u3_noun cor)
 {
-  u3_noun sut, ref, van;
+  u3_noun bat, sut, ref, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__fuse + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__fuse + ((!!vet) << 8);
+    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_fuse.c
+++ b/pkg/urbit/jets/f/ut_fuse.c
@@ -17,7 +17,7 @@ u3wfu_fuse(u3_noun cor)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__fuse + ((!!vet) << 8);
-    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
+    u3_noun key = u3z_key_3(fun_m, sut, ref, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_mint.c
+++ b/pkg/urbit/jets/f/ut_mint.c
@@ -6,20 +6,20 @@
 u3_noun
 u3wfu_mint(u3_noun cor)
 {
-  u3_noun sut, gol, gen, van;
+  u3_noun bat, sut, gol, gen, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                             u3x_sam_3, &gen,
-                             u3x_con, &van,
-                             0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &gol,
+                              u3x_sam_3, &gen,
+                              u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
     c3_m  fun_m = 141 + c3__mint;
     u3_noun vrf = u3r_at(u3qfu_van_vrf, van);
-    u3_noun key = u3z_key_4(fun_m, vrf, sut, gol, gen);
+    u3_noun key = u3z_key_5(fun_m, bat, vrf, sut, gol, gen);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_mint.c
+++ b/pkg/urbit/jets/f/ut_mint.c
@@ -19,7 +19,7 @@ u3wfu_mint(u3_noun cor)
   else {
     c3_m  fun_m = 141 + c3__mint;
     u3_noun vrf = u3r_at(u3qfu_van_vrf, van);
-    u3_noun key = u3z_key_5(fun_m, bat, vrf, sut, gol, gen);
+    u3_noun key = u3z_key_5(fun_m, vrf, sut, gol, gen, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_mull.c
+++ b/pkg/urbit/jets/f/ut_mull.c
@@ -6,20 +6,21 @@
 u3_noun
 u3wfu_mull(u3_noun cor)
 {
-  u3_noun sut, gol, dox, gen, van;
+  u3_noun bat, sut, gol, dox, gen, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                             u3x_sam_6, &dox,
-                             u3x_sam_7, &gen,
-                             u3x_con, &van,
-                             0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &gol,
+                              u3x_sam_6, &dox,
+                              u3x_sam_7, &gen,
+                              u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__mull + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_4(fun_m, sut, gol, dox, gen);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__mull + ((!!vet) << 8);
+    u3_noun key = u3z_key_5(fun_m, bat, sut, gol, dox, gen);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_mull.c
+++ b/pkg/urbit/jets/f/ut_mull.c
@@ -20,7 +20,7 @@ u3wfu_mull(u3_noun cor)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__mull + ((!!vet) << 8);
-    u3_noun key = u3z_key_5(fun_m, bat, sut, gol, dox, gen);
+    u3_noun key = u3z_key_5(fun_m, sut, gol, dox, gen, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_nest.c
+++ b/pkg/urbit/jets/f/ut_nest.c
@@ -7,24 +7,24 @@ u3_noun
 u3wfu_nest_dext(u3_noun dext_core)
 {
   u3_noun nest_in_core, nest_core;
-  u3_noun sut, ref, van, seg, reg, gil;
+  u3_noun bat, sut, ref, van, seg, reg, gil;
 
-  if ( (u3_none == (nest_in_core = u3r_at(3, dext_core))) ||
-       (c3n == u3r_mean(nest_in_core, u3x_sam_2, &seg,
-                                      u3x_sam_6, &reg,
-                                      u3x_sam_7, &gil,
-                                      7, &nest_core,
-                                      0)) ||
-       (c3n == u3r_mean(nest_core, u3x_sam_3, &ref,
-                                   u3x_con, &van,
-                                   0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if (  (u3_none == (nest_in_core = u3r_at(3, dext_core)))
+     || (c3n == u3r_mean(nest_in_core, u3x_sam_2, &seg,
+                                       u3x_sam_6, &reg,
+                                       u3x_sam_7, &gil,
+                                       u3x_con, &nest_core, 0))
+     || (c3n == u3r_mean(nest_core, u3x_sam_3, &ref,
+                                    u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__dext + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_2(fun_m, sut, ref);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__dext + ((!!vet) << 8);
+    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_nest.c
+++ b/pkg/urbit/jets/f/ut_nest.c
@@ -24,7 +24,7 @@ u3wfu_nest_dext(u3_noun dext_core)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__dext + ((!!vet) << 8);
-    u3_noun key = u3z_key_3(fun_m, bat, sut, ref);
+    u3_noun key = u3z_key_3(fun_m, sut, ref, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_rest.c
+++ b/pkg/urbit/jets/f/ut_rest.c
@@ -17,7 +17,7 @@ u3wfu_rest(u3_noun cor)
   else {
     u3_weak vet = u3r_at(u3qfu_van_vet, van);
     c3_m  fun_m = 141 + c3__rest + ((!!vet) << 8);
-    u3_noun key = u3z_key_3(fun_m, bat, sut, leg);
+    u3_noun key = u3z_key_3(fun_m, sut, leg, bat);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/jets/f/ut_rest.c
+++ b/pkg/urbit/jets/f/ut_rest.c
@@ -6,16 +6,18 @@
 u3_noun
 u3wfu_rest(u3_noun cor)
 {
-  u3_noun sut, leg, van;
+  u3_noun bat, sut, leg, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &leg, u3x_con, &van, 0)) ||
-       (u3_none == (sut = u3r_at(u3x_sam, van))) )
+  if ( (c3n == u3r_mean(cor, u3x_sam, &leg, u3x_con, &van, 0))
+     || (u3_none == (bat = u3r_at(u3x_bat, van)))
+     || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {
     return u3m_bail(c3__fail);
   }
   else {
-    c3_m  fun_m = 141 + c3__rest + ((!!u3r_at(u3qfu_van_vet, van)) << 8);
-    u3_noun key = u3z_key_2(fun_m, sut, leg);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    c3_m  fun_m = 141 + c3__rest + ((!!vet) << 8);
+    u3_noun key = u3z_key_3(fun_m, bat, sut, leg);
     u3_weak pro = u3z_find(key);
 
     if ( u3_none != pro ) {

--- a/pkg/urbit/noun/zave.c
+++ b/pkg/urbit/noun/zave.c
@@ -25,6 +25,11 @@ u3z_key_4(c3_m fun, u3_noun one, u3_noun two, u3_noun tri, u3_noun qua)
 {
   return u3nc(fun, u3nq(u3k(one), u3k(two), u3k(tri), u3k(qua)));
 }
+u3_noun
+u3z_key_5(c3_m fun, u3_noun one, u3_noun two, u3_noun tri, u3_noun qua, u3_noun qin)
+{
+  return u3nc(fun, u3nq(u3k(one), u3k(two), u3k(tri), u3nc(u3k(qua), u3k(qin))));
+}
 
 /* u3z_find(): find in memo cache.  Arguments retained.
 */


### PR DESCRIPTION
This resolves a basic safety issue with the partial memoization in the decapitated jets.