### PR TITLE
hark: remove 'archived' view, use 'dismiss'

### DIFF
--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -10,11 +10,10 @@ import { StoreState } from "../store/type";
 
 type HarkState = Pick<StoreState,
   "notificationsChatConfig"
-  | "notificationsGroupConfig" 
-  | "notificationsGraphConfig" 
+  | "notificationsGroupConfig"
+  | "notificationsGraphConfig"
   | "notifications"
   | "notificationsCount"
-  | "archivedNotifications"
   | "unreads">;
 
 export const HarkReducer = (json: any, state: HarkState) => {
@@ -163,7 +162,7 @@ function updateUnreads(state: HarkState, index: NotifIndex, f: (u: number) => nu
       } else if('chat' in index) {
         const curr = state.unreads.chat[index.chat.chat] || 0
         state.unreads.chat[index.chat.chat] = f(curr);
-      } 
+      }
 }
 
 function added(json: any, state: HarkState) {
@@ -200,11 +199,7 @@ const timebox = (json: any, state: HarkState) => {
   const data = _.get(json, "timebox", false);
   if (data) {
     const time = makePatDa(data.time);
-    if (data.archive) {
-      state.archivedNotifications.set(time, data.notifications);
-    } else {
       state.notifications.set(time, data.notifications);
-    }
   }
 };
 
@@ -290,17 +285,9 @@ function archive(json: any, state: HarkState) {
       notifIdxEqual(index, idxNotif.index)
     );
     state.notifications.set(time, unarchived);
-    const archiveBox = state.archivedNotifications.get(time) || [];
     const readCount = archived.filter(
       ({ notification }) => !notification.read
     ).length;
     updateUnreads(state, index, x => x - readCount);
-    state.archivedNotifications.set(time, [
-      ...archiveBox,
-      ...archived.map(({ notification, index }) => ({
-        notification: { ...notification, read: true },
-        index,
-      })),
-    ]);
   }
 }

--- a/pkg/interface/src/logic/store/store.ts
+++ b/pkg/interface/src/logic/store/store.ts
@@ -98,7 +98,6 @@ export default class GlobalStore extends BaseStore<StoreState> {
       inbox: {},
       chatSynced: null,
       notifications: new BigIntOrderedMap<Timebox>(),
-      archivedNotifications: new BigIntOrderedMap<Timebox>(),
       notificationsGroupConfig: [],
       notificationsChatConfig: [],
       notificationsGraphConfig: {

--- a/pkg/interface/src/logic/store/type.ts
+++ b/pkg/interface/src/logic/store/type.ts
@@ -11,7 +11,7 @@ import { ConnectionStatus } from '~/types/connection';
 import {Graphs} from '~/types/graph-update';
 import {
   Notifications,
-  NotificationGraphConfig, 
+  NotificationGraphConfig,
   GroupNotificationsConfig,
   LocalUpdateRemoteContentPolicy,
   BackgroundConfig,
@@ -60,7 +60,6 @@ export interface StoreState {
   inbox: Inbox;
   pendingMessages: Map<Path, Envelope[]>;
 
-  archivedNotifications: Notifications;
   notifications: Notifications;
   notificationsGraphConfig: NotificationGraphConfig;
   notificationsGroupConfig: GroupNotificationsConfig;

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -100,7 +100,7 @@ function NotificationWrapper(props: {
         </StatelessAsyncAction>
         {!props.archived && (
           <StatelessAsyncAction name={time.toString()} onClick={onArchive} backgroundColor="transparent">
-            Archive
+            Dismiss
           </StatelessAsyncAction>
         )}
       </Row>

--- a/pkg/interface/src/views/apps/notifications/notifications.tsx
+++ b/pkg/interface/src/views/apps/notifications/notifications.tsx
@@ -71,11 +71,6 @@ export default function NotificationsScreen(props: any) {
                       </HeaderLink>
                     </Box>
                     <Box>
-                      <HeaderLink current={view} view="archive">
-                        Archive
-                      </HeaderLink>
-                    </Box>
-                    <Box>
                       <HeaderLink current={view} view="preferences">
                         Preferences
                       </HeaderLink>
@@ -115,14 +110,6 @@ export default function NotificationsScreen(props: any) {
                     </Box>
                   </Dropdown>
                 </Row>
-                {view === "archive" && (
-                  <Inbox
-                    {...props}
-                    archive={props.archivedNotifications}
-                    showArchive
-                    filter={filter.groups}
-                  />
-                )}
                 {view === "preferences" && (
                   <NotificationPreferences
                     graphConfig={props.notificationsGraphConfig}


### PR DESCRIPTION
- Removes 'Archive' view from the inbox.
- Removed 'archivedNotifications' from all store, reducer logic
- Says 'Dismiss' instead of 'Archive'

<img width="828" alt="image" src="https://user-images.githubusercontent.com/20846414/99743293-6952c500-2aa3-11eb-9e44-78417dbbed16.png">

cc @urcades 

Is there anything we used `archivedNotifications` for? Is this a thorough and concise surgery?