### PR TITLE
u3: adds bytecode ops and protocol for dynamic hints

### DIFF
--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1485,6 +1485,19 @@ _n_rewo(c3_y* buf, c3_w* ip_w)
   return one | (two << 8) | (tre << 16) | (qua << 24);
 }
 
+/* _n_swap(): swap two items on the top of the stack, return pointer to top
+ */
+static inline u3_noun*
+_n_swap(c3_ys mov, c3_ys off)
+{
+  u3_noun* top = _n_peek(off);
+  u3_noun*  up = _n_peet(mov, off);
+  u3_noun  tmp = *up;
+  *up  = *top;
+  *top = tmp;
+  return top;
+}
+
 #ifdef VERBOSE_BYTECODE
 /* _n_print_byc(): print bytecode. used for debugging.
  */
@@ -1602,19 +1615,6 @@ u3n_find(u3_noun key, u3_noun fol)
   pog_p = u3of(u3n_prog, _n_find(key, fol));
   u3t_off(noc_o);
   return pog_p;
-}
-
-/* _n_swap(): swap two items on the top of the stack, return pointer to top
- */
-static inline u3_noun*
-_n_swap(c3_ys mov, c3_ys off)
-{
-  u3_noun* top = _n_peek(off);
-  u3_noun* up   = _n_peet(mov, off);
-  u3_noun  tmp  = *up;
-  *up  = *top;
-  *top = tmp;
-  return top;
 }
 
 /* _n_kick(): stop tracing noc and kick a u3j_site.

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1680,7 +1680,7 @@ u3n_find(u3_noun key, u3_noun fol)
 **            lit: hint atom. TRANSFER
 **            bus: subject. RETAIN
 **            out: token for _n_hilt_hind();
-**                 conventually, [lit] or [lit data]. ~ if unused.
+**                 conventionally, [lit] or [lit data]. ~ if unused.
 **
 **                 any hints herein must be whitelisted in _n_burn().
 */
@@ -1708,7 +1708,7 @@ _n_hilt_hind(u3_noun tok, u3_noun pro)  // transfer, retain
 **            bus: subject. RETAIN
 **            clu: product of the hint-formula. TRANSFER
 **                 also, token for _n_hint_hind();
-**                 conventually, [hint-atom] or [hint-atom data]. ~ if unused.
+**                 conventionally, [hint-atom] or [hint-atom data]. ~ if unused.
 **
 **                 any hints herein must be whitelisted in _n_burn().
 */


### PR DESCRIPTION
All currently supported hints have their own bytecode ops, which is good for performance, but not for extensibility. This PR adds a dynamic hint protocol to the bytecode interpreter, whereby additional hints can be whitelisted for compilation and implemented via before/after callbacks.

This PR is not compatible with any pre-existing pier, as it changes some existing bytecode ops (although calling `u3m_reclaim()` on boot is probably enough to work around for this for now). I'll be adding a version tag to the memory image  shortly, in order to support changes likes this in the future.

//cc @frodwith (and thanks for all the help!)