### PR TITLE
publish: styles preview

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -82,7 +82,7 @@ export function NotePreview(props: NotePreviewProps) {
           <Box color={isRead ? "gray" : "green"} mr={3}>
             {date}
           </Box>
-          <Box mr={3}><Text>{commentDesc}</Text></Box>
+          <Box mr={3}>{commentDesc}</Box>
           <Box>{rev.valueOf() === 1 ? `1 Revision` : `${rev} Revisions`}</Box>
         </Box>
       </Col>

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Col, Box } from "@tlon/indigo-react";
-import { cite } from "~/logic/lib/util";
-import { Note } from "~/types/publish-update";
-import { Contact } from "~/types/contact-update";
-import ReactMarkdown from "react-markdown";
 import moment from "moment";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import ReactMarkdown from "react-markdown";
+import { Col, Box, Text } from "@tlon/indigo-react";
+
+import { cite } from "~/logic/lib/util";
+import { Contact } from "~/types/contact-update";
 import { GraphNode } from "~/types/graph-update";
 import {
   getComments,
@@ -62,8 +62,8 @@ export function NotePreview(props: NotePreviewProps) {
   return (
     <Link to={url}>
       <Col mb={4}>
-        <WrappedBox mb={1}>{title}</WrappedBox>
-        <WrappedBox mb={1}>
+        <WrappedBox mb={1}><Text bold>{title}</Text></WrappedBox>
+        <WrappedBox mb={1} className="md">
           <ReactMarkdown
             unwrapDisallowed
             allowedTypes={["text", "root", "break", "paragraph"]}
@@ -82,7 +82,7 @@ export function NotePreview(props: NotePreviewProps) {
           <Box color={isRead ? "gray" : "green"} mr={3}>
             {date}
           </Box>
-          <Box mr={3}>{commentDesc}</Box>
+          <Box mr={3}><Text>{commentDesc}</Text></Box>
           <Box>{rev.valueOf() === 1 ? `1 Revision` : `${rev} Revisions`}</Box>
         </Box>
       </Col>

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -59,7 +59,7 @@ export function Notebook(props: NotebookProps & RouteComponentProps) {
   const showNickname = contact?.nickname && !hideNicknames;
 
   return (
-    <Col gapY="4" pt={4} mx="auto" px={3} maxWidth="500px">
+    <Col gapY="4" pt={4} mx="auto" px={3} maxWidth="768px">
       <Row justifyContent="space-between">
         <Box>
           <Text> {metadata?.title}</Text>


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/182

I realize this changes some design (@jyng @urcades) but I think it's closer to the spec than before, and it basically just unifies it to use the same styling as on the inside, plus bolding the title...which I think is in spec? I mean it's all changing soon but this fixes it in the interim.

Before:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/3999320/99853788-78d01d80-2b38-11eb-8cfb-1af053686e43.png">

After:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/3999320/99854063-fac04680-2b38-11eb-86ea-d9ccbdfc6637.png">
