### PR TITLE
spider: make handle-stop-thread into a get by instead of a got by to …

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -392,17 +392,20 @@
 ++  handle-stop-thread
   |=  [=tid nice=?]
   ^-  (quip card ^state)
-  =/  =yarn  (~(got by tid.state) tid)
-  ?:  (has-yarn running.state yarn)
+  =/  yarn=(unit yarn)  (~(get by tid.state) tid)
+  ?~  yarn
+    ~&  %stopping-nonexistent-thread
+    [~ state]
+  ?:  (has-yarn running.state u.yarn)
     ?:  nice
-      (thread-done yarn *vase)
-    (thread-fail yarn %cancelled ~)
-  ?:  (~(has by starting.state) yarn)
+      (thread-done u.yarn *vase)
+    (thread-fail u.yarn %cancelled ~)
+  ?:  (~(has by starting.state) u.yarn)
     (thread-fail-not-running tid %stopped-before-started ~)
-  ~&  [%thread-not-started yarn]
+  ~&  [%thread-not-started u.yarn]
   ?:  nice
-    (thread-done yarn *vase)
-  (thread-fail yarn %cancelled ~)
+    (thread-done u.yarn *vase)
+  (thread-fail u.yarn %cancelled ~)
 ::
 ++  take-input
   |=  [=yarn input=(unit input:strand)]


### PR DESCRIPTION
…fix failing +on-load.

Note: this has been confirmed to fix #3970.