### PR TITLE
arvo: unflop the spur in scry

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae9cf9424cb0f4ce515d477646844dfdab57a2cbd1f3b1e2d65662cce1d09654
-size 6306749
+oid sha256:d89b2dd60b56680fb290f3782ab6137488a2df9e43db726199d9f8968db5831c
+size 6314841

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -248,7 +248,7 @@
       ::
       =?  a  &(?=(^ a) =('' i.a))
         t.a
-      (fall (de-beam:format a) [`beak`[p q r]:dir (flop a)])
+      (fall (de-beam:format a) [`beak`[p q r]:dir a])
     =+  vez=hoon-parser
     (sear plex:vez (stag %clsg poor:vez))
   ::
@@ -591,7 +591,7 @@
                     %0  ~
                     %1  [[%rose [~ "  " ~] (skol p.q.cay) ~] maar]
                     %2  [[%rose [~ "  " ~] (dy-show-type-noun p.q.cay) ~] maar]
-                    ::%3  handled above 
+                    ::%3  handled above
                     %4  ~
                     %5  [[%rose [~ "  " ~] (xskol p.q.cay) ~] maar]
                   ==
@@ -1014,7 +1014,7 @@
         "/"  ?:(=(%home q.dir) "=" (trip q.dir))
         "/"  ?:(=([%ud 0] r.dir) "=" (scow r.dir))
       ==
-    ?:(=(~ s.dir) "" (spud (flop s.dir)))
+    ?:(=(~ s.dir) "" (spud s.dir))
   ::
   ++  he-prom                                           ::  send prompt
     %-  he-diff

--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -67,7 +67,7 @@
     |-  ^+  [fex this]
     ?~  daz  [fex this]
     =/  dap-pax=path  /app/[i.daz]/hoon
-    =/  dap-arch  .^(arch cy+(en-beam now-beak (flop dap-pax)))
+    =/  dap-arch  .^(arch cy+(en-beam now-beak dap-pax))
     ?~  fil.dap-arch
       $(daz t.daz)
     =/  sing=card

--- a/pkg/arvo/gen/glass.hoon
+++ b/pkg/arvo/gen/glass.hoon
@@ -116,7 +116,7 @@
   ::  pax: full path at `tyl`
   ::  lon: directory at `tyl`
   ::
-  =/  pax  (en-beam:format bec tyl)
+  =/  pax  (en-beam:format bec (flop tyl))
   =/  lon  .^(arch %cy pax)
   =?  hav  ?=(^ fil.lon)
       ::

--- a/pkg/arvo/gen/hood/mount.hoon
+++ b/pkg/arvo/gen/hood/mount.hoon
@@ -12,6 +12,6 @@
     ==
 ?~  pot
   =+  bem=(need (de-beam:format pax))
-  $(pot ~[?^(s.bem i.s.bem q.bem)])
+  $(pot ~[?^(s.bem (rear s.bem) q.bem)])
 :-  %kiln-mount
 [pax v.pot]

--- a/pkg/arvo/gen/metal.hoon
+++ b/pkg/arvo/gen/metal.hoon
@@ -256,7 +256,7 @@
       ::  pax: full path at `tyl`
       ::  lon: directory at `tyl`
       ::
-      =/  pax  (en-beam:format bec tyl)
+      =/  pax  (en-beam:format bec (flop tyl))
       =/  lon  .^(arch %cy pax)
       =?  hav  ?=(^ fil.lon)
           ?.  ?=({$hoon *} tyl)

--- a/pkg/arvo/gen/timers.hoon
+++ b/pkg/arvo/gen/timers.hoon
@@ -5,5 +5,5 @@
   [%tang >timers< ~]
 .^  (list [date=@da =duct])
   %bx
-  (en-beam:format [p.bec %$ r.bec] /timers/debug)
+  (en-beam:format [p.bec %$ r.bec] /debug/timers)
 ==

--- a/pkg/arvo/lib/strandio.hoon
+++ b/pkg/arvo/lib/strandio.hoon
@@ -424,7 +424,7 @@
   =/  m  (strand ,vase)
   ^-  form:m
   ;<  =riot:clay  bind:m
-    (warp ship desk ~ %sing %a case (flop spur))
+    (warp ship desk ~ %sing %a case spur)
   ?~  riot
     (strand-fail %build-file >arg< ~)
   ?>  =(%vase p.r.u.riot)
@@ -468,7 +468,7 @@
   |=  [[=ship =desk =case:clay] =spur]
   =*  arg  +<
   =/  m  (strand ,cage)
-  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %x case (flop spur))
+  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %x case spur)
   ?~  riot
     (strand-fail %read-file >arg< ~)
   (pure:m r.u.riot)
@@ -476,14 +476,14 @@
 ++  check-for-file
   |=  [[=ship =desk =case:clay] =spur]
   =/  m  (strand ,?)
-  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %x case (flop spur))
+  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %x case spur)
   (pure:m ?=(^ riot))
 ::
 ++  list-tree
   |=  [[=ship =desk =case:clay] =spur]
   =*  arg  +<
   =/  m  (strand ,(list path))
-  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %t case (flop spur))
+  ;<  =riot:clay  bind:m  (warp ship desk ~ %sing %t case spur)
   ?~  riot
     (strand-fail %list-tree >arg< ~)
   (pure:m !<((list path) q.r.u.riot))

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -200,7 +200,7 @@
   ?.  ?=(^ ved)  ~
   =/  ron=@tas  u.hyr
   =/  bed=beam
-    [[u.fal u.dyc (case p.u.ved)] (flop tyl)]
+    [[u.fal u.dyc (case p.u.ved)] tyl]
   =/  bop=(unit (unit (cask meta)))
     (sod ref ~ ron bed)
   ?~  bop  ~
@@ -453,7 +453,7 @@
             [%& p.bed]
             q.bed
             `coin`[%$ r.bed]
-            (flop s.bed)
+            s.bed
         ==
       ::
       ::  |spin:plow:va: move statefully

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -644,6 +644,14 @@
   ?~  a  ~
   [b $(a (dec a))]
 ::
+++  rear                                                ::  last item of list
+  ~/  %rear
+  |*  a=(list)
+  ^-  _?>(?=(^ a) i.a)
+  ?>  ?=(^ a)
+  ?:  =(~ t.a)  i.a  ::NOTE  avoiding tmi
+  $(a t.a)
+::
 ++  reel                                                ::  right fold
   ~/  %reel
   |*  {a/(list) b/_=>(~ |=({* *} +<+))}
@@ -708,6 +716,14 @@
     !!
   ?:  =(0 a)  i.b
   $(b t.b, a (dec a))
+::
+++  snip                                                ::  drop tail off list
+  ~/  %snip
+  |*  a=(list)
+  ^+  a
+  ?~  a  ~
+  ?:  =(~ t.a)  ~
+  [i.a $(a t.a)]
 ::
 ++  sort  !.                                            ::  quicksort
   ~/  %sort

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2581,7 +2581,7 @@
     =-  ?~(- ~ `[nam (lent s.bem) (silt `(list path)`-)])
     %+  skim  can
     |=  pax/path
-    &(=(p.bem our) =(q.bem syd) =((flop s.bem) (scag (lent s.bem) pax)))
+    &(=(p.bem our) =(q.bem syd) =(s.bem (scag (lent s.bem) pax)))
   ::
   ::  Mount a beam to unix
   ::
@@ -4069,7 +4069,7 @@
       !!  ::  fire next in queue
     =^  mos  ruf
       =/  den  ((de our now ski hen ruf) our q.bem)
-      abet:(into:den (flop s.bem) all.req fis.req)
+      abet:(into:den s.bem all.req fis.req)
     [mos ..^$]
   ::
       %merg                                               ::  direct state up

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -644,7 +644,7 @@
     ?-    -.action
         %gen
       =/  bek=beak  [our desk.generator.action da+now]
-      =/  sup=spur  (flop path.generator.action)
+      =/  sup=spur  path.generator.action
       =/  ski       (scry [%141 %noun] ~ %ca bek sup)
       =/  cag=cage  (need (need ski))
       ?>  =(%vase p.cag)
@@ -768,7 +768,7 @@
     ++  do-scry
       |=  [care=term =desk =path]
       ^-  (unit (unit cage))
-      (scry [%141 %noun] ~ care [our desk da+now] (flop path))
+      (scry [%141 %noun] ~ care [our desk da+now] path)
     ::
     ++  error-response
       |=  [status=@ud =tape]
@@ -1650,7 +1650,7 @@
         =*  desc=tape  "from {(trip have)} to json"
         =/  tube=(unit tube:clay)
           =/  tuc=(unit (unit cage))
-            (scry [%141 %noun] ~ %cc [our %home da+now] (flop /[have]/json))
+            (scry [%141 %noun] ~ %cc [our %home da+now] /[have]/json)
           ?.  ?=([~ ~ *] tuc)  ~
           `!<(tube:clay q.u.u.tuc)
         ?~  tube

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -473,7 +473,7 @@
     |=  [dap=term =case:clay]
     ^-  (each agent tang)
     =/  bek=beak  [our %home case]
-    =/  sky  (ski [%141 %noun] ~ %ca bek /hoon/[dap]/app)
+    =/  sky  (ski [%141 %noun] ~ %ca bek /app/[dap]/hoon)
     ?~  sky  |+[leaf+"gall: {<dap>} scry blocked"]~
     ?~  u.sky  |+[leaf+"gall: {<dap>} scry failed"]~
     =/  =cage  u.u.sky
@@ -903,7 +903,7 @@
       =/  =case:clay  da+now
       =/  =mars:clay  [p.cage mark]:deal
       =/  mars-path   /[a.mars]/[b.mars]
-      =/  sky  (ski [%141 %noun] ~ %cc [our %home case] (flop mars-path))
+      =/  sky  (ski [%141 %noun] ~ %cc [our %home case] mars-path)
       ?-    sky
           ?(~ [~ ~])
         =/  ror  "gall: poke cast fail :{(trip dap)} {<mars>}"
@@ -1114,7 +1114,7 @@
         =/  =case:clay  da+now
         =/  bek=beak    [our %home case]
         =/  mars-path  /[a.mars]/[b.mars]
-        =/  sky  (ski [%141 %noun] ~ %cc bek (flop mars-path))
+        =/  sky  (ski [%141 %noun] ~ %cc bek mars-path)
         ?-    sky
             ?(~ [~ ~])
           %-  (slog leaf+"watch-as fact conversion find-fail" >sky< ~)
@@ -1278,7 +1278,7 @@
       =/  tub=(unit tube:clay)
         ?:  =(have want)  `(bake same ^vase)
         =/  tuc=(unit (unit cage))
-          (ski [%141 %noun] ~ %cc [our %home da+now] (flop /[have]/[want]))
+          (ski [%141 %noun] ~ %cc [our %home da+now] /[have]/[want])
         ?.  ?=([~ ~ *] tuc)  ~
         `!<(tube:clay q.u.u.tuc)
       ?~  tub

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5515,7 +5515,7 @@
   ++  en-beam                                           ::  beam to path
     |=  bem/beam
     ^-  path
-    [(scot %p p.bem) q.bem (scot r.bem) (flop s.bem)]
+    [(scot %p p.bem) q.bem (scot r.bem) s.bem]
   ::                                                    ::  ++de-beam:format
   ++  de-beam                                           ::  parse path to beam
     |=  pax/path
@@ -5528,7 +5528,7 @@
     %+  biff  (slay i.t.t.pax)
     |=  cis/coin
     ?.  ?=({$$ case} cis)  ~
-    `(unit beam)`[~ [who dex `case`p.cis] (flop t.t.t.pax)]
+    `(unit beam)`[~ [who dex `case`p.cis] t.t.t.pax]
   ::
   ++  json-rn                                           ::  json to rn parser
     %+  knee  *rn  |.

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -76,7 +76,7 @@
 +$  life  @ud                                           ::  ship key revision
 +$  rift  @ud                                           ::  ship continuity
 +$  mime  (pair mite octs)                              ::  mimetyped data
-+$  octs  (pair @ud cord)                               ::  octet-stream
++$  octs  (pair @ud @)                                  ::  octet-stream
 +$  sock  (pair ship ship)                              ::  outgoing [our his]
 ::+|
 ::
@@ -6491,7 +6491,7 @@
     ++  apex                                            ::  top level
       =+  spa=;~(pose comt whit)
       %+  knee  *manx  |.  ~+
-      %+  ifix  
+      %+  ifix
         [;~(plug (punt decl) (star spa)) (star spa)]
       ;~  pose
         %+  sear  |=({a/marx b/marl c/mane} ?.(=(c n.a) ~ (some [a b])))

--- a/pkg/arvo/ted/build-cast.hoon
+++ b/pkg/arvo/ted/build-cast.hoon
@@ -8,6 +8,6 @@
 =+  !<([pax=path ~] arg)
 ?~  bem=(de-beam:format pax)
   (strand-fail:strand %path-not-beam >pax< ~)
-=/  =mars:clay  [i.t i]:?>(?=([@ @ ~] s.u.bem) s.u.bem)
+=/  =mars:clay  [i i.t]:?>(?=([@ @ ~] s.u.bem) s.u.bem)
 ;<  =tube:clay  bind:m  (build-cast:strandio -.u.bem mars)
 (pure:m !>(tube))

--- a/pkg/arvo/ted/build-mark.hoon
+++ b/pkg/arvo/ted/build-mark.hoon
@@ -8,6 +8,6 @@
 =+  !<([pax=path ~] arg)
 ?~  bem=(de-beam:format pax)
   (strand-fail:strand %path-not-beam >pax< ~)
-=/  =mark  (head s.u.bem)
+=/  =mark  (rear s.u.bem)
 ;<  =dais:clay  bind:m  (build-mark:strandio -.u.bem mark)
 (pure:m !>(dais))

--- a/pkg/arvo/ted/diff.hoon
+++ b/pkg/arvo/ted/diff.hoon
@@ -23,7 +23,7 @@
   ^-  form:m
   =/  beam  (need (de-beam:format path))
   ;<  =riot:clay  bind:m
-    (warp:strandio p.beam q.beam ~ %sing %x r.beam (flop s.beam))
+    (warp:strandio p.beam q.beam ~ %sing %x r.beam s.beam)
   ?~  riot
     (strand-fail:strandio %file-not-found >path< ~)
   (pure:m r.u.riot)

--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -80,20 +80,20 @@
   =*  loop  $
   ?~  bez
     (pure:m fiz)
-  ;<  hav=?  bind:m  (check-for-file:strandio -.i.bez hoon+s.i.bez)
+  ;<  hav=?  bind:m  (check-for-file:strandio -.i.bez (snoc s.i.bez %hoon))
   ?:  hav
-    loop(bez t.bez, fiz (~(put in fiz) [i.bez(s hoon+s.i.bez) ~]))
+    loop(bez t.bez, fiz (~(put in fiz) [i.bez(s (snoc s.i.bez %hoon)) ~]))
   ;<  fez=(list path)  bind:m  (list-tree:strandio i.bez)
   ?.  =(~ fez)
-    =/  foz  (turn fez |=(path [[-.i.bez (flop +<)] ~]))
+    =/  foz  (turn fez |=(path [[-.i.bez +<] ~]))
     loop(bez t.bez, fiz (~(gas in fiz) foz))
   ~|  bad-test-beam+i.bez
-  =/  tex=term  =-(?>(((sane %tas) -) -) (head s.i.bez))
-  =/  xup=path  (tail s.i.bez)
-  ;<  hov=?  bind:m  (check-for-file:strandio i.bez(s hoon+xup))
+  =/  tex=term  =-(?>(((sane %tas) -) -) (rear s.i.bez))
+  =/  xup=path  (snip s.i.bez)
+  ;<  hov=?  bind:m  (check-for-file:strandio i.bez(s (snoc xup %hoon)))
   ?.  hov
     ~|(no-tests-at-path+i.bez !!)
-  loop(bez t.bez, fiz (~(put in fiz) [[-.i.bez hoon+xup] `tex]))
+  loop(bez t.bez, fiz (~(put in fiz) [[-.i.bez (snoc xup %hoon)] `tex]))
 --
 ^-  thread:spider
 |=  arg=vase
@@ -107,7 +107,7 @@
 |-  ^-  form:m
 =*  gather-tests  $
 ?^  fiz
-  ~>  %slog.0^leaf+"test: building {(spud (flop s.beam.i.fiz))}"
+  ~>  %slog.0^leaf+"test: building {(spud s.beam.i.fiz)}"
   ;<  cor=vase  bind:m  (build-file:strandio beam.i.fiz)
   =/  arms=(list test-arm)  (get-test-arms cor)
   =?  arms  ?=(^ test.i.fiz)
@@ -116,7 +116,7 @@
     ?:  =(name.i.arms u.test.i.fiz)
       [i.arms]~
     $(arms t.arms)
-  =.  test-arms  (~(put by test-arms) (flop (tail s.beam.i.fiz)) arms)
+  =.  test-arms  (~(put by test-arms) (snip s.beam.i.fiz) arms)
   gather-tests(fiz t.fiz)
 %-  pure:m  !>  ^=  ok
 %+  roll  (resolve-test-paths test-arms)

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -2369,7 +2369,7 @@
 ++  scry-provides-code  ^-  sley
   |=  [* (unit (set monk)) =term =beam]
   ^-  (unit (unit cage))
-  ?:  &(=(%ca term) =(/hoon/handler/gen s.beam))
+  ?:  &(=(%ca term) =(/gen/handler/hoon s.beam))
     :+  ~  ~
     vase+!>(!>(|=(* |=(* [[%404 ~] ~]))))
   ?:  &(=(%cb term) =(/json s.beam))

--- a/pkg/arvo/tests/sys/zuse/format.hoon
+++ b/pkg/arvo/tests/sys/zuse/format.hoon
@@ -85,7 +85,7 @@
 ::    path)
 ::
 ++  test-beam
-  =/  b=beam  [[p=~zod q=%home r=[%ud p=12]] s=/hoon/zuse/sys]
+  =/  b=beam  [[p=~zod q=%home r=[%ud p=12]] s=/sys/zuse/hoon]
   =/  p=path  /~zod/home/12/sys/zuse/hoon
   ;:  weld
     ::  proper encode


### PR DESCRIPTION
As requested, no longer use reversed paths in sley-style peek handling.

I think this is the last of the "reverse path" shenanigans.