### PR TITLE
landscape: fix link route breaking popover

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -95,7 +95,7 @@ export function LinkResource(props: LinkResourceProps) {
           }}
         />
         <Route
-          path={relativePath("/:index/:commentId?")}
+          path={relativePath("/:index(\\d+)/:commentId?")}
           render={(props) => {
             const index = bigInt(props.match.params.index);
             const editCommentId = props.match.params.commentId || null;


### PR DESCRIPTION
When you're on a link page, hitting the settings popover will trigger an error since the LinkResource matches the path. This makes it so that it only matches numerical indexes.