### PR TITLE
docs: fix simple typo, loobean -> boolean

### DIFF
--- a/doc/spec/u3.md
+++ b/doc/spec/u3.md
@@ -60,7 +60,7 @@ types are wordy and annoying.  We've replaced them with:
       typedef uint8_t c3_b;   // bit
 
       typedef uint8_t c3_t;   // boolean
-      typedef uint8_t c3_o;   // loobean
+      typedef uint8_t c3_o;   // boolean
       typedef uint8_t c3_g;   // 5-bit atom for a 32-bit log.
       typedef uint32_t c3_l;  // little; 31-bit unsigned integer
       typedef uint32_t c3_m;  // mote; also c3_l; LSB first a-z 4-char string.
@@ -72,7 +72,7 @@ types are wordy and annoying.  We've replaced them with:
       typedef uintptr_t c3_p; // pointer-length uint - really really bad
       typedef intptr_t c3_ps; // pointer-length int - really really bad
 
-Some of these need explanation.  A loobean is a Nock boolean -
+Some of these need explanation.  A boolean is a Nock boolean -
 Nock, for mysterious reasons, uses 0 as true (always say "yes")
 and 1 as false (always say "no").
 
@@ -129,7 +129,7 @@ The code (from `defs.h`) tells the story:
     #     define c3a(x, y)   __(_(x) && _(y))
     #     define c3o(x, y)   __(_(x) || _(y))
 
-In short, use `_()` to turn a loobean into a boolean, `__` to go
+In short, use `_()` to turn a boolean into a boolean, `__` to go
 the other way.  Use `!` as usual, `c3y` for yes and `c3n` for no,
 `c3a` for and and `c3o` for or.
 

--- a/pkg/urbit/include/c/types.h
+++ b/pkg/urbit/include/c/types.h
@@ -17,7 +17,7 @@
       typedef uint8_t c3_b;   // bit
 
       typedef uint8_t c3_t;   // boolean
-      typedef uint8_t c3_o;   // loobean
+      typedef uint8_t c3_o;   // boolean
       typedef uint8_t c3_g;   // 32-bit log - 0-31 bits
       typedef uint32_t c3_l;  // little; 31-bit unsigned integer
       typedef uint32_t c3_m;  // mote; also c3_l; LSB first a-z 4-char string.

--- a/pkg/urbit/include/noun/aliases.h
+++ b/pkg/urbit/include/noun/aliases.h
@@ -61,11 +61,11 @@
 
   /**  Macros.
   **/
-    /* u3_assure(): loobean assert, bailing with %fail.
+    /* u3_assure(): boolean assert, bailing with %fail.
     */
 #     define u3_assure(x)  if ( !_(x) ) { u3m_bail(c3__fail); }
 
-    /* u3_assert(): loobean assert, bailing with %exit.
+    /* u3_assert(): boolean assert, bailing with %exit.
     */
 #     define u3_assent(x)  if ( !_(x) ) { u3m_bail(c3__exit); }
 


### PR DESCRIPTION
There is a small typo in doc/spec/u3.md, pkg/urbit/include/c/types.h, pkg/urbit/include/noun/aliases.h.

Should read `boolean` rather than `loobean`.

