### PR TITLE
pill: change to ropsten

### DIFF
--- a/bin/ivory.pill
+++ b/bin/ivory.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fae6432f7fd049042ed0f26c606325cf05e46f8ebd2703e5d95c054b7f0a0c8
+oid sha256:20057d491e10d2ba0afce72833dd45e78b746fc3a33122337ad346f9addfca66
 size 1320607

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f112c8ba5ed0248c39babb00ab8f8ae6bb949c8502820fec4f3468ebc0677eb0
-size 6324006
+oid sha256:1f7e5913134048073737c5ba380fabc9c3819a37038a1db8b657c9605d9e9bc9
+size 6324130

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -8007,7 +8007,7 @@
       ::  #  constants
       ::
       ::  contract addresses
-      ++  contracts  mainnet-contracts
+      ++  contracts  ropsten-contracts
       ++  mainnet-contracts
         |%
         ::  azimuth: data contract


### PR DESCRIPTION
We'll revert this on release, but in the meantime it's convenient to have all our pills point to the ropsten contracts so we don't have to constantly build testnet pills on a separate branch.  Here's a sample command for how to run a ropsten ~zod.  Obviously, you'll need ~zod's ropsten key and a url for a ropsten ethereum node; let me know if you need them.

```
rm -rf zod; ~/urbit/pkg/urbit/build/urbit -w zod -k zod-8.key -H test.urbit.org -B ~/urbit/bin/solid.pill -e http://ROPSTEN_DOMAIN_REDACTED:8545 -J ~/urbit/bin/ivory.pill
```