### PR TITLE
landscape: fix new chat creation 404; fix new resource clobbering

### DIFF
--- a/pkg/interface/src/views/landscape/components/Content.js
+++ b/pkg/interface/src/views/landscape/components/Content.js
@@ -69,7 +69,7 @@ export const Content = (props) => {
             <Notifications {...props} />
           )}
         />
-        <GraphApp {...props} />
+        <GraphApp path="/~graph" {...props} />
         <Route
           render={p => (
             <ErrorComponent

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -173,6 +173,7 @@ export function GroupsPane(props: GroupsPaneProps) {
                 {...routeProps}
                 api={api}
                 baseUrl={baseUrl}
+                chatSynced={props.chatSynced}
                 associations={associations}
                 groups={groups}
                 group={groupPath}

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -38,6 +38,7 @@ interface NewChannelProps {
   api: GlobalApi;
   associations: Associations;
   contacts: Rolodex;
+  chatSynced: any;
   groups: Groups;
   group?: string;
   workspace: Workspace;
@@ -94,6 +95,9 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
 
       if (!group) {
         await waiter(p => Boolean(p?.groups?.[`/ship/~${window.ship}/${resId}`]));
+      }
+      if (moduleType === 'chat') {
+        await waiter(p => Boolean(p?.chatSynced?.[`/~${window.ship}/${resId}`]));
       }
       actions.setStatus({ success: null });
       const resourceUrl = parentPath(location.pathname);

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -50,7 +50,9 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
   const waiter = useWaitForProps(props, 5000);
 
   const onSubmit = async (values: FormSchema, actions) => {
-    const resId: string = stringToSymbol(values.name);
+    const resId: string = stringToSymbol(values.name)
+      + ((workspace?.type !== 'home') ? `-${Math.floor(Math.random() * 10000)}`
+      : '');
     try {
       const { name, description, moduleType, ships } = values;
       switch (moduleType) {
@@ -130,8 +132,8 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
         onSubmit={onSubmit}
       >
         <Form>
-          <Col 
-            maxWidth="348px" 
+          <Col
+            maxWidth="348px"
             gapY="4"
           >
             <Col gapY="2">


### PR DESCRIPTION
- During our OTA last week we needed to redirect graph resources without knowing what their module type was (only available in metadata-store, which we don't get until we accept). In constructing a join flow that awaited the metadata @liam-fitzgerald restored the `GraphApp` component but it clobbered the catch-all 404 routing. We make the graphapp routing specific to `/~graph`.
- Passes `props.chatSynced` to `NewChannel` and awaits its arrival before redirecting chat resources (which was giving a false positive `isChatMissing`, redirecting the user to a 404 page). (#3923)
- Adds a four digit identifier to grouped resource paths to prevent clobbering when making two resources of the same name across groups (eg. "General"). (#3996)