### PR TITLE
hark-store: fix caching of merged notifications

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -166,11 +166,16 @@
         ?~  existing-notif
           notification
         (merge-notification:ha u.existing-notif notification)
+      =/  new-read=?
+        ?~  existing-notif
+          %.y
+        read.u.existing-notif
+      =.  read.new  %.n
       =/  new-timebox=timebox:store
         (~(put by timebox) index new)
       :-  (give:ha [/updates]~ %added last-seen index new)
       %_  state
-        +  ?~(existing-notif (upd-unreads:ha index last-seen %.n) +.state)
+        +  ?.(new-read +.state (upd-unreads:ha index last-seen %.n))
         notifications  (put:orm notifications last-seen new-timebox)
       ==
     ++  read-index


### PR DESCRIPTION
If a notification came in that merged with a notification that had
already been read, then it would not be added to the cache properly and
therefore would not correctly send %read updates when %read-index was
called.

cc: @vvisigoth 

Fixes #3977