### PR TITLE
hark: update mark conversion for editable comments

### DIFF
--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -5,8 +5,9 @@
   ++  noun  i
   ++  notification-kind
     ?+  index.p.i  ~
-      [@ ~]    `[%link 0]
-      [@ @ @ ~]  `[%comment 1]
+      [@ ~]       `[%link 0]
+      [@ @ %1 ~]  `[%comment 1]
+      [@ @ @ ~]   `[%edit-comment 1]
     ==
   --
 ++  grab

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -8,8 +8,10 @@
   ::
   ++  notification-kind
     ?+  index.p.i   ~
-      [@ %1 @ ~]  `[%note 0]
-      [@ %2 @ @ ~]  `[%comment 1]
+      [@ %1 %1 ~]    `[%note 0]
+      [@ %1 @ ~]     `[%edit-note 0]
+      [@ %2 @ %1 ~]  `[%comment 1]
+      [@ %2 @ @ ~]   `[%edit-comment 1]
     ==
   --
 ++  grab

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -42,8 +42,12 @@ function describeNotification(description: string, plural: boolean) {
       return `added ${pluralize("new link", plural)} to`;
     case "comment":
       return `left ${pluralize("comment", plural)} on`;
-    case "note":
+    case "edit-comment":
+      return `updated ${pluralize("comment", plural)} on`;
+    case "new-note":
       return `posted ${pluralize("note", plural)} to`;
+    case "edit-note":
+      return `updated ${pluralize("note", plural)} in`;
     case "mention":
       return "mentioned you on";
     default:


### PR DESCRIPTION
Updated mark conversion so that edits to comments are notified
separately to new comments.

UX note (cc: @urcades ):
This will notify users if they're subscribed to the parent node i.e. if they've unmuted the book or link that the comment was left on. Should we expose following a comment for updates instead? e.g. click 'notify me on update' -> get notified when comment changes. 