### PR TITLE
graph-store: safely peek update-log

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -748,12 +748,14 @@
       [%x %peek-update-log @ @ ~]
     =/  =ship   (slav %p i.t.t.path)
     =/  =term   i.t.t.t.path
-    =/  update-log=(unit update-log:store)  (~(get by update-logs) [ship term])
-    ?~  update-log  [~ ~]
-    =/  result=(unit [time update:store])
-      (peek:orm-log:store u.update-log)
-    ?~  result  [~ ~]
-    ``noun+!>([~ -.u.result])
+    =/  m-update-log=(unit update-log:store)  (~(get by update-logs) [ship term])
+    :-  ~  :-  ~  :-  %noun
+    !>  ^-  (unit time)
+    %+  biff  m-update-log
+    |=  =update-log:store
+    =/  result=(unit [=time =update:store])
+      (peek:orm-log:store update-log)
+    (bind result |=([=time update:store] time))
   ==
   ::
   ++  get-node


### PR DESCRIPTION
Safely returns a null when either the update-log does not exist, or it
is empty

Fixes #3976