### PR TITLE
landscape: add breach notification

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -14,7 +14,7 @@ import './css/fonts.css';
 import light from './themes/light';
 import dark from './themes/old-dark';
 
-import { Text, Anchor } from '@tlon/indigo-react';
+import { Text, Anchor, Row } from '@tlon/indigo-react';
 
 import { Content } from './landscape/components/Content';
 import StatusBar from './components/StatusBar';
@@ -26,6 +26,7 @@ import GlobalSubscription from '~/logic/subscription/global';
 import GlobalApi from '~/logic/api/global';
 import { uxToHex } from '~/logic/lib/util';
 import { foregroundFromBackground } from '~/logic/lib/sigil';
+
 
 const Root = styled.div`
   font-family: ${p => p.theme.fonts.sans};
@@ -130,6 +131,9 @@ class App extends React.Component {
     const notificationsCount = state.notificationsCount || 0;
     const doNotDisturb = state.doNotDisturb || false;
 
+    const showBanner = localStorage.getItem("2020BreachBanner") || "flex";
+    let banner = null;
+
     return (
       <ThemeProvider theme={theme}>
         <Helmet>
@@ -138,7 +142,21 @@ class App extends React.Component {
             : null}
         </Helmet>
         <Root background={background}>
-        <Text p='2' backgroundColor='yellow' color='#000000'>A network-wide breach is scheduled for early December 2020. Please visit <Anchor target="_blank" href="https://urbit.org/breach" color='inherit'>urbit.org/breach</Anchor> for more information.</Text>
+          <Row
+            ref={e => banner = e}
+            display={showBanner}
+            justifyContent="space-between"
+            width='100%'
+            p='2'
+            backgroundColor='yellow'>
+          <Text color='#000000'>
+            A network-wide breach is scheduled for early December 2020. Please visit <Anchor target="_blank" href="https://urbit.org/breach" color='inherit'>urbit.org/breach</Anchor> for more information.
+              </Text>
+            <Text cursor='pointer' fontWeight='500' onClick={() => {
+              banner.style.displaydisplay = "none";
+              localStorage.setItem("2020BreachBanner", "none");
+            }}>Dismiss</Text>
+          </Row>
           <Router>
             <ErrorBoundary>
               <StatusBarWithRouter

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -14,6 +14,8 @@ import './css/fonts.css';
 import light from './themes/light';
 import dark from './themes/old-dark';
 
+import { Text, Anchor } from '@tlon/indigo-react';
+
 import { Content } from './landscape/components/Content';
 import StatusBar from './components/StatusBar';
 import Omnibox from './components/leap/Omnibox';
@@ -136,6 +138,7 @@ class App extends React.Component {
             : null}
         </Helmet>
         <Root background={background}>
+        <Text p='2' backgroundColor='yellow' color='#000000'>A network-wide breach is scheduled for early December 2020. Please visit <Anchor target="_blank" href="https://urbit.org/breach" color='inherit'>urbit.org/breach</Anchor> for more information.</Text>
           <Router>
             <ErrorBoundary>
               <StatusBarWithRouter


### PR DESCRIPTION
- [x] Pending urbit.org FAQ deployment.
- [ ] Pending paired PR for `na-release/candidate` to remove banner.
- [x] Pending cutoff date for leaving a "has been breached" notice for stragglers.
- [x] Pending "dismiss" logic using `localStorage` (need to look at how we did the UX for OS1 again...)

<img width="814" alt="Screen Shot 2020-11-24 at 11 49 12 PM" src="https://user-images.githubusercontent.com/20846414/100184632-efaa4500-2eaf-11eb-8b0a-d2c00d23d697.png">
