### PR TITLE
publish: amend snippets, add images to snippets

### DIFF
--- a/pkg/interface/src/logic/lib/publish.ts
+++ b/pkg/interface/src/logic/lib/publish.ts
@@ -113,6 +113,6 @@ export function getComments(node: GraphNode): GraphNode {
 
 export function getSnippet(body: string) {
   const start = body.slice(0, body.indexOf('\n', 2));
-  return start === body ? start : `${start}...`;
+  return (start === body || start.startsWith("![")) ? start : `${start}...`;
 }
 

--- a/pkg/interface/src/logic/lib/publish.ts
+++ b/pkg/interface/src/logic/lib/publish.ts
@@ -106,13 +106,13 @@ export function getLatestCommentRevision(node: GraphNode): [number, Post] {
 export function getComments(node: GraphNode): GraphNode {
   const comments = node.children.get(bigInt(2));
   if(!comments) {
-    return { post: buntPost(), children: new BigIntOrderedMap() } 
+    return { post: buntPost(), children: new BigIntOrderedMap() }
   }
   return comments;
 }
 
 export function getSnippet(body: string) {
-  const start = body.slice(0, 400);
+  const start = body.slice(0, body.indexOf('\n', 2));
   return start === body ? start : `${start}...`;
 }
- 
+

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -3,7 +3,7 @@ import moment from "moment";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import ReactMarkdown from "react-markdown";
-import { Col, Box, Text } from "@tlon/indigo-react";
+import { Col, Box, Text, Image } from "@tlon/indigo-react";
 
 import { cite } from "~/logic/lib/util";
 import { Contact } from "~/types/contact-update";
@@ -67,7 +67,10 @@ export function NotePreview(props: NotePreviewProps) {
           <Text fontSize='14px'>
           <ReactMarkdown
             unwrapDisallowed
-            allowedTypes={["text", "root", "break", "paragraph"]}
+            allowedTypes={["text", "root", "break", "paragraph", "image"]}
+            renderers={{
+              image: (props) => <Image src={props.src} maxHeight='300px' style={{ objectFit: 'cover' }}/>
+            }}
             source={snippet}
           />
           </Text>

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -1,26 +1,29 @@
-import React from "react";
-import moment from "moment";
-import { Link } from "react-router-dom";
-import styled from "styled-components";
-import ReactMarkdown from "react-markdown";
-import { Col, Box, Text, Image } from "@tlon/indigo-react";
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { Col, Row, Box, Text, Icon, Image } from '@tlon/indigo-react';
 
-import { cite } from "~/logic/lib/util";
-import { Contact } from "~/types/contact-update";
-import { GraphNode } from "~/types/graph-update";
+import Author from '~/views/components/Author';
+import { GraphNode } from '~/types/graph-update';
+import { Contacts, Group } from '~/types';
 import {
   getComments,
   getLatestRevision,
-  getSnippet,
-} from "~/logic/lib/publish";
+  getSnippet
+} from '~/logic/lib/publish';
+import GlobalApi from '~/logic/api/global';
+import ReactMarkdown from 'react-markdown';
 
 interface NotePreviewProps {
   host: string;
   book: string;
   node: GraphNode;
-  contact?: Contact;
+  hideAvatars?: boolean;
   hideNicknames?: boolean;
   baseUrl: string;
+  contacts: Contacts;
+  api: GlobalApi;
+  group: Group;
 }
 
 const WrappedBox = styled(Box)`
@@ -28,29 +31,14 @@ const WrappedBox = styled(Box)`
 `;
 
 export function NotePreview(props: NotePreviewProps) {
-  const { node, contact } = props;
+  const { node, contacts, hideAvatars, hideNicknames, group } = props;
   const { post } = node;
   if (!post) {
     return null;
   }
 
-  let name = post?.author;
-  if (contact && !props.hideNicknames) {
-    name = contact.nickname.length > 0 ? contact.nickname : post?.author;
-  }
-  if (name === post?.author) {
-    name = cite(post?.author);
-  }
-
   const numComments = getComments(node).children.size;
-  const commentDesc =
-    numComments === 0
-      ? "No Comments"
-      : numComments === 1
-      ? "1 Comment"
-      : `${numComments} Comments`;
-  const date = moment(post["time-sent"]).fromNow();
-  const url = `${props.baseUrl}/note/${post.index.split("/")[1]}`;
+  const url = `${props.baseUrl}/note/${post.index.split('/')[1]}`;
 
   // stubbing pending notification-store
   const isRead = true;
@@ -60,37 +48,53 @@ export function NotePreview(props: NotePreviewProps) {
   const snippet = getSnippet(body);
 
   return (
-    <Link to={url}>
-      <Col mb={4}>
-        <WrappedBox mb={1}><Text bold fontSize='0'>{title}</Text></WrappedBox>
-        <WrappedBox mb={1}>
+    <Box width='100%'>
+      <Link to={url}>
+        <Col
+          lineHeight='tall'
+          width='100%'
+          color={isRead ? 'washedGray' : 'blue'}
+          border={1}
+          borderRadius={2}
+          alignItems='flex-start'
+          overflow='hidden'
+          p='2'
+        >
+          <WrappedBox mb={2}><Text bold fontSize='0'>{title}</Text></WrappedBox>
+          <WrappedBox>
           <Text fontSize='14px'>
-          <ReactMarkdown
-            unwrapDisallowed
-            allowedTypes={["text", "root", "break", "paragraph", "image"]}
-            renderers={{
-              image: (props) => <Image src={props.src} maxHeight='300px' style={{ objectFit: 'cover' }}/>
-            }}
-            source={snippet}
-          />
-          </Text>
-        </WrappedBox>
-        <Box color="gray" display="flex">
-          <Box
-            mr={3}
-            fontFamily={
-              contact?.nickname && !props.hideNicknames ? "sans" : "mono"
-            }
-          >
-            {name}
-          </Box>
-          <Box color={isRead ? "gray" : "green"} mr={3}>
-            {date}
-          </Box>
-          <Box mr={3}>{commentDesc}</Box>
-          <Box>{rev.valueOf() === 1 ? `1 Revision` : `${rev} Revisions`}</Box>
+            <ReactMarkdown
+              unwrapDisallowed
+              allowedTypes={['text', 'root', 'break', 'paragraph', 'image']}
+              renderers={{
+                image: props => <Image src={props.src} maxHeight='300px' style={{ objectFit: 'cover' }} />
+              }}
+              source={snippet}
+            />
+            </Text>
+          </WrappedBox>
+        </Col>
+      </Link>
+      <Row minWidth='0' flexShrink={0} width="100%" justifyContent="space-between" py={3} bg="white">
+        <Author
+          showImage
+          contacts={contacts}
+          ship={post?.author}
+          date={post?.['time-sent']}
+          hideAvatars={hideAvatars || false}
+          hideNicknames={hideNicknames || false}
+          group={group}
+          api={props.api}
+        />
+        <Box ml="auto" mr={1}>
+          <Link to={url}>
+            <Box display='flex'>
+              <Icon color='blue' icon='Chat' />
+              <Text color='blue' ml={1}>{numComments}</Text>
+            </Box>
+          </Link>
         </Box>
-      </Col>
-    </Link>
+      </Row>
+    </Box>
   );
 }

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -62,13 +62,15 @@ export function NotePreview(props: NotePreviewProps) {
   return (
     <Link to={url}>
       <Col mb={4}>
-        <WrappedBox mb={1}><Text bold>{title}</Text></WrappedBox>
-        <WrappedBox mb={1} className="md">
+        <WrappedBox mb={1}><Text bold fontSize='0'>{title}</Text></WrappedBox>
+        <WrappedBox mb={1}>
+          <Text fontSize='14px'>
           <ReactMarkdown
             unwrapDisallowed
             allowedTypes={["text", "root", "break", "paragraph"]}
             source={snippet}
           />
+          </Text>
         </WrappedBox>
         <Box color="gray" display="flex">
           <Box

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -1,15 +1,11 @@
-import React, { PureComponent } from "react";
-import { Link, RouteComponentProps, Route, Switch } from "react-router-dom";
-import { NotebookPosts } from "./NotebookPosts";
-import { roleForShip } from "~/logic/lib/group";
-import { Box, Button, Text, Row, Col } from "@tlon/indigo-react";
-import { Groups } from "~/types/group-update";
-import { Contacts, Rolodex } from "~/types/contact-update";
-import GlobalApi from "~/logic/api/global";
-import styled from "styled-components";
-import { Associations, Graph, Association } from "~/types";
-import { deSig } from "~/logic/lib/util";
-import { StatelessAsyncButton } from "~/views/components/StatelessAsyncButton";
+import React from 'react';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { NotebookPosts } from './NotebookPosts';
+import { Box, Button, Text, Row, Col } from '@tlon/indigo-react';
+import { Groups } from '~/types/group-update';
+import { Contacts, Rolodex } from '~/types/contact-update';
+import GlobalApi from '~/logic/api/global';
+import { Associations, Graph, Association, LocalUpdateRemoteContentPolicy } from '~/types';
 
 interface NotebookProps {
   api: GlobalApi;
@@ -22,9 +18,9 @@ interface NotebookProps {
   contacts: Rolodex;
   groups: Groups;
   hideNicknames: boolean;
+  hideAvatars: boolean;
   baseUrl: string;
   rootUrl: string;
-  associations: Associations;
 }
 
 interface NotebookState {
@@ -39,18 +35,20 @@ export function Notebook(props: NotebookProps & RouteComponentProps) {
     notebookContacts,
     groups,
     hideNicknames,
+    hideAvatars,
     association,
-    graph,
+    graph
   } = props;
   const { metadata } = association;
 
-  const group = groups[association?.["group-path"]];
-  if (!group) return null; // Waitin on groups to populate
+  const group = groups[association?.['group-path']];
+  if (!group) {
+    return null; // Waitin on groups to populate
+  }
 
   const relativePath = (p: string) => props.baseUrl + p;
 
   const contact = notebookContacts?.[ship];
-  const role = group ? roleForShip(group, window.ship) : undefined;
   const isOwn = `~${window.ship}` === ship;
 
   const isWriter =
@@ -65,13 +63,13 @@ export function Notebook(props: NotebookProps & RouteComponentProps) {
           <Text> {metadata?.title}</Text>
           <br />
           <Text color="lightGray">by </Text>
-          <Text fontFamily={showNickname ? "sans" : "mono"}>
+          <Text fontFamily={showNickname ? 'sans' : 'mono'}>
             {showNickname ? contact?.nickname : ship}
           </Text>
         </Box>
         {isWriter && (
-          <Link to={relativePath("/new")}>
-            <Button primary style={{ cursor: "pointer" }}>
+          <Link to={relativePath('/new')}>
+            <Button primary style={{ cursor: 'pointer' }}>
               New Post
             </Button>
           </Link>
@@ -82,9 +80,12 @@ export function Notebook(props: NotebookProps & RouteComponentProps) {
         graph={graph}
         host={ship}
         book={book}
-        contacts={!!notebookContacts ? notebookContacts : {}}
+        contacts={notebookContacts ? notebookContacts : {}}
         hideNicknames={hideNicknames}
+        hideAvatars={hideAvatars}
         baseUrl={props.baseUrl}
+        api={props.api}
+        group={group}
       />
     </Col>
   );

--- a/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
@@ -1,15 +1,19 @@
-import React, { Component } from "react";
-import { Col } from "@tlon/indigo-react";
-import { NotePreview } from "./NotePreview";
-import { Contacts, Graph } from "~/types";
+import React from 'react';
+import { Col } from '@tlon/indigo-react';
+import { NotePreview } from './NotePreview';
+import { Contacts, Graph, Group } from '~/types';
+import GlobalApi from '~/logic/api/global';
 
 interface NotebookPostsProps {
   contacts: Contacts;
   graph: Graph;
   host: string;
   book: string;
-  hideNicknames?: boolean;
   baseUrl: string;
+  hideAvatars?: boolean;
+  hideNicknames?: boolean;
+  api: GlobalApi;
+  group: Group;
 }
 
 export function NotebookPosts(props: NotebookPostsProps) {
@@ -22,10 +26,11 @@ export function NotebookPosts(props: NotebookPostsProps) {
               key={date.toString()}
               host={props.host}
               book={props.book}
-              contact={props.contacts[node.post.author]}
+              contacts={props.contacts}
               node={node}
-              hideNicknames={props.hideNicknames}
               baseUrl={props.baseUrl}
+              api={props.api}
+              group={props.group}
             />
           )
       )}

--- a/pkg/interface/src/views/apps/publish/css/custom.css
+++ b/pkg/interface/src/views/apps/publish/css/custom.css
@@ -187,7 +187,7 @@
   color:var(--gray);
 }
 
-.md p {
+.md {
   line-height: 1.5;
 }
 .md code, .md pre {
@@ -201,7 +201,7 @@
   border-bottom-width: 1px;
 }
 
-md img {
+.md img {
   margin-bottom: 8px;
 }
 

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -6,25 +6,24 @@ import { Sigil } from "~/logic/lib/sigil"
 import { uxToHex, cite } from "~/logic/lib/util";
 import { Contacts, Rolodex } from "~/types/contact-update";
 import OverlaySigil from "./OverlaySigil";
-import { Group, Association, LocalUpdateRemoteContentPolicy } from "~/types";
+import { Group, Association } from "~/types";
 import GlobalApi from "~/logic/api/global";
 import { useHistory } from "react-router-dom";
 
 interface AuthorProps {
-  contacts: Rolodex;
+  contacts: Contacts;
   ship: string;
   date: number;
   showImage?: boolean;
   hideAvatars: boolean;
   hideNicknames: boolean;
   children?: ReactNode;
-  remoteContentPolicy: LocalUpdateRemoteContentPolicy;
   group: Group;
   api: GlobalApi;
 }
 
 export default function Author(props: AuthorProps) {
-  const { contacts, ship = '', date, showImage, hideAvatars, hideNicknames, remoteContentPolicy, group, api } = props;
+  const { contacts, ship = '', date, showImage, hideAvatars, hideNicknames, group, api } = props;
   const history = useHistory();
   let contact;
   if (contacts) {


### PR DESCRIPTION
After #3989 I noticed our `md` class didn't have styling for non-`<p>` characters, which our body content used for stripping headers and the like, leading the layout to look quite uneven.

This PR makes `getSnippet` take up until the first `\n` character as of index `2` to get the first line; wraps the snippet in indigo-react, sidestepping the CSS styling with its "sometimes 14px margin-bottom, sometimes 2px" due to not every snippet having a paragraph element.

I also went ahead and rendered image previews if the first line is an image, containing it in a 300px block.

Before / after (note "On Odyssey" being smaller even though it's header copy, because we're escaping headers in the snippet):

<img width="904" alt="Screen Shot 2020-11-25 at 12 19 42 AM" src="https://user-images.githubusercontent.com/20846414/100186454-094d8b80-2eb4-11eb-9673-c12cce9b4562.png">

<img width="873" alt="Screen Shot 2020-11-25 at 12 18 53 AM" src="https://user-images.githubusercontent.com/20846414/100186441-02267d80-2eb4-11eb-924d-5d2e8f39ea80.png">
