### PR TITLE
graph-store: add basic sanity checker

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -17,7 +17,10 @@
 ::
 ++  orm      orm:store
 ++  orm-log  orm-log:store
-+$  debug-input  [%validate-graph =resource:store]
++$  debug-input  
+  $%  [%validate-graph =resource:store]
+      [%check-hooks ~]
+  ==
 --
 ::
 =|  state-2
@@ -79,7 +82,12 @@
       |=(a=* *update-log:store)
     ==
   ::
-    %2  [cards this(state old)]
+      %2  
+    =.  cards
+      :_  cards
+      =-  [%pass / %agent [our.bowl %graph-store] %poke -]
+      noun+!>([%check-hooks ~])
+    [cards this(state old)]
   ==
   ::
   ++  change-revision-graph
@@ -588,10 +596,57 @@
   ++  debug
     |=  =debug-input
     ^-  (quip card _state)
-    =/  [=graph:store mark=(unit mark:store)]
-      (~(got by graphs) resource.debug-input)
-    ?>  (validate-graph graph mark)
-    [~ state]
+    ?-  -.debug-input
+        %validate-graph
+      =/  [=graph:store mark=(unit mark:store)]
+        (~(got by graphs) resource.debug-input)
+      ?>  (validate-graph graph mark)
+      [~ state]
+      ::
+        %check-hooks
+      :_  state
+      %+  roll
+        ~(tap in ~(key by graphs))
+      |=  [=res out=(list card)]
+      %+  weld  out
+      ?:  =(our.bowl entity.res)
+        (check-push res)
+      (check-pull res)
+    ==
+  ::
+  ++  scry-pull-hook
+    .^  (set res)
+        %gx
+        (scot %p our.bowl)
+        %graph-pull-hook
+        (scot %da now.bowl)
+        /tracking/noun
+    ==
+  ::
+  ++  scry-push-hook
+    .^  (set res)
+        %gx
+        (scot %p our.bowl)
+        %graph-pull-hook
+        (scot %da now.bowl)
+        /tracking/noun
+    ==
+  ::
+  ++  check-pull
+    |=  =res
+    ^-  (list card)
+    ?:  (~(has in scry-pull-hook) res)
+      ~
+    =-  [%pass /hooks %agent [our.bowl %graph-pull-hook] %poke -]~
+    pull-hook-action+!>([%add entity.res res])
+  ::
+  ++  check-push
+    |=  =res
+    ^-  (list card)
+    ?:  (~(has in scry-push-hook) res)
+      ~
+    =-  [%pass /hooks %agent [our.bowl %graph-push-hook] %poke -]~
+    push-hook-action+!>([%add res])
   ::
   ++  validate-graph
     |=  [=graph:store mark=(unit mark:store)]

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -282,7 +282,9 @@
       ++  on-peek   
         |=  =path
         ^-  (unit (unit cage))
-        (on-peek:og path)
+        ?.  ?=([%x %tracking ~] path)
+          (on-peek:og path)
+        ``noun+!>(~(key by tracking))
     --
   |_  =bowl:gall
   +*  og   ~(. pull-hook bowl)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -285,7 +285,12 @@
         =^  cards  push-hook
           (on-fail:og term tang)
         [cards this]
-      ++  on-peek   on-peek:og
+      ++  on-peek
+        |=  =path
+        ^-  (unit (unit cage))
+        ?.  ?=([%x %sharing ~] path)
+          (on-peek:og path)
+        ``noun+!>(sharing)
     --
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)


### PR DESCRIPTION
A small subset of %sane's functionality to go out in the next OTA. When paired with #4022 , should fix all broken subscriptions for graph-store. I'm aware this a slight layering violation, but priority should lie with the stability of the livenet. We can transplant this logic out into `%sane` later. 