### PR TITLE
build: disable ci release tarball upload on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,9 @@
 #
 #   https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 
-name: Build, test, and upload urbit release tarball
+name: Build and test urbit binaries
 
-on:
-  push: null
-  pull_request: null
+on: [push, pull_request]
 
 jobs:
   urbit:
@@ -57,7 +55,7 @@ jobs:
 
       - run: nix-build -A urbit --arg enableStatic true
 
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
+      - if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
         run: nix-build -A urbit-tests
 
   haskell:
@@ -81,40 +79,3 @@ jobs:
       - run: nix-build -A hs.urbit-king.components.exes.urbit-king --arg enableStatic true
       - run: nix-build -A hs-checks
       - run: nix-build shell.nix
-
-  upload:
-    needs: [urbit, haskell]
-    strategy:
-      matrix:
-        include:
-          - { os: ubuntu-latest, system: x86_64-linux }
-          - { os: macos-latest, system: x86_64-darwin }
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v8
-        with:
-          name: mars
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          version: '290.0.1'
-          service_account_key: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
-          project_id: ${{ secrets.GCS_PROJECT }}
-          export_default_credentials: true
-
-      - run: nix-build -A tarball
-
-      - name: Run upload to bootstrap.urbit.org
-        run: |
-          version="$(cat ./pkg/urbit/version)"
-          system="$(nix eval --raw '(builtins.currentSystem)')"
-          target="gs://bootstrap.urbit.org/ci/urbit-v${version}-${system}-${GITHUB_SHA:0:9}.tgz"
-
-          gsutil cp -n ./result "$target"
-
-          echo "upload to $target complete."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@
 #
 #   https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 
-name: Build and test urbit binaries
+name: build
 
 on: [push, pull_request]
 
@@ -55,7 +55,7 @@ jobs:
 
       - run: nix-build -A urbit --arg enableStatic true
 
-      - if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
         run: nix-build -A urbit-tests
 
   haskell:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
-on: [release]
+on:
+  release: null
+  push:
+    tags: ['*']
 
 jobs:
   upload:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Upload urbit release tarball
+name: release
 
 on: [release]
 
@@ -27,7 +27,7 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT }}
           export_default_credentials: true
 
-      - run: nix-build -A tarball
+      - run: nix-build -A tarball --arg enableStatic true
 
       - name: Run upload to bootstrap.urbit.org
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Upload urbit release tarball
+
+on: [release]
+
+jobs:
+  upload:
+    strategy:
+      matrix:
+        include:
+          - { os: ubuntu-latest, system: x86_64-linux }
+          - { os: macos-latest, system: x86_64-darwin }
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: mars
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          version: '290.0.1'
+          service_account_key: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
+          project_id: ${{ secrets.GCS_PROJECT }}
+          export_default_credentials: true
+
+      - run: nix-build -A tarball
+
+      - name: Run upload to bootstrap.urbit.org
+        run: |
+          version="$(cat ./pkg/urbit/version)"
+          system="$(nix eval --raw '(builtins.currentSystem)')"
+          target="gs://bootstrap.urbit.org/ci/urbit-v${version}-${system}-${GITHUB_SHA:0:9}.tgz"
+
+          gsutil cp -n ./result "$target"
+
+          echo "upload to $target complete."


### PR DESCRIPTION
* Splits the tarball upload into a separate workflow that is only triggered when any kind of draft/create/update of a release occurs. Currently it just continues to upload an artefact named according to the pattern: `gs://bootstrap.urbit.org/ci/urbit-v${version}-${system}-${GITHUB_SHA:0:9}.tgz` - I assume you'll want this to match the release name?
* The (vere) tests potentially rerun for every push and when any pull request is initiated. I've disabled this behaviour so it'll only occur when a pull request is created/pushed to.