### PR TITLE
lib/hooks: virtualise kick handler to ensure subscription integrity

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -158,6 +158,7 @@
         og   ~(. pull-hook bowl)
         hc   ~(. +> bowl)
         def  ~(. (default-agent this %|) bowl)
+    ::
     ++  on-init
       ^-  [(list card:agent:gall) agent:gall]
       =^  cards  pull-hook
@@ -311,6 +312,7 @@
     --
   |_  =bowl:gall
   +*  og   ~(. pull-hook bowl)
+  ::
   ++  mule-scry
     |=  [ref=* raw=*]
     =/  pax=(unit path)

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -304,33 +304,35 @@
       =.  tracking
         (~(put by tracking) resource ship)
       :_  state
-      ~[(watch-resource resource /)]
+      (watch-resource resource /)
     ::
     ++  remove
       |=  =resource
-      :-  ~[(leave-resource resource)]
+      :-  (leave-resource resource)
       state(tracking (~(del by tracking) resource))
     --
   ::
   ++  leave-resource
     |=  rid=resource
-    ^-  card
-    =/  =ship
-      (~(got by tracking) rid)
+    ^-  (list card)
+    =/  ship=(unit ship)
+      (~(get by tracking) rid)
+    ?~  ship  ~
     =/  =wire
       (make-wire pull+resource+(en-path:resource rid))
-    [%pass wire %agent [ship push-hook-name.config] %leave ~]
+    [%pass wire %agent [u.ship push-hook-name.config] %leave ~]~
 
   ++  watch-resource
     |=  [rid=resource pax=path]
-    ^-  card
-    =/  =ship
-      (~(got by tracking) rid)
+    ^-  (list card)
+    =/  ship=(unit ship)
+      (~(get by tracking) rid)
+    ?~  ship  ~
     =/  =path
       (welp resource+(en-path:resource rid) pax)
     =/  =wire
       (make-wire pull+path)
-    [%pass wire %agent [ship push-hook-name.config] %watch path]
+    [%pass wire %agent [u.ship push-hook-name.config] %watch path]~
   ::
   ++  make-wire
     |=  =wire


### PR DESCRIPTION
- Virtualises the kick handler for the inner door in lib/pull-hook, so
that crashes in the handler do not cause a dangling resource with no
subscription. Additionally, failed kicks now cause the sync to be
dropped into a failed-kicks map in the state, where we attempt to
recover from the failure in the on-load. Unfortunately, we can't catch
blocking scries, so we sanity check the path (if it's a gall scry, ensure
that the ship and case are [our now]:bowl).
- If the %kick handler of the inner-core crashes, then we never get to
resubscribe, thus leaving a dangling entry in the state with no
corresponding subscription. Updates the pull-hook-action pokes to not
crash when given a dangling entry.