### PR TITLE
various: start threads with unit of tuple args

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -728,6 +728,16 @@
     ::
     ++  dy-cage       |=(num=@ud (~(got by rez) num))   ::  known cage
     ++  dy-vase       |=(num=@ud q:(dy-cage num))       ::  known vase
+    ::
+    ++  dy-some
+      |=  src=(list dojo-source)
+      ^-  vase
+      ?~  src   !>(~)
+      %+  slop  !>(~)
+      |-
+      ?~  t.src  (dy-vase p.i.src)
+      (slop (dy-vase p.i.src) $(src t.src))
+    ::
     ++  dy-sore
       |=  src=(list dojo-source)
       ^-  vase
@@ -850,7 +860,7 @@
         [%pass /wool %agent [our.hid %spider] %watch /thread-result/[tid]]
       %-  he-card
       =/  =cage  ::  also sub
-        [%spider-start !>([~ `tid fil (dy-sore src)])]
+        [%spider-start !>([~ `tid fil (dy-some src)])]
       [%pass /wool %agent [our.hid %spider] %poke cage]
     ::
     ++  dy-make                                         ::  build step

--- a/pkg/arvo/app/glob.hoon
+++ b/pkg/arvo/app/glob.hoon
@@ -183,7 +183,7 @@
   ^-  (quip card _this)
   ?:  ?=([%start ~] wire)
     =/  new-tid=@ta  (cat 3 'glob--' (scot %uv eny.bowl))
-    =/  args  [~ `new-tid %glob !>([hash.state ~])]
+    =/  args  [~ `new-tid %glob !>([~ hash.state])]
     =/  action  !>([%unserve-dir serve-path])
     :_  this(glob.state `[%| new-tid])
     :~  (poke-file-server our.bowl %file-server-action action)

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -148,7 +148,7 @@
               [our.bowl %spider]
               %poke
               %spider-start
-              !>([~ `tid thread.observer (slop q.cage.sign !>(~))])
+              !>([~ `tid thread.observer (slop !>(~) q.cage.sign)])
       ==  ==
     ==
   ::

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -290,7 +290,7 @@
   =/  body=json
     (need (de-json:html q.u.body.request.inbound-request))
   =/  input=vase
-    (slop (tube !>(body)) !>(~))
+    (slop !>(~) (tube !>(body)))
   =/  =start-args
     [~ `tid thread input]
   =^  cards  state

--- a/pkg/arvo/ted/build-cast.hoon
+++ b/pkg/arvo/ted/build-cast.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([pax=path ~] arg)
+=+  !<([~ pax=path] arg)
 ?~  bem=(de-beam:format pax)
   (strand-fail:strand %path-not-beam >pax< ~)
 =/  =mars:clay  [i i.t]:?>(?=([@ @ ~] s.u.bem) s.u.bem)

--- a/pkg/arvo/ted/build-file.hoon
+++ b/pkg/arvo/ted/build-file.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([pax=path ~] arg)
+=+  !<([~ pax=path] arg)
 ?^  bem=(de-beam:format pax)
   (build-file:strandio u.bem)
 (strand-fail:strand %path-not-beam >pax< ~)

--- a/pkg/arvo/ted/build-mark.hoon
+++ b/pkg/arvo/ted/build-mark.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([pax=path ~] arg)
+=+  !<([~ pax=path] arg)
 ?~  bem=(de-beam:format pax)
   (strand-fail:strand %path-not-beam >pax< ~)
 =/  =mark  (rear s.u.bem)

--- a/pkg/arvo/ted/diff.hoon
+++ b/pkg/arvo/ted/diff.hoon
@@ -6,7 +6,7 @@
 =/  m  (strand ,vase)
 ^-  form:m
 |^
-=+  !<([=a=path =b=path ~] arg)
+=+  !<([~ =a=path =b=path] arg)
 =/  a-mark=mark  -:(flop a-path)
 =/  b-mark=mark  -:(flop b-path)
 ?.  =(a-mark b-mark)

--- a/pkg/arvo/ted/dns/address.hoon
+++ b/pkg/arvo/ted/dns/address.hoon
@@ -6,7 +6,7 @@
 |^
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<  [adr=address:dns ~]  arg
+=+  !<  [~ adr=address:dns]  arg
 ::
 ;<  our=ship  bind:m  get-our:strandio
 =/  rac  (clan:title our)

--- a/pkg/arvo/ted/glob.hoon
+++ b/pkg/arvo/ted/glob.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([hash=@uv ~] arg)
+=+  !<([~ hash=@uv] arg)
 =/  url  "https://bootstrap.urbit.org/glob-{(scow %uv hash)}.glob"
 ;<  =cord  bind:m  (fetch-cord:strandio url)
 =+  ;;(=glob:glob (cue cord))

--- a/pkg/arvo/ted/graph/create.hoon
+++ b/pkg/arvo/ted/graph/create.hoon
@@ -29,7 +29,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=action:graph-view ~] arg)
+=+  !<([~ =action:graph-view] arg)
 ?>  ?=(%create -.action)
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ::

--- a/pkg/arvo/ted/graph/delete.hoon
+++ b/pkg/arvo/ted/graph/delete.hoon
@@ -57,7 +57,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=action:graph-view ~] arg)
+=+  !<([~ =action:graph-view] arg)
 ?>  ?=(%delete -.action)
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ?.  =(our.bowl entity.rid.action)

--- a/pkg/arvo/ted/graph/groupify.hoon
+++ b/pkg/arvo/ted/graph/groupify.hoon
@@ -43,7 +43,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=action:graph-view ~] arg)
+=+  !<([~ =action:graph-view] arg)
 ?>  ?=(%groupify -.action)
 ;<  =group  bind:m  (scry-group rid.action)
 ?.  hidden.group

--- a/pkg/arvo/ted/graph/join.hoon
+++ b/pkg/arvo/ted/graph/join.hoon
@@ -28,7 +28,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=action:graph-view ~] arg)
+=+  !<([~ =action:graph-view] arg)
 ?>  ?=(%join -.action)
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ?:  =(our.bowl entity.rid.action)

--- a/pkg/arvo/ted/graph/leave.hoon
+++ b/pkg/arvo/ted/graph/leave.hoon
@@ -49,7 +49,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=action:graph-view ~] arg)
+=+  !<([~ =action:graph-view] arg)
 ?>  ?=(%leave -.action)
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ?:  =(our.bowl entity.rid.action)

--- a/pkg/arvo/ted/graph/restore.hoon
+++ b/pkg/arvo/ted/graph/restore.hoon
@@ -12,7 +12,7 @@
 =/  m  (strand ,vase)
 ^-  form:m
 =+  !<
-      [[rid=resource title=@t description=@t group=resource module=@t ~] ~]
+      [~ rid=resource title=@t description=@t group=resource module=@t ~]
     arg
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ::  unarchive graph and share it

--- a/pkg/arvo/ted/hi.hoon
+++ b/pkg/arvo/ted/hi.hoon
@@ -5,7 +5,8 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([who=ship mez=$@(~ [=tape ~])] arg)
-=/  message  ?~(mez '' (crip tape.mez))
+=+  !<([~ arg=$@(who=ship [who=ship mez=tape])] arg)
+=/  [who=ship message=@t]
+  ?@(arg [who.arg ''] [who.arg (crip mez.arg)])
 ;<  ~  bind:m  (poke:strandio [who %hood] %helm-hi !>(message))
 (pure:m !>("hi {<who>} successful"))

--- a/pkg/arvo/ted/invite/accepted-graph.hoon
+++ b/pkg/arvo/ted/invite/accepted-graph.hoon
@@ -10,7 +10,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([=update:inv ~] arg)
+=+  !<([~ =update:inv] arg)
 ?.  ?=(%accepted -.update)
   (pure:m !>(~))
 ;<  =bowl:spider  bind:m  get-bowl:strandio
@@ -21,8 +21,7 @@
 ;<  ~  bind:m
   %+  poke-our  %spider
   =-  spider-start+!>([`tid.bowl ~ %graph-join -])
-  %+  slop
-    !>  ^-  action:graph-view
-    [%join resource.invite ship.invite]
-  !>(~)
+  %+  slop  !>(~)
+  !>  ^-  action:graph-view
+  [%join resource.invite ship.invite]
 (pure:m !>(~))

--- a/pkg/arvo/ted/migrate-channels.hoon
+++ b/pkg/arvo/ted/migrate-channels.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=/  [og-path=path ng-path=path ~]  !<([path path ~] arg)
+=/  [~ og-path=path ng-path=path]  !<([~ path path] arg)
 ;<  bol=bowl:spider  bind:m  get-bowl:strandio
 |^
 ::

--- a/pkg/arvo/ted/read.hoon
+++ b/pkg/arvo/ted/read.hoon
@@ -7,7 +7,7 @@
 ^-  form:m
 ::  Parse arguments as ship, desk, and path
 ::
-=+  !<([=care:clay =ship =desk =case =target=path ~] arg)
+=+  !<([~ =care:clay =ship =desk =case =target=path] arg)
 ::  Read the file, possibly asyncrhonously
 ::
 ;<  =bowl:spider  bind:m  get-bowl:strandio

--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -104,8 +104,10 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
+=/  paz=(list path)
+  (tail !<([~ (list path)] arg))
 =/  bez=(list beam)
-  (turn !<((list path) arg) |=(p=path (need (de-beam:format p))))
+  (turn paz |=(p=path (need (de-beam:format p))))
 ;<  fiz=(set [=beam test=(unit term)])  bind:m  (find-test-files bez)
 =>  .(fiz (sort ~(tap in fiz) aor))
 =|  test-arms=(map path (list test-arm))

--- a/pkg/arvo/ted/time.hoon
+++ b/pkg/arvo/ted/time.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([arg=@dr ~] arg)
+=+  !<([~ arg=@dr] arg)
 ;<  now-1=@da  bind:m  get-time:strandio
 ;<  ~          bind:m  (sleep:strandio arg)
 ;<  now-2=@da  bind:m  get-time:strandio

--- a/pkg/arvo/ted/tree.hoon
+++ b/pkg/arvo/ted/tree.hoon
@@ -5,7 +5,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([pax=path ~] arg)
+=+  !<([~ pax=path] arg)
 ;<  bek=beak  bind:m  get-beak:strandio
 ;<  paz=(list path)  bind:m  (list-tree:strandio bek (flop pax))
 (pure:m !>(paz))


### PR DESCRIPTION
As suggested in https://github.com/urbit/urbit/pull/3738#issuecomment-713031839.

Instead of a list of arguments with trailing `~`, dojo now passes threads and generators a a tuple of the arguments. If no arguments are given, still passes `~`. We update the generaters/threads themselves, and all other callsites, to match.

Notable changes include:
- In the `path` argument case, we can no longer distinguish between no arguments and `/` (without adding additional clarification, like `unit` or explicit trailing `~`).  This currently affects the pill generators and `|init-oauth2`, but the `/` case wasn't reasonable for those anyway.
- Similarly, the atom argument case is affected, making it harder to distinguish between no arguments and `0`. For `:dns|request` and `|moon` this doesn't matter. `|trim` can no longer send a `%trim` with priority 0, but arguably only the system should be able to send that anyway?
- Optional arguments in some cases lead to type errors. In `|mount`'s case, `?(path [path @tas])` is a `fish-loop`. We're forced to move the optional mount point name into the named arguments section.
- Threads and generators that take lists of arguments, like `+cat` and `-test`, now require  an explicit trailing `~` when called.

I didn't test _all_ of these, but I made sure to hit the non-trivial cases at least.