### PR TITLE
chat-fe: autodismiss mentions whilst in channel

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -182,6 +182,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     if (this.props.unreadCount === 0) return;
     this.props.api.chat.read(this.props.station);
     this.props.api.hark.readIndex({ chat: { chat: this.props.station, mention: false }});
+    this.props.api.hark.readIndex({ chat: { chat: this.props.station, mention: true }});
   }
 
   fetchMessages(start, end, force = false): Promise<void> {


### PR DESCRIPTION
Automatically dismiss relevant mentions when a chat is marked as read

Fixes: #3977 