### PR TITLE
aqua: rework how it uses azimuth

### DIFF
--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -21,11 +21,15 @@
 ::  We get ++unix-event and ++pill from /-aquarium
 ::
 /-  aquarium
-/+  pill, default-agent
+/+  pill, default-agent, aqua-azimuth, dbug, verb
 =,  pill-lib=pill
 =,  aquarium
 =>  $~  |%
-    +$  state
+    +$  versioned-state
+      $%  state-0
+          state-1
+      ==
+    +$  state-0
       $:  %0
           pil=pill
           assembled=*
@@ -33,7 +37,16 @@
           fleet-snaps=(map term (map ship pier))
           piers=(map ship pier)
       ==
+    +$  state-1
+      $:  %1
+          pil=pill
+          assembled=*
+          tym=@da
+          fleet-snaps=(map term fleet)
+          piers=fleet
+      ==
     ::
+    +$  fleet  [ships=(map ship pier) azi=az-state]
     +$  pier
       $:  snap=*
           event-log=(list unix-timed-event)
@@ -42,9 +55,11 @@
       ==
     --
 ::
-=|  state
-=*  all-state  -
+=|  state-1
+=*  state  -
 =<
+  %-  agent:dbug
+  %+  verb  |
   ^-  agent:gall
   |_  =bowl:gall
   +*  this       .
@@ -52,24 +67,37 @@
       ac         ~(. aqua-core bowl)
       def        ~(. (default-agent this %|) bowl)
   ++  on-init           `this
-  ++  on-save  !>(all-state)
+  ++  on-save  !>(state)
   ++  on-load
-    |=  old-state=vase
+    |=  old-vase=vase
     ^-  step:agent:gall
     ~&  prep=%aqua
-    =+  new=((soft state) !<(* old-state))
-    ?~  new
-      `this
-    `this(all-state u.new)
+    =+  !<(old=versioned-state old-vase)
+    =|  cards=(list card:agent:gall)
+    |-
+    ?-  -.old
+    ::  wipe fleets and piers rather than give them falsely nulled azimuth state
+    ::
+        %0
+      %_  $
+        -.old            %1
+        fleet-snaps.old  *(map term fleet)
+        piers.old        *fleet
+      ==
+    ::
+        %1
+      [cards this(state old)]
+    ==
   ::
   ++  on-poke
     |=  [=mark =vase]
     ^-  step:agent:gall
-    =^  cards  all-state
+    =^  cards  state
       ?+  mark  ~|([%aqua-bad-mark mark] !!)
-          %aqua-events  (poke-aqua-events:ac !<((list aqua-event) vase))
-          %pill         (poke-pill:ac !<(pill vase))
-          %noun         (poke-noun:ac !<(* vase))
+          %aqua-events     (poke-aqua-events:ac !<((list aqua-event) vase))
+          %pill            (poke-pill:ac !<(pill vase))
+          %noun            (poke-noun:ac !<(* vase))
+          %azimuth-action  (poke-azimuth-action:ac !<(azimuth-action vase))
       ==
     [cards this]
   ::
@@ -92,7 +120,18 @@
   ++  on-peek   peek:ac
   ::
   ++  on-agent  on-agent:def
-  ++  on-arvo   on-arvo:def
+  ::
+  ++  on-arvo
+    |=  [=wire sign=sign-arvo]
+    ^-  step:agent:gall
+    ?+  wire  (on-arvo:def wire sign)
+        [%wait @ ~]
+      ?>  ?=(%wake +<.sign)
+      =/  wen=@da  (slav %da i.t.wire)
+      =^  cards  state
+        (handle-wake:ac wen)
+      [cards this]
+    ==
   ++  on-fail   on-fail:def
   --
 ::
@@ -110,7 +149,7 @@
 ::
 ++  pe
   |=  who=ship
-  =+  (~(gut by piers) who *pier)
+  =+  (~(gut by ships.piers) who *pier)
   =*  pier-data  -
   |%
   ::
@@ -118,7 +157,7 @@
   ::
   ++  abet-pe
     ^+  this
-    =.  piers  (~(put by piers) who pier-data)
+    =.  ships.piers  (~(put by ships.piers) who pier-data)
     this
   ::
   ::  Initialize new ship
@@ -248,7 +287,19 @@
   this
 ::
 ++  abet-aqua
-  ^-  (quip card:agent:gall state)
+  ^-  (quip card:agent:gall _state)
+  ::
+  ::  interecept %request effects to handle azimuth subscription
+  ::
+  =.  this
+    %-  emit-cards
+    %-  zing
+    %+  turn  ~(tap by unix-effects)
+    |=  [=ship ufs=(list unix-effect)]
+    %+  murn  ufs
+    |=  uf=unix-effect
+    (router:aqua-azimuth our.hid ship uf azi.piers)
+  ::
   =.  this
     =/  =path  /effect
     %-  emit-cards
@@ -300,20 +351,19 @@
     =/  =path  /boths/(scot %p ship)
     [%give %fact ~[path] %aqua-boths !>(`aqua-boths`[ship (flop bo)])]
   ::
-  [(flop cards) all-state]
+  [(flop cards) state]
 ::
 ++  emit-cards
   |=  ms=(list card:agent:gall)
   =.  cards  (weld ms cards)
   this
 ::
-::
 ::  Run all events on all ships until all queues are empty
 ::
 ++  plow-all
   |-  ^+  this
   =/  who
-    =/  pers  ~(tap by piers)
+    =/  pers  ~(tap by ships.piers)
     |-  ^-  (unit ship)
     ?~  pers
       ~
@@ -331,7 +381,7 @@
 ::
 ++  poke-pill
   |=  p=pill
-  ^-  (quip card:agent:gall state)
+  ^-  (quip card:agent:gall _state)
   =.  this  apex-aqua  =<  abet-aqua
   =.  pil  p
   ~&  lent=(met 3 (jam boot-ova.pil))
@@ -362,7 +412,7 @@
 ::
 ++  poke-noun
   |=  val=*
-  ^-  (quip card:agent:gall state)
+  ^-  (quip card:agent:gall _state)
   =.  this  apex-aqua  =<  abet-aqua
   ^+  this
   ::  Could potentially factor out the three lines of turn-ships
@@ -391,7 +441,7 @@
       =/  txt  .^(@ %cx (weld pax /hoon))
       [/vane/[vane] [%veer v pax txt]]
     =>  .(this ^+(this this))
-    =^  ms  all-state  (poke-pill pil)
+    =^  ms  state  (poke-pill pil)
     (emit-cards ms)
   ::
       [%swap-files ~]
@@ -402,7 +452,7 @@
       %-  unix-event
       %-  %*(. file-ovum:pill-lib directories slim-dirs)
       /(scot %p our.hid)/work/(scot %da now.hid)
-    =^  ms  all-state  (poke-pill pil)
+    =^  ms  state  (poke-pill pil)
     (emit-cards ms)
   ::
       [%wish hers=* p=@t]
@@ -412,12 +462,14 @@
     (wish:(pe who) p.val)
   ::
       [%unpause-events hers=*]
+    =.  this  start-azimuth-timer
     %+  turn-ships  ((list ship) hers.val)
     |=  [who=ship thus=_this]
     =.  this  thus
     start-processing-events:(pe who)
   ::
       [%pause-events hers=*]
+    =.  this  stop-azimuth-timer
     %+  turn-ships  ((list ship) hers.val)
     |=  [who=ship thus=_this]
     =.  this  thus
@@ -428,17 +480,47 @@
     this
   ==
 ::
+::  Make changes to azimuth state for the current fleet
+::
+++  poke-azimuth-action
+  |=  act=azimuth-action
+  ^-  (quip card:agent:gall _state)
+  =.  this  apex-aqua  =<  abet-aqua
+  ^+  this
+  ?-  -.act
+  ::
+      %init-azimuth
+    =.  azi.piers  *az-state
+    start-azimuth-timer
+  ::
+      %spawn
+    =.  state  (spawn who.act)
+    this
+  ::
+      %breach
+    ::  should we remove the pier from state here?
+    =.  state  (breach who.act)
+    this
+  ::
+  ==
+::
 ::  Apply a list of events tagged by ship
 ::
 ++  poke-aqua-events
   |=  events=(list aqua-event)
-  ^-  (quip card:agent:gall state)
+  ^-  (quip card:agent:gall _state)
   =.  this  apex-aqua  =<  abet-aqua
   %+  turn-events  events
   |=  [ae=aqua-event thus=_this]
   =.  this  thus
   ?-  -.ae
+  ::
       %init-ship
+    ::  XX  Note that the keys that get passed in are unused. The keys field
+    ::      should be deleted now that aqua is capable of managing azimuth state
+    ::      internally. Its been left this way for now until all the ph tests
+    ::      can be rewritten
+    =/  keys=dawn-event:able:jael  (dawn who.ae)
     =.  this  abet-pe:(publish-effect:(pe who.ae) [/ %sleep ~])
     =/  initted
       =<  plow
@@ -451,7 +533,7 @@
           :^  //term/1  %boot  &
           ?~  keys.ae
             [%fake who.ae]
-          [%dawn u.keys.ae]
+          [%dawn keys]
           -.userspace-ova.pil
           [//http-client/0v1n.2m9vh %born ~]
           [//http-server/0v1n.2m9vh %born ~]
@@ -464,27 +546,36 @@
     stop-processing-events:(pe who.ae)
   ::
       %snap-ships
+    =.  this
+      %+  turn-ships  (turn ~(tap by ships.piers) head)
+      |=  [who=ship thus=_this]
+      =.  this  thus
+      (publish-effect:(pe who) [/ %kill ~])
     =.  fleet-snaps
       %+  ~(put by fleet-snaps)  lab.ae
+      :_  azi.piers
       %-  malt
       %+  murn  hers.ae
       |=  her=ship
       ^-  (unit (pair ship pier))
-      =+  per=(~(get by piers) her)
+      =+  per=(~(get by ships.piers) her)
       ?~  per
         ~
       `[her u.per]
+    =.  this   stop-azimuth-timer
+    =.  piers  *fleet
     (pe -.hers.ae)
   ::
       %restore-snap
     =.  this
-      %+  turn-ships  (turn ~(tap by piers) head)
+      %+  turn-ships  (turn ~(tap by ships.piers) head)
       |=  [who=ship thus=_this]
       =.  this  thus
-      (publish-effect:(pe who) [/ %sleep ~])
-    =.  piers  (~(uni by piers) (~(got by fleet-snaps) lab.ae))
+      (publish-effect:(pe who) [/ %kill ~])
+    =.  piers  (~(got by fleet-snaps) lab.ae)
+    =.  this   start-azimuth-timer
     =.  this
-      %+  turn-ships  (turn ~(tap by piers) head)
+      %+  turn-ships  (turn ~(tap by ships.piers) head)
       |=  [who=ship thus=_this]
       =.  this  thus
       (publish-effect:(pe who) [/ %restore ~])
@@ -537,18 +628,163 @@
   ^-  (unit (unit cage))
   ?+  path  ~
       [%x %fleet-snap @ ~]  ``noun+!>((~(has by fleet-snaps) i.t.t.path))
-      [%x %ships ~]         ``noun+!>((turn ~(tap by piers) head))
+      [%x %fleets ~]        ``noun+!>((turn ~(tap by fleet-snaps) head))
+      [%x %ships ~]         ``noun+!>((turn ~(tap by ships.piers) head))
       [%x %pill ~]          ``pill+!>(pil)
       [%x %i @ @ @ @ @ *]
     =/  who  (slav %p i.t.t.path)
-    =/  pier  (~(get by piers) who)
+    =/  pier  (~(get by ships.piers) who)
     ?~  pier
       ~
     :^  ~  ~  %noun  !>
     (peek:(pe who) t.t.t.path)
+      [%x %log-info ~]
+    ``noun+!>([lives.azi.piers (lent logs.azi.piers) tym.azi.piers])
   ==
 ::
 ::  Trivial scry for mock
 ::
 ++  scry  |=([* *] ~)
+::
+++  handle-wake
+  |=  wen=@da
+  ^-  (quip card:agent:gall _state)
+  =.  this  apex-aqua  =<  abet-aqua
+  ?.  =(wen tym.azi.piers)
+    this
+  =.  state  (spam-logs 10)
+  start-azimuth-timer
+::
+++  start-azimuth-timer
+  ^+  this
+  =?  this  !=(tym.azi.piers *@da)
+    stop-azimuth-timer
+  =/  until=@da  (add now.hid ~s40)
+  =.  tym.azi.piers  until
+  %-  emit-cards
+  [%pass /wait/(scot %da until) %arvo %b %wait until]~
+::
+++  stop-azimuth-timer
+  ^+  this
+  =*  tym  tym.azi.piers
+  ?:  =(tym *@da)
+    this
+  %-  emit-cards
+  [%pass /wait/(scot %da tym) %arvo %b %rest tym]~
+::
+++  spam-logs
+  |=  n=@
+  ^-  _state
+  =*  loop  $
+  ?:  =(n 0)
+    state
+  =/  new-state=_state
+    ?.  (~(has by lives.azi.piers) ~fes)
+      (spawn ~fes)
+    (cycle-keys ~fes)
+  =.  state  new-state
+  loop(n (dec n))
+::
+++  spawn
+  |=  who=@p
+  ^-  _state
+  ?<  (~(has by lives.azi.piers) who)
+  =.  lives.azi.piers  (~(put by lives.azi.piers) who [1 0])
+  =.  logs.azi.piers
+    %+  weld  logs.azi.piers
+    :_  ~
+    %-  changed-keys:lo:aqua-azimuth
+    :*  who
+        (get-public:aqua-azimuth who 1 %crypt)
+        (get-public:aqua-azimuth who 1 %auth)
+        1
+        1
+    ==
+  (spam-logs 10)
+::
+++  cycle-keys
+  |=  who=@p
+  ^-  _state
+  =/  prev
+    ~|  no-such-ship+who
+    (~(got by lives.azi.piers) who)
+  =/  lyfe  +(lyfe.prev)
+  =.  lives.azi.piers  (~(put by lives.azi.piers) who [lyfe rut.prev])
+  =.  logs.azi.piers
+    %+  weld  logs.azi.piers
+    :_  ~
+    %-  changed-keys:lo:aqua-azimuth
+    :*  who
+        (get-public:aqua-azimuth who lyfe %crypt)
+        (get-public:aqua-azimuth who lyfe %auth)
+        1
+        lyfe
+    ==
+  state
+::
+++  breach
+  |=  who=@p
+  ^-  _state
+  =.  state  (cycle-keys who)
+  =/  prev   (~(got by lives.azi.piers) who)
+  =/  rut  +(rut.prev)
+  =.  lives.azi.piers  (~(put by lives.azi.piers) who [lyfe.prev rut])
+  =.  logs.azi.piers
+    %+  weld  logs.azi.piers
+    [(broke-continuity:lo:aqua-azimuth who rut) ~]
+  (spam-logs 10)
+::
+++  dawn
+  |=  who=ship
+  ^-  dawn-event:able:jael
+  ?>  ?=(?(%czar %king %duke) (clan:title who))
+  =/  spon=(list [ship point:azimuth])
+    %-  flop
+    |-  ^-  (list [ship point:azimuth])
+    =/  =ship  (^sein:title who)
+    =/  a-point=[^ship point:azimuth]
+      =/  spon-spon  [& (^sein:title ship)]
+      =/  life-rift  ~|([ship lives.azi.piers] (~(got by lives.azi.piers) ship))
+      =/  =life  lyfe.life-rift
+      =/  =rift  rut.life-rift
+      =/  =pass
+        %^    pass-from-eth:azimuth
+            (as-octs:mimes:html (get-public:aqua-azimuth ship life %crypt))
+          (as-octs:mimes:html (get-public:aqua-azimuth ship life %auth))
+        1
+      :^    ship
+          *[address address address address]:azimuth
+        `[life=life pass rift spon-spon ~]
+      ~
+    ?:  ?=(%czar (clan:title ship))
+      [a-point]~
+    [a-point $(who ship)]
+  =/  =seed:able:jael
+    =/  life-rift  (~(got by lives.azi.piers) who)
+    =/  =life  lyfe.life-rift
+    [who life sec:ex:(get-keys:aqua-azimuth who life) ~]
+  :*  seed
+      spon
+      get-czars
+      ~[~['arvo' 'netw' 'ork']]
+      0
+      `(need (de-purl:html 'http://localhost:8545'))
+  ==
+::
+::  Should only do galaxies
+::
+++  get-czars
+  ^-  (map ship [rift life pass])
+  %-  malt
+  %+  murn
+    ~(tap by lives.azi.piers)
+  |=  [who=ship lyfe=life rut=rift]
+  ?.  =(%czar (clan:title who))
+    ~
+  %-  some
+  :^  who  rut  lyfe
+  %^    pass-from-eth:azimuth
+      (as-octs:mimes:html (get-public:aqua-azimuth who lyfe %crypt))
+    (as-octs:mimes:html (get-public:aqua-azimuth who lyfe %auth))
+  1
 --

--- a/pkg/arvo/gen/aqua/breach.hoon
+++ b/pkg/arvo/gen/aqua/breach.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  [* [her=ship ~] ~]
+:-  %azimuth-action
+[%breach her]

--- a/pkg/arvo/gen/aqua/init-azimuth.hoon
+++ b/pkg/arvo/gen/aqua/init-azimuth.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  [* ~ ~]
+:-  %azimuth-action
+[%init-azimuth ~]

--- a/pkg/arvo/gen/aqua/init.hoon
+++ b/pkg/arvo/gen/aqua/init.hoon
@@ -3,4 +3,4 @@
 :-  %say
 |=  [* [her=ship ~] ~]
 :-  %aqua-events
-[%init-ship her ~]~
+[%init-ship her `*dawn-event:able:jael]~

--- a/pkg/arvo/gen/aqua/restore-fleet.hoon
+++ b/pkg/arvo/gen/aqua/restore-fleet.hoon
@@ -1,6 +1,6 @@
 /-  aquarium
 =,  aquarium
 :-  %say
-|=  [* [label=@ta] ~]
+|=  [* [label=@ta ~] ~]
 :-  %aqua-events
-[%snap-ships label]~
+[%restore-snap label]~

--- a/pkg/arvo/gen/aqua/snap-fleet.hoon
+++ b/pkg/arvo/gen/aqua/snap-fleet.hoon
@@ -1,7 +1,7 @@
 /-  aquarium
 =,  aquarium
 :-  %say
-|=  [[now=@da eny=@uvJ bec=beak] [label=@ta] ships=(list ship)]
+|=  [[now=@da eny=@uvJ bec=beak] [label=@ta ships=(list ship)] ~]
 :-  %aqua-events
 =?  ships  ?=(~ ships)
   .^((list ship) %gx /(scot %p p.bec)/aqua/(scot %da now)/ships/noun)

--- a/pkg/arvo/gen/aqua/spawn.hoon
+++ b/pkg/arvo/gen/aqua/spawn.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  [* [her=ship ~] ~]
+:-  %azimuth-action
+[%spawn her]

--- a/pkg/arvo/lib/aqua-azimuth.hoon
+++ b/pkg/arvo/lib/aqua-azimuth.hoon
@@ -1,0 +1,241 @@
+/-  *aquarium
+::
+|%
+::
+++  extract-request
+  |=  [uf=unix-effect dest=@t]
+  ^-  (unit [num=@ud =request:http])
+  ?.  ?=(%request -.q.uf)  ~
+  ?.  =(dest url.request.q.uf)  ~
+  `[id.q.uf request.q.uf]
+::
+++  router
+  |=  [our=ship her=ship uf=unix-effect azi=az-state]
+  ^-  (unit card:agent:gall)
+  =,  enjs:format
+  =/  ask  (extract-request uf 'http://localhost:8545/')
+  ?~  ask
+    ~
+  ?~  body.request.u.ask
+    ~
+  =/  req  q.u.body.request.u.ask
+  |^  ^-  (unit card:agent:gall)
+  =/  method  (get-method req)
+  ?:  =(method 'eth_blockNumber')
+    :-  ~
+    %+  answer-request  req
+    s+(crip (num-to-hex:ethereum latest-block))
+  ?:  =(method 'eth_getBlockByNumber')
+    :-  ~
+    %+  answer-request  req
+    :-  %o
+    =/  number  (hex-to-num:ethereum (get-first-param req))
+    =/  hash  (number-to-hash number)
+    =/  parent-hash  (number-to-hash ?~(number number (dec number)))
+    %-  malt
+    ^-  (list (pair term json))
+    :~  hash+s+(crip (prefix-hex:ethereum (render-hex-bytes:ethereum 32 hash)))
+        number+s+(crip (num-to-hex:ethereum number))
+        'parentHash'^s+(crip (num-to-hex:ethereum parent-hash))
+    ==
+  ?:  =(method 'eth_getLogs')
+    :-  ~
+    %+  answer-request  req
+    ?^  (get-param-obj-maybe req 'blockHash')
+      %-  logs-by-hash
+      (get-param-obj req 'blockHash')
+    %+  logs-by-range
+      (get-param-obj req 'fromBlock')
+    (get-param-obj req 'toBlock')
+  ~&  [%ph-azimuth-miss req]
+  ~
+  ::
+  ++  latest-block
+    (add launch:contracts:azimuth (dec (lent logs.azi)))
+  ::
+  ++  get-single-req
+    |=  req=@t
+    =/  batch
+      ((ar:dejs:format same) (need (de-json:html req)))
+    ?>  ?=([* ~] batch)
+    i.batch
+  ::
+  ++  get-id
+    |=  req=@t
+    =,  dejs:format
+    %.  (get-single-req req)
+    (ot id+so ~)
+  ::
+  ++  get-method
+    |=  req=@t
+    =,  dejs:format
+    ~|  req=req
+    %.  (get-single-req req)
+    (ot method+so ~)
+  ::
+  ++  get-param-obj
+    |=  [req=@t param=@t]
+    =,  dejs:format
+    %-  hex-to-num:ethereum
+    =/  array
+      %.  (get-single-req req)
+      (ot params+(ar (ot param^so ~)) ~)
+    ?>  ?=([* ~] array)
+    i.array
+  ::
+  ++  get-param-obj-maybe
+    |=  [req=@t param=@t]
+    ^-  (unit @ud)
+    =,  dejs-soft:format
+    =/  array
+      %.  (get-single-req req)
+      (ot params+(ar (ot param^so ~)) ~)
+    ?~  array
+      ~
+    :-  ~
+    ?>  ?=([* ~] u.array)
+    %-  hex-to-num:ethereum
+    i.u.array
+  ::
+  ++  get-first-param
+    |=  req=@t
+    =,  dejs:format
+    =/  id
+      %.  (get-single-req req)
+      (ot params+(at so bo ~) ~)
+    -.id
+  ::
+  ++  answer-request
+    |=  [req=@t result=json]
+    ^-  card:agent:gall
+    =/  resp
+      %-  crip
+      %-  en-json:html
+      :-  %a  :_  ~
+      %-  pairs
+      :~  id+s+(get-id req)
+          jsonrpc+s+'2.0'
+          result+result
+      ==
+    =/  events=(list aqua-event)
+      :_  ~
+      :*  %event
+          her
+          //http-client/0v1n.2m9vh
+          %receive
+          num.u.ask
+          [%start [200 ~] `(as-octs:mimes:html resp) &]
+      ==
+    :*  %pass  /aqua-events
+        %agent  [our %aqua]
+        %poke  %aqua-events
+        !>(events)
+    ==
+  ::
+  ++  number-to-hash
+    |=  =number:block:able:jael
+    ^-  @
+    ?:  (lth number launch:contracts:azimuth)
+      (cat 3 0x5364 (sub launch:contracts:azimuth number))
+    (cat 3 0x5363 (sub number launch:contracts:azimuth))
+  ::
+  ++  hash-to-number
+    |=  =hash:block:able:jael
+    (add launch:contracts:azimuth (div hash 0x1.0000))
+  ::
+  ++  logs-by-range
+    |=  [from-block=@ud to-block=@ud]
+    %+  logs-to-json  (max launch:contracts:azimuth from-block)
+    ?:  (lth to-block launch:contracts:azimuth)
+      ~
+    %+  swag
+      ?:  (lth from-block launch:contracts:azimuth)
+         [0 +((sub to-block launch:contracts:azimuth))]
+      :-  (sub from-block launch:contracts:azimuth)
+      +((sub to-block from-block))
+    logs.azi
+  ::
+  ++  logs-by-hash
+    |=  =hash:block:able:jael
+    =/  =number:block:able:jael  (hash-to-number hash)
+    (logs-by-range number number)
+  ::
+  ++  logs-to-json
+    |=  [count=@ud selected-logs=(list az-log)]
+    ^-  json
+    :-  %a
+    |-  ^-  (list json)
+    ?~  selected-logs
+      ~
+    :_  $(selected-logs t.selected-logs, count +(count))
+    %-  pairs
+    :~  'logIndex'^s+'0x0'
+        'transactionIndex'^s+'0x0'
+        :+  'transactionHash'  %s
+        (crip (prefix-hex:ethereum (render-hex-bytes:ethereum 32 `@`0x5362)))
+      ::
+        :+  'blockHash'  %s
+        =/  hash  (number-to-hash count)
+        (crip (prefix-hex:ethereum (render-hex-bytes:ethereum 32 hash)))
+      ::
+        :+  'blockNumber'  %s
+        (crip (num-to-hex:ethereum count))
+      ::
+        :+  'address'  %s
+        (crip (address-to-hex:ethereum azimuth:contracts:azimuth))
+      ::
+        'type'^s+'mined'
+      ::
+        'data'^s+data.i.selected-logs
+        :+  'topics'  %a
+        %+  turn  topics.i.selected-logs
+        |=  topic=@ux
+        ^-  json
+        :-  %s
+        %-  crip
+        %-  prefix-hex:ethereum
+        (render-hex-bytes:ethereum 32 `@`topic)
+    ==
+  --
+::
+++  get-keys
+  |=  [who=@p lyfe=life]
+  ^-  acru:ames
+  %+  pit:nu:crub:crypto  32
+  (can 5 [1 (scot %p who)] [1 (scot %ud lyfe)] ~)
+::
+++  get-public
+  |=  [who=@p lyfe=life typ=?(%auth %crypt)]
+  =/  bod  (rsh 3 1 pub:ex:(get-keys who lyfe))
+  =+  [enc=(rsh 8 1 bod) aut=(end 8 1 bod)]
+  ?:  =(%auth typ)
+    aut
+  enc
+::
+::  Generate logs
+::
+++  lo
+  =,  azimuth-events:azimuth
+  |%
+  ++  broke-continuity
+    |=  [who=ship rut=rift]
+    ^-  az-log
+    :-  ~[^broke-continuity who]
+    %-  crip
+    %-  prefix-hex:ethereum
+    (render-hex-bytes:ethereum 32 `@`rut)
+  ::
+  ++  changed-keys
+    |=  [who=ship enc=@ux aut=@ux crypto=@ud lyfe=life]
+    ^-  az-log
+    :-  ~[^changed-keys who]
+    %-  crip
+    %-  prefix-hex:ethereum
+    ;:  welp
+        (render-hex-bytes:ethereum 32 `@`enc)
+        (render-hex-bytes:ethereum 32 `@`aut)
+        (render-hex-bytes:ethereum 32 `@`crypto)
+        (render-hex-bytes:ethereum 32 `@`lyfe)
+    ==
+  --
+--

--- a/pkg/arvo/lib/ph/io.hoon
+++ b/pkg/arvo/lib/ph/io.hoon
@@ -8,6 +8,12 @@
   ^-  form:m
   (poke-our %aqua %aqua-events !>(events))
 ::
+++  send-azimuth-action
+  |=  =azimuth-action
+  =/  m  (strand ,~)
+  ^-  form:m
+  (poke-our %aqua %azimuth-action !>(azimuth-action))
+::
 ++  take-unix-effect
   =/  m  (strand ,[ship unix-effect])
   ^-  form:m
@@ -34,7 +40,7 @@
   =/  m  (strand ,~)
   ^-  form:m
   ~&  >  "starting"
-  ;<  ~  bind:m  (start-threads vane-threads)
+  ;<  tids=(map term tid:spider)  bind:m  (start-threads vane-threads)
   ;<  ~  bind:m  (watch-our /effect %aqua /effect)
   ::  Get our very own event with no mistakes in it... yet.
   ::
@@ -64,22 +70,49 @@
 ::
 ++  start-threads
   |=  threads=(list term)
-  =/  m  (strand ,~)
+  =/  m  (strand ,(map term tid:spider))
   ^-  form:m
   ;<  =bowl:spider  bind:m  get-bowl
+  =|  tids=(map term tid:spider)
   |-  ^-  form:m
   =*  loop  $
   ?~  threads
-    (pure:m ~)
+    (pure:m tids)
+  =/  tid
+    %+  scot  %ta
+    (cat 3 (cat 3 'strand_' i.threads) (scot %uv (sham i.threads eny.bowl)))
   =/  poke-vase  !>([`tid.bowl ~ i.threads *vase])
   ;<  ~  bind:m  (poke-our %spider %spider-start poke-vase)
-  loop(threads t.threads)
+  loop(threads t.threads, tids (~(put by tids) i.threads tid))
 ::
 ++  stop-threads
   |=  threads=(list term)
   =/  m  (strand ,~)
   ^-  form:m
   (pure:m ~)
+::
+::  XX  +spawn-aqua and +breach-aqua mean do these actions using aqua's internal
+::      azimuth management system, eventually these should just replace +spawn
+::      +breach
+::
+++  init-azimuth
+  =/  m  (strand ,~)
+  ^-  form:m
+  (send-azimuth-action %init-azimuth ~)
+::
+++  spawn-aqua
+  |=  =ship
+  ~&  >  "spawning {<ship>}"
+  =/  m  (strand ,~)
+  ^-  form:m
+  (send-azimuth-action %spawn ship)
+::
+++  breach-aqua
+  |=  =ship
+  ~&  >  "breaching {<ship>}"
+  =/  m  (strand ,~)
+  ^-  form:m
+  (send-azimuth-action %breach ship)
 ::
 ++  spawn
   |=  [=tid:spider =ship]
@@ -126,6 +159,39 @@
   ?:  =([~ new-rut] rut)
     (pure:m ~)
   loop
+::
+++  breach-and-hear-aqua
+  |=  [who=ship her=ship]
+  =/  m  (strand ,~)
+  ;<  =bowl:spider  bind:m  get-bowl
+  =/  aqua-pax
+    :-  %i
+    /(scot %p her)/j/(scot %p her)/rift/(scot %da now.bowl)/(scot %p who)/noun
+  =/  old-rut  ;;((unit @) (scry-aqua:util noun our.bowl now.bowl aqua-pax))
+  =/  new-rut
+    ?~  old-rut
+      1
+    +(+.old-rut)
+  ;<  ~  bind:m  (send-azimuth-action %breach who)
+  |-  ^-  form:m
+  =*  loop  $
+  ;<  ~  bind:m  (sleep ~s1)
+  ;<  =bowl:spider  bind:m  get-bowl
+  =/  aqua-pax
+    :-  %i
+    /(scot %p her)/j/(scot %p her)/rift/(scot %da now.bowl)/(scot %p who)/noun
+  =/  rut  (scry-aqua:util noun our.bowl now.bowl aqua-pax)
+  ?:  =([~ new-rut] rut)
+    (pure:m ~)
+  loop
+::
+++  init-ship
+  |=  =ship
+  =/  m  (strand ,~)
+  ^-  form:m
+  ~&  >  "starting {<ship>}"
+  ;<  ~  bind:m  (send-events (init:util ship `*dawn-event:able:jael))
+  (check-ship-booted ship)
 ::
 ++  real-ship
   |=  [=tid:spider =ship]

--- a/pkg/arvo/lib/strandio.hoon
+++ b/pkg/arvo/lib/strandio.hoon
@@ -654,7 +654,8 @@
   =/  m  (strand ,tid:spider)
   ^-  form:m
   ;<  =bowl:spider  bind:m  get-bowl
-  =/  tid  (scot %ta (cat 3 'strand_' (scot %uv (sham file eny.bowl))))
+  =/  tid
+    (scot %ta (cat 3 (cat 3 'strand_' file) (scot %uv (sham file eny.bowl))))
   =/  poke-vase  !>([`tid.bowl `tid file *vase])
   ;<  ~  bind:m  (poke-our %spider %spider-start poke-vase)
   ;<  ~  bind:m  (sleep ~s0)  ::  wait for thread to start

--- a/pkg/arvo/sur/aquarium.hoon
+++ b/pkg/arvo/sur/aquarium.hoon
@@ -13,6 +13,12 @@
 /+  pill
 =,  pill-lib=pill
 |%
++$  az-log  [topics=(lest @) data=@t]
++$  az-state
+  $:  logs=(list az-log)
+      lives=(map ship [lyfe=life rut=rift])
+      tym=@da
+  ==
 ++  ph-event
   $%  [%test-done p=?]
       aqua-event
@@ -27,6 +33,12 @@
       [%snap-ships lab=term hers=(list ship)]
       [%restore-snap lab=term]
       [%event who=ship ue=unix-event]
+  ==
+::
++$  azimuth-action
+  $%  [%init-azimuth ~]
+      [%spawn who=ship]
+      [%breach who=ship]
   ==
 ::
 +$  aqua-effects
@@ -57,6 +69,7 @@
       [%ergo p=@tas q=mode:clay]
       [%sleep ~]
       [%restore ~]
+      [%kill ~]
       [%init ~]
       [%request id=@ud request=request:http]
   ==

--- a/pkg/arvo/ted/aqua/behn.hoon
+++ b/pkg/arvo/ted/aqua/behn.hoon
@@ -85,7 +85,7 @@
   --
 --
 ::
-%+  aqua-vane-thread  ~[%sleep %restore %doze]
+%+  aqua-vane-thread  ~[%sleep %restore %doze %kill]
 |_  =bowl:spider
 +*  this  .
 ++  handle-unix-effect
@@ -96,6 +96,7 @@
       %sleep    abet-pe:handle-sleep:(pe bowl who)
       %restore  abet-pe:handle-restore:(pe bowl who)
       %doze     abet-pe:(handle-doze:(pe bowl who) ue)
+      %kill     `(~(del by piers) who)
     ==
   [cards this]
 ::

--- a/pkg/arvo/ted/aqua/dill.hoon
+++ b/pkg/arvo/ted/aqua/dill.hoon
@@ -25,6 +25,7 @@
         %sag  ~&  [%save-jamfile-to p.b]  line
         %sav  ~&  [%save-file-to p.b]  line
         %url  ~&  [%activate-url p.b]  line
+        %klr  ~&  %unhandled-case-klr  ""
     ==
   ~?  !=(~ last-line)  last-line
   ~

--- a/pkg/arvo/ted/aqua/eyre.hoon
+++ b/pkg/arvo/ted/aqua/eyre.hoon
@@ -100,7 +100,7 @@
   --
 --
 ::
-%+  aqua-vane-thread  ~[%sleep %restore %thus]
+%+  aqua-vane-thread  ~[%sleep %restore %thus %kill]
 |_  =bowl:spider
 +*  this  .
 ++  handle-unix-effect
@@ -111,6 +111,7 @@
       %sleep    abet-pe:handle-sleep:(pe bowl who)
       %restore  abet-pe:handle-restore:(pe bowl who)
       %thus     abet-pe:(handle-thus:(pe bowl who) ue)
+      %kill     `(~(del by piers) who)
     ==
   [cards this]
 ::

--- a/pkg/arvo/ted/ph/breach-hi-aqua.hoon
+++ b/pkg/arvo/ted/ph/breach-hi-aqua.hoon
@@ -1,0 +1,19 @@
+/-  spider
+/+  *ph-io, *ph-util
+=,  strand=strand:spider
+^-  thread:spider
+|=  vase
+=/  m  (strand ,vase)
+;<  =bowl:spider  bind:m  get-bowl
+;<  ~  bind:m  start-simple
+;<  ~  bind:m  init-azimuth
+;<  ~  bind:m  (spawn-aqua ~bud)
+;<  ~  bind:m  (spawn-aqua ~dev)
+;<  ~  bind:m  (init-ship ~bud)
+;<  ~  bind:m  (init-ship ~dev)
+;<  ~  bind:m  (send-hi ~bud ~dev)
+;<  ~  bind:m  (breach-and-hear-aqua ~dev ~bud)
+;<  ~  bind:m  (send-hi-not-responding ~bud ~dev)
+;<  ~  bind:m  (init-ship ~dev)
+;<  ~  bind:m  (wait-for-output ~bud "hi ~dev successful")
+(pure:m *vase)

--- a/pkg/arvo/ted/ph/start-drivers.hoon
+++ b/pkg/arvo/ted/ph/start-drivers.hoon
@@ -1,0 +1,13 @@
+/-  spider
+/+  *ph-io, *ph-util
+=,  strand=strand:spider
+^-  thread:spider
+|=  vase
+=/  m  (strand ,vase)
+;<  =bowl:spider  bind:m  get-bowl
+;<  ~  bind:m  start-simple
+|-
+=*  loop  $
+~&  >>  %looping
+;<  ~  bind:m  (sleep ~s5)
+loop


### PR DESCRIPTION
In order to make it much easier to work with fleets of ships, aqua now stores azimuth state internally rather than relying on a thread.