### PR TITLE
dojo: correct mark conversion scry path

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -869,7 +869,7 @@
       ::
           %as
         =/  cag=cage  (dy-cage p.q.bil)
-        =+  .^(=tube:clay cc+(en-beam:format he-beak /[p.bil]/[p.cag]))
+        =+  .^(=tube:clay cc+(en-beam:format he-beak /[p.cag]/[p.bil]))
         (dy-hand p.bil (tube q.cag))
       ::
           %do


### PR DESCRIPTION
Fixes an instance that hadn't accounted for #3994 yet. This broke `&json &blit bel+~` and other conversion cases.

Went over the rest of dojo again, but I think this is the only one I missed. All other calls take arguments from contexts that should already have unflopped spurs.