### PR TITLE
landscape: QA grab-bag

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -240,7 +240,7 @@ export class MessageWithSigil extends PureComponent<MessageProps> {
               className={`mw5 db truncate pointer`}
               ref={e => nameSpan = e}
               onClick={() => {
-                writeText(msg.author);
+                writeText(`~${msg.author}`);
                 copyNotice(name);
               }}
               title={`~${msg.author}`}

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -23,9 +23,9 @@ export const UnreadMarker = React.forwardRef(({ dayBreak, when }, ref) => (
 ));
 
 export const DayBreak = ({ when }) => (
-  <div className="pv3 gray2 b--gray2 flex items-center justify-center f9 w-100">
-    <p>{moment(when).calendar(null, { sameElse: DATESTAMP_FORMAT })}</p>
-  </div>
+  <Row pb='3' alignItems="center" justifyContent="center" width='100%'>
+    <Text gray>{moment(when).calendar(null, { sameElse: DATESTAMP_FORMAT })}</Text>
+  </Row>
 );
 
 interface ChatMessageProps {

--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -3,7 +3,7 @@ import { UnControlled as CodeEditor } from 'react-codemirror2';
 import { MOBILE_BROWSER_REGEX } from "~/logic/lib/util";
 import CodeMirror from 'codemirror';
 
-import { Row, BaseInput } from '@tlon/indigo-react';
+import { Row, BaseTextArea } from '@tlon/indigo-react';
 
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/addon/display/placeholder';
@@ -167,9 +167,10 @@ export default class ChatEditor extends Component {
         color="black"
       >
         {MOBILE_BROWSER_REGEX.test(navigator.userAgent)
-          ? <BaseInput
+          ? <BaseTextArea
             fontFamily={inCodeMode ? 'Source Code Pro' : 'Inter'}
             fontSize="14px"
+            lineHeight="tall"
             style={{ width: '100%', background: 'transparent', color: 'currentColor' }}
             placeholder={inCodeMode ? "Code..." : "Message..."}
             onKeyUp={event => {

--- a/pkg/interface/src/views/apps/profile/profile.tsx
+++ b/pkg/interface/src/views/apps/profile/profile.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Route, Link, Switch } from "react-router-dom";
 import Helmet from 'react-helmet';
 
-import { Box, Text, Row, Col, Icon } from "@tlon/indigo-react";
+import { Box, Text, Row, Col, Icon, BaseImage } from "@tlon/indigo-react";
 
 import { Sigil } from "~/logic/lib/sigil";
 import { uxToHex, MOBILE_BROWSER_REGEX } from "~/logic/lib/util";
@@ -65,6 +65,9 @@ export default function ProfileScreen(props: any) {
           history.replace("/~profile/identity");
         }
 
+        const image = (!props?.hideAvatars && contact?.avatar)
+          ? <BaseImage src={contact.avatar} width='100%' height='100%' style={{ objectFit: 'cover' }} />
+          : <Sigil ship={`~${ship}`} size={80} color={sigilColor} />;
         return (
           <Box height="100%" px={[0, 3]} pb={[0, 3]} borderRadius={1}>
             <Box
@@ -96,7 +99,7 @@ export default function ProfileScreen(props: any) {
                     justifyContent="center"
                     alignItems="center"
                   >
-                    <Sigil ship={`~${ship}`} size={80} color={sigilColor} />
+                    {image}
                   </Box>
                 </Box>
                 <Box width="100%" py={3} zIndex='2'>
@@ -129,6 +132,8 @@ export default function ProfileScreen(props: any) {
                     path="/~/default"
                     api={props.api}
                     s3={props.s3}
+                    hideAvatars={props.hideAvatars}
+                    hideNicknames={props.hideNicknames}
                   />
                   </>
                 )}

--- a/pkg/interface/src/views/apps/profile/profile.tsx
+++ b/pkg/interface/src/views/apps/profile/profile.tsx
@@ -12,7 +12,16 @@ import { ContactCard } from "~/views/landscape/components/ContactCard";
 
 const SidebarItem = ({ children, view, current }) => {
   const selected = current === view;
-  const color = selected ? "blue" : "black";
+  const icon = (view) => {
+    switch(view) {
+    case 'identity':
+      return 'Smiley';
+    case 'settings':
+      return 'Adjust';
+    default:
+      return 'Circle'
+    }
+  }
   return (
     <Link to={`/~profile/${view}`}>
       <Row
@@ -20,10 +29,10 @@ const SidebarItem = ({ children, view, current }) => {
         verticalAlign="middle"
         py={1}
         px={3}
-        backgroundColor={selected ? "washedBlue" : "white"}
+        backgroundColor={selected ? "washedGray" : "white"}
       >
-        <Icon mr={2} display="inline-block" icon="Circle" color={color} />
-        <Text color={color} fontSize={0}>
+        <Icon mr={2} display="inline-block" icon={icon(view)} color='black' />
+        <Text color='black' fontSize={0}>
           {children}
         </Text>
       </Row>

--- a/pkg/interface/src/views/apps/profile/profile.tsx
+++ b/pkg/interface/src/views/apps/profile/profile.tsx
@@ -104,6 +104,7 @@ export default function ProfileScreen(props: any) {
                 alignItems="center"
                 px={3}
                 borderBottom={1}
+                fontSize='0'
                 borderBottomColor="washedGray"
               >
                 <Link to="/~profile">{"<- Back"}</Link>

--- a/pkg/interface/src/views/apps/publish/components/EditPost.tsx
+++ b/pkg/interface/src/views/apps/publish/components/EditPost.tsx
@@ -50,6 +50,8 @@ export function EditPost(props: EditPostProps & RouteComponentProps) {
   return (
     <PostForm
       initial={initial}
+      cancel
+      history={history}
       onSubmit={onSubmit}
       submitLabel="Update"
       loadingText="Updating..."

--- a/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
@@ -1,17 +1,19 @@
-import React from "react";
-import * as Yup from "yup";
+import React from 'react';
+import * as Yup from 'yup';
 import {
-  Box,
   ManagedTextInputField as Input,
   Row,
   Col,
-} from "@tlon/indigo-react";
-import { AsyncButton } from "../../../components/AsyncButton";
-import { Formik, Form, FormikHelpers } from "formik";
-import { MarkdownField } from "./MarkdownField";
+  Button
+} from '@tlon/indigo-react';
+import { AsyncButton } from '../../../components/AsyncButton';
+import { Formik, Form, FormikHelpers } from 'formik';
+import { MarkdownField } from './MarkdownField';
 
 interface PostFormProps {
   initial: PostFormSchema;
+  cancel?: boolean;
+  history?: any;
   onSubmit: (
     values: PostFormSchema,
     actions: FormikHelpers<PostFormSchema>
@@ -21,8 +23,8 @@ interface PostFormProps {
 }
 
 const formSchema = Yup.object({
-  title: Yup.string().required("Title cannot be blank"),
-  body: Yup.string().required("Post cannot be blank"),
+  title: Yup.string().required('Title cannot be blank'),
+  body: Yup.string().required('Post cannot be blank')
 });
 
 export interface PostFormSchema {
@@ -31,7 +33,7 @@ export interface PostFormSchema {
 }
 
 export function PostForm(props: PostFormProps) {
-  const { initial, onSubmit, submitLabel, loadingText } = props;
+  const { initial, onSubmit, cancel, submitLabel, loadingText, history } = props;
 
   return (
     <Col width="100%" height="100%" p={[2, 4]}>
@@ -41,18 +43,26 @@ export function PostForm(props: PostFormProps) {
         onSubmit={onSubmit}
         validateOnBlur
       >
-        <Form style={{ display: "contents"}}>
-          <Row flexShrink='0' flexDirection={["column-reverse", "row"]} mb={4} gapX={4} justifyContent='space-between'>
+        <Form style={{ display: 'contents' }}>
+          <Row flexShrink='0' flexDirection={['column-reverse', 'row']} mb={4} gapX={4} justifyContent='space-between'>
             <Input maxWidth='40rem' width='100%' flexShrink={[0, 1]} placeholder="Post Title" id="title" />
-            <AsyncButton
+              <Row flexDirection={['column', 'row']} mb={[4,0]}>
+              <AsyncButton
+                ml={[0,2]}
+                flexShrink={0}
+                primary
+                loadingText={loadingText}
+              >
+                {submitLabel}
+              </AsyncButton>
+              {cancel && <Button
               ml={[0,2]}
-              mb={[4,0]}
-              flexShrink={0}
-              primary
-              loadingText={loadingText}
-            >
-              {submitLabel}
-            </AsyncButton>
+              mt={[2,0]}
+              onClick={() => {
+                history.goBack();
+              }}
+              type="button">Cancel</Button>}
+            </Row>
           </Row>
           <MarkdownField flexGrow={1} id="body" />
         </Form>

--- a/pkg/interface/src/views/landscape/components/ContactCard.tsx
+++ b/pkg/interface/src/views/landscape/components/ContactCard.tsx
@@ -71,12 +71,15 @@ const emptyContact = {
 export function ContactCard(props: ContactCardProps) {
   const us = `~${window.ship}`;
   const { contact, rootIdentity } = props;
-  const onSubmit = async (values: Contact, actions: FormikHelpers<Contact>) => {
+  const onSubmit = async (values: any, actions: FormikHelpers<Contact>) => {
     try {
       if(!contact) {
         const [,,ship] = props.path.split('/');
         values.color = uxToHex(values.color);
-        await props.api.contacts.share(ship, props.path, us, values)
+        const sharedValues = Object.assign({}, values);
+        sharedValues.avatar = (values.avatar === "") ? null : { url: values.avatar };
+        console.log(values);
+        await props.api.contacts.share(ship, props.path, us, sharedValues);
         actions.setStatus({ success: null });
         return;
       }

--- a/pkg/interface/src/views/landscape/components/ContactCard.tsx
+++ b/pkg/interface/src/views/landscape/components/ContactCard.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   Text,
   Row,
+  BaseImage
 } from "@tlon/indigo-react";
 import { Formik, FormikHelpers } from "formik";
 import { Contact } from "~/types/contact-update";
@@ -25,6 +26,8 @@ interface ContactCardProps {
   api: GlobalApi;
   s3: S3State;
   rootIdentity: Contact;
+  hideAvatars: boolean;
+  hideNicknames: boolean;
 }
 
 const formSchema = Yup.object({
@@ -111,6 +114,11 @@ export function ContactCard(props: ContactCardProps) {
   };
 
   const hexColor = contact?.color ? `#${uxToHex(contact.color)}` : "#000000";
+  const image = (!props?.hideAvatars && contact?.avatar)
+    ? <BaseImage src={contact.avatar} width='100%' height='100%' style={{ objectFit: 'cover' }} />
+    : <Sigil ship={us} size={32} color={hexColor} />;
+
+  const nickname = (!props.hideNicknames && contact?.nickname) ? contact.nickname : "";
 
   return (
     <Box p={4} height="100%" overflowY="auto">
@@ -132,9 +140,11 @@ export function ContactCard(props: ContactCardProps) {
             pb={3}
             alignItems="center"
           >
-            <Sigil size={32} classes="" color={hexColor} ship={us} />
+            <Box height='32px' width='32px'>
+              {image}
+            </Box>
             <Box ml={2}>
-              <Text fontFamily="mono">{us}</Text>
+              <Text mono={!Boolean(nickname)}>{nickname}</Text>
             </Box>
           </Row>
           <ImageInput id="avatar" label="Avatar" s3={props.s3} />

--- a/pkg/interface/src/views/landscape/components/InvitePopover.tsx
+++ b/pkg/interface/src/views/landscape/components/InvitePopover.tsx
@@ -90,7 +90,9 @@ export function InvitePopover(props: InvitePopoverProps) {
             borderColor="washedGray"
             borderRadius={1}
             maxHeight="472px"
-            width="380px"
+            width="100%"
+            maxWidth="380px"
+            mx={[4,0]}
             bg="white"
           >
             <Formik

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -347,7 +347,7 @@ function Participant(props: {
               </Action>
               {props.role === 'admin' && (
                 <>
-                  {!isInvite && (
+                  {(!isInvite && contact.patp !== window.ship) && (
                     <StatelessAsyncAction onClick={onBan} bg="transparent">
                       <Text color="red">Ban from {title}</Text>
                     </StatelessAsyncAction>
@@ -358,9 +358,9 @@ function Participant(props: {
                     </StatelessAsyncAction>
                   ) : (
                     <>
-                      <StatelessAsyncAction onClick={onKick} bg="transparent">
+                    {(contact.patp !== window.ship) && (<StatelessAsyncAction onClick={onKick} bg="transparent">
                         <Text color="red">Kick from {title}</Text>
-                      </StatelessAsyncAction>
+                      </StatelessAsyncAction>)}
                       <StatelessAsyncAction onClick={onPromote} bg="transparent">
                         Promote to Admin
                       </StatelessAsyncAction>

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -353,9 +353,9 @@ function Participant(props: {
                     </StatelessAsyncAction>
                   )}
                   {role === 'admin' ? (
-                    <StatelessAsyncAction onClick={onDemote} bg="transparent">
+                    group?.tags?.role?.admin?.size > 1 && (<StatelessAsyncAction onClick={onDemote} bg="transparent">
                       Demote from Admin
-                    </StatelessAsyncAction>
+                    </StatelessAsyncAction>)
                   ) : (
                     <>
                     {(contact.patp !== window.ship) && (<StatelessAsyncAction onClick={onKick} bg="transparent">

--- a/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
+++ b/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
@@ -144,6 +144,8 @@ export function PopoverRoutes(
                         contact={props.contacts[window.ship]}
                         rootIdentity={props.rootIdentity}
                         api={props.api}
+                        hideAvatars={props.hideAvatars}
+                        hideNicknames={props.hideNicknames}
                         path={props.association["group-path"]}
                         s3={props.s3}
                       />


### PR DESCRIPTION
- Adds 'cancel' button when editing a note. If the field is dirty, MarkdownField still prevents navigation.

<img width="731" alt="image" src="https://user-images.githubusercontent.com/20846414/100938907-7a4bff00-34c3-11eb-8f8c-b8f704518d9f.png">

- Adds a leading sig when copying patps from Chat (#4059)
- Mobile input for Chat overflows vertically by using textarea instead of input.
- Chat's Daybreak marker is padded evenly with other chat messages, removing `pt='3'` since `pt='3'` is already inherited by the renderSigil component.
- Admins can no longer ban themselves.
- Admins can no longer demote themselves if they are the only admin in the group.
- Invite popover now has some margin on mobile devices.
- Amends the 'Back' link size on mobile views of our root identity card to match current Indigo.
- Profile now has icons, and its sidebar matches the styling of other sidebars (gray background, not blue).
- Fixes an issue where if you set an avatar while sharing your contact for the first time — or if your root identity had an avatar set — you couldn't ever share your contact card. This is because contact-json wants `{ url: avatar }` but we were passing the URL as a straight string; whereas we caught that if we were *editing* the card. Additionally our field should've passed blank strings to the backend as `null` for avatars, but it wasn't, so if you wiped the input field to try and fix it, it would still fail. (#4064)
- If you set an avatar or nickname in a group or on your root identity, the contact card field now reflects that choice (if your ship settings allow it).

<img width="661" alt="Screenshot 2020-12-02 at 5 20 17 PM" src="https://user-images.githubusercontent.com/20846414/100938863-6902f280-34c3-11eb-986c-3d0489fedc70.png">
