### PR TITLE
AsyncButton, StatelessAsyncs: protect against double submit

### DIFF
--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -1693,9 +1693,8 @@
       "integrity": "sha512-3OPSdf9cejP/TSzWXuBaYbzLtAfBzQnc75SlPLkoPfwpxnv1Bvy9hiWngLY0WnKRR6lMOldnkYQCCuNWeDibYQ=="
     },
     "@tlon/indigo-react": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@tlon/indigo-react/-/indigo-react-1.2.5.tgz",
-      "integrity": "sha512-NOQTwH74l/XXMIfQ4ZzymvZuk1WK1nmO552TmXrQxBUSb7HmdlA8anG5oRrvnLJTkajLCY59McLkDca+lCcvwg==",
+      "version": "github:urbit/indigo-react#05b0732bc57fd3a38c1036b5efefcd7983d9c79f",
+      "from": "github:urbit/indigo-react#lf/hide-disabled",
       "requires": {
         "@reach/menu-button": "^0.10.5",
         "react": "^16.13.1",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -9,7 +9,7 @@
     "@reach/menu-button": "^0.10.5",
     "@reach/tabs": "^0.10.5",
     "@tlon/indigo-light": "^1.0.3",
-    "@tlon/indigo-react": "1.2.5",
+    "@tlon/indigo-react": "urbit/indigo-react#lf/hide-disabled",
     "@tlon/sigil-js": "^1.4.2",
     "aws-sdk": "^2.726.0",
     "big-integer": "^1.6.48",

--- a/pkg/interface/src/views/components/AsyncButton.tsx
+++ b/pkg/interface/src/views/components/AsyncButton.tsx
@@ -29,10 +29,15 @@ export function AsyncButton({
   }, [status]);
 
   return (
-    <Button disabled={!isValid} type="submit" {...rest}>
+    <Button
+      hideDisabled={isSubmitting}
+      disabled={!isValid || isSubmitting}
+      type="submit"
+      {...rest}
+    >
       {isSubmitting ? (
         <LoadingSpinner
-          foreground={rest.primary ? "white" : 'black'}
+          foreground={rest.primary ? "white" : "black"}
           background="gray"
         />
       ) : success === true ? (

--- a/pkg/interface/src/views/components/StatelessAsyncAction.tsx
+++ b/pkg/interface/src/views/components/StatelessAsyncAction.tsx
@@ -8,6 +8,7 @@ import { useFormikContext } from "formik";
 interface AsyncActionProps {
   children: ReactNode;
   name: string;
+  disabled?: boolean;
   onClick: (e: React.MouseEvent) => Promise<void>;
 }
 
@@ -15,6 +16,7 @@ export function StatelessAsyncAction({
   children,
   onClick,
   name = '',
+  disabled = false,
   ...rest
 }: AsyncActionProps & Parameters<typeof Action>[0]) {
   const {
@@ -23,7 +25,10 @@ export function StatelessAsyncAction({
   } = useStatelessAsyncClickable(onClick, name);
 
   return (
-    <Action onClick={handleClick} {...rest}>
+    <Action
+      hideDisabled={!disabled}
+      disabled={disabled || state === 'loading'}
+      onClick={handleClick} {...rest}>
       {state === "error" ? (
         "Error"
       ) : state === "loading" ? (

--- a/pkg/interface/src/views/components/StatelessAsyncButton.tsx
+++ b/pkg/interface/src/views/components/StatelessAsyncButton.tsx
@@ -7,7 +7,7 @@ import { useStatelessAsyncClickable } from "~/logic/lib/useStatelessAsyncClickab
 
 interface AsyncButtonProps {
   children: ReactNode;
-  name: string;
+  name?: string;
   onClick: (e: React.MouseEvent) => Promise<void>;
 }
 
@@ -15,6 +15,7 @@ export function StatelessAsyncButton({
   children,
   onClick,
   name = "",
+  disabled = false,
   ...rest
 }: AsyncButtonProps & Parameters<typeof Button>[0]) {
   const {
@@ -23,7 +24,12 @@ export function StatelessAsyncButton({
   } = useStatelessAsyncClickable(onClick, name);
 
   return (
-    <Button onClick={handleClick} {...rest}>
+    <Button 
+      hideDisabled={!disabled}
+      disabled={disabled || state === 'loading'}
+      onClick={handleClick}
+      {...rest}
+    >
       {state === "error" ? (
         "Error"
       ) : state === "loading" ? (


### PR DESCRIPTION
Disables AsyncButton if the form is submitting, to prevent accidental double submits.

Supersedes #3877 