### PR TITLE
king: Create a new stats subsystem; count some stuff in Ames

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/King/App.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/App.hs
@@ -119,7 +119,8 @@ defaultLogFile :: IO FilePath
 defaultLogFile = do
   logDir <- getXdgDirectory XdgCache "urbit"
   createDirectoryIfMissing True logDir
-  pure (logDir </> "king.log")
+  logId :: Word32 <- randomIO
+  pure (logDir </> "king-" <> show logId <> ".log")
 
 runKingEnvNoLog :: RIO KingEnv a -> IO a
 runKingEnvNoLog act = runKingEnv mempty mempty act

--- a/pkg/hs/urbit-king/lib/Urbit/Prelude.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Prelude.hs
@@ -16,6 +16,7 @@ module Urbit.Prelude
     , io, rio
     , logTrace
     , acquireWorker, acquireWorkerBound
+    , hark
     ) where
 
 import ClassyPrelude
@@ -38,6 +39,8 @@ import RIO (HasLogFunc, LogFunc, LogLevel(..), logDebug, logError, logFuncL,
             logInfo, logOptionsHandle, logOther, logWarn, mkLogFunc,
             setLogMinLevel, setLogUseLoc, setLogUseTime, withLogFunc)
 
+import qualified RIO
+
 io :: MonadIO m => IO a -> m a
 io = liftIO
 
@@ -47,6 +50,9 @@ rio = liftRIO
 logTrace :: HasLogFunc e => Utf8Builder -> RIO e ()
 logTrace = logOther "trace"
 
+-- | Composes a log message out of textual components.
+hark :: [Text] -> Utf8Builder
+hark = RIO.displayBytesUtf8 . foldMap encodeUtf8
 
 -- Utils for Spawning Worker Threads -------------------------------------------
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -193,6 +193,7 @@ realUdpServ por hos sat = do
       enqueueRecvPacket p a b = do
         did <- atomically (tryWriteTBQueue qRecv (p, a, b))
         when (did == False) $ do
+          bump (asUqf sat)
           logWarn $ displayShow $ ("AMES", "UDP",)
             "Dropping inbound packet because queue is full."
 
@@ -233,9 +234,11 @@ realUdpServ por hos sat = do
       Just sk -> do
         recvPacket sk >>= \case
           Left exn -> do
+            bump (asUdf sat)
             logError "AMES: UDP: Failed to receive packet"
             signalBrokenSocket sk
           Right Nothing -> do
+            bump (asUi6 sat)
             logError "AMES: UDP: Dropping non-ipv4 packet"
             pure ()
           Right (Just (b, p, a)) -> do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -34,6 +34,7 @@ where
 
 import Urbit.Prelude
 import Urbit.Vere.Ports
+import Urbit.Vere.Stat
 
 import Network.Socket
 
@@ -156,8 +157,9 @@ realUdpServ
    . (HasLogFunc e, HasPortControlApi e)
   => PortNumber
   -> HostAddress
+  -> AmesStat
   -> RIO e UdpServ
-realUdpServ por hos = do
+realUdpServ por hos sat = do
   logInfo $ displayShow ("AMES", "UDP", "Starting real UDP server.")
 
   env <- ask
@@ -239,6 +241,7 @@ realUdpServ por hos = do
             pure ()
           Right (Just (b, p, a)) -> do
             logDebug "AMES: UDP: Received packet."
+            atomically $ modifyTVar' (asUdp sat) (+ 1)
             enqueueRecvPacket p a b
 
   let shutdown = do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -34,13 +34,12 @@ where
 
 import Urbit.Prelude
 import Urbit.Vere.Ports
-import Urbit.Vere.Stat
 
 import Network.Socket
 
 import Control.Monad.STM         (retry)
 import Network.Socket.ByteString (recvFrom, sendTo)
-
+import Urbit.Vere.Stat           (AmesStat(..), bump)
 
 -- Types -----------------------------------------------------------------------
 
@@ -241,7 +240,7 @@ realUdpServ por hos sat = do
             pure ()
           Right (Just (b, p, a)) -> do
             logDebug "AMES: UDP: Received packet."
-            atomically $ modifyTVar' (asUdp sat) (+ 1)
+            bump (asUdp sat)
             enqueueRecvPacket p a b
 
   let shutdown = do

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
@@ -23,6 +23,7 @@ import RIO.Directory
 import Urbit.Arvo
 import Urbit.King.App
 import Urbit.Vere.Pier.Types
+import Urbit.Vere.Stat
 
 import Control.Monad.STM      (retry)
 import System.Environment     (getExecutablePath)
@@ -429,9 +430,11 @@ drivers
   -> Site.KingSubsite
   -> RAcquire e ([Ev], RAcquire e Drivers)
 drivers env who isFake plan scry termSys stderr serfSIGINT sub = do
+  stat@Stat{..} <- newStat
+
   (behnBorn, runBehn) <- rio Behn.behn'
-  (termBorn, runTerm) <- rio (Term.term' termSys serfSIGINT)
-  (amesBorn, runAmes) <- rio (Ames.ames' who isFake scry stderr)
+  (termBorn, runTerm) <- rio (Term.term' termSys (renderStat stat) serfSIGINT)
+  (amesBorn, runAmes) <- rio (Ames.ames' who isFake statAmes scry stderr)
   (httpBorn, runEyre) <- rio (Eyre.eyre' who isFake stderr sub)
   (clayBorn, runClay) <- rio Clay.clay'
   (irisBorn, runIris) <- rio Iris.client'

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
@@ -9,6 +9,11 @@ data Stat = Stat
 data AmesStat = AmesStat
   { asUdp :: TVar Word
   , asRcv :: TVar Word
+  , asSup :: TVar Word
+  , asFwd :: TVar Word
+  , asDrt :: TVar Word
+  , asDvr :: TVar Word
+  , asDml :: TVar Word
   , asSwp :: TVar Word
   , asBal :: TVar Word
   , asOky :: TVar Word
@@ -18,10 +23,21 @@ newStat :: MonadIO m => m Stat
 newStat = do
   asUdp <- newTVarIO 0
   asRcv <- newTVarIO 0
+  asSup <- newTVarIO 0
+  asFwd <- newTVarIO 0
+  asDrt <- newTVarIO 0
+  asDvr <- newTVarIO 0
+  asDml <- newTVarIO 0
   asSwp <- newTVarIO 0
   asBal <- newTVarIO 0
   asOky <- newTVarIO 0
   pure Stat{statAmes = AmesStat{..}}
+
+bump :: MonadIO m => TVar Word -> m ()
+bump s = atomically $ bump' s
+
+bump' :: TVar Word -> STM ()
+bump' s = modifyTVar' s (+ 1)
 
 type RenderedStat = [Text]
 
@@ -30,10 +46,15 @@ renderStat Stat{statAmes = AmesStat{..}} =
   sequence
     [ pure "stat:"
     , pure "  ames:"
-    ,     ("    udp: " <>) <$> tshow <$> readTVarIO asUdp
-    ,     ("    rcv: " <>) <$> tshow <$> readTVarIO asRcv
-    ,     ("    swp: " <>) <$> tshow <$> readTVarIO asSwp
-    ,     ("    bal: " <>) <$> tshow <$> readTVarIO asBal
-    ,     ("    oky: " <>) <$> tshow <$> readTVarIO asOky
+    ,     ("    udp ingress:             " <>) <$> tshow <$> readTVarIO asUdp
+    ,     ("    driver ingress:          " <>) <$> tshow <$> readTVarIO asRcv
+    ,     ("    sent to serf:            " <>) <$> tshow <$> readTVarIO asSup
+    ,     ("    forwarded:               " <>) <$> tshow <$> readTVarIO asFwd
+    ,     ("    dropped (unroutable):    " <>) <$> tshow <$> readTVarIO asDrt
+    ,     ("    dropped (wrong version): " <>) <$> tshow <$> readTVarIO asDvr
+    ,     ("    dropped (malformed):     " <>) <$> tshow <$> readTVarIO asDml
+    ,     ("    serf swapped:            " <>) <$> tshow <$> readTVarIO asSwp
+    ,     ("    serf bailed:             " <>) <$> tshow <$> readTVarIO asBal
+    ,     ("    serf okay:               " <>) <$> tshow <$> readTVarIO asOky
     ]
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
@@ -1,0 +1,39 @@
+module Urbit.Vere.Stat where
+
+import Urbit.Prelude
+
+data Stat = Stat
+  { statAmes :: AmesStat
+  }
+
+data AmesStat = AmesStat
+  { asUdp :: TVar Word
+  , asRcv :: TVar Word
+  , asSwp :: TVar Word
+  , asBal :: TVar Word
+  , asOky :: TVar Word
+  }
+
+newStat :: MonadIO m => m Stat
+newStat = do
+  asUdp <- newTVarIO 0
+  asRcv <- newTVarIO 0
+  asSwp <- newTVarIO 0
+  asBal <- newTVarIO 0
+  asOky <- newTVarIO 0
+  pure Stat{statAmes = AmesStat{..}}
+
+type RenderedStat = [Text]
+
+renderStat :: MonadIO m => Stat -> m RenderedStat
+renderStat Stat{statAmes = AmesStat{..}} =
+  sequence
+    [ pure "stat:"
+    , pure "  ames:"
+    ,     ("    udp: " <>) <$> tshow <$> readTVarIO asUdp
+    ,     ("    rcv: " <>) <$> tshow <$> readTVarIO asRcv
+    ,     ("    swp: " <>) <$> tshow <$> readTVarIO asSwp
+    ,     ("    bal: " <>) <$> tshow <$> readTVarIO asBal
+    ,     ("    oky: " <>) <$> tshow <$> readTVarIO asOky
+    ]
+

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Stat.hs
@@ -8,8 +8,13 @@ data Stat = Stat
 
 data AmesStat = AmesStat
   { asUdp :: TVar Word
+  , asUqf :: TVar Word
+  , asUdf :: TVar Word
+  , asUi6 :: TVar Word
   , asRcv :: TVar Word
   , asSup :: TVar Word
+  , asSrf :: TVar Word
+  , asQuf :: TVar Word
   , asFwd :: TVar Word
   , asDrt :: TVar Word
   , asDvr :: TVar Word
@@ -22,8 +27,13 @@ data AmesStat = AmesStat
 newStat :: MonadIO m => m Stat
 newStat = do
   asUdp <- newTVarIO 0
+  asUqf <- newTVarIO 0
+  asUdf <- newTVarIO 0
+  asUi6 <- newTVarIO 0
   asRcv <- newTVarIO 0
   asSup <- newTVarIO 0
+  asSrf <- newTVarIO 0
+  asQuf <- newTVarIO 0
   asFwd <- newTVarIO 0
   asDrt <- newTVarIO 0
   asDvr <- newTVarIO 0
@@ -47,8 +57,13 @@ renderStat Stat{statAmes = AmesStat{..}} =
     [ pure "stat:"
     , pure "  ames:"
     ,     ("    udp ingress:             " <>) <$> tshow <$> readTVarIO asUdp
+    ,     ("    udp queue evict:         " <>) <$> tshow <$> readTVarIO asUqf
+    ,     ("    udp recv fail:           " <>) <$> tshow <$> readTVarIO asUdf
+    ,     ("    udp dropped non-ipv4:    " <>) <$> tshow <$> readTVarIO asUi6
     ,     ("    driver ingress:          " <>) <$> tshow <$> readTVarIO asRcv
-    ,     ("    sent to serf:            " <>) <$> tshow <$> readTVarIO asSup
+    ,     ("    enqueued for serf:       " <>) <$> tshow <$> readTVarIO asSup
+    ,     ("    sent to serf:            " <>) <$> tshow <$> readTVarIO asSrf
+    ,     ("    serf queue evict:        " <>) <$> tshow <$> readTVarIO asQuf
     ,     ("    forwarded:               " <>) <$> tshow <$> readTVarIO asFwd
     ,     ("    dropped (unroutable):    " <>) <$> tshow <$> readTVarIO asDrt
     ,     ("    dropped (wrong version): " <>) <$> tshow <$> readTVarIO asDvr

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
@@ -562,10 +562,6 @@ localClient doneSignal = fst <$> mkRAcquire start stop
                   writeTQueue wq [Term.Trace "interrupt\r\n"]
                   writeTQueue rq $ Ctl $ Cord "c"
                 loop rd
-              else if w == 20 then do
-                -- DC4 (^T)
-                atomically $ writeTQueue wq [Term.Trace "<stat>\r\n"]
-                loop rd
               else if w <= 26 then do
                 case pack [BS.w2c (w + 97 - 1)] of
                     "d" -> atomically doneSignal


### PR DESCRIPTION
To address the problem of alleged dropped packets in kh, we add a bunch of counters at each step of the ames driver pipeline. The intent was for these to be part of a system like the SIGINFO/SIGUSR2 handler in classic vere, but it turned out, surprisingly and disappointingly, to be much easier to surface these via the new runtime subsite that @Fang- and I developed. So visit `/~_~/stat` to get your stats.

We also append 32 bits of random to the end of the default log filename so you can keep your old logs. That way, when something goes wrong (e.g. oom), we have more insight into what it was even if the ship has been restarted.