### PR TITLE
u3: disable +scot and +scow jets

### DIFF
--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -944,8 +944,11 @@ static u3j_core _141_qua_d[] =
   { "mole", 7, _141_qua_mole_a, 0, _141_qua_mole_ha },
   { "mule", 7, _141_qua_mule_a, 0, _141_qua_mule_ha },
 
-  { "scot", 7, _141_qua_scot_a, 0, _141_qua_scot_ha },
-  { "scow", 7, _141_qua_scow_a, 0, _141_qua_scow_ha },
+  //  XX disabled, implicated in memory corruption
+  //  write tests and re-enable
+  //
+  // { "scot", 7, _141_qua_scot_a, 0, _141_qua_scot_ha },
+  // { "scow", 7, _141_qua_scow_a, 0, _141_qua_scow_ha },
   { "slaw", 7, _141_qua_slaw_a, 0, _141_qua_slaw_ha },
   {}
 };


### PR DESCRIPTION
Disabling these jets (from #2853) resolved memory corruption issues (in the king process) on the testnet. More debugging will be needed to find the root cause (test coverage remains wanting, yet highly desirable). Disabling for now ...