### PR TITLE
pull-hook: fix handle-kick printouts

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -332,7 +332,7 @@
         p.u.cas
       now.bowl
     ::  catch bad gall scries early
-    ?:  ?&  =((end 3 1 i.u.pax) %g)
+    ?:  ?&  =((end 3 i.u.pax) %g)
             ?|  !=(`our.bowl ship)
                 !=(dat now.bowl)
             ==

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -339,6 +339,7 @@
         ==
       ~
     ``.^(* u.pax)
+  ::
   ++  handle-kick
     |=  [rid=resource =ship]
     ^-  (quip card _state)
@@ -349,13 +350,16 @@
       :-  -:!>(*(unit path)) 
       ?:(?=(%0 -.res) p.res ~)
     =?  failed-kicks  !?=(%0 -.res)
-      =/  tang
+      =/  =tang
         :+  leaf+"failed kick handler, please report" 
           leaf+"{<rid>} in {(trip dap.bowl)}"
         ?:  ?=(%2 -.res)
           p.res
         ?>  ?=(%1 -.res)
-        (turn `(list *)`p.res (cork path smyt))
+        =/  paths=(unit (list path))  ((soft (list path)) p.res)
+        ?~  paths  ~
+        %+  turn  u.paths
+        (cork path smyt)
       %-  (slog tang)
       (~(put by failed-kicks) rid ship)
     ?^  pax

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -356,10 +356,9 @@
         ?:  ?=(%2 -.res)
           p.res
         ?>  ?=(%1 -.res)
-        =/  paths=(unit (list path))  ((soft (list path)) p.res)
-        ?~  paths  ~
-        %+  turn  u.paths
-        (cork path smyt)
+        =/  maybe-path=(unit path)  ((soft path) p.res)
+        ?~  maybe-path  ~
+        [(smyt u.maybe-path) ~]
       %-  (slog tang)
       (~(put by failed-kicks) rid ship)
     ?^  pax


### PR DESCRIPTION
For some reason, on na-release/candidate, `lib/pull-hook` fails to compile. This addresses that issue.