### PR TITLE
leap: position notification dot relatively

### DIFF
--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -41,7 +41,7 @@ export class OmniboxResult extends Component {
              (icon === 'Terminal') ? 'Dojo'  : icon;
       graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'inbox') {
-      graphic = <Box display='flex' verticalAlign='middle'>
+      graphic = <Box display='flex' verticalAlign='middle' position="relative">
         <Icon display='inline-block' verticalAlign='middle' icon='Inbox' mr='2' size='16px' color={iconFill} />
         {(notifications > 0 || inviteCount.length > 0) && (
           <Icon display='inline-block' icon='Bullet' style={{ position: 'absolute', top: -5, left: 5 }} color={bulletFill} />


### PR DESCRIPTION
After indigo-react 1.2.15, Box no longer has `position:relative` by default.

While we caught this elsewhere, we dropped this in Leap results, aligning the
notification dot to the top left of the browser window instead.

Targeting na-release/candidate as it'll inevitably get merged downstream into next-userspace and this is otherwise a regression.