### PR TITLE
hoon: fixes logic bug in date printer (truncation)

### DIFF
--- a/nix/lib/test-fake-ship.nix
+++ b/nix/lib/test-fake-ship.nix
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation {
     #  run the unit tests
     #
     herb ./pier -d '~&  ~  ~&  %test-unit-start  ~'
-    herb ./pier -d '####-test %/tests'
+    herb ./pier -d '####-test %/tests ~'
     herb ./pier -d '~&  ~  ~&  %test-unit-end  ~'
 
     #  use the :test app to build all agents, generators, and marks

--- a/pkg/arvo/lib/aqua-azimuth.hoon
+++ b/pkg/arvo/lib/aqua-azimuth.hoon
@@ -206,8 +206,8 @@
 ::
 ++  get-public
   |=  [who=@p lyfe=life typ=?(%auth %crypt)]
-  =/  bod  (rsh 3 1 pub:ex:(get-keys who lyfe))
-  =+  [enc=(rsh 8 1 bod) aut=(end 8 1 bod)]
+  =/  bod  (rsh 3 pub:ex:(get-keys who lyfe))
+  =+  [enc=(rsh 8 bod) aut=(end 8 bod)]
   ?:  =(%auth typ)
     aut
   enc

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5475,9 +5475,7 @@
               %a
             =+  yod=(yore q.p.lot)
             =?  rep  ?=(^ f.t.yod)  ['.' (s-co f.t.yod)]
-            =?  rep  ?&  ?=(^ f.t.yod)
-                         !|(=(0 h.t.yod) =(0 m.t.yod) =(0 s.t.yod))
-                     ==
+            =?  rep  !&(?=(~ f) =(0 h) =(0 m) =(0 s)):t.yod
               =.  rep  ['.' (y-co s.t.yod)]
               =.  rep  ['.' (y-co m.t.yod)]
               ['.' '.' (y-co h.t.yod)]


### PR DESCRIPTION
Fixes a terrible bug i introduced into `@da` coin printing in #3636, wherein timestamps with *either* zero seconds/minutes/hours were printed as if all of their seconds/minutes/hours were zero (and truncated). Flagged by @philipcmonk.

Also fixes some calls to `+end` and +rsh` (api changed in #4060) that weren't updated when merged (in #4074).
