### PR TITLE
ames: don't crash on forward-lane scry

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -984,10 +984,12 @@
       [%peers @ *]
     =/  who  (slaw %p i.t.tyl)
     ?~  who  [~ ~]
-    ?~  peer=(~(get by peers.ames-state) u.who)
-      [~ ~]
-    ?+  t.t.tyl  [~ ~]
-      ~  ``noun+!>(u.peer)
+    =/  peer  (~(get by peers.ames-state) u.who)
+    ?+    t.t.tyl  [~ ~]
+        ~
+      ?~  peer
+        [~ ~]
+      ``noun+!>(u.peer)
     ::
         [%forward-lane ~]
       ::


### PR DESCRIPTION
Ames crashed on this scry if it hadn't heard of the ship, so if you had five of them in a row it would give up on stateless forwarding.  This is possibly the reason for the occasional time we've seen forwarding revert on mainnet, but it's especially important in the new breach when the first ships will mostly be talking to ships that haven't migrated yet.