### PR TITLE
nix: don't install urbit-debug by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	nix-build -A urbit -A herb --no-out-link
 
 install:
-	nix-env -f . -iA urbit -iA urbit-debug -iA herb
+	nix-env -f . -iA urbit -iA herb
 
 release:
 	sh/release


### PR DESCRIPTION
The urbit and urbit-debug derivations both produce an urbit-worker
binary, and they conflict.

I've been running this locally for a while, if there's no better fix, this could go in as a workaround.

References #4089