### PR TITLE
pull-hook: make wires more stable identifiers based on resource

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -404,7 +404,7 @@
     =/  =wire
       (make-wire pull+resource+(en-path:resource rid))
     [%pass wire %agent [u.ship push-hook-name.config] %leave ~]~
-
+  ::
   ++  watch-resource
     |=  [rid=resource pax=path]
     ^-  (list card)
@@ -414,7 +414,7 @@
     =/  =path
       (welp resource+(en-path:resource rid) pax)
     =/  =wire
-      (make-wire pull+path)
+      (make-wire pull+resource+(en-path:resource rid))
     [%pass wire %agent [u.ship push-hook-name.config] %watch path]~
   ::
   ++  make-wire


### PR DESCRIPTION
Prevent proliferation of wires by removing path-specific details from wires when `%watch`ing from pull-hook.