### PR TITLE
Add provenance to gall tasks & scrys - confine vanes from gall apps.

### DIFF
--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -357,7 +357,7 @@
   ++  on-watch  on-watch:def
   ++  on-leave  on-leave:def
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit [%noun vase]))
     ?+    path  ~
         [%x %domain-validation @t ~]

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -189,7 +189,7 @@
       ?>  ?=(^ old-path)
       ?.  =('~' i.old-path)
         ~
-      [%give %kick ~[mailbox+old-path] ~]~
+      [%give %kick ~[mailbox+old-path] ~ ~]~
     ::
     ++  add-members-group
       |=  [=path ships=(set ship)]
@@ -531,7 +531,7 @@
   ?>  ?=(%message -.act)
   ::  local
   :_  state
-  ?:  (team:title our.bol src.bol)
+  ?:  (team:title our.bol ship.src.bol)
     ?.  (~(has by synced) path.act)
       ~
     =*  letter  letter.envelope.act
@@ -546,8 +546,8 @@
   ?~  ship  ~
   ?.  =(u.ship our.bol)  ~
   ::  check if write is permitted
-  ?.  (is-member:grp src.bol (group-from-chat path.act))  ~
-  =:  author.envelope.act  src.bol
+  ?.  (is-member:grp ship.src.bol (group-from-chat path.act))  ~
+  =:  author.envelope.act  ship.src.bol
       when.envelope.act  now.bol
   ==
   [%pass / %agent [our.bol %chat-store] %poke %chat-action !>(act)]~
@@ -557,7 +557,7 @@
   ^-  (quip card _state)
   ?-  -.act
       %add-owned
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     =/  chat-path  [%mailbox path.act]
     =/  chat-wire  [%store path.act]
     ?:  (~(has by synced) path.act)  [~ state]
@@ -570,7 +570,7 @@
     ==
   ::
       %add-synced
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     ?<  =(ship.act our.bol)
     ?:  (~(has by synced) path.act)  [~ state]
     =.  synced  (~(put by synced) path.act ship.act)
@@ -598,11 +598,11 @@
     ?~  ship
       ~&  [dap.bol %unknown-host-cannot-leave path.act]
       [~ state]
-    ?:  &(!=(u.ship src.bol) ?!((team:title our.bol src.bol)))
+    ?:  &(!=(u.ship ship.src.bol) ?!((team:title our.bol ship.src.bol)))
       [~ state]
     =.  synced  (~(del by synced) path.act)
     :_  state
-    :*  [%give %kick ~[[%mailbox path.act]] ~]
+    :*  [%give %kick ~[[%mailbox path.act]] ~ ~]
         [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]
         (pull-wire u.ship [%mailbox path.act])
         (pull-wire u.ship [%store path.act])
@@ -613,7 +613,7 @@
 ++  watch-synced
   |=  pax=path
   ^-  (list card)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   [%give %fact ~ %chat-hook-update !>([%initial synced])]~
 ::
 ++  watch-mailbox
@@ -622,7 +622,7 @@
   ?>  ?=(^ pax)
   ?>  (~(has by synced) pax)
   ::  check if read is permitted
-  ?>  (is-member:grp src.bol (group-from-chat pax))
+  ?>  (is-member:grp ship.src.bol (group-from-chat pax))
   =/  box  (chat-scry pax)
   ?~  box  !!
   [%give %fact ~ %chat-update !>([%create pax])]~
@@ -635,7 +635,7 @@
   =/  backlog-latest=(unit @ud)  (rush (snag last `(list @ta)`pax) dem:ag)
   =/  pas  `path`(oust [last 1] `(list @ta)`pax)
   ?>  ?=([* ^] pas)
-  ?>  (is-member:grp src.bol (group-from-chat pas))
+  ?>  (is-member:grp ship.src.bol (group-from-chat pas))
   =/  envs  envelopes:(need (chat-scry pas))
   =/  length  (lent envs)
   =/  latest
@@ -648,7 +648,7 @@
   :~  [%give %fact ~ %chat-update !>([%create pas])]~
       ?.  ?&(?=(^ backlog-latest) (~(has by allow-history) pas))  ~
       [%give %fact ~ %chat-update vase]~
-      [%give %kick [%backlog pax]~ `src.bol]~
+      [%give %kick [%backlog pax]~ `ship.src.bol ~]~
   ==
 ::
 ++  fact-invite-update
@@ -689,12 +689,12 @@
   %+  turn
     ~(tap in ships.update)
   |=  =ship
-  [%give %kick [%mailbox chat]~ `ship]
+  [%give %kick [%mailbox chat]~ `ship ~]
 ::
 ++  fact-chat-update
   |=  [wir=wire =update:store]
   ^-  (quip card _state)
-  ?:  (team:title our.bol src.bol)
+  ?:  (team:title our.bol ship.src.bol)
     (handle-local update)
   (handle-foreign update)
 ::
@@ -728,18 +728,18 @@
     ?>  ?=([* ^] path.update)
     =/  shp  (~(get by synced) path.update)
     ?~  shp  ~
-    ?.  =(src.bol u.shp)  ~
+    ?.  =(ship.src.bol u.shp)  ~
     [(chat-poke [%create path.update])]~
   ::
       %delete
     ?>  ?=([* ^] path.update)
     =/  shp  (~(get by synced) path.update)
     ?~  shp  [~ state]
-    ?.  =(u.shp src.bol)  [~ state]
+    ?.  =(u.shp ship.src.bol)  [~ state]
     =.  synced  (~(del by synced) path.update)
     :_  state
     :-  (chat-poke [%delete path.update])
-    :~  [%pass [%mailbox path.update] %agent [src.bol %chat-hook] %leave ~]
+    :~  [%pass [%mailbox path.update] %agent [ship.src.bol %chat-hook] %leave ~]
         [%give %fact [/synced]~ %chat-hook-update !>([%initial synced])]
     ==
   ::
@@ -748,7 +748,7 @@
     ?>  ?=([* ^] path.update)
     =/  shp  (~(get by synced) path.update)
     ?~  shp  ~
-    ?.  =(src.bol u.shp)  ~
+    ?.  =(ship.src.bol u.shp)  ~
     [(chat-poke [%message path.update envelope.update])]~
   ::
       %messages
@@ -756,7 +756,7 @@
     ?>  ?=([* ^] path.update)
     =/  shp  (~(get by synced) path.update)
     ?~  shp  ~
-    ?.  =(src.bol u.shp)  ~
+    ?.  =(ship.src.bol u.shp)  ~
     [(chat-poke [%messages path.update envelopes.update])]~
   ==
 ::

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -65,7 +65,7 @@
         (~(put in subs) sub)
       =?  cards  ?=(^ kick-paths)
         :_  cards
-        [%give %kick kick-paths ~]
+        [%give %kick kick-paths ~ ~]
       $(old [%3 inbox])
     ::
       ?(%0 %1)  $(old (old-to-2 inbox.old))
@@ -86,7 +86,7 @@
     ~/  %chat-store-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =^  cards  state
       ?+  mark  (on-poke:def mark vase)
         %json         (poke-json:cc !<(json vase))
@@ -100,7 +100,7 @@
     |=  =path
     ^-  (quip card _this)
     |^
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =/  cards=(list card)
       ?+    path  (on-watch:def path)
           [%keys ~]     (give %chat-update !>([%keys ~(key by inbox)]))
@@ -121,9 +121,9 @@
   ++  on-leave  on-leave:def
   ++  on-peek
     ~/  %chat-store-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
-    ?+  path  (on-peek:def path)
+    ?+  path  (on-peek:def prov path)
         [%x %all ~]        ``noun+!>(inbox)
         [%x %keys ~]       ``noun+!>(~(key by inbox))
         [%x %envelopes *]  (peek-x-envelopes:cc t.t.path)

--- a/pkg/arvo/app/chat-view.hoon
+++ b/pkg/arvo/app/chat-view.hoon
@@ -67,7 +67,7 @@
     ~/  %chat-view-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     ?+    mark  (on-poke:def mark vase)
         %handle-http-request
       =+  !<([eyre-id=@ta =inbound-request:eyre] vase)
@@ -89,7 +89,7 @@
     ~/  %chat-view-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     |^
     ?:  ?=([%http-response *] path)
       [~ this]
@@ -196,14 +196,14 @@
 ++  poke-json
   |=  jon=json
   ^-  (list card)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   (poke-chat-view-action (action:dejs:view jon))
 ::
 ++  poke-chat-view-action
   |=  act=action:view
   ^-  (list card)
   |^
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   ?-  -.act
       %create
     ?>  ?=(^ app-path.act)

--- a/pkg/arvo/app/contact-hook.hoon
+++ b/pkg/arvo/app/contact-hook.hoon
@@ -110,7 +110,7 @@
           ~(val by sup.bol)
         |=([=ship =path] path)
       ?~  paths  ~
-      [%give %kick paths ~]~
+      [%give %kick paths ~ ~]~
     ::
     ++  pass-store
       |=  [=wire =task:agent:gall]
@@ -196,14 +196,14 @@
   |=  [=path =ship act=contact-action]
   ^-  (list card)
   ::  local
-  ?:  (team:title our.bol src.bol)
+  ?:  (team:title our.bol ship.src.bol)
     ?.  |(=(path /~/default) (~(has by synced) path))  ~
     =/  shp  ?:(=(path /~/default) our.bol (~(got by synced) path))
     =/  appl  ?:(=(shp our.bol) %contact-store %contact-hook)
     [%pass / %agent [shp appl] %poke %contact-action !>(act)]~
   ::  foreign
   =/  shp  (~(got by synced) path)
-  ?.  |(=(shp our.bol) =(src.bol ship))  ~
+  ?.  |(=(shp our.bol) =(ship.src.bol ship))  ~
   ::  scry group to check if ship is a member
   =/  =group  (need (group-scry path))
   ?.  (~(has in members.group) shp)  ~
@@ -214,7 +214,7 @@
   ^-  (quip card _state)
   ?-  -.act
       %add-owned
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     =/  contact-path  [%contacts path.act]
     ?:  (~(has by synced) path.act)
       [~ state]
@@ -225,7 +225,7 @@
     ==
   ::
       %add-synced
-    ?>  (team:title our.bol src.bol)
+    ?>  (team:title our.bol ship.src.bol)
     ?:  (~(has by synced) path.act)  [~ state]
     =.  synced  (~(put by synced) path.act ship.act)
     =/  contact-path  [%contacts path.act]
@@ -237,15 +237,15 @@
       %remove
     =/  ship  (~(get by synced) path.act)
     ?~  ship  [~ state]
-    ?:  &(=(u.ship our.bol) (team:title our.bol src.bol))
+    ?:  &(=(u.ship our.bol) (team:title our.bol ship.src.bol))
       ::  delete one of our.bol own paths
       :_  state(synced (~(del by synced) path.act))
       %-  zing
       :~  (pull-wire [%contacts path.act])
-          [%give %kick ~[[%contacts path.act]] ~]~
+          [%give %kick ~[[%contacts path.act]] ~ ~]~
           [%give %fact [/synced]~ %contact-hook-update !>([%initial synced])]~
       ==
-    ?.  |(=(u.ship src.bol) (team:title our.bol src.bol))
+    ?.  |(=(u.ship ship.src.bol) (team:title our.bol ship.src.bol))
       ::  if neither ship = source or source = us, do nothing
       [~ state]
     ::  delete a foreign ship's path
@@ -266,14 +266,14 @@
   ?>  (~(has by synced) pax)
   ::  scry groups to check if ship is a member
   =/  =group  (need (group-scry pax))
-  ?>  (~(has in members.group) src.bol)
+  ?>  (~(has in members.group) ship.src.bol)
   =/  contacts  (need (contacts-scry pax))
   [%give %fact ~ %contact-update !>([%contacts pax contacts])]~
 ::
 ++  watch-synced
   |=  pax=path
   ^-  (list card)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   [%give %fact ~ %contact-hook-update !>([%initial synced])]~
 ::
 ++  watch-ack
@@ -317,7 +317,7 @@
   |=  [wir=wire fact=contact-update]
   ^-  (quip card _state)
   |^
-  ?:  (team:title our.bol src.bol)
+  ?:  (team:title our.bol ship.src.bol)
     (local fact)
   :_  state
   (foreign fact)
@@ -350,7 +350,7 @@
     ?+  -.fact  ~
         %contacts
       =/  owner  (~(got by synced) path.fact)
-      ?>  =(owner src.bol)
+      ?>  =(owner ship.src.bol)
       =/  have-contacts=(unit contacts)
         (contacts-scry path.fact)
       ?~  have-contacts
@@ -387,18 +387,18 @@
         %add
       =/  owner  (~(get by synced) path.fact)
       ?~  owner  ~
-      ?>  |(=(u.owner src.bol) =(src.bol ship.fact))
+      ?>  |(=(u.owner ship.src.bol) =(ship.src.bol ship.fact))
       ~[(contact-poke [%add path.fact ship.fact contact.fact])]
     ::
         %remove
       =/  owner  (~(get by synced) path.fact)
       ?~  owner  ~
-      ?>  |(=(u.owner src.bol) =(src.bol ship.fact))
+      ?>  |(=(u.owner ship.src.bol) =(ship.src.bol ship.fact))
       ~[(contact-poke [%remove path.fact ship.fact])]
     ::
         %edit
       =/  owner  (~(got by synced) path.fact)
-      ?>  |(=(owner src.bol) =(src.bol ship.fact))
+      ?>  |(=(owner ship.src.bol) =(ship.src.bol ship.fact))
       ~[(contact-poke [%edit path.fact ship.fact edit-field.fact])]
     ==
   --
@@ -461,7 +461,7 @@
     %-  zing
     %+  turn  ~(tap in ships)
     |=  =ship
-    :~  [%give %kick ~[[%contacts path]] `ship]
+    :~  [%give %kick ~[[%contacts path]] `ship ~]
         ?:  =(ship our.bol)
           (contact-poke [%delete path])
         (contact-poke [%remove path ship])

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -95,7 +95,7 @@
           |=([=ship =path] path)
         ?~  paths  cards
         :_  cards
-        [%give %kick paths ~]
+        [%give %kick paths ~ ~]
       ==
 
     =/  new-rolodex=^rolodex
@@ -118,7 +118,7 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =^  cards  state
       ?+  mark  (on-poke:def mark vase)
         ::%json            (poke-json:cc !<(json vase))
@@ -129,7 +129,7 @@
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     |^
     =/  cards=(list card)
       ?+    path  (on-watch:def path)
@@ -149,7 +149,7 @@
   ::
   ++  on-leave  on-leave:def
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
     ?+  path  (on-peek:def path)
         [%x %all ~]       ``noun+!>(rolodex)
@@ -182,13 +182,13 @@
 ::++  poke-json
 ::  |=  =json
 ::  ^-  (quip move _this)
-::  ?>  (team:title our.bol src.bol)
+::  ?>  (team:title our.bol ship.src.bol)
 ::  (poke-contact-action (json-to-action json))
 ::
 ++  poke-contact-action
   |=  action=contact-action
   ^-  (quip card _state)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   ?-  -.action
       %create   (handle-create +.action)
       %delete   (handle-delete +.action)

--- a/pkg/arvo/app/contact-view.hoon
+++ b/pkg/arvo/app/contact-view.hoon
@@ -69,7 +69,7 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     ?+  mark  (on-poke:def mark vase)
         %json                 [(poke-json:cc !<(json vase)) this]
         %contact-view-action
@@ -86,7 +86,7 @@
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     ?:  ?=([%http-response *] path)  [~ this]
     ?.  =(/primary path)  (on-watch:def path)
     [[%give %fact ~ %json !>((update-to-json [%initial all-scry:cc]))]~ this]
@@ -132,13 +132,13 @@
 ++  poke-json
   |=  jon=json
   ^-  (list card)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   (poke-contact-view-action (json-to-view-action jon))
 ::
 ++  poke-contact-view-action
   |=  act=contact-view-action
   ^-  (list card)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   ?-  -.act
       %create
     =/  rid=resource

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -43,7 +43,7 @@
     |=  [=mark =vase]
     ^-  (quip card _this)
     ?:  ?=(%noun mark)
-      ?>  (team:title [our src]:bowl)
+      ?>  (team:title [our ship.src]:bowl)
       =/  code  !<((unit @t) vase)
       =/  msg=tape
         ?~  code

--- a/pkg/arvo/app/dns-collector.hoon
+++ b/pkg/arvo/app/dns-collector.hoon
@@ -68,7 +68,7 @@
   ++  handle-dns-address
     |=  adr=address:dns
     ^-  (quip card _this)
-    =*  who  src.bowl
+    =*  who  ship.src.bowl
     =/  rac  (clan:title who)
     ?.  ?=(?(%king %duke) rac)
       ~|  [%dns-collector-bind-invalid who]  !!
@@ -95,7 +95,7 @@
     ^-  (quip card _this)
     ::  XX or confirm valid binding?
     ::
-    ?.  (team:title [our src]:bowl)
+    ?.  (team:title [our ship.src]:bowl)
       ~|  %complete-yoself  !!
     =*  adr  address.binding
     =*  tuf  turf.binding
@@ -141,7 +141,7 @@
 ::
 ++  on-leave  on-leave:def
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   ?+  path  [~ ~]
       [%x %requested ~]  [~ ~ %requested !>(~(tap by requested.state))]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1516,7 +1516,7 @@
         %revoke-remote-login
       =/  who  !<(@p vase)
       :_  state(acl (~(del in acl) who))
-      [%give %kick ~ `who]~
+      [%give %kick ~ `who ~]~
     ::
         %list-remote-logins
       ~&  acl
@@ -1541,8 +1541,8 @@
 ++  on-watch
   |=  =path
   ^-  (quip card:agent:gall _..on-init)
-  ?>  ?|  (team:title our.hid src.hid)
-          (~(has in acl) src.hid)
+  ?>  ?|  (team:title our.hid ship.src.hid)
+          (~(has in acl) ship.src.hid)
       ==
   ?>  ?=([%sole @ ~] path)
   =/  id  i.t.path
@@ -1561,7 +1561,7 @@
   [~ ..on-init]
 ::
 ++  on-peek
-  |=  path
+  |=  [prov=path =path]
   *(unit (unit cage))
 ::
 ++  on-agent

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -285,7 +285,7 @@
 ::    /block/some-path: get next block number to check for /some-path
 ::
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   ?+    path  ~
       [%x %block ^]

--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -106,7 +106,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   ?+  mark  (on-poke:def mark vase)
       %file-server-action  (file-server-action !<(action:srv vase))
       %handle-http-request
@@ -294,7 +294,7 @@
   |=  =path
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   ?+  path  (on-watch:def path)
       [%http-response *]  [~ this]
       [%all ~]            [(give [%configuration configuration]) this]
@@ -318,9 +318,9 @@
 ::
 ++  on-leave  on-leave:def
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?+  path  (on-peek:def path)
+  ?+  path  (on-peek:def prov path)
       [%x %clay %base %hash ~]
     =/  versions  (base-hash:version [our now]:bowl)
     ``hash+!>(?~(versions 0v0 (end [0 25] i.versions)))

--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -28,9 +28,9 @@
   =/  group-paths  (groups-from-resource:met [%graph (en-path:res resource)])
   ?~  group-paths  %.n
   ?:  requires-admin
-    (is-admin:grp src.bowl i.group-paths)
-  ?|  (is-member:grp src.bowl i.group-paths)
-      (is-admin:grp src.bowl i.group-paths)
+    (is-admin:grp ship.src.bowl i.group-paths)
+  ?|  (is-member:grp ship.src.bowl i.group-paths)
+      (is-admin:grp ship.src.bowl i.group-paths)
   ==
 ::
 ++  is-allowed-remove
@@ -45,7 +45,7 @@
   ^-  ?
   =/  =node:store
     (got-node:gra resource index)
-  ?|  =(author.post.node src.bowl)
+  ?|  =(author.post.node ship.src.bowl)
       (is-allowed resource bowl %.y)
   ==
 --
@@ -137,10 +137,10 @@
   ?+  -.q.update       [~ this]
       %remove-graph
     :_  this
-    [%give %kick ~[resource+(en-path:res resource.q.update)] ~]~
+    [%give %kick ~[resource+(en-path:res resource.q.update)] ~ ~]~
   ::
       %archive-graph
     :_  this
-    [%give %kick ~[resource+(en-path:res resource.q.update)] ~]~
+    [%give %kick ~[resource+(en-path:res resource.q.update)] ~ ~]~
   ==
 --

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -39,7 +39,7 @@
   =|  cards=(list card)
   |^
   ?-    -.old
-      %0  
+      %0
     %_    $
       -.old  %1
     ::
@@ -153,7 +153,7 @@
         post.node(index (snoc index.post.node atom), hash ~)
       ==
     --
-  ::  
+  ::
   ++  maybe-unix-to-da
     |=  =atom
     ^-  @
@@ -193,7 +193,7 @@
   |=  =path
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =/  cards=(list card)
     ?+  path       (on-watch:def path)
         [%updates ~]   ~
@@ -213,7 +213,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
         %graph-update  (graph-update !<(update:store vase))
@@ -569,7 +569,7 @@
         [cards state]
       =*  update  upd.i.updates
       =^  crds  state
-        %-  graph-update 
+        %-  graph-update
         ^-  update:store
         ?-  -.q.update
             %add-nodes          update(resource.q resource)
@@ -616,11 +616,11 @@
 ::
 ++  on-peek
   ~/  %graph-store-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   |^
-  ?>  (team:title our.bowl src.bowl)
-  ?+  path  (on-peek:def path)
+  ?>  (team:title our.bowl ship.src.bowl)
+  ?+  path  (on-peek:def prov path)
       [%x %graph-mark @ @ ~]
     =/  =ship   (slav %p i.t.t.path)
     =/  =term   i.t.t.t.path
@@ -784,7 +784,7 @@
   ^-  (quip card _this)
   ?+  wire  (on-arvo:def wire sign-arvo)
   ::
-  ::  old wire, do nothing 
+  ::  old wire, do nothing
       [%graph *]  [~ this]
   ::
       [%validator @ ~]

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -52,7 +52,7 @@
     %.n
   |^
   =/  role=(unit (unit role-tag))
-    (role-for-ship:grp resource.update src.bowl)
+    (role-for-ship:grp resource.update ship.src.bowl)
   ?~  role
     non-member
   ?~  u.role
@@ -64,9 +64,9 @@
   ==
   ++  member
     ?:  ?=(%add-members -.update)
-      =(~(tap in ships.update) ~[src.bowl])
+      =(~(tap in ships.update) ~[ship.src.bowl])
     ?:  ?=(%remove-members -.update)
-      =(~(tap in ships.update) ~[src.bowl])
+      =(~(tap in ships.update) ~[ship.src.bowl])
     %.n
   ++  admin
     !?=(?(%remove-group %add-group) -.update)
@@ -76,8 +76,8 @@
     -.update
   ++  non-member
     ?&  ?=(%add-members -.update)
-        (can-join:grp resource.update src.bowl)
-        =(~(tap in ships.update) ~[src.bowl])
+        (can-join:grp resource.update ship.src.bowl)
+        =(~(tap in ships.update) ~[ship.src.bowl])
     ==
   --
 ::
@@ -99,7 +99,7 @@
     =/  paths
       ~[resource+(en-path:resource resource.update)]
     :_  this
-    [%give %kick paths ~]~
+    [%give %kick paths ~ ~]~
   ?.  ?=(%remove-members -.update)
     [~ this]
   =/  paths
@@ -108,7 +108,7 @@
   %+  turn
     ~(tap in ships.update)
   |=  =ship
-  [%give %kick paths `ship]
+  [%give %kick paths `ship ~]
 ::
 ++  initial-watch
   |=  [=path rid=resource]
@@ -116,7 +116,7 @@
   =/  group
     (scry-group:grp rid)
   ?>  ?=(^ group)
-  ?>  (~(has in members.u.group) src.bowl)
+  ?>  (~(has in members.u.group) ship.src.bowl)
   !>  ^-  update:store
   [%initial-group rid u.group]
 ::

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -120,6 +120,7 @@
       ^-  card
       :+  %give  %kick
       :_  ~
+      :_  ~
       %~  tap  by
       %+  roll  ~(val by sup.bowl)
       |=  [[=ship pax=path] paths=(set path)]
@@ -163,7 +164,7 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =^  cards  state
       ?+    mark  (on-poke:def mark vase)
           ?(%group-update %group-action)
@@ -175,7 +176,7 @@
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     ?>  ?=([%groups ~] path)
     :_  this
     [%give %fact ~ %group-update !>([%initial groups])]~
@@ -183,9 +184,9 @@
   ++  on-leave  on-leave:def
   ::
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
-    ?+  path  (on-peek:def path)
+    ?+  path  (on-peek:def prov path)
         [%y %groups ~]
       =/  =arch
         :-  ~
@@ -248,7 +249,7 @@
 ++  poke-group-update
   |=  =update:store
   ^-  (quip card _state)
-  ?>  (team:title our.bol src.bol)
+  ?>  (team:title our.bol ship.src.bol)
   |^
   ?-  -.update
       %add-group       (add-group +.update)

--- a/pkg/arvo/app/hark-chat-hook.hoon
+++ b/pkg/arvo/app/hark-chat-hook.hoon
@@ -76,7 +76,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
         %hark-chat-hook-action

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -81,7 +81,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
         %hark-graph-hook-action

--- a/pkg/arvo/app/hark-group-hook.hoon
+++ b/pkg/arvo/app/hark-group-hook.hoon
@@ -58,7 +58,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
         %hark-group-hook-action

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -61,7 +61,7 @@
     (gas:orm *notifications:store (tap:orm archive.old))
   `this(-.state old, +.state (inflate-cache old))
 ::
-++  on-watch  
+++  on-watch
   |=  =path
   ^-  (quip card _this)
   |^
@@ -104,10 +104,10 @@
     [%timebox time archived ~(tap by timebox)]
   --
 ::
-++  on-peek   
-  |=  =path
+++  on-peek
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?+  path  (on-peek:def path)
+  ?+  path  (on-peek:def prov path)
     ::
       [%x %recent ?(%archive %inbox) @ @ ~]
     =/  is-archive
@@ -122,7 +122,7 @@
     %+  turn
       %+  scag  length
       %+  slag  offset
-      %-  tap-nonempty:ha 
+      %-  tap-nonempty:ha
       ?:(is-archive archive notifications)
     |=  [time=@da =timebox:store]
     ^-  update:store
@@ -135,7 +135,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
         %hark-action   (hark-action !<(action:store vase))
@@ -155,7 +155,7 @@
       %unread   (unread +.action)
       %set-dnd  (set-dnd +.action)
     ==
-    ++  add  
+    ++  add
       |=  [=index:store =notification:store]
       ^-  (quip card _state)
       =/  =timebox:store
@@ -184,7 +184,7 @@
       =/  times=(list @da)
         ~(tap in (~(gut by by-index) index ~))
       =|  cards=(list card)
-      |- 
+      |-
       ?~  times
         [cards state]
       =*  time  i.times
@@ -253,7 +253,7 @@
 ++  on-agent  on-agent:def
 ::
 ++  on-leave  on-leave:def
-++  on-arvo  
+++  on-arvo
   |=  [=wire =sign-arvo]
   ^-  (quip card _this)
   ?.  ?=([%autoseen ~] wire)
@@ -339,7 +339,7 @@
   ^+  +.state
   %_    +.state
     ::
-      by-index 
+      by-index
     %.  [index time]
     ?:  read
       ~(del ju by-index)
@@ -356,7 +356,7 @@
     +.state
   =/  unreads  ~(tap by timebox.i.nots)
   |-  =*  inner  $
-  ?~  unreads  
+  ?~  unreads
     outer(nots t.nots)
   =*  notification  q.i.unreads
   =*  index         p.i.unreads

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -44,10 +44,10 @@
 ::
 ++  on-leave  on-leave:def
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?+  path  (on-peek:def path)
-    [* %kiln *]  (on-peek:kiln-core path)
+  ?+  path  (on-peek:def prov path)
+    [* %kiln *]  (on-peek:kiln-core prov path)
   ==
 ::
 ++  on-save   !>(state)

--- a/pkg/arvo/app/invite-hook.hoon
+++ b/pkg/arvo/app/invite-hook.hoon
@@ -38,7 +38,7 @@
     =/  act=action  !<(action vase)
     ?+  -.act     ~
         %invites
-      ?.  (team:title [our src]:bowl)  ~
+      ?.  (team:title [our ship.src]:bowl)  ~
       ::  outgoing. we must be inviting other ships. send them each an invite
       ::
       %+  turn  ~(tap in recipients.invites.act)
@@ -56,7 +56,7 @@
       ==
     ::
         %invite
-      ?:  (team:title [our src]:bowl)
+      ?:  (team:title [our ship.src]:bowl)
         ::  outgoing. we must be inviting another ship. send them the invite.
         ::
         ?<  (team:title our.bowl recipient.invite.act)

--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -83,7 +83,7 @@
 ++  on-watch
   |=  =path
   ^-  (quip card _this)
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =/  cards=(list card)
     ?+    path  (on-watch:def path)
         [%all ~]      [%give %fact ~ %invite-update !>([%initial invites])]~
@@ -98,7 +98,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark  (on-poke:def mark vase)
       %invite-action  (poke-invite-action !<(action:store vase))
@@ -185,9 +185,9 @@
   --
 ::
 ++  on-peek
-  |=  =path
+  |=  [=prov =path]
   ^-  (unit (unit cage))
-  ?+  path  (on-peek:def path)
+  ?+  path  (on-peek:def prov path)
       [%x %all ~]
     ``noun+!>(invites)
   ::

--- a/pkg/arvo/app/launch.hoon
+++ b/pkg/arvo/app/launch.hoon
@@ -117,7 +117,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark  (on-poke:def mark vase)
         %launch-action  (poke-action !<(action:store vase))
@@ -172,7 +172,7 @@
   |=  =path
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =/  cards=(list card)
     ?+  path       (on-watch:def path)
         [%all ~]   (give [%initial tiles tile-ordering first-time])
@@ -187,9 +187,9 @@
   --
 ::
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?.  (team:title our.bowl src.bowl)  ~
+  ?.  (team:title our.bowl ship.src.bowl)  ~
   ?+  path  [~ ~]
       [%x %tiles ~]       ``noun+!>([tiles tile-ordering])
       [%x %first-time ~]  ``noun+!>(first-time)

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -114,9 +114,9 @@
 ::
 ++  on-leave  on-leave:def
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?+  path  (on-peek:def path)
+  ?+  path  (on-peek:def prov path)
     [%x %export-all ~]
     ``noun+!>((jam (export-all our.bowl now.bowl)))
   ==

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -98,13 +98,13 @@
   |^
   ?-  -.act
       %add-owned
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     :-  ~
     ?:  (~(has by synced) path.act)  state
     state(synced (~(put by synced) path.act our.bowl))
   ::
       %add-synced
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =/  =path  [%group path.act]
     ?:  (~(has by synced) path.act)  [~ state]
     :_  state(synced (~(put by synced) path.act ship.act))
@@ -113,12 +113,12 @@
       %remove
     =/  ship  (~(get by synced) path.act)
     ?~  ship  [~ state]
-    ?:  &(!=(u.ship src.bowl) ?!((team:title our.bowl src.bowl)))
+    ?:  &(!=(u.ship ship.src.bowl) ?!((team:title our.bowl ship.src.bowl)))
       [~ state]
     :_  state(synced (~(del by synced) path.act))
     %-  zing
     :~  (unsubscribe [%group path.act] u.ship)
-        [%give %kick ~[[%group path.act]] ~]~
+        [%give %kick ~[[%group path.act]] ~ ~]~
     ==
   ==
   ::
@@ -134,12 +134,12 @@
   |=  act=metadata-action
   ^-  (list card)
   |^
-  ?:  (team:title our.bowl src.bowl)
+  ?:  (team:title our.bowl ship.src.bowl)
     ?-  -.act
         %add     (send group-path.act)
         %remove  (send group-path.act)
     ==
-  ?>  (is-member:grp src.bowl group-path.act)
+  ?>  (is-member:grp ship.src.bowl group-path.act)
   ?-  -.act
       %add     (metadata-poke our.bowl %metadata-store)
       %remove  (metadata-poke our.bowl %metadata-store)
@@ -171,7 +171,7 @@
   ^-  (list card)
   |^
   ?>  =(our.bowl (~(got by synced) path))
-  ?>  (is-member:grp src.bowl path)
+  ?>  (is-member:grp ship.src.bowl path)
   %+  turn  ~(tap by (metadata-scry path))
   |=  [[=group-path =md-resource] =metadata]
   ^-  card
@@ -193,7 +193,7 @@
   |=  [wir=wire fact=metadata-update]
   ^-  (quip card _state)
   |^
-  [?:((team:title our.bowl src.bowl) handle-local handle-foreign) state]
+  [?:((team:title our.bowl ship.src.bowl) handle-local handle-foreign) state]
   ::
   ++  handle-local
     ?+  -.fact  ~
@@ -213,15 +213,15 @@
   ++  handle-foreign
     ?+  -.fact  ~
         %add
-      ?.  =(src.bowl (~(got by synced) group-path.fact))  ~
+      ?.  =(ship.src.bowl (~(got by synced) group-path.fact))  ~
       (poke fact)
     ::
         %update-metadata
-      ?.  =(src.bowl (~(got by synced) group-path.fact))  ~
+      ?.  =(ship.src.bowl (~(got by synced) group-path.fact))  ~
       (poke [%add +.fact])
     ::
         %remove
-      ?.  =(src.bowl (~(got by synced) group-path.fact))  ~
+      ?.  =(ship.src.bowl (~(got by synced) group-path.fact))  ~
       (poke fact)
     ==
   ::

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -163,10 +163,10 @@
       %+  turn  ~(tap in ~(key by associations))
       |=  [g=group-path r=md-resource]
       ^-  [md-resource group-path]
-      [r g] 
+      [r g]
     ::
     ++  rebuild-group-indices
-      |=  =^associations 
+      |=  =^associations
       %-  ~(gas ju *(jug group-path md-resource))
       ~(tap in ~(key by associations))
     ::
@@ -186,7 +186,7 @@
       %+  turn  ~(tap by associations)
       |=  [[=group-path =md-resource] m=metadata]
       ^-  [[^group-path ^md-resource] metadata]
-      ?.  =(app-name.md-resource app)  
+      ?.  =(app-name.md-resource app)
         [[group-path md-resource] m]
       =/  new-app-path=path
         ?.  ?=([@ @ ~] app-path.md-resource)
@@ -273,7 +273,7 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     =^  cards  state
       ?+  mark  (on-poke:def mark vase)
           %metadata-action
@@ -302,7 +302,7 @@
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  (team:title our.bowl src.bowl)
+    ?>  (team:title our.bowl ship.src.bowl)
     |^
     =/  cards=(list card)
       ?+  path  (on-watch:def path)
@@ -326,9 +326,9 @@
     --
   ::
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
-    ?+  path  (on-peek:def path)
+    ?+  path  (on-peek:def prov path)
         [%y %group-indices ~]     ``noun+!>(group-indices)
         [%y %app-indices ~]       ``noun+!>(app-indices)
         [%y %resource-indices ~]  ``noun+!>(resource-indices)
@@ -362,7 +362,7 @@
 ++  poke-metadata-action
   |=  act=metadata-action
   ^-  (quip card _state)
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   ?-  -.act
       %add     (handle-add group-path.act resource.act metadata.act)
       %remove  (handle-remove group-path.act resource.act)

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -92,7 +92,7 @@
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card _this)
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   ?.  ?=(%observe-action mark)
     (on-poke:def mark vase)
   =/  =action:sur  !<(action:sur vase)

--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -176,7 +176,7 @@
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   ``noun+!>(state)
 ::  +on-agent: handle ames ack

--- a/pkg/arvo/app/s3-store.hoon
+++ b/pkg/arvo/app/s3-store.hoon
@@ -36,7 +36,7 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =^  cards  state
     ?+  mark        (on-poke:def mark vase)
         %s3-action  (poke-action !<(action vase))
@@ -76,7 +76,7 @@
   |=  =path
   ^-  (quip card _this)
   |^
-  ?>  (team:title our.bowl src.bowl)
+  ?>  (team:title our.bowl ship.src.bowl)
   =/  cards=(list card)
     ?+  path      (on-watch:def path)
         [%all ~]
@@ -95,9 +95,9 @@
 ++  on-leave  on-leave:def
 ++  on-peek
   ~/  %s3-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
-  ?.  (team:title our.bowl src.bowl)  ~
+  ?.  (team:title our.bowl ship.src.bowl)  ~
   ?+    path  [~ ~]
       [%x %credentials ~]
     [~ ~ %s3-update !>(`update`[%credentials credentials])]

--- a/pkg/arvo/app/shoe.hoon
+++ b/pkg/arvo/app/shoe.hoon
@@ -65,8 +65,8 @@
       %demo
     :-  ~
     :-  %sole
-    =/  =tape  "{(scow %p src.bowl)} ran the command"
-    ?.  =(src our):bowl
+    =/  =tape  "{(scow %p ship.src.bowl)} ran the command"
+    ?.  =(ship.src our):bowl
       [%txt tape]
     [%klr [[`%br ~ `%g] [(crip tape)]~]~]
   ::
@@ -74,14 +74,14 @@
     :-  [sole-id]~
     :+  %row
       ~[8 27 35 5]
-    ~[p+src.bowl da+now.bowl t+'plenty room here!' t+'less here!']
+    ~[p+ship.src.bowl da+now.bowl t+'plenty room here!' t+'less here!']
   ::
       %table
     :-  [sole-id]~
     :^  %table
         ~[t+'ship' t+'date' t+'long text' t+'tldr']
       ~[8 27 35 5]
-    :~  ~[p+src.bowl da+now.bowl t+'plenty room here!' t+'less here!']
+    :~  ~[p+ship.src.bowl da+now.bowl t+'plenty room here!' t+'less here!']
         ~[p+~marzod t+'yesterday' t+'sometimes:\0anewlines' t+'newlines']
     ==
   ==
@@ -89,8 +89,8 @@
 ++  can-connect
   |=  sole-id=@ta
   ^-  ?
-  ?|  =(~zod src.bowl)
-      (team:title [our src]:bowl)
+  ?|  =(~zod ship.src.bowl)
+      (team:title [our ship.src]:bowl)
   ==
 ::
 ++  on-connect      on-connect:des

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -143,7 +143,7 @@
       sc           ~(. spider-core bowl)
       def          ~(. (default-agent this %|) bowl)
   ::
-  ++  on-init   
+  ++  on-init
     ^-  (quip card _this)
     :_  this
     ~[bind-eyre:sc]
@@ -154,7 +154,7 @@
     =+  !<(any=clean-slate-any old-state)
     =?  any  ?=(^ -.any)  (old-to-1 any)
     =?  any  ?=(~ -.any)  (old-to-1 any)
-    =^  upgrade-cards  any  
+    =^  upgrade-cards  any
       (old-to-2 any)
     ?>  ?=(%2 -.any)
     ::
@@ -202,7 +202,7 @@
         %spider-start  (handle-start-thread:sc !<(start-args vase))
         %spider-stop   (handle-stop-thread:sc !<([tid ?] vase))
       ::
-          %handle-http-request   
+          %handle-http-request
         (handle-http-request:sc !<([@ta =inbound-request:eyre] vase))
       ==
     [cards this]
@@ -220,9 +220,10 @@
   ::
   ++  on-leave  on-leave:def
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
-    ?+    path  (on-peek:def path)
+    ?+    path  (on-peek:def prov path)
+    
         [%x %tree ~]
       ``noun+!>((turn (tap-yarn running.state) head))
     ::
@@ -271,7 +272,7 @@
   |=  [eyre-id=@ta =inbound-request:eyre]
   ^-  (quip card _state)
   ?>  authenticated.inbound-request
-  =/  url 
+  =/  url
     (parse-request-line:server url.request.inbound-request)
   ?>  ?=([%spider @t @t @t ~] site.url)
   =*  input-mark   i.t.site.url
@@ -283,7 +284,7 @@
     (~(put by serving.state) tid [eyre-id output-mark])
   =+  .^
       =tube:clay
-      %cc 
+      %cc
       /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/json/[input-mark]
     ==
   ?>  ?=(^ body.request.inbound-request)
@@ -431,7 +432,7 @@
     ^-  ^card
     ?+  card  card
         [%pass * *]  [%pass [%thread tid p.card] q.card]
-        [%give ?(%fact %kick) *]
+        [%give ?(%fact %kick) * *]
       =-  card(paths.p -)
       %+  turn  paths.p.card
       |=  =path
@@ -461,13 +462,13 @@
   |=  [=tid =term =tang]
   ^-  (list card)
   :~  [%give %fact ~[/thread-result/[tid]] %thread-fail !>([term tang])]
-      [%give %kick ~[/thread-result/[tid]] ~]
+      [%give %kick ~[/thread-result/[tid]] ~ ~]
   ==
 ++  thread-http-fail
   |=  [=tid =term =tang]
   ^-  (quip card ^state)
   =-  (fall - `state)
-  %+  bind  
+  %+  bind
     (~(get by serving.state) tid)
   |=  [eyre-id=@ta output=mark]
   :_  state(serving (~(del by serving.state) tid))
@@ -497,7 +498,7 @@
   |=  [=tid =vase]
   ^-  (quip card ^state)
   =-  (fall - `state)
-  %+  bind  
+  %+  bind
     (~(get by serving.state) tid)
   |=  [eyre-id=@ta output=mark]
   =+    .^
@@ -516,7 +517,7 @@
   =/  =tid  (yarn-to-tid yarn)
   =/  done-cards=(list card)
     :~  [%give %fact ~[/thread-result/[tid]] %thread-done vase]
-        [%give %kick ~[/thread-result/[tid]] ~]
+        [%give %kick ~[/thread-result/[tid]] ~ ~]
     ==
   =^  http-cards  state
     (thread-http-response tid vase)

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -48,7 +48,7 @@
         ::  use that vase in place of +on-save's.
         ::
         =/  result=(each ^vase tang)
-          (mule |.(q:(need (need (on-peek:ag /x/dbug/state)))))
+          (mule |.(q:(need (need (on-peek:ag /x/dbug/state /g/dbug)))))
         ?:(?=(%& -.result) p.result on-save:ag)
       %+  slap
         (slop state !>([bowl=bowl ..zuse]))
@@ -60,13 +60,13 @@
         [%leaf "no matching subscriptions"]~
       %+  murn
         %+  sort  ~(tap by sup.bowl)
-        |=  [[* a=[=ship =path]] [* b=[=ship =path]]]
-        (aor [path ship]:a [path ship]:b)
-      |=  [=duct [=ship =path]]
+        |=  [[* a=[=ship prov=path =path]] [* b=[=ship prov=path =path]]]
+        (aor [path ship prov]:a [path ship prov]:b)
+      |=  [=duct [=ship prov=path =path]]
       ^-  (unit tank)
       =;  relevant=?
         ?.  relevant  ~
-        `>[path=path from=ship duct=duct]<
+        `>[path=path from=ship prov=path duct=duct]<
       ?:  ?=(~ about.dbug)  &
       ?-  -.about.dbug
         %ship  =(ship ship.about.dbug)
@@ -99,10 +99,10 @@
     ==
   ::
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
     ?.  ?=([@ %dbug *] path)
-      (on-peek:ag path)
+      (on-peek:ag prov path)
     ?+  path  [~ ~]
       [%u %dbug ~]                 ``noun+!>(&)
       [%x %dbug %state ~]          ``noun+!>(on-save:ag)

--- a/pkg/arvo/lib/default-agent.hoon
+++ b/pkg/arvo/lib/default-agent.hoon
@@ -29,7 +29,7 @@
   `agent
 ::
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ~|  "unexpected scry into {<dap.bowl>} on path {<path>}"
   !!
 ::

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -146,9 +146,9 @@
 ++  peer                                              ::
   |=  pax=path
   ~|  [%drum-unauthorized our+our.hid src+src.hid]    ::  ourself
-  ?>  (team:title our.hid src.hid)               ::  or our own moon
+  ?>  (team:title our.hid ship.src.hid)               ::  or our own moon
   =<  se-abet  =<  se-view
-  (se-text "[{<src.hid>}, driving {<our.hid>}]")
+  (se-text "[{<ship.src.hid>}, driving {<our.hid>}]")
 ::
 ++  poke-set-boot-apps                                ::
   |=  lit=?

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -140,14 +140,14 @@
   ?:  =(%fail mes)
     ~&  %poke-hi-fail
     !!
-  abet:(flog %text "< {<src.bowl>}: {(trip mes)}")
+  abet:(flog %text "< {<ship.src.bowl>}: {(trip mes)}")
 ::
 ++  poke-atom
   |=  ato=@
   =+  len=(scow %ud (met 3 ato))
   =+  gum=(scow %p (mug ato))
   =<  abet
-  (flog %text "< {<src.bowl>}: atom: {len} bytes, mug {gum}")
+  (flog %text "< {<ship.src.bowl>}: atom: {len} bytes, mug {gum}")
 ::
 ++  coup-hi
   |=  [pax=path cop=(unit tang)]  =<  abet

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -56,7 +56,7 @@
   ==
 --
 |=  [bowl:gall state]
-?>  =(src our)
+?>  =(ship.src our)
 |_  moz=(list card:agent:gall)
 +$  state      ^state      ::  proxy
 +$  any-state  ^any-state  ::  proxy
@@ -106,7 +106,7 @@
   ..abet
 ::
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   ?.  ?=([%x %kiln %ota ~] path)
     [~ ~]

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -1,8 +1,8 @@
 ::  lib/pull-hook: helper for creating a push hook
-::  
+::
 ::   lib/pull-hook is a helper for automatically pulling data from a
-::   corresponding push-hook to a store. 
-::   
+::   corresponding push-hook to a store.
+::
 ::   ## Interfacing notes:
 ::
 ::   The inner door may interact with the library by producing cards.
@@ -37,7 +37,7 @@
       update-mark=term
       push-hook-name=term
   ==
-::  
+::
 ::  $base-state-0: state for the pull hook
 ::
 ::    .tracking: a map of resources we are pulling, and the ships that
@@ -60,7 +60,7 @@
 ::
 +$  state-2  [%2 base-state-1]
 ::
-+$  versioned-state 
++$  versioned-state
   $%  state-0
       state-1
       state-2
@@ -131,7 +131,7 @@
     *[(list card) _^|(..on-init)]
   ::
   ++  on-peek
-    |~  path
+    |~  [path path]
     *(unit (unit cage))
   ::
   ++  on-agent
@@ -170,16 +170,16 @@
       =/  old
         !<(versioned-state old-vase)
       =|  cards=(list card:agent:gall)
-      |^ 
+      |^
       ?-  -.old
-          %2  
+          %2
         =^  og-cards   pull-hook
           (on-load:og inner-state.old)
         =.  state  old
         =^  retry-cards  state
           retry-failed-kicks
         :_  this
-        :(weld cards og-cards retry-cards) 
+        :(weld cards og-cards retry-cards)
         ::
           %1  $(old [%2 +.old ~])
         ::
@@ -231,7 +231,7 @@
     ++  on-poke
       |=  [=mark =vase]
       ^-  [(list card:agent:gall) agent:gall]
-      ?>  (team:title our.bowl src.bowl)
+      ?>  (team:title our.bowl ship.src.bowl)
       ?.  =(mark %pull-hook-action)
         =^  cards  pull-hook
           (on-poke:og mark vase)
@@ -243,7 +243,7 @@
     ++  on-watch
       |=  =path
       ^-  [(list card:agent:gall) agent:gall]
-      ?>  (team:title our.bowl src.bowl)
+      ?>  (team:title our.bowl ship.src.bowl)
       ?.  ?=([%tracking ~] path)
         =^  cards  pull-hook
           (on-watch:og path)
@@ -265,7 +265,7 @@
       ?+   -.sign  (on-agent:def wire sign)
           %kick
         =^  cards  state
-          (handle-kick:hc rid src.bowl)
+          (handle-kick:hc rid ship.src.bowl)
         [cards this]
       ::
           %watch-ack
@@ -305,10 +305,10 @@
         =^  cards  pull-hook
           (on-fail:og term tang)
         [cards this]
-      ++  on-peek   
-        |=  =path
+      ++  on-peek
+        |=  [prov=path =path]
         ^-  (unit (unit cage))
-        (on-peek:og path)
+        (on-peek:og prov path)
     --
   |_  =bowl:gall
   +*  og   ~(. pull-hook bowl)
@@ -346,12 +346,12 @@
     =/  res=toon
       (mock [|.((on-pull-kick:og rid)) %9 2 %0 1] mule-scry)
     =/  pax=(unit path)
-      !<  (unit path) 
-      :-  -:!>(*(unit path)) 
+      !<  (unit path)
+      :-  -:!>(*(unit path))
       ?:(?=(%0 -.res) p.res ~)
     =?  failed-kicks  !?=(%0 -.res)
       =/  =tang
-        :+  leaf+"failed kick handler, please report" 
+        :+  leaf+"failed kick handler, please report"
           leaf+"{<rid>} in {(trip dap.bowl)}"
         ?:  ?=(%2 -.res)
           p.res

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -1,12 +1,12 @@
 ::  lib/push-hook: helper for creating a push hook
-::  
+::
 ::   lib/push-hook is a helper for automatically pushing data from a
 ::   local store to the corresponding pull-hook on remote ships. It also
 ::   proxies remote pokes to the store.
 ::
 ::   ## Interfacing notes:
 ::
-::   The inner door may interact with the library by producing cards. 
+::   The inner door may interact with the library by producing cards.
 ::   Do not pass any cards on a wire beginning with /helper as these
 ::   wires are reserved by this library. Any watches/pokes/peeks not
 ::   listed below will be routed to the inner door.
@@ -30,7 +30,7 @@
 +$  card  card:agent:gall
 ::
 ::  $config: configuration for the push hook
-::  
+::
 ::    .store-name: name of the store to proxy pokes and
 ::    subscriptions to
 ::    .store-path: subscription path to receive updates on
@@ -69,7 +69,7 @@
   |_  bowl:gall
   ::
   ::  +resource-for-update: get affected resource from an update
-  ::  
+  ::
   ::    Given a vase of the update, the mark of which is
   ::    update-mark.config, produce the affected resource, if any.
   ::
@@ -133,7 +133,7 @@
     *[(list card) _^|(..on-init)]
   ::
   ++  on-peek
-    |~  path
+    |~  [path path]
     *(unit (unit cage))
   ::
   ++  on-agent
@@ -172,9 +172,9 @@
       =/  old
         !<(versioned-state old-vase)
       =|  cards=(list card:agent:gall)
-      |^ 
+      |^
       ?-  -.old
-          %1  
+          %1
         =^  og-cards   push-hook
           (on-load:og inner-state.old)
         [(weld cards og-cards) this(state old)]
@@ -188,7 +188,7 @@
             kicked-watches
           ?~  paths  cards
           :_   cards
-          [%give %kick paths ~]
+          [%give %kick paths ~ ~]
         ==
       ==
       ::
@@ -213,13 +213,13 @@
       |=  [=mark =vase]
       ^-  (quip card:agent:gall agent:gall)
       ?:  =(mark %push-hook-action)
-        ?>  (team:title our.bowl src.bowl)
+        ?>  (team:title our.bowl ship.src.bowl)
         =^  cards  state
           (poke-hook-action:hc !<(action vase))
         [cards this]
       ::
       ?:  =(mark update-mark.config)
-        ?:  (team:title [our src]:bowl)
+        ?:  (team:title [our ship.src]:bowl)
           :_  this
           (forward-update:hc vase)
         =^  cards  state
@@ -326,7 +326,7 @@
       =.  sharing
         (~(del in sharing) rid)
       :_  state
-      [%give %kick ~(tap in paths) ~]~
+      [%give %kick ~(tap in paths) ~ ~]~
     ::
     ++  revoke
       |=  [ships=(set ship) rid=resource]
@@ -339,7 +339,7 @@
       ^-  (unit card)
       ?.  (~(has in ships) her)
         ~
-      `[%give %kick ~[path] `her]
+      `[%give %kick ~[path] `her ~]
     --
   ++  incoming-subscriptions
     |=  prefix=path

--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -70,7 +70,7 @@
       [%http-response-data !>(data.simple-payload)]
     :~  [%give %fact ~[/http-response/[eyre-id]] header-cage]
         [%give %fact ~[/http-response/[eyre-id]] data-cage]
-        [%give %kick ~[/http-response/[eyre-id]] ~]
+        [%give %kick ~[/http-response/[eyre-id]] ~ ~]
     ==
   --
 ++  gen

--- a/pkg/arvo/lib/shoe.hoon
+++ b/pkg/arvo/lib/shoe.hoon
@@ -98,7 +98,7 @@
     *(quip card _^|(..on-init))
   ::
   ++  on-peek
-    |~  path
+    |~  [path path]
     *(unit (unit cage))
   ::
   ++  on-agent
@@ -132,7 +132,7 @@
   ::
   ++  can-connect
     |=  sole-id=@ta
-    (team:title [our src]:bowl)
+    (team:title [our ship.src]:bowl)
   ::
   ++  on-connect
     |=  sole-id=@ta
@@ -347,7 +347,7 @@
     [(deal cards) this]
   ::
   ++  on-peek
-    |=  =path
+    |=  [prov=path =path]
     ^-  (unit (unit cage))
     ?.  =(/x/dbug/state path)  ~
     ``noun+(slop on-save:og !>(shoe=state))

--- a/pkg/arvo/lib/skeleton.hoon
+++ b/pkg/arvo/lib/skeleton.hoon
@@ -30,7 +30,7 @@
   !!
 ::
 ++  on-peek
-  |~  path
+  |~  [path path]
   ^-  (unit (unit cage))
   !!
 ::

--- a/pkg/arvo/lib/strand.hoon
+++ b/pkg/arvo/lib/strand.hoon
@@ -10,7 +10,7 @@
 +$  tid   @tatid
 +$  bowl
   $:  our=ship
-      src=ship
+      src=[=ship =path]
       tid=tid
       mom=(unit tid)
       wex=boat:gall

--- a/pkg/arvo/lib/verb.hoon
+++ b/pkg/arvo/lib/verb.hoon
@@ -60,10 +60,10 @@
   [[(emit-event %on-leave path) cards] this]
 ::
 ++  on-peek
-  |=  =path
+  |=  [prov=path =path]
   ^-  (unit (unit cage))
   %-  (print bowl |.("{<dap.bowl>}: on-peek on path {<path>}"))
-  (on-peek:ag path)
+  (on-peek:ag prov path)
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -160,7 +160,7 @@
       ::
       ++  deal                                          ::  pass to %gall
         |=  [=wire =deal:gall]
-        (pass wire [%g %deal [our our] ram deal])
+        (pass wire [%g %deal [our our /d] ram deal])
       ::
       ++  pass                                          ::  pass note
         |=  [=wire =note]

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -771,12 +771,12 @@
     |=  [app=term =inbound-request:eyre]
     ^-  (list move)
     :~  :*  duct  %pass  /watch-response/[eyre-id]
-            %g  %deal  [our our]  app
+            %g  %deal  [our our /e]  app
             %watch  /http-response/[eyre-id]
         ==
       ::
         :*  duct  %pass  /run-app-request/[eyre-id]
-            %g  %deal  [our our]  app
+            %g  %deal  [our our /e]  app
             %poke  %handle-http-request
             !>([eyre-id inbound-request])
         ==
@@ -799,7 +799,7 @@
       :_  state
       :_  ~
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.u.connection
+          %g  %deal  [our our /e]  app.action.u.connection
           %leave  ~
       ==
     ::
@@ -1373,7 +1373,7 @@
           ^-  move
           :^  duct  %pass  /channel/poke/[channel-id]/(scot %ud request-id.i.requests)
           =,  i.requests
-          :*  %g  %deal  `sock`[our ship]  app
+          :*  %g  %deal  `sock`[our ship /e]  app
               `task:agent:gall`[%poke-as mark %json !>(json)]
           ==
         ::
@@ -1388,7 +1388,7 @@
           ^-  move
           :^  duct  %pass
             (subscription-wire channel-id request-id ship app)
-          :*  %g  %deal  [our ship]  app
+          :*  %g  %deal  [our ship /e]  app
               `task:agent:gall`[%watch path]
           ==
         ::
@@ -1423,7 +1423,7 @@
           =,  u.maybe-subscription
           :^  duc  %pass
             (subscription-wire channel-id subscription-id.i.requests ship app)
-          :*  %g  %deal  [our ship]  app
+          :*  %g  %deal  [our ship /e]  app
               `task:agent:gall`[%leave ~]
           ==
         ::
@@ -1473,7 +1473,7 @@
       ^-  move
       :^  duct  %pass
         (subscription-wire channel-id request-id ship app)
-      [%g %deal [our ship] app `task:agent:gall`[%leave ~]]
+      [%g %deal [our ship /e] app `task:agent:gall`[%leave ~]]
     ::  +emit-event: records an event occurred, possibly sending to client
     ::
     ::    When an event occurs, we need to record it, even if we immediately
@@ -1565,7 +1565,7 @@
         =+  (~(got by subscriptions.u.channel) request-id)
         :^  duct  %pass
           (subscription-wire channel-id request-id ship app)
-        [%g %deal [our ship] app %leave ~]
+        [%g %deal [our ship /e] app %leave ~]
       ::  update channel state to reflect the %kick
       ::
       =?  u.channel  kicking
@@ -1758,7 +1758,7 @@
       ^-  move
       :^  duc  %pass
         (subscription-wire channel-id request-id ship app)
-      [%g %deal [our ship] app %leave ~]
+      [%g %deal [our ship /e] app %leave ~]
     --
   ::  +handle-gall-error: a call to +poke-http-response resulted in a %coup
   ::
@@ -1772,7 +1772,7 @@
         ~
       :_  ~
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.connection
+          %g  %deal  [our our /e]  app.action.connection
           %leave  ~
       ==
     ::
@@ -1917,7 +1917,7 @@
         ~
       :_  ~
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.u.connection-state
+          %g  %deal  [our our /e]  app.action.u.connection-state
           %leave  ~
       ==
     --
@@ -2266,7 +2266,7 @@
       :_  http-server-gate
       =/  cmd
         [%acme %poke `cage`[%acme-order !>(mod)]]
-      [duct %pass /acme/order %g %deal [our our] cmd]~
+      [duct %pass /acme/order %g %deal [our our /e] cmd]~
     ==
   ::
       %request

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -39,7 +39,7 @@
 ::
 +$  routes
   $:  disclosing=(unit (set ship))
-      attributing=ship
+      attributing=[=ship =path]
   ==
 ::  $yoke: agent runner state
 ::
@@ -88,13 +88,20 @@
 ::    %u: leave
 ::
 +$  ames-request-all
-  $%  [%0 ames-request]
+  $%  [%0 ames-request-0]
+      [%1 ames-request]
   ==
 +$  ames-request
+  $%  [%m prov=path =mark noun=*]
+      [%l prov=path =mark =path]
+      [%s prov=path =path]
+      [%u ~]
+  ==
++$  ames-request-0
   $%  [%m =mark noun=*]
       [%l =mark =path]
       [%s =path]
-      [%u ~]
+      [%u =path]
   ==
 ::  $remote-request: kinds of agent actions that can cross the network
 ::
@@ -250,6 +257,30 @@
     --
 ~%  %gall-top  ..is  ~
 |%
+++  en-snare
+  |=  prov=path
+  ^-  slyt
+  %-  sloy
+  %-  en-sley
+  |=  $:  lyc=gang                                      ::  leakset
+          cyr=term                                      ::  perspective
+          bem=beam                                      ::  path
+      ==
+  ^-  (unit (unit cage))
+  =*  args  +<
+  =/  =shop  &/p.bem
+  =*  dap  q.bem
+  =/  =coin  $/r.bem
+  =*  path  s.bem
+  ?.  ?=(%.y -.shop)
+    ~
+  =/  =ship  p.shop
+  =/  vane  (end 3 cyr)
+  =/  care  ;;(@t (rsh 3 cyr))
+  ?.  =(%g vane)  (rof args)
+  ?:  |(=(care %u) |(=(care %$) =(s.bem /whey)))  (rof args)
+  =/  =routes  [~ ship prov]
+  (mo-peek:mo dap routes care path)
 ::  +mo: Arvo-level move handling
 ::
 ::    An outer core responsible for routing moves to and from Arvo; it calls
@@ -320,7 +351,7 @@
     ?^  existing
       =.  yokes.state
         (~(put by yokes.state) dap u.existing(beak bek))
-      =/  =routes  [disclosing=~ attributing=our]
+      =/  =routes  [disclosing=~ attributing=[our /g]]
       =/  ap-core  (ap-abed:ap dap routes)
       =.  ap-core  (ap-reinstall:ap-core agent)
       =.  mo-core  ap-abet:ap-core
@@ -337,7 +368,7 @@
     ::
     =/  old  mo-core
     =/  wag
-      =/  =routes  [disclosing=~ attributing=our]
+      =/  =routes  [disclosing=~ attributing=[our /g]]
       =/  ap-core  (ap-abed:ap dap routes)
       (ap-upgrade-state:ap-core ~)
     ::
@@ -398,18 +429,18 @@
   ::
   ++  mo-send-foreign-request
     ~/  %mo-send-foreign-request
-    |=  [=ship foreign-agent=term =deal]
+    |=  [=ship foreign-agent=term prov=path =deal]
     ^+  mo-core
     ::
     =.  mo-core  (mo-track-ship ship)
     ?<  ?=(?(%raw-poke %poke-as) -.deal)
     =/  =ames-request-all
-      :-  %0
+      :-  %1
       ?-  -.deal
-        %poke      [%m p.cage.deal q.q.cage.deal]
+        %poke      [%m prov p.cage.deal q.q.cage.deal]
         %leave     [%u ~]
-        %watch-as  [%l [mark path]:deal]
-        %watch     [%s path.deal]
+        %watch-as  [%l prov [mark path]:deal]
+        %watch     [%s prov path.deal]
       ==
     ::
     =/  wire
@@ -424,7 +455,7 @@
         (~(gut by outstanding.state) [wire hen] *(qeu remote-request))
       (~(put by outstanding.state) [wire hen] (~(put to stand) -.deal))
     (mo-pass wire note-arvo)
-  ::  +mo-track-ship: subscribe to ames and jael for notices about .ship
+      ::  +mo-track-ship: subscribe to ames and jael for notices about .ship
   ::
   ++  mo-track-ship
     |=  =ship
@@ -482,7 +513,7 @@
     ?~  agents
       mo-core
     =.  mo-core
-      =/  =routes  [disclosing=~ attributing=ship]
+      =/  =routes  [disclosing=~ attributing=[ship /g]]
       =/  app  (ap-abed:ap name.i.agents routes)
       ap-abet:(ap-breach:app ship)
     $(agents t.agents)
@@ -584,7 +615,7 @@
     ?~  agents  mo-core
     ::
     =.  mo-core
-      =/  =routes  [disclosing=~ attributing=our]
+      =/  =routes  [disclosing=~ attributing=[our /g]]
       =/  app  (ap-abed:ap i.agents routes)
       ap-abet:(ap-clog:app ship.sign-arvo)
     ::
@@ -680,8 +711,8 @@
       ::
       =/  sys-wire  [%sys wire]
       ::  TODO: %drip %kick so app crash can't kill the remote %pull
-      ::
-      =/  =ames-request-all  [%0 %u ~]
+      ::  also: maybe add path to %u case? (how?)
+      =/  =ames-request-all  [%1 %u ~]
       =.  mo-core
         (mo-pass sys-wire %a %plea ship %g /ge/[foreign-agent] ames-request-all)
       =.  mo-core  (mo-give %unto %kick ~)
@@ -717,14 +748,14 @@
         mo-core
       =/  app
         =/  =ship  (slav %p i.t.t.path)
-        =/  =routes  [disclosing=~ attributing=ship]
+        =/  =routes  [disclosing=~ attributing=[ship /[-.sign-arvo]]]
         (ap-abed:ap dap routes)
       ::
       =.  app  (ap-generic-take:app t.t.t.path sign-arvo)
       ap-abet:app
     ?>  ?=([%out @ @ *] t.t.path)
     =/  =ship  (slav %p i.t.t.t.path)
-    =/  =routes  [disclosing=~ attributing=ship]
+    =/  =routes  [disclosing=~ attributing=[ship /[-.sign-arvo]]]
     =/  =sign:agent  +>.sign-arvo
     ?:  ?=(%| -.agent.u.yoke)
       =/  blocked=(qeu blocked-move)
@@ -758,7 +789,7 @@
     =^  [=duct =routes blocker=(each deal sign:agent)]  blocked
       ~(get to blocked)
     =/  =move
-      =/  =sock  [attributing.routes our]
+      =/  =sock  =+(attributing.routes [ship our path])
       =/  card
         ?:  ?=(%& -.blocker)
           [%slip %g %deal sock dap p.blocker]
@@ -767,6 +798,7 @@
     $(moves [move moves])
   ::  +mo-filter-queue: remove all blocked tasks from ship.
   ::
+  ::  TODO: also check path of attributing
   ++  mo-filter-queue
     |=  =ship
     =/  agents=(list [name=term blocked=(qeu blocked-move)])
@@ -785,7 +817,7 @@
         new-agents  (~(put by new-agents) name.i.agents new-blocked)
       ==
     =^  mov=blocked-move  blocked.i.agents  ~(get to blocked.i.agents)
-    =?  new-blocked  !=(ship attributing.routes.mov)
+    =?  new-blocked  !=(ship ship.attributing.routes.mov)
       (~(put to new-blocked) mov)
     $
   ::  +mo-fade: put app to sleep
@@ -793,7 +825,7 @@
   ++  mo-fade
     |=  [dap=term style=?(%slay %idle %jolt)]
     ^+  mo-core
-    =/  =routes  [disclosing=~ attributing=our]
+    =/  =routes  [disclosing=~ attributing=[our /g]]
     =/  app  (ap-abed:ap dap routes)
     =.  mo-core  ap-abet:(ap-fade:app style)
     =.  mo-core
@@ -887,10 +919,10 @@
   ::    +deal.  Otherwise simply apply the action to the agent.
   ::
   ++  mo-handle-local
-    |=  [=ship agent=term =deal]
+    |=  [=ship prov=path agent=term =deal]
     ^+  mo-core
     ::
-    =/  =routes  [disclosing=~ attributing=ship]
+    =/  =routes  [disclosing=~ attributing=[ship prov]]
     =/  running  (~(get by yokes.state) agent)
     =/  is-running  ?~(running %| ?=(%& -.agent.u.running))
     =/  is-blocked  (~(has by blocked.state) agent)
@@ -926,7 +958,13 @@
         %s  [%watch path.ames-request]
         %u  [%leave ~]
       ==
-    (mo-pass wire %g %deal [ship our] agent-name deal)
+    %:  mo-pass
+        wire  %g  %deal
+        :: TODO: maybe add prov to leave?
+        :: don't /really/ need to because it'll find from the outgoing
+        [ship our ?:(?=(?(%m %l %s) -.ames-request) prov.ames-request /leave)]
+        agent-name  deal
+    ==
   ::  +mo-handle-ames-response: handle ames response message.
   ::
   ++  mo-handle-ames-response
@@ -997,7 +1035,7 @@
         ?:  ?=(%| -.res)
           (mean p.res)
         egg(p.old-state `agent`p.res)
-      =/  =routes  [disclosing=~ attributing=our]
+      =/  =routes  [disclosing=~ attributing=[our /g]]
       (ap-yoke dap routes yoke)
     ::  +ap-yoke: initialize agent state, starting from a $yoke
     ::
@@ -1047,13 +1085,13 @@
         =/  inbound-paths=(set path)
           %-  silt
           %+  turn  ~(tap by inbound.watches.current-agent)
-          |=  [=duct =ship =path]
+          |=  [=duct =ship prov=path =path]
           path
         =/  will=(list card:agent:gall)
           %+  welp
             ?:  =(~ inbound-paths)
               ~
-            [%give %kick ~(tap in inbound-paths) ~]~
+            [%give %kick ~(tap in inbound-paths) ~ ~]~
           %+  turn  ~(tap by outbound.watches.current-agent)
           |=  [[=wire =ship =term] ? =path]
           [%pass wire %agent [ship term] %leave ~]
@@ -1076,7 +1114,7 @@
           %give
         =/  =gift:agent  p.card
         ?:  ?=(%kick -.gift)
-          =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ship.gift)
+          =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ship.gift prov.gift)
           %+  turn  ducts
           |=  =duct
           ~?  &(=(duct system-duct.state) !=(agent-name %hood))
@@ -1086,7 +1124,7 @@
         ?.  ?=(%fact -.gift)
           [agent-duct %give %unto gift]~
         ::
-        =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ~)
+        =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ~ ~)
         =/  =cage  cage.gift
         %-  zing
         %+  turn  ducts
@@ -1127,12 +1165,16 @@
         =.  wire
           ?:  ?=(%agent -.neat)
             [%out (scot %p ship.neat) name.neat wire]
-          [(scot %p attributing.agent-routes) wire]
+          [(scot %p ship.attributing.agent-routes) wire]
         =.  wire  [%use agent-name nonce.current-agent wire]
         =/  =note-arvo
           ?-  -.neat
-            %arvo   note-arvo.neat
-            %agent  [%g %deal [our ship.neat] [name deal]:neat]
+              %arvo   note-arvo.neat
+              %agent
+            :*  %g  %deal
+            [our ship.neat /g/[agent-name]]
+            [name deal]:neat
+            ==
           ==
         [duct %pass wire note-arvo]~
       ==
@@ -1141,7 +1183,7 @@
     ++  ap-breach
       |=  =ship
       ^+  ap-core
-      =/  in=(list [=duct =^ship =path])
+      =/  in=(list [=duct =^ship prov=path =path])
         ~(tap by inbound.watches.current-agent)
       |-  ^+  ap-core
       ?^  in
@@ -1173,7 +1215,7 @@
       |=  =ship
       ^+  ap-core
       ::
-      =/  in=(list [=duct =^ship =path])
+      =/  in=(list [=duct =^ship prov=path =path])
         ~(tap by inbound.watches.current-agent)
       |-  ^+  ap-core
       ?~  in  ap-core
@@ -1190,31 +1232,49 @@
     ::  +ap-ducts-from-paths: get ducts subscribed to paths
     ::
     ++  ap-ducts-from-paths
-      |=  [target-paths=(list path) target-ship=(unit ship)]
+      |=  $:  target-paths=(list path)
+              target-ship=(unit ship)
+              target-prov=(unit path)
+          ==
       ^-  (list duct)
       ?~  target-paths
-        ?~  target-ship
-          ~[agent-duct]
-        %+  murn  ~(tap by inbound.watches.current-agent)
-        |=  [=duct =ship =path]
-        ^-  (unit ^duct)
-        ?:  =(target-ship `ship)
+        ?.  |(?=(~ target-ship) ?=(~ target-prov))
+            ~[agent-duct]
+        ?:  &(?=(~ target-ship) ?=(^ target-prov))
+          %+  murn  ~(tap by inbound.watches.current-agent)
+          |=  [=duct =ship prov=path =path]
+          ^-  (unit ^duct)
+          ?:  =(target-prov `prov)
           `duct
-        ~
+          ~
+        ?:  &(?=(^ target-ship) ?=(~ target-prov))
+          %+  murn  ~(tap by inbound.watches.current-agent)
+          |=  [=duct =ship prov=path =path]
+          ^-  (unit ^duct)
+          ?:  =(target-ship `ship)
+            `duct
+            ~
+        %+  murn  ~(tap by inbound.watches.current-agent)
+        |=  [=duct =ship prov=path =path]
+        ^-  (unit ^duct)
+        ?:  &(=(target-ship `ship) =(target-prov `prov))
+          `duct
+          ~
       %-  zing
       %+  turn  target-paths
       |=  =path
-      (ap-ducts-from-path path target-ship)
+      (ap-ducts-from-path path target-ship target-prov)
     ::  +ap-ducts-from-path: get ducts subscribed to path
     ::
     ++  ap-ducts-from-path
-      |=  [target-path=path target-ship=(unit ship)]
+      |=  [target-path=path target-ship=(unit ship) target-prov=(unit path)]
       ^-  (list duct)
       %+  murn  ~(tap by inbound.watches.current-agent)
-      |=  [=duct =ship =path]
+      |=  [=duct =ship prov=path =path]
       ^-  (unit ^duct)
       ?:  ?&  =(target-path path)
               |(=(target-ship ~) =(target-ship `ship))
+              |(=(target-prov ~) =(target-prov `prov))
           ==
         `duct
       ~
@@ -1246,7 +1306,8 @@
       ::  call the app's +on-peek, producing [~ ~] if it crashes
       ::
       =/  peek-result=(each (unit (unit cage)) tang)
-        (ap-mule-peek |.((on-peek:ap-agent-core [care tyl])))
+        =+  prov=path.attributing.agent-routes
+        (ap-mule-peek |.((on-peek:ap-agent-core prov [care tyl])))
       ?:  ?=(%| -.peek-result)
         ((slog leaf+"peek bad result" p.peek-result) [~ ~])
       ::  for non-%x scries, or failed %x scries, or %x results that already
@@ -1298,8 +1359,8 @@
               attributing.agent-routes                ::  guest
               agent-name                              ::  agent
           ==                                          ::
-          :*  wex=outbound.watches.current-agent  ::  outgoing
-              sup=inbound.watches.current-agent  ::  incoming
+          :*  wex=outbound.watches.current-agent      ::  outgoing
+              sup=inbound.watches.current-agent       ::  incoming
           ==                                          ::
           :*  act=change.stats.current-agent          ::  tick
               eny=eny.stats.current-agent             ::  nonce
@@ -1342,7 +1403,7 @@
       ~/  %ap-subscribe
       |=  pax=path
       ^+  ap-core
-      =/  incoming  [attributing.agent-routes pax]
+      =/  incoming  =+(attributing.agent-routes [ship path pax])
       =.  inbound.watches.current-agent
         (~(put by inbound.watches.current-agent) agent-duct incoming)
       =^  maybe-tang  ap-core
@@ -1491,7 +1552,7 @@
       ::
       =^  maybe-tang  ap-core
         %+  ap-ingest  ~  |.
-        (on-leave:ap-agent-core q.incoming)
+        (on-leave:ap-agent-core r.incoming)
       ?^  maybe-tang
         (ap-error %leave u.maybe-tang)
       ap-core
@@ -1501,7 +1562,7 @@
       ^+  ap-core
       ::
       =>  ap-load-delete
-      (ap-give %kick ~ ~)
+      (ap-give %kick ~ ~ ~)
     ::  +ap-kill-up-slip: 2-sided kill from publisher side by slip
     ::
     ::  +ap-kill-up is reentrant if you call it in the
@@ -1513,7 +1574,7 @@
       |=  =duct
       ^-  (list move)
       ::
-      :~  [duct %slip %g %deal [our our] agent-name %leave ~]
+      :~  [duct %slip %g %deal [our our /g] agent-name %leave ~]
           [duct %give %unto %kick ~]
       ==
     ::  +ap-kill-down: 2-sided kill from subscriber side
@@ -1539,7 +1600,8 @@
     ++  ap-mule
       |=  run=_^?(|.(*step:agent))
       ^-  (each step:agent tang)
-      =/  res  (mock [run %9 2 %0 1] (sloy ski))
+      =+  prov=path.attributing.agent-routes
+      =/  res  (mock [run %9 2 %0 1] (en-snare prov))
       ?-  -.res
         %0  [%& !<(step:agent [-:!>(*step:agent) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -1548,9 +1610,11 @@
     ::  +ap-mule-peek: same as +ap-mule but for (unit (unit cage))
     ::
     ++  ap-mule-peek
+
       |=  run=_^?(|.(*(unit (unit cage))))
       ^-  (each (unit (unit cage)) tang)
-      =/  res  (mock [run %9 2 %0 1] (sloy ski))
+      =+  prov=path.attributing.agent-routes
+      =/  res  (mock [run %9 2 %0 1] (en-snare prov))
       ?-  -.res
         %0  [%& !<((unit (unit cage)) [-:!>(*(unit (unit cage))) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -1612,7 +1676,7 @@
         `duct.move
       ::
       =/  quit-map=bitt
-        (malt (turn quits |=(=duct [duct *[ship path]])))
+        (malt (turn quits |=(=duct [duct *[ship path path]])))
       (~(dif by inbound.watches.current-agent) quit-map)
     ::  +ap-handle-peers: handle new outbound.watches
     ::
@@ -1677,8 +1741,8 @@
     =/  [=sock =term =deal]  [p q r]:task
     ?.  =(q.sock our)
       ?>  =(p.sock our)
-      mo-abet:(mo-send-foreign-request:mo-core q.sock term deal)
-    mo-abet:(mo-handle-local:mo-core p.sock term deal)
+      mo-abet:(mo-send-foreign-request:mo-core q.sock term r.sock deal)
+    mo-abet:(mo-handle-local:mo-core p.sock r.sock term deal)
   ::
       %goad  mo-abet:(mo-goad:mo-core agent.task)
       %init  [~ gall-payload(system-duct.state duct)]
@@ -1692,7 +1756,8 @@
     =/  agent-name  i.t.path
     ::
     =+  ;;(=ames-request-all noun)
-    ?>  ?=(%0 -.ames-request-all)
+    :: TODO: handle %0
+    ?>  ?=(%1 -.ames-request-all)
     =>  (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
     mo-abet
   ::
@@ -1750,7 +1815,7 @@
     [~ ~]
   ?.  ?=(^ path)
     ~
-  =/  =routes  [~ ship]
+  =/  =routes  [~ ship /arvo]
   (mo-peek:mo dap routes care path)
 ::  +stay: save without cache
 ::

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -209,7 +209,7 @@
         /[app]/poke
         %g
         %deal
-        [our our]
+        [our our /j]
         app
         %poke
         %azimuth-tracker-poke
@@ -649,7 +649,7 @@
         [app path]
         %g
         %deal
-        [our our]
+        [our our /j]
         app
         %watch
         path

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -77,7 +77,7 @@
 +$  rift  @ud                                           ::  ship continuity
 +$  mime  (pair mite octs)                              ::  mimetyped data
 +$  octs  (pair @ud @)                                  ::  octet-stream
-+$  sock  (pair ship ship)                              ::  outgoing [our his]
++$  sock  (trel ship ship path)                              ::  outgoing [our his]
 +$  stub  (list (pair stye (list @c)))                  ::  styled unicode
 +$  stye  (pair (set deco) (pair tint tint))            ::  decos/bg/fg
 +$  styl  %+  pair  (unit deco)                         ::  cascading style
@@ -1707,7 +1707,7 @@
     +$  task                                            ::  incoming request
       $~  [%vega ~]                                     ::
       $%  [%conf dap=term]                              ::  start agent
-          [%deal p=sock q=term r=deal]                  ::  full transmission
+          [%deal p=sock q=term r=deal]           ::  full transmission
           [%goad force=? agent=(unit dude)]             ::  rebuild agent(s)
           [%sear =ship]                                 ::  clear pending queues
           [%fade dap=term style=?(%slay %idle %jolt)]   ::  put app to sleep
@@ -1717,13 +1717,13 @@
           $>(%plea vane-task)                           ::  network request
       ==                                                ::
     --  ::able
-  +$  bitt  (map duct (pair ship path))                 ::  incoming subs
+  +$  bitt  (map duct (trel ship path path))            ::  incoming subs
   +$  boat                                              ::  outgoing subs
     %+  map  [=wire =ship =term]                        ::
     [acked=? =path]                                     ::
   +$  bowl                                              ::  standard app state
           $:  $:  our=ship                              ::  host
-                  src=ship                              ::  guest
+                  src=[=ship =path]                      ::  guest
                   dap=term                              ::  agent
               ==                                        ::
               $:  wex=boat                              ::  outgoing subs
@@ -1772,7 +1772,7 @@
       ==
     +$  gift
       $%  [%fact paths=(list path) =cage]
-          [%kick paths=(list path) ship=(unit ship)]
+          [%kick paths=(list path) ship=(unit ship) prov=(unit path)]
           [%watch-ack p=(unit tang)]
           [%poke-ack p=(unit tang)]
       ==
@@ -1808,7 +1808,7 @@
         *(quip card _^|(..on-init))
       ::
       ++  on-peek
-        |~  path
+        |~  [path path]
         *(unit (unit cage))
       ::
       ++  on-agent

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -400,7 +400,7 @@
       ^=  expected-move
         :~  :*  duct=~[/http-blah]  %pass
                 /watch-response/[eyre-id]
-                %g  %deal  [~nul ~nul]  %app1  %leave  ~
+                %g  %deal  [~nul ~nul /nul]  %app1  %leave  ~
             ==
           ::
             :*  duct=~[/http-blah]  %give  %response
@@ -1904,7 +1904,7 @@
             ==
             :*  duct=~[/http-put-request]  %pass
               /channel/subscription/'0123456789abcdef'/'1'/~nul/two
-              %g  %deal  [~nul ~nul]  %two  %leave  ~
+              %g  %deal  [~nul ~nul /null]  %two  %leave  ~
             ==
             :*  duct=~[/http-get-open]
                 %give


### PR DESCRIPTION
I built this on na-release/candidate so that's the target branch I have, for now, not expecting to get this into the breach though.

I have some other PR's I need to attend to before I continue with this, but a brief outline:

In order for gall apps to appropriately be confined so that they may not arbitrarily read from clay, scry the keys of the jael, or send whatever tasks they choose to gall apps and vanes, I have systematically recorded provenance information into scrys and tasks from gall agents. Right now, provenance is a path, but will only ever be /arvo, /g/[agent], or /[vane] in it's current shape based on how gall.hoon records it. Vanes can arbitrarily choose their provenance - this seems fine, as vanes shouldn't ever really be third party and shouldn't ever act maliciously, and also one can imagine with a more confined userspace client eyre can safely forward provenance information from client actions and so it is good for it to describe its own provenance.

With this provenance information, gall can manage an ACL for vanes, and gall agents may choose whatever permissions system they want, be they acl's or capabilities, enforced by the provenance of tasks and scrys.

This also works for remote actions, and ought to be revisited in light of remote scry when that work matures. Of course, another ship could always fake the provenance of an action, but if one trusts a users *morals*, it is secure up to the person being naive enough to grant an arbitrary third party application to invoke some other application which invokes yours remotely.

Provenance is in the bowl of every gall agent, even for gifts (this is possible for gifts because the provenance is associated with the wire), and is also present in $bitt for all incoming subscriptions(outgoing can simply be constructed with /g/[ship.src.bol], for now), except in +on-peek where it is in the sample of the gate. (need to look into what bowls are when +on-peek is called... it shouldn't have entropy, but may it have other things?...)

I create a new gate in gall.hoon called +en-snare which accepts a path for provenance and returns a $slyt which may be passed into mock in +ap-mule and +ap-mule-peek. Right now, it's very simple, and does the same logic +scry does in gall.hoon, but rather for scrys targeting apps it uses the internal +mo-peek instead of routing it through the roof. However, it should check to make sure the scry'ing application may scry a vane when it's not going to a gall agent.

The main task which remains is confining the vanes, which is now possible with above affordances. It seems like the simplest way here is best, as one can always build more sophisticated permissions system on top of gall agents which have a very simple ACL permission to the vane. If a permission system proves itself to particularly strong in practice, it could be moved up the stack later. It seems like there should be a bespoke agent which has special privileges to update gall's acl on the vanes, and maybe even do some forwarding of tasks and scrys. The permissions may include updating the permissions themselves. The permissions should probably come out of a sensible analysis of all vane tasks and scrys - factoring in read vs write in certain cases, and having attention to detail to the tasks involved in certain vanes. A simple role-based solution here would do the trick, I think, associating roles with provenance paths.

tagging @philipcmonk since this came out of extensive discussion with him

n.b. don't expect this to work by merging into home - I tested this by commenting out the commits to home with herb in solid.sh. I haven't yet built a +load case for gall to migrate from state version %7