### PR TITLE
vere: webslog atom tanks, and webflogs

### DIFF
--- a/pkg/urbit/vere/io/http.c
+++ b/pkg/urbit/vere/io/http.c
@@ -1936,7 +1936,13 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
     u3_weak data = u3_none;
 
     if ( c3y == u3a_is_atom(tan) ) {
-      data = u3nt(u3_nul, u3r_met(3, tan), u3k(tan));
+      u3_noun lin = u3i_list(u3i_string("data:"),
+                             u3k(tan),
+                             c3_s2('\n', '\n'),
+                             u3_none);
+      u3_atom txt = u3qc_rap(3, lin);
+      data = u3nt(u3_nul, u3r_met(3, txt), txt);
+      u3z(lin);
     }
     else {
       u3_weak wol = u3_none;

--- a/pkg/urbit/vere/lord.c
+++ b/pkg/urbit/vere/lord.c
@@ -366,6 +366,8 @@ _lord_plea_slog(u3_lord* god_u, u3_noun dat)
 static void
 _lord_plea_flog(u3_lord* god_u, u3_noun dat)
 {
+  u3_pier* pir_u = god_u->cb_u.ptr_v;
+
   if ( c3n == u3a_is_atom(dat) ) {
     return _lord_plea_foul(god_u, c3__flog, dat);
   }
@@ -374,7 +376,10 @@ _lord_plea_flog(u3_lord* god_u, u3_noun dat)
   u3C.stderr_log_f(tan_c);
   c3_free(tan_c);
 
-  god_u->cb_u.slog_f(god_u->cb_u.ptr_v, 0, dat);
+  if ( 0 != pir_u->sog_f ) {
+    pir_u->sog_f(pir_u->sop_p, 0, u3k(dat));
+  }
+  u3z(dat);
 }
 
 /* _lord_plea_peek_bail(): hear serf %peek %bail

--- a/pkg/urbit/vere/lord.c
+++ b/pkg/urbit/vere/lord.c
@@ -366,17 +366,15 @@ _lord_plea_slog(u3_lord* god_u, u3_noun dat)
 static void
 _lord_plea_flog(u3_lord* god_u, u3_noun dat)
 {
-  u3_noun pri, tan;
-  c3_w pri_w;
-
   if ( c3n == u3a_is_atom(dat) ) {
-    return _lord_plea_foul(god_u, c3__slog, dat);
+    return _lord_plea_foul(god_u, c3__flog, dat);
   }
 
-  c3_c* tan_c = u3r_string(tan);
+  c3_c* tan_c = u3r_string(dat);
   u3C.stderr_log_f(tan_c);
   c3_free(tan_c);
-  u3z(dat);
+
+  god_u->cb_u.slog_f(god_u->cb_u.ptr_v, 0, dat);
 }
 
 /* _lord_plea_peek_bail(): hear serf %peek %bail


### PR DESCRIPTION
As discussed out of band: fixes the webslog callback to handle cords correctly, fixes the flog callback, and sends flogs to the webslog callback.