### PR TITLE
Add deeper property existence check to landscape background value setting

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -106,10 +106,7 @@ class App extends React.Component {
   }
 
   faviconString() {
-    let background = '#ffffff';
-    if (this.state.contacts.hasOwnProperty('/~/default')) {
-      background = `#${uxToHex(this.state.contacts['/~/default'][window.ship].color)}`;
-    }
+    let background = this.state.contacts?.['/~/default']?.[window.ship]?.color ? `#${uxToHex(this.state.contacts['/~/default'][window.ship].color)}` : '#ffffff';
     const foreground = foregroundFromBackground(background);
     const svg = sigiljs({
       patp: window.ship,


### PR DESCRIPTION
Component: Landscape

Check more specifically for the existence of a `color` attribute before attempting to override the default of `#ffffff`.