### PR TITLE
landscape: various regressions

### DIFF
--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -94,7 +94,7 @@ const GraphNodeContent = ({ contents, contacts, mod, description, index, remoteC
           <Box mb="2" fontWeight="500">
             <Text>{header}</Text>
           </Box>
-          <Box overflow="hidden" maxHeight="400px">
+          <Box overflow="hidden" maxHeight="400px" position="relative">
             <Text lineHeight="tall">{snippet}</Text>
             <FilterBox
               width="100%"

--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -76,7 +76,7 @@ export function ShipSearch(props: InviteSearchProps) {
       if(ob.isValidPatp(ship)) {
         checkInput(true, ship);
       } else {
-        checkInput(ship.length !== 1, undefined) 
+        checkInput(ship.length !== 1, undefined)
       }
     },
     [checkInput]
@@ -90,7 +90,7 @@ export function ShipSearch(props: InviteSearchProps) {
     (s: string) => {
       setTouched(true);
       checkInput(true, undefined);
-      s = `~${deSig(s)}`;
+      s = `${deSig(s)}`;
       setSelected(v => _.uniq([...v, s]))
     },
     [setTouched, checkInput, setSelected]

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -127,7 +127,7 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
             };
             return (
               <Col overflowY="auto" p={3}>
-                <Box pb='3' display={['block', 'none']} onClick={() => history.push(props.baseUrl)}>
+                <Box color='black' pb='4' display={['block', 'none']} onClick={() => history.push(props.baseUrl)}>
                   {'<- Back'}
                 </Box>
                 <Box fontWeight="bold" mb={4} color="black">


### PR DESCRIPTION
- Adding writers and unmanaged channel creation has been silently broken after #3998 because the ship search returns sig'd patps. Because we compare unsig'd patps everywhere the ship search is used and the invite popover desigs them anyway, I just removed the sig.
- Snippet gradients would take up the full height of the screen in hark because `position='relative'` is no longer implicit in `<Box>` (indigo-react 1.2.15+). This passes the relative positioning for that instance.