### PR TITLE
observe-hook: spider wasn't always issuing thread-results, so we got %watch-not-unique. we now make unique wires, but spider's issue remains

### DIFF
--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -134,9 +134,9 @@
   ^-  (quip card _this)
   |^
   ?+  wire  (on-agent:def wire sign)
-    [%observer @ ~]        on-observer
+    [%observer @ ~]          on-observer
     [%thread-result @ @ ~]   on-thread-result
-    [%thread-start @ @ ~]  on-thread-start
+    [%thread-start @ @ ~]    on-thread-start
   ==
   ::
   ++  on-observer

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -135,7 +135,7 @@
   |^
   ?+  wire  (on-agent:def wire sign)
     [%observer @ ~]        on-observer
-    [%thread-result @ ~]   on-thread-result
+    [%thread-result @ @ ~]   on-thread-result
     [%thread-start @ @ ~]  on-thread-start
   ==
   ::
@@ -167,7 +167,7 @@
       =/  tid  (scot %uv (sham eny.bowl))
       :_  this
       :~  :*  %pass
-              [%thread-result i.t.wire ~]
+              [%thread-result i.t.wire tid ~]
               %agent
               [our.bowl %spider]
               %watch
@@ -184,7 +184,7 @@
     ==
   ::
   ++  on-thread-result
-    ?>  ?=([%thread-result @ ~] wire)
+    ?>  ?=([%thread-result @ @ ~] wire)
     ?+    -.sign  (on-agent:def wire sign)
       %kick       [~ this]
       %watch-ack  [~ this]


### PR DESCRIPTION
Fixes #4114. We got a repro on Isaac's ship and resolved it by making this change. This issue may be representative of a deeper issue in `%spider` where spider may not be issuing `%thread-results` deterministically every time a thread is completed. Unsure. Regardless, no functionality was broken, and everything continues to work in this PR.

cc @philipcmonk 