### PR TITLE
jael: account for step in deriving code

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -1043,7 +1043,8 @@
     =/  who  (slaw %p i.tyl)
     ?~  who  [~ ~]
     =/  sec  (~(got by jaw.own.pki.lex) lyf.own.pki.lex)
-    ``[%noun !>((end 6 (shaf %pass (shax sec))))]
+    =/  sal  (add %pass step.own.pki.lex)
+    ``[%noun !>((end 6 (shaf sal (shax sec))))]
   ::
       %life
     ?.  ?=([@ ~] tyl)  [~ ~]


### PR DESCRIPTION
This had regressed during ~~some breach-related merge~~ a sloppy merge I did. Multiple commits/branches had touched this codepath recently, eating the code step change introduced in #3217.

For reference, the code from the PR:

https://github.com/urbit/urbit/blob/4804cb78646b72dab036591ed74d490722ddb1cd/pkg/arvo/sys/vane/jael.hoon#L1085-L1090
 
Current jael had the simplification applied properly, but lost the step salting.

Fixes #4126.