### PR TITLE
hoon: add jet hint for +redo

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -10679,6 +10679,7 @@
     ==
   ::                                                    ::
   ++  redo                                              ::  refurbish faces
+    ~/  %redo
     |=  $:  ::  ref: raw payload
             ::
             ref=type


### PR DESCRIPTION
A wise man once told me we probably want this to show up in profiling output.