### PR TITLE
graph-store: no-op if we already have *any* of the indexes in an %add-nodes event

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -297,10 +297,8 @@
       |^
       =/  [=graph:store mark=(unit mark:store)]
         (~(got by graphs) resource)
-      ::  no-op if we already have any of the nodes
-      ?:  (check-for-duplicates resource ~(key by nodes))
-        ::~&  nooped-due-to-duplicate-nodes+[resource nodes]
-        [~ state]
+      ~|  "cannot add duplicate nodes to {<resource>}"
+      ?<  (check-for-duplicates graph ~(key by nodes))
       =/  =update-log:store  (~(got by update-logs) resource)
       =.  update-log
         (put:orm-log update-log time [%0 time [%add-nodes resource nodes]])
@@ -316,24 +314,21 @@
       ==
       ::
       ++  check-for-duplicates
-        |=  [=resource:store nodes=(set index:store)]
+        |=  [=graph:store nodes=(set index:store)]
         ^-  ?
-        =|  has-duplicates=_|
+        =/  has-duplicates  %.n
         =/  node-list  ~(tap in nodes)
         |-
         ?~  node-list
           has-duplicates
-        =?  has-duplicates  (has-node resource i.node-list)  %.y
+        =.  has-duplicates
+          |(has-duplicates (has-node graph i.node-list))
         $(node-list t.node-list)
       ::
       ++  has-node
-        |=  [=resource:store =index:store]
+        |=  [=graph:store =index:store]
         ^-  ?
-        =/  parent-graph=(unit marked-graph:store)
-          (~(get by graphs) resource)
-        ?~  parent-graph  %.n
         =/  node=(unit node:store)  ~
-        =/  =graph:store  p.u.parent-graph
         |-
         ?~  index
           ?=(^ node)

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -316,13 +316,10 @@
       ++  check-for-duplicates
         |=  [=graph:store nodes=(set index:store)]
         ^-  ?
-        =/  has-duplicates  %.n
         =/  node-list  ~(tap in nodes)
         |-
-        ?~  node-list
-          has-duplicates
-        =.  has-duplicates
-          |(has-duplicates (has-node graph i.node-list))
+        ?~  node-list  %.n
+        ?:  (has-node graph i.node-list)  %.y
         $(node-list t.node-list)
       ::
       ++  has-node


### PR DESCRIPTION
For some reason, we receive 8-10 facts for every individual update that is performed to graph-store. I believe the root cause stems from the `lib/push-hook` or `lib/pull-hook` libraries, given the behavior, though it could also stem from the frontend if we are repeatedly sending events to the host. My guess is that the issue is in `%pull-hook` somehow. However, we now no-op aggressively within `%graph-store`, which is righteous, and we no longer spam notifications on livenet, a very noticeable symptom.

Unfortunately, we now query graph-store twice as much in order to determine if we already have a node. I don't expect noticeable slow-down, but it will definitely affect the time complexity of the `%add-nodes` operation.

The root cause should be investigated as soon as possible next week.

Fixes the symptom of #4012 but not the root cause.