### PR TITLE
graph-pull-hook: silence issues temporarily

### DIFF
--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -29,7 +29,12 @@
 ++  on-peek       on-peek:def
 ++  on-arvo       on-arvo:def
 ++  on-fail       on-fail:def
-++  on-agent      on-agent:def
+++  on-agent
+  |=  [=wire =sign:agent:gall]
+  ^-  (quip card _this)
+  ?:  ?=(%poke-ack -.sign)  `this
+  (on-agent:def wire sign)
+::
 ++  on-watch      on-watch:def
 ++  on-leave      on-leave:def
 ++  on-pull-nack


### PR DESCRIPTION
Silence issues with nacked `%poke-ack`s occurring in `%graph-pull-hook` due to the mysterious duplicate message bug.

If anyone can stamp this, that would be nice.