### PR TITLE
ames: Fix stuck flows caused by %strange-current

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2381,6 +2381,19 @@
     ::
     =.  queued-message-acks.state
       (~(del by queued-message-acks.state) current.state)
+    ::  clear all packets from this message from the packet pump
+    ::
+    ::    Note we did this when the original packet came in, a few lines
+    ::    above.  It's not clear why, but it doesn't always clear the
+    ::    packets when it's not the current message.  As a workaround,
+    ::    we clear the packets again when we catch up to this packet.
+    ::
+    ::    This is slightly inefficient because we run this twice for
+    ::    each packet and it may emit a few unnecessary packets, but
+    ::    but it's not incorrect.  pump-metrics are updated only once,
+    ::    at the time when we actually delete the packet.
+    ::
+    =.  message-pump  (run-packet-pump %done current.state lag=*@dr)
     ::  give %done to vane if we're ready
     ::
     ?-    -.u.cur

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -871,12 +871,12 @@
     ?^  dud
       ?+  -.task
           (on-crud:event-core -.task tang.u.dud)
-        %hear  (on-hole:event-core [lane blob]:task)
+        %hear  (on-hear:event-core lane.task blob.task dud)
       ==
     ::
     ?-  -.task
       %born  on-born:event-core
-      %hear  (on-hear:event-core [lane blob]:task)
+      %hear  (on-hear:event-core [lane blob ~]:task)
       %heed  (on-heed:event-core ship.task)
       %init  on-init:event-core
       %jilt  (on-jilt:event-core ship.task)
@@ -1194,15 +1194,15 @@
     =/  =channel     [[our ship] now channel-state -.peer-state]
     abet:on-jilt:(make-peer-core peer-state channel)
   ::  +on-hear: handle raw packet receipt
-  ::  +on-hole: handle packet crash notification
   ::
-  ++  on-hear  |=([l=lane b=blob] (on-hear-packet l (decode-packet b) ok=&))
-  ++  on-hole  |=([l=lane b=blob] (on-hear-packet l (decode-packet b) ok=|))
+  ++  on-hear
+    |=  [l=lane b=blob d=(unit goof)]
+    (on-hear-packet l (decode-packet b) d)
   ::  +on-hear-packet: handle mildly processed packet receipt
   ::
   ++  on-hear-packet
     ~/  %on-hear-packet
-    |=  [=lane =packet ok=?]
+    |=  [=lane =packet dud=(unit goof)]
     ^+  event-core
     ::
     ?:  =(our sndr.packet)
@@ -1226,7 +1226,7 @@
   ::
   ++  on-hear-forward
     ~/  %on-hear-forward
-    |=  [=lane =packet ok=?]
+    |=  [=lane =packet dud=(unit goof)]
     ^+  event-core
     %-  %^  trace  for.veb  sndr.packet
         |.("forward: {<sndr.packet>} -> {<rcvr.packet>}")
@@ -1246,7 +1246,7 @@
   ::
   ++  on-hear-open
     ~/  %on-hear-open
-    |=  [=lane =packet ok=?]
+    |=  [=lane =packet dud=(unit goof)]
     ^+  event-core
     ::  assert the comet can't pretend to be a moon or other address
     ::
@@ -1283,7 +1283,7 @@
   ::
   ++  on-hear-shut
     ~/  %on-hear-shut
-    |=  [=lane =packet ok=?]
+    |=  [=lane =packet dud=(unit goof)]
     ^+  event-core
     =/  sndr-state  (~(get by peers.ames-state) sndr.packet)
     ::  if we don't know them, maybe enqueue a jael %public-keys request
@@ -1338,7 +1338,7 @@
     ::  perform peer-specific handling of packet
     ::
     =/  peer-core  (make-peer-core peer-state channel)
-    abet:(on-hear-shut-packet:peer-core lane shut-packet ok)
+    abet:(on-hear-shut-packet:peer-core lane shut-packet dud)
   ::  +on-take-boon: receive request to give message to peer
   ::
   ++  on-take-boon
@@ -1897,7 +1897,7 @@
     ::  +on-hear-shut-packet: handle receipt of ack or message fragment
     ::
     ++  on-hear-shut-packet
-      |=  [=lane =shut-packet ok=?]
+      |=  [=lane =shut-packet dud=(unit goof)]
       ^+  peer-core
       ::  update and print connection status
       ::
@@ -1906,12 +1906,15 @@
       =/  =bone  bone.shut-packet
       ::
       ?:  ?=(%& -.meat.shut-packet)
-        (run-message-sink bone %hear lane shut-packet ok)
-      ::  ignore .ok for |message-pump; just try again on error
+        (run-message-sink bone %hear lane shut-packet ?=(~ dud))
+      ::  Just try again on error, printing trace
       ::
       ::    Note this implies that vanes should never crash on %done,
       ::    since we have no way to continue using the flow if they do.
       ::
+      =+  ?~  dud  ~
+          %.  ~
+          (slog leaf+"ames: crashed on message ack" >mote.u.dud< tang.u.dud)
       (run-message-pump bone %hear [message-num +.meat]:shut-packet)
     ::  +on-memo: handle request to send message
     ::


### PR DESCRIPTION
@belisarius222 and I identified an issue about a year ago that caused flows to occasionally stick, so we added the `%strange-current` assertion to try to catch the issue earlier.  This has showed up from time to time in the last year, and @ixv and I worked out a fix.

An example of the problem is when we're sending messages 288 and 289 and we've received a message-level ack for 289 but not 288, but there are also fragments of 289 which have not been acknowledged, so they remain in our packet pump.  The fragments of 289 *should* have been removed from packet pump when the whole message was acknowledged, but for some reason they weren't.

The first commit in this PR simply runs `on-done` in the packet pump (this is what clears straggler fragments from the packet pump) as we process messages, so that if for some reason there are stragglers, they're removed.  As noted in the comment, this is slightly inefficient but is not a problem I believe.  I still wish I understand why they're not removed earlier.

The second commit adds tags to the bare numbers in ames-verb printfs, because it takes way longer to tell what's happening without them.

The third commit threads error traces a little further and prints them if we crash while handling a message-level ack.  Consistently crashing while handling a message-level ack is very bad since all we can do is retry -- if we skip giving that to a vane, then we violate the invariant that vanes will receive all acks in order.

fixes #2505
