### PR TITLE
dbug: make subscription items header match the table

### DIFF
--- a/pkg/interface/dbug/src/js/views/eyre.js
+++ b/pkg/interface/dbug/src/js/views/eyre.js
@@ -121,7 +121,7 @@ export class Eyre extends Component {
       </>);
       const subscriptionItems = c.subscriptions.map(s => {
         //NOTE jsx sorta copied from /components/subscriptions
-        return {key: `${s.id} ${s.app} ${s.ship} ${s.path}`, jsx: (
+        return {key: `${s.id} ${s.ship} ${s.app} ${s.path}`, jsx: (
           <div class="flex">
             <div class="flex-auto" style={{maxWidth: '15%'}}>
               {s.id}
@@ -144,7 +144,7 @@ export class Eyre extends Component {
       return {key: c.session, jsx: (
         <Summary summary={summary} details={(
           <SearchableList
-            placeholder="id, app, ship, path"
+            placeholder="id, ship, app, path"
             items={subscriptionItems}
           />
         )} />


### PR DESCRIPTION
I changed the header to match the table instead of the other way around  due to my preference.
Untested.  Did not update `pkg/arvo/app/debug/js/index.js` or pill.  Not sure if this is the correct branch to PR against.
If the change is correct can someone take this and do a proper PR?
