### PR TITLE
graph-store: silence duplicate message assertion temporarily

### DIFF
--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -22,21 +22,16 @@
     dep   ~(. (default:pull-hook this config) bowl)
     gra   ~(. graph bowl)
 ::
-++  on-init       on-init:def
-++  on-save       !>(~)
-++  on-load       on-load:def
-++  on-poke       on-poke:def
-++  on-peek       on-peek:def
-++  on-arvo       on-arvo:def
-++  on-fail       on-fail:def
-++  on-agent
-  |=  [=wire =sign:agent:gall]
-  ^-  (quip card _this)
-  ?:  ?=(%poke-ack -.sign)  `this
-  (on-agent:def wire sign)
-::
-++  on-watch      on-watch:def
-++  on-leave      on-leave:def
+++  on-init   on-init:def
+++  on-save   !>(~)
+++  on-load   on-load:def
+++  on-poke   on-poke:def
+++  on-peek   on-peek:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+++  on-agent  on-agent:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
 ++  on-pull-nack
   |=  [=resource =tang]
   ^-  (quip card _this)

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -297,8 +297,13 @@
       |^
       =/  [=graph:store mark=(unit mark:store)]
         (~(got by graphs) resource)
-      ~|  "cannot add duplicate nodes to {<resource>}"
-      ?<  (check-for-duplicates graph ~(key by nodes))
+      ::  TODO: turn back on assertion once issue with 8-10x facts being
+      ::  issued is resolved. Too noisy for now
+      ::
+      ::  ~|  "cannot add duplicate nodes to {<resource>}"
+      ::  ?<  (check-for-duplicates graph ~(key by nodes))
+      ?:  (check-for-duplicates graph ~(key by nodes))
+        [~ state]
       =/  =update-log:store  (~(got by update-logs) resource)
       =.  update-log
         (put:orm-log update-log time [%0 time [%add-nodes resource nodes]])


### PR DESCRIPTION
The previous hook silencing didn't work, so we'll temporarily silence this duplicate issue by not crashing. Upon solving the likely root cause that may stem from `%push-hook`, we will turn back on the assertion, as it is useful for checking whether our invariants hold. It is currently too noisy and we know that the issue is occurring, so we don't need it to be on.