### PR TITLE
push-hook: push out facts to each path only a single time

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -297,13 +297,8 @@
       |^
       =/  [=graph:store mark=(unit mark:store)]
         (~(got by graphs) resource)
-      ::  TODO: turn back on assertion once issue with 8-10x facts being
-      ::  issued is resolved. Too noisy for now
-      ::
-      ::  ~|  "cannot add duplicate nodes to {<resource>}"
-      ::  ?<  (check-for-duplicates graph ~(key by nodes))
-      ?:  (check-for-duplicates graph ~(key by nodes))
-        [~ state]
+      ~|  "cannot add duplicate nodes to {<resource>}"
+      ?<  (check-for-duplicates graph ~(key by nodes))
       =/  =update-log:store  (~(got by update-logs) resource)
       =.  update-log
         (put:orm-log update-log time [%0 time [%add-nodes resource nodes]])

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -268,7 +268,6 @@
         %+  weld
           (push-updates:hc q.cage.sign)
         cards
-
       ==
       ++  on-leave
         |=  =path
@@ -374,6 +373,8 @@
     =/  prefix=path
       resource+(en-path:resource u.rid)
     =/  paths=(list path)
+      %~  tap  in
+      %-  silt
       %+  turn
         (incoming-subscriptions prefix)
       |=([ship pax=path] pax)


### PR DESCRIPTION
The push-hook library was iterating through incoming subscriptions and was sending out the same fact to the same path multiple times. It now taps the list of paths it takes in so as to deduplicate them prior to issuing facts. Perhaps this could be pulled up into Gall?

Thanks for helping me find this, @philipcmonk. This PR also turns back on noisy printing of duplicates in `%graph-store`, because that will help us root out any future issues in the stack that cause duplicate messages to be sent. There won't be any duplicate facts anymore at present so the terminal will continue to be quiet.

Messages sent over the `%push-hook` will now cause 10x less network traffic than they did previously.

cc: @vvisigoth @matildepark The root cause has been found and resolved.