### PR TITLE
hark-graph-hook, hark-store: set last-updated on self posts

### DIFF
--- a/pkg/arvo/app/glob.hoon
+++ b/pkg/arvo/app/glob.hoon
@@ -5,7 +5,7 @@
 /-  glob
 /+  default-agent, verb, dbug
 |%
-++  hash  0v3t3u8.g4h6p.ckag1.tpdjo.785v5
+++  hash  0v1.pr789.2ugh8.chgtm.dlmfn.cc9pr
 +$  state-0  [%0 hash=@uv glob=(unit (each glob:glob tid=@ta))]
 +$  all-states
   $%  state-0

--- a/pkg/arvo/app/glob.hoon
+++ b/pkg/arvo/app/glob.hoon
@@ -5,7 +5,7 @@
 /-  glob
 /+  default-agent, verb, dbug
 |%
-++  hash  0vada5t.b1gqn.oo4ga.6o12h.ek1ot
+++  hash  0v3t3u8.g4h6p.ckag1.tpdjo.785v5
 +$  state-0  [%0 hash=@uv glob=(unit (each glob:glob tid=@ta))]
 +$  all-states
   $%  state-0

--- a/pkg/arvo/app/glob.hoon
+++ b/pkg/arvo/app/glob.hoon
@@ -5,7 +5,7 @@
 /-  glob
 /+  default-agent, verb, dbug
 |%
-++  hash  0v1.pr789.2ugh8.chgtm.dlmfn.cc9pr
+++  hash  0v2.4fgj3.q9463.10ksb.jmhse.00031
 +$  state-0  [%0 hash=@uv glob=(unit (each glob:glob tid=@ta))]
 +$  all-states
   $%  state-0

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -1,6 +1,6 @@
 ::  hark-graph-hook: notifications for graph-store [landscape]
 ::
-/-  post, group-store, metadata-store, hook=hark-graph-hook
+/-  post, group-store, metadata-store, hook=hark-graph-hook, store=hark-store
 /+  resource, metadata, default-agent, dbug, graph-store, graph, grouplib=group, store=hark-store
 ::
 ::
@@ -19,7 +19,7 @@
   ==
 ::
 +$  notif-kind
-  [name=@t parent-lent=@ud mode=?(%each %count) watch=?]
+  [name=@t parent-lent=@ud mode=?(%each %count %none) watch=?]
 ::
 ++  scry
   |*  [[our=@p now=@da] =mold p=path]
@@ -340,7 +340,6 @@
   ::
   ++  update-unread-count
     |=  [=notif-kind =index:store time=@da ref=index:graph-store]
-    =.  description.index  name.notif-kind
     =/  =stats-index:store
       (to-stats-index:store index)
     ?-  mode.notif-kind 
@@ -352,10 +351,11 @@
   ++  self-post
     |=  $:  =node:graph-store
             =index:store
-            mode=?(%count %each)
+            mode=?(%count %each %none)
             watch=?
         ==
     ^+  update-core 
+    ?:  ?=(%none mode)  update-core
     =/  =stats-index:store
       (to-stats-index:store index)
     =.  update-core

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -158,6 +158,36 @@
       (graph-update !<(update:graph-store q.cage.sign))
     [cards this]
   ==
+  ::
+  ++  graph-update
+    |=  =update:graph-store
+    ^-  (quip card _state)
+    ?+    -.q.update  `state
+        %add-graph  (add-graph resource.q.update)
+      ::
+        ?(%remove-graph %archive-graph)  
+      (remove-graph resource.q.update)
+      ::
+        %add-nodes
+      =*  rid  resource.q.update
+      (check-nodes ~(val by nodes.q.update) rid)
+    ==
+  ::
+  ++  remove-graph
+    |=  rid=resource
+    =/  unwatched
+      %-  ~(gas in *_watching)
+      %+  skim  ~(tap in watching)
+      |=  [r=resource idx=index:graph-store]
+      =(r rid)
+    :_  state(watching (~(dif in watching) unwatched))
+    ^-  (list card)
+    :-  (poke-hark:ha %remove-graph rid)
+    %-  zing
+    %+  turn  ~(tap in unwatched)
+    |=  [r=resource =index:graph-store]
+    (give:ha ~[/updates] %ignore r index)
+  ::
   ++  add-graph
     |=  rid=resource
     ^-  (quip card _state)
@@ -181,15 +211,6 @@
     :_   state(watching (~(put in watching) [rid ~]))
     (weld cards (give:ha ~[/updates] %listen [rid ~]))
   ::
-  ++  graph-update
-    |=  =update:graph-store
-    ^-  (quip card _state)
-    ?:  ?=(%add-graph -.q.update)
-      (add-graph resource.q.update)
-    ?.  ?=(%add-nodes -.q.update)
-      [~ state]
-    =*  rid  resource.q.update
-    (check-nodes ~(val by nodes.q.update) rid)
   ::
   ++  check-nodes
     |=  $:  nodes=(list node:graph-store)
@@ -198,8 +219,10 @@
     =/  group=(unit resource)
       (group-from-app-resource:met %graph rid)
     ?~  group  
+      ~&  no-group+rid
       `state
     =/  metadata=(unit metadata:metadata-store)
+      ~&  no-metadata+rid
       (peek-metadata:met %graph u.group rid)
     ?~  metadata  `state
     abet:check:(abed:handle-update:ha rid nodes u.group module.u.metadata)

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -21,29 +21,26 @@
 +$  notif-kind
   [name=@t parent-lent=@ud mode=?(%each %count) watch=?]
 ::
+++  scry
+  |*  [[our=@p now=@da] =mold p=path]
+  ?>  ?=(^ p)
+  ?>  ?=(^ t.p)
+  .^(mold i.p (scot %p our) i.t.p (scot %da now) t.t.p)
+::
+++  scry-conversion
+  |=  [[our=@p now=@da] desk=term =mark]
+  ~+
+  %^  scry  [our now]
+    tube:clay
+  /cc/[desk]/[mark]/notification-kind
+
+::
 --
 ::
 =|  state-0
 =*  state  -
 ::
-=>
-  |_  =bowl:gall
-  ::
-  ++  scry
-    |*  [=mold p=path]
-    ?>  ?=(^ p)
-    ?>  ?=(^ t.p)
-    .^(mold i.p (scot %p our.bowl) i.t.p (scot %da now.bowl) t.t.p)
-  ::
-  ++  give
-    |=  [paths=(list path) =update:hook]
-    ^-  (list card)
-    [%give %fact paths hark-graph-hook-update+!>(update)]~
-  ::
-  ++  watch-graph
-    ^-  card
-    [%pass /graph %agent [our.bowl %graph-store] %watch /updates]
-  --
+=<
 %-  agent:dbug
 ^-  agent:gall
 ~%  %hark-graph-hook-agent  ..card  ~
@@ -187,135 +184,17 @@
     ?.  ?=(%add-nodes -.q.update)
       [~ state]
     =*  rid  resource.q.update
-    (check-nodes ~(tap by nodes.q.update) rid)
+    (check-nodes ~(val by nodes.q.update) rid)
   ::
   ++  check-nodes
-    |=  $:  nodes=(list [p=index:graph-store q=node:graph-store])
+    |=  $:  nodes=(list node:graph-store)
             rid=resource
         ==
     =/  group=resource
       (need (group-from-app-resource:met %graph rid))
     =/  =metadata:metadata-store
       (need (peek-metadata:met %graph group rid))
-    =+  %+  scry:ha
-           ,mark=(unit mark)
-        /gx/graph-store/graph-mark/(scot %p entity.rid)/[name.rid]/noun
-    =+  %+  scry:ha
-          ,=tube:clay
-        /cc/[q.byk.bowl]/[(fall mark %graph-validator-link)]/notification-kind
-    =|  cards=(list card)
-    |^
-    ?~  nodes
-      [cards state]
-    =*  index  p.i.nodes
-    =*  node   q.i.nodes
-    =^  node-cards  state
-      (check-node node tube)
-    %_    $
-      nodes  t.nodes
-      cards  (weld node-cards cards)
-    ==
-    ::
-    ++  check-node-children
-      |=  [=node:graph-store =tube:clay]
-      ^-  (quip card _state)
-      ?:  ?=(%empty -.children.node)
-        [~ state]
-      =/  children=(list [=atom =node:graph-store])
-        (tap:orm:graph-store p.children.node)
-      =|  cards=(list card)
-      |-  ^-  (quip card _state)
-      ?~  children
-        [cards state]
-      =^  new-cards  state
-        (check-node node.i.children tube)
-      %_    $
-        cards  (weld cards new-cards)
-        children  t.children
-      ==
-    ::
-    ++  check-node
-      |=  [=node:graph-store =tube:clay]
-      ^-  (quip card _state)
-      =^  child-cards  state
-        (check-node-children node tube)
-      =+  !<  notif-kind=(unit notif-kind)
-          (tube !>([0 post.node]))
-      ?~  notif-kind
-        [child-cards state]
-      =/  desc=@t
-        ?:  (is-mention contents.post.node)
-          %mention
-        name.u.notif-kind
-      =/  parent=index:post
-        (scag parent-lent.u.notif-kind index.post.node)
-      =/  notif-index=index:store
-        [%graph group rid module.metadata desc parent]
-      ?:  =(our.bowl author.post.node)
-        =^  self-cards  state
-          (self-post node notif-index [mode watch]:u.notif-kind)
-        :_  state
-        (weld child-cards self-cards)
-      :_  state
-      %+  weld  child-cards
-      %+  weld
-          %^     update-unread-count
-            mode.u.notif-kind  notif-index 
-          [time-sent index]:post.node
-      ?.  ?|  =(desc %mention)
-              (~(has in watching) [rid parent])
-          ==
-        ~
-      =/  =contents:store
-        [%graph (limo post.node ~)]
-      ~[(add-unread notif-index [time-sent.post.node %.n contents])]
-    ::
-    ++  is-mention
-      |=  contents=(list content:post)
-      ^-  ?
-      ?.  mentions  %.n
-      ?~  contents  %.n
-      ?.  ?=(%mention -.i.contents)
-        $(contents t.contents)
-      ?:  =(our.bowl ship.i.contents)
-        %.y
-      $(contents t.contents)
-    ::
-    ++  self-post
-      |=  $:  =node:graph-store
-              =index:store
-              mode=?(%count %each)
-              watch=?
-          ==
-      ^-  (quip card _state)
-      =|  cards=(list card)
-      =?  cards  ?=(%count mode)
-        :_  cards
-        (poke-hark %read-count index)
-      ?.  &(watch watch-on-self)
-        [cards state]
-      :-  cards
-      state(watching (~(put in watching) [rid index.post.node]))
-    ::
-    ++  poke-hark
-      |=  =action:store
-      ^-  card
-      =-  [%pass / %agent [our.bowl %hark-store] %poke -]
-      hark-action+!>(action)
-    ::
-    ++  update-unread-count
-      |=  [mode=?(%count %each %none) =index:store time=@da ref=index:graph-store]
-      ?-  mode 
-        %count  ~[(poke-hark %unread-count index time)]
-        %each   ~[(poke-hark %unread-each index ref time)]
-        %none  ~
-      ==
-    ::
-    ++  add-unread
-      |=  [=index:store =notification:store]
-      (poke-hark %add-note index notification)
-    ::
-    --
+    abet:check:(abed:handle-update:ha rid nodes group module.metadata)
   --
 ::
 ++  on-peek  on-peek:def
@@ -334,4 +213,154 @@
   ==
 ++  on-fail   on-fail:def
 --
-
+::
+|_  =bowl:gall
+::
+::
+++  give
+  |=  [paths=(list path) =update:hook]
+  ^-  (list card)
+  [%give %fact paths hark-graph-hook-update+!>(update)]~
+::
+++  watch-graph
+  ^-  card
+  [%pass /graph %agent [our.bowl %graph-store] %watch /updates]
+::
+++  poke-hark
+  |=  =action:store
+  ^-  card
+  =-  [%pass / %agent [our.bowl %hark-store] %poke -]
+  hark-action+!>(action)
+::
+++  is-mention
+  |=  contents=(list content:post)
+  ^-  ?
+  ?.  mentions  %.n
+  ?~  contents  %.n
+  ?.  ?=(%mention -.i.contents)
+    $(contents t.contents)
+  ?:  =(our.bowl ship.i.contents)
+    %.y
+  $(contents t.contents)
+::
+++  handle-update
+  |_  $:  rid=resource  ::  input
+          updates=(list node:graph-store)
+          group=resource
+          module=term
+          hark-pokes=(list action:store)  :: output
+          new-watches=(list index:graph-store)
+      ==
+  ++  update-core  .
+  ::
+  ++  abed
+    |=  [r=resource upds=(list node:graph-store) grp=resource mod=term]
+    update-core(rid r, updates upds)
+  ::
+  ++  get-conversion
+    ^-  tube:clay
+    =+  %^  scry  [our now]:bowl
+           ,mark=(unit mark)
+        /gx/graph-store/graph-mark/(scot %p entity.rid)/[name.rid]/noun
+    ?~  mark
+      |=(v=vase !>(~))
+    (scry-conversion [our now]:bowl q.byk.bowl u.mark)
+  ::
+  ++  abet
+    ^-  (quip card _state)
+    :_  state(watching (~(uni in watching) (silt (turn new-watches (lead rid)))))
+    ^-  (list card)
+    %+  welp  (turn (flop hark-pokes) poke-hark)
+    %-  zing
+    %+  turn  (flop new-watches) 
+    |=(=index:graph-store (give ~[/updates] [%listen rid index]))
+  ::
+  ++  hark
+    |=  =action:store
+    ^+  update-core
+    update-core(hark-pokes [action hark-pokes])
+  ::
+  ++  new-watch
+    |=  =index:graph-store
+    update-core(new-watches [index new-watches])
+  ::
+  ++  check
+    |-  ^+  update-core
+    ?~  updates  
+      update-core
+    =/  core=_update-core
+      (check-node i.updates)
+    =.  updates.core  t.updates
+    $(update-core core)
+  ::
+  ++  check-node-children
+    |=  =node:graph-store
+    ^+  update-core
+    ?:  ?=(%empty -.children.node)
+      update-core
+    =/  children=(list [=atom =node:graph-store])
+      (tap:orm:graph-store p.children.node)
+    |-  ^+  update-core
+    ?~  children
+      update-core
+    =.  update-core  (check-node node.i.children)
+    $(children t.children)
+  ::
+  ++  check-node
+    |=  =node:graph-store
+    ^+  update-core
+    =.  update-core  (check-node-children node)
+    =+  !<  notif-kind=(unit notif-kind)
+        (get-conversion !>([0 post.node]))
+    ?~  notif-kind
+      update-core
+    =/  desc=@t
+      ?:  (is-mention contents.post.node)
+        %mention
+      name.u.notif-kind
+    =*  not-kind  u.notif-kind
+    =/  parent=index:post
+      (scag parent-lent.not-kind index.post.node)
+    =/  notif-index=index:store
+      [%graph group rid module desc parent]
+    =?  update-core  =(our.bowl author.post.node)
+      (self-post node notif-index [mode watch]:not-kind)
+    =.  update-core
+      (update-unread-count mode.not-kind notif-index [time-sent index]:post.node)
+    =?    update-core
+        ?&  !=(our.bowl author.post.node)
+        ?|  =(desc %mention)
+            (~(has in watching) [rid parent])
+        ==  == 
+      =/  =contents:store
+        [%graph (limo post.node ~)]
+      (add-unread notif-index [time-sent.post.node %.n contents])
+    update-core
+  ::
+  ++  update-unread-count
+    |=  [mode=?(%count %each %none) =index:store time=@da ref=index:graph-store]
+    ?-  mode 
+      %count  (hark %unread-count index time)
+      %each   (hark %unread-each index ref time)
+      %none   update-core
+    ==
+  ::
+  ++  self-post
+    |=  $:  =node:graph-store
+            =index:store
+            mode=?(%count %each)
+            watch=?
+        ==
+    ^+  update-core 
+    =?  update-core  ?=(%count mode)
+      (hark %read-count index)
+    =?  update-core  &(watch watch-on-self)
+      (new-watch index.post.node)
+    update-core
+  ::
+  ++  add-unread
+    |=  [=index:store =notification:store]
+    (hark %add-note index notification)
+  ::
+  --
+--

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -222,7 +222,6 @@
       ~&  no-group+rid
       `state
     =/  metadata=(unit metadata:metadata-store)
-      ~&  no-metadata+rid
       (peek-metadata:met %graph u.group rid)
     ?~  metadata  `state
     abet:check:(abed:handle-update:ha rid nodes u.group module.u.metadata)

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -159,7 +159,7 @@
     [cards this]
   ==
   ++  add-graph
-    |=  [rid=resource =graph:graph-store]
+    |=  rid=resource
     ^-  (quip card _state)
     =/  group-rid=(unit resource)
       (group-from-app-resource:met %graph rid) 
@@ -172,14 +172,20 @@
       |(is-hidden &(watch-on-self =(our.bowl entity.rid)))
     ?.  should-watch
       `state
-    :-  (give:ha ~[/updates] %listen [rid ~])
-    state(watching (~(put in watching) [rid ~]))
+    =/  graph=graph:graph-store  :: graph in subscription is bunted 
+      (get-graph-mop:gra rid)
+    =/  node=(unit node:graph-store)
+      (bind (peek:orm:graph-store graph) |=([@ =node:graph-store] node))
+    =^  cards  state
+      (check-nodes (drop node) rid)
+    :_   state(watching (~(put in watching) [rid ~]))
+    (weld cards (give:ha ~[/updates] %listen [rid ~]))
   ::
   ++  graph-update
     |=  =update:graph-store
     ^-  (quip card _state)
     ?:  ?=(%add-graph -.q.update)
-      (add-graph resource.q.update graph.q.update)
+      (add-graph resource.q.update)
     ?.  ?=(%add-nodes -.q.update)
       [~ state]
     =*  rid  resource.q.update

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -1,7 +1,7 @@
 ::  hark-graph-hook: notifications for graph-store [landscape]
 ::
-/-  store=hark-store, post, group-store, metadata-store, hook=hark-graph-hook
-/+  resource, metadata, default-agent, dbug, graph-store, graph, grouplib=group
+/-  post, group-store, metadata-store, hook=hark-graph-hook
+/+  resource, metadata, default-agent, dbug, graph-store, graph, grouplib=group, store=hark-store
 ::
 ::
 ~%  %hark-graph-hook-top  ..part  ~
@@ -191,7 +191,8 @@
         ==
     =/  group=(unit resource)
       (group-from-app-resource:met %graph rid)
-    ?~  group  `state
+    ?~  group  
+      `state
     =/  metadata=(unit metadata:metadata-store)
       (peek-metadata:met %graph u.group rid)
     ?~  metadata  `state
@@ -327,7 +328,7 @@
     ?:  =(our.bowl author.post.node)
       (self-post node notif-index [mode watch]:not-kind)
     =.  update-core
-      (update-unread-count mode.not-kind notif-index [time-sent index]:post.node)
+      (update-unread-count not-kind notif-index [time-sent index]:post.node)
     =?    update-core
         ?|  =(desc %mention)
             (~(has in watching) [rid parent])
@@ -338,10 +339,13 @@
     update-core
   ::
   ++  update-unread-count
-    |=  [mode=?(%count %each %none) =index:store time=@da ref=index:graph-store]
-    ?-  mode 
-      %count  (hark %unread-count index time)
-      %each   (hark %unread-each index ref time)
+    |=  [=notif-kind =index:store time=@da ref=index:graph-store]
+    =.  description.index  name.notif-kind
+    =/  =stats-index:store
+      (to-stats-index:store index)
+    ?-  mode.notif-kind 
+      %count  (hark %unread-count stats-index time)
+      %each   (hark %unread-each stats-index ref time)
       %none   update-core
     ==
   ::
@@ -352,10 +356,12 @@
             watch=?
         ==
     ^+  update-core 
+    =/  =stats-index:store
+      (to-stats-index:store index)
     =.  update-core
-      (hark %seen-index time-sent.post.node index)
+      (hark %seen-index time-sent.post.node stats-index)
     =?  update-core  ?=(%count mode)
-      (hark %read-count index)
+      (hark %read-count stats-index)
     =?  update-core  &(watch watch-on-self)
       (new-watch index.post.node)
     update-core

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -33,7 +33,6 @@
   %^  scry  [our now]
     tube:clay
   /cc/[desk]/[mark]/notification-kind
-
 ::
 --
 ::
@@ -323,15 +322,14 @@
       (scag parent-lent.not-kind index.post.node)
     =/  notif-index=index:store
       [%graph group rid module desc parent]
-    =?  update-core  =(our.bowl author.post.node)
+    ?:  =(our.bowl author.post.node)
       (self-post node notif-index [mode watch]:not-kind)
     =.  update-core
       (update-unread-count mode.not-kind notif-index [time-sent index]:post.node)
     =?    update-core
-        ?&  !=(our.bowl author.post.node)
         ?|  =(desc %mention)
             (~(has in watching) [rid parent])
-        ==  == 
+        ==
       =/  =contents:store
         [%graph (limo post.node ~)]
       (add-unread notif-index [time-sent.post.node %.n contents])
@@ -352,6 +350,8 @@
             watch=?
         ==
     ^+  update-core 
+    =.  update-core
+      (hark %seen-index time-sent.post.node index)
     =?  update-core  ?=(%count mode)
       (hark %read-count index)
     =?  update-core  &(watch watch-on-self)

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -189,11 +189,13 @@
     |=  $:  nodes=(list node:graph-store)
             rid=resource
         ==
-    =/  group=resource
-      (need (group-from-app-resource:met %graph rid))
-    =/  =metadata:metadata-store
-      (need (peek-metadata:met %graph group rid))
-    abet:check:(abed:handle-update:ha rid nodes group module.metadata)
+    =/  group=(unit resource)
+      (group-from-app-resource:met %graph rid)
+    ?~  group  `state
+    =/  metadata=(unit metadata:metadata-store)
+      (peek-metadata:met %graph u.group rid)
+    ?~  metadata  `state
+    abet:check:(abed:handle-update:ha rid nodes u.group module.u.metadata)
   --
 ::
 ++  on-peek  on-peek:def
@@ -254,7 +256,7 @@
   ::
   ++  abed
     |=  [r=resource upds=(list node:graph-store) grp=resource mod=term]
-    update-core(rid r, updates upds)
+    update-core(rid r, updates upds, group grp, module mod)
   ::
   ++  get-conversion
     ^-  tube:clay

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -259,6 +259,8 @@
       %read-note     (read-note +.action)
       %unread-note   (unread-note +.action)
     ::
+      %seen-index    (seen-index +.action)
+    ::
       %read-all      read-all
     ::
       %set-dnd       (set-dnd +.action)
@@ -412,6 +414,14 @@
       :_  state
       %+  welp  cards
       (give:ha ~[/updates] %read-index index)
+    ::
+    ++  seen-index
+      |=  [time=@da =index:store]
+      ^-  (quip card _state)
+      :-  (give:ha ~[/updates] %seen-index time index)
+      %_  state
+        last-seen  (~(put by last-seen) index time)
+      ==
     ::
     ++  read-all
       ^-  (quip card _state)

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -198,15 +198,8 @@
     ^-  update:store
     :-  %more
     ^-  (list update:store)
-    :+  give-unreads
-      [%set-dnd dnd]
-    %+  weld
-      %+  turn
-        (tap-nonempty:ha archive)
-      (timebox-update &)
-    %+  turn
-      (tap-nonempty:ha notifications)
-    (timebox-update |)
+    :-  give-unreads
+    [%set-dnd dnd]~
   ::
   ++  give-since-unreads
     ^-  (list [stats-index:store stats:store])
@@ -234,12 +227,6 @@
     ^-  update:store
     :-  %unreads
     (weld give-each-unreads give-since-unreads)
-  ::
-  ++  timebox-update
-    |=  archived=?
-    |=  [time=@da =timebox:store]
-    ^-  update:store
-    [%timebox time archived ~(tap by timebox)]
   --
 ::
 ++  on-peek   

--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -24,6 +24,6 @@
     <div id="portal-root"></div>
     <script src="/~landscape/js/channel.js"></script>
     <script src="/~landscape/js/session.js"></script>
-    <script src="/~landscape/js/bundle/index.9b0a67d07399229dd21d.js"></script>
+    <script src="/~landscape/js/bundle/index.1cb7440ffa276aed26e1.js"></script>
   </body>
 </html>

--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -24,6 +24,6 @@
     <div id="portal-root"></div>
     <script src="/~landscape/js/channel.js"></script>
     <script src="/~landscape/js/session.js"></script>
-    <script src="/~landscape/js/bundle/index.62662aa281a9e96213cd.js"></script>
+    <script src="/~landscape/js/bundle/index.0c203f2fb79b4540f6d1.js"></script>
   </body>
 </html>

--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -24,6 +24,6 @@
     <div id="portal-root"></div>
     <script src="/~landscape/js/channel.js"></script>
     <script src="/~landscape/js/session.js"></script>
-    <script src="/~landscape/js/bundle/index.1cb7440ffa276aed26e1.js"></script>
+    <script src="/~landscape/js/bundle/index.62662aa281a9e96213cd.js"></script>
   </body>
 </html>

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -22,7 +22,7 @@
   ^-  graph:store
   =/  =update:store
     (get-graph res)
-  ?>  ?=(%0 -.res)
+  ?>  ?=(%0 -.update)
   ?>  ?=(%add-graph -.q.update)
   graph.q.update
 ::

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -17,6 +17,15 @@
   %+  scry-for  update:store
   /graph/(scot %p entity.res)/[name.res]
 ::
+++  get-graph-mop
+  |=  res=resource
+  ^-  graph:store
+  =/  =update:store
+    (get-graph res)
+  ?>  ?=(%0 -.res)
+  ?>  ?=(%add-graph -.q.update)
+  graph.q.update
+::
 ++  gut-younger-node-siblings
   |=  [res=resource =index:store]
   ^-  (map index:store node:store)

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -84,6 +84,7 @@
         %read-count  (index +.upd)
         %unread-each  (unread-each +.upd)
         %unread-count  (unread-count +.upd)
+        %seen-index  (seen-index +.upd)
         %unreads   (unreads +.upd)
         ::
           ?(%archive %read-note %unread-note)
@@ -137,6 +138,13 @@
       :~  time+s+(scot %ud tim)
           index+(index idx)
       ==
+    ++  seen-index
+      |=  [tim=@da idx=^index]
+      ^-  json
+      %-  pairs
+      :~  time+(time tim)
+          index+(index idx)
+      ==     
     ::
     ++  more
       |=  upds=(list ^update)

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -27,6 +27,17 @@
         description+so
         index+(su ;~(pfix fas (more fas dem)))
     ==
+  ::
+  ++  stats-index
+    %-  of
+    :~  graph+graph-stats-index
+        group+dejs:resource
+    ==
+  ++  graph-stats-index
+    %-  ot
+    :~  graph+dejs:resource
+        index+graph-index
+    ==
   ::  parse date as @ud
   ::    TODO: move to zuse
   ++  sd
@@ -41,6 +52,8 @@
     :~  time+sd
         index+index
     ==
+  ++  graph-index
+    (su ;~(pfix fas (more fas dem)))
   ::
   ++  add
     |=  jon=json
@@ -48,8 +61,8 @@
   ::
   ++  read-graph-index
     %-  ot
-    :~  index+index
-        target+(su ;~(pfix fas (more fas dem)))
+    :~  index+stats-index
+        target+graph-index
     ==
   ::
   ++  action
@@ -61,7 +74,7 @@
         read-note+notif-ref
         add-note+add
         set-dnd+bo
-        read-count+index
+        read-count+stats-index
         read-each+read-graph-index
     ==
   --
@@ -81,7 +94,7 @@
         %count    (numb count.upd)
         %more     (more +.upd)
         %read-each  (read-each +.upd)
-        %read-count  (index +.upd)
+        %read-count  (stats-index +.upd)
         %unread-each  (unread-each +.upd)
         %unread-count  (unread-count +.upd)
         %seen-index  (seen-index +.upd)
@@ -91,16 +104,33 @@
         (notif-ref +.upd)
     ==
     ::
+    ++  stats-index
+      |=  s=^stats-index
+      %+  frond  -.s
+      |^
+      ?-  -.s
+        %graph  (graph-stats-index +.s)
+        %group  (enjs:resource +.s)
+      ==
+      ::
+      ++  graph-stats-index
+        |=  [graph=resource =index:graph-store]
+        %-  pairs
+        :~  graph+(enjs:resource graph)
+            index+(index:enjs:graph-store index)
+        ==
+      --
+    ::
     ++  unreads
-      |=  l=(list [^index ^index-stats]) 
+      |=  l=(list [^stats-index ^stats]) 
       ^-  json 
       :-  %a
       ^-  (list json)
       %+  turn  l
-      |=  [idx=^index stats=^index-stats]
+      |=  [idx=^stats-index s=^stats]
       %-  pairs
-      :~  stats+(index-stats stats)
-          index+(index idx)
+      :~  stats+(stats s)
+          index+(stats-index idx)
       ==
     ::
     ++  unread
@@ -114,13 +144,13 @@
         (numb num.unreads)
       ==
     ::
-    ++  index-stats
-      |=  stats=^index-stats
+    ++  stats
+      |=  s=^stats
       ^-  json
       %-  pairs
-      :~  unreads+(unread unreads.stats)
-          notifications+(numb notifications.stats)
-          last+(time last-seen.stats)
+      :~  unreads+(unread unreads.s)
+          notifications+(numb notifications.s)
+          last+(time last-seen.s)
       ==
     ++  added
       |=  [tim=@da idx=^index not=^notification]
@@ -139,11 +169,11 @@
           index+(index idx)
       ==
     ++  seen-index
-      |=  [tim=@da idx=^index]
+      |=  [tim=@da idx=^stats-index]
       ^-  json
       %-  pairs
       :~  time+(time tim)
-          index+(index idx)
+          index+(stats-index idx)
       ==     
     ::
     ++  more
@@ -244,26 +274,45 @@
       ==
     ::
     ++  read-each
-      |=  [=^index target=index:graph-store]
+      |=  [s=^stats-index target=index:graph-store]
       %-  pairs
-      :~  index+(^index index)
+      :~  index+(stats-index s)
           target+(index:enjs:graph-store target)
       ==
     ::
     ++  unread-each
-      |=  [=^index target=index:graph-store tim=@da]
+      |=  [s=^stats-index target=index:graph-store tim=@da]
       %-  pairs
-      :~  index+(^index index)
+      :~  index+(stats-index s)
           target+(index:enjs:graph-store target)
           last+(time tim)
       ==
     ::
     ++  unread-count
-      |=  [=^index tim=@da]
+      |=  [s=^stats-index tim=@da]
       %-  pairs
-      :~  index+(^index index)
+      :~  index+(stats-index s)
           last+(time tim)
       ==
     --
   --
+::
+++  to-stats-index
+  |=  =index
+  ^-  stats-index
+  ?-  -.index
+    %graph  [%graph graph.index index.index]
+    %group  [%group group.index]
+  ==
+++  stats-index-is-index
+  |=  [=stats-index =index]
+  ?-    -.index
+      %graph  
+    ?.  ?=(%graph -.stats-index)  %.n
+    =([graph index]:index [graph index]:stats-index)
+    ::
+      %group  
+    ?.  ?=(%group -.stats-index)  %.n
+    =(group:index group:stats-index)
+  ==
 --

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -31,12 +31,12 @@
   ++  stats-index
     %-  of
     :~  graph+graph-stats-index
-        group+dejs:resource
+        group+dejs-path:resource
     ==
   ++  graph-stats-index
     %-  ot
-    :~  graph+dejs:resource
-        index+graph-index
+    :~  graph+dejs-path:resource
+        index+graph-store-index
     ==
   ::  parse date as @ud
   ::    TODO: move to zuse
@@ -52,7 +52,7 @@
     :~  time+sd
         index+index
     ==
-  ++  graph-index
+  ++  graph-store-index
     (su ;~(pfix fas (more fas dem)))
   ::
   ++  add
@@ -62,7 +62,7 @@
   ++  read-graph-index
     %-  ot
     :~  index+stats-index
-        target+graph-index
+        target+graph-store-index
     ==
   ::
   ++  action
@@ -110,13 +110,13 @@
       |^
       ?-  -.s
         %graph  (graph-stats-index +.s)
-        %group  (enjs:resource +.s)
+        %group  s+(enjs-path:resource +.s)
       ==
       ::
       ++  graph-stats-index
         |=  [graph=resource =index:graph-store]
         %-  pairs
-        :~  graph+(enjs:resource graph)
+        :~  graph+s+(enjs-path:resource graph)
             index+(index:enjs:graph-store index)
         ==
       --

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -97,6 +97,7 @@
         %read-count  (stats-index +.upd)
         %unread-each  (unread-each +.upd)
         %unread-count  (unread-count +.upd)
+        %remove-graph  s+(enjs-path:resource +.upd)
         %seen-index  (seen-index +.upd)
         %unreads   (unreads +.upd)
         ::

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -7,7 +7,7 @@
     ?+  index.p.i  ~
       [@ ~]       `[%link 0 %each %.y]
       [@ @ %1 ~]  `[%comment 1 %count %.n]
-      [@ @ @ ~]   `[%edit-comment 1 %count %.n]
+      [@ @ @ ~]   `[%edit-comment 1 %none %.n]
     ==
   --
 ++  grab

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -9,9 +9,9 @@
   ++  notification-kind
     ?+  index.p.i   ~
       [@ %1 %1 ~]    `[%note 0 %each %.n]
-      [@ %1 @ ~]     `[%edit-note 0 %each %.n]
+      [@ %1 @ ~]     `[%edit-note 0 %none %.n]
       [@ %2 @ %1 ~]  `[%comment 1 %count %.n]
-      [@ %2 @ @ ~]   `[%edit-comment 1 %count %.n]
+      [@ %2 @ @ ~]   `[%edit-comment 1 %none %.n]
     ==
   --
 ++  grab

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -95,6 +95,7 @@
       [%unread-note time=@da index]
     ::
       [%seen-index time=@da =stats-index]
+      [%remove-graph =resource]
     ::
       [%read-all ~]
       [%set-dnd dnd=?]
@@ -123,6 +124,7 @@
       [%added time=@da =index =notification]
       [%timebox time=@da archived=? =(list [index notification])]
       [%count count=@ud]
+      [%clear =stats-index]
       [%unreads unreads=(list [stats-index stats])]
   ==
 --

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -37,8 +37,9 @@
 ::
 ++  state-one
   |%
-  +$  state-1
-    $:  unreads-each=(jug index index:graph-store)
+  +$  state
+    $:  %1
+        unreads-each=(jug index index:graph-store)
         unreads-count=(map index @ud)
         last-seen=(map index @da)
         =notifications

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -101,8 +101,6 @@
   $%  action
       [%more more=(list update)]
       [%added time=@da =index =notification]
-      [%read-index =index]
-      [%read time=@da =index]
       [%timebox time=@da archived=? =(list [index notification])]
       [%count count=@ud]
       [%unreads unreads=(list [index index-stats])]

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -35,6 +35,19 @@
     [date=@da read=? =contents]
   --
 ::
+++  state-one
+  |%
+  +$  state-1
+    $:  unreads-each=(jug index index:graph-store)
+        unreads-count=(map index @ud)
+        last-seen=(map index @da)
+        =notifications
+        archive=notifications
+        current-timebox=@da
+        dnd=_|
+    ==
+  --
+::
 +$  index
   $%  $:  %graph
           group=resource
@@ -70,26 +83,32 @@
   $%  [%add-note =index =notification]
       [%archive time=@da index]
     ::
-      [%unread-count =index =time]
-      [%read-count =index]
+      [%unread-count =stats-index =time]
+      [%read-count =stats-index]
     ::
-      [%unread-each =index ref=index:graph-store time=@da]
-      [%read-each index ref=index:graph-store]
+    ::
+      [%unread-each =stats-index ref=index:graph-store time=@da]
+      [%read-each =stats-index ref=index:graph-store]
     ::
       [%read-note time=@da index]
       [%unread-note time=@da index]
     ::
-      [%seen-index time=@da =index]
+      [%seen-index time=@da =stats-index]
     ::
       [%read-all ~]
       [%set-dnd dnd=?]
       [%seen ~]
   ==
 ::
+++  stats-index
+  $%  [%graph graph=resource =index:graph-store]
+      [%group group=resource]
+  ==
+::
 +$  indexed-notification
   [index notification]
 ::
-+$  index-stats
++$  stats
   [notifications=@ud =unreads last-seen=@da]
 ::
 +$  unreads
@@ -103,6 +122,6 @@
       [%added time=@da =index =notification]
       [%timebox time=@da archived=? =(list [index notification])]
       [%count count=@ud]
-      [%unreads unreads=(list [index index-stats])]
+      [%unreads unreads=(list [stats-index stats])]
   ==
 --

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -79,6 +79,8 @@
       [%read-note time=@da index]
       [%unread-note time=@da index]
     ::
+      [%seen-index time=@da =index]
+    ::
       [%read-all ~]
       [%set-dnd dnd=?]
       [%seen ~]

--- a/pkg/interface/src/logic/api/hark.ts
+++ b/pkg/interface/src/logic/api/hark.ts
@@ -199,7 +199,7 @@ export class HarkApi extends BaseApi<StoreState> {
   getMore(archive = false) {
     const offset = this.store.state[
       archive ? 'archivedNotifications' : 'notifications'
-    ].size;
+    ]?.size || 0;
     const count = 3;
     return this.getSubset(offset,count, archive);
   }

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -142,6 +142,14 @@ function reduce(data: any, state: HarkState) {
   unreadSince(data, state);
   unreadEach(data, state);
   seenIndex(data, state);
+  removeGraph(data, state);
+}
+
+function removeGraph(json: any, state: HarkState) {
+  const data = _.get(json, 'remove-graph');
+  if(data) {
+    delete state.unreads.graph[data];
+  }
 }
 
 function seenIndex(json: any, state: HarkState) {

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -205,7 +205,6 @@ function updateUnreadCount(state: HarkState, index: NotifIndex, count: (c: numbe
   const property = [index.graph.graph, index.graph.index, 'unreads'];
   const curr = _.get(state.unreads.graph, property, 0);
   const newCount = count(curr)
-  state.notifications = state.notificationsCount + (newCount - curr);
   _.set(state.unreads.graph, property, newCount);
 }
 
@@ -217,7 +216,6 @@ function updateUnreads(state: HarkState, index: NotifIndex, f: (us: Set<string>)
   const oldSize = unreads.size;
   f(unreads);
   const newSize = unreads.size;
-  state.notificationsCount += (newSize - oldSize);
   _.set(state.unreads.graph, [index.graph.graph, index.graph.index, 'unreads'], unreads);
 }
 

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -140,6 +140,14 @@ function reduce(data: any, state: HarkState) {
   readSince(data, state);
   unreadSince(data, state);
   unreadEach(data, state);
+  seenIndex(data, state);
+}
+
+function seenIndex(json: any, state: HarkState) {
+  const data = _.get(json, 'seen-index');
+  if(data) {
+    updateNotificationStats(state, data.index, 'last', () => data.time);
+  }
 }
 
 function readEach(json: any, state: HarkState) {
@@ -159,8 +167,8 @@ function readSince(json: any, state: HarkState) {
 
 function unreadSince(json: any, state: HarkState) {
   const data = _.get(json, 'unread-count');
-  console.log(data);
   if(data) {
+    console.log(data);
     updateNotificationStats(state, data.index, 'last', () => data.last)
     updateUnreadCount(state, data.index, u => u + 1);
   }

--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -76,7 +76,6 @@ export const LinkItem = (props: LinkItemProps) => {
 
   const markRead = () => {
     api.hark.markEachAsRead(props.association, '/', `/${index}`, 'link', 'link');
-    console.log('mark read');
   }
   return (
     <Box width="100%" {...rest}>

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -45,12 +45,14 @@ export function Note(props: NoteProps & RouteComponentProps) {
 
   const comments = getComments(note);
   const [revNum, title, body, post] = getLatestRevision(note);
+  const index = note.post.index.split('/');
+
+  const noteId = bigInt(index[1]);
   useEffect(() => {
-    api.hark.markEachAsRead(props.association, '/', post.index, 'note', 'publish');
+    api.hark.markEachAsRead(props.association, '/',`/${index[1]}/1/1`, 'note', 'publish');
   }, [props.association]);
 
 
-  const noteId = bigInt(note.post.index.split('/')[1]);
 
   let adminLinks: JSX.Element | null = null;
   if (window.ship === note?.post?.author) {

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -45,7 +45,7 @@ export function NotePreview(props: NotePreviewProps) {
 
   const [rev, title, body, content] = getLatestRevision(node);
   const appPath = `/ship/${props.host}/${props.book}`;
-  const isUnread = props.unreads.graph?.[appPath]?.['/']?.unreads?.has(content.index);
+  const isUnread = props.unreads.graph?.[appPath]?.['/']?.unreads?.has(`/${noteId}/1/1`);
 
   const snippet = getSnippet(body);
 


### PR DESCRIPTION
- Adds a `%seen-index` poke to update the last-seen timestamp independently of the unread count
- hark-graph-hook now produces a `%seen-index` on a self post
- hark-graph-hook refactored for clarity
 
