### PR TITLE
default.nix: fix typo in examples section

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
    Note that on linux the previous command is equivalent to:
 
      $ nix-build -A urbit --argstr crossSystem x86_64-unknown-linux-musl \
-                          --arg enableSatic true
+                          --arg enableStatic true
 
    Static urbit-king binary:
 


### PR DESCRIPTION
should be `enableStatic` not `enableSatic`

Took me a couple of minutes to figure out why `nix-build -A urbit --argstr crossSystem x86_64-unknown-linux-musl --arg enableSatic true` was trying to build different things than `nix-build -A urbit --arg enableStatic true` even though they were supposed to be exactly equivalent commands. 