### PR TITLE
drum: update app index early when unlinking

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -793,6 +793,7 @@
     ?-  fec
       [%bel *]  ta-bel
       [%blk *]  +>
+      [%bye *]  +>(..ta (se-klin gyl))
       [%clr *]  +>(..ta (se-blit fec))
       [%det *]  (ta-got +.fec)
       [%err *]  (ta-err p.fec)

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -564,7 +564,12 @@
 ::
 ++  se-klin                                           ::  disconnect app
   |=  gyl=gill:gall
-  +>(eel (~(del in eel) gyl))
+  =/  gil=(unit gill:gall)  se-agon
+  =.  eel  (~(del in eel) gyl)
+  ?~  gil  +>.$
+  ?:  =(gyl u.gil)
+    +>.$(inx 0)
+  (se-alas u.gil)
 ::
 ++  se-link                                           ::  connect to app
   |=  gyl=gill:gall

--- a/pkg/arvo/mar/sole/effect.hoon
+++ b/pkg/arvo/mar/sole/effect.hoon
@@ -75,7 +75,7 @@
           info+(tape ~(ram re tank))
       ==
     ::
-        ?(%bel %clr %nex)
+        ?(%bel %clr %nex %bye)
       (frond %act %s -.sef)
     ==
   --

--- a/pkg/arvo/sur/sole.hoon
+++ b/pkg/arvo/sur/sole.hoon
@@ -30,6 +30,7 @@
 +$  sole-effect                                         ::  app to sole
   $%  [%bel ~]                                          ::  beep
       [%blk p=@ud q=@c]                                 ::  blink+match char at
+      [%bye ~]                                          ::  close session
       [%clr ~]                                          ::  clear screen
       [%det sole-change]                                ::  edit command
       [%err p=@ud]                                      ::  error point


### PR DESCRIPTION
This fixes an issue where ctrl-d-ing to unlink the current app would crash.

The added logic also happens in `+se-drop`, which will get called by
`+se-abet` if we did unlink an application. But `+se-agon` depends on the
index being sane, and may be called between `+se-klin` and `+se-abet`.