### PR TITLE
sole: add %bye effect for closing the session

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -793,6 +793,7 @@
     ?-  fec
       [%bel *]  ta-bel
       [%blk *]  +>
+      [%bye *]  +>(..ta (se-klin gyl))
       [%clr *]  +>(..ta (se-blit fec))
       [%det *]  (ta-got +.fec)
       [%err *]  (ta-err p.fec)

--- a/pkg/arvo/mar/sole/effect.hoon
+++ b/pkg/arvo/mar/sole/effect.hoon
@@ -75,7 +75,7 @@
           info+(tape ~(ram re tank))
       ==
     ::
-        ?(%bel %clr %nex)
+        ?(%bel %clr %nex %bye)
       (frond %act %s -.sef)
     ==
   --

--- a/pkg/arvo/sur/sole.hoon
+++ b/pkg/arvo/sur/sole.hoon
@@ -30,6 +30,7 @@
 +$  sole-effect                                         ::  app to sole
   $%  [%bel ~]                                          ::  beep
       [%blk p=@ud q=@c]                                 ::  blink+match char at
+      [%bye ~]                                          ::  close session
       [%clr ~]                                          ::  clear screen
       [%det sole-change]                                ::  edit command
       [%err p=@ud]                                      ::  error point


### PR DESCRIPTION
This lets applications suggest to the client that they should gracefully
unsubscribe from the session.

Arguably this might be accomplished by `%kick`-ing the client and then
crashing on their subsequent resubscribe, but that requires tracking
their sole session id and has less semantic clarity on what's happening.

Of course this doesn't _guarantee_ that the client will actually close their session, but that's on them. This will give applications more control over their sole sessions, letting them create more explicitly short-lived experiences, instead of lingering in the user's drum ring until they manually `|unlink`.  
(Think along the lines of, chess session that closes once the game is over, `|link`ing into a remote feedback form, etc)

Depends on (and targets) #4167, because this would hit the same issue that ctrl-d-ing did.