### PR TITLE
u3: revive hashboard

### DIFF
--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -17,11 +17,13 @@
 
 static u3j_harm _140_hex_mimes_base16_en_a[] = {{".2", u3we_en_base16}, {}};
 static c3_c* _140_hex_mimes_base16_en_ha[] = {
+  "669807766b6802719769fcbfe149d77fb352fcf0922afaf35dc4ab8c201d84e5",
   0
 };
 
 static u3j_harm _140_hex_mimes_base16_de_a[] = {{".2", u3we_de_base16}, {}};
 static c3_c* _140_hex_mimes_base16_de_ha[] = {
+  "f1e04d0f452f2783e17b3bd5bbbcf95a651624fe7a2aca28dd9a7feae1319734",
   0
 };
 
@@ -31,6 +33,7 @@ static u3j_core _140_hex_mimes_base16_d[] =
     {}
   };
 static c3_c* _140_hex_mimes_base16_ha[] = {
+  "c71bdcc8542fd49aa307f296ac097e300a714fb3b3d1e475426f0916fa61f12c",
   0
 };
 
@@ -39,92 +42,99 @@ static u3j_core _140_hex_mimes_d[] =
     {}
   };
 static c3_c* _140_hex_mimes_ha[] = {
+  "bca2510fd7172643812f9d224deb95ddd69400c990db3d8cfb517a7292e8f06e",
   0
 };
 
 static u3j_harm _140_hex_aes_ecba_en_a[] = {{".2", u3wea_ecba_en}, {}};
 static c3_c* _140_hex_aes_ecba_en_ha[] = {
-  "a4eaaead7ffeb213cf8d611f20d7be4786b34f31a27f41c77538125992107c2d",
+  "d7674ad72666a787580c52785c5d4d37ca462ba05e904efbeded5d1bd8b02b4b",
   0
 };
 static u3j_harm _140_hex_aes_ecba_de_a[] = {{".2", u3wea_ecba_de}, {}};
 static c3_c* _140_hex_aes_ecba_de_ha[] = {
-  "f34036da1666cd2a19be04684f44486fe5e90cbab96d5288e19c4e2bad6e07dd",
+  "6e6599e93bea2e4297b621814bfb17a9b10849f920d50b14e808ef2e4fe62383",
   0
 };
 static u3j_harm _140_hex_aes_ecbb_en_a[] = {{".2", u3wea_ecbb_en}, {}};
 static c3_c* _140_hex_aes_ecbb_en_ha[] = {
-  "44678df63ff8c63be64266d3c06c4a27efbe99f21f078ed3698d3d45fae1807f",
+  "2c0e3c8f4d741b37324563ecd0ab8fbf87721d1e017f1eeeaf8b6a60515c483b",
   0
 };
 static u3j_harm _140_hex_aes_ecbb_de_a[] = {{".2", u3wea_ecbb_de}, {}};
 static c3_c* _140_hex_aes_ecbb_de_ha[] = {
-  "81d2f078236aecaecfebd1d0f69fad64dcada7a7478f50c97ecf7d43a5b48f0c",
+  "cf78f314a1dbbc53b28d6405b98c66a4451350757872d8f7cf0477411e731acc",
   0
 };
 static u3j_harm _140_hex_aes_ecbc_en_a[] = {{".2", u3wea_ecbc_en}, {}};
 static c3_c* _140_hex_aes_ecbc_en_ha[] = {
-  "ecc3da3bdd3381476eb826cdfb1b839b19e550bb3b4798c8cf7c308efa897c79",
+  "f56450f2662082e27ba1aecd2fe04c66aa8641d6eb155f8d3707e242a1e1cf1c",
   0
 };
 static u3j_harm _140_hex_aes_ecbc_de_a[] = {{".2", u3wea_ecbc_de}, {}};
 static c3_c* _140_hex_aes_ecbc_de_ha[] = {
-  "62e93207275b261a281ad76250408da7cfc6eb6e87bc4b3fd5d99bbf8acc58bd",
+  "28c8c44002799fbe94d4aa07922f2b74dbbf234c84684cd8c3187622b4be6a5f",
   0
 };
 
 static u3j_harm _140_hex_aes_cbca_en_a[] = {{".2", u3wea_cbca_en}, {}};
 static c3_c* _140_hex_aes_cbca_en_ha[] = {
-  "6b9c992891931f63d0db62d7b28436f88fa6a5cad9920740e94b531cdbf6a7ea",
+  "f85366d520b3179c5dabfb58ee1fa0554f5044f676340439db875841cd4058de",
   0
 };
 static u3j_harm _140_hex_aes_cbca_de_a[] = {{".2", u3wea_cbca_de}, {}};
 static c3_c* _140_hex_aes_cbca_de_ha[] = {
-  "7ddd8a076c15ff737f9e3a0b91bc531c4f7f4a40733fb23e3a3dde98be86bb63",
+  "8b876fbdb1849d8fbabba5e143aea0532a0e5dfff1c784d7ad15fd497ea376b1",
   0
 };
 static u3j_harm _140_hex_aes_cbcb_en_a[] = {{".2", u3wea_cbcb_en}, {}};
 static c3_c* _140_hex_aes_cbcb_en_ha[] = {
-  "449ea4600038a80c659705342f6f855a683ad933543679c8f37239e4e438b0d1",
+  "6f961e0629c5efce47793e6a352220d355bb8fba6656c6941a68efb3ba10999d",
   0
 };
 static u3j_harm _140_hex_aes_cbcb_de_a[] = {{".2", u3wea_cbcb_de}, {}};
 static c3_c* _140_hex_aes_cbcb_de_ha[] = {
-  "7c26d5e55854c26ddfd3c42c4ae90b496cb81b67bb86eacfb6a5f3328bd6404b",
+  "7ee2f33f80612e91fda1fd84201266dea6cab596a4e23a535d1a14fb0763f1a3",
   0
 };
 static u3j_harm _140_hex_aes_cbcc_en_a[] = {{".2", u3wea_cbcc_en}, {}};
 static c3_c* _140_hex_aes_cbcc_en_ha[] = {
-  "5c1a99a2a95cef482951a833dfe1d567f0c3ba41db8250baa2c34e7465fd6ee9",
+  "b2578cf17a3095f48cc96cf7690dd7ab4f4e0b76b2578eadc1dce31a075f5b12",
   0
 };
 static u3j_harm _140_hex_aes_cbcc_de_a[] = {{".2", u3wea_cbcc_de}, {}};
 static c3_c* _140_hex_aes_cbcc_de_ha[] = {
-  "b9d521b4d5e1d9387b34bbf5ca38f4d52ba86952ea54490dad7e2670183c572b",
+  "36586f89d702bedb8c2a01ea3614f61627e762488e373106cbb1b27c46e3493c",
   0
 };
 static u3j_harm _140_hex_aes_siva_en_a[] = {{".2", u3wea_siva_en}, {}};
 static c3_c* _140_hex_aes_siva_en_ha[] = {
+  "2a137039301788b8540ed81cbfafe450c9306348d02a6576f5c14f6d6f20ba81",
   0
 };
 static u3j_harm _140_hex_aes_siva_de_a[] = {{".2", u3wea_siva_de}, {}};
 static c3_c* _140_hex_aes_siva_de_ha[] = {
+  "d0130e9229e71c589429dd87843dc104bc4ee5b426400a547081d8c91a548eaa",
   0
 };
 static u3j_harm _140_hex_aes_sivb_en_a[] = {{".2", u3wea_sivb_en}, {}};
 static c3_c* _140_hex_aes_sivb_en_ha[] = {
+  "1638f56e8728f285e4175c7b514c5a4e1a24205acf33e105f0513cad7ae843cf",
   0
 };
 static u3j_harm _140_hex_aes_sivb_de_a[] = {{".2", u3wea_sivb_de}, {}};
 static c3_c* _140_hex_aes_sivb_de_ha[] = {
+  "64c9b199fffd6d31baf7457bf27d5a510121be45201b2ae5cc1d9565c0bdd0ff",
   0
 };
 static u3j_harm _140_hex_aes_sivc_en_a[] = {{".2", u3wea_sivc_en}, {}};
 static c3_c* _140_hex_aes_sivc_en_ha[] = {
+  "d721486dea943efd52d9e6450f4f48dd191c89637a2f842d3ff6edfd3beecbb9",
   0
 };
 static u3j_harm _140_hex_aes_sivc_de_a[] = {{".2", u3wea_sivc_de}, {}};
 static c3_c* _140_hex_aes_sivc_de_ha[] = {
+  "3ded831b992ea100582229a4d1d9b5c80380128ae6b59b5bb36403ed13dc5d55",
   0
 };
 
@@ -134,7 +144,7 @@ static u3j_core _140_hex_aes_ecba_d[] =
     {}
   };
 static c3_c* _140_hex_aes_ecba_ha[] = {
-  "95a46cbd493f303080f31b9b376df4c981cee336223bd6cffa7c971d38c2749b",
+  "693409d27b777f73ce92cebd38e9ebceebe1e9c27ad8c9de9afc091e31bd7d9f",
   0
 };
 
@@ -144,7 +154,7 @@ static u3j_core _140_hex_aes_ecbb_d[] =
     {}
   };
 static c3_c* _140_hex_aes_ecbb_ha[] = {
-  "6d9488a29d64e307bbce89400bc13420e0ea52a158715cae4f663536ed0a9a58",
+  "7255c39f10e068007d0d64dd40e4f6e83492ed2e3222919440be0d28fd42a5e3",
   0
 };
 
@@ -154,7 +164,7 @@ static u3j_core _140_hex_aes_ecbc_d[] =
     {}
   };
 static c3_c* _140_hex_aes_ecbc_ha[] = {
-  "6c998edf14a8ca78ef1c03c31804662422b424187741c7f9ea8fa721de7b5bcb",
+  "65da73b8de06a6660ca2d36be881b708362e1f8bc12c01290aed90fdb2977667",
   0
 };
 
@@ -164,7 +174,7 @@ static u3j_core _140_hex_aes_cbca_d[] =
     {}
   };
 static c3_c* _140_hex_aes_cbca_ha[] = {
-  "59b5e7a31d01156e1c1c9332ce2ef57211b4f2ce27854bc2fe901cffc30fd93d",
+  "420d04c03b7816b656fe4e8d9fce04f7e6d51d3d274c6511e89cfdb43ebf107e",
   0
 };
 
@@ -174,7 +184,7 @@ static u3j_core _140_hex_aes_cbcb_d[] =
     {}
   };
 static c3_c* _140_hex_aes_cbcb_ha[] = {
-  "b7dd467d0920c5eaf9703af6c5c4a04f419ba010e75035072109d49dbcb1983c",
+  "1b84daab497795f2afd7238a6a6090be68b78eb6051b0ffa076b2ed9fedeebe5",
   0
 };
 
@@ -184,7 +194,7 @@ static u3j_core _140_hex_aes_cbcc_d[] =
     {}
   };
 static c3_c* _140_hex_aes_cbcc_ha[] = {
-  "703d019a7e12ca9c2836707f60cdb8d32b61b20c720e438d84d3a787f20e99f5",
+  "3bab1a59c7673afeb659821d54754e8e5e281243e79624fdbe4d7f85cae192c5",
   0
 };
 
@@ -194,6 +204,7 @@ static u3j_core _140_hex_aes_siva_d[] =
     {}
   };
 static c3_c* _140_hex_aes_siva_ha[] = {
+  "435c5c769d2522d71ab60332bb57440d69c6803d5ca9a5faae88c825cb55d72e",
   0
 };
 static u3j_core _140_hex_aes_sivb_d[] =
@@ -202,6 +213,7 @@ static u3j_core _140_hex_aes_sivb_d[] =
     {}
   };
 static c3_c* _140_hex_aes_sivb_ha[] = {
+  "0683f3f9067c2a16f68805c778c404179dc5df9019bbbe0f8d680a99a69e61fc",
   0
 };
 static u3j_core _140_hex_aes_sivc_d[] =
@@ -210,6 +222,7 @@ static u3j_core _140_hex_aes_sivc_d[] =
     {}
   };
 static c3_c* _140_hex_aes_sivc_ha[] = {
+  "23ef582f110d28aff82b0795305b02e5a718d667bcae97091c08bc26790e7176",
   0
 };
 
@@ -226,12 +239,13 @@ static u3j_core _140_hex_aes_d[] =
     {}
   };
 static c3_c* _140_hex_aes_ha[] = {
-  "a5340a7ffcb8adac8085317094b9bd6bc4eb0a52badbbfb138e9ff3ce8b49a97",
+  "ca4c1b0cff03db74ceca1b844f0223d669aa42934152a784d431469f0eb71527",
   0
 };
 
 static u3j_harm _140_hex_leer_a[] = {{".2", u3we_leer}, {}};
 static c3_c* _140_hex_leer_ha[] = {
+  "8a4486bb09639f6b8cf7631f9bf883256529c6d7d9aa320ab6dfa5517611f0d7",
   0
 };
 static u3j_harm _140_hex_lore_a[] = {{".2", u3we_lore}, {}};
@@ -241,7 +255,7 @@ static c3_c* _140_hex_lore_ha[] = {
 };
 static u3j_harm _140_hex_loss_a[] = {{".2", u3we_loss}, {}};
 static c3_c* _140_hex_loss_ha[] = {
-  "6c4fe849ec8520e847c09804c056aa0c5c890553e53f07c00b6e1f158e6deb8f",
+  "67aacd21484078828ad4342297d44c38d9213b8809f83f695c2996378a92dc2a",
   0
 };
 static u3j_harm _140_hex_lune_a[] = {{".2", u3we_lune}, {}};
@@ -252,22 +266,22 @@ static c3_c* _140_hex_lune_ha[] = {
 
 static u3j_harm _140_hex_coed__ed_puck_a[] = {{".2", u3wee_puck}, {}};
 static c3_c* _140_hex_coed__ed_puck_ha[] = {
-  "540b16bba2321015feeb401cd65150d2050188de57041fd9d3d1ac8902cc1e63",
+  "1bc694675842345c50b0e20a2193bb5bcbb42f163fc832431a3d1822a81e4c98",
   0
 };
 static u3j_harm _140_hex_coed__ed_sign_a[] = {{".2", u3wee_sign}, {}};
 static c3_c* _140_hex_coed__ed_sign_ha[] = {
-  "de2e5ebf5bdb96e24e05a231b4eac0e0f803984c69948c16cd0e2397aa5dabc1",
+  "34ad749bf8443611cbf1f7de90a066318bd12be36f2f7f6f55281f6f7ed79754",
   0
 };
 static u3j_harm _140_hex_coed__ed_veri_a[] = {{".2", u3wee_veri}, {}};
 static c3_c* _140_hex_coed__ed_veri_ha[] = {
-  "a0fa913b3a823e67ae3d6f416d623c9ff692a324deffd80d057020bbac91d223",
+  "047a7eeccb2e68aeeee631b6db86e11a5a3aa9e179660553eca6304327612dcf",
   0
 };
 static u3j_harm _140_hex_coed__ed_shar_a[] = {{".2", u3wee_shar}, {}};
 static c3_c* _140_hex_coed__ed_shar_ha[] = {
-  "2115b6722bf59ebac897791293eeb7fe0a83e73b1e57d4a098d52af0948cb7b4",
+  "52d3b0a2f51f2b0a9dd72bb33db38c73dc873029c365d871d0559a1472a80e72",
   0
 };
 
@@ -276,15 +290,31 @@ static u3j_harm _140_hex_coed__ed_point_add_a[] =
 
 static u3j_harm _140_hex_coed__ed_scalarmult_a[] =
     {{".2", u3wee_scalarmult}, {}};
+static c3_c* _140_hex_coed__ed_scalarmult_ha[] = {
+  "72e71cd3aa3af429cd65baa78632500c60edd1d4c82a39d3ba7f231ef97e6316",
+  0
+};
 
 static u3j_harm _140_hex_coed__ed_scalarmult_base_a[] =
     {{".2", u3wee_scalarmult_base}, {}};
+static c3_c* _140_hex_coed__ed_scalarmult_base_ha[] = {
+  "976fdb8251f9b767af689a0d2c41b88941921bf53777c1ceeb5297511021f9d8",
+  0
+};
 
 static u3j_harm _140_hex_coed__ed_add_scalarmult_scalarmult_base_a[] =
     {{".2", u3wee_add_scalarmult_scalarmult_base}, {}};
+static c3_c* _140_hex_coed__ed_add_scalarmult_scalarmult_base_ha[] = {
+  "11819071c24a2d7b36daea6e16c78b2e05f9ca3e857cf4815ffe652ce677a61a",
+  0
+};
 
 static u3j_harm _140_hex_coed__ed_add_double_scalarmult_a[] =
     {{".2", u3wee_add_double_scalarmult}, {}};
+static c3_c* _140_hex_coed__ed_add_double_scalarmult_ha[] = {
+  "0fab78a1e890e53cecade1c22b95813db77e066044e33417a0919695b6cde9ba",
+  0
+};
 
 static u3j_core _140_hex_coed__ed_d[] =
   { { "sign", 7, _140_hex_coed__ed_sign_a, 0, _140_hex_coed__ed_sign_ha },
@@ -292,16 +322,20 @@ static u3j_core _140_hex_coed__ed_d[] =
     { "veri", 7, _140_hex_coed__ed_veri_a, 0, _140_hex_coed__ed_veri_ha },
     { "shar", 7, _140_hex_coed__ed_shar_a, 0, _140_hex_coed__ed_shar_ha },
     { "point-add", 7, _140_hex_coed__ed_point_add_a, 0, 0 },
-    { "scalarmult", 7, _140_hex_coed__ed_scalarmult_a, 0, 0 },
-    { "scalarmult-base", 7, _140_hex_coed__ed_scalarmult_base_a, 0, 0 },
+    { "scalarmult", 7, _140_hex_coed__ed_scalarmult_a, 0,
+      _140_hex_coed__ed_scalarmult_ha },
+    { "scalarmult-base", 7, _140_hex_coed__ed_scalarmult_base_a, 0,
+      _140_hex_coed__ed_scalarmult_base_ha },
     { "add-scalarmult-scalarmult-base", 7,
-      _140_hex_coed__ed_add_scalarmult_scalarmult_base_a, 0, 0 },
+      _140_hex_coed__ed_add_scalarmult_scalarmult_base_a, 0,
+      _140_hex_coed__ed_add_scalarmult_scalarmult_base_ha },
     { "add-double-scalarmult", 7,
-      _140_hex_coed__ed_add_double_scalarmult_a, 0, 0 },
+      _140_hex_coed__ed_add_double_scalarmult_a, 0,
+      _140_hex_coed__ed_add_double_scalarmult_ha },
     {}
   };
 static c3_c* _140_hex_coed__ed_ha[] = {
-  "33223ee36ddc84831eff43939b035afe00bb23c7ba1475cbeadb24954216b814",
+  "7a44a962aa72933588b5c99a8b68ebac21ce3c4710c081cb66b3599b45af9ced",
   0
 };
 
@@ -310,13 +344,13 @@ static u3j_core _140_hex_coed_d[] =
   {}
 };
 static c3_c* _140_hex_coed_ha[] = {
-  "1f68bb8e3214032195e1183e61b05bccff19808df3cbdaeb6c7fcce9cd27a24d",
+  "4be0254f06d953b69509eb15550595ffad8767d3c3dc2dafcd7c22f92f7704c4",
   0
 };
 
   static u3j_harm _140_hex_hmac_hmac_a[] = {{".2", u3we_hmac}, {}};
   static c3_c* _140_hex_hmac_hmac_ha[] = {
-    "41a3eb915ac8105751d5bc7ac309a21400896a82e129d3314cc5be300f2660db",
+    "d0dbd778156aef21d18f44a8cffd87296826120af5a4af020dd7aff0f95f03b1",
     0
   };
 static u3j_core _140_hex_hmac_d[] =
@@ -324,13 +358,13 @@ static u3j_core _140_hex_hmac_d[] =
     {}
   };
 static c3_c* _140_hex_hmac_ha[] = {
-  "c6cacf4657372591769ccb9b686be4c16d7dbe0d815f4b8d9e81ddc97c36b770",
+  "976bb4508dbe659eb12aa32d4a481dbd885e40f8a15c505762f1acf43b744234",
   0
 };
 
   static u3j_harm _140_hex_argon2_a[] = {{".2", u3we_argon2}, {}};
   static c3_c* _140_hex_argon2_ha[] = {
-    "ef21e4f9108b5f2e6831145df4c21e0d44152abcd0f575532894d406425c04c9",
+    "4df7cec141ffa2cc76b058846474ca42cc9840666ee3e7e80e565803e83ea98b",
     0
   };
 static u3j_core _140_hex_argon_d[] =
@@ -338,18 +372,27 @@ static u3j_core _140_hex_argon_d[] =
     {}
   };
 static c3_c* _140_hex_argon_ha[] = {
-  "7d8acf91db0262d485641547db6cc9ab4ef260c393fc7f12336fab393263056a",
+  "dc704c786192ecd09d4c206a8f28db3202b6e0eb03e3ce63a95987510ac312d6",
   0
 };
 
 static c3_c* _140_hex_secp_secp256k1_make_ha[] = { 0 };
 static u3j_harm _140_hex_secp_secp256k1_make_a[] = {{".2", u3we_make, c3y}, {}};
-static c3_c* _140_hex_secp_secp256k1_sign_ha[] = { 0 };
+static c3_c* _140_hex_secp_secp256k1_sign_ha[] = {
+  "3e75b3452b74776488d5eec75a91211700d9f360a4e06dd779600d5128d9c600",
+  0
+};
 static u3j_harm _140_hex_secp_secp256k1_sign_a[] = {{".2", u3we_sign, c3y}, {}};
-static c3_c* _140_hex_secp_secp256k1_reco_ha[] = { 0 };
+static c3_c* _140_hex_secp_secp256k1_reco_ha[] = {
+  "449f3aa878b61962c3048e167c23ba54a0736d3aa1ab7762bd54016fbba136ee",
+  0
+};
 static u3j_harm _140_hex_secp_secp256k1_reco_a[] = {{".2", u3we_reco, c3y}, {}};
 
-static c3_c* _140_hex_secp_secp256k1_ha[] = { 0 };
+static c3_c* _140_hex_secp_secp256k1_ha[] = {
+  "e7fc0971a970aba7ded43bd89e9c82623eb2f346c9c720c63b22f2a646927861",
+  0
+};
 static u3j_core _140_hex_secp_secp256k1_d[] =
   { { "make", 7, _140_hex_secp_secp256k1_make_a, 0, _140_hex_secp_secp256k1_make_ha },
     { "sign", 7, _140_hex_secp_secp256k1_sign_a, 0, _140_hex_secp_secp256k1_sign_ha },
@@ -357,7 +400,10 @@ static u3j_core _140_hex_secp_secp256k1_d[] =
     {}
   };
 
-static c3_c* _140_hex_secp_ha[] = { 0 };
+static c3_c* _140_hex_secp_ha[] = {
+  "9f5c23f0e7923b6cf1603388ba52401b6e43881be3560b3acfaab20b25071792",
+  0
+};
 static u3j_core _140_hex_secp_d[] =
   { { "secp256k1", 3, 0, _140_hex_secp_secp256k1_d, _140_hex_secp_secp256k1_ha },
     {}
@@ -365,7 +411,7 @@ static u3j_core _140_hex_secp_d[] =
 
   static u3j_harm _140_hex_blake2b_a[] = {{".2", u3we_blake, c3y}, {}};
   static c3_c* _140_hex_blake2b_ha[] = {
-    "affddbd9861660e0381edf82c88da18e18d2dd0aa0f430f9d8661c5a57e13cb5",
+    "c432216ca53b5ad2284259167952761bb1046e280268c4d3b9ca70a2024e1934",
     0
   };
 static u3j_core _140_hex_blake_d[] =
@@ -373,13 +419,13 @@ static u3j_core _140_hex_blake_d[] =
     {}
   };
 static c3_c* _140_hex_blake_ha[] = {
-  "3a63284428b509489233513a0d6b13f705a67c5bed4354a64ef09054529a7c35",
+  "ff30d99ffb3e13d8aa50b2b8461c8edfabf0e76de22312d16d1d6daaf3636b5f",
   0
 };
 
   static u3j_harm _140_hex_ripemd_160_a[] = {{".2", u3we_ripe, c3y}, {}};
   static c3_c* _140_hex_ripemd_160_ha[] = {
-    "c918e263c56723986b6a5ba4a994199ec2afe12df42b2efa497e1b51f572ce13",
+    "176684b29926a01f5c60fa584e4691b0cbdc9b93608dcbe7d0cf3585683fa42f",
     0
   };
 static u3j_core _140_hex_ripe_d[] =
@@ -387,7 +433,7 @@ static u3j_core _140_hex_ripe_d[] =
     {}
   };
 static c3_c* _140_hex_ripe_ha[] = {
-  "fe7e2579d5053dead2f5ce27e0aa6bda1f9a84684db45349af38fe5bc827613a",
+  "b0cb16bf206c0496bb480e5759ea1afa7dee1748b64e5243c23fddb09720ebd0",
   0
 };
 
@@ -410,7 +456,7 @@ static u3j_core _140_hex_d[] =
   {}
 };
 static c3_c* _140_hex_ha[] = {
-  "b3352eada800d6c9db030ac128262e8286c245162b2ab2b317c43dc39f3e152d",
+  "7e393356dd7ac64eed5cd9f5cf0e320d401ca36a0a0ce0f954e7538824114844",
   0
 };
 
@@ -423,7 +469,7 @@ static c3_c* _140_pen_cell_ha[] = {
 };
 static u3j_harm _140_pen_comb_a[] = {{".2", u3wf_comb}, {}};
 static c3_c* _140_pen_comb_ha[] = {
-  "137e940853b2f823bac751069f7dd3e81367bda77037afe1c3cb4d0cd26982db",
+  "f9e37c3b3d5036c31af60f7047391594068638b54db7cf94bfea9dabbdffa547",
   0
 };
 static u3j_harm _140_pen_cons_a[] = {{".2", u3wf_cons}, {}};
@@ -443,7 +489,7 @@ static c3_c* _140_pen_face_ha[] = {
 };
 static u3j_harm _140_pen_fitz_a[] = {{".2", u3wf_fitz}, {}};
 static c3_c* _140_pen_fitz_ha[] = {
-  "31ebe9b8ece572a90c8e8d6b8b334f445c010b92c0ce83380d0fd6ad21b014af",
+  "469abe976ec15eeff9a87bce385f2c87c9bd89814ce2858aa9fee094beea1e5d",
   0
 };
 static u3j_harm _140_pen_flan_a[] = {{".2", u3wf_flan}, {}};
@@ -463,7 +509,7 @@ static c3_c* _140_pen_flor_ha[] = {
 };
 static u3j_harm _140_pen_fork_a[] = {{".2", u3wf_fork}, {}};
 static c3_c* _140_pen_fork_ha[] = {
-  "000af0f7a46f669c66b4f5d2de1d28544f093b579d93c16e41e717c3c40d1823",
+  "36f0ea0e2eb30328b8b83ed43a81c8c9a1f5b4c5a03fd68fd25701991a40b9dd",
   0
 };
 
@@ -478,52 +524,64 @@ static c3_c* _140_pen_look_ha[] = {
 };
 static u3j_harm _140_pen_loot_a[] = {{".2", u3wf_loot}, {}};
 static c3_c* _140_pen_loot_ha[] = {
-  "be73de8944cd05c117fa698523940fd0a6a2a2286c56d8586ae35034d0a32200",
+  "e275da4562ae6da9bd333aeae6b9829e886874c8b891898c0ef5306268eb45c1",
   0
 };
 
   static u3j_harm _140_pen__ut_crop_a[] = {{".2", u3wfu_crop}, {}};
   static c3_c* _140_pen__ut_crop_ha[] = {
-    "d83e5e47f712870aba815d79943d287cbefdc00640409464b30bf755115d4a1a",
+    "e2c6fc3e714a3a98ccd28423dcb9f2c6480935e26b54dd0581eb2ad7e5b16d6f",
     0
   };
   static u3j_harm _140_pen__ut_fish_a[] = {{".2", u3wfu_fish}, {}};
   static c3_c* _140_pen__ut_fish_ha[] = {
-    "2fd315436f48351002d9aa8c137649ca95b01fd57dba09db53d7235f84a284bf",
+    "080caee60b5ee4616bf9568bdbceabbf044379c47466e0ae3968cb0146049a84",
     0
   };
   static u3j_harm _140_pen__ut_fuse_a[] = {{".2", u3wfu_fuse}, {}};
   static c3_c* _140_pen__ut_fuse_ha[] = {
-    "43d8bfdf9255f548bb58d9975bac273e2dcebe5ae98bd7e466b6fff6ff43a944",
+    "519aac7b40b7018d5df00ddf3977c2ebe0c2e05bcee34796d56a1d54c15e0c84",
     0
   };
   static u3j_harm _140_pen__ut_mint_a[] = {{".2", u3wfu_mint}, {}};
   static c3_c* _140_pen__ut_mint_ha[] = {
-    "43a06316365bcd14a94f8ed1f3fe5a8f61d1da5bea989296a192b62a966fca11",
+    "7d980f7425b51bb10fbbd8b465b5d83f5dd4cb6e66d88758a9f7490b812a765e",
     0
   };
   static u3j_harm _140_pen__ut_mull_a[] = {{".2", u3wfu_mull}, {}};
   static c3_c* _140_pen__ut_mull_ha[] = {
-    "9fe555b3f9ad666f04194037437d71ee98f6b884f7aacc46a11ad27407cb7e8e",
+    "c806329aefd920501ea0faa0cfb0ce3280a74408782efe6d82878ec43ec44fb7",
     0
   };
-  static c3_c* _140_pen__ut_nest_ha[] = {0};
-      static u3j_harm _140_pen__ut_nest_dext_a[] = {{".2", u3wfu_nest_dext}, {}};
-      static c3_c* _140_pen__ut_nest_dext_ha[] = {0};
+
+    static u3j_harm _140_pen__ut_nest_dext_a[] = {{".2", u3wfu_nest_dext}, {}};
+    static c3_c* _140_pen__ut_nest_dext_ha[] = {
+      "72f33df96800034fc63531293f9b110e6505027195bf8a10ff94b9a1f1ef719b",
+      0
+    };
     static u3j_core _140_pen__ut_nest_in_d[] =
       {
         { "nest-dext", 3, _140_pen__ut_nest_dext_a, 0, _140_pen__ut_nest_dext_ha },
         {}
       };
-    static c3_c* _140_pen__ut_nest_in_ha[] = {0};
+    static c3_c* _140_pen__ut_nest_in_ha[] = {
+      "68378dfa1d1fee0b1cd9593fb561234cec2ae9371a5ffa287c3d2ab9620e198c",
+      0
+    };
+
   static u3j_core _140_pen__ut_nest_d[] =
     {
       { "nest-in", 7, 0, _140_pen__ut_nest_in_d, _140_pen__ut_nest_in_ha },
       {}
     };
+  static c3_c* _140_pen__ut_nest_ha[] = {
+    "1e8de5d1225facc1158c92c2ea5e0dc84129cbb317fde3691e224b8c2550d950",
+    0
+  };
+
   static u3j_harm _140_pen__ut_rest_a[] = {{".2", u3wfu_rest}, {}};
   static c3_c* _140_pen__ut_rest_ha[] = {
-    "2e2d15f3efca0a4bf8ce08cca48c54d1d5a7204e2b0525137f59c3e7b037d2fd",
+    "b4a83073f4cb03898ef099fab5722a046122dc96a5332ffc82f988df6c186e74",
     0
   };
 
@@ -540,14 +598,55 @@ static u3j_core _140_pen__ut_d[] =
   };
 
 static c3_c* _140_pen__ut_ha[] = {
-  "479d0051e5fabe291e4cded603a071fce0f10734503638fd7d30e9c6d799969c",
+  "50c79204c82a3ba8f01e085a2e27e7716e5c7ab1929f94423ef1da92cf5ac631",
   0
 };
 
 static u3j_hood _140_pen__ut_ho[] = {
+  { "ar",     12282 },
   { "fan",  28, c3n },
   { "rib",  58, c3n },
   { "vet",  59, c3n },
+
+  { "blow",    6015 },
+  { "burp",     342 },
+  { "busk",    1373 },
+  { "buss",     374 },
+  { "crop",    1494 },
+  { "duck",    1524 },
+  { "dune",    2991 },
+  { "dunk",    3066 },
+  { "epla",   12206 },
+  { "emin",    1534 },
+  { "emul",    6134 },
+  { "feel",    1502 },
+  { "felt",      94 },
+  { "fine",   49086 },
+  { "fire",       4 },
+  { "fish",    6006 },
+  { "fond",   12283 },
+  { "fund",    6014 },
+  //  XX +funk is not part of +ut, and this hook appears to be unused
+  //  remove from here and the +ut hint
+  //
+  { "funk", 0xbefafa, c3y, 31 },
+  { "fuse",   24021 },
+  { "gain",     380 },
+  { "lose", 0x2fefe },
+  { "mile",     382 },
+  { "mine",     372 },
+  { "mint",   49083 },
+  { "moot", 0x2feff },
+  { "mull",   24020 },
+  { "nest",      92 },
+  { "peel",    1526 },
+  { "play",    3006 },
+  { "peek",    1532 },
+  { "repo",      22 },
+  { "rest",    6102 },
+  { "tack",    6007 },
+  { "toss",   24540 },
+  { "wrap",    6140 },
   {},
 };
 
@@ -588,13 +687,13 @@ static u3j_core _140_pen_d[] =
   {}
 };
 static c3_c* _140_pen_ha[] = {
-  "5197c4be0f72a57d77ecda9f3976ba06cd22648751f434f40162f6759688b725",
+  "e6c9e2362bdf2d1f9a2837a0efa154c0b8b9d51aea03a86b5aece573ff423cb1",
   0
 };
 
 static u3j_hood _140_pen_ho[] = {
-  { "ap", 86 },
-  { "ut", 342 },
+  { "ap", 22 },
+  { "ut", 86 },
   {},
 };
 
@@ -602,12 +701,13 @@ static u3j_hood _140_pen_ho[] = {
 */
 static u3j_harm _140_qua_trip_a[] = {{".2", u3we_trip}, {}};
 static c3_c* _140_qua_trip_ha[] = {
-  "2f4df71315caaab44495ebd6b0c541484cb76d26d4caa306207a33876b09509c",
+  "05423b940d10d03891cc23f36eea14b233e5884ef539de3d985d6818dd427b05",
   0
 };
 
 static u3j_harm _140_qua_slaw_a[] = {{".2", u3we_slaw}, {}};
 static c3_c* _140_qua_slaw_ha[] = {
+  "306c9692f48e2700675ed6581e9df4feaee951e1bed3cad7f89aab392e80000f",
   0
 };
 static u3j_harm _140_qua_scot_a[] = {{".2", u3we_scot}, {}};
@@ -631,12 +731,12 @@ static c3_c* _140_qua__po_ins_ha[] = {
 };
 static u3j_harm _140_qua__po_tod_a[] = {{".2", u3wcp_tod}, {}};
 static c3_c* _140_qua__po_tod_ha[] = {
-  "c69fdde3a83159207e1e838e960fe48e809fc9eb296300ee85169aadf126339c",
+  "153aeba45ca2a87aa918e9cea1b26e8104a6e4395979257b075546c1e2654a17",
   0
 };
 static u3j_harm _140_qua__po_tos_a[] = {{".2", u3wcp_tos}, {}};
 static c3_c* _140_qua__po_tos_ha[] = {
-  "eba705fc6e46193f4a4f3e20c37f06140d0b8eae0f8db6e6c7a53659803a3f04",
+  "7c5ffad03bcf8b4ea9bdf0c7f7500351923bc0431f3d62d6ce0472790f668fb4",
   0
 };
   static u3j_core _140_qua__po_d[] =
@@ -647,13 +747,13 @@ static c3_c* _140_qua__po_tos_ha[] = {
       {}
     };
   static c3_c* _140_qua__po_ha[] = {
-    "6ca8581f72f693ae465e658fd58e8cb7d705927f67254bcc95a449df9c9f7d1b",
+    "efc5fa7c0efedd490e9a270bb5cf9f90809e6b224f8a381a6b8a481253b237a1",
     0
   };
 
 static u3j_harm _140_qua__bend_fun_a[] = {{".2", u3we_bend_fun}, {}};
 static c3_c* _140_qua__bend_fun_ha[] = {
-  "6a560ff29ece25d1f02a60a500feeb6288ec4d51b27b759fb8066abdce74ddbb",
+  "e6ea05e3d765a005fccde9eb88fb93e06f0b6ea198afa8ed599b056ba179396a",
   0
 };
   static u3j_core _140_qua__bend_d[] =
@@ -661,7 +761,7 @@ static c3_c* _140_qua__bend_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__bend_ha[] = {
-    "f9d15e37e625cec2d505532a2d83a7eba9dd9afb339d0a4e83613f5eca2e6c88",
+    "adc59c6db6d5b26122bc6c04e25c3efe830c9eef68ecf81c492a59ee5e9e20a2",
     0
   };
 
@@ -695,7 +795,7 @@ static c3_c* _140_qua__cook_fun_ha[] = {
 
 static u3j_harm _140_qua__comp_fun_a[] = {{".2", u3we_comp_fun}, {}};
 static c3_c* _140_qua__comp_fun_ha[] = {
-  "60e5ff2cea860d80f8af65e1323518f58a081b93b49ad7351a1ea1dfe87380e4",
+  "bd7fdba84b05b00a63c24d19a03b882578ee9a3b922a3a688f7827c6e64daf96",
   0
 };
   static u3j_core _140_qua__comp_d[] =
@@ -703,7 +803,7 @@ static c3_c* _140_qua__comp_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__comp_ha[] = {
-    "4960a20da1b43ff953b86ba08cbdeb9a4468af8bfd27fcde12f39f1449fdee9c",
+    "7baad25ba87bcbba8ce4fe328280a799765dcf62a8bb761ffd87b939dd8734f2",
     0
   };
 
@@ -723,7 +823,7 @@ static c3_c* _140_qua__easy_fun_ha[] = {
 
 static u3j_harm _140_qua__glue_fun_a[] = {{".2", u3we_glue_fun}, {}};
 static c3_c* _140_qua__glue_fun_ha[] = {
-  "7a4b978b56658b5c93fc79cb9394e3b46b9f02428a3668958de05e326c512d6b",
+  "ffe0fe8815a2298c51a58e963efbbb7af90830abf11ce50bf9a47f479ce452fb",
   0
 };
   static u3j_core _140_qua__glue_d[] =
@@ -731,7 +831,7 @@ static c3_c* _140_qua__glue_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__glue_ha[] = {
-    "9510f468b9c5d64f80a20d56d8cffd7a1ba0b6444aef9299f2d0a8c3e619b387",
+    "079c8a395428c2921b266a84bcf271fbe62f3d873b26680661e13a78df1a3989",
     0
   };
 
@@ -751,7 +851,7 @@ static c3_c* _140_qua__here_fun_ha[] = {
 
 static u3j_harm _140_qua__just_fun_a[] = {{".2", u3we_just_fun}, {}};
 static c3_c* _140_qua__just_fun_ha[] = {
-  "2a77a5aec1b5394cd282f7ba3a6a0492906446e18f9569b15810c979ec5842de",
+  "38bf1fb843bc29837868f2828f32d7e2bbb419b0cb9a1236adea28dfc6ce1040",
   0
 };
   static u3j_core _140_qua__just_d[] =
@@ -759,13 +859,13 @@ static c3_c* _140_qua__just_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__just_ha[] = {
-    "3d3f00579c4b1d2707418eff6cdb037e95f5c499d986a3cdb535faa35bbf05a6",
+    "7d6b2165e52dec478d96cf72478a35b7a92b014e6a15f046f026c0c8cb07679b",
     0
   };
 
 static u3j_harm _140_qua__mask_fun_a[] = {{".2", u3we_mask_fun}, {}};
 static c3_c* _140_qua__mask_fun_ha[] = {
-  "04bd9009b0c52c6140256c9694df4823e735733ed0c825b14a1f7bce1f8fc0f8",
+  "892dfcd5f3d90981fa6e7608e93f0517000d316e7d9c07b3bd390c4966c97f5f",
   0
 };
   static u3j_core _140_qua__mask_d[] =
@@ -773,13 +873,13 @@ static c3_c* _140_qua__mask_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__mask_ha[] = {
-    "9ec051bb1101cfd7411795e30c43a0564b80c7d2ca68940ef54f9f6d332adac0",
+    "48e11fc12d7c453cda6ca42577d68e968446aa4d0ad3b99cc674affc7f4507b4",
     0
   };
 
 static u3j_harm _140_qua__shim_fun_a[] = {{".2", u3we_shim_fun}, {}};
 static c3_c* _140_qua__shim_fun_ha[] = {
-  "64c01dcfb9d3a66fbfcf6182770cf3421f1be08c693d61476d0dfc223fc6b762",
+  "4e26a0e98adb13ee6718fd68d90910c630df9bb7023b3e3ef40cda6710075fc9",
   0
 };
   static u3j_core _140_qua__shim_d[] =
@@ -787,7 +887,7 @@ static c3_c* _140_qua__shim_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__shim_ha[] = {
-    "838be7322079341d7f0135069d84212527a8dfefd7fab7cafa5e1d5d18406228",
+    "226b96d1a59daada23a1ea80227c2dbf32ddd748d4c6363f316147ab7f292ced",
     0
   };
 
@@ -807,7 +907,7 @@ static c3_c* _140_qua__stag_fun_ha[] = {
 
 static u3j_harm _140_qua__stew_fun_a[] = {{".2", u3we_stew_fun}, {}};
 static c3_c* _140_qua__stew_fun_ha[] = {
-  "677c85d6ba46e134025f652d94049b3db54b576d32159707d16a4c0a56578951",
+  "a700f6bdfdb83ba33b2a3fe92fda3cb1bbfe95e595401538c8371b55fcc61447",
   0
 };
   static u3j_core _140_qua__stew_d[] =
@@ -815,13 +915,13 @@ static c3_c* _140_qua__stew_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__stew_ha[] = {
-    "11b3c70145eedcd888f4b3f51861e759da7405b0b93398b59cfb82d187b29889",
+    "29303fd6ab78cbbccdfc5bcf23d0bff126a0ef2bf4fa11ce70fcf4e6aa5fe60b",
     0
   };
 
 static u3j_harm _140_qua__stir_fun_a[] = {{".2", u3we_stir_fun}, {}};
 static c3_c* _140_qua__stir_fun_ha[] = {
-  "ad1e756459e084cc7463c6e1ebdcef013fdfbe915c345657aee859622e311985",
+  "6251308ea3c741e76ef9cb2dc5a71c9d8706d6cce6fdb420fef12915e0c032d6",
   0
 };
   static u3j_core _140_qua__stir_d[] =
@@ -829,7 +929,7 @@ static c3_c* _140_qua__stir_fun_ha[] = {
       {}
     };
   static c3_c* _140_qua__stir_ha[] = {
-    "aa51d9e03f44ae821553dde66bf84e40e1b95867d5ccc51ed6f390771c97a708",
+    "4e466aef4d91f0ced008c00e8a4330afb3a43ef81dc1a6d93f1853685f69b9ca",
     0
   };
 
@@ -841,12 +941,12 @@ static c3_c* _140_qua_pfix_ha[] = {
 
 static u3j_harm _140_qua_plug_a[] = {{".2", u3we_plug}, {}};
 static c3_c* _140_qua_plug_ha[] = {
-  "dd5a5a82b572ebb3009f9e1dbb52d0a955273742b8e1f5be27885ca208a0c9c7",
+  "5f5a9824e0952fd565748cc0a20f96cf883a41e2f5707c8a7797e6edd617b79c",
   0
 };
 static u3j_harm _140_qua_pose_a[] = {{".2", u3we_pose}, {}};
 static c3_c* _140_qua_pose_ha[] = {
-  "8586df7438d5b37935f9fa1bc3ac6d8740f13fa9885f6b4f1acfe672e4e4cc33",
+  "5c77203f288ef0f7bcd87871c69673db7fc804b647ecc42992707dc32f0f4611",
   0
 };
 
@@ -858,10 +958,12 @@ static c3_c* _140_qua_sfix_ha[] = {
 
 static u3j_harm _140_qua_mink_a[] = {{".2", u3we_mink}, {}};
 static c3_c* _140_qua_mink_ha[] = {
+  "99b653da6a21fa3375424811af288f59164592ece4a072abc460df03e81abcaf",
   0
 };
 static u3j_harm _140_qua_mole_a[] = {{".2", u3we_mole}, {}};
 static c3_c* _140_qua_mole_ha[] = {
+  "029c1acaff1911c54ce31a3693397394604ea970bf076078c1a1cfa23d2fa74e",
   0
 };
 static u3j_harm _140_qua_mule_a[] = {{".2", u3we_mule}, {}};
@@ -909,13 +1011,14 @@ static u3j_core _140_qua_d[] =
   {}
 };
 static c3_c* _140_qua_ha[] = {
-  "0efd1620ed40369f957d53d796c0bf497e0585100829e5f37ede41f6a841d0f8",
+  "db9b4b21c0a8a8324105cbccc1421ef2a715ef0562c280b943fe1d96651cd9cc",
   0
 };
 
 static u3j_hood _140_qua_ho[] = {
   { "mute", 0x2fbabe },
-  { "show", 24406 },
+  { "show",    24406 },
+  { "mure",     1404 },
   {},
 };
 
@@ -1239,7 +1342,7 @@ static c3_c* _140_tri__rh_ha[] = {
 
   static u3j_harm _140_tri__og_raw_a[] = {{".2", u3weo_raw}, {}};
   static c3_c* _140_tri__og_raw_ha[] = {
-    "280709dd8e0e720487dc9af267e0b44d096a59d7257b11a66d1d43f0608cfc3a",
+    "bbcbefc237dbebf6c141ba14fd9e0464a836127fd123d10da5f121e82d49ebdb",
     0
   };
 static u3j_core _140_tri__og_d[] =
@@ -1247,13 +1350,13 @@ static u3j_core _140_tri__og_d[] =
     {}
   };
 static c3_c* _140_tri__og_ha[] = {
-  "6e39a44e0fc50378090e8c71f0cfac01d3ee07f11f5125f71619605d86b51676",
+  "74b9ae67eeabbffcff969ac7fdc7f4f0f4f67af64931e969bcac50d084e15fc0",
   0
 };
 
   static u3j_harm _140_tri__sha_sha1_a[] = {{".2", u3we_sha1}, {}};
   static c3_c* _140_tri__sha_sha1_ha[] = {
-    "20a18116548d3bfa459ae426d92a1c27535425b124d6a48ec1642945d27e5548",
+    "75aababa0688619d9df36238269119302a64ad2e3c69c53bd0057fe6b1abaf0c",
     0
   };
 static u3j_core _140_tri__sha_d[] =
@@ -1261,29 +1364,42 @@ static u3j_core _140_tri__sha_d[] =
     {}
   };
 static c3_c* _140_tri__sha_ha[] = {
-  "d3e4be4c3a39f94a51f675fd9a712bf1cfef9ac7ae6fc980160fc370a93bbf3b",
+  "3c22d2f8719cb626e8dfe1a4206bcbc14b678c1422c48322054b40f84416d557",
   0
 };
 
 static u3j_harm _140_tri_shax_a[] = {{".2", u3we_shax}, {}};
 static c3_c* _140_tri_shax_ha[] = {
-  "48ee5b29692df484bd1d0fd30ca01ea843f89f70fff8698a8f6af5c38639afe8",
+  "0fc53de3ddc8b8f84a46136f1728fa3ed66a5113888d14907589d16bf5927ad8",
   0
 };
 static u3j_harm _140_tri_shay_a[] = {{".2", u3we_shay}, {}};
 static c3_c* _140_tri_shay_ha[] = {
-  "02bcd048fca47fe895b5da5412cf1472eb09abbd2513de96d30a784f629410c9",
+  "b6dbc72e15c2204f83f902619b7a60328f29c9d302ddb35c435111dea28c5470",
   0
 };
 static u3j_harm _140_tri_shas_a[] = {{".2", u3we_shas}, {}};
 static c3_c* _140_tri_shas_ha[] = {
-  "d6e39714b8e1a324be185a6d4f7a776f78eedd54becc820edbe53ce83f239e9b",
+  "5230583767b7625b3496248ed03b6b94c1d4ee9b26342f9390bf999ec9b6cfdb",
   0
 };
 static u3j_harm _140_tri_shal_a[] = {{".2", u3we_shal}, {}};
 static c3_c* _140_tri_shal_ha[] = {
-  "a9b750ed311b4fde51a51374cea35c6e0c4775908c9ad997ee470a003f086290",
+  "3242912e29e3e1ed8d1a395cc860a82d78961b4278ed79bbdeb37cb5615bbf20",
   0
+};
+
+static u3j_core _140_ob_d[] =
+{ {}
+};
+static c3_c* _140_ob_ha[] = {
+  "13ebfbdee69396bc1d980fc4dcbcdaa9cc3fb9c011e6cf188e71311a8bffc8e6",
+  0
+};
+static u3j_hood _140_ob_ho[] = {
+  { "fein",  42 },
+  { "fynd",  20 },
+  {},
 };
 
 static u3j_core _140_tri_d[] =
@@ -1300,22 +1416,31 @@ static u3j_core _140_tri_d[] =
   { "shay", 7, _140_tri_shay_a, 0, _140_tri_shay_ha },
   { "shas", 7, _140_tri_shas_a, 0, _140_tri_shas_ha },
   { "shal", 7, _140_tri_shal_a, 0, _140_tri_shal_ha },
+  { "ob",   3, 0, _140_ob_d, _140_ob_ha, _140_ob_ho },
   {}
 };
 static c3_c* _140_tri_ha[] = {
-  "6c8837fca8182e808dfd8019435663b584a79a6572e9b33f1c3f4afe0a86f6b9",
+  "e7339eb317038f64555717c5624e4571fe9654d471c1a78454129afdbcad9b53",
   0
+};
+
+static u3j_hood _140_tri_ho[] = {
+  { "ob",      20 },
+  { "yore",  5462 },
+  { "year", 44975 },
+  {},
 };
 
 /* layer two
 */
 static u3j_harm _140_two_find_a[] = {{".2", u3wb_find, c3y}, {}};
 static c3_c* _140_two_find_ha[] = {
+  "cab18d537962b48d38fa061844f44c4635ee11c74fdf403aa80d3a6d1b15c177",
   0
 };
 static u3j_harm _140_two_flop_a[] = {{".2", u3wb_flop, c3y}, {}};
 static c3_c* _140_two_flop_ha[] = {
-  "73ac3be0119bcb822621de738f90975d98ce1ff3fb9a52853adc638271f61cd2",
+  "73d496aac2ce6fd9475645c76f949ae0228f8f5ae6738529b08ed9aeb58255fe",
   0
 };
 static u3j_harm _140_two_lent_a[] = {{".2", u3wb_lent, c3y}, {}};
@@ -1335,12 +1460,12 @@ static c3_c* _140_two_lien_ha[] = {
 };
 static u3j_harm _140_two_murn_a[] = {{".2", u3wb_murn, c3y}, {}};
 static c3_c* _140_two_murn_ha[] = {
-  "e3ce526989bdb076849f594d6e2f72670d69e7d5d7d8b7bae464cf318a65f357",
+  "53257aaee131c2a892529c2ee75271160811814086456e8fdf249eebdf31b990",
   0
 };
 static u3j_harm _140_two_need_a[] = {{".2", u3wb_need, c3y}, {}};
 static c3_c* _140_two_need_ha[] = {
-  "7bb1c43a5766a77fea1dc949121dd3f13529da62b726c76f34248047bc74f29f",
+  "bfdd39af478811efe816e69e8c9202d10c41f646c0d27f39c23e4fe1aec807dd",
   0
 };
 static u3j_harm _140_two_reap_a[] = {{".2", u3wb_reap, c3y}, {}};
@@ -1355,7 +1480,7 @@ static c3_c* _140_two_reel_ha[] = {
 };
 static u3j_harm _140_two_roll_a[] = {{".2", u3wb_roll, c3y}, {}};
 static c3_c* _140_two_roll_ha[] = {
-  "42abc6b3defd7c5eb8f6d14d57a14ba2a02d559907c03140c70a65e0803c01e5",
+  "42abc6b3defd7c5eb8f6d14d57a14ba2a02d559907c03141c70a65e0803c01e5",
   0
 };
 static u3j_harm _140_two_skid_a[] = {{".2", u3wb_skid, c3y}, {}};
@@ -1390,12 +1515,12 @@ static c3_c* _140_two_snag_ha[] = {
 };
 static u3j_harm _140_two_sort_a[] = {{".2", u3wb_sort, c3y}, {}};
 static c3_c* _140_two_sort_ha[] = {
-  "f3f89553fc2eafd9702b9533b6dd405bae8056b4aa9674d5f12248d5a964149f",
+  "dc14f91fdedacd3b77bdf241d22555fe2bf0a231e9cab58b4ae779791e54c4e7",
   0
 };
 static u3j_harm _140_two_turn_a[] = {{".2", u3wb_turn, c3y}, {}};
 static c3_c* _140_two_turn_ha[] = {
-  "cd4a292788acd440d6ace689f82fa999b342bb749585bc0e173098529bb75fb8",
+  "e13d9f52434ba810e182017f50a73d4d44eaa298a833231e90353f2a32ea6a78",
   0
 };
 static u3j_harm _140_two_weld_a[] = {{".2", u3wb_weld, c3y}, {}};
@@ -1405,10 +1530,12 @@ static c3_c* _140_two_weld_ha[] = {
 };
 static u3j_harm _140_two_welp_a[] = {{".2", u3wb_welp, c3y}, {}};
 static c3_c* _140_two_welp_ha[] = {
+  "0bccae6625e62ce622c62f9e828a2a6469e2fbf42342d95e23c3b926f340140d",
   0
 };
 static u3j_harm _140_two_zing_a[] = {{".2", u3wb_zing, c3y}, {}};
 static c3_c* _140_two_zing_ha[] = {
+  "113bdea043e9e05cf4a63dac793caf34634bc58414d00250af87139405521b9d",
   0
 };
 
@@ -1419,27 +1546,27 @@ static c3_c* _140_two_bex_ha[] = {
 };
 static u3j_harm _140_two_can_a[] = {{".2", u3wc_can, c3y}, {}};
 static c3_c* _140_two_can_ha[] = {
-  "5fe17c6d254a231e8c9ff94bc47f994c0c1bc202cc9fc2705faaf3fb351c78ec",
+  "c49ee52487369ba17a0105a61aa658df60e7a537e3e8737ab582644fe00b3938",
   0
 };
 static u3j_harm _140_two_cat_a[] = {{".2", u3wc_cat, c3y}, {}};
 static c3_c* _140_two_cat_ha[] = {
-  "292d9fd88787d017fc1bfd743950d33143b8847212cad718b391a92ba725475a",
+  "467f007931110ac0755dcd44c5aaee65785a63b9042b8eea6a7838fa86cc5d8f",
   0
 };
 static u3j_harm _140_two_con_a[] = {{".2", u3wc_con, c3y}, {}};
 static c3_c* _140_two_con_ha[] = {
-  "4a5b1e559516a4208ac058371e045dcbe237dbc56a0a51f9cd4647c1efda5e5d",
+  "d20f091bd4f28d37c1a78373df939f3d3a41e025129e9a2bb5e2b9a710358965",
   0
 };
 static u3j_harm _140_two_cut_a[] = {{".2", u3wc_cut, c3y}, {}};
 static c3_c* _140_two_cut_ha[] = {
-  "c5892a89fb38f542b111240e882f02e0fdece4d91a90e5bf2d1f32c0a4770ffb",
+  "96bb4e9a259d6a1ede5461956b6a6fb73f05cb8e745c4803c2bae4ec0b7f0800",
   0
 };
 static u3j_harm _140_two_dis_a[] = {{".2", u3wc_dis, c3y}, {}};
 static c3_c* _140_two_dis_ha[] = {
-  "a2e8b319b7b87d93572622b2b982d23c3f833b7fd652fc26ac8718153fbc0235",
+  "4b3987314451e20a45d2c7baff51d5d39be57e5970f23f86df4dd6569826ddff",
   0
 };
 static u3j_harm _140_two_dor_a[] = {{".2", u3wc_dor, c3y}, {}};
@@ -1449,77 +1576,77 @@ static c3_c* _140_two_dor_ha[] = {
 };
 static u3j_harm _140_two_end_a[] = {{".2", u3wc_end, c3y}, {}};
 static c3_c* _140_two_end_ha[] = {
-  "45a0efc0c4ae4b93f554d480a9d2c52474d5ebd6b1b9b0ab888b9bee2117db55",
+  "403c9f12f2481966ffb07842006713149960c67c6bcad8edd78cdf837bc0d854",
   0
 };
 static u3j_harm _140_two_gor_a[] = {{".2", u3wc_gor, c3y}, {}};
 static c3_c* _140_two_gor_ha[] = {
-  "3ab7d6a56b8b347bd677a77ec43cda984d1eb869bab5c9bc2185f5c4a366703a",
+  "8a1e3ed1de749ff2ff61d489466df618e4e0773498cb9693ec2e612e9733385c",
   0
 };
 static u3j_harm _140_two_lsh_a[] = {{".2", u3wc_lsh, c3y}, {}};
 static c3_c* _140_two_lsh_ha[] = {
-  "a93f01f1db5bcaf1973d01234bbcec8f8adf9d6402a8d715a1b13b70a140a428",
+  "3db89b02bc596a57c7fb72a991c9fbf3197de501c56b3d1df26911b664c45f3d",
   0
 };
 static u3j_harm _140_two_met_a[] = {{".2", u3wc_met, c3y}, {}};
 static c3_c* _140_two_met_ha[] = {
-  "6654d029fcee53f56439e35e824d955a1ec4081134916b0c5394941febb17b1e",
+  "39dc9b1d10d9e93414b43f315f9a375596c99b4e8172d71d26759996bb7bab08",
   0
 };
 static u3j_harm _140_two_mix_a[] = {{".2", u3wc_mix, c3y}, {}};
 static c3_c* _140_two_mix_ha[] = {
-  "311a0350d86dac62f8f4b89c8fdf3ec61f14a4d66cc4cf59f9f548f806e4fe31",
+  "c84b3e487850d73dd5e4af18fb54b623028be3c45ae9b712718754233057fbc3",
   0
 };
 static u3j_harm _140_two_mor_a[] = {{".2", u3wc_mor, c3y}, {}};
 static c3_c* _140_two_mor_ha[] = {
-  "10ee585bfd1f9109535f09a57fd86e02522e9f019d05edfb70bcedf8b01521b8",
+  "7c2d86e952606e571e5bcd988e70ded072c0eaa45d1fd958849d76360a763ddf",
   0
 };
 static u3j_harm _140_two_mug_a[] = {{".2", u3wc_mug, c3y}, {}};
 static c3_c* _140_two_mug_ha[] = {
-  "4ce008be48d5e609df8fa981bdce3d00722128aab1702573aa0c1a528477c3a7",
+  "6da3f3aa1e951ef2d00e5131945d140fb52728558867237891e029160b7f5010",
   0
 };
 static u3j_harm _140_two_muk_a[] = {{".2", u3wc_muk, c3y}, {}};
 static c3_c* _140_two_muk_ha[] = {
-  "de425abca39f90204eee4b89958f4b1be21eada95754ffc37597bd76653a689d",
+  "5a04a09bf7d22c8ef048ba2cc86be8f3a02066eab84cf4a45bbdf2bf534ff9f6",
   0
 };
 static u3j_harm _140_two_pow_a[] = {{".2", u3wc_pow, c3y}, {}};
 static c3_c* _140_two_pow_ha[] = {
-  "3bc8ad91db75395dc15a996ae7e8c2522f97d8f4b8037e23e2675061c5029792",
+  "6cfcb9da6ad812eb72788e22e1370b4ab1b6ab64ab0628dfdff78ccead325406",
   0
 };
 static u3j_harm _140_two_rap_a[] = {{".2", u3wc_rap, c3y}, {}};
 static c3_c* _140_two_rap_ha[] = {
-  "575b53509cddb0a58026f885bd0f53be371ba9f5720f09c4c28a2ba97f89ae99",
+  "f694f96bcbf97b339285d6c73ed5d33d112b911f7a991acefdef223ff01d8834",
   0
 };
 static u3j_harm _140_two_rep_a[] = {{".2", u3wc_rep, c3y}, {}};
 static c3_c* _140_two_rep_ha[] = {
-  "41c77539ac2d81936770a56791f19156c57e3faf46be3d3b7f4426d87a5a199b",
+  "25aa2f1746e1cf2235117f22a3db152fa86e003d9bf9f9cfcda79e76e51f382f",
   0
 };
 static u3j_harm _140_two_rev_a[] = {{".2", u3wc_rev, c3y}, {}};
 static c3_c* _140_two_rev_ha[] = {
-  "e9cbd82073ced7b2b96a6ba0a4794c9f5dc90ddc362f9de5a65a1f2fa4fa9cd3",
+  "15e20592ac1d9c0c80d99589e67cadb4ed7566be1d21844bbe7ef936e0db4524",
   0
 };
 static u3j_harm _140_two_rip_a[] = {{".2", u3wc_rip, c3y}, {}};
 static c3_c* _140_two_rip_ha[] = {
-  "e8e0b834aded0d2738bcf38a93bf373d412a51e0cee7f274277a6393e634a65e",
+  "16026c27499953978f69dbf81c1530b2dec8d5a2403c5561f7a5afcc180e129e",
   0
 };
 static u3j_harm _140_two_rsh_a[] = {{".2", u3wc_rsh, c3y}, {}};
 static c3_c* _140_two_rsh_ha[] = {
-  "a401145b4c11ec8d17a729fe30f06c295865ffed1b970b0a788f0fec1ed0a703",
+  "55bd777f239a2a7c849e0c7a35bb967b79279c79bbd985f31ba272761f97928f",
   0
 };
 static u3j_harm _140_two_swp_a[] = {{".2", u3wc_swp, c3y}, {}};
 static c3_c* _140_two_swp_ha[] = {
-  "f809ed11a87db6cef8944c7252d53cda1e030240ee52912c3843d56805ac17fa",
+  "2c4583c36d73c9c2857052b893b87e1170a794e0edbbdba9d767ba7639e7c1ec",
   0
 };
 static u3j_harm _140_two_sqt_a[] = {{".2", u3wc_sqt, c3y}, {}};
@@ -1529,27 +1656,28 @@ static c3_c* _140_two_sqt_ha[] = {
 };
 static u3j_harm _140_two_xeb_a[] = {{".2", u3wc_xeb, c3y}, {}};
 static c3_c* _140_two_xeb_ha[] = {
-  "39501080d96580dab9086d3cbdf95356c0821897fd54a930a8cfe2684cf3c7de",
+  "41403aafe1e2ccb1a02edde96fe742085feffe028d02529eb2b13f925884a499",
   0
 };
 
   static u3j_harm _140_two__in_apt_a[] = {{".2", u3wdi_apt}, {}};
   static c3_c* _140_two__in_apt_ha[] = {
+    "a40812fa255f13afdaf196bff38d2d9bfcb38f09c48ace9139a2701a555a0c9a",
     0
   };
   static u3j_harm _140_two__in_bif_a[] = {{".2", u3wdi_bif}, {}};
   static c3_c* _140_two__in_bif_ha[] = {
-    "7ccbde61c80246056f6acfd8dc30f560af9e5abd44841c22ba0f49951dbc2f2a",
+    "edd0d727b9099e75c3e5b73b3025ad9737136eacedc2f8088b6edb02dbe06cb3",
     0
   };
   static u3j_harm _140_two__in_del_a[] = {{".2", u3wdi_del}, {}};
   static c3_c* _140_two__in_del_ha[] = {
-    "b03dc379cfa0b9eca24cf01d57cadd20f65c64311b5ee90732ec2def97c8a673",
+    "33a21e7aaf71105e2d48e1af61ff463fb8a0b7e04f8a8c30a6f6a2d1f967795f",
     0
   };
   static u3j_harm _140_two__in_dif_a[] = {{".2", u3wdi_dif}, {}};
   static c3_c* _140_two__in_dif_ha[] = {
-    "e4367b9e5d425687a18c98def65e36385d05b4e7ed5d30420807bf147fd5fabb",
+    "a488f0be5adbb1c04e2038a2315ac065591e7daadcafc1d47aea272979680468",
     0
   };
   static u3j_harm _140_two__in_gas_a[] = {{".2", u3wdi_gas}, {}};
@@ -1559,24 +1687,29 @@ static c3_c* _140_two_xeb_ha[] = {
   };
   static u3j_harm _140_two__in_has_a[] = {{".2", u3wdi_has}, {}};
   static c3_c* _140_two__in_has_ha[] = {
-    "eebeebeaff243c5795575a468191474459c7b191fb575e1b96feb484fcbc19dc",
+    "a65e666e92176401040a883801e4f05bd650fe6c094a6c8d7f4afcaee9cf55ad",
     0
   };
 
   static u3j_harm _140_two__in_int_a[] = {{".2", u3wdi_int}, {}};
-  static c3_c* _140_two__in_int_ha[] = {0};
+  static c3_c* _140_two__in_int_ha[] = {
+    "a71b0e355fa02d18447c02922f69096f42043da451e8c79e7a9270460c3a44e6",
+    0
+  };
 
   static u3j_harm _140_two__in_put_a[] = {{".2", u3wdi_put}, {}};
   static c3_c* _140_two__in_put_ha[] = {
-    "4a9fd615fecd2fd36485b3a2f24cdc13afc86f9a478362934b4654297496a03c",
+    "19b27267e18ef156d85d84d37e02692a17fec0b7a2a0fe4120a3ae02b841c8f4",
     0
   };
   static u3j_harm _140_two__in_rep_a[] = {{".2", u3wdi_rep}, {}};
   static c3_c* _140_two__in_rep_ha[] = {
+    "05bfb84a52ed8ccc330a96faca29a49afd28300960ac089d00dba32212b971a7",
     0
   };
   static u3j_harm _140_two__in_run_a[] = {{".2", u3wdi_run}, {}};
   static c3_c* _140_two__in_run_ha[] = {
+    "7f2061dbee19fa20925bd5a80cc41ed71e462e0f49ee6e845fd750c219734864",
     0
   };
   static u3j_harm _140_two__in_tap_a[] = {{".2", u3wdi_tap}, {}};
@@ -1591,7 +1724,7 @@ static c3_c* _140_two_xeb_ha[] = {
   };
   static u3j_harm _140_two__in_uni_a[] = {{".2", u3wdi_uni}, {}};
   static c3_c* _140_two__in_uni_ha[] = {
-    "8369d11970bfa09bd20c5b112a353fa10e8e64c9c081e3a5b17bcf3700127add",
+    "6bd72ef1fb12482a839f4435a2b163ace1b56036297a3cec6968be33d6863096",
     0
   };
 
@@ -1612,34 +1745,37 @@ static u3j_core _140_two__in_d[] =
     {}
   };
 static c3_c* _140_two__in_ha[] = {
-  "abf20b11b7d7f9aa8cc7b4de01c15ec3aca3ea07ca09a461a3277fe24c640849",
+  "8bbb90ce0a49d627194aa267f6cf1fd78df677111b553ce03119fea19f9d763c",
   0
 };
   static u3j_harm _140_two__by_all_a[] = {{".2", u3wdb_all, c3y}, {}};
   static c3_c* _140_two__by_all_ha[] = {
+    "c2e87d0047c14b4488d03aad98fa43080c736d86d2ff723a037aaf1843aa9285",
     0
   };
   static u3j_harm _140_two__by_any_a[] = {{".2", u3wdb_any, c3y}, {}};
   static c3_c* _140_two__by_any_ha[] = {
+    "96b95c942dcbc97f5291fa6f7342c3e19a87d69cc254965b0f75d95133a19301",
     0
   };
   static u3j_harm _140_two__by_apt_a[] = {{".2", u3wdb_apt, c3y}, {}};
   static c3_c* _140_two__by_apt_ha[] = {
+    "1f0a6f8b945b243520b77069060589938d9e651e34b24924db9528d02a98014f",
     0
   };
   static u3j_harm _140_two__by_bif_a[] = {{".2", u3wdb_bif, c3y}, {}};
   static c3_c* _140_two__by_bif_ha[] = {
-    "09ce4cf00dd9b4f95d4d93a984ffab94cb99cb6017bb73531245ea4813855f4e",
+    "d377a032a3866e76f6f5217c7c0ed0519b768d8b1c5107e35f7dbf18d8f60880",
     0
   };
   static u3j_harm _140_two__by_del_a[] = {{".2", u3wdb_del, c3y}, {}};
   static c3_c* _140_two__by_del_ha[] = {
-    "c51c30a2c58c351d4c7cbc3f8276432140b74f3f2b3a76db4b46b189f5cd8cfe",
+    "09f78d6235d3fce8303c7bc663988349b7d4592abdacfb09b833d2f43629b6b6",
     0
   };
   static u3j_harm _140_two__by_dif_a[] = {{".2", u3wdb_dif, c3y}, {}};
   static c3_c* _140_two__by_dif_ha[] = {
-    "f40cac6183410ea88c1d6dd43fd2b2c7fb6178bcbf9d5ceb4accf5e28a0c1103",
+    "0334e6df6fd0bd5013b94a1b22c29e4c436da0a2d5573f1992faad1c8a059cc7",
     0
   };
   static u3j_harm _140_two__by_gas_a[] = {{".2", u3wdb_gas, c3y}, {}};
@@ -1649,7 +1785,7 @@ static c3_c* _140_two__in_ha[] = {
   };
   static u3j_harm _140_two__by_get_a[] = {{".2", u3wdb_get, c3y}, {}};
   static c3_c* _140_two__by_get_ha[] = {
-    "ce021b5e383d672ab43d771857239b6789a8cdb145a626799c77c748a2f7c918",
+    "4de4cea8fa98ef48e9faae10c90ba5bd77971670030ffb00483d0608af4c466f",
     0
   };
   static u3j_harm _140_two__by_has_a[] = {{".2", u3wdb_has, c3y}, {}};
@@ -1659,28 +1795,34 @@ static c3_c* _140_two__in_ha[] = {
   };
 
   static u3j_harm _140_two__by_int_a[] = {{".2", u3wdb_int, c3y}, {}};
-  static c3_c* _140_two__by_int_ha[] = {0};
+  static c3_c* _140_two__by_int_ha[] = {
+    "a2345429482c271a1668f3c0675a559452bb7b13cb7393c3acb7de44c603aef9",
+    0
+  };
 
   static u3j_harm _140_two__by_jab_a[] = {{".2", u3wdb_jab, c3y}, {}};
   static c3_c* _140_two__by_jab_ha[] = {
-    "8bc992aefabd2e0f43c900f2c4f3b06cf330973774d8f43428049cc3b3cb5b94",
+    "48930133d9b26e912dce54d1bc486cfe9dcb32bb3c2b1ad76143382799aec156",
     0
   };
   static u3j_harm _140_two__by_key_a[] = {{".2", u3wdb_key, c3y}, {}};
   static c3_c* _140_two__by_key_ha[] = {
+    "0096c77b93e9fe36b98d9f433eb73300f024283b93b3d73a4001afb9f9804d1b",
     0
   };
   static u3j_harm _140_two__by_put_a[] = {{".2", u3wdb_put, c3y}, {}};
   static c3_c* _140_two__by_put_ha[] = {
-    "2cc9f005fde5314e9ad545286493a8c81b5c3b775d645ad82954f405d9414a32",
+    "b7307589fed604bfb92e8ad5ffad611c82d835baf02a86c6911b279930f4e8d7",
     0
   };
   static u3j_harm _140_two__by_rep_a[] = {{".2", u3wdb_rep, c3y}, {}};
   static c3_c* _140_two__by_rep_ha[] = {
+    "05bfb84a52ed8ccc330a96faca29a49afd28300960ac089d00dba32212b971a7",
     0
   };
   static u3j_harm _140_two__by_run_a[] = {{".2", u3wdb_run, c3y}, {}};
   static c3_c* _140_two__by_run_ha[] = {
+    "adea01e9036e0b40e4969814d4eed935d7d69a52e4a55de5520df2fa5204d8e7",
     0
   };
   static u3j_harm _140_two__by_tap_a[] = {{".2", u3wdb_tap, c3y}, {}};
@@ -1690,14 +1832,17 @@ static c3_c* _140_two__in_ha[] = {
   };
   static u3j_harm _140_two__by_uni_a[] = {{".2", u3wdb_uni, c3y}, {}};
   static c3_c* _140_two__by_uni_ha[] = {
+    "f18bc4dac19abe14a6f56afc15d838b7394d48969156f4b37c3c84edd5d46752",
     0
   };
   static u3j_harm _140_two__by_urn_a[] = {{".2", u3wdb_urn, c3y}, {}};
   static c3_c* _140_two__by_urn_ha[] = {
+    "a409cf78e7f1c2ce8440115730f74367839b658cde2d6a1daa8af067b790eb83",
     0
   };
   static u3j_harm _140_two__by_wyt_a[] = {{".2", u3wdb_wyt, c3y}, {}};
   static c3_c* _140_two__by_wyt_ha[] = {
+    "fac9248ebd1defade9df695cd81f94355bebb271f85b164ff34658a5f45c71a0",
     0
   };
 
@@ -1724,18 +1869,18 @@ static u3j_core _140_two__by_d[] =
     {}
   };
 static c3_c* _140_two__by_ha[] = {
-  "2bb4c60da0ae916cd0aa596588bdd0f7070f0832e698526aac951fd55a4abbdc",
+  "9c70e973de46335405a7ff932d4742743f54db579f2584758ef2b02afd4fbfe8",
   0
 };
 
 static u3j_harm _140_two_cue_a[] = {{".2", u3we_cue}, {}};
 static c3_c* _140_two_cue_ha[] = {
-  "87acffeccdc6e1ce72d74e41f91c8f1d190f70e09ce755c6a487e0c951dcc139",
+  "a52b584c5a92fc653e47f50c3389caf3427e13d20ddb8bd701a2d7bca12cb742",
   0
 };
 static u3j_harm _140_two_jam_a[] = {{".2", u3we_jam}, {}};
 static c3_c* _140_two_jam_ha[] = {
-  "5c52fe8ebea73c478aaac344d06e9ff48c075be67c3a3cc77a57ef0143bd9219",
+  "61f86be74cb1fd5a1d7f531cc9588f8f34a972be8de487c93d25c8e026592ed2",
   0
 };
 static u3j_harm _140_two_mat_a[] = {{".2", u3we_mat}, {}};
@@ -1750,7 +1895,7 @@ static c3_c* _140_two_rub_ha[] = {
 };
 
 static u3j_core _140_two_d[] =
-{ { "tri",  3, 0, _140_tri_d, _140_tri_ha },
+{ { "tri",  3, 0, _140_tri_d, _140_tri_ha, _140_tri_ho },
 
   { "find", 7, _140_two_find_a, 0, _140_two_find_ha },
   { "flop", 7, _140_two_flop_a, 0, _140_two_flop_ha },
@@ -1808,7 +1953,7 @@ static u3j_core _140_two_d[] =
   {}
 };
 static c3_c* _140_two_ha[] = {
-  "56cd63625015fb07de63ad95cbb90a303dd2e1e1efca4c93a1bc053e0b6a9f7a",
+  "f693e1f5ff57ec741fe28a48a18252b3e12dead2bfe3bcd4ea8e904a36905c0b",
   0
 };
 
@@ -1882,7 +2027,7 @@ static c3_c* _140_one_peg_ha[] = {
 };
 static u3j_harm _140_one_mas_a[] = {{".2", u3wc_mas, c3y}, {}};
 static c3_c* _140_one_mas_ha[] = {
-  "94bfb3ec6e032bf386349e9ae0784f37144e65692830d11a06fa89602e313f7f",
+  "1439dcd809f0819b09fb5fe7e83bc1292ca6fd33b5819d78e706d402c053b02a",
   0
 };
 
@@ -1907,7 +2052,7 @@ static u3j_core _140_one_d[] =
   {}
 };
 static c3_c* _140_one_ha[] = {
-  "3f22006efef06ab8171cfd03057dbcb1af325c16f03662a67119d4060b3b0f6a",
+  "2501f8dbe62384d144ab0f805501ed66325bd77a733eca0c80d1da673e4b16fb",
   0
 };
 
@@ -1916,7 +2061,7 @@ u3j_core _k140_d[] =
   {}
 };
 static c3_c* _k140_ha[] = {
-  "7768e2670a7d95397c0587f4d7834652602f70f0206efce6c3345c3f70dfc12a",
+  "9b82a903093c077afb3f0b9d4e95e1a9c9789d1ca605b57bbacf79857e3d5c52",
   0
 };
 

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -1796,13 +1796,13 @@ _cj_minx(u3_noun cey, u3_noun cor)
 }
 
 static void
-_cj_print_tas(FILE* fh, u3_noun tas)
+_cj_print_tas(u3_noun tas)
 {
   c3_w  met_w = u3r_met(3, tas);
   c3_c* str_c = alloca(met_w + 1);
   u3r_bytes(0, met_w, (c3_y*)str_c, tas);
   str_c[met_w] = 0;
-  fprintf(fh, "/%s", str_c);
+  u3l_log("/%s", str_c);
 }
 
 /* _cj_mine(): declare a core and produce location. RETAIN.
@@ -1851,7 +1851,7 @@ _cj_mine(u3_noun cey, u3_noun cor, u3_noun bas)
         u3_noun i = bal;
         u3l_log("hot jet: ");
         while ( i != u3_nul ) {
-          _cj_print_tas(stderr, u3h(i));
+          _cj_print_tas(u3h(i));
           i = u3t(i);
         }
         u3l_log("\r\n  axe %d, jax %d,\r\n  bash ", axe, jax_l);


### PR DESCRIPTION
The PR brings hashboard up-to-date with hoon %140, adding and updating hooks and battery hashes. 

There's currently no command-line option to enable hashboard, the simplest way to run it is to just ensure that `u3_Host.ops_u.has` is set to `c3n` in `daemon/main.c`. I'll think about a better way to expose that control. I have also not tested switching to hashboard on a pier booted with only %fast-hint registration. Both are out of scope for this PR.

