### PR TITLE
vere: set arvo verbosity based on presence of -v

### DIFF
--- a/pkg/urbit/vere/io/fore.c
+++ b/pkg/urbit/vere/io/fore.c
@@ -121,14 +121,10 @@ _fore_io_talk(u3_auto* car_u)
 
   //  set verbose as per -v
   //
-  //    XX should be explicit, not a toggle
-  //
-  if ( c3y == u3_Host.ops_u.veb ) {
-    //  XX this path shouldn't be necessary
-    //
-    wir = u3nt(c3__term, '1', u3_nul);
-    cad = u3nc(c3__verb, u3_nul);
-
+  {
+    c3_o lac_o = ( c3y == u3_Host.ops_u.veb ) ? c3n : c3y;
+    wir = u3nc(c3__arvo, u3_nul);
+    cad = u3nt(c3__verb, u3_nul, lac_o);
     u3_auto_plan(car_u, u3_ovum_init(0, u3_blip, wir, cad));
   }
 

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1707,20 +1707,18 @@ _pier_boot_make(u3_noun who, u3_noun wyr, u3_noun ven, u3_noun pil)
   //  prepend entropy and identity to the module sequence
   //
   {
-    u3_noun wir, cad;
+    u3_noun cad, wir = u3nt(u3_blip, c3__arvo, u3_nul);
     c3_w    eny_w[16];
-
     c3_rand(eny_w);
-    wir = u3nt(u3_blip, c3__arvo, u3_nul);
+
     cad = u3nc(c3__wack, u3i_words(16, eny_w));
-    bot_u.mod = u3nc(u3nc(wir, cad), bot_u.mod);
+    bot_u.mod = u3nc(u3nc(u3k(wir), cad), bot_u.mod);
+
+    cad = u3nc(c3__whom, who);                    // transfer [who]
+    bot_u.mod = u3nc(u3nc(u3k(wir), cad), bot_u.mod);
 
     wir = u3nt(u3_blip, c3__arvo, u3_nul);
-    cad = u3nc(c3__whom, who);  // transfer
-    bot_u.mod = u3nc(u3nc(wir, cad), bot_u.mod);
-
-    wir = u3nt(u3_blip, c3__arvo, u3_nul);
-    bot_u.mod = u3nc(u3nc(wir, wyr), bot_u.mod);
+    bot_u.mod = u3nc(u3nc(wir, wyr), bot_u.mod);  // transfer [wir] and [wyr]
   }
 
   //  prepend legacy boot event to the userspace sequence

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1711,6 +1711,9 @@ _pier_boot_make(u3_noun who, u3_noun wyr, u3_noun ven, u3_noun pil)
     c3_w    eny_w[16];
     c3_rand(eny_w);
 
+    cad = u3nt(c3__verb, u3_nul, ( c3y == u3_Host.ops_u.veb ) ? c3n : c3y);
+    bot_u.mod = u3nc(u3nc(u3k(wir), cad), bot_u.mod);
+
     cad = u3nc(c3__wack, u3i_words(16, eny_w));
     bot_u.mod = u3nc(u3nc(u3k(wir), cad), bot_u.mod);
 


### PR DESCRIPTION
... instead of simply toggling whatever state was previous set. Fixes #4107