### PR TITLE
hoon: crash with valid tank on %eror

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8363,7 +8363,7 @@
         [%bust *]  ~(example ax %base p.gen)
         [%ktcl *]  ~(factory ax p.gen)
         [%dbug *]   q.gen
-        [%eror *]  ~>(%slog.[0 leaf=p.gen] !!)
+        [%eror *]  ~_((crip p.gen) !!)
     ::
         [%knit *]                                       ::
       :+  %tsgr  [%ktts %v %$ 1]                        ::  =>  v=.


### PR DESCRIPTION
Fixes #4169 (or, at least, that specific instance of it). We may still want to virtualize `$tank` printing in the king.