### PR TITLE
jael: fix breach notification ordering

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -681,7 +681,7 @@
         |
       ?.  ?=([[@ *] *] b)
         &
-      (lth i.i.a i.i.b)
+      (lth (end 3 i.i.a) (end 3 i.i.b))
     --
   ::
   ++  get-source


### PR DESCRIPTION
When we changed wires from /a/foo to /ames/foo, our sorting function
started sorting by last character instead of first character, so breach
notifications were given to gall before ames.  This made gall try to
resubscribe before ames cleared its state, so the message would be lost.

Fixes #4177