### PR TITLE
interface: fix missing archiveBox by removing Archive view

### DIFF
--- a/pkg/interface/src/logic/api/hark.ts
+++ b/pkg/interface/src/logic/api/hark.ts
@@ -196,12 +196,10 @@ export class HarkApi extends BaseApi<StoreState> {
     });
   }
 
-  getMore(archive = false) {
-    const offset = this.store.state[
-      archive ? 'archivedNotifications' : 'notifications'
-    ]?.size || 0;
+  getMore() {
+    const offset = this.store.state['notifications']?.size || 0;
     const count = 3;
-    return this.getSubset(offset,count, archive);
+    return this.getSubset(offset, count, false);
   }
 
   async getSubset(offset:number, count:number, isArchive: boolean) {

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -363,12 +363,5 @@ function archive(json: any, state: HarkState) {
       notifIdxEqual(index, idxNotif.index)
     );
     state.notifications.set(time, unarchived);
-    state.archivedNotifications.set(time, [
-      ...archiveBox,
-      ...archived.map(({ notification, index }) => ({
-        notification: { ...notification, read: true },
-        index,
-      })),
-    ]);
   }
 }

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -148,7 +148,6 @@ export default function Inbox(props: {
           api={api}
         />
       )}
-
       {_.map(
         notificationsByDay,
         (timeboxes, idx) =>

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -100,7 +100,7 @@ function NotificationWrapper(props: {
         </StatelessAsyncAction>
         {!props.archived && (
           <StatelessAsyncAction name={time.toString()} onClick={onArchive} backgroundColor="transparent">
-            Read
+            Dismiss
           </StatelessAsyncAction>
         )}
       </Row>

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -100,7 +100,7 @@ function NotificationWrapper(props: {
         </StatelessAsyncAction>
         {!props.archived && (
           <StatelessAsyncAction name={time.toString()} onClick={onArchive} backgroundColor="transparent">
-            Archive
+            Read
           </StatelessAsyncAction>
         )}
       </Row>

--- a/pkg/interface/src/views/apps/notifications/notifications.tsx
+++ b/pkg/interface/src/views/apps/notifications/notifications.tsx
@@ -71,11 +71,6 @@ export default function NotificationsScreen(props: any) {
                       </HeaderLink>
                     </Box>
                     <Box>
-                      <HeaderLink current={view} view="archive">
-                        Archive
-                      </HeaderLink>
-                    </Box>
-                    <Box>
                       <HeaderLink current={view} view="preferences">
                         Preferences
                       </HeaderLink>
@@ -115,14 +110,6 @@ export default function NotificationsScreen(props: any) {
                     </Box>
                   </Dropdown>
                 </Row>
-                {view === "archive" && (
-                  <Inbox
-                    {...props}
-                    archive={props.archivedNotifications}
-                    showArchive
-                    filter={filter.groups}
-                  />
-                )}
                 {view === "preferences" && (
                   <NotificationPreferences
                     graphConfig={props.notificationsGraphConfig}


### PR DESCRIPTION
This fixes #4187 by removing the "archive" view in notifcations and the references to it in the reducers. The archive functionality had been partially removed from the frontend, but not all the way, which was causing JS errors when you tried to click the archive button on a notification. This resolves that issue and has been tested to work on `~tacryt-socryp`.

@philipcmonk I'd like to cut a release to hotfix this issue upon having this PR approved. Would you have time to chat? I'm new to doing these deploys and would like to get it right.