### PR TITLE
weather: add style for 'Clear'

### DIFF
--- a/pkg/interface/src/views/apps/launch/components/tiles/weather.js
+++ b/pkg/interface/src/views/apps/launch/components/tiles/weather.js
@@ -6,6 +6,7 @@ import ErrorBoundary from '~/views/components/ErrorBoundary';
 import Tile from './tile';
 
 export const weatherStyleMap = {
+  Clear: 'rgba(67, 169, 255, 0.4)',
   Sunny: 'rgba(67, 169, 255, 0.4)',
   PartlyCloudy: 'rgba(178, 211, 255, 0.33)',
   Cloudy: 'rgba(136, 153, 176, 0.43)',


### PR DESCRIPTION
"Clear" is a possible weather style that currently gets displayed as transparent. my bad.