### PR TITLE
Add GitHub Action & Workflow for glob + OTA

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,0 +1,5 @@
+FROM jaredtobin/janeway:v0.13.1
+COPY entrypoint.sh /entrypoint.sh
+USER 0:0
+EXPOSE 22/tcp
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,5 +1,4 @@
 FROM jaredtobin/janeway:v0.13.1
 COPY entrypoint.sh /entrypoint.sh
-USER 0:0
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/glob/action.yml
+++ b/.github/actions/glob/action.yml
@@ -1,0 +1,25 @@
+name: 'glob'
+description: 'Create a glob and deploy it to a moon'
+inputs:
+  - ship:
+      description: "Ship to deploy to"
+      required: true
+  - credentials:
+      description: "base64-encoded GCP Service Account credentials"
+      required: true
+  - ssh-sec-key:
+      description: "A base64-encoded SSH secret key for the container to use"
+      required: true
+  - ssh-pub-key:
+      description: "The corresponding base64-encoded SSH public key"
+      required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.ship }}
+    - ${{ inputs.credentials }}
+    - ${{ inputs.ssh-sec-key }}
+    - ${{ inputs.ssh-pub-key }}
+

--- a/.github/actions/glob/action.yml
+++ b/.github/actions/glob/action.yml
@@ -1,18 +1,18 @@
 name: 'glob'
 description: 'Create a glob and deploy it to a moon'
 inputs:
-  - ship:
-      description: "Ship to deploy to"
-      required: true
-  - credentials:
-      description: "base64-encoded GCP Service Account credentials"
-      required: true
-  - ssh-sec-key:
-      description: "A base64-encoded SSH secret key for the container to use"
-      required: true
-  - ssh-pub-key:
-      description: "The corresponding base64-encoded SSH public key"
-      required: true
+  ship:
+    description: "Ship to deploy to"
+    required: true
+  credentials:
+    description: "base64-encoded GCP Service Account credentials"
+    required: true
+  ssh-sec-key:
+    description: "A base64-encoded SSH secret key for the container to use"
+    required: true
+  ssh-pub-key:
+    description: "The corresponding base64-encoded SSH public key"
+    required: true
 
 runs:
   using: 'docker'

--- a/.github/actions/glob/entrypoint.sh
+++ b/.github/actions/glob/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+cd "$GITHUB_WORKSPACE" || exit
+
+echo "$2" | base64 -d > service-account
+echo "$3" | base64 -d > id_ssh
+echo "$4" | base64 -d > id_ssh.pub
+
+chmod 600 service-account
+chmod 600 id_ssh
+chmod 600 id_ssh.pub
+
+janeway release glob --no-pill \
+    --credentials service-account \
+    --ssh-key id_ssh \
+    --do-it-live \
+  | bash
+
+SHORTHASH=$(git rev-parse --short HEAD)
+
+janeway release prepare-ota arvo-glob-"$SHORTHASH" "$1" \
+    --credentials service-account \
+    --ssh-key id_ssh \
+    --do-it-live \
+  | bash
+
+janeway release perform-ota "$1" \
+    --credentials service-account \
+    --ssh-key id_ssh \
+    --do-it-live \
+  | bash
+

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -2,16 +2,18 @@ name: glob
 on:
   push:
     branches:
-      - 'jt/lacd'
+      - 'release/next-js'
   pull_request:
     branches:
-      - 'jt/lacd'
+      - 'release/next-js'
 jobs:
   glob:
     runs-on: ubuntu-latest
     name: "Create and deploy a glob to ~lomlyx-lopsem-nidsut-tomdun"
     steps:
       - uses: actions/checkout@v2
+        with:
+          lfs: true
       - uses: ./.github/actions/glob
         with:
           ship: 'lomlyx-lopsem-nidsut-tomdun'

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Create and deploy a glob to ~lomlyx-lopsem-nidsut-tomdun"
     steps:
       - uses: actions/checkout@v2
-      - uses: .github/actions/glob
+      - uses: ./.github/actions/glob
         with:
           ship: 'lomlyx-lopsem-nidsut-tomdun'
           credentials: ${{ secrets.JANEWAY_SERVICE_KEY }}

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -1,0 +1,21 @@
+name: glob
+on:
+  push:
+    branches:
+      - 'jt/lacd'
+  pull_request:
+    branches:
+      - 'jt/lacd'
+jobs:
+  glob:
+    runs-on: ubuntu-latest
+    name: "Create and deploy a glob to ~lomlyx-lopsem-nidsut-tomdun"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: .github/actions/glob
+        with:
+          - ship: 'lomlyx-lopsem-nidsut-tomdun'
+          - credentials: ${{ secrets.JANEWAY_SERVICE_KEY }}
+          - ssh-sec-key: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
+          - ssh-pub-key: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: .github/actions/glob
         with:
-          - ship: 'lomlyx-lopsem-nidsut-tomdun'
-          - credentials: ${{ secrets.JANEWAY_SERVICE_KEY }}
-          - ssh-sec-key: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          - ssh-pub-key: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          ship: 'lomlyx-lopsem-nidsut-tomdun'
+          credentials: ${{ secrets.JANEWAY_SERVICE_KEY }}
+          ssh-sec-key: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
+          ssh-pub-key: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
 


### PR DESCRIPTION
Adds an action that globs and OTAs relevant changes to a target ship, plus a workflow that invokes the action (deploying to `~lomlyx-lopsem-nidsut-tomdun`) whenever `release/next-js` is pushed or PR'd to.

Once this is merged to master, it can be activated on `release/next-js` by simply merging master into that.

cc @liam-fitzgerald @tacryt-socryp @vvisigoth @galenwp 