### PR TITLE
clay: condense +pile-rule

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -807,75 +807,49 @@
     ++  pile-rule
       |=  pax=path
       %-  full
-      %+  ifix  [gay gay]
-      %+  cook  |=(pile +<)
-      ;~  pfix
+      %+  ifix
+        :_  gay
         ::  parse optional /? and ignore
         ::
-        ;~  pose
-          (cold ~ ;~(plug fas wut gap dem gap))
-          (easy ~)
+        ;~(plug gay (punt ;~(plug fas wut gap dem gap)))
+      |^
+      ;~  plug
+        %+  cook  (bake zing (list (list taut)))
+        %+  rune  hep
+        (most ;~(plug com gaw) taut-rule)
+      ::
+        %+  cook  (bake zing (list (list taut)))
+        %+  rune  lus
+        (most ;~(plug com gaw) taut-rule)
+      ::
+        %+  rune  tis
+        ;~(plug sym ;~(pfix gap fas (more fas urs:ab)))
+      ::
+        %+  rune  tar
+        ;~  (glue gap)
+          sym
+          ;~(pfix cen sym)
+          ;~(pfix fas (more fas urs:ab))
         ==
       ::
-        ;~  plug
-          ;~  pose
-            ;~  sfix
-              %+  cook  |=((list (list taut)) (zing +<))
-              %+  more  gap
-              ;~  pfix  ;~(plug fas hep gap)
-                (most ;~(plug com gaw) taut-rule)
-              ==
-              gap
-            ==
-            (easy ~)
-          ==
-        ::
-          ;~  pose
-            ;~  sfix
-              %+  cook  |=((list (list taut)) (zing +<))
-              %+  more  gap
-              ;~  pfix  ;~(plug fas lus gap)
-                (most ;~(plug com gaw) taut-rule)
-              ==
-              gap
-            ==
-            (easy ~)
-          ==
-        ::
-          ;~  pose
-            ;~  sfix
-              %+  cook  |=((list [face=term =path]) +<)
-              %+  more  gap
-              ;~  pfix  ;~(plug fas tis gap)
-                %+  cook  |=([term path] +<)
-                ;~(plug sym ;~(pfix ;~(plug gap fas) (more fas urs:ab)))
-              ==
-              gap
-            ==
-            (easy ~)
-          ==
-        ::
-          ;~  pose
-            ;~  sfix
-              %+  cook  |=((list [face=term =mark =path]) +<)
-              %+  more  gap
-              ;~  pfix  ;~(plug fas tar gap)
-                %+  cook  |=([term mark path] +<)
-                ;~  plug
-                  sym
-                  ;~(pfix ;~(plug gap cen) sym)
-                  ;~(pfix ;~(plug gap fas) (more fas urs:ab))
-                ==
-              ==
-              gap
-            ==
-            (easy ~)
-          ==
-        ::
-          %+  cook  |=(huz=(list hoon) `hoon`tssg+huz)
-          (most gap tall:(vang & pax))
-        ==
+        %+  stag  %tssg
+        (most gap tall:(vang & pax))
       ==
+      ::
+      ++  pant
+        |*  fel=^rule
+        ;~(pose fel (easy ~))
+      ::
+      ++  mast
+        |*  [bus=^rule fel=^rule]
+        ;~(sfix (more bus fel) bus)
+      ::
+      ++  rune
+        |*  [bus=^rule fel=^rule]
+        %-  pant
+        %+  mast  gap
+        ;~(pfix fas bus gap fel)
+      --
     ::
     ++  taut-rule
       %+  cook  |=(taut +<)


### PR DESCRIPTION
Rewrites the `+pile-rule` parsing rule for compactness and legibility. This is a purely stylistic change.

As briefly discussed out of band, @belisarius222. 