### PR TITLE
4164: fixes display issue with jobs / gigs based on faulty hark state

### DIFF
--- a/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
@@ -46,16 +46,17 @@ export function useGraphModule(
 ): SidebarAppConfig {
   const getStatus = useCallback(
     (s: string) => {
-      const unreads = graphUnreads?.[s]?.['/']?.unreads;
-      if(typeof unreads === 'number' ? unreads > 0 : unreads?.size ?? 0 > 0) {
-        return 'unread';
-      }
       const [, , host, name] = s.split("/");
       const graphKey = `${host.slice(1)}/${name}`;
-
       if (!graphKeys.has(graphKey)) {
         return "unsubscribed";
       }
+
+      const unreads = graphUnreads?.[s]?.['/']?.unreads;
+      if (typeof unreads === 'number' ? unreads > 0 : unreads?.size ?? 0 > 0) {
+        return 'unread';
+      }
+
       return undefined;
     },
     [graphs, graphKeys, graphUnreads]


### PR DESCRIPTION
On @matildepark's ship, the "Jobs + Gigs" Publish channel has an unread state in `%hark-store` but no corresponding graph (because it was unsubscribed). This made the interface get into a state where the graph could not be joined because of the way the sidebar routing works. I fixed the sidebar routing to prioritize showing the "unsubscribed" state if we do not have the graph key for a particular graph, as `%graph-store` is the source of truth for whether we have a channel or not.

This fixes the presentation of the issue, but highlights an issue with `%hark-graph-hook` in which somehow the entry in `%hark-store` was not removed when the corresponding graph was removed.

cc: @liam-fitzgerald, something to look into when you get back.

Band-aids a fix for #4164.