### PR TITLE
notifications: clear state before processing initial update

### DIFF
--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -8,6 +8,7 @@ import {
 import { makePatDa } from "~/logic/lib/util";
 import _ from "lodash";
 import {StoreState} from "../store/type";
+import { BigIntOrderedMap } from '../lib/BigIntOrderedMap';
 
 type HarkState = Pick<StoreState, "notifications" | "notificationsGraphConfig" | "notificationsGroupConfig" | "unreads" | "notificationsChatConfig">;
 
@@ -177,6 +178,7 @@ function unreadEach(json: any, state: HarkState) {
 function unreads(json: any, state: HarkState) {
   const data = _.get(json, 'unreads');
   if(data) {
+    clearState(state);
     console.log(data);
     data.forEach(({ index, stats }) => {
       const { unreads, notifications, last } = stats;
@@ -191,6 +193,29 @@ function unreads(json: any, state: HarkState) {
       }
     });
   }
+}
+
+function clearState(state){
+  let initialState = {
+    notifications: new BigIntOrderedMap<Timebox>(),
+    archivedNotifications: new BigIntOrderedMap<Timebox>(),
+    notificationsGroupConfig: [],
+    notificationsChatConfig: [],
+    notificationsGraphConfig: {
+      watchOnSelf: false,
+      mentions: false,
+      watching: [],
+    },
+    unreads: {
+      graph: {},
+      group: {}
+    },
+    notificationsCount: 0
+  };
+
+  Object.keys(initialState).forEach(key => {
+    state[key] = initialState[key];
+  });
 }
 
 function updateUnreadCount(state: HarkState, index: NotifIndex, count: (c: number) => number) {


### PR DESCRIPTION
If a subscription restarts, hark will send an %unread update, which functions as an initial-state update, but the reducer just treats it as a normal update, adding unread counts rather than setting them. This PR fixes that by clearing the notifications state before processing the update.