### PR TITLE
meta: glob action tweaks

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaredtobin/janeway:v0.13.2
+FROM jaredtobin/janeway:v0.13.1
 COPY entrypoint.sh /entrypoint.sh
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/glob/entrypoint.sh
+++ b/.github/actions/glob/entrypoint.sh
@@ -10,7 +10,13 @@ chmod 600 service-account
 chmod 600 id_ssh
 chmod 600 id_ssh.pub
 
-janeway release glob --dev --no-pill \
+LANDSCAPE_STREAM="development"
+export LANDSCAPE_STREAM
+
+LANDSCAPE_SHORTHASH="${GITHUB_SHA:0:7}"
+export LANDSCAPE_SHORTHASH
+
+janeway release glob --no-pill \
     --credentials service-account \
     --ssh-key id_ssh \
     --do-it-live \


### PR DESCRIPTION
Sets two environment variables, `LANDSCAPE_STREAM` and `LANDSCAPE_SHORTHASH`, to be employed by Landscape builds.  Also reverts the janeway version used to v0.13.1 as the --dev flag is unnecessary.