### PR TITLE
landscape: allow most patp punctation in tokenize

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -52,13 +52,16 @@ const tokenizeMessage = (text) => {
           }
           messages.push({ url: str });
           message = [];
-        } else if(urbitOb.isValidPatp(str) && !isInCodeBlock) {
+        } else if (urbitOb.isValidPatp(str.replace(/[^a-z\-\~]/g, '')) && !isInCodeBlock) {
           if (message.length > 0) {
             // If we're in the middle of a message, add it to the stack and reset
             messages.push({ text: message.join(' ') });
             message = [];
           }
-          messages.push({ mention: str });
+          messages.push({ mention: str.replace(/[^a-z\-\~]/g, '') });
+          if (str.replace(/[a-z\-\~]/g, '').length > 0) {
+            messages.push({ text: str.replace(/[a-z\-\~]/g, '') });
+          }
           message = [];
 
         } else {


### PR DESCRIPTION
cc @tylershuster 

When writing a message and tokenising its contents, we now use a regex to check patp validation against the substring *excluding all characters not lowercase alphabetical*; then if needed, appends a subsequent text node for the end punctuation.

This excludes sigs, though, eg. `oh ~radbur-sivmus~~ hello~` won't work; this should probably be discouraged anyway, since `~` is our mention character.

See #4183 for the reported issue.