### PR TITLE
shipSearch: skip validating 'undefined'

### DIFF
--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -64,6 +64,8 @@ export function ShipSearch(props: InviteSearchProps) {
     if(valid) {
       setInputShip(ship);
       setError(error === INVALID_SHIP_ERR ? undefined : error);
+    } else if (ship === undefined) {
+      return;
     } else {
       setError(INVALID_SHIP_ERR);
       setInputTouched(false);


### PR DESCRIPTION
See #4218 for filed issue.

The conditional validation logic in shipSearch tripped over cases where ship was `undefined`, like when you type a space and then backspace. We just `return` in such cases instead of setting the field to return an error.

cc @tylershuster 