### PR TITLE
interface: fixes bug where profile overlay would crash due to hook use

### DIFF
--- a/pkg/interface/src/logic/lib/util.ts
+++ b/pkg/interface/src/logic/lib/util.ts
@@ -357,7 +357,8 @@ export function pluralize(text: string, isPlural = false, vowel = false) {
   return isPlural ? `${text}s`: `${vowel ? 'an' : 'a'} ${text}`;
 }
 
-export function useShowNickname(contact: Contact | null): boolean {
-  const hideNicknames = useLocalState(state => state.hideNicknames);
+// Hide is an optional second parameter for when this function is used in class components
+export function useShowNickname(contact: Contact | null, hide?: boolean): boolean {
+  const hideNicknames = typeof hide !== 'undefined' ? hide : useLocalState(state => state.hideNicknames);
   return !!(contact && contact.nickname && !hideNicknames);
 }

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -18,6 +18,7 @@ type ProfileOverlayProps = ColProps & {
   group?: Group;
   onDismiss(): void;
   hideAvatars: boolean;
+  hideNicknames: boolean;
   history: any;
   api: any;
 }
@@ -61,6 +62,7 @@ class ProfileOverlay extends PureComponent<ProfileOverlayProps, {}> {
       bottomSpace,
       group = false,
       hideAvatars,
+      hideNicknames,
       history,
       onDismiss,
       ...rest
@@ -89,7 +91,7 @@ class ProfileOverlay extends PureComponent<ProfileOverlayProps, {}> {
         classes="brt2"
         svgClass="brt2"
         />;
-    const showNickname = useShowNickname(contact);
+    const showNickname = useShowNickname(contact, hideNicknames);
 
     //  TODO: we need to rethink this "top-level profile view" of other ships
     /* if (!group.hidden) {
@@ -147,4 +149,4 @@ class ProfileOverlay extends PureComponent<ProfileOverlayProps, {}> {
   }
 }
 
-export default withLocalState(ProfileOverlay, ['hideAvatars']);
+export default withLocalState(ProfileOverlay, ['hideAvatars', 'hideNicknames']);


### PR DESCRIPTION
my bad.

this passes a second parameter to `useShowNickname` for manual override of `hideNicknames` state variable. lmk if there's a better way to do this.