### PR TITLE
landscape: edit comments include leading sig

### DIFF
--- a/pkg/interface/src/views/components/Comments.tsx
+++ b/pkg/interface/src/views/components/Comments.tsx
@@ -77,7 +77,7 @@ export function Comments(props: CommentsProps) {
       if ('text' in curr) {
         val = val + curr.text;
       } else if ('mention' in curr) {
-        val = val + curr.mention;
+        val = val + `~${curr.mention}`;
       } else if ('url' in curr) {
         val = val + curr.url;
       } else if ('code' in curr) {


### PR DESCRIPTION
See #4212 for original filed issue.

When we get the comment content for an initial value — so we can edit its contents — we reduce mentioned children without adding their leading sig, because graph-store doesn't use the leading sig on the back-end. We just append the leading sig for this purpose, so the resubmitted comment includes the mention.