### PR TITLE
tally: add generator for measuring group activity

### DIFF
--- a/pkg/arvo/gen/tally.hoon
+++ b/pkg/arvo/gen/tally.hoon
@@ -1,0 +1,122 @@
+/-  gr=group, md=metadata-store, ga=graph-store
+/+  re=resource
+!:
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        args=?(~ [shy=? ~])
+        ~
+    ==
+::
+=/  shy=?   ?~(args & shy.args)
+=*  our=@p  p.beak
+::
+|^
+=;  out=(list @t)
+  :-  %tang
+  %-  flop  ::NOTE  tang is bottom-up
+  :*  ''
+      'tallied your activity score! find the results below.'
+    ::
+      ?:  shy
+        'to show non-anonymized resource identifiers, +tally |'
+      'showing plain resource identifiers, share with care.'
+    ::
+      'counted from groups and channels that you are hosting.'
+      'groups are listed with their member count.'
+      'channels are listed with activity from the past week:'
+      '  - amount of top-level content'
+      '  - amount of unique authors'
+      ''
+      (snoc out '')
+  ==
+::  gather local non-dm groups, sorted by size
+::
+=/  groups=(list [local=? resource:re members=@ud])
+  %+  murn
+    %~  tap  in
+    %~  key  by
+    dir:(scry arch %y %group-store /groups)
+  |=  i=@ta
+  =/  r=resource:re  (de-path:re (stab i))
+  =/  g=(unit group:gr)
+    %+  scry  (unit group:gr)
+    [%x %group-store [%groups (snoc (en-path:re r) %noun)]]
+  ?:  |(?=(~ g) hidden.u.g)
+    ~
+  `[=(our entity.r) r ~(wyt in members.u.g)]
+=/  crowds=(list [resource:re @ud])
+  %+  sort  (turn (skim groups head) tail)
+  |=  [[* a=@ud] [* b=@ud]]
+  (gth a b)
+::  gather local per-group channels
+::
+=/  channels=(map resource:re (list [module=term =resource:re]))
+  %-  ~(gas by *(map resource:re (list [module=term =resource:re])))
+  %+  turn  crowds
+  |=  [r=resource:re *]
+  :-  r
+  %+  murn
+    %~  tap   by
+    %+  scry  associations:md
+    [%x %metadata-store [%group (snoc (en-path:re r) %noun)]]
+  |=  [[* m=md-resource:md] metadata:md]
+  ::NOTE  we only count graphs for now
+  ?.  &(=(%graph app-name.m) =(our creator))  ~
+  `[module (de-path:re app-path.m)]
+::  count activity per channel
+::
+=/  activity=(list [resource:re members=@ud (list [resource:re mod=term week=@ud authors=@ud])])
+  %+  turn  crowds
+  |=  [g=resource:re m=@ud]
+  :+  g  m
+  %+  turn  (~(got by channels) g)
+  |=  [m=term r=resource:re]
+  :+  r  m
+  ::NOTE  graph-store doesn't use the full resource-style path here!
+  =/  upd=update:ga
+    %+  scry  update:ga
+    [%x %graph-store /graph/(scot %p entity.r)/[name.r]/noun]
+  ?>  ?=(%add-graph -.q.upd)
+  =/  mo  ((ordered-map atom node:ga) gth)
+  =/  week=(list [@da node:ga])
+    (tap:mo (subset:mo graph.q.upd ~ `(sub now ~d7)))
+  :-  (lent week)
+  %~  wyt  in
+  %+  roll  week
+  |=  [[* [author=ship *] *] a=(set ship)]
+  (~(put in a) author)
+::  render results
+::
+:-  (tac 'the date is ' (scot %da now))
+:-  :(tac 'you are in ' (render-number (lent groups)) ' group(s).')
+:-  :(tac 'you are hosting ' (render-number (lent crowds)) ' group(s):')
+%-  zing
+%+  turn  activity
+|=  [g=resource:re m=@ud chans=(list [resource:re term @ud @ud])]
+^-  (list @t)
+:-  :(tac 'group, ' (render-resource g) ', ' (render-number m))
+%+  turn  chans
+|=  [c=resource:re m=term w=@ud a=@ud]
+;:  tac  ' chan, '
+  (render-resource c)  ', '
+  m                    ', '
+  (render-number w)    ', '
+  (render-number a)
+==
+::
+++  scry
+  |*  [=mold care=term app=term =path]
+  .^(mold (tac %g care) (scot %p our) app (scot %da now) path)
+::
+++  tac  (cury cat 3)
+::
+++  render-resource
+  |=  r=resource:re
+  ?:  shy
+    (crip ((x-co:co 8) (mug r)))
+  :(tac (scot %p entity.r) '/' name.r)
+::
+++  render-number
+  |=  n=@ud
+  (crip ((d-co:co 1) n))
+--

--- a/pkg/arvo/gen/tally.hoon
+++ b/pkg/arvo/gen/tally.hoon
@@ -88,7 +88,11 @@
 ::  render results
 ::
 :-  (tac 'the date is ' (scot %da now))
-:-  :(tac 'you are in ' (render-number (lent groups)) ' group(s).')
+:-  :(tac 'you are in ' (render-number (lent groups)) ' group(s):')
+:-  =-  (roll - tac)
+    %+  join  ', '
+    %+  turn  groups
+    |=([* r=resource:re *] (render-resource r))
 :-  :(tac 'you are hosting ' (render-number (lent crowds)) ' group(s):')
 %-  zing
 %+  turn  activity


### PR DESCRIPTION
Scrapes groups and graphs for member counts and recent activity respectively,
and uses that to print out a "tally" of activity for all local groups and their
channels. Since this output is intended to be shared with other parties,
anonymizes resource identifiers by default.

Example output, from a ship hosting a couple low-activity groups.

```
> +tally

tallied your activity score! find the results below.
to show non-anonymized resource identifiers, +tally |
counted from groups and channels that you are hosting.
groups are listed with their member count.
channels are listed with activity from the past week:
  - amount of top-level content
  - amount of unique authors

the date is ~2021.1.6..17.41.04..0daa
you are in 3 group(s).
you are hosting 3 group(s):
group, 2627f969, 103
 chan, 574bcec1, chat, 0, 0
 chan, 6016c0a5, chat, 7, 1
 chan, 2a5141ef, chat, 11, 4
 chan, 3d4fe01a, chat, 0, 0
 chan, 63261571, chat, 0, 0
 chan, 6275e690, chat, 25, 5
 chan, 39b03c56, chat, 31, 6
 chan, 794f43a6, chat, 0, 0
group, 5db104dd, 10
 chan, 69e410fc, chat, 2, 2
group, 3f5d063f, 2
```

This isn't the prettiest thing I ever wrote, but it gets the job done.

As requested by @vvisigoth. Rationale is that we want some way for group hosts to opt in to sharing activity metrics, but don't want to auto-run anything on people's ships, and don't want to leak any details outside of that activity. Having copy-paste-able output like this will make that easier, and will also let hosts peek at a rudimentary activity overview without ever sharing anything.