### PR TITLE
term: use 'this' in notificationscount

### DIFF
--- a/pkg/interface/src/views/apps/term/app.js
+++ b/pkg/interface/src/views/apps/term/app.js
@@ -47,7 +47,7 @@ export default class TermApp extends Component {
     return (
       <>
         <Helmet defer={false}>
-          <title>{ props.notificationsCount ? `(${String(this.props.notificationsCount) }) `: '' }Landscape</title>
+          <title>{ this.props.notificationsCount ? `(${String(this.props.notificationsCount) }) `: '' }Landscape</title>
         </Helmet>
         <Box
           height='100%'


### PR DESCRIPTION
cc @tylershuster 

#4197 checks for props.notificationsCount in the interface, but Term doesn't pull props out of `this`.

Fixes urbit/landscape#221