### PR TITLE
hark-group-hook: add type checking to vase sent to %hark-store, fix #4217

### DIFF
--- a/pkg/arvo/app/hark-group-hook.hoon
+++ b/pkg/arvo/app/hark-group-hook.hoon
@@ -148,7 +148,9 @@
     |=  [=index:store =notification:store]
     ^-  card 
     =-  [%pass / %agent [our.bowl %hark-store] %poke -]
-    hark-action+!>([%add index notification])
+    :-  %hark-action
+    !>  ^-  action:store
+    [%add-note index notification]
   --
 ::
 ++  on-peek  on-peek:def


### PR DESCRIPTION
Fixes #4217. Have tested it.