### PR TITLE
landscape: use 'collections' icon

### DIFF
--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -25,7 +25,7 @@ import ChatMessage, {MessageWithoutSigil} from "../chat/components/ChatMessage";
 
 function getGraphModuleIcon(module: string) {
   if (module === "link") {
-    return "Links";
+    return "Collection";
   }
   return _.capitalize(module);
 }

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -37,7 +37,7 @@ export class OmniboxResult extends Component {
         || icon.toLowerCase() === 'links'
         || icon.toLowerCase() === 'terminal')
     {
-      icon = (icon === 'Link')     ? 'Links' :
+      icon = (icon === 'Link')     ? 'Collection' :
              (icon === 'Terminal') ? 'Dojo'  : icon;
       graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='16px' color={iconFill} />;
     } else if (icon === 'inbox') {

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -27,7 +27,7 @@ function SidebarItemIndicator(props: { status?: SidebarItemStatus }) {
 const getAppIcon = (app: string, mod: string) => {
   if (app === "graph") {
     if (mod === "link") {
-      return "Links";
+      return "Collection";
     }
     return _.capitalize(mod);
   }


### PR DESCRIPTION
Swaps out the Links icon for the Collections icon in the sidebar, Leap, and the Notifications inbox.

Fixes https://github.com/urbit/landscape/issues/224