### PR TITLE
publish: renders line breaks

### DIFF
--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -22,25 +22,16 @@ export function MentionText(props: MentionTextProps) {
   const { content, contacts, contact, group } = props;
 
   return (
-    <>
-      {_.map(content, (c, idx) => {
+    <RichText contacts={contacts} contact={contact} group={group}>
+      {content.reduce((accum, c) => {
         if ("text" in c) {
-          return (
-            <RichText
-              inline
-              key={idx}
-            >
-              {c.text}
-            </RichText>
-          );
+          return accum + c.text;
         } else if ("mention" in c) {
-          return (
-            <Mention key={idx} contacts={contacts || {}} contact={contact || {}} group={group} ship={c.mention} />
-          );
+          return accum + `[~${c.mention}]`;
         }
-        return null;
-      })}
-    </>
+        return accum;
+      }, '')}
+    </RichText>
   );
 }
 

--- a/pkg/interface/src/views/components/RichText.js
+++ b/pkg/interface/src/views/components/RichText.js
@@ -3,8 +3,11 @@ import RemoteContent from '~/views/components/RemoteContent';
 import { hasProvider } from 'oembed-parser';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
-
 import { BaseAnchor, Text } from '@tlon/indigo-react';
+import { isValidPatp } from 'urbit-ob';
+
+import { deSig } from '~/logic/lib/util';
+import { Mention } from '~/views/components/MentionText';
 
 const DISABLED_BLOCK_TOKENS = [
   'indentedCode',
@@ -23,19 +26,27 @@ const RichText = React.memo(({ disableRemoteContent, ...props }) => (
   <ReactMarkdown
     {...props}
     renderers={{
-      link: (props) => {
+      link: (linkProps) => {
         if (disableRemoteContent) {
-          props.remoteContentPolicy = {
+          linkProps.remoteContentPolicy = {
             imageShown: false,
             audioShown: false,
             videoShown: false,
             oembedShown: false
           };
         }
-        if (hasProvider(props.href)) {
-          return <RemoteContent className="mw-100" url={props.href} />;
+        if (hasProvider(linkProps.href)) {
+          return <RemoteContent className="mw-100" url={linkProps.href} />;
         }
-        return <BaseAnchor target='_blank' rel='noreferrer noopener' borderBottom='1px solid' {...props}>{props.children}</BaseAnchor>;
+        
+        return <BaseAnchor target='_blank' rel='noreferrer noopener' borderBottom='1px solid' {...linkProps}>{linkProps.children}</BaseAnchor>;
+      },
+      linkReference: (linkProps) => {
+        const linkText = String(linkProps.children[0].props.children);
+        if (isValidPatp(linkText)) {
+          return <Mention contacts={props.contacts || {}} contact={props.contact || {}} group={props.group} ship={deSig(linkText)} />;
+        }
+        return linkText;
       },
       paragraph: (paraProps) => {
         return <Text display={props.inline ? 'inline' : 'block'} mb='2' {...props}>{paraProps.children}</Text>;


### PR DESCRIPTION
fixes #4245

This is a bit of a novel approach — it reduces the content in `<MentionText>` down to a single child `<RichText>` whose markdown-formatted content contains specially-formatted (but hopefully logical) links, which are then parsed by `<RichText>` into actual `<Mention>` objects.

**Before:**
<img width="537" alt="image" src="https://user-images.githubusercontent.com/3999320/104045009-cbba6e80-5192-11eb-8cf4-dcc898fb7bae.png">

**After:**
<img width="537" alt="image" src="https://user-images.githubusercontent.com/3999320/104045036-d6750380-5192-11eb-9b70-85929c9938f5.png">
