### PR TITLE
chat: separate text nodes with line breaks

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -260,7 +260,7 @@ const ContentBox = styled(Box)`
 export const MessageWithoutSigil = ({ timestamp, contacts, msg, measure, group }) => (
   <>
     <Text flexShrink={0} mono gray display='inline-block' pt='2px' lineHeight='tall' className="child">{timestamp}</Text>
-    <ContentBox flexShrink={0} fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
+    <ContentBox display='flex' flexShrink={0} fontSize='14px' className="clamp-message" style={{ flexGrow: 1 }}>
       {msg.contents.map((c, i) => (
         <MessageContent
           key={i}

--- a/pkg/interface/src/views/apps/chat/components/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/content/text.js
@@ -29,7 +29,7 @@ const renderers = {
     return <Text mono p='1' backgroundColor='washedGray' style={{ whiteSpace: 'preWrap'}}>{value}</Text>
   },
   paragraph: ({ children }) => {
-    return (<Text fontSize="14px">{children}</Text>);
+    return (<Text display='block' lineHeight='tall' fontSize="14px">{children}</Text>);
   },
   code: ({language, value}) => {
     return <Text
@@ -96,7 +96,7 @@ export default class TextContent extends Component {
       );
     } else {
       return (
-        <Text mx="2px" flexShrink={0} color='black' fontSize={props.fontSize ? props.fontSize : '14px'} lineHeight="tall" style={{ overflowWrap: 'break-word' }}>
+        <Text display='flex' flexDirection='column' mx="2px" flexShrink={0} color='black' fontSize={props.fontSize ? props.fontSize : '14px'} lineHeight="tall" style={{ overflowWrap: 'break-word' }}>
           <MessageMarkdown source={content.text} />
         </Text>
       );

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -66,6 +66,7 @@ export function Mention(props: {
         position="relative"
         display="inline-block"
         cursor="pointer"
+        lineHeight='tall'
       >
       {showOverlay && (
         <ProfileOverlay


### PR DESCRIPTION
Getting creative with flexbox to break up text nodes as line-broken content while still flexing mentions onto the same line. See #4202.

<img width="290" alt="Screen Shot 2021-01-08 at 3 17 34 PM" src="https://user-images.githubusercontent.com/20846414/104060522-063cff00-51c5-11eb-872b-ef8a4c1da5ca.png">

cc @tylershuster — mind looking through chat logs and mentions inside comments in other apps to see if this introduces any quirks?