### PR TITLE
add basic browser notifications

### DIFF
--- a/pkg/interface/src/views/apps/notifications/preferences.tsx
+++ b/pkg/interface/src/views/apps/notifications/preferences.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 
-import { Box, Col, ManagedCheckboxField as Checkbox } from "@tlon/indigo-react";
+import { Box, Button, Col, ManagedCheckboxField as Checkbox } from "@tlon/indigo-react";
 import { Formik, Form, FormikHelpers } from "formik";
 import * as Yup from "yup";
 import _ from "lodash";
@@ -82,6 +82,7 @@ export default function NotificationPreferences(
             id="mentions"
             caption="Notify me if someone mentions my @p in a channel I've joined"
           />
+          {Notification.permission === 'default' ? <Button onClick={() => Notification.requestPermission()}>Allow Notifications</Button>: null}
         </Col>
       </Form>
     </FormikOnBlur>


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/195

This is sort of a draft to think about how this could work. Not that it doesn't actually work on its own, but a) I think that it probably shouldn't be implemented until part two of the state hooks projects gets implemented and b) it exposes some interesting considerations that haven't been undertaken yet.

This works by adding a button to the notification "preferences" tab that prompts you to allow notifications. After that, whenever a new notification comes in (not on the initial fetch), it pings you letting you know there is a new notification. As you can see [here](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification#parameters), there are quite a few things we can do at this point.

Some of those are only made available via the use of service workers. This is a way we could alert people when they get notifications even when landscape isn't running, but the creation of a service worker would be a significant project on its own.

RFC @urcades @matildepark @liam-fitzgerald and of course anyone else