### PR TITLE
chat: fix 'enter' behaviour on iOS

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -173,8 +173,9 @@ export default class ChatEditor extends Component {
             lineHeight="tall"
             style={{ width: '100%', background: 'transparent', color: 'currentColor' }}
             placeholder={inCodeMode ? "Code..." : "Message..."}
-            onKeyUp={event => {
+            onKeyDown={event => {
               if (event.key === 'Enter') {
+                event.preventDefault();
                 this.submit();
               } else {
                 this.messageChange(null, null, event.target.value);


### PR DESCRIPTION
If you typed, eg. `~bitbet-bolbel/urbit-community` on iOS it wouldn't render as a link because `Enter` would be submitted. We use `onKeyDown` to prevent this and stop propagation properly.