### PR TITLE
Nix build for a 'smart' docker image that can load keyfiles or a pier and boot a ship

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,16 +47,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      # We only want the extra nix config on linux, where it is necessary
+      # for the docker build. We don't want in on Mac, where it isn't but
+      # it breaks the nix install. The two `if` clauses should be mutually
+      # exclusive
       - uses: cachix/install-nix-action@v12
+        with:
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - uses: cachix/install-nix-action@v12
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+
       - uses: cachix/cachix-action@v8
         with:
-          name: ares
+          name: ${{ secrets.CACHIX_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-build -A urbit --arg enableStatic true
 
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         run: nix-build -A urbit-tests
+
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: nix-build -A docker-image
 
   haskell:
     strategy:
@@ -73,7 +88,7 @@ jobs:
       - uses: cachix/install-nix-action@v12
       - uses: cachix/cachix-action@v8
         with:
-          name: ares
+          name: ${{ secrets.CACHIX_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-build -A hs.urbit-king.components.exes.urbit-king --arg enableStatic true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,43 @@
+name: release-docker
+
+on:
+  release: null
+  push:
+    tags: ['urbit-v*']
+
+jobs:
+  upload:
+    strategy:
+      matrix:
+        include:
+          - { os: ubuntu-latest, system: x86_64-linux }
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+        with:
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+      - uses: cachix/cachix-action@v8
+        with:
+          name: ${{ secrets.CACHIX_NAME }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: docker/docker-login-action@v1.8.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: christian-korneck/update-container-description-action@v1
+        env:
+          DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+        with:
+          destination_container_repo: ${{ secrets.DOCKERHUB_USERNAME }}/urbit
+          provider: dockerhub
+          short_description: 'Urbit: a clean-slate OS and network for the 21st century'
+          readme_file: 'pkg/docker-image/README.md'
+
+      - run: |
+          version="$(cat ./pkg/urbit/version)"
+          $(nix-build -A skopeo)/bin/skopeo --insecure-policy copy tarball:$(nix-build -A docker-image) docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:v$version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: cachix/install-nix-action@v12
       - uses: cachix/cachix-action@v8
         with:
-          name: ares
+          name: ${{ secrets.CACHIX_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - uses: google-github-actions/setup-gcloud@v0.2.0

--- a/default.nix
+++ b/default.nix
@@ -160,6 +160,8 @@ let
       };
     };
 
+    inherit (pkgsNative) skopeo;
+
     # A convenience function for constructing a shell.nix for any of the
     # pkgsLocal derivations by automatically propagating any dependencies 
     # to the nix-shell.

--- a/default.nix
+++ b/default.nix
@@ -115,6 +115,8 @@ let
 
     urbit = callPackage ./nix/pkgs/urbit { inherit enableStatic; };
 
+    docker-image = callPackage ./nix/pkgs/docker-image { };
+
     hs = callPackage ./nix/pkgs/hs {
       inherit enableStatic;
       inherit (pkgsCross) haskell-nix;

--- a/nix/pkgs/docker-image/default.nix
+++ b/nix/pkgs/docker-image/default.nix
@@ -1,0 +1,59 @@
+{ urbit, libcap, coreutils, bashInteractive, dockerTools, writeScriptBin, amesPort ? 34343 }:
+let
+  startUrbit = writeScriptBin "start-urbit" ''
+    #!${bashInteractive}/bin/bash
+
+    set -eu
+
+    # Check if there is a keyfile, if so boot a ship with its name, and then remove the key
+    if [ -e *.key ]; then
+      # Get the name of the key
+      keynames="*.key"
+      keys=( $keynames )
+      keyname=''${keys[0]}
+      mv $keyname /tmp
+
+      # Boot urbit with the key, exit when done booting
+      urbit -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p ${toString amesPort} -x
+
+      # Remove the keyfile for security
+      rm /tmp/$keyname
+      rm *.key || true
+    elif [ -e *.comet ]; then
+      cometnames="*.comet"
+      comets=( $cometnames )
+      cometname=''${comets[0]}
+      rm *.comet
+
+      urbit -c $(basename $cometname .comet) -p ${toString amesPort} -x
+    fi
+
+    # Find the first directory and start urbit with the ship therein
+    dirnames="*/"
+    dirs=( $dirnames )
+    dirname=''${dirnames[0]}
+
+    urbit -p ${toString amesPort} $dirname
+    '';
+    
+    
+in dockerTools.buildImage {
+  name = "urbit";
+  tag = "v${urbit.version}";
+  contents = [ bashInteractive urbit startUrbit coreutils ];
+  runAsRoot = ''
+    #!${bashInteractive}
+    mkdir -p /urbit
+    mkdir -p /tmp
+    ${libcap}/bin/setcap 'cap_net_bind_service=+ep' /bin/urbit
+    '';
+  config = {
+    Cmd = [ "/bin/start-urbit" ];
+    Env = [ "PATH=/bin" ];
+    WorkingDir = "/urbit";
+    Volumes = {
+      "/urbit" = {};
+    };
+    Expose = [ "80/tcp" "${toString amesPort}/udp" ];
+  };
+}

--- a/pkg/docker-image/README.md
+++ b/pkg/docker-image/README.md
@@ -1,0 +1,39 @@
+# Official Urbit Docker Image
+
+This is the official Docker image for [Urbit](https://urbit.org). 
+
+Urbit is a clean-slate OS and network for the 21st century.
+
+## Using
+
+To use this image, you should mount a volume with a keyfile, comet file, or existing pier at `/urbit`, and map ports
+as described below.
+
+### Volume Mount
+This image expects a volume mounted at `/urbit`. This volume should initially obtain one of
+
+- A keyfile `<shipname>.key` for a galaxy, star, planet, or moon. See the setup instructions for Urbit for information on [obtaining a keyfile](https://urbit.org/using/install/). 
+  * e.g. `sampel-palnet.key` for the planet `sampel-palnet`.
+  to urbit to boot a ship from an existing pier, and in most cases (other than comets) will be named for the ship.
+- An empty file with the extension `.comet`. This will cause Urbit to boot a [comet](https://urbit.org/docs/glossary/comet/) in a pier named for the `.comet` file (less the extension).
+  * e.g. starting with an empty file `my-urbit-bot.comet` will result in Urbit booting a comet into the pier
+    `my-urbit-bot` under your volume.
+- An existing pier as a directory `<shipname>`. You can migrate an existing ship to a new docker container in this way by placing its pier under the volume.
+  * e.g. if your ship is `sampel-palnet` then you likely have a directory `sampel-palnet` whose path you pass to `./urbit` when starting. While your ship is not running, move this directory to the volume and then start the container.
+
+The first two options result in Urbit attempting to boot either the ship named by the name of the keyfile, or a comet. In both cases, after that boot is successful, the `.key` or `.comet` file will be removed from the volume and the pier will take its place.
+
+In consequence, it is safe to remove the container and start a new container which mounts the same volume, e.g. to upgrade the version of the urbit binary by running a later container version. It is also possible to stop the container and then move the pier away e.g. to a location where you will run it directly with the Urbit binary.
+
+### Ports
+The image includes `EXPOSE` directives for TCP port 80 and UDP port 34343. Port `80` is used for Urbit's HTTP interface for both [Landscape](https://urbit.org/docs/glossary/landscape/) and for [API calls](https://urbit.org/using/integrating-api/) to the ship. Port `34343` is used by [Ames](https://urbit.org/docs/glossary/ames/) for ship-to-ship communication.
+
+You can either pass the `-P` flag to docker to map ports directly to the corresponding ports on the host, or map them individually with `-p` flags. For local testing the latter is often convenient, for instance to remap port 80 to an unprivileged port.
+
+## Extending
+
+You likely do not want to extend this image. External applications which interact with Urbit do so primarily via an HTTP API, which should be exposed as described above. For containerized applications using Urbit, it is more appropriate to use a container orchestration service such as Docker Compose or Kubernetes to run Urbit alongside other containers which will interface with its API.
+
+## Development
+The docker image is built by a Nix derivation in the [`nix/pkgs/docker-image/default.nix`](https://github.com/urbit/urbit/tree/master/nix/pkgs/docker-image/default.nix) file under the Urbit git repository.
+

--- a/pkg/docker-image/README.md
+++ b/pkg/docker-image/README.md
@@ -10,16 +10,15 @@ To use this image, you should mount a volume with a keyfile, comet file, or exis
 as described below.
 
 ### Volume Mount
-This image expects a volume mounted at `/urbit`. This volume should initially obtain one of
+This image expects a volume mounted at `/urbit`. This volume should initially contain one of
 
 - A keyfile `<shipname>.key` for a galaxy, star, planet, or moon. See the setup instructions for Urbit for information on [obtaining a keyfile](https://urbit.org/using/install/). 
   * e.g. `sampel-palnet.key` for the planet `sampel-palnet`.
-  to urbit to boot a ship from an existing pier, and in most cases (other than comets) will be named for the ship.
 - An empty file with the extension `.comet`. This will cause Urbit to boot a [comet](https://urbit.org/docs/glossary/comet/) in a pier named for the `.comet` file (less the extension).
   * e.g. starting with an empty file `my-urbit-bot.comet` will result in Urbit booting a comet into the pier
     `my-urbit-bot` under your volume.
 - An existing pier as a directory `<shipname>`. You can migrate an existing ship to a new docker container in this way by placing its pier under the volume.
-  * e.g. if your ship is `sampel-palnet` then you likely have a directory `sampel-palnet` whose path you pass to `./urbit` when starting. While your ship is not running, move this directory to the volume and then start the container.
+  * e.g. if your ship is `sampel-palnet` then you likely have a directory `sampel-palnet` whose path you pass to `./urbit` when starting. [Move your pier](https://urbit.org/using/operations/using-your-ship/#moving-your-pier) directory to the volume and then start the container.
 
 The first two options result in Urbit attempting to boot either the ship named by the name of the keyfile, or a comet. In both cases, after that boot is successful, the `.key` or `.comet` file will be removed from the volume and the pier will take its place.
 
@@ -36,4 +35,3 @@ You likely do not want to extend this image. External applications which interac
 
 ## Development
 The docker image is built by a Nix derivation in the [`nix/pkgs/docker-image/default.nix`](https://github.com/urbit/urbit/tree/master/nix/pkgs/docker-image/default.nix) file under the Urbit git repository.
-


### PR DESCRIPTION
This PR adds Nix and GitHub Actions builds for a docker image for Urbit, pushed to `tloncorp/urbit`

Builds are done alongside Urbit, Docker Hub pushes are done whenever a tag matching `urbit-v*` is pushed to GitHub/urbit/urbit

## Pre-merge requirements

- [x] I parameterized the name of the cachix cache, so `secrets.CACHIX_NAME` should be set to `ares`
- [x] `secrets.DOCKER_USERNAME` needs to be set to the docker hub username (`tloncorp` I think) for publishing, and `secrets.DOCKER_TOKEN` must be set to the *password* (not a PAT, otherwise README updating does not work, this is a docker hub limitation)

Once this is done the `build.yml` file will also build the docker image, and the `release-docker.yml` file will push the image to docker hub with a tag corresponding to the Urbit version, whenever a tag matching `urbit-v*` is pushed.

This PR tracks the progress on #1934 and my corresponding [proposal](https://grants.urbit.org/proposals/626138244-docker-image-for-cloud-container-orchestration)

## TODO list:
- [x] Nix: build for a docker image that can load keyfiles or a pier from a volume mount.
  * [x] Testing
    + [x] Boot from a .key file (tested on moons)
    + [x] Delete the container and make a new container, booting from the existing pier
    + [x] Touch a <name>.comet file and then make a container, resulting in a pier <name> for a new comet.
- [x] CI:
  * [x] Build docker image in CI (add to list of nix attributes built in `.github/workflows/build.yml`)
  * [x] Push docker image to a public Docker Hub repository (using [Skopeo](https://github.com/containers/skopeo) as per the Nixpkgs manual, add to `.github/workflows/release.yml`)
  * [x] Update docker hub readme with readme for our docker image (see [update-container-description-action](https://github.com/christian-korneck/update-container-description-action), add to `.github/workflows/release.yml`)
- [ ] Docs:
  * [x] README (to be visible on GitHub and Docker Hub, see CI push above, explaining how to boot from keyfiles and piers, and how to boot comets
    + [x] Ports to publish (HTTP/Eyre and UDP/Ames)
    + [x] Volume mountpoints and behavior (keyfile/pier/comet)
  * [ ] Azure Container Instances deployment guide - TBW on urbit.org
  * [ ] Amazon ECS deployment guide - TBW on urbit.org