### PR TITLE
Reference urbit/urbit repository when submitting issues

### DIFF
--- a/pkg/interface/src/views/components/StatusBar.js
+++ b/pkg/interface/src/views/components/StatusBar.js
@@ -54,7 +54,7 @@ const StatusBar = (props) => {
           onClick={() => window.open(
             'https://github.com/urbit/landscape/issues/new' +
             '?assignees=&labels=development-stream&title=&' +
-            `body=commit:%20${process.env.LANDSCAPE_SHORTHASH}`
+            `body=commit:%20urbit/urbit@${process.env.LANDSCAPE_SHORTHASH}`
             )}
           >
           <Text color='#000000'>Submit <Text color='#000000' display={['none', 'inline']}>an</Text> issue</Text>


### PR DESCRIPTION
At present issues opened by the 'Submit an issue' button are opened in the urbit/landscape repo, but since the relevant commit doesn't exist in that repository, GitHub fails to auto-link it.  This prepends `urbit/urbit@` to the rendered Landscape shorthash, which I *think* should cause GitHub to auto-link the commit appropriately.