### PR TITLE
hark-store: Fix channel marking as read crash

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -398,6 +398,7 @@
         ::  cache is inconsistent iff we didn't directly
         ::  call this through %read-note or %unread-note
         &(=(read read.u.not) !?=(?(%read-note %unread-note) -.in))
+      ~&  >>  "Inconsistent hark cache, rebuilding"
       rebuild-cache
     =.  u.tib
       (~(put by u.tib) index u.not(read read))

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -388,21 +388,21 @@
     |=  [time=@da =index:store read=?]
     ^+  poke-core
     =.  poke-core  (upd-cache read time index)
-    =/  t=(unit timebox:store)
+    =/  tib=(unit timebox:store)
       (get:orm notifications time)
-    ?~  t  poke-core
-    =/  n=(unit notification:store)
-      (~(get by u.t) index)
-    ?~  n  poke-core
+    ?~  tib  poke-core
+    =/  not=(unit notification:store)
+      (~(get by u.tib) index)
+    ?~  not  poke-core
     =?    poke-core
         ::  cache is inconsistent iff we didn't directly
         ::  call this through %read-note or %unread-note
-        &(=(read read.u.n) !?=(?(%read-note %unread-note) -.in))
+        &(=(read read.u.not) !?=(?(%read-note %unread-note) -.in))
       rebuild-cache
-    =.  u.t
-      (~(put by u.t) index u.n(read read))
+    =.  u.tib
+      (~(put by u.tib) index u.not(read read))
     =.  notifications
-      (put:orm notifications time u.t)
+      (put:orm notifications time u.tib)
     poke-core
   ::
   ++  read-note

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -384,7 +384,6 @@
     (give %archive time index)
   ::
   ::  if we detect cache inconsistencies, wipe and rebuild
-  ::  TODO: where are these coming from?
   ++  change-read-status
     |=  [time=@da =index:store read=?]
     ^+  poke-core
@@ -490,6 +489,10 @@
     ?~  keys
       poke-core
     ?.  (stats-index-is-index:store stats-index i.keys)
+      $(keys t.keys)
+    =/  =notification:store
+      (~(got by (gut-orm notifications time)) i.keys)
+    ?:  read.notification
       $(keys t.keys)
     =/  core
       (read-note time i.keys)


### PR DESCRIPTION
Fixes #4201 by checking if the notification was already read before attempting to mark it as read.