### PR TITLE
hark-graph-hook: fix muting on %remove-graph

### DIFF
--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -176,7 +176,7 @@
   ++  remove-graph
     |=  rid=resource
     =/  unwatched
-      %-  ~(gas in *_watching)
+      %-  ~(gas in *(set [resource index:graph-store]))
       %+  skim  ~(tap in watching)
       |=  [r=resource idx=index:graph-store]
       =(r rid)


### PR DESCRIPTION
*_watching was bunting to watching (i.e. a no-op), causing watching to
be wiped everytimne a graph was removed