### PR TITLE
chat: unreverse keys when getting unread msg

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -258,7 +258,7 @@ export default class ChatWindow extends Component<ChatWindowProps, ChatWindowSta
     const messageProps = { association, group, contacts, unreadMarkerRef, history, api };
 
     const keys = graph.keys().reverse();
-    const unreadIndex = keys[this.props.unreadCount];
+    const unreadIndex = graph.keys()[this.props.unreadCount];
     const unreadMsg = unreadIndex && graph.get(unreadIndex);
 
     return (


### PR DESCRIPTION
See #4219 for filed issue.

The unread message banner was getting its sourced unread message from the index of the last unread message; but this was itself called from a reversed `graph.keys()`, so if I have 9 unreads, it seems like it would get the 9th oldest loaded in, not the 9th newest?

If we call `graph.keys()` for this message without the reverse, the banner's timestamp functions as it should.