### PR TITLE
hark: address phantom dot on archive

### DIFF
--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -386,5 +386,7 @@ function archive(json: any, state: HarkState) {
       notifIdxEqual(index, idxNotif.index)
     );
     state.notifications.set(time, unarchived);
+    const newlyRead = archived.filter(x => !x.notification.read).length;
+    updateNotificationStats(state, index, 'notifications', (x) => x - newlyRead);
   }
 }


### PR DESCRIPTION
We simply did not update the notification count when a notification was archived. Fixed

Fixes https://github.com/urbit/landscape/issues/233