### PR TITLE
meta: bump janeway version in glob action

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaredtobin/janeway:v0.13.1
+FROM jaredtobin/janeway:v0.13.3
 COPY entrypoint.sh /entrypoint.sh
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/glob/entrypoint.sh
+++ b/.github/actions/glob/entrypoint.sh
@@ -10,13 +10,7 @@ chmod 600 service-account
 chmod 600 id_ssh
 chmod 600 id_ssh.pub
 
-LANDSCAPE_STREAM="development"
-export LANDSCAPE_STREAM
-
-LANDSCAPE_SHORTHASH="${GITHUB_SHA:0:7}"
-export LANDSCAPE_SHORTHASH
-
-janeway release glob --no-pill \
+janeway release glob --dev --no-pill \
     --credentials service-account \
     --ssh-key id_ssh \
     --do-it-live \


### PR DESCRIPTION
Uses janeway v0.13.3 in the glob action, which allows us to remove some of the hacky steps introduced to the entrypoint script in 17f3431b43.