### PR TITLE
landscape: pass contact to profile overlay thoroughly

### DIFF
--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -44,7 +44,7 @@ export function Mention(props: {
   const { contacts, ship } = props;
   let { contact } = props;
 
-  contact = (contact?.nickname) ? contact : contacts?.[ship];
+  contact = (contact?.color) ? contact : contacts?.[ship];
 
   const showNickname = useShowNickname(contact);
 


### PR DESCRIPTION
See #4258 for filed issue.

After #4132, an edge case was introduced where pilots with avatars set, but not nicknames, would have a contact-less profile overlay card inside mentions. 

This is because that PR used the existence of a nickname property to check if we had a contact passed to the component (as some layouts elsewhere in the interface pass the entire contacts rolodex to parse through ourselves). We always have a color in a contact prop, so we use that instead to check for its existence.