### PR TITLE
publish: automatically continue lists

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
@@ -10,6 +10,7 @@ import CodeMirror from "codemirror";
 
 import "codemirror/mode/markdown/markdown";
 import "codemirror/addon/display/placeholder";
+import "codemirror/addon/edit/continuelist";
 
 import "codemirror/lib/codemirror.css";
 import { Box } from "@tlon/indigo-react";
@@ -54,6 +55,7 @@ export function MarkdownEditor(
     scrollbarStyle: "native",
     // cursorHeight: 0.85,
     placeholder: placeholder || "",
+    extraKeys: { 'Enter': 'newlineAndIndentContinueMarkdownList' }
   };
 
   const editor: React.RefObject<any> = useRef();


### PR DESCRIPTION
See #3329 for filed issue.

Imports [continueList](https://codemirror.net/doc/manual.html#addons) CodeMirror addon and hooks into 'Enter' to prefix the next line with another list item if we're in a list.