### PR TITLE
Use bot to execute merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: merge
 on:
   push:
     branches:
-      - 'jt/merge-via-bot'
+      - 'master'
 jobs:
   merge-to-next-js:
     runs-on: ubuntu-latest
@@ -12,6 +12,6 @@ jobs:
       - uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
-          target_branch: jt/testo
+          target_branch: release/next-js
           github_token: ${{ secrets.JANEWAY_BOT_TOKEN }}
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: merge
 on:
   push:
     branches:
-      - 'master'
+      - 'jt/merge-via-bot'
 jobs:
   merge-to-next-js:
     runs-on: ubuntu-latest
@@ -12,6 +12,6 @@ jobs:
       - uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
-          target_branch: release/next-js
-          github_token: ${{ github.token }}
+          target_branch: jt/testo
+          github_token: ${{ secrets.JANEWAY_BOT_TOKEN }}
 


### PR DESCRIPTION
Per GitHub,

> When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run.

The merge workflow previously used the default GITHUB_TOKEN, and so would fail to trigger the desired glob workflow when auto-merging 'master' to 'release/next-js'.  Now our handy new janeway bot does it for us.