### PR TITLE
chat: allow line breaks in markdown

### DIFF
--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -8137,6 +8137,11 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
+    "remark-breaks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-2.0.1.tgz",
+      "integrity": "sha512-CZKI8xdPUnvMqPxYEIBBUg8C0B0kyn14lkW0abzhfh/P71YRIxCC3wvBh6AejQL602OxF6kNRl1x4HAZA07JyQ=="
+    },
     "remark-disable-tokenizers": {
       "version": "1.0.24",
       "resolved": "https://registry.npmjs.org/remark-disable-tokenizers/-/remark-disable-tokenizers-1.0.24.tgz",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^5.0.0",
     "react-virtuoso": "^0.20.0",
     "react-visibility-sensor": "^5.1.1",
+    "remark-breaks": "^2.0.1",
     "remark-disable-tokenizers": "^1.0.24",
     "style-loader": "^1.2.1",
     "styled-components": "^5.1.0",

--- a/pkg/interface/src/views/apps/chat/components/content/text.js
+++ b/pkg/interface/src/views/apps/chat/components/content/text.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
+import RemarkBreaks from 'remark-breaks';
 import urbitOb from 'urbit-ob';
 import { Text } from '@tlon/indigo-react';
 
@@ -67,6 +68,7 @@ const MessageMarkdown = React.memo(props => (
       return true;
     }}
     plugins={[[
+      RemarkBreaks,
       RemarkDisableTokenizers,
       { block: DISABLED_BLOCK_TOKENS, inline: DISABLED_INLINE_TOKENS }
     ]]} />


### PR DESCRIPTION
See #4202 for filed issue.

Uses RemarkBreaks plugin to render line breaks as `<br>` instead of rendering as child text nodes.

OK, one last time @tylershuster...

<img width="219" alt="image" src="https://user-images.githubusercontent.com/20846414/104660007-bf9f4700-5693-11eb-9bfe-7890e5b2d7aa.png">
