### PR TITLE
build: tag docker image as "latest"

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -40,4 +40,8 @@ jobs:
 
       - run: |
           version="$(cat ./pkg/urbit/version)"
-          $(nix-build -A skopeo)/bin/skopeo --insecure-policy copy tarball:$(nix-build -A docker-image) docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:v$version
+          skopeo="$(nix-build -A skopeo)/bin/skopeo"
+          image="$(nix-build -A docker-image)"
+          $skopeo --insecure-policy copy tarball:$docker docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:v$version 
+          # Apply 'latest' tag. This won't re-copy any layers since layers are checked by hash before copying
+          $skopeo --insecure-policy copy tarball:$docker docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:latest


### PR DESCRIPTION
When pushing the docker image, update the "latest" tag as well as
pushing a tag for the current Urbit version. This way users pulling
tloncorp/urbit:latest will always get an image with the latest point
release of Urbit.

@jtobin this is a convenience fix for the docker image release cc @jalehman 