### PR TITLE
graph-store: log %add-graph

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -230,7 +230,7 @@
     ?>  ?=(%0 -.update)
     =?  p.update  =(p.update *time)  now.bowl
     ?-  -.q.update
-        %add-graph          (add-graph +.q.update)
+        %add-graph          (add-graph p.update +.q.update)
         %remove-graph       (remove-graph +.q.update)
         %add-nodes          (add-nodes p.update +.q.update)
         %remove-nodes       (remove-nodes p.update +.q.update)
@@ -247,7 +247,8 @@
     ==
     ::
     ++  add-graph
-      |=  $:  =resource:store
+      |=  $:  =time
+              =resource:store
               =graph:store
               mark=(unit mark:store)
               overwrite=?
@@ -258,9 +259,13 @@
                   !(~(has by graphs) resource)
           ==  ==
       ?>  (validate-graph graph mark)
+      =/  =logged-update:store
+        [%0 time %add-graph resource graph mark overwrite]
+      =/  =update-log:store
+        (gas:orm-log ~ [time logged-update] ~)
       :_  %_  state
               graphs       (~(put by graphs) resource [graph mark])
-              update-logs  (~(put by update-logs) resource (gas:orm-log ~ ~))
+              update-logs  (~(put by update-logs) resource update-log)
               archive      (~(del by archive) resource)
             ::
               validators
@@ -643,6 +648,7 @@
         %-  graph-update 
         ^-  update:store
         ?-  -.q.update
+            %add-graph          update(resource.q resource)
             %add-nodes          update(resource.q resource)
             %remove-nodes       update(resource.q resource)
             %add-signatures     update(resource.uid.q resource)

--- a/pkg/arvo/sur/graph-store.hoon
+++ b/pkg/arvo/sur/graph-store.hoon
@@ -34,7 +34,8 @@
   ==
 ::
 +$  logged-update-0
-  $%  [%add-nodes =resource nodes=(map index node)]
+  $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+      [%add-nodes =resource nodes=(map index node)]
       [%remove-nodes =resource indices=(set index)]
       [%add-signatures =uid =signatures]
       [%remove-signatures =uid =signatures]
@@ -42,7 +43,6 @@
 ::
 +$  update-0
   $%  logged-update-0
-      [%add-graph =resource =graph mark=(unit mark) overwrite=?]
       [%remove-graph =resource]
     ::
       [%add-tag =term =resource]


### PR DESCRIPTION
When a graph is joined, the subscriber receives an %add-graph update
that corresponds to the current state of the graph. This was not logged,
so if the graph did not recieve any updates before the subscription was
kicked, the whole graph would be have to be sent again. This would be
largely asymptomatic, however hark-store assumes that %add-graph will
only be emitted when a new graph is joined or created. As such, we log
this initial update, so that the push-hook can correctly ascertain the
backlog it needs to send and so %add-graph is only emitted once per
graph. This also opens the door for time-varying scries into
graph-store.

Fixes #4290