### PR TITLE
build: docker-image: Use docker instead of Skopeo to push

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -40,8 +40,12 @@ jobs:
 
       - run: |
           version="$(cat ./pkg/urbit/version)"
-          skopeo="$(nix-build -A skopeo)/bin/skopeo"
           image="$(nix-build -A docker-image)"
-          $skopeo --insecure-policy copy tarball:$docker docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:v$version 
-          # Apply 'latest' tag. This won't re-copy any layers since layers are checked by hash before copying
-          $skopeo --insecure-policy copy tarball:$docker docker://${{ secrets.DOCKERHUB_USERNAME }}/urbit:latest
+          imageName="$(nix-instantiate --eval -A docker-image.imageName | cut -d'"' -f2)"
+          imageTag="$(nix-instantiate --eval -A docker-image.imageTag | cut -d'"' -f2)"
+          # Load the image from the nix-built tarball
+          docker load -i $image
+          docker tag "$imageName:$imageTag" ${{secrets.DOCKERHUB_USERNAME }}/urbit:v$version
+          docker tag "$imageName:$imageTag" ${{secrets.DOCKERHUB_USERNAME }}/urbit:latest
+          docker push ${{secrets.DOCKERHUB_USERNAME }}/urbit:v$version
+          docker push ${{secrets.DOCKERHUB_USERNAME }}/urbit:latest


### PR DESCRIPTION
Hosted container services such as Azure Container Images are broken
by the absence of metadata in images pushed by Skopeo. Using Docker we
can push and ensure all metadata is in place.

Tested on: GitHub Actions for black-river-software/urbit fork.