### PR TITLE
ames: cache message +jam in +on-memo

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -180,6 +180,9 @@
     $(index +(index), sorted [(~(got by fragments) index) sorted])
   ::
   (cue (rep 13 (flop sorted)))
+::  +jim: caching +jam
+::
+++  jim  |=(n=* ~+((jam n)))
 ::  +bind-duct: find or make new $bone for .duct in .ossuary
 ::
 ++  bind-duct
@@ -1931,7 +1934,7 @@
           ==
         now
       ::
-      =/  =message-blob  (dedup-message (jam payload))
+      =/  =message-blob  (dedup-message (jim payload))
       =.  peer-core  (run-message-pump bone %memo message-blob)
       ::
       ?:  &(=(%boon valence) ?=(?(%dead %unborn) -.qos.peer-state))


### PR DESCRIPTION
Tested with @tacryt-socryp.  Reduces number of calls to `+jam` when publishing chat messages down to one total, as opposed to one per subscriber.  Since the `~+` cache does not persist across Arvo events, this doesn't catch all cases of message duplication, but it catches the common use case of Gall `%fact`s being delivered to many subscribers in a single Arvo event.