### PR TITLE
Remove use of CACHIX_NAME in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: cachix/cachix-action@v8
         with:
-          name: ${{ secrets.CACHIX_NAME }}
+          name: ares
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-build -A urbit --arg enableStatic true
@@ -88,7 +88,7 @@ jobs:
       - uses: cachix/install-nix-action@v12
       - uses: cachix/cachix-action@v8
         with:
-          name: ${{ secrets.CACHIX_NAME }}
+          name: ares
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-build -A hs.urbit-king.components.exes.urbit-king --arg enableStatic true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -22,7 +22,7 @@ jobs:
             system-features = nixos-test benchmark big-parallel kvm
       - uses: cachix/cachix-action@v8
         with:
-          name: ${{ secrets.CACHIX_NAME }}
+          name: ares
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: docker/docker-login-action@v1.8.0
         with:


### PR DESCRIPTION
The use of the CACHIX_NAME secret introduces problems with external PRs, in particular, so this just repeats what was done in 10855b9ec517906de2734b8239185d5e37f6d40a.

cc @eamsden