### PR TITLE
localState: prevent serialization of HTMLElement

### DIFF
--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -40,7 +40,8 @@ const useLocalState = create<LocalState>(persist((set, get) => ({
     }
   })),
   set: fn => set(produce(fn))
-}), {
+  }), {
+  blacklist: ['suspendedFocus', 'toggleOmnibox'],
   name: 'localReducer'
 }));
 

--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -41,7 +41,7 @@ const useLocalState = create<LocalState>(persist((set, get) => ({
   })),
   set: fn => set(produce(fn))
   }), {
-  blacklist: ['suspendedFocus', 'toggleOmnibox'],
+  blacklist: ['suspendedFocus', 'toggleOmnibox', 'omniboxShown'],
   name: 'localReducer'
 }));
 


### PR DESCRIPTION
suspendedFocus may contain an HTMElement, which would throw an error
when it was serialized. Prevents this by adding suspendedFocus and omniboxShown to the
serialization blacklist.