### PR TITLE
peek date

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -193,8 +193,12 @@
   `..on-init
 ::
 ++  on-peek
-  |=  path
-  *(unit (unit cage))
+  |=  =path
+  ^-  (unit (unit cage))
+  ?+  path  (on-peek:def path)
+    [%x %date ~]
+    ``date+!>(now:bowl)
+  ==
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]

--- a/pkg/arvo/mar/date.hoon
+++ b/pkg/arvo/mar/date.hoon
@@ -1,0 +1,13 @@
+|_  date=@da
+::
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  date
+  ++  json  s+(scot %da date)
+  --
+++  grab
+  |%
+  ++  noun  @da
+  --
+--


### PR DESCRIPTION
I needed to get current date in urbit format for Airlock metadata-store because it expects it only in this format `~2021.1.26..15.19.30..aa0f`

so I thought maybe i could scry current date from urbit but didn't find any way to do it so made this code change. I thought maybe hood was the right place but idk?