### PR TITLE
import/export fixes

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -726,7 +726,8 @@
       $:  %0
           p=time
           $=  q
-          $%  [%add-nodes =resource:store nodes=(tree [index:store tree-node])]
+          $%  [%add-graph =resource:store =tree-graph mark=(unit ^mark) ow=?]
+              [%add-nodes =resource:store nodes=(tree [index:store tree-node])]
               [%remove-nodes =resource:store indices=(tree index:store)]
               [%add-signatures =uid:store signatures=tree-signatures]
               [%remove-signatures =uid:store signatures=tree-signatures]
@@ -806,6 +807,14 @@
       ^-  logged-update:store
       :+  %0  p.t
       ?-  -.q.t
+          %add-graph
+        :*  %add-graph
+            resource.q.t
+            (remake-graph tree-graph.q.t)
+            mark.q.t
+            ow.q.t
+        ==
+      ::
           %add-nodes
         :-  %add-nodes
         :-  resource.q.t

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -29,8 +29,6 @@
         %contact-store
         %contact-hook
         %invite-store
-        %chat-store
-        %chat-hook
         %graph-store
     ==
   |=  app=@tas


### PR DESCRIPTION
Stops trying to export from chat-store and chat-hook since they're no longer in use. Fixes an out of date type in the graph-store import flow.