### PR TITLE
interface: consistent hover events

### DIFF
--- a/pkg/interface/src/logic/lib/util.ts
+++ b/pkg/interface/src/logic/lib/util.ts
@@ -363,11 +363,11 @@ export function useShowNickname(contact: Contact | null, hide?: boolean): boolea
   return !!(contact && contact.nickname && !hideNicknames);
 }
 
-export function useHovering() {
+export const useHovering = (props: {withParent?: boolean} = {}): Record<string, unknown> => {
   const [hovering, setHovering] = useState(false);
   const bind = {
-    onMouseEnter: () => setHovering(true),
+    ...(props.withParent === true ? { onMouseOver: () => setHovering(true) } : { onMouseEnter: () => setHovering(true) }),
     onMouseLeave: () => setHovering(false)
   };
   return { hovering, bind };
-}
+};

--- a/pkg/interface/src/logic/lib/util.ts
+++ b/pkg/interface/src/logic/lib/util.ts
@@ -363,10 +363,18 @@ export function useShowNickname(contact: Contact | null, hide?: boolean): boolea
   return !!(contact && contact.nickname && !hideNicknames);
 }
 
-export const useHovering = (props: {withParent?: boolean} = {}): Record<string, unknown> => {
+interface useHoveringInterface {
+  hovering: boolean;
+  bind: {
+    onMouseOver: () => void,
+    onMouseLeave: () => void
+  }
+}
+
+export const useHovering = (): useHoveringInterface => {
   const [hovering, setHovering] = useState(false);
   const bind = {
-    ...(props.withParent === true ? { onMouseOver: () => setHovering(true) } : { onMouseEnter: () => setHovering(true) }),
+    onMouseOver: () => setHovering(true),
     onMouseLeave: () => setHovering(false)
   };
   return { hovering, bind };

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -84,7 +84,7 @@ function NotificationWrapper(props: {
     return api.hark[func](notif);
   }, [notif, api, isMuted]);
 
-  const { hovering, bind } = useHovering({ withParent: true });
+  const { hovering, bind } = useHovering();
 
   const changeMuteDesc = isMuted ? "Unmute" : "Mute";
   return (

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -84,7 +84,7 @@ function NotificationWrapper(props: {
     return api.hark[func](notif);
   }, [notif, api, isMuted]);
 
-  const { hovering, bind } = useHovering();
+  const { hovering, bind } = useHovering({ withParent: true });
 
   const changeMuteDesc = isMuted ? "Unmute" : "Mute";
   return (


### PR DESCRIPTION
Changes the mouse event handler so the notification dismissal control persists between actions, regardless of browser. 

Fixes urbit/landscape#265