### PR TITLE
interface: adds serviceworker

### DIFF
--- a/pkg/arvo/app/landscape/index.html
+++ b/pkg/arvo/app/landscape/index.html
@@ -24,6 +24,13 @@
     <div id="portal-root"></div>
     <script src="/~landscape/js/channel.js"></script>
     <script src="/~landscape/js/session.js"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/serviceworker.js');
+        });
+      }
+    </script>
     <script src="/~landscape/js/bundle/index.5fdbe84c6b57646a6a6b.js"></script>
   </body>
 </html>

--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -63,6 +63,12 @@ if(urbitrc.URL) {
           return '/index.js'
         }
       },
+      '/~landscape/js/serviceworker.js': {
+        target: 'http://localhost:9000',
+        pathRewrite: (req, path) => {
+          return '/serviceworker.js'
+        }
+      },
       '**': {
         changeOrigin: true,
         target: urbitrc.URL,
@@ -77,7 +83,8 @@ if(urbitrc.URL) {
 module.exports = {
   mode: 'development',
   entry: {
-    app: './src/index.js'
+    app: './src/index.js',
+    serviceworker: './src/serviceworker.js'
   },
   module: {
     rules: [
@@ -126,10 +133,13 @@ module.exports = {
   ],
   watch: true,
   output: {
-    filename: 'index.js',
-    chunkFilename: 'index.js',
+    filename: (pathData) => {
+      return pathData.chunk.name === 'app' ? 'index.js' : '[name].js';
+    },
+    chunkFilename: '[name].js',
     path: path.resolve(__dirname, '../dist'),
-    publicPath: '/'
+    publicPath: '/',
+    globalObject: 'this'
   },
   optimization: {
     minimize: false,

--- a/pkg/interface/config/webpack.prod.js
+++ b/pkg/interface/config/webpack.prod.js
@@ -7,7 +7,8 @@ const webpack = require('webpack');
 module.exports = {
   mode: 'production',
   entry: {
-     app: './src/index.js'
+     app: './src/index.js',
+     serviceworker: './src/serviceworker.js'
   },
   module: {
     rules: [
@@ -64,7 +65,9 @@ module.exports = {
     // }),
   ],
   output: {
-    filename: 'index.[contenthash].js',
+    filename: (pathData) => {
+      return pathData.chunk.name === 'app' ? 'index.[contenthash].js' : '[name].js';
+    },
     path: path.resolve(__dirname, '../../arvo/app/landscape/js/bundle'),
     publicPath: '/'
   },

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -10407,6 +10407,66 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "workbox-cacheable-response": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.0.2.tgz",
+      "integrity": "sha512-OrgFiYWkmFXDIbNRYSu+fchcfoZqyJ4yZbdc8WKUjr9v/MghKHfR9u7UI077xBkjno5J3YNpbwx73/no3HkrzA==",
+      "requires": {
+        "workbox-core": "^6.0.2"
+      }
+    },
+    "workbox-core": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.0.2.tgz",
+      "integrity": "sha512-Ksl6qeikGb+BOCILoCUJGxwlEQOeeqdpOnpOr9UDt3NtacPYbfYBmpYpKArw5DFWK+5geBsFqgUUlXThlCYfKQ=="
+    },
+    "workbox-expiration": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.0.2.tgz",
+      "integrity": "sha512-6+nbR18cklAdI3BPT675ytftXPwnVbXGR8mPWNWTJtl5y2urRYv56ZOJLD7FBFVkZ8EjWiRhNP/A0fkxgdKtWQ==",
+      "requires": {
+        "workbox-core": "^6.0.2"
+      }
+    },
+    "workbox-precaching": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.0.2.tgz",
+      "integrity": "sha512-sqKWL2emzmGnfJpna+9RjUkUiqQO++AKfwljCbgkHg8wBbVLy/rnui3eelKgAI7D8R31LJFfiZkY/kXmwkjtlQ==",
+      "requires": {
+        "workbox-core": "^6.0.2",
+        "workbox-routing": "^6.0.2",
+        "workbox-strategies": "^6.0.2"
+      }
+    },
+    "workbox-recipes": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.0.2.tgz",
+      "integrity": "sha512-ewZIHO4jYE6bnEeUIYS6joQy3l+MydpOsVr2F6EpE8ps++z1ScbSdLtJU+yu6WuO3lH44HFZLeFxYQqYm50QAA==",
+      "requires": {
+        "workbox-cacheable-response": "^6.0.2",
+        "workbox-core": "^6.0.2",
+        "workbox-expiration": "^6.0.2",
+        "workbox-precaching": "^6.0.2",
+        "workbox-routing": "^6.0.2",
+        "workbox-strategies": "^6.0.2"
+      }
+    },
+    "workbox-routing": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.0.2.tgz",
+      "integrity": "sha512-iQ9ch3fL1YpztDLfHNURaHQ0ispgPCdzWmZZhtSHUyy/+YkTlIiDVTbOQCIpHIrWlKQiim6X3K2ItIy1FW9+wA==",
+      "requires": {
+        "workbox-core": "^6.0.2"
+      }
+    },
+    "workbox-strategies": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.0.2.tgz",
+      "integrity": "sha512-HjLnYCVS60U7OKhl5NIq8NAQXrotJQRDakmIONnRlQIlP2If/kAiQSUP3QCHMq4EeXGiF+/CdlR1/bhYBHZzZg==",
+      "requires": {
+        "workbox-core": "^6.0.2"
+      }
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -44,6 +44,10 @@
     "styled-system": "^5.1.5",
     "suncalc": "^1.8.0",
     "urbit-ob": "^5.0.1",
+    "workbox-core": "^6.0.2",
+    "workbox-precaching": "^6.0.2",
+    "workbox-recipes": "^6.0.2",
+    "workbox-routing": "^6.0.2",
     "yup": "^0.29.3",
     "zustand": "^3.3.1"
   },

--- a/pkg/interface/src/serviceworker.js
+++ b/pkg/interface/src/serviceworker.js
@@ -1,0 +1,70 @@
+import { registerRoute } from 'workbox-routing';
+import {
+  NetworkFirst,
+  StaleWhileRevalidate,
+  CacheFirst,
+} from 'workbox-strategies';
+
+// Used for filtering matches based on status code, header, or both
+import { CacheableResponsePlugin } from 'workbox-cacheable-response';
+// Used to limit entries in cache, remove entries after a certain period of time
+import { ExpirationPlugin } from 'workbox-expiration';
+
+// Cache page navigations (html) with a Network First strategy
+registerRoute(
+  // Check to see if the request is a navigation to a new page
+  ({ request }) => request.mode === 'navigate',
+  // Use a Network First caching strategy
+  new NetworkFirst({
+    // Put all cached files in a cache named 'pages'
+    cacheName: 'pages',
+    plugins: [
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
+    ],
+  }),
+);
+
+// Cache CSS, JS, and Web Worker requests with a Stale While Revalidate strategy
+registerRoute(
+  // Check to see if the request's destination is style for stylesheets, script for JavaScript, or worker for web worker
+  ({ request }) =>
+    request.destination === 'style' ||
+    request.destination === 'script' ||
+    request.destination === 'worker',
+  // Use a Stale While Revalidate caching strategy
+  new StaleWhileRevalidate({
+    // Put all cached files in a cache named 'assets'
+    cacheName: 'assets',
+    plugins: [
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
+    ],
+  }),
+);
+   
+// Cache images with a Cache First strategy
+registerRoute(
+  // Check to see if the request's destination is style for an image
+  ({ request }) => request.destination === 'image',
+  // Use a Cache First caching strategy
+  new CacheFirst({
+    // Put all cached files in a cache named 'images'
+    cacheName: 'images',
+    plugins: [
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
+      // Don't cache more than 50 items, and expire them after 30 days
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 24 * 30, // 30 Days
+      }),
+    ],
+  }),
+);


### PR DESCRIPTION
This adds a serviceworker with the boilerplate from https://developers.google.com/web/tools/workbox/guides/get-started and starts to cache images. Seems...faster?

Preliminary work to out-of-tab browser notifications and other wondrous splendiferousnesses


@liam-fitzgerald RFC