### PR TITLE
interface: sigil color for comets

### DIFF
--- a/pkg/interface/src/logic/lib/sigil.js
+++ b/pkg/interface/src/logic/lib/sigil.js
@@ -8,46 +8,58 @@ export const foregroundFromBackground = (background) => {
     g: parseInt(background.slice(3, 5), 16),
     b: parseInt(background.slice(5, 7), 16)
   };
-  const brightness = ((299 * rgb.r) + (587 * rgb.g) + (114 * rgb.b)) / 1000;
+  const brightness = (299 * rgb.r + 587 * rgb.g + 114 * rgb.b) / 1000;
   const whiteBrightness = 255;
 
-  return ((whiteBrightness - brightness) < 50) ? 'black' : 'white';
+  return whiteBrightness - brightness < 50 ? 'black' : 'white';
 };
 
-export const Sigil = memo(({ classes = '', color, foreground = '', ship, size, svgClass = '', icon = false, padded = false }) => {
-  const padding = (icon && padded) ? '2px' : '0px';
-  const innerSize = (icon && padded) ? (Number(size) - 4) : size;
-  const foregroundColor = foreground ? foreground : foregroundFromBackground(color);
-  return ship.length > 14
-    ? (<Box
-        backgroundColor='black'
+export const Sigil = memo(
+  ({
+    classes = '',
+    color,
+    foreground = '',
+    ship,
+    size,
+    svgClass = '',
+    icon = false,
+    padded = false
+  }) => {
+    const padding = icon && padded ? '2px' : '0px';
+    const innerSize = icon && padded ? Number(size) - 4 : size;
+    const foregroundColor = foreground
+      ? foreground
+      : foregroundFromBackground(color);
+    return ship.length > 14 ? (
+      <Box
+        backgroundColor={color}
         borderRadius={icon ? '1' : '0'}
         display='inline-block'
         height={size}
         width={size}
         className={classes}
-       />) : (
-       <Box
+      />
+    ) : (
+      <Box
         display='inline-block'
         borderRadius={icon ? '1' : '0'}
         flexBasis={size}
         backgroundColor={color}
         padding={padding}
         className={classes}
-       >
-      {sigil({
-        patp: ship,
-        renderer: reactRenderer,
-        size: innerSize,
-        icon,
-        colors: [
-          color,
-          foregroundColor
-        ],
-        class: svgClass
-      })}
-    </Box>);
-});
+      >
+        {sigil({
+          patp: ship,
+          renderer: reactRenderer,
+          size: innerSize,
+          icon,
+          colors: [color, foregroundColor],
+          class: svgClass
+        })}
+      </Box>
+    );
+  }
+);
 
 Sigil.displayName = 'Sigil';
 


### PR DESCRIPTION
Comets need sigils with background colors too. Passes the color in to the Box used by comets (shipname > 14 chars).

Also a formatting change, but I noted the operative line with a comment.

Fixes urbit/landscape#316