### PR TITLE
publish: fixes codeblock wrapping behavior

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -109,7 +109,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
           <Text ml={2}>{adminLinks}</Text>
         </Box>
       </Col>
-      <Box color="black" className="md" style={{ overflowWrap: "break-word" }}>
+      <Box color="black" className="md" style={{ overflowWrap: "break-word", overflow: "hidden" }}>
         <ReactMarkdown source={body} linkTarget={"_blank"} />
       </Box>
       <NoteNavigation

--- a/pkg/interface/src/views/apps/publish/css/custom.css
+++ b/pkg/interface/src/views/apps/publish/css/custom.css
@@ -192,6 +192,7 @@
 }
 .md code, .md pre {
   font-family: "Source Code Pro", mono;
+  white-space: pre-wrap;
 }
 .md ul>li, .md ol>li {
   line-height: 1.5;


### PR DESCRIPTION
fixes https://github.com/urbit/landscape/issues/324

Seems fine to `overflow: hidden` `Note`s, right?