### PR TITLE
contact-hooks: some improvments 

### DIFF
--- a/pkg/arvo/app/contact-pull-hook.hoon
+++ b/pkg/arvo/app/contact-pull-hook.hoon
@@ -9,6 +9,7 @@
       update:store
       %contact-update
       %contact-push-hook
+      %.y  :: necessary to enable p2p
   ==
 --
 ::
@@ -32,6 +33,7 @@
 ++  on-agent  on-agent:def
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
+++  resource-for-update  resource-for-update:con
 ++  on-pull-nack
   |=  [=resource =tang]
   ^-  (quip card _this)

--- a/pkg/arvo/app/contact-push-hook.hoon
+++ b/pkg/arvo/app/contact-push-hook.hoon
@@ -49,45 +49,7 @@
     %disallow    %.n
     %set-public  %.n
   ==
-::
-++  resource-for-update
-  |=  =vase
-  ^-  (list resource:res)
-  |^
-  =/  =update:store  !<(update:store vase)
-  ?-  -.update
-    %initial     ~
-    %add         (rids-for-ship ship.update)
-    %remove      (rids-for-ship ship.update)
-    %edit        (rids-for-ship ship.update)
-    %allow       ~
-    %disallow    ~
-    %set-public  ~
-  ==
-  ::
-  ++  rids-for-ship
-    |=  s=ship
-    ^-  (list resource:res)
-    ::  if the ship is in any group that I am pushing updates for, push
-    ::  it out to that resource.
-    ::
-    =/  rids
-      %+  skim  ~(tap in scry-sharing)
-      |=  r=resource:res
-      (is-member:grp s r)
-    ?.  =(s our.bowl)
-      rids
-    (snoc rids [our.bowl %''])
-  ::
-  ++  scry-sharing
-    .^  (set resource:res)
-      %gx
-      (scot %p our.bowl)
-      %contact-push-hook
-      (scot %da now.bowl)
-      /sharing/noun
-    ==
-  --
+++  resource-for-update  resource-for-update:con
 ::
 ++  initial-watch
   |=  [=path =resource:res]

--- a/pkg/arvo/app/contact-push-hook.hoon
+++ b/pkg/arvo/app/contact-push-hook.hoon
@@ -55,7 +55,7 @@
   |=  [=path =resource:res]
   ^-  vase
   |^
-  ?>  (is-allowed:con src.bowl)
+  ?>  (is-allowed:con resource src.bowl)
   !>  ^-  update:store
   [%initial rolo %.n]
   ::

--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -9,6 +9,7 @@
       update:store
       %graph-update
       %graph-push-hook
+      %.n
   ==
 --
 ::
@@ -48,4 +49,6 @@
   =/  maybe-time  (peek-update-log:gra resource)
   ?~  maybe-time  `/
   `/(scot %da u.maybe-time)
+::
+++  resource-for-update  resource-for-update:gra
 --

--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -92,27 +92,7 @@
       %tag-queries        %.n
       %run-updates        (is-allowed resource.q.update bowl %.y)
   ==
-::
-++  resource-for-update
-  |=  =vase
-  ^-  (list resource:res)
-  =/  =update:store  !<(update:store vase)
-  ?-  -.q.update
-      %add-graph          ~[resource.q.update]
-      %remove-graph       ~[resource.q.update]
-      %add-nodes          ~[resource.q.update]
-      %remove-nodes       ~[resource.q.update]
-      %add-signatures     ~[resource.uid.q.update]
-      %remove-signatures  ~[resource.uid.q.update]
-      %archive-graph      ~[resource.q.update]
-      %unarchive-graph    ~
-      %add-tag            ~
-      %remove-tag         ~
-      %keys               ~
-      %tags               ~
-      %tag-queries        ~
-      %run-updates        ~[resource.q.update]
-  ==
+++  resource-for-update  resource-for-update:gra
 ::
 ++  initial-watch
   |=  [=path =resource:res]

--- a/pkg/arvo/app/group-pull-hook.hoon
+++ b/pkg/arvo/app/group-pull-hook.hoon
@@ -14,6 +14,7 @@
       update:store
       %group-update
       %group-push-hook
+      %.n
   ==
 ::
 --
@@ -28,6 +29,7 @@
 +*  this        .
     def         ~(. (default-agent this %|) bowl)
     dep         ~(. (default:pull-hook this config) bowl)
+    grp         ~(. grpl bowl)
 ::
 ++  on-init  on-init:def
 ++  on-save  !>(~)
@@ -45,8 +47,11 @@
   :_  this
   =-  [%pass / %agent [our.bowl %group-store] %poke -]~
   group-update+!>([%remove-group resource ~])
+::
 ++  on-pull-kick
   |=  =resource
   ^-  (unit path)
   `/
+::
+++  resource-for-update  resource-for-update:grp
 --

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -141,14 +141,7 @@
         =(~(tap in ships.update) ~[src.bowl])
     ==
   --
-::
-++  resource-for-update
-  |=  =vase
-  ^-  (list resource)
-  =/  =update:store  !<(update:store vase)
-  ?:  ?=(%initial -.update)
-    ~
-  ~[resource.update]
+++  resource-for-update  resource-for-update:grp
 ::
 ++  take-update
   |=   =vase

--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -15,6 +15,7 @@
       update:metadata
       %metadata-update
       %metadata-push-hook
+      %.n
   ==
 +$  state-zero
   [%0 previews=(map resource group-preview:metadata)]
@@ -126,6 +127,7 @@
 ++  on-arvo   on-arvo:def
 ::
 ++  on-fail   on-fail:def
+++  resource-for-update  resource-for-update:met
 ++  on-pull-nack
   |=   [=resource =tang]
   ^-  (quip card _this)

--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -86,13 +86,7 @@
   ?~  u.role  %.n
   ?=(?(%admin %moderator) u.u.role)
 ::
-++  resource-for-update
-  |=  =vase
-  ^-  (list resource)
-  =/  =update:store  !<(update:store vase)
-  ?.  ?=(?(%add %remove %initial-group) -.update)  ~
-  ~[group.update]
-::
+++  resource-for-update  resource-for-update:met
 ++  take-update
   |=   =vase
   ^-  [(list card) agent]

--- a/pkg/arvo/lib/contact.hoon
+++ b/pkg/arvo/lib/contact.hoon
@@ -40,32 +40,34 @@
     ?.  =(s our.bowl)
       rids
     (snoc rids [our.bowl %''])
-  ::
-  ++  scry-sharing
-    .^  (set resource)
-      %gx
-      (scot %p our.bowl)
-      %contact-push-hook
-      (scot %da now.bowl)
-      /sharing/noun
-    ==
   --
+++  scry-sharing
+  .^  (set resource)
+    %gx
+    (scot %p our.bowl)
+    %contact-push-hook
+    (scot %da now.bowl)
+    /sharing/noun
+  ==
 ::
 ++  get-contact
   |=  =ship
   ^-  (unit contact:store)
-  =/  upd  (scry-for (unit update:store) /contact/(scot %p ship))
-  ?~  upd  ~
-  ?>  ?=(%add -.u.upd)
-  `contact.u.upd
+  =/  =rolodex:store
+    (scry-for rolodex:store /all)
+  (~(get by rolodex) ship)
 ::
 ++  is-allowed
-  |=  =ship
+  |=  [rid=resource =ship]
   ^-  ?
+  =/  grp  ~(. group bowl)
   =/  shp  (scry-for ? /allowed-ship/(scot %p ship))
   ?:  shp  %.y
+  ?:  ?&  (~(has in scry-sharing) rid)
+          (~(has in (members:grp rid)) ship)
+      ==
+    %.y
   =/  allowed-groups  ~(tap in (scry-for (set resource) /allowed-groups))
-  =/  grp  ~(. group bowl)
   |-
   ?~  allowed-groups  %.n
   ?:  (~(has in (members:grp i.allowed-groups)) ship)

--- a/pkg/arvo/lib/contact.hoon
+++ b/pkg/arvo/lib/contact.hoon
@@ -1,6 +1,7 @@
 /-  store=contact-store, *resource
-/+  group
+/+  group, grpl=group
 |_  =bowl:gall
++*  grp  ~(. grpl bowl)
 ++  scry-for
   |*  [=mold =path]
   .^  mold
@@ -10,6 +11,45 @@
     (scot %da now.bowl)
     (snoc `^path`path %noun)
   ==
+::
+++  resource-for-update
+  |=  =vase
+  ^-  (list resource)
+  |^
+  =/  =update:store  !<(update:store vase)
+  ?-  -.update
+    %initial     ~
+    %add         (rids-for-ship ship.update)
+    %remove      (rids-for-ship ship.update)
+    %edit        (rids-for-ship ship.update)
+    %allow       ~
+    %disallow    ~
+    %set-public  ~
+  ==
+  ::
+  ++  rids-for-ship
+    |=  s=ship
+    ^-  (list resource)
+    ::  if the ship is in any group that I am pushing updates for, push
+    ::  it out to that resource.
+    ::
+    =/  rids
+      %+  skim  ~(tap in scry-sharing)
+      |=  r=resource
+      (is-member:grp s r)
+    ?.  =(s our.bowl)
+      rids
+    (snoc rids [our.bowl %''])
+  ::
+  ++  scry-sharing
+    .^  (set resource)
+      %gx
+      (scot %p our.bowl)
+      %contact-push-hook
+      (scot %da now.bowl)
+      /sharing/noun
+    ==
+  --
 ::
 ++  get-contact
   |=  =ship

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -11,6 +11,27 @@
     (snoc `^path`path %noun)
   ==
 ::
+++  resource-for-update
+  |=  =vase
+  ^-  (list resource)
+  =/  =update:store  !<(update:store vase)
+  ?-  -.q.update
+      %add-graph          ~[resource.q.update]
+      %remove-graph       ~[resource.q.update]
+      %add-nodes          ~[resource.q.update]
+      %remove-nodes       ~[resource.q.update]
+      %add-signatures     ~[resource.uid.q.update]
+      %remove-signatures  ~[resource.uid.q.update]
+      %archive-graph      ~[resource.q.update]
+      %unarchive-graph    ~
+      %add-tag            ~
+      %remove-tag         ~
+      %keys               ~
+      %tags               ~
+      %tag-queries        ~
+      %run-updates        ~[resource.q.update]
+  ==
+::
 ++  get-graph
   |=  res=resource
   ^-  update:store

--- a/pkg/arvo/lib/group.hoon
+++ b/pkg/arvo/lib/group.hoon
@@ -3,6 +3,15 @@
 ::
 |_  =bowl:gall
 +$  card  card:agent:gall
+::
+++  resource-for-update
+  |=  =vase
+  ^-  (list resource)
+  =/  =update:store  !<(update:store vase)
+  ?:  ?=(%initial -.update)
+    ~
+  ~[resource.update]
+::
 ++  scry-for
   |*  [=mold =path]
   =.  path

--- a/pkg/arvo/lib/metadata.hoon
+++ b/pkg/arvo/lib/metadata.hoon
@@ -4,6 +4,13 @@
 /+  resource
 ::
 |_  =bowl:gall
+++  resource-for-update
+  |=  =vase
+  ^-  (list resource)
+  =/  =update:store  !<(update:store vase)
+  ?.  ?=(?(%add %remove %initial-group) -.update)  ~
+  ~[group.update]
+::  
 ++  app-paths-from-group
   |=  [=app-name:store group=resource]
   ^-  (list resource)

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -30,12 +30,15 @@
 ::    .store-name: name of the store to send subscription updates to.
 ::    .update-mark: mark that updates will be tagged with
 ::    .push-hook-name: name of the corresponding push-hook
+::    .no-validate: If true, don't validate that resource/wire/src match
+::    up
 ::
 +$  config
   $:  store-name=term
       update=mold
       update-mark=term
       push-hook-name=term
+      no-validate=_|
   ==
 ::  
 ::  $base-state-0: state for the pull hook
@@ -106,6 +109,14 @@
   ++  on-pull-kick
     |~  resource
     *(unit path)
+  ::  +resource-for-update: get resources from vase
+  ::
+  ::    This should be identical to the +resource-for-update arm in the
+  ::    corresponding push-hook
+  ::
+  ++  resource-for-update
+    |~  vase
+    *(list resource)
   ::
   ::  from agent:gall
   ++  on-init
@@ -470,24 +481,30 @@
       /helper/pull-hook
     wire
   ::
-  ++  get-conversion
-    .^  tube:clay
-      %cc  (scot %p our.bowl)  %home  (scot %da now.bowl)
-      /[update-mark.config]/resource
-    ==
-  ::
   ++  give-update
     ^-  card
     [%give %fact ~[/tracking] %pull-hook-update !>(tracking)]
+  ::
+  ++  check-src
+    |=  resources=(set resource)
+    ^-  ?
+    %+  roll  ~(tap in resources)
+    |=  [rid=resource out=_|]
+    ?:  out  %.y
+    ?~  ship=(~(get by tracking) rid)
+      %.n
+    =(src.bowl u.ship)
   ::
   ++  update-store
     |=  [wire-rid=resource =vase]
     ^-  card
     =/  =wire
       (make-wire /store)
-    =+  !<(rid=resource (get-conversion vase))
-    ?>  =(src.bowl (~(got by tracking) rid))
-    ?>  =(wire-rid rid)
+    =+  resources=(~(gas in *(set resource)) (resource-for-update:og vase))
+    ?>  ?|  no-validate.config
+        ?&  (check-src resources)
+            (~(has in resources) wire-rid)
+        ==  ==
     [%pass wire %agent [our.bowl store-name.config] %poke update-mark.config vase]
   --
 --


### PR DESCRIPTION
- Adds %no-validate flag, to prevent checking the wire/src.bowl/resource all match-up to enable P2P connections. 
- Moves the resource-for-update back into the inner door, to match the push-hook.
- Fixes `+get-contact` and `+is-allowed`

This is about as much as I can do given what I know. Unsure how you intend to share contacts to the hosts, but contacts that are on the host are propagated fine to members of the group. 