### PR TITLE
Invites: update for new group-view

### DIFF
--- a/pkg/arvo/app/invite-store.hoon
+++ b/pkg/arvo/app/invite-store.hoon
@@ -38,7 +38,9 @@
   %_  this
       invites.state
     %-  ~(gas by *invites:store)
-    [%graph *invitatory:store]~
+    :~  [%graph *invitatory:store]
+        [%groups *invitatory:store]
+    ==
   ==
 ::
 ++  on-save   !>(state)

--- a/pkg/arvo/lib/group-view.hoon
+++ b/pkg/arvo/lib/group-view.hoon
@@ -14,6 +14,7 @@
         remove+remove
         join+join
         leave+leave
+        invite+invite
     ==
   ::
   ++  create
@@ -32,6 +33,13 @@
     %-  ot
     :~  resource+dejs:resource
         ship+(su ;~(pfix sig fed:ag))
+    ==
+  ::
+  ++  invite
+    %-  ot
+    :~  resource+dejs:resource
+        ships+(as (su ;~(pfix sig fed:ag)))
+        description+so
     ==
   --
 ::

--- a/pkg/arvo/sur/group-view.hoon
+++ b/pkg/arvo/sur/group-view.hoon
@@ -9,6 +9,8 @@
       ::  client side
       [%join =resource =ship]
       [%leave =resource]
+      ::
+      [%invite =resource ships=(set ship) description=@t]
   ==
 
 ::

--- a/pkg/arvo/ted/group/invite.hoon
+++ b/pkg/arvo/ted/group/invite.hoon
@@ -1,0 +1,58 @@
+/-  spider,
+    metadata=metadata-store,
+    *group,
+    inv=invite-store,
+    store=group-store,
+    push-hook
+/+  strandio, resource, view=group-view, grpl=group
+=>
+|%
+++  strand    strand:spider
+++  poke      poke:strandio
+++  poke-our  poke-our:strandio
+++  gallify-bowl
+  |=  =bowl:spider
+  ^-  bowl:gall
+  :*  [our src %$]:bowl
+      [~ ~]
+      [0 eny now byk]:bowl
+  ==
+::
+++  invite-ships
+  |=  [ships=(set ship) rid=resource description=cord]
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  =bowl:spider  bind:m  get-bowl:strandio
+  =/  =action:inv
+    :^  %invites  %groups  (shaf %group-uid eny.bowl)
+    ^-  multi-invite:inv
+    [our.bowl %group-push-hook rid ships description]
+  ;<  ~  bind:m  (poke-our %invite-hook invite-action+!>(action))
+  (pure:m ~)
+::
+++  add-pending
+  |=  [ships=(set ship) rid=resource]
+  =/  m  (strand ,~)
+  ^-  form:m
+  =/  =action:store
+    [%change-policy rid %invite %add-invites ships]
+  ;<  ~  bind:m  (poke-our %group-push-hook %group-update !>(action))
+  (pure:m ~)
+--
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<([~ =action:view] arg)
+?>  ?=(%invite -.action)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+=/  =bowl:gall  (gallify-bowl bowl)
+?>  (~(is-admin grpl bowl) our.bowl resource.action)
+;<  ~  bind:m 
+  (invite-ships [ships resource description]:action)
+=/  =group
+  (need (~(scry-group grpl bowl) resource.action))
+?:  ?=(%open -.policy.group)
+  (pure:m !>(~))
+;<  ~  bind:m  (add-pending [ships resource]:action)
+(pure:m !>(~))

--- a/pkg/interface/src/logic/api/groups.ts
+++ b/pkg/interface/src/logic/api/groups.ts
@@ -67,6 +67,18 @@ export default class GroupsApi extends BaseApi<StoreState> {
     });
   }
 
+  invite(ship: string, name: string, ships: Patp[], description: string) {
+    const resource = makeResource(ship, name);
+    return this.viewThread('group-invite', {
+      invite: {
+        resource,
+        ships,
+        description
+      }
+    });
+
+  }
+
   private proxyAction(action: GroupAction) {
     return this.action('group-push-hook', 'group-update', action);
   }

--- a/pkg/interface/src/views/components/Invite.tsx
+++ b/pkg/interface/src/views/components/Invite.tsx
@@ -12,8 +12,16 @@ export class InviteItem extends Component<{invite: Invite, onAccept: (i: any) =>
       <>
       <Box width='100%' p='4'>
         <Box width='100%' verticalAlign='middle'>
-          <Text display='block' pb='2' gray><Text mono>{cite(props.invite.resource.ship)}</Text> invited you to <Text fontWeight='500'>{props.invite.resource.name}</Text></Text>
+          <Text display='block' pb='2' gray>
+            <Text mono>{cite(props.invite.resource.ship)}</Text> 
+            {" "}invited you to{" "}
+            <Text fontWeight='500'>{props.invite.resource.name}</Text></Text>
         </Box>
+        {props.invite.text && (
+          <Box pb="2">
+            <Text gray>{props.invite.text}</Text>
+          </Box>
+        )}
         <Row>
           <StatelessAsyncAction 
             name="accept"

--- a/pkg/interface/src/views/landscape/components/JoinGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/JoinGroup.tsx
@@ -85,7 +85,7 @@ export function JoinGroup(props: JoinGroupProps) {
       await waiter((p: JoinGroupProps) => {
         return group in p.groups && 
           (group in (p.associations?.graph ?? {})
-            || group in (p.associations?.contacts ?? {}))
+            || group in (p.associations?.groups ?? {}))
       });
       if(props.groups?.[group]?.hidden) {
         const { metadata } = associations.graph[group];


### PR DESCRIPTION
Adds a -group-invite thread to invite users to groups.
Updates the interface to call into the thread correctly
Fixes a bug preventing speedy joins from being redirected correctly
Correctly initialises the state of invite-store
Now prompts for an invite description and displays it, if set.
![Capture d’écran 2021-02-03 à 10 01 42 AM](https://user-images.githubusercontent.com/46801558/106679257-f79d0880-6607-11eb-872a-e0228f2e7251.png)
![Capture d’écran 2021-02-03 à 10 10 33 AM](https://user-images.githubusercontent.com/46801558/106679307-13a0aa00-6608-11eb-99a5-407c8796ab3a.png)
