### PR TITLE
interface: fix profile overlay positioning in chat

### DIFF
--- a/pkg/interface/src/views/components/OverlaySigil.tsx
+++ b/pkg/interface/src/views/components/OverlaySigil.tsx
@@ -60,14 +60,8 @@ class OverlaySigil extends PureComponent<OverlaySigilProps, OverlaySigilState> {
     if (this.containerRef && this.containerRef.current) {
       const container = this.containerRef.current;
       const scrollWindow = this.props.scrollWindow;
-
-      const bottomSpace = scrollWindow
-        ? scrollWindow.scrollHeight - container.offsetTop - scrollWindow.scrollTop
-        : 'auto';
-      const topSpace = scrollWindow
-        ? scrollWindow.offsetHeight - bottomSpace - OVERLAY_HEIGHT
-        : 0;
-
+      const bottomSpace =  scrollWindow.clientHeight - ((container.getBoundingClientRect().top + OVERLAY_HEIGHT) - scrollWindow.getBoundingClientRect().top);
+      const topSpace = container.getBoundingClientRect().top - scrollWindow.getBoundingClientRect().top;
       this.setState({
         topSpace,
         bottomSpace

--- a/pkg/interface/src/views/components/OverlaySigil.tsx
+++ b/pkg/interface/src/views/components/OverlaySigil.tsx
@@ -60,8 +60,8 @@ class OverlaySigil extends PureComponent<OverlaySigilProps, OverlaySigilState> {
     if (this.containerRef && this.containerRef.current) {
       const container = this.containerRef.current;
       const scrollWindow = this.props.scrollWindow;
-      const bottomSpace =  scrollWindow.clientHeight - ((container.getBoundingClientRect().top + OVERLAY_HEIGHT) - scrollWindow.getBoundingClientRect().top);
-      const topSpace = container.getBoundingClientRect().top - scrollWindow.getBoundingClientRect().top;
+      const bottomSpace =  scrollWindow ? scrollWindow.clientHeight - ((container.getBoundingClientRect().top + OVERLAY_HEIGHT) - scrollWindow.getBoundingClientRect().top) : 'auto';
+      const topSpace = scrollWindow ? container.getBoundingClientRect().top - scrollWindow.getBoundingClientRect().top : 0;
       this.setState({
         topSpace,
         bottomSpace


### PR DESCRIPTION
Restores the intended dynamic positioning of the profile overlay in chat messages. Calculates the space between a chat message and the vertical bounds of the chat window using client geometry, rather than scroll offset, which would sometimes throw a false positive and position the profile overlay contents below the chat window.

Fixes [urbit/landscape#303](https://github.com/urbit/landscape/issues/303)