### PR TITLE
meta: update janeway dep in glob action

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaredtobin/janeway:v0.13.3
+FROM jaredtobin/janeway:v0.13.4
 COPY entrypoint.sh /entrypoint.sh
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This should unbreak the glob action.  I recently pushed an image for the latest janeway version, but am not yet sure why the old one became unavailable..