### PR TITLE
hark, metadata-hook: fix OTAs

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -22,6 +22,7 @@
       state:state-one:store
       state-2
       state-3
+      state-4
   ==
 +$  unread-stats
   [indices=(set index:graph-store) last=@da]
@@ -37,13 +38,16 @@
   ==
 ::
 +$  state-2
-  [%2 base-state]
+  [%2 state-two:store]
 ::
 +$  state-3
-  [%3 base-state]
+  [%3 state-two:store]
+::
++$  state-4
+  [%4 base-state]
 ::
 +$  inflated-state
-  $:  state-3
+  $:  state-4
       cache
   ==
 ::  $cache: useful to have precalculated, but can be derived from state
@@ -84,9 +88,16 @@
   =|  cards=(list card)
   |^  
   ?-  -.old
-      %3  
+      %4  
     :-  (flop cards)
     this(-.state old, +.state (inflate-cache:ha old))
+    ::
+      %3
+    %_  $
+      -.old  %4
+      notifications.old  (convert-notifications-3 notifications.old)
+      archive.old  (convert-notifications-3 archive.old)
+    ==
     ::
       %2
     %_  $
@@ -96,7 +107,6 @@
       :_  cards
       [%pass / %agent [our dap]:bowl %poke noun+!>(%fix-dangling)]
     ==
-    
     ::
       %1
     %_  $
@@ -125,7 +135,55 @@
       ==
     ==
   ==
-  ::  discard publish edits 
+  ::
+  ++  convert-notifications-3
+    |=  old=notifications:state-two:store
+    %+  gas:orm  *notifications:store
+    ^-  (list [@da timebox:store])
+    %+  murn  
+      (tap:orm:state-two:store old)
+    |=  [time=@da =timebox:state-two:store]
+    ^-  (unit [@da timebox:store])
+    =/  new-timebox=timebox:store
+      (convert-timebox-3 timebox)
+    ?:  =(0 ~(wyt by new-timebox))
+      ~ 
+    `[time new-timebox]
+  ::
+  ++  convert-timebox-3
+    |=  =timebox:state-two:store
+    ^-  timebox:store
+    %-  ~(gas by *timebox:store)
+    ^-  (list [index:store notification:store])
+    %+  murn
+      ~(tap by timebox)
+    |=  [=index:store =notification:state-two:store]
+    ^-  (unit [index:store notification:store])
+    =/  new-notification=(unit notification:store)
+      (convert-notification-3 notification)
+    ?~  new-notification  ~
+    `[index u.new-notification]
+  ::
+  ++  convert-notification-3
+    |=  =notification:state-two:store
+    ^-  (unit notification:store)
+    ?:  ?=(%graph -.contents.notification)
+      `notification
+    =/  con=(list group-contents:store)
+      (convert-group-contents-3 list.contents.notification)
+    ?:  =(~ con)  ~
+    =,  notification
+    `[date read %group con]
+  ::
+  ++  convert-group-contents-3
+    |=  con=(list group-contents:state-two:store)
+    ^-  (list group-contents:store)
+    %+  murn  con
+    |=  =group-contents:state-two:store
+    ^-  (unit group-contents:store)
+    ?.  ?=(?(%add-members %remove-members) -.group-contents)  ~
+    `group-contents
+  ::
   ++  uni-by
     |=  [a=(set index:graph-store) b=(set index:graph-store)]
     =/  merged
@@ -149,13 +207,13 @@
   ::
   ++  convert-notifications-1
     |=  old=notifications:state-zero:store
-    %+  gas:orm  *notifications:store
-    ^-  (list [@da timebox:store])
+    %+  gas:orm:state-two:store  *notifications:state-two:store
+    ^-  (list [@da timebox:state-two:store])
     %+  murn  
       (tap:orm:state-zero:store old)
     |=  [time=@da =timebox:state-zero:store]
-    ^-  (unit [@da timebox:store])
-    =/  new-timebox=timebox:store
+    ^-  (unit [@da timebox:state-two:store])
+    =/  new-timebox=timebox:state-two:store
       (convert-timebox-1 timebox)
     ?:  =(0 ~(wyt by new-timebox))
       ~ 
@@ -163,21 +221,20 @@
   ::
   ++  convert-timebox-1
     |=  =timebox:state-zero:store
-    ^-  timebox:store
-    %-  ~(gas by *timebox:store)
-    ^-  (list [index:store notification:store])
+    ^-  timebox:state-two:store
+    %-  ~(gas by *timebox:state-two:store)
+    ^-  (list [index:store notification:state-two:store])
     %+  murn
       ~(tap by timebox)
     |=  [=index:state-zero:store =notification:state-zero:store]
-    ^-  (unit [index:store notification:store])
+    ^-  (unit [index:store notification:state-two:store])
     =/  new-index=(unit index:store)
       (convert-index-1 index)
-    =/  new-notification=(unit notification:store)
+    =/  new-notification=(unit notification:state-two:store)
       (convert-notification-1 notification)
     ?~  new-index  ~
     ?~  new-notification  ~
     `[u.new-index u.new-notification]
-
   ::
   ++  convert-index-1
     |=  =index:state-zero:store 
@@ -192,7 +249,7 @@
   ::
   ++  convert-notification-1
     |=  =notification:state-zero:store
-    ^-  (unit notification:store)
+    ^-  (unit notification:state-two:store)
     ?:  ?=(%chat -.contents.notification)
       ~
     `notification
@@ -682,7 +739,7 @@
   ==
 ::
 ++  inflate-cache
-  |=  state-3
+  |=  state-4
   ^+  +.state
   =/  nots=(list [p=@da =timebox:store])
     (tap:orm notifications)

--- a/pkg/arvo/app/metadata-hook.hoon
+++ b/pkg/arvo/app/metadata-hook.hoon
@@ -18,11 +18,11 @@
 ::
 +$  state-zero
   $:  %0
-      synced=(map group-path ship)
+      synced=(map path ship)
   ==
 +$   state-one
   $:  %1
-      synced=(map group-path ship)
+      synced=(map path ship)
   ==
 +$   state-two
   [%2 ~]
@@ -39,8 +39,6 @@
 ++  on-save   !>(state)
 ++  on-load
   |=  =vase
-  ?:  =(1 1)
-    `this
   =+  !<(old=versioned-state vase)
   |^
   ?:  ?=(%2 -.old)

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -255,7 +255,10 @@
     |=  m=md-resource-1
     ^-  (unit md-resource:store)
     %+  bind  (de-path-soft:resource path.m)
-    |=(rid=resource [app-name.m rid])
+    |=  rid=resource
+    :_  rid
+    ?:  =(%contacts app-name.m)   %groups
+    app-name.m
   ::
   ++  metadata-1-to-2
     |=  m=metadata-1

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -25,6 +25,13 @@
         [%chat chat=path mention=?]
     ==
   ::
+  +$  group-contents
+    $~  [%add-members *resource ~]
+    $%  [%add *]
+        [%remove *]  :: old metadata actions
+        $>(?(%add-members %remove-members) update:group-store)
+    ==
+  ::
   +$  contents
     $%  [%graph =(list post:post)]
         [%group =(list group-contents)]
@@ -42,11 +49,45 @@
         unreads-each=(jug index index:graph-store)
         unreads-count=(map index @ud)
         last-seen=(map index @da)
+        =notifications:state-two
+        archive=notifications:state-two
+        current-timebox=@da
+        dnd=_|
+    ==
+  --
+++  state-two
+  =<  state
+  |% 
+  +$  state
+    $:  unreads-each=(jug stats-index index:graph-store)
+        unreads-count=(map stats-index @ud)
+        last-seen=(map stats-index @da)
         =notifications
         archive=notifications
         current-timebox=@da
         dnd=_|
     ==
+  ::
+  ++  orm
+    ((ordered-map @da timebox) gth)
+  ::
+  +$  notification
+    [date=@da read=? =contents]
+  ::
+  +$  contents
+    $%  [%graph =(list post:post)]
+        [%group =(list group-contents)]
+    ==
+  ::
+  +$  group-contents
+    group-contents:state-zero
+  ::
+  +$  timebox
+    (map index notification)
+  ::
+  +$  notifications
+    ((mop @da timebox) gth)
+  ::
   --
 ::
 +$  index


### PR DESCRIPTION
- Addresses metadata-hook crash
- Discards the unused `metadata-update` portion of `group-contents` in hark, to allow vases to nest properly.

This branch OTAs fine onto a `-L` copy of ~hastuc-dibtux