### PR TITLE
hark-store: crash on invalid note read

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -448,6 +448,7 @@
         &(=(read read.u.not) !?=(?(%read-note %unread-note) -.in))
       ~&  >>  "Inconsistent hark cache, rebuilding"
       rebuild-cache
+    ?<  &(=(read read.u.not) ?=(?(%read-note %unread-note) -.in))
     =.  u.tib
       (~(put by u.tib) index u.not(read read))
     =.  notifications


### PR DESCRIPTION
Two %read-note actions set on the same notification could cause the
cache to become invalid. Instead, crash if we read a note that is
already read.

Fixes https://github.com/urbit/landscape/issues/276