### PR TITLE
VirtualScroller: performance improvements

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -50,7 +50,7 @@ interface ChatMessageProps {
   highlighted?: boolean;
 }
 
-export default class ChatMessage extends Component<ChatMessageProps> {
+export default class ChatMessage extends PureComponent<ChatMessageProps> {
   private divRef: React.RefObject<HTMLDivElement>;
 
   constructor(props) {


### PR DESCRIPTION
curry and memoize the measure function, to prevent needless rerenders.
Mark ChatMessage as a PureComponent, to capitalize on prop equality.
Bind the onScroll handler in didMount so we can mark it as passive,
easing render times.

This causes a local copy of this branch (i.e. development, no optimisations etc.) to be about as fast, if not faster than the current mainnet production build. 
cc: @tylershuster have I done anything stupid?