### PR TITLE
contact-store: prevent hook forwarding loop

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -137,6 +137,9 @@
       ++  edit-contact
         |=  [=contact:store edit=edit-field:store]
         ^-  contact:store
+        ::  ensure difference
+        =;  new=contact:store
+          ?<(=(contact new) new)
         ?-  -.edit
           %nickname  contact(nickname nickname.edit)
           %bio       contact(bio bio.edit)

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -111,6 +111,11 @@
     ++  handle-add
       |=  [=ship =contact:store]
       ^-  (quip card _state)
+      ::  ensure difference
+      =/  old=(unit contact:store)  (~(get by rolodex) ship)
+      ?>  ?|  ?=(~ old)
+              !=(contact(last-updated *@da) u.old(last-updated *@da))
+          ==
       =.  last-updated.contact  now.bowl
       :-  (send-diff [%add ship contact] =(ship our.bowl))
       state(rolodex (~(put by rolodex) ship contact))

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -113,9 +113,10 @@
       ^-  (quip card _state)
       ::  ensure difference
       =/  old=(unit contact:store)  (~(get by rolodex) ship)
-      ?>  ?|  ?=(~ old)
+      ?.  ?|  ?=(~ old)
               !=(contact(last-updated *@da) u.old(last-updated *@da))
           ==
+        [~ state]
       =.  last-updated.contact  now.bowl
       :-  (send-diff [%add ship contact] =(ship our.bowl))
       state(rolodex (~(put by rolodex) ship contact))
@@ -123,7 +124,8 @@
     ++  handle-remove
       |=  =ship
       ^-  (quip card _state)
-      ?>  (~(has by rolodex) ship)
+      ?.  (~(has by rolodex) ship)
+        [~ state]
       :-  (send-diff [%remove ship] =(ship our.bowl))
       ?:  =(ship our.bowl)
         state(rolodex (~(put by rolodex) our.bowl *contact:store))
@@ -133,8 +135,10 @@
       |=  [=ship =edit-field:store]
       |^
       ^-  (quip card _state)
-      =/  contact  (~(got by rolodex) ship)
-      =.  contact  (edit-contact contact edit-field)
+      =/  old  (~(got by rolodex) ship)
+      =/  contact  (edit-contact old edit-field)
+      ?:  =(old contact)
+        [~ state]
       =.  last-updated.contact  now.bowl
       :-  (send-diff [%edit ship edit-field] =(ship our.bowl))
       state(rolodex (~(put by rolodex) ship contact))
@@ -142,9 +146,6 @@
       ++  edit-contact
         |=  [=contact:store edit=edit-field:store]
         ^-  contact:store
-        ::  ensure difference
-        =;  new=contact:store
-          ?<(=(contact new) new)
         ?-  -.edit
           %nickname  contact(nickname nickname.edit)
           %bio       contact(bio bio.edit)


### PR DESCRIPTION
This is a possible fix for the forwarding loop problem. I'm unsure what the best way to address this is. Maybe a `+validate-update` arm in the pull-hook? 

The forwarding loop occurs like so.

1 host subscribes to a members profile.
2 member subscribe to the groups contact information.
3 member updates their profile, causing a fact to be sent to their push-hook
4 this causes the host to receive the same fact, which they then forward onto the groups contact subscription.
5 the member then receives the fact on the groups subscription, which goes to the store and then the push hook
6 GOTO 4