### PR TITLE
metadata: prevent automatic pinning during migration

### DIFF
--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -181,6 +181,8 @@
   =/  rid=resource
     (de-path:resource t.path)
   =/  prev=(unit group-preview:metadata)
+    ?^  (peek-metadatum:met %groups rid)  
+      (some (get-preview:met rid))
     (~(get by previews) rid)
   :_  this
   ?~  prev

--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -42,32 +42,13 @@
   =+  !<(=hook-update:store vase)
   ?.  ?=(%req-preview -.hook-update)
     (on-poke:def mark vase)
-  =*  rid  group.hook-update
-  |^
-  ?>  =(entity.rid our.bowl)
-  ?>  (can-join:grp rid src.bowl)
-  =/  members
-    ~(wyt in (members:grp rid))
-  =/  =metadatum:store
-    %-  need
-    %+  mate  (peek-metadatum:met %groups rid)
-    (peek-metadatum:met %graph rid)
+  ?>  =(entity.group.hook-update our.bowl)
+  =/  =group-preview:store
+    (get-preview:met group.hook-update)
   :_  this
-  =;  =cage
-    [%pass / %agent [src.bowl %metadata-pull-hook] %poke cage]~
-  :-  %metadata-hook-update
-  !>  ^-  hook-update:store
-  [%preview rid channels members channel-count metadatum]
-  ::
-  ++  channels
-    %-  ~(gas by *associations:store)
-    %+  skim  ~(tap by (app-metadata-for-group:met rid %graph))
-    |=([=md-resource:store group=resource =metadatum:store] preview.metadatum)
-  ::   
-  ++  channel-count
-    ~(wyt by (app-metadata-for-group:met rid %graph))
-  --
-
+  =-  [%pass / %agent [src.bowl %metadata-pull-hook] %poke -]~
+  metadata-hook-update+!>(`hook-update:store`[%preview group-preview])
+::
 ++  on-agent  on-agent:def
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -269,6 +269,7 @@
       date-created  date-created.m
       creator       creator.m
       module        module.m
+      preview       %.n
     ==
   ::
   ++  rebuild-resource-indices

--- a/pkg/arvo/lib/metadata.hoon
+++ b/pkg/arvo/lib/metadata.hoon
@@ -1,9 +1,33 @@
 ::  metadata: helpers for getting data from the metadata-store
 ::
 /-  store=metadata-store
-/+  resource
+/+  resource, grpl=group
 ::
 |_  =bowl:gall
++*  grp  ~(. grpl bowl)
+::
+++  get-preview
+  |=  rid=resource
+  |^  ^-  group-preview:store
+  ?>  (can-join:grp rid src.bowl)
+  =/  members
+    ~(wyt in (members:grp rid))
+  =/  =metadatum:store
+    %-  need
+    %+  mate  (peek-metadatum %groups rid)
+    (peek-metadatum %graph rid)
+  [rid channels members channel-count metadatum]
+  ::
+  ++  channels
+    %-  ~(gas by *associations:store)
+    %+  scag  5  
+    %+  skim  ~(tap by (app-metadata-for-group rid %graph))
+    |=([=md-resource:store group=resource =metadatum:store] preview.metadatum)
+  ::   
+  ++  channel-count
+    ~(wyt by (app-metadata-for-group rid %graph))
+  --
+::
 ++  resource-for-update
   |=  =vase
   ^-  (list resource)


### PR DESCRIPTION
Prevents channels automatically becoming pinned during migration
Also moves the preview generation logic into `lib/metadata.hoon` and generates it directly on the pull-hook side, if we already have it. 