### PR TITLE
contact-hooks: prevent infinite hook loop

### DIFF
--- a/pkg/arvo/app/contact-push-hook.hoon
+++ b/pkg/arvo/app/contact-push-hook.hoon
@@ -46,6 +46,7 @@
   =/  =share  !<(share vase)
   :_  this  :_  ~
   ?:  =(our.bowl src.bowl)
+    ?<  =(ship.share our.bowl)
     ::  proxy poke
     %+  poke:pass:io  [ship.share dap.bowl]
     contact-share+!>([%share our.bowl])

--- a/pkg/interface/src/views/apps/chat/components/ShareProfile.js
+++ b/pkg/interface/src/views/apps/chat/components/ShareProfile.js
@@ -101,7 +101,9 @@ export const ShareProfile = (props) => {
     } else if (!group.hidden) {
       const [,,ship,name] = groupPath.split('/');
       await api.contacts.allowGroup(ship,name);
-      await api.contacts.share(ship);
+      if(ship !== `~${window.ship}`) {
+        await api.contacts.share(ship);
+      }
       setShowBanner(false);
     }
   };


### PR DESCRIPTION
- Prevents infinite loop in proxy a %share action
- Does not send a %share if we are the recipient
