### PR TITLE
groups, settings, contacts: make them compile and run scries properly

### DIFF
--- a/pkg/arvo/app/contact-push-hook.hoon
+++ b/pkg/arvo/app/contact-push-hook.hoon
@@ -32,10 +32,14 @@
 ::
 ++  on-init
   ^-  (quip card _this)
-  :_  this  :_  ~
-  =-  [%pass /us %agent [our.bowl %contact-push-hook] %poke %push-hook-action -]
-  !>  ^-  action:push-hook
-  [%add [our.bowl %'']]
+  :_  this
+  :-  %+  poke-our:pass:io  %contact-push-hook
+      :-  %push-hook-action
+      !>(`action:push-hook`[%add [our.bowl %'']])
+  %+  murn  ~(tap in scry-groups:grp)
+  |=  rid=res
+  ?.  =(our.bowl entity.rid)  ~
+  `(poke-self:pass:io push-hook-action+!>([%add rid]))
 ::
 ++  on-save   !>(~)
 ++  on-load   on-load:def

--- a/pkg/arvo/app/settings-store.hoon
+++ b/pkg/arvo/app/settings-store.hoon
@@ -33,7 +33,7 @@
     ?-  -.old
         %0  
       :_  this(state old)
-      =-  [%pass / %agent [our dap]:bowl %poke -]~
+      =-  [%pass / %agent [our dap]:bol %poke -]~
       settings-event+!>([%put-entry %tutorial %seen b+%|])
     ==
   ::

--- a/pkg/arvo/lib/group.hoon
+++ b/pkg/arvo/lib/group.hoon
@@ -43,7 +43,7 @@
     (scot %p our.bowl)
     %group-store
     (scot %da now.bowl)
-    /groups/noun
+    /groups
   ==
 ::
 ++  members


### PR DESCRIPTION
settings-store didn’t compile, and contact-pull-hook scry would fail every time because it was written wrong.