### PR TITLE
metadata-pull-hook: keep track of pending requests

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -3,7 +3,7 @@
 :: data store that holds individual contact data
 ::
 /-  store=contact-store, *resource
-/+  default-agent, dbug, *migrate, contact
+/+  default-agent, dbug, *migrate, contact, verb
 |%
 +$  card  card:agent:gall
 +$  state-4
@@ -25,6 +25,7 @@
 =|  state-4
 =*  state  -
 %-  agent:dbug
+%+  verb  |
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .

--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -195,10 +195,10 @@
   =+  !<(=hook-update:metadata vase)
   ?.  ?=(%preview -.hook-update)
     (on-poke:def mark vase)
-  =.  previews
-    (~(put by previews) group.hook-update +.hook-update)
-  =.  pending
-    (~(del in pending) group.hook-update)
+  =:  pending   (~(del in pending) group.hook-update)
+        previews
+      (~(put by previews) group.hook-update +.hook-update)
+    ==
   :_  this
   =/  =path
     preview+(en-path:resource group.hook-update)

--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -215,8 +215,10 @@
         [%preview @ @ @ ~]
       ?.  ?=(%poke-ack -.sign)
         (on-agent:def:hc wire sign)
-      :_  state
-      ?~  p.sign  ~
+      ?~  p.sign  `state
+      =/  rid
+        (de-path:resource t.wire)
+      :_  state(pending (~(del in pending) rid))
       (fact-kick:io wire tang+!>(u.p.sign))
     ==
   [cards this]


### PR DESCRIPTION
Backstop the overflow of requests that is occurring on livenet right now because of the slow OTA processing time. 