### PR TITLE
landscape: ignore punctuation tokenizing URLs

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -1,6 +1,6 @@
 import urbitOb from 'urbit-ob';
 
-const URL_REGEX = new RegExp(String(/^((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)/.source));
+const URL_REGEX = new RegExp(String(/^((\w+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)/.source));
 
 const isUrl = (string) => {
   try {


### PR DESCRIPTION
Tiny fix to the URL regex so that it doesn't store punctuation marks (e.g. ",") inside the urls, breaking the links.