### PR TITLE
contact-store: enforce timestamp ordering on %initial

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -104,17 +104,18 @@
       |=  [rolo=rolodex:store is-public=?]
       ^-  (quip card _state)
       =/  our-contact  (~(got by rolodex) our.bowl)
-      ::
       =/  diff-rolo=rolodex:store
         %-  ~(gas by *rolodex:store)
         %+  skim  ~(tap in rolo)
         |=  [=ship =contact:store]
         ?~  local-con=(~(get by rolodex) ship)  %.y
         (gth last-updated.contact last-updated.u.local-con)
-      =.  rolodex  (~(uni by rolodex) diff-rolo)
-      =.  rolodex  (~(put by rolodex) our.bowl our-contact)
-      :_  state(rolodex rolodex)
-      (send-diff [%initial rolodex is-public] %.n)
+      =/  new-rolo=rolodex:store
+        (~(uni by rolodex) diff-rolo)
+      =.  new-rolo  (~(put by new-rolo) our.bowl our-contact)
+      ?:  =(new-rolo rolodex)  `state
+      :_  state(rolodex new-rolo)
+      (send-diff [%initial new-rolo is-public] %.n)
     ::
     ++  handle-add
       |=  [=ship =contact:store]

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -104,7 +104,14 @@
       |=  [rolo=rolodex:store is-public=?]
       ^-  (quip card _state)
       =/  our-contact  (~(got by rolodex) our.bowl)
-      =.  rolodex  (~(uni by rolodex) rolo)
+      ::
+      =/  diff-rolo=rolodex:store
+        %-  ~(gas by *rolodex:store)
+        %+  skim  ~(tap in rolo)
+        |=  [=ship =contact:store]
+        ?~  local-con=(~(get by rolodex) ship)  %.y
+        (gth last-updated.contact last-updated.u.local-con)
+      =.  rolodex  (~(uni by rolodex) diff-rolo)
       =.  rolodex  (~(put by rolodex) our.bowl our-contact)
       :_  state(rolodex rolodex)
       (send-diff [%initial rolodex is-public] %.n)


### PR DESCRIPTION
Will stop flickering due to an excess of `%kick`s but does nothing for the network load causing the kicks in the first place. 