### PR TITLE
landscape: various fixes for breakage from OTA

### DIFF
--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -221,7 +221,6 @@
     (node-to-indexed-post node)
   =/  =permission-level:store
     (get-permission permissions is-admin writers)
-  ~&  permission-level
   ?-  permission-level
       %yes  %.y
       %no   %.n
@@ -238,7 +237,7 @@
   |=  [=resource:res indices=(set index:store)]
   ^-  ?
   %-  (bond |.(%.n))
-  %+  biff  (get-roles-writers-variation)
+  %+  biff  (get-roles-writers-variation resource)
   |=  [is-admin=? writers=(set ship) vip=vip-metadata:metadata]
   %-  some  
   %+  levy  ~(tap by indices)

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -42,7 +42,7 @@
   |^
   ?.  =(mark %sane)
     (on-poke:def mark vase)
-  [sane this]
+  [(sane !<(?(%check %fix) vase)) this]
   ::
   ++  scry-sharing
     .^  (set resource)
@@ -54,7 +54,12 @@
     ==
   ::
   ++  sane
+    |=  input=?(%check %fix)
     ^-  (list card)
+    =;  cards=(list card)
+      ?:  =(%check input)
+        ~&(cards ~)
+      cards
     %+  murn
       ~(tap in scry-sharing)
     |=  rid=resource
@@ -67,7 +72,7 @@
     =/  subs=(set ship)
       (get-subscribers-for-group rid)
     =/  to-remove=(set ship)
-      (~(dif in members.group) subs)
+      (~(dif in members.group) (~(gas in subs) our.bowl ~))
     ?~  to-remove  ~
     `(poke-store %remove-members rid to-remove)
   ::

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -30,7 +30,7 @@
 ::
 ::
 /-  *group
-/+  store=group-store, default-agent, verb, dbug, resource, *migrate
+/+  store=group-store, default-agent, verb, dbug, resource, *migrate, agentio
 |%
 +$  card  card:agent:gall
 ::
@@ -111,6 +111,8 @@
     ?>  (team:title our.bowl src.bowl)
     =^  cards  state
       ?+    mark  (on-poke:def mark vase)
+        %sane  (poke-sane:gc !<(?(%check %fix) vase))
+      ::
           ?(%group-update %group-action)
         (poke-group-update:gc !<(update:store vase))
       ::
@@ -189,6 +191,7 @@
   --
 ::
 |_  bol=bowl:gall
++*  io  ~(. agentio bol)
 ++  peek-group
   |=  rid=resource
   ^-  (unit group)
@@ -212,6 +215,27 @@
       (~(has in banned.policy) ship)
       (~(has in ban-ranks.policy) (clan:title ship))
     ==
+  ==
+++  poke-sane
+  |=  input=?(%check %fix)
+  ^-  (quip card _state)
+  =;  cards=(list card)
+    ?:  =(%check input)
+      ~&  cards
+      `state
+    [cards state]
+  %+  roll  ~(tap in ~(key by groups))
+  |=  [rid=resource out=(list card)]
+  ?.  ?&  =(entity.rid our.bol)
+          !(~(has in members:(~(got by groups) rid)) our.bol)
+      ==
+    out
+  =/  =wire
+    sane+(en-path:resource rid)
+  =*  poke-self  ~(poke-self pass:io wire)
+  %+  weld  out
+  :~  (poke-self group-update+!>([%add-members rid (silt our.bol ~)]))
+      (poke-self group-update+!>([%add-tag rid %admin (silt our.bol ~)]))
   ==
 ::
 ++  poke-import

--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -661,8 +661,7 @@
         unreads-each    (~(run by unreads-each) _~)      
         notifications  (~(run by notifications) _~)
       ==
-    =>  rebuild-cache
-    seen
+    (give:seen:rebuild-cache %read-all ~)
   ::
   ++  set-dnd
     |=  d=?

--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -64,7 +64,7 @@
   =/  role=(unit (unit role-tag))
     (role-for-ship:grp group.update src.bowl)
   =/  =metadatum:store
-    (need (peek-metadatum:met %contacts group.update))
+    (need (peek-metadatum:met %groups group.update))
   ?~  role  %.n
   ?^  u.role  
     ?=(?(%admin %moderator) u.u.role)

--- a/pkg/arvo/gen/metadata-store/remove.hoon
+++ b/pkg/arvo/gen/metadata-store/remove.hoon
@@ -9,12 +9,12 @@
 ::  and looking for the entry with an app-path that is similar to the
 ::  title of the channel
 ::  
-/-  *metadata-store
+/-  metadata=metadata-store
 /+  resource
 :-  %say
 |=  $:  [now=@da eny=@uvJ =beak]
-        [[group=term app=term =path ~] ~]
+        [[group=term app=term rid=resource ~] ~]
     ==
 :-  %metadata-action
-^-  metadata-action
-[%remove (en-path:resource [p.beak group]) app path]
+^-  action:metadata
+[%remove [p.beak group] app rid]

--- a/pkg/arvo/ted/sane.hoon
+++ b/pkg/arvo/ted/sane.hoon
@@ -3,15 +3,16 @@
 =>  
 |%
 ++  strand  strand:spider
++$  input  ?(%fix %check)
 ::
 ++  supported-apps
   ^-  (list term)
-  :~  %graph-pull-hook
-      %group-pull-hook
-      %group-push-hook
+  :~  %group-push-hook
+      %group-store
   ==
 ::
 ++  poke-all-sane
+  |=  =input
   =/  m  (strand ,~)
   ^-  form:m
   =/  apps  supported-apps
@@ -19,13 +20,14 @@
   ?~  apps
     (pure:m ~)
   =*  app  i.apps
-  ;<  ~   bind:m  (poke-our app sane+!>(%sane))
+  ;<  ~   bind:m  (poke-our app sane+!>(input))
   loop(apps t.apps)
 --
 ::
 ^-  thread:spider
-|=  vase
+|=  vas=vase
 =/  m  (strand ,vase)
-;<  ~  bind:m  poke-all-sane 
-;<  ~  bind:m  (poke-our %sane noun+!>(%fix))
+=+  !<([~ in=input] vas)
+;<  ~  bind:m  (poke-all-sane in)
+;<  ~  bind:m  (poke-our %sane noun+!>(in))
 (pure:m !>("Done"))

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -112,6 +112,14 @@ function reduce(data: any, state: HarkState) {
   unreadEach(data, state);
   seenIndex(data, state);
   removeGraph(data, state);
+  readAll(data, state);
+}
+
+function readAll(json: any, state: HarkState) {
+  const data = _.get(json, 'read-all');
+  if(data) { 
+    clearState(state);
+  }
 }
 
 function removeGraph(json: any, state: HarkState) {

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -78,7 +78,7 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps) {
         };
 
         const resource = resourceFromPath(group);
-        writers = _.compact(writers);
+        writers = _.compact(writers).map(s => `~${s}`);
         const us = `~${window.ship}`;
         if(values.writePerms === 'self') {
           await api.groups.addTag(resource, tag, [us]);

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -42,9 +42,9 @@ export function SidebarListHeader(props: {
   );
 
   const groupPath = getGroupFromWorkspace(props.workspace);
-  const role = props.groups?.[groupPath] ? roleForShip(props.groups[groupPath], window.ship) : undefined;
+  const role = groupPath && props.groups?.[groupPath] ? roleForShip(props.groups[groupPath], window.ship) : undefined;
   const memberMetadata =
-    groupPath ? props.associations.contacts?.[groupPath].metadata.vip === 'member-metadata' : false;
+    groupPath ? props.associations.groups?.[groupPath].metadata.vip === 'member-metadata' : false;
 
   const isAdmin = memberMetadata || (role === "admin") || (props.workspace?.type === 'home') || (props.workspace?.type === "messages");
 

--- a/pkg/interface/src/views/landscape/index.tsx
+++ b/pkg/interface/src/views/landscape/index.tsx
@@ -117,6 +117,7 @@ export default class Landscape extends Component<LandscapeProps, {}> {
                 <Body>
                   <Box maxWidth="300px">
                     <NewGroup
+                      associations={props.associations}
                       groups={props.groups}
                       contacts={props.contacts}
                       api={props.api}


### PR DESCRIPTION
hark-store: give %read-all fact

Fixes urbit/landscape#402

metadata-push-hook: correct association key

Fixes urbit/landscape#405

SidebarListHeader: look in %groups not %contacts assocs

Fixes urbit/landscape#405

AddGroup: fix activation from leap

Fixes urbit/landscape#439

metadata-store: update +remove

Fixes urbit/landscape#428

graph-push-hook: correctly call +get-roles-writers-variation

Fixes urbit/landscape#423
Fixes urbit/landscape#424

sane: fix accidental self kick

Does not remove ourselves from the group when run. Additionally adds
card preview support to the inside app pokes.

Fixes urbit/landscape#442
