### PR TITLE
LinkWindow: add missing 'text' import

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkWindow.tsx
+++ b/pkg/interface/src/views/apps/links/LinkWindow.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback, useEffect, useMemo } from "react";
-import { Col } from "@tlon/indigo-react";
+import { Col, Text } from "@tlon/indigo-react";
 import bigInt from 'big-integer';
 import {
   Association,


### PR DESCRIPTION
We were missing the "Text" import in LinkWindow so collections that don't allow us to post would crash on render, unless we already had the graph, in which case it would function fine.

Fixes urbit/landscape#433