### PR TITLE
chat: render all code output, not just first line

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/content/code.js
+++ b/pkg/interface/src/views/apps/chat/components/content/code.js
@@ -23,7 +23,7 @@ export default class CodeContent extends Component {
           style={{ whiteSpace: 'pre' }}
           backgroundColor='washedGray'
         >
-          {content.code.output[0].join('\n')}
+          {content.code.output.join('\n')}
         </Text>
       ) : null;
 


### PR DESCRIPTION
Fixes an unfiled bug where Landscape was only rendering the first line of code message output. This has likely been at large since the graph-store migration in December.

Code output is now an array of messages, not an array within an array's `[0]`:

<img width="454" alt="image" src="https://user-images.githubusercontent.com/20846414/108118754-cfcc8c80-706c-11eb-969e-07f32b861133.png">

We were looking for `code.output[0]`, thus we only rendered line 1 of the Dojo response.