### PR TITLE
gall: fixes to %boon handling

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ee4e9394edf0d6e16586f5c8a26d716aaa85435fc0cfba3cc4470315282dab4
-size 8723705
+oid sha256:c2a0dcf375880feafb317ad440bbf042ba2e4c7d15ad97e37b7b98197b7c7488
+size 8787841

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9433e0a7f1edbdcc6c8ac3e70c9516061d35218e5a1dc3192b2189dfb28cdc88
-size 9539470
+oid sha256:7ee4e9394edf0d6e16586f5c8a26d716aaa85435fc0cfba3cc4470315282dab4
+size 8723705

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1909,6 +1909,9 @@
       =/  =bone  bone.shut-packet
       ::
       ?:  ?=(%& -.meat.shut-packet)
+        =+  ?~  dud  ~
+            %.  ~
+            (slog leaf+"ames: crashed on fragment" >mote.u.dud< tang.u.dud)
         (run-message-sink bone %hear lane shut-packet ?=(~ dud))
       ::  Just try again on error, printing trace
       ::
@@ -1917,7 +1920,7 @@
       ::
       =+  ?~  dud  ~
           %.  ~
-          (slog leaf+"ames: crashed on message ack" >mote.u.dud< tang.u.dud)
+          (slog leaf+"ames: crashed on ack" >mote.u.dud< tang.u.dud)
       (run-message-pump bone %hear [message-num +.meat]:shut-packet)
     ::  +on-memo: handle request to send message
     ::
@@ -2203,12 +2206,15 @@
         ?.  ?=([%hear * * ok=%.n] task)
           ::  fresh boon; give message to client vane
           ::
-          %-  (trace msg.veb |.("boon {<her.channel^bone=bone -.task>}"))
+          %-  %+  trace  msg.veb
+              =/  dat  [her.channel bone=bone message-num=message-num -.task]
+              |.("sink boon {<dat>}")
           peer-core
         ::  we previously crashed on this message; notify client vane
         ::
         %-  %+  trace  msg.veb
-            |.("crashed on boon {<her.channel^bone=bone -.task>}")
+            =/  dat  [her.channel bone=bone message-num=message-num -.task]
+            |.("crashed on sink boon {<dat>}")
         boon-to-lost
       ::  +boon-to-lost: convert all boons to losts
       ::
@@ -2226,7 +2232,9 @@
       ++  on-sink-nack-trace
         |=  [=message-num message=*]
         ^+  peer-core
-        %-  (trace msg.veb |.("nack trace {<her.channel^bone=bone>}"))
+        %-  %+  trace  msg.veb
+            =/  dat  [her.channel bone=bone message-num=message-num]
+            |.("sink naxplanation {<dat>}")
         ::
         =+  ;;  =naxplanation  message
         ::  ack nack-trace message (only applied if we don't later crash)
@@ -2243,7 +2251,9 @@
       ++  on-sink-plea
         |=  [=message-num message=*]
         ^+  peer-core
-        %-  (trace msg.veb |.("plea {<her.channel^bone=bone>}"))
+        %-  %+  trace  msg.veb
+            =/  dat  [her.channel bone=bone message-num=message-num]
+            |.("sink plea {<dat>}")
         ::  is this the first time we're trying to process this message?
         ::
         ?.  ?=([%hear * * ok=%.n] task)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1911,7 +1911,9 @@
       ?:  ?=(%& -.meat.shut-packet)
         =+  ?~  dud  ~
             %.  ~
-            (slog leaf+"ames: crashed on fragment" >mote.u.dud< tang.u.dud)
+            %+  slog
+              leaf+"ames: {<her.channel>} fragment crashed {<mote.u.dud>}"
+            ?.(msg.veb ~ tang.u.dud)
         (run-message-sink bone %hear lane shut-packet ?=(~ dud))
       ::  Just try again on error, printing trace
       ::
@@ -1920,7 +1922,8 @@
       ::
       =+  ?~  dud  ~
           %.  ~
-          (slog leaf+"ames: crashed on ack" >mote.u.dud< tang.u.dud)
+          %+  slog  leaf+"ames: {<her.channel>} ack crashed {<mote.u.dud>}"
+          ?.(msg.veb ~ tang.u.dud)
       (run-message-pump bone %hear [message-num +.meat]:shut-packet)
     ::  +on-memo: handle request to send message
     ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -3810,7 +3810,8 @@
       ::  virtualize to catch and produce deterministic failures
       ::
       !.
-      =-  ?:(?=(%& -<) p.- ((slog p.-) [[~ ~] fod]))
+      =-  ?:  ?=(%& -<)  p.-
+          ((slog leaf+"gall: read-at-aeon fail {<mun>}" p.-) [[~ ~] fod])
       %-  mule  |.
       ?-  care.mun
           %d

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -939,15 +939,13 @@
       =/  sky  (rof ~ %cb [our %home case] /[mark.ames-response])
       ?-    sky
           ?(~ [~ ~])
-        =/  ror  "gall: ames mark fail {<mark.ames-response>}"
-        (mo-give %done `vale+[leaf+ror]~)
+        (mean leaf+"gall: ames mark fail {<mark.ames-response>}" ~)
       ::
           [~ ~ *]
         =+  !<(=dais:clay q.u.u.sky)
         =/  res  (mule |.((vale:dais noun.ames-response)))
         ?:  ?=(%| -.res)
-          =/  ror  "gall: ames vale fail {<mark.deal>}"
-          (mo-give %done `vale+[leaf+ror p.res])
+          (mean leaf+"gall: ames vale fail {<mark.ames-response>}" p.res)
         =.  mo-core
           %+  mo-pass  /nowhere
           [%c %warp our %home ~ %sing %b case /[mark.ames-response]]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -680,12 +680,9 @@
       ::  note this should only happen on reverse bones, so only facts
       ::  and kicks
       ::
-      =/  sys-wire  [%sys wire]
       ::  TODO: %drip %kick so app crash can't kill the remote %pull
       ::
-      =/  =ames-request-all  [%0 %u ~]
-      =.  mo-core
-        (mo-pass sys-wire %a %plea ship %g /ge/[foreign-agent] ames-request-all)
+      =.  mo-core  (mo-send-foreign-request ship foreign-agent %leave ~)
       =.  mo-core  (mo-give %unto %kick ~)
       mo-core
     ==


### PR DESCRIPTION
When receiving a `%lost` from Ames, Gall was sending a `%u` message to leave the subscription.  However, Gall wasn't calling the normal routine for this, so it wasn't adding the leave request to its request queue -- this was causing the request queue to become desynchronized, which at least partially contributed to the repeating "2nd watch ack" printfs.

This fix does not recover from a broken queue (at least not on my ship), but it should prevent a working queue from desynchronizing.  I'm not yet sure how we should try to recover from this condition, but it might be good to get this onto the network ASAP to prevent more ships from entering the error condition.

EDIT:
The first commit only fixed one of a few problems going on simultaneously.  https://github.com/urbit/urbit/pull/4454/commits/d317a0847b88e209b5c0e29dfb791aabf33b3889 fixed another one: Gall had been trying to %give a %done to Ames if it was unable to process a %boon from Ames.  This was the wrong thing to do, because Ames clients should not ack %boon's, and because Gall's attempt at acking actually delivered the %done back to itself, causing a later crash in wire parsing.  Now Gall crashes deliberately, Ames prints the stack trace, and then Gall (mostly) correctly enqueues a %leave to Ames in response.

This PR does not fix a serious underlying issue in Gall's handling of %boon's and %done's from Ames.  Gall does not properly handle acks to outgoing sequences of repeating %leave and %watch moves over Ames, leading to the "2nd-watch-ack" error message and potentially to more serious inconsistencies.

The solution to this problem is out of scope for this PR, but it will probably involve having Gall assign a nonce to each %watch message, which it will send to the publisher Gall, who will include the nonce in all %fact and %kick messages while that instance of the subscription is active.  When the client resubscribes, it will send a %watch with a new nonce.  This will allow the subscriber to ignore responses (%done's, %fact's, and %kick's) on an already-defunct nonce and prevent queue desynchronization.