### PR TITLE
import/export: fixup

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -79,12 +79,15 @@
   ^-  (quip card _this)
   ?>  (team:title our.bowl src.bowl)
   |^
-  =^  cards  state
-    ?+  mark  (on-poke:def mark vase)
-      %contact-update  (update !<(update:store vase))
-      %import          (import q.vase)
-    ==
-  [cards this]
+  ?+  mark  (on-poke:def mark vase)
+      %contact-update
+    =^  cards  state
+      (update !<(update:store vase))
+    [cards this]
+  ::
+      %import
+    (on-load !>(;;(versioned-state q.vase)))
+  ==
   ::
   ++  update
     |=  =update:store
@@ -205,12 +208,6 @@
         [/updates /all ~]
       [%give %fact paths %contact-update !>(update)]~
     --
-  ::
-  ++  import
-    |=  arc=*
-    ^-  (quip card _state)
-    ::  note: we are purposefully wiping all state before state-4
-    [~ *state-4]
   --
 ::
 ++  on-peek
@@ -246,6 +243,9 @@
       [(slav %p i.t.t.path) i.t.t.t.path]
     =/  =ship  (slav %p i.t.t.t.t.path)
     ``json+!>(`json`b+(is-allowed:con resource ship))
+  ::
+      [%x %export ~]
+    ``noun+!>(state)
   ==
 ::
 ++  on-leave  on-leave:def

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -1,5 +1,5 @@
-/-  lens, *sole
-/+  *server, default-agent
+/-  lens, *sole, *archive
+/+  *server, default-agent, *archive
 /=  lens-mark  /mar/lens/command  ::  TODO: ask clay to build a $tube
 =,  format
 |%
@@ -9,29 +9,13 @@
   $%  [%json =json]
       [%mime =mime]
   ==
+::
 +$  state
   $%  $:  %0
           job=(unit [eyre-id=@ta com=command:lens])
       ==
   ==
 ::
-++  export-app
-  |=  [app=@tas our=@p now=@da]
-  .^(* %gx /(scot %p our)/[app]/(scot %da now)/export/noun)
-++  export-all
-  |=  [our=@p now=@da]
-  ^-  (list [@tas *])
-  %+  turn
-    ^-  (list @tas)
-    :~  %group-store
-        %metadata-store
-        %contact-store
-        %contact-hook
-        %invite-store
-        %graph-store
-    ==
-  |=  app=@tas
-  [app (export-app app our now)]
 --
 ::
 =|  =state
@@ -48,6 +32,7 @@
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card:agent:gall _this)
+  |^
   ::
   ?:  &(?=(%noun mark) ?=(%cancel q.vase))
     ~&  %lens-cancel
@@ -64,13 +49,17 @@
   =/  body=@t  q:(need body.request.inbound-request)
   ?:  =('#import_' (end [3 8] body))
     ~&  %import-all
-    =/  by-app  ;;((list [@tas *]) (cue (rsh [3 8] body)))
+    =/  arc=archive-0  (refine-archive (cue (rsh [3 8] body)))
     :_  this
     %+  weld  (give-simple-payload:app eyre-id not-found:gen)
-    %+  turn  by-app
-    |=  [app=@tas data=*]
-    ^-  card:agent:gall
-    [%pass /import-all %agent [our.bowl app] %poke %import !>(data)]
+    :~  (poke-import group-store.arc)
+        (poke-import metadata-store.arc)
+        (poke-import contact-store.arc)
+        (poke-import invite-store.arc)
+        (poke-import graph-store.arc)
+        (poke-import settings-store.arc)
+    ==
+  ::
   =/  jon=json
     (need (de-json:html body))
   =/  com=command:lens
@@ -80,23 +69,13 @@
     :_  this(job.state (some [eyre-id com]))
     [%pass /sole %agent [our.bowl %dojo] %watch /sole/[eyre-id]]~
   ::
-      %export
-    :_  this(job.state (some [eyre-id com]))
-    [%pass /export %agent [our.bowl app.source.com] %watch /export]~
-  ::
-      %import
-    ?~  enc=(de:base64:mimes:html base64-jam.source.com)
-      !!
-    ::
-    =/  c=*  (cue q.u.enc)
-    ::
-    :_  this(job.state (some [eyre-id com]))
-    [%pass /import %agent [our.bowl app.source.com] %poke %import !>(c)]~
+      %export  !!
+      %import  !!
   ::
       %export-all
     =/  output  (crip "{<our.bowl>}-export/atom")
     =/  jon
-      =/  =atom  (jam (export-all our.bowl now.bowl))
+      =/  =atom  (jam (jam (export-all our.bowl now.bowl)))
       =/  =octs  [(met 3 atom) atom]
       =/  enc    (en:base64:mimes:html octs)
       (pairs:enjs:format file+s+output data+s+enc ~)
@@ -108,14 +87,24 @@
     ~&  %import-all
     =/  enc  (de:base64:mimes:html base64-jam.source.com)
     ?~  enc  !!
-    =/  by-app  ;;((list [@tas *]) (cue q.u.enc))
+    =/  jam-arc  (lsh [3 1] q.u.enc)
+    =/  arc=archive-0  (refine-archive (cue ;;(@ (cue jam-arc))))
     :_  this
     %+  weld  (give-simple-payload:app eyre-id not-found:gen)
-    %+  turn  by-app
+    :~  (poke-import group-store.arc)
+        (poke-import metadata-store.arc)
+        (poke-import contact-store.arc)
+        (poke-import invite-store.arc)
+        (poke-import graph-store.arc)
+        (poke-import settings-store.arc)
+    ==
+  ==
+  ::
+  ++  poke-import
     |=  [app=@tas data=*]
     ^-  card:agent:gall
     [%pass /import-all %agent [our.bowl app] %poke %import !>(data)]
-  ==
+  --
 ::
 ++  on-watch
   |=  =path

--- a/pkg/arvo/app/settings-store.hoon
+++ b/pkg/arvo/app/settings-store.hoon
@@ -40,17 +40,21 @@
     |=  [mar=mark vas=vase]
     ^-  (quip card _this)
     ?>  (team:title our.bol src.bol)
-    ?.  ?=(%settings-event mar)
-      (on-poke:def mar vas)
-    =/  evt=event  !<(event vas)
-    =^  cards  state
-      ?-  -.evt
-        %put-bucket  (put-bucket:do key.evt bucket.evt)
-        %del-bucket  (del-bucket:do key.evt)
-        %put-entry   (put-entry:do buc.evt key.evt val.evt)
-        %del-entry   (del-entry:do buc.evt key.evt)
-      ==
-    [cards this]
+    ?+  mar  (on-poke:def mar vas)
+        %import
+      (on-load !>(;;(versioned-state q.vas)))
+    ::
+        %settings-event
+      =/  evt=event  !<(event vas)
+      =^  cards  state
+        ?-  -.evt
+          %put-bucket  (put-bucket:do key.evt bucket.evt)
+          %del-bucket  (del-bucket:do key.evt)
+          %put-entry   (put-entry:do buc.evt key.evt val.evt)
+          %del-entry   (del-entry:do buc.evt key.evt)
+        ==
+      [cards this]
+    ==
   ::
   ++  on-watch
     |=  pax=path
@@ -93,6 +97,9 @@
       =/  entry=(unit val)  (~(get by bucket) key)
       ?~  entry  [~ ~]
       ``settings-data+!>(entry+u.entry)
+    ::
+        [%x %export ~]
+      ``noun+!>(state)
     ==
   ::
   ++  on-agent  on-agent:def

--- a/pkg/arvo/lib/archive.hoon
+++ b/pkg/arvo/lib/archive.hoon
@@ -1,0 +1,49 @@
+/-  *archive
+|%
+::
+++  export-app
+  |=  [app=@tas our=@p now=@da]
+  .^(* %gx /(scot %p our)/[app]/(scot %da now)/export/noun)
+::
+++  export-all
+  |=  [our=@p now=@da]
+  ^-  archive-0
+  :*  %0
+      group-store+(export-app %group-store our now)
+      metadata-store+(export-app %metadata-store our now)
+      contact-store+(export-app %contact-store our now)
+      invite-store+(export-app %invite-store our now)
+      graph-store+(export-app %graph-store our now)
+      settings-store+(export-app %settings-store our now)
+  ==
+::
+::  +refine-archive: type raw noun as an archive, and migrate it to the latest
+::                   archive version
+::
+++  refine-archive
+  |=  arc-raw=*
+  ^-  archive-0
+  |^
+  ?@  -.arc-raw
+    =/  arc  ;;(versioned-archive arc-raw)
+    (migrate arc)
+  =/  arc  ;;(pre-versioned-archive arc-raw)
+  =/  new-arc=versioned-archive
+    :*  %0
+        group-store.arc
+        metadata-store.arc
+        contact-store.arc
+        invite-store.arc
+        graph-store.arc
+        [%settings-store %0 ~]
+    ==
+  (migrate new-arc)
+  ::
+  ++  migrate
+    |=  arc=versioned-archive
+    ^-  archive-0
+    ?-  -.arc
+      %0  arc
+    ==
+  --
+--

--- a/pkg/arvo/sur/archive.hoon
+++ b/pkg/arvo/sur/archive.hoon
@@ -1,0 +1,25 @@
+|%
++$  pre-versioned-archive
+  $:  group-store=[%group-store *]
+      metadata-store=[%metadata-store *]
+      contact-store=[%contact-store *]
+      contact-hook=[%contact-hook *]
+      invite-store=[%invite-store *]
+      graph-store=[%graph-store *]
+      ~
+  ==
+::
++$  archive-0
+  $:  %0
+      group-store=[%group-store *]
+      metadata-store=[%metadata-store *]
+      contact-store=[%contact-store *]
+      invite-store=[%invite-store *]
+      graph-store=[%graph-store *]
+      settings-store=[%settings-store *]
+  ==
+::
++$  versioned-archive
+  $%  archive-0
+  ==
+--


### PR DESCRIPTION
- Fixes issues with the herb pathway for import/export:
  - makes it interoperable with the vere version by double jamming like vere already does
  - adds a trailing null byte that would get trimmed in the conversion to base64
- Adds a versioning scheme for archives
- Adds import/export for settings-store

Still todo: make sure contact-store, group-store, and metadata-store set up subscriptions properly.

Made this as a draft PR mainly because I'd like feedback on whether the versioning scheme seems sane.