### PR TITLE
contact-store: upon %edit of a nonexistent contact, make an empty contact and set that field

### DIFF
--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -101,7 +101,7 @@
     ==
     ::
     ++  handle-initial
-      |=  [rolo=rolodex:store is-public=?]
+      |=  [rolo=rolodex:store *]
       ^-  (quip card _state)
       =/  our-contact  (~(got by rolodex) our.bowl)
       =/  diff-rolo=rolodex:store

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -143,7 +143,7 @@
       |=  [=ship =edit-field:store timestamp=@da]
       |^
       ^-  (quip card _state)
-      =/  old  (~(got by rolodex) ship)
+      =/  old  (fall (~(get by rolodex) ship) *contact:store)
       ?:  (lte timestamp last-updated.old)
         [~ state]
       =/  contact  (edit-contact old edit-field)


### PR DESCRIPTION
Resolves crash condition and sets the information using what we have.

Also fixes https://github.com/urbit/landscape/issues/408