### PR TITLE
chat: only show avatars if we have them

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -233,6 +233,10 @@ export const MessageWithSigil = (props) => {
   const stamp = moment.unix(msg['time-sent'] / 1000);
   const contact = `~${msg.author}` in contacts ? contacts[`~${msg.author}`] : false;
   const showNickname = useShowNickname(contact);
+  const { hideAvatars } =
+    useLocalState(({ hideAvatars }) =>
+      ({ hideAvatars })
+    );
   const shipName = showNickname ? contact.nickname : cite(msg.author);
   const copyNotice = 'Copied';
   const color = contact
@@ -268,8 +272,7 @@ export const MessageWithSigil = (props) => {
     return () => clearTimeout(timer);
   }, [displayName]);
 
-  const img =
-    contact && contact.avatar !== null ? (
+  const img = contact?.avatar && !hideAvatars ? (
       <BaseImage
         display='inline-block'
         src={contact.avatar}

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -117,6 +117,7 @@ export function Omnibox(props: OmniboxProps) {
     props.toggle();
     if (defaultApps.includes(app.toLowerCase())
         || app === 'profile'
+        || app === 'messages'
         || app === 'Links'
         || app === 'Terminal'
         || app === 'home'

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -8,6 +8,7 @@ import { HoverBoxLink } from '~/views/components/HoverBox';
 import { Sigil } from '~/logic/lib/sigil';
 import { getModuleIcon, getItemTitle, uxToHex } from '~/logic/lib/util';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
+import useLocalState from '~/logic/state/local';
 import { TUTORIAL_HOST, TUTORIAL_GROUP } from '~/logic/lib/tutorialModal';
 import { SidebarAppConfigs, SidebarItemStatus } from './types';
 import { Workspace } from '~/types/workspace';
@@ -55,6 +56,9 @@ export function SidebarItem(props: {
     return null;
   }
   const DM = (isUnmanaged && props.workspace?.type === 'messages');
+  const { hideAvatars, hideNicknames } = useLocalState(({ hideAvatars, hideNicknames }) => ({
+    hideAvatars, hideNicknames
+  }));
   const itemStatus = app.getStatus(path);
   const hasUnread = itemStatus === 'unread' || itemStatus === 'mention';
 
@@ -81,12 +85,12 @@ export function SidebarItem(props: {
   let img = null;
 
   if (urbitOb.isValidPatp(title)) {
-    if (props.contacts?.[title] && props.contacts[title].avatar) {
+    if (props.contacts?.[title]?.avatar && !hideAvatars) {
       img = <BaseImage src={props.contacts[title].avatar} width='16px' height='16px' borderRadius={2} />;
     } else {
       img = <Sigil ship={title} color={`#${uxToHex(props.contacts?.[title]?.color || '0x0')}`} icon padding={2} size={16} />;
     }
-    if (props.contacts?.[title] && props.contacts[title].nickname) {
+    if (props.contacts?.[title]?.nickname && !hideNicknames) {
       title = props.contacts[title].nickname;
     }
   } else {


### PR DESCRIPTION
Also respects CalmEngine, as (unfiled) we weren't checking `hideAvatars` before rendering inside chat messages.

Fixes urbit/landscape#315