### PR TITLE
metadata: do not generate previews for hidden groups

### DIFF
--- a/pkg/arvo/lib/metadata.hoon
+++ b/pkg/arvo/lib/metadata.hoon
@@ -13,9 +13,7 @@
   =/  members
     ~(wyt in (members:grp rid))
   =/  =metadatum:store
-    %-  need
-    %+  mate  (peek-metadatum %groups rid)
-    (peek-metadatum %graph rid)
+    (need (peek-metadatum %groups rid))
   [rid channels members channel-count metadatum]
   ::
   ++  channels


### PR DESCRIPTION
Fixes an issues where groups that were originally hidden but got groupified will be unable to be joined. We no longer render previews for hidden groups anyway, so just discard. 
cc: @yosoyubik 