### PR TITLE
chatMessage: pass history to overlays

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -227,6 +227,7 @@ export const MessageAuthor = ({
   associations,
   groups,
   scrollWindow,
+  history,
   ...rest
 }) => {
   const dark = useLocalState((state) => state.dark);


### PR DESCRIPTION
Fixes unfiled bug where window.History was passed instead of react-router's history, so profile overlay redirects didn't work on development stream.