### PR TITLE
ci: fix test harness output, report build failures

### DIFF
--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -106,11 +106,18 @@
 ++  on-peek   on-peek:def
 ++  on-agent  on-agent:def
 ++  on-arvo
+  =>  |%
+      ++  report
+        |*  [=path ok=?]
+        =/  =tank  leaf+"{?:(ok "built " "FAILED")}  {(spud path)}"
+        ~>(%slog.[0 tank] same)
+      --
+  ::
   |=  [=wire =sign-arvo]
   ^-  [(list card) _this]
-  ?.  ?=([%build *] wire)
-    (on-arvo:def wire sign-arvo)
-  ?.  ?=(%writ +<.sign-arvo)
+  ?.  ?&  ?=([%build *] wire)
+          ?=([%clay %writ *] sign-arvo)
+      ==
     (on-arvo:def wire sign-arvo)
   =/  =path  t.wire
   ?+    path  ~|(path+path !!)
@@ -118,41 +125,29 @@
     =/  ok
       ?~  p.sign-arvo  |
       (~(nest ut -:!>(*agent:gall)) | -:!<(vase q.r.u.p.sign-arvo))
-    ~&  ?:  ok
-          agent-built+path
-        agent-failed+path
+    %-  (report path ok)
     =?  app-ok.state  !ok  %.n
     =.  app.state  (~(del in app.state) path)
     ~?  =(~ app.state)
-      ?:  app-ok.state
-        %all-agents-built
-      %some-agents-failed
+      ?:(app-ok.state %all-agents-built %some-agents-failed)
     [~ this]
   ::
       [%mar *]
     =/  ok  ?=(^ p.sign-arvo)
-    ~&  ?:  ok
-          mark-built+path
-        mark-failed+path
+    %-  (report path ok)
     =?  mar-ok.state  !ok  %.n
     =.  mar.state  (~(del in mar.state) path)
     ~?  =(~ mar.state)
-      ?:  mar-ok.state
-        %all-marks-built
-      %some-marks-failed
+      ?:(mar-ok.state %all-marks-built %some-marks-failed)
     [~ this]
   ::
       [%gen *]
     =/  ok  ?=(^ p.sign-arvo)
-    ~&  ?:  ok
-          generator-built+path
-        generator-failed+path
+    %-  (report path ok)
     =?  gen-ok.state  !ok  %.n
     =.  gen.state  (~(del in gen.state) path)
     ~?  =(~ gen.state)
-      ?:  gen-ok.state
-        %all-generators-built
-      %some-generators-failed
+      ?:(gen-ok.state %all-generators-built %some-generators-failed)
     [~ this]
   ==
 ++  on-fail   on-fail:def

--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -40,7 +40,7 @@
     =.  mar-ok.state  %.y
     =+  .^(paz=(list path) ct+(en-beam now-beak /mar))
     |-  ^+  [fex this]
-    ?~  paz  [fex this]
+    ?~  paz  [(flop fex) this]
     =/  xap=path  (flop i.paz)
     ?.  ?=([%hoon *] xap)
       $(paz t.paz)
@@ -63,7 +63,7 @@
     ?>  =(~ app.state)
     =.  app-ok.state  %.y
     =+  .^(app-arch=arch cy+(en-beam now-beak /app))
-    =/  daz  ~(tap in ~(key by dir.app-arch))
+    =/  daz  (sort ~(tap in ~(key by dir.app-arch)) |=((pair) !(aor p q)))
     |-  ^+  [fex this]
     ?~  daz  [fex this]
     =/  dap-pax=path  /app/[i.daz]/hoon
@@ -86,7 +86,7 @@
     =.  gen-ok.state  %.y
     =+  .^(paz=(list path) ct+(en-beam now-beak /gen))
     |-  ^+  [fex this]
-    ?~  paz  [fex this]
+    ?~  paz  [(flop fex) this]
     =/  xap=path  (flop i.paz)
     ?.  ?=([%hoon *] xap)
       $(paz t.paz)

--- a/pkg/arvo/gen/tally.hoon
+++ b/pkg/arvo/gen/tally.hoon
@@ -59,10 +59,10 @@
     %~  tap   by
     %+  scry  associations:md
     [%x %metadata-store [%group (snoc (en-path:re r) %noun)]]
-  |=  [[* m=md-resource:md] metadata:md]
+  |=  [m=md-resource:md association:md]
   ::NOTE  we only count graphs for now
-  ?.  &(=(%graph app-name.m) =(our creator))  ~
-  `[module (de-path:re app-path.m)]
+  ?.  &(=(%graph app-name.m) =(our creator.metadatum))  ~
+  `[module.metadatum resource.m]
 ::  count activity per channel
 ::
 =/  activity=(list [resource:re members=@ud (list [resource:re mod=term week=@ud authors=@ud])])

--- a/pkg/arvo/lib/strandio.hoon
+++ b/pkg/arvo/lib/strandio.hoon
@@ -442,19 +442,19 @@
   ;<  ~  bind:m  (send-request (hiss-to-request:html hiss))
   take-maybe-sigh
 ::
-::  +build-fail: build the source file at the specified $beam
+::  +build-file: build the source file at the specified $beam
 ::
 ++  build-file
   |=  [[=ship =desk =case] =spur]
   =*  arg  +<
-  =/  m  (strand ,vase)
+  =/  m  (strand ,(unit vase))
   ^-  form:m
   ;<  =riot:clay  bind:m
     (warp ship desk ~ %sing %a case spur)
   ?~  riot
-    (strand-fail %build-file >arg< ~)
+    (pure:m ~)
   ?>  =(%vase p.r.u.riot)
-  (pure:m !<(vase q.r.u.riot))
+  (pure:m (some !<(vase q.r.u.riot)))
 ::  +build-mark: build a mark definition to a $dais
 ::
 ++  build-mark

--- a/pkg/arvo/ted/build-file.hoon
+++ b/pkg/arvo/ted/build-file.hoon
@@ -6,6 +6,9 @@
 =/  m  (strand ,vase)
 ^-  form:m
 =+  !<([~ pax=path] arg)
-?^  bem=(de-beam pax)
-  (build-file:strandio u.bem)
-(strand-fail:strand %path-not-beam >pax< ~)
+?~  bem=(de-beam pax)
+  (strand-fail:strand %path-not-beam >pax< ~)
+;<  vax=(unit vase)  bind:m  (build-file:strandio u.bem)
+?^  vax
+  (pure:m u.vax)
+(strand-fail:strand %build-file >u.bem< ~)

--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -92,8 +92,12 @@
       ?.  =(%hoon (rear p))  ~
       (some [[-.i.bez p] ~])
     loop(bez t.bez, fiz (~(gas in fiz) foz))
-  ~|  bad-test-beam+i.bez
-  =/  tex=term  =-(?>(((sane %tas) -) -) (rear s.i.bez))
+  ::
+  ::  XX this logic appears to be vestigial
+  ::
+  =/  tex=term
+    ~|  bad-test-beam+i.bez
+    =-(?>(((sane %tas) -) -) (rear s.i.bez))
   =/  xup=path  (snip s.i.bez)
   ;<  hov=?  bind:m  (check-for-file:strandio i.bez(s (snoc xup %hoon)))
   ?.  hov
@@ -107,16 +111,23 @@
 =/  paz=(list path)
   (tail !<([~ (list path)] arg))
 =/  bez=(list beam)
-  (turn paz |=(p=path (need (de-beam p))))
+  (turn paz |=(p=path ~|([%test-not-beam p] (need (de-beam p)))))
 ;<  fiz=(set [=beam test=(unit term)])  bind:m  (find-test-files bez)
 =>  .(fiz (sort ~(tap in fiz) aor))
 =|  test-arms=(map path (list test-arm))
+=|  build-ok=?
 |-  ^-  form:m
 =*  gather-tests  $
 ?^  fiz
-  ~>  %slog.0^leaf+"test: building {(spud s.beam.i.fiz)}"
-  ;<  cor=vase  bind:m  (build-file:strandio beam.i.fiz)
-  =/  arms=(list test-arm)  (get-test-arms cor)
+  ;<  cor=(unit vase)  bind:m  (build-file:strandio beam.i.fiz)
+  ?~  cor
+    ~>  %slog.0^leaf+"FAILED  {(spud s.beam.i.fiz)} (build)"
+    gather-tests(fiz t.fiz, build-ok |)
+  ~>  %slog.0^leaf+"built   {(spud s.beam.i.fiz)}"
+  =/  arms=(list test-arm)  (get-test-arms u.cor)
+  ::
+  ::  XX this logic appears to be vestigial
+  ::
   =?  arms  ?=(^ test.i.fiz)
     |-  ^+  arms
     ?~  arms  ~|(no-test-arm+i.fiz !!)
@@ -127,7 +138,7 @@
   gather-tests(fiz t.fiz)
 %-  pure:m  !>  ^=  ok
 %+  roll  (resolve-test-paths test-arms)
-|=  [[=path =test-func] ok=_`?`%&]
+|=  [[=path =test-func] ok=_build-ok]
 ^+  ok
 =/  res  (run-test path test-func)
 %-  (slog (flop tang.res))

--- a/pkg/arvo/tests/lib/pkcs.hoon
+++ b/pkg/arvo/tests/lib/pkcs.hoon
@@ -327,7 +327,7 @@
     :: echo "hello" | openssl dgst -sha256 -sign private.pem | base64
     %+  expect-eq
       !>  exp2b64
-      !>  (en:base64 (met 3 sig) (swp 3 sig))
+      !>  (en:base64:mimes:html (met 3 sig) (swp 3 sig))
   ==
 ::
 ++  test-csr


### PR DESCRIPTION
This fixes #3598 (or at least all known causes -- the whole herb/lens/test harness is still pretty fragile). It also fixes a couple current build/test failures. I'm targeting master to fix CI quickly and broadly.