### PR TITLE
chat: correctly position mentions

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -448,7 +448,7 @@ export const Message = ({
               const first = (i) => (i === 0);
               return (
                 <Mention
-                  marginLeft={first(i) ? "-4px" : "0"}
+                  first={first(i)}
                   group={group}
                   scrollWindow={scrollWindow}
                   ship={content.mention}

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -445,8 +445,10 @@ export const Message = ({
                 </Box>
               );
             case 'mention':
+              const first = (i) => (i === 0);
               return (
                 <Mention
+                  marginLeft={first(i) ? "-4px" : "0"}
                   group={group}
                   scrollWindow={scrollWindow}
                   ship={content.mention}

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -38,8 +38,9 @@ export function Mention(props: {
   group: Group;
   scrollWindow?: HTMLElement;
   ship: string;
+  first?: Boolean;
 }) {
-  const { contacts, ship, scrollWindow, ...rest } = props;
+  const { contacts, ship, scrollWindow, first, ...rest } = props;
   let { contact } = props;
   contact = contact?.color ? contact : contacts?.[ship];
   const history = useHistory();
@@ -56,7 +57,8 @@ export function Mention(props: {
     <Box position='relative' display='inline-block' cursor='pointer' {...rest}>
       <Text
         onClick={() => toggleOverlay()}
-        mx={1}
+        marginLeft={first? 0 : 1}
+        marginRight={1}
         px={1}
         bg='washedBlue'
         color='blue'

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -39,7 +39,7 @@ export function Mention(props: {
   scrollWindow?: HTMLElement;
   ship: string;
 }) {
-  const { contacts, ship, scrollWindow } = props;
+  const { contacts, ship, scrollWindow, ...rest } = props;
   let { contact } = props;
   contact = contact?.color ? contact : contacts?.[ship];
   const history = useHistory();
@@ -53,7 +53,7 @@ export function Mention(props: {
   }, [showOverlay]);
 
   return (
-    <Box position='relative' display='inline-block' cursor='pointer'>
+    <Box position='relative' display='inline-block' cursor='pointer' {...rest}>
       <Text
         onClick={() => toggleOverlay()}
         mx={1}


### PR DESCRIPTION
Horizontally aligns a mention in a chat message if it is the first thing in the message; adds a margin if it is inline with surrounding text.

Fixes urbit/landscape#468