### PR TITLE
notifications: fix negative unread count

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -279,7 +279,6 @@
     %+  turn
       ~(tap by unreads-count)
     |=  [=stats-index:store count=@ud]
-    ?>  ?=(%graph -.stats-index)
     :*  stats-index
         ~(wyt in (~(gut by by-index) stats-index ~))
         [%count count]
@@ -297,10 +296,27 @@
         (~(gut by last-seen) stats-index *time)
     ==
   ::
+  ++  give-group-unreads
+    ^-  (list [stats-index:store stats:store])
+    %+  murn  ~(tap by by-index)
+    |=  [=stats-index:store nots=(set [time index:store])]
+    ?.  ?=(%group -.stats-index)
+      ~
+    :-  ~
+    :*  stats-index
+        ~(wyt in nots)
+        [%count 0]
+        *time
+    ==
+  ::
   ++  give-unreads
     ^-  update:store
     :-  %unreads
-    (weld give-each-unreads give-since-unreads)
+    ;:  weld 
+      give-each-unreads 
+      give-since-unreads
+      give-group-unreads
+    ==
   --
 ::
 ++  on-peek   

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -235,8 +235,8 @@ function updateNotificationStats(state: HarkState, index: NotifIndex, statField:
       const curr = _.get(state.unreads.graph, [index.graph.graph, index.graph.index, statField], 0);
       _.set(state.unreads.graph, [index.graph.graph, index.graph.index, statField], f(curr));
     } else if('group' in index) {
-      const curr = _.get(state.unreads.group, [index.group.group, statField], 0);
-      _.set(state.unreads.group, [index.group.group, statField], f(curr));
+      const curr = _.get(state.unreads.group, [index.group, statField], 0);
+      _.set(state.unreads.group, [index.group, statField], f(curr));
     }
 }
 


### PR DESCRIPTION
notifications: reduce group stats properly

hark-store: give stats facts for group notifications

Group notifications were being left out of the initial %unreads fact,
which was causing faulty calculation of notification counts  on the
frontend

Fixes urbit/landscape#276
