### PR TITLE
zuse: time conversion fixes

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2a0dcf375880feafb317ad440bbf042ba2e4c7d15ad97e37b7b98197b7c7488
-size 8787841
+oid sha256:65ad594ab389394b97fcd8bb58f25b88ec283c4142983858c1a2c3b01e14215c
+size 8841004

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3368,16 +3368,10 @@
       (poq (wit jon))
     ::                                                  ::  ++di:dejs:format
     ++  di                                              ::  millisecond date
-      %+  cu
-        |=  a=@u  ^-  @da
-        (from-unix-ms:chrono:userlib a)
-      ni
+      (cu from-unix-ms:chrono:userlib ni)
     ::                                                  ::  ++du:dejs:format
     ++  du                                              ::  second date
-      %+  cu
-        |=  a=@u  ^-  @da
-        (from-unix:chrono:userlib a)
-      ni
+      (cu from-unix:chrono:userlib ni)
     ::                                                  ::  ++mu:dejs:format
     ++  mu                                              ::  true unit
       |*  wit=fist
@@ -3587,10 +3581,7 @@
       (bind (stud:chrono:userlib p.jon) |=(a=date (year a)))
     ::
     ++  di                                              ::  millisecond date
-      %+  cu
-        |=  a=@u  ^-  @da
-        (from-unix-ms:chrono:userlib a)
-      ni
+      (cu from-unix-ms:chrono:userlib ni)
     ::
     ++  mu                                              ::  true unit
       |*  wit=fist

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3297,11 +3297,14 @@
       %-  flop
       |-  ^-  ^tape
       ?:(=(0 a) ~ [(add '0' (mod a 10)) $(a (div a 10))])
+    ::                                                  ::  ++sect:enjs:format
+    ++  sect                                            ::  s timestamp
+      |=  a=^time
+      (numb (unt:chrono:userlib a))
     ::                                                  ::  ++time:enjs:format
     ++  time                                            ::  ms timestamp
       |=  a=^time
-      =-  (numb (div (mul - 1.000) ~s1))
-      (add (div ~s1 2.000) (sub a ~1970.1.1))
+      (numb (unm:chrono:userlib a))
     ::                                                  ::  ++path:enjs:format
     ++  path                                            ::  string from path
       |=  a=^path
@@ -3367,7 +3370,13 @@
     ++  di                                              ::  millisecond date
       %+  cu
         |=  a=@u  ^-  @da
-        (add ~1970.1.1 (div (mul ~s1 a) 1.000))
+        (from-unix-ms:chrono:userlib a)
+      ni
+    ::                                                  ::  ++du:dejs:format
+    ++  du                                              ::  second date
+      %+  cu
+        |=  a=@u  ^-  @da
+        (from-unix:chrono:userlib a)
       ni
     ::                                                  ::  ++mu:dejs:format
     ++  mu                                              ::  true unit
@@ -3580,7 +3589,7 @@
     ++  di                                              ::  millisecond date
       %+  cu
         |=  a=@u  ^-  @da
-        (add ~1970.1.1 (div (mul ~s1 a) 1.000))
+        (from-unix-ms:chrono:userlib a)
       ni
     ::
     ++  mu                                              ::  true unit
@@ -5408,13 +5417,20 @@
     ::                                                  ::::
   ++  chrono  ^?
     |%
-    ::  +from-unix: unix timestamp to @da
+    ::  +from-unix: unix seconds to @da
     ::
     ++  from-unix
       |=  timestamp=@ud
       ^-  @da
       %+  add  ~1970.1.1
       (mul timestamp ~s1)
+    ::  +from-unix-ms: unix milliseconds to @da
+    ::
+    ++  from-unix-ms
+      |=  timestamp=@ud
+      ^-  @da
+      %+  add  ~1970.1.1
+      (div (mul ~s1 timestamp) 1.000)
     ::                                                  ::  ++dawn:chrono:
     ++  dawn                                            ::  Jan 1 weekday
       |=  yer=@ud
@@ -5533,9 +5549,13 @@
       ++  dd                                            ::  two digits
         (bass 10 (stun 2^2 dit))
       --  ::
+    ::                                                  ::  ++unm:chrono:userlib
+    ++  unm                                             ::  Urbit to Unix ms
+      |=  a=@da
+      (div (mul (sub a ~1970.1.1) 1.000) ~s1)
     ::                                                  ::  ++unt:chrono:userlib
     ++  unt                                             ::  Urbit to Unix time
-      |=  a=@
+      |=  a=@da
       (div (sub a ~1970.1.1) ~s1)
     ::                                                  ::  ++yu:chrono:userlib
     ++  yu                                              ::  UTC format constants

--- a/pkg/arvo/tests/sys/zuse/format.hoon
+++ b/pkg/arvo/tests/sys/zuse/format.hoon
@@ -170,11 +170,15 @@
     %+  expect-eq
       !>  [%o (molt props)]
       !>  (pairs props)
+    ::  sect - stored as integer number of seconds since the unix epoch
+    %+  expect-eq
+      !>  [%n '1']
+      !>  (sect ~1970.1.1..0.0.1)
     ::  time - stored as integer number of milliseconds since the unix epoch
     ::
     %+  expect-eq
-      !>   [%n '1000']
-      !>   (time ~1970.1.1..0.0.1)
+      !>  [%n '1000']
+      !>  (time ~1970.1.1..0.0.1)
     :: ship - store ship identity as a string
     ::
     %+  expect-eq


### PR DESCRIPTION
State before: in `chrono:userlib`, there were second-resolution
`@da`-to-unix and unix-to-`@da` functions. In `en`/`dejs:format`, there were
millisecond-resolution `@da`-to-unix and unix-to-`@da` functions. The
`@da`-to-unix path in `time:enjs` confusingly rounded to the nearest
millisecond, meaning millisecond *n* was a label for [*n*-0.5, *n*+0.5) rather
than [*n*, *n*+1).

This adds a millisecond-resolution `@da`-to-unix and unix-to-`@da` to
`chrono:userlib`, and a second-resolution conversion to `en`/`dejs:format`.
It makes use of the `chrono:userlib` functions in `en`/`dejs`, and doesn't do
any rounding.

Backwards-incompatible changes:

- made `unt:chrono:userlib` take `@da` rather than `@`.