### PR TITLE
ShipSearch: update for flattened contacts

### DIFF
--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -48,16 +48,16 @@ const getNicknameForShips = (groups: Groups, contacts: Rolodex): readonly [strin
       }
     }
 
-    const groupContacts = contacts[path];
+    const groupContacts = contacts;
 
     if (groupContacts) {
       const groupEntries = group.members.values();
       for (const member of groupEntries) {
-        if (groupContacts[member]) {
+        if (groupContacts[`~${member}`]) {
           if (nicknames.has(member)) {
-            nicknames.get(member)?.push(groupContacts[member].nickname);
+            nicknames.get(member)?.push(groupContacts[`~${member}`].nickname);
           } else {
-            nicknames.set(member, [groupContacts[member].nickname]);
+            nicknames.set(member, [groupContacts[`~${member}`].nickname]);
           }
         }
       }


### PR DESCRIPTION
Fixes an unfiled bug where we didn't show nicknames in ShipSearch after the contact-store rewrite, since contacts aren't grouped anymore.