### PR TITLE
chat: correctly pad daybreak divider

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -189,7 +189,6 @@ export default class ChatMessage extends Component<ChatMessageProps> {
         ref={this.divRef}
         pt={renderSigil ? 2 : 0}
         pb={isLastMessage ? 4 : 2}
-        pr={5}
         className={containerClass}
         style={style}
       >
@@ -199,10 +198,10 @@ export default class ChatMessage extends Component<ChatMessageProps> {
         {renderSigil ? (
           <>
             <MessageAuthor pb={'2px'} {...messageProps} />
-            <Message pl={5} pr={3} {...messageProps} />
+            <Message pl={5} pr={4} {...messageProps} />
           </>
         ) : (
-          <Message pl={5} pr={3} timestampHover {...messageProps} />
+          <Message pl={5} pr={4} timestampHover {...messageProps} />
         )}
         <Box style={unreadContainerStyle}>
           {isLastRead ? (


### PR DESCRIPTION
Pads the message content itself, not the daybreak or unread dividers.

![image](https://user-images.githubusercontent.com/748181/108891212-76b8a780-75dc-11eb-9fa8-21acf417cf87.png)

Fixes urbit/landscape#475.