### PR TITLE
landscape: bring placeholder group joins to parity

### DIFF
--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -71,20 +71,15 @@ export function GroupLink(
         pr="2"
         onClick={showModal}
         cursor='pointer'
+        opacity={preview ? '1' : '0.6'}
       >
-        {preview ? (
-          <>
-            <MetadataIcon height={6} width={6} metadata={preview.metadata} />
-            <Col>
-            <Text ml="2" fontWeight="medium">
-              {preview.metadata.title}
-            </Text>
-            <Text pt='1' ml='2'>{preview.members} members</Text>
-            </Col>
-          </>
-        ) : (
-          <Text mono>{name}</Text>
-        )}
+        <MetadataIcon height={6} width={6} metadata={preview ? preview.metadata : {"color": "0x0"}} />
+          <Col>
+          <Text ml="2" fontWeight="medium" mono={!preview}>
+            {preview ? preview.metadata.title : name}
+          </Text>
+          <Text pt='1' ml='2'>{preview ? preview.members : "Unknown"} members</Text>
+        </Col>
       </Row>
     </Box>
   );

--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -78,7 +78,7 @@ export function GroupLink(
           <Text ml="2" fontWeight="medium" mono={!preview}>
             {preview ? preview.metadata.title : name}
           </Text>
-          <Text pt='1' ml='2'>{preview ? preview.members : "Unknown"} members</Text>
+          <Text pt='1' ml='2'>{preview ? `${preview.members} members` : "Fetching member count"}</Text>
         </Col>
       </Row>
     </Box>

--- a/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
+++ b/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
@@ -15,7 +15,7 @@ export function MetadataIcon(props: MetadataIconProps) {
   const bgColor = metadata.picture ? {} : { bg: `#${uxToHex(metadata.color)}` };
 
   return (
-    <Box {...bgColor} {...rest}>
+    <Box {...bgColor} {...rest} borderRadius={2}>
       {metadata.picture && <Image height="100%" src={metadata.picture} />}
     </Box>
   );


### PR DESCRIPTION
cc @urcades 

<img width="595" alt="image" src="https://user-images.githubusercontent.com/20846414/108910951-9956ba80-75f4-11eb-8375-e87dfdc0f55d.png">

Fixes urbit/landscape#478