### PR TITLE
GroupSearch: use includes, not startsWith

### DIFF
--- a/pkg/interface/src/views/components/GroupSearch.tsx
+++ b/pkg/interface/src/views/components/GroupSearch.tsx
@@ -145,7 +145,7 @@ export function GroupSearch<I extends string, V extends FormValues<I>>(props: Gr
                 disabled={props.maxLength ? value.length >= props.maxLength : false}
                 renderCandidate={renderCandidate}
                 search={(s: string, a: Association) =>
-                  a.metadata.title.toLowerCase().startsWith(s.toLowerCase())
+                  a.metadata.title.toLowerCase().includes(s.toLowerCase())
                 }
                 getKey={(a: Association) => a.group}
                 onSelect={onSelect}


### PR DESCRIPTION
Loosely searches for group titles.

Fixes urbit/landscape#477