### PR TITLE
launch: fix modal backgrounds

### DIFF
--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -48,12 +48,12 @@ export default function LaunchApp(props) {
       position={["relative", "absolute"]}
       left="0"
       bottom="0"
-      bg="#f2f2f2"
+      backgroundColor="white"
       ml={3}
       mb={3}
       borderRadius={2}
+      overflow='hidden'
       fontSize={0}
-      p={2}
       cursor="pointer"
       onClick={() => {
         writeText(props.baseHash);
@@ -63,7 +63,9 @@ export default function LaunchApp(props) {
         }, 2000);
       }}
     >
-      <Text mono bold color="#000000">{hashText || props.baseHash}</Text>
+      <Box backgroundColor="washedGray" p={2}>
+        <Text mono bold>{hashText || props.baseHash}</Text>
+      </Box>
     </Box>
   );
 
@@ -180,8 +182,8 @@ export default function LaunchApp(props) {
           />
           <ModalButton
             icon="Plus"
-            bg="#f2f2f2"
-            color="#000"
+            bg="washedGray"
+            color="black"
             text="New Group"
             style={{ gridColumnStart: 1 }}
           >
@@ -189,8 +191,8 @@ export default function LaunchApp(props) {
           </ModalButton>
           <ModalButton
             icon="Boot"
-            bg="#f2f2f2"
-            color="#000"
+            bg="washedGray"
+            color="black"
             text="Join Group"
           >
             <JoinGroup {...props} />

--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -180,7 +180,7 @@ export default function LaunchApp(props) {
           />
           <ModalButton
             icon="Plus"
-            bg="washedGray"
+            bg="#f2f2f2"
             color="#000"
             text="New Group"
             style={{ gridColumnStart: 1 }}
@@ -189,7 +189,7 @@ export default function LaunchApp(props) {
           </ModalButton>
           <ModalButton
             icon="Boot"
-            bg="washedGray"
+            bg="#f2f2f2"
             color="#000"
             text="Join Group"
           >

--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -63,7 +63,7 @@ export default function LaunchApp(props) {
         }, 2000);
       }}
     >
-      <Text mono bold>{hashText || props.baseHash}</Text>
+      <Text mono bold color="#000000">{hashText || props.baseHash}</Text>
     </Box>
   );
 

--- a/pkg/interface/src/views/apps/launch/components/ModalButton.tsx
+++ b/pkg/interface/src/views/apps/launch/components/ModalButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Icon, Text } from '@tlon/indigo-react';
+import { Row, Button, Icon, Text } from '@tlon/indigo-react';
 import { useModal } from '~/logic/lib/useModal';
 
 const ModalButton = (props) => {
@@ -13,17 +13,18 @@ const ModalButton = (props) => {
         onClick={showModal}
         display='flex'
         cursor='pointer'
-        justifyContent="start"
-        bg={bg}
-        p={2}
+        bg="white"
+        overflow='hidden'
         border={0}
+        p={0}
         borderRadius={2}
         {...rest}
       >
+        <Row bg={bg} p={2} width='100%' justifyContent="start" alignItems="center">
         <Icon icon={props.icon} mr={2} color={color}></Icon>
         <Text color={color} fontWeight="medium" whiteSpace='nowrap'>
           {props.text}
-        </Text>
+        </Text></Row>
       </Button>
     </>
   );


### PR DESCRIPTION
I used `washedGray` and forgot it was an opacity colour — falling back to the hex here.