### PR TITLE
Revert "landscape: allow most patp punctation in tokenize"

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -52,16 +52,13 @@ const tokenizeMessage = (text) => {
           }
           messages.push({ url: str });
           message = [];
-        } else if (urbitOb.isValidPatp(str.replace(/[^a-z\-\~]/g, '')) && !isInCodeBlock) {
+        } else if(urbitOb.isValidPatp(str) && !isInCodeBlock) {
           if (message.length > 0) {
             // If we're in the middle of a message, add it to the stack and reset
             messages.push({ text: message.join(' ') });
             message = [];
           }
-          messages.push({ mention: str.replace(/[^a-z\-\~]/g, '') });
-          if (str.replace(/[a-z\-\~]/g, '').length > 0) {
-            messages.push({ text: str.replace(/[a-z\-\~]/g, '') });
-          }
+          messages.push({ mention: str });
           message = [];
 
         } else {


### PR DESCRIPTION
Reverts urbit/urbit#4224

This is more trouble than it's worth — needs another pass at tokenising.

Fixes https://github.com/urbit/landscape/issues/275, https://github.com/urbit/landscape/issues/277