### PR TITLE
leap: truncate statuses

### DIFF
--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Box, Row, Icon, Text } from '@tlon/indigo-react';
 import defaultApps from '~/logic/lib/default-apps';
 import Sigil from '~/logic/lib/sigil';
-import { uxToHex } from '~/logic/lib/util';
+import { uxToHex, cite } from '~/logic/lib/util';
 
 export class OmniboxResult extends Component {
   constructor(props) {
@@ -99,7 +99,7 @@ export class OmniboxResult extends Component {
         style={{ flexShrink: 0 }}
         mr='1'
         >
-          {text}
+          {text.startsWith("~") ? cite(text) : text}
         </Text>
         <Text pr='2'
         display="inline-block"

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -87,25 +87,29 @@ export class OmniboxResult extends Component {
       }
       onClick={navigate}
       width="100%"
+      justifyContent="space-between"
       ref={this.result}
       >
+      <Box display="flex" verticalAlign="middle" maxWidth="60%" flexShrink={0}>
         {graphic}
         <Text
-        display="inline-block"
-        verticalAlign="middle"
         mono={(icon == 'profile' && text.startsWith('~'))}
         color={this.state.hovered || selected === link ? 'white' : 'black'}
-        maxWidth="60%"
-        style={{ flexShrink: 0 }}
         mr='1'
         >
           {text.startsWith("~") ? cite(text) : text}
         </Text>
+        </Box>
         <Text pr='2'
         display="inline-block"
         verticalAlign="middle"
         color={this.state.hovered || selected === link ? 'white' : 'black'}
         width='100%'
+        minWidth={0}
+        textOverflow="ellipsis"
+        whiteSpace="pre"
+        overflow="hidden"
+        maxWidth="40%"
         textAlign='right'
         >
           {subtext}


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/487

<img width="473" alt="Screen Shot 2021-02-25 at 1 39 56 PM" src="https://user-images.githubusercontent.com/20846414/109200963-38072680-776f-11eb-87af-541294dc3db3.png">

We also cite patps now to render comets a bit more palatably.