### PR TITLE
links: enforce valid URI on render

### DIFF
--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -67,6 +67,7 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
   const size = node.children ? node.children.size : 0;
   const contents = node.post.contents;
   const hostname = URLparser.exec(contents[1].url) ? URLparser.exec(contents[1].url)[4] : null;
+  const href = URLparser.exec(contents[1].url) ? contents[1].url : `http://${contents[1].url}`
 
   const baseUrl = props.baseUrl || `/~404/${resource}`;
 
@@ -120,7 +121,7 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
         <RemoteContent
           ref={r => { remoteRef.current = r }}
           renderUrl={false}
-          url={contents[1].url}
+          url={href}
           text={contents[0].text}
           unfold={true}
           onLoad={onMeasure}
@@ -145,7 +146,7 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
           }}
         />
         <Text color="gray" p={2} flexShrink={0}>
-          <Anchor  target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }} href={contents[1].url}>
+          <Anchor  target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }} href={href}>
             <Box display='flex'>
               <Icon icon='ArrowExternal' mr={1} />{hostname}
             </Box>


### PR DESCRIPTION
We actually enforce URI validation *really aggressively* on submit from Landscape — we don't care what the type is (we take `gopher://`, `ipfs://`, just fine), we just want some prefix on that link.

But when we render a link, we trust the URL contents. If you manually poke a link into a collection without a URI prefix, the link won't work when clicking in Landscape. So now we look for a prefix; if there isn't any, we prefix `http://`.

Fixes urbit/landscape#280.