### PR TITLE
groups: reduce added member from pending

### DIFF
--- a/pkg/interface/src/logic/reducers/group-update.ts
+++ b/pkg/interface/src/logic/reducers/group-update.ts
@@ -61,6 +61,7 @@ export default class GroupReducer<S extends GroupState> {
   reduce(json: Cage, state: S) {
     const data = json.groupUpdate;
     if (data) {
+      console.log(data);
       this.initial(data, state);
       this.addMembers(data, state);
       this.addTag(data, state);
@@ -116,6 +117,12 @@ export default class GroupReducer<S extends GroupState> {
       const resourcePath = resourceAsPath(resource);
       for (const member of ships) {
         state.groups[resourcePath].members.add(member);
+        if (
+            'invite' in state.groups[resourcePath].policy &&
+            state.groups[resourcePath].policy.invite.pending.has(member)
+           ) {
+             state.groups[resourcePath].policy.invite.pending.delete(member)
+           }
       }
     }
   }


### PR DESCRIPTION
Currently there's an edge case where if you have a private group, and someone joins it, and you in the same session look at your participants, you'll appear to have more "pending" than you actually have, because we don't reduce the member out of the pending set until next load.

This checks if we're invite-only; if so, an added member is removed from the set when we reduce.

Tested on both a private and public group, works without crash or incident, fixes issue.

Fixes urbit/landscape#490.