### PR TITLE
hark-store: bunt cache before rebuilding

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -767,6 +767,8 @@
 ++  inflate-cache
   |=  state-4
   ^+  +.state
+  =.  +.state
+    *cache
   =/  nots=(list [p=@da =timebox:store])
     (tap:orm notifications)
   |-  =*  outer  $


### PR DESCRIPTION
Previously, rebuilding the cache in any scenario other than on-load would add
missing notifications but not remove read or dismissed notifications

Fixes urbit/landscape#479