### PR TITLE
fix Ames comet handshake

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1217,7 +1217,7 @@
       on-hear-forward
     ::
     ?:  ?&  ?=(%pawn (clan:title sndr.packet))
-            !(~(has by peers.ames-state) sndr.packet)
+            !?=([~ %known *] (~(get by peers.ames-state) sndr.packet))
         ==
       on-hear-open
     on-hear-shut

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1289,14 +1289,9 @@
     |=  [=lane =packet dud=(unit goof)]
     ^+  event-core
     =/  sndr-state  (~(get by peers.ames-state) sndr.packet)
-    ::  if we don't know them, maybe enqueue a jael %public-keys request
-    ::
-    ::    Ignore encrypted packets from alien comets.
-    ::    TODO: maybe crash?
+    ::  if we don't know them, ask jael for their keys and enqueue
     ::
     ?.  ?=([~ %known *] sndr-state)
-      ?:  =(%pawn (clan:title sndr.packet))
-        event-core
       (enqueue-alien-todo sndr.packet |=(alien-agenda +<))
     ::  decrypt packet contents using symmetric-key.channel
     ::


### PR DESCRIPTION
This fixes a bug where if a ship tried to send an Ames message to a comet before the comet had contacted it, it would ignore all packets from that comet without ever applying any self-attestation packets the comet sent it.  Confirmed on a live repro with @ixv that previously stuck `|hi`'s go through after applying this change.

This also changes the behavior on hearing a "shut" encrypted packet from a comet whose keys we don't know yet but to whom we have messages enqueued.  Instead of no-op'ing, we now crash, expecting an "open" unencrypted self-attestation packet instead.  It's difficult to imagine this working correctly any other way without adding an "open or shut" bit back into the packet format.

If we tried to enqueue them, for example, then we wouldn't know whether they decrypt properly until we've heard the self-attestation packet, which could be used in a resource exhaustion attack by getting us to hold onto and then try to decrypt a bunch of bogus packets.  In general with comets I think it's probably safer to err on the side of as little queueing as possible.

I think crashing is fine, though.  It arguably fits better into our general paradigm of crashing on invalid packets, and it shouldn't be harmful.  If a few shut packets arrive out of order and crash before the attestation packet arrives, they should get processed successfully after the attestation packet arrives and the comet sends them again.