### PR TITLE
landscape: grabbag

### DIFF
--- a/pkg/interface/src/views/components/Body.tsx
+++ b/pkg/interface/src/views/components/Body.tsx
@@ -5,7 +5,7 @@ import { Box } from '@tlon/indigo-react';
 export function Body(
   props: { children: ReactNode } & Parameters<typeof Box>[0]
 ) {
-  const { children, ...boxProps } = props;
+  const { children, border, ...boxProps } = props;
   return (
     <Box fontSize={0} px={[0, 3]} pb={[0, 3]} height="100%" width="100%">
       <Box
@@ -13,11 +13,11 @@ export function Body(
         height="100%"
         width="100%"
         borderRadius={2}
-        border={[0, 1]}
+        border={border ? border : [0, 1]}
         borderColor={['washedGray', 'washedGray']}
         {...boxProps}
       >
-        {props.children}
+        {children}
       </Box>
     </Box>
   );

--- a/pkg/interface/src/views/components/GroupSearch.tsx
+++ b/pkg/interface/src/views/components/GroupSearch.tsx
@@ -41,6 +41,7 @@ const Candidate = ({ title, selected, onClick }): ReactElement => (
   <CandidateBox
     onClick={onClick}
     selected={selected}
+    cursor="pointer"
     borderColor="washedGray"
     color="black"
     fontSize={0}

--- a/pkg/interface/src/views/components/Loading.tsx
+++ b/pkg/interface/src/views/components/Loading.tsx
@@ -8,10 +8,10 @@ interface LoadingProps {
 }
 export function Loading({ text }: LoadingProps) {
   return (
-    <Body>
+    <Body border="0">
       <Center height="100%">
         <LoadingSpinner />
-        {Boolean(text) && <Text>{text}</Text>}
+        {Boolean(text) && <Text ml={4}>{text}</Text>}
       </Center>
     </Body>
   );

--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -78,6 +78,7 @@ const Candidate = ({ title, detail, selected, onClick }): ReactElement => (
     bg="white"
     color="black"
     fontSize={0}
+    cursor="pointer"
     p={1}
     width="100%"
   >

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
@@ -151,7 +151,7 @@ export function GraphPermissions(props: GraphPermissionsProps) {
     }
   };
 
-  const schema = formSchema(Array.from(group.members));
+  const schema = formSchema(Array.from(group?.members ?? []));
 
   return (
     <Formik

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
@@ -51,8 +51,8 @@ export function ChannelPopoverRoutes(props: ChannelPopoverRoutesProps) {
   };
   const handleArchive = async () => {
     const [,,,name] = association.resource.split('/');
-    await api.graph.deleteGraph(name);
-    history.push(props.baseUrl);
+    api.graph.deleteGraph(name);
+    return history.push(props.rootUrl);
   };
 
   const canAdmin = isChannelAdmin(group, association.resource);

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
@@ -22,6 +22,7 @@ import { isChannelAdmin, isHost } from '~/logic/lib/group';
 
 interface ChannelPopoverRoutesProps {
   baseUrl: string;
+  rootUrl: string;
   association: Association;
   group: Group;
   groups: Groups;

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -206,7 +206,7 @@ export function GroupsPane(props: GroupsPaneProps) {
               resource={groupAssociation.group}
                       />;
           } else {
-            summary = (<Box p="4"><Text fontSize="0" color='gray'>
+            summary = (<Box p="4"><Text color='gray'>
                         Create or select a channel to get started
                       </Text></Box>);
           }


### PR DESCRIPTION
- Archiving a channel will crash right now instead of redirecting us properly — we return the redirect and skip waiting on the delete now
- Loading a channel has a border, which was annoying me, so I made a prop to remove it if we need to. We also space "Creating DM" apart from the spinner
- "Create or select a channel" was too small, now it is not
- ShipSearch and GroupSearch show a pointer now