### PR TITLE
hark-graph-hook: upgrade notification-kind to allow for sibling autowatches

### DIFF
--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -24,8 +24,6 @@
       watch-on-self=_&
   ==
 ::
-+$  notif-kind
-  [name=@t parent-lent=@ud mode=?(%each %count %none) watch=?]
 ::
 ++  scry
   |*  [[our=@p now=@da] =mold p=path]
@@ -223,11 +221,11 @@
     |=  [=index:graph-store out=(list card)]
     =|  =indexed-post:graph-store
     =.  index.p.indexed-post  index
-    =+  !<(u-notif-kind=(unit notif-kind) (tube !>(indexed-post)))
+    =+  !<(u-notif-kind=(unit notif-kind:hook) (tube !>(indexed-post)))
     ?~  u-notif-kind  out
     =*  notif-kind  u.u-notif-kind
     =/  =stats-index:store
-      [%graph rid (scag parent-lent.notif-kind index)]
+      [%graph rid (scag parent.index-len.notif-kind index)]
     ?.  ?=(%each mode.notif-kind)  out
     :_  out 
     (poke-hark %read-each stats-index index)
@@ -382,8 +380,12 @@
     update-core(hark-pokes [action hark-pokes])
   ::
   ++  new-watch
-    |=  =index:graph-store
-    update-core(new-watches [index new-watches])
+    |=  [=index:graph-store =watch-for:hook =index-len:hook]
+    =?  new-watches  =(%siblings watch-for)
+      [(scag parent.index-len index) new-watches]
+    =?  new-watches  =(%children watch-for)
+      [(scag self.index-len index) new-watches]
+    update-core
   ::
   ++  check
     |-  ^+  update-core
@@ -411,7 +413,7 @@
     |=  =node:graph-store
     ^+  update-core
     =.  update-core  (check-node-children node)
-    =+  !<  notif-kind=(unit notif-kind)
+    =+  !<  notif-kind=(unit notif-kind:hook)
         (get-conversion !>([0 post.node]))
     ?~  notif-kind
       update-core
@@ -421,11 +423,11 @@
       name.u.notif-kind
     =*  not-kind  u.notif-kind
     =/  parent=index:post
-      (scag parent-lent.not-kind index.post.node)
+      (scag parent.index-len.not-kind index.post.node)
     =/  notif-index=index:store
       [%graph group rid module desc parent]
     ?:  =(our.bowl author.post.node)
-      (self-post node notif-index [mode watch]:not-kind)
+      (self-post node notif-index not-kind)
     =.  update-core
       (update-unread-count not-kind notif-index [time-sent index]:post.node)
     =?    update-core
@@ -438,7 +440,7 @@
     update-core
   ::
   ++  update-unread-count
-    |=  [=notif-kind =index:store time=@da ref=index:graph-store]
+    |=  [=notif-kind:hook =index:store time=@da ref=index:graph-store]
     =/  =stats-index:store
       (to-stats-index:store index)
     ?-  mode.notif-kind 
@@ -450,19 +452,18 @@
   ++  self-post
     |=  $:  =node:graph-store
             =index:store
-            mode=?(%count %each %none)
-            watch=?
+            =notif-kind:hook
         ==
     ^+  update-core 
-    ?:  ?=(%none mode)  update-core
+    ?:  ?=(%none mode.notif-kind)  update-core
     =/  =stats-index:store
       (to-stats-index:store index)
     =.  update-core
       (hark %seen-index time-sent.post.node stats-index)
-    =?  update-core  ?=(%count mode)
+    =?  update-core  ?=(%count mode.notif-kind)
       (hark %read-count stats-index)
-    =?  update-core  &(watch watch-on-self)
-      (new-watch index.post.node)
+    =?  update-core  watch-on-self
+      (new-watch index.post.node [watch-for index-len]:notif-kind)
     update-core
   ::
   ++  add-unread

--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -18,7 +18,7 @@
   ::
   ++  notification-kind
     ?+  index.p.i  ~
-      [@ ~]  `[%message 0 %count %.n]
+      [@ ~]  `[%message [0 1] %count %none]
     ==
   --
 ++  grab

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -26,9 +26,9 @@
   ::
   ++  notification-kind
     ?+  index.p.i  ~
-      [@ ~]       `[%link 0 %each %.y]
-      [@ @ %1 ~]  `[%comment 1 %count %.n]
-      [@ @ @ ~]   `[%edit-comment 1 %none %.n]
+      [@ ~]       `[%link [0 1] %each %children]
+      [@ @ %1 ~]  `[%comment [1 2] %count %siblings]
+      [@ @ @ ~]   `[%edit-comment [1 2] %none %none]
     ==
   --
 ++  grab

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -25,10 +25,10 @@
   ::
   ++  notification-kind
     ?+  index.p.i   ~
-      [@ %1 %1 ~]    `[%note 0 %each %.n]
-      [@ %1 @ ~]     `[%edit-note 0 %none %.n]
-      [@ %2 @ %1 ~]  `[%comment 1 %count %.n]
-      [@ %2 @ @ ~]   `[%edit-comment 1 %none %.n]
+      [@ %1 %1 ~]    `[%note [0 1] %each %children]
+      [@ %1 @ ~]     `[%edit-note [0 1] %none %none]
+      [@ %2 @ %1 ~]  `[%comment [1 3] %count %siblings]
+      [@ %2 @ @ ~]   `[%edit-comment [1 3] %none %none]
     ==
   --
 ++  grab

--- a/pkg/arvo/sur/hark-graph-hook.hoon
+++ b/pkg/arvo/sur/hark-graph-hook.hoon
@@ -1,6 +1,17 @@
 /-  *resource, graph-store, post
 ^?
 |%
+::
++$  mode  ?(%each %count %none)
+::
++$  watch-for  ?(%siblings %children %none)
+::
++$  index-len
+  [parent=@ud self=@ud] 
+::
++$  notif-kind
+  [name=@t =index-len =mode =watch-for]
+::
 +$  action
   $%
     [?(%listen %ignore) graph=resource =index:post]


### PR DESCRIPTION
This is the new autowatching behaviour: 
- chat: none
- publish & links: posting a link will autowatch it for comments, commenting will autowatch for further comments
