### PR TITLE
landscape: two edge cases

### DIFF
--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -115,10 +115,14 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps): ReactE
 
   return (
     <Col overflowY="auto" p={3} backgroundColor="white">
-      <Box pb='3' display={['block', 'none']} onClick={() => history.push(props.baseUrl)}>
-        <Text fontSize='0' bold>{'<- Back'}</Text>
+      <Box
+        pb='3'
+        display={workspace?.type === 'messages' ? 'none' : ['block', 'none']}
+        onClick={() => history.push(props.baseUrl)}
+      >
+        <Text>{'<- Back'}</Text>
       </Box>
-      <Box color="black">
+      <Box>
         <Text fontSize={2} bold>{workspace?.type === 'messages' ? 'Direct Message' : 'New Channel'}</Text>
       </Box>
       <Formik

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -90,7 +90,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
         >
           <Link to={`/~landscape${workspace}`}> {'<- Back'}</Link>
         </Box>
-        <Box px={1} mr={2} minWidth={0} display="flex" flexShrink={0}>
+        <Box px={1} mr={2} minWidth={0} display="flex" flexShrink={[1, 0]}>
           <Text
             mono={urbitOb.isValidPatp(title)}
             fontSize='2'
@@ -101,7 +101,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
             overflow="hidden"
             whiteSpace="pre"
             minWidth={0}
-            flexShrink={0}
+            flexShrink={1}
           >
             {title}
           </Text>
@@ -109,7 +109,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
         <Row
           display={['none', 'flex']}
           verticalAlign="middle"
-          flexShrink={1}
+          flexShrink={2}
           minWidth={0}
           title={association?.metadata?.description}
         >
@@ -125,7 +125,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
             {(workspace === '/messages') ? recipient : association?.metadata?.description}
           </TruncatedText>
         </Row>
-        <Box flexGrow={1} />
+        <Box flexGrow={1} flexShrink={0} />
         {canWrite && (
           <Link to={resourcePath('/new')} style={{ flexShrink: '0' }}>
             <Text bold pr='3' color='blue'>+ New Post</Text>


### PR DESCRIPTION
- On mobile devices, long channel names can push the menu offscreen. However, we don't want the title to be shrunk by a long description. We want the description to shrink first. So we set flex-shrink priorities, and also don't let the title shrink on desktop.
- On mobile devices, the direct message menu had a "<- Back" arrow from the NewChannel view it's using having responsive logic for navigation. NewChannel should probably inherit some sort of "non-resource skeleton" instead of bolting specific navigation but this just disregards it inside the messages workspace.