### PR TITLE
zuse: fix ordered-map delete many

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -960,7 +960,6 @@
       =.  snd.ship-state
         %-  ~(run by snd.ship-state)
         |=  =message-pump-state
-        =*  p  packet-pump-state.message-pump-state
         =.  num-live.metrics.packet-pump-state.message-pump-state
           ~(wyt in live.packet-pump-state.message-pump-state)
         message-pump-state

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5258,8 +5258,8 @@
       ?>  ?=(^ a)
       =^  res  acc  (f state.acc n.a)
       ?~  res
-        [del=& ..node]
-      [del=| ..node(val.n.a u.res)]
+        [del=& this]
+      [del=| this(val.n.a u.res)]
     ::  +left: recurse on left subtree, copying mutant back into .l.a
     ::
     ++  left

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5207,20 +5207,6 @@
     ?:  (mor key.n.l.a key.n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
-  ::  +nup: delete root, reporting which side was promoted
-  ::
-  ++  nup
-    |=  a=(tree item)
-    ^-  [pro=?(%l %r) res=(tree item)]
-    ::
-    ?>  ?=(^ a)
-    ::  delete .n.a; merge and balance .l.a and .r.a
-    ::
-    ?~  l.a  r/r.a
-    ?~  r.a  l/l.a
-    ?:  (mor key.n.l.a key.n.r.a)
-      l/l.a(r (nip a(l r.l.a)))
-    r/r.a(l (nip a(r l.r.a)))
   ::  +traverse: stateful partial inorder traversal
   ::
   ::    Mutates .state on each run of .f.  Starts at .start key, or if

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5245,8 +5245,7 @@
       =.  this  left
       ?:  stop.acc  this
       =^  del  this  node
-      ?:  stop.acc  this
-      =.  this  right
+      =?  this  !stop.acc  right
       =?  a  del  (nip a)
       this
     ::  +node: run .f on .n.a, updating .a, .state, and .stop

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5244,59 +5244,48 @@
     =/  acc  [stop=`?`%.n state=state]
     =<  abet  =<  main
     |%
+    ++  this  .
     ++  abet  [state.acc a]
     ::  +main: main recursive loop; performs a partial inorder traversal
     ::
     ++  main
-      ^+  .
+      ^+  this
       ::  stop if empty or we've been told to stop
       ::
-      ?~  a  .
-      ?:  stop.acc  .
+      ?:  =(~ a)  this
+      ?:  stop.acc  this
       ::  inorder traversal: left -> node -> right, until .f sets .stop
       ::
-      =>  left
-      ?:  stop.acc  .
-      =>  node
-      ?:  stop.acc  .
-      right
+      =.  this  left
+      ?:  stop.acc  this
+      =^  del  this  node
+      ?:  stop.acc  this
+      =.  this  right
+      =?  a  del  (nip a)
+      this
     ::  +node: run .f on .n.a, updating .a, .state, and .stop
     ::
     ++  node
-      ^+  .
+      ^+  [del=*? this]
       ::  run .f on node, updating .stop.acc and .state.acc
       ::
-      =^  res  acc
-        ?>  ?=(^ a)
-        (f state.acc n.a)
-      ::  if we kept the node, replace its .val; order is unchanged
-      ::
-      ?^  res
-        ?>  ?=(^ a)
-        ..node(val.n.a u.res)
-      ::  .f requested node deletion; delete root, then maybe recurse
-      ::
-      ::    If +nup promoted the left side, we're done; don't process
-      ::    the left-hand side twice.  If +nup promoted a non-null right
-      ::    side, recurse on the new root.
-      ::
-      =^  pro  a  (nup a)
-      ?-  pro
-        %l  ..node
-        %r  ?~(a ..node node)
-      ==
+      ?>  ?=(^ a)
+      =^  res  acc  (f state.acc n.a)
+      ?~  res
+        [del=& ..node]
+      [del=| ..node(val.n.a u.res)]
     ::  +left: recurse on left subtree, copying mutant back into .l.a
     ::
     ++  left
-      ^+  .
-      ?~  a  .
+      ^+  this
+      ?~  a  this
       =/  lef  main(a l.a)
       lef(a a(l a.lef))
     ::  +right: recurse on right subtree, copying mutant back into .r.a
     ::
     ++  right
-      ^+  .
-      ?~  a  .
+      ^+  this
+      ?~  a  this
       =/  rig  main(a r.a)
       rig(a a(r a.rig))
     --

--- a/pkg/arvo/tests/sys/zuse/ordered-map.hoon
+++ b/pkg/arvo/tests/sys/zuse/ordered-map.hoon
@@ -130,12 +130,28 @@
   ==
 ::
 ++  test-ordered-map-traverse-delete-all  ^-  tang
-  =/  q  ((ordered-map ,@ ,~) lte)
-  =/  o  (gas:q ~ ~[1/~ 2/~ 3/~])
-  =/  b  ((traverse:q ,~) o ~ |=([~ key=@ ~] [~ %| ~]))
-  %+  expect-eq
-    !>  [~ ~]
-    !>  b
+  ;:  weld
+    =/  q  ((ordered-map ,@ ,~) lte)
+    =/  o  (gas:q ~ ~[1/~ 2/~ 3/~])
+    =/  b  ((traverse:q ,~) o ~ |=([~ key=@ ~] [~ %| ~]))
+    %+  expect-eq
+      !>  [~ ~]
+      !>  b
+  ::
+    =/  c
+      :~  [[2.127 1] ~]  [[2.127 2] ~]  [[2.127 3] ~]
+          [[2.127 7] ~]  [[2.127 8] ~]  [[2.127 9] ~]
+      ==
+    =/  compare
+      |=  [[aa=@ ab=@] [ba=@ bb=@]]
+      ?:((lth aa ba) %.y ?:((gth aa ba) %.n (lte ab bb)))
+    =/  q  ((ordered-map ,[@ @] ,~) compare)
+    =/  o  (gas:q ~ c)
+    =/  b  ((traverse:q ,~) o ~ |=([~ key=[@ @] ~] [~ %| ~]))
+    %+  expect-eq
+      !>  [~ ~]
+      !>  b
+  ==
 ::
 ++  test-ordered-map-uni  ^-  tang
   ::

--- a/pkg/arvo/tests/sys/zuse/ordered-map.hoon
+++ b/pkg/arvo/tests/sys/zuse/ordered-map.hoon
@@ -129,6 +129,14 @@
       !>  -.b
   ==
 ::
+++  test-ordered-map-traverse-delete-all  ^-  tang
+  =/  q  ((ordered-map ,@ ,~) lte)
+  =/  o  (gas:q ~ ~[1/~ 2/~ 3/~])
+  =/  b  ((traverse:q ,~) o ~ |=([~ key=@ ~] [~ %| ~]))
+  %+  expect-eq
+    !>  [~ ~]
+    !>  b
+::
 ++  test-ordered-map-uni  ^-  tang
   ::
   =/  a=(tree [@ud @tas])  (gas:atom-map ~ (scag 4 test-items))


### PR DESCRIPTION
The ordered map `+traverse` function failed to delete all items because it could skip a node under certain deletion conditions.  This fixes that, confirmed by a new test that failed with the old implementation.

This should fix the [ames: strange current issue](http://github.com/urbit/urbit/issues/4424).