### PR TITLE
king: fix textAsTa

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/KingSubsite.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/KingSubsite.hs
@@ -116,7 +116,7 @@ kingSubsite who scry stat func = do
               => Text
               -> RIO e (Maybe Bool)
     scryAuth cookie =
-      scryNow scry "ex" "" ["authenticated", "cookie", textAsTa cookie]
+      scryNow scry "ex" "" ["authenticated", "cookie", textAsT cookie]
 
 fourOhFourSubsite :: Ship -> KingSubsite
 fourOhFourSubsite who = KS $ \req respond ->

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
@@ -13,7 +13,7 @@ module Urbit.Noun.Conversions
   , Path(..), EvilPath(..), Ship(..)
   , Lenient(..), pathToFilePath, filePathToPath
   , showUD, tshowUD
-  , textAsTa
+  , textAsT
   ) where
 
 import ClassyPrelude hiding (hash)
@@ -556,8 +556,8 @@ instance FromNoun Knot where
       else fail ("Non-ASCII chars in knot: " <> unpack txt)
 
 -- equivalent of (cury scot %t)
-textAsTa :: Text -> Text
-textAsTa = ("~~" <>) . concatMap \case
+textAsT :: Text -> Text
+textAsT = ("~~" <>) . concatMap \case
   ' ' -> "."
   '.' -> "~."
   '~' -> "~~"

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
@@ -562,7 +562,7 @@ textAsTa = ("~~" <>) . concatMap \case
   '.' -> "~."
   '~' -> "~~"
   c   ->
-    if C.isAlphaNum c || (c == '-') then
+    if (C.isAlphaNum c && not (C.isUpper c)) || (c == '-') then
       T.singleton c
     else
       if C.ord c < 0x10 then "~0" else "~"


### PR DESCRIPTION
`textAsTa` was not properly handling uppercase alphanumerics. This would
break subsite authentication when there are uppercase characters in your
cookies.

Should now be equivalent to `(cury scot %t)`.

dojo:

```
> (scot %t 'urbauth-zod=0v2.d0q3n.4jgsq.fl9jk.mp2nd.97uu6; lang=en-US')
~.~~urbauth-zod~3d.0v2~.d0q3n~.4jgsq~.fl9jk~.mp2nd~.97uu6~3b..lang~3d.en-~55.~53.
```

ghci:

```
λ> textAsTa "urbauth-zod=0v2.d0q3n.4jgsq.fl9jk.mp2nd.97uu6; lang=en-US"
"~~urbauth-zod~3d.0v2~.d0q3n~.4jgsq~.fl9jk~.mp2nd~.97uu6~3b..lang~3d.en-~55.~53."
```