### PR TITLE
Add objectFit='cover' to various Landscape avatars to avoid aspect ratio squishing

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -130,7 +130,13 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
         props.ourContact &&
         ((props.ourContact.avatar !== null) && !props.hideAvatars)
       )
-      ? <BaseImage src={props.ourContact.avatar} height={16} width={16} className="dib" />
+      ? <BaseImage 
+          src={props.ourContact.avatar} 
+          height={16} 
+          width={16} 
+          style={{ objectFit: 'cover' }}
+          display='inline-block'
+        />
       : <Sigil
         ship={window.ship}
         size={16}

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -278,6 +278,7 @@ export const MessageAuthor = ({
     contact?.avatar && !hideAvatars ? (
       <BaseImage
         display='inline-block'
+        style={{ objectFit: 'cover' }}
         src={contact.avatar}
         height={16}
         width={16}

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -47,6 +47,7 @@ export default function Author(props: AuthorProps): ReactElement {
       <BaseImage
         display='inline-block'
         src={contact.avatar}
+        style={{ objectFit: 'cover' }}
         height={16}
         width={16}
       />

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -98,6 +98,7 @@ class ProfileOverlay extends PureComponent<
       contact?.avatar && !hideAvatars ? (
         <BaseImage
           display='inline-block'
+          style={{ objectFit: 'cover' }}
           src={contact.avatar}
           height={72}
           width={72}

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -10,6 +10,7 @@ import {
   Row,
   Text,
   Icon,
+  Image,
   Action,
   StatelessTextInput as Input
 } from '@tlon/indigo-react';
@@ -297,7 +298,7 @@ function Participant(props: {
 
   const avatar =
     contact?.avatar !== null && !hideAvatars ? (
-      <img 
+      <Image 
         src={contact.avatar} 
         height={32} 
         width={32} 

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -297,7 +297,13 @@ function Participant(props: {
 
   const avatar =
     contact?.avatar !== null && !hideAvatars ? (
-      <img src={contact.avatar} height={32} width={32} className="dib" />
+      <img 
+        src={contact.avatar} 
+        height={32} 
+        width={32} 
+        display='inline-block'
+        style={{ objectFit: 'cover' }} 
+      />
     ) : (
       <Sigil ship={contact.patp} size={32} color={`#${color}`} />
     );


### PR DESCRIPTION
**PLEASE NOTE** I was unable to test this PR locally as I had issues cloning the repository (something with `con.c`, notable that I initially attempted to clone via Windows, fool that I am!).

Anyway, shout out to @matildepark for telling me where to change the things that needed to change. You may also wish to squash these commits as they were made via GitHub web (due to aforesaid git clone issue).