### PR TITLE
MetadataIcon: use box-shadow

### DIFF
--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -26,9 +26,6 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
     <Col {...rest} ref={anchorRef} gapY="4">
       <Row gapX="2" width="100%">
         <MetadataIcon
-          borderRadius="1"
-          border="1"
-          borderColor="lightGray"
           width="40px"
           height="40px"
           metadata={metadata}

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -178,7 +178,7 @@ export function GroupSwitcher(props: {
             }
           >
             <Row flexGrow={1} alignItems="center" width='100%' minWidth='0' flexShrink={0}>
-              { metadata && <MetadataIcon flexShrink={0} mr="2" border="1" borderColor="lightGray" borderRadius="1" metadata={metadata} height="24px" width="24px" /> }
+              { metadata && <MetadataIcon flexShrink={0} mr="2" metadata={metadata} height="24px" width="24px" /> }
               <Text flexShrink={1} lineHeight="1.1" fontSize='2' fontWeight="700" overflow='hidden' display='inline-block' flexShrink='1' style={{ textOverflow: 'ellipsis', whiteSpace: 'pre' }}>{title}</Text>
               </Row>
           </Dropdown>

--- a/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
+++ b/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
@@ -15,7 +15,7 @@ export function MetadataIcon(props: MetadataIconProps) {
   const bgColor = metadata.picture ? {} : { bg: `#${uxToHex(metadata.color)}` };
 
   return (
-    <Box {...bgColor} {...rest} borderRadius={2} overflow="hidden">
+    <Box {...bgColor} {...rest} borderRadius={2} boxShadow="inset 0 0 0 -1px" color="lightGray" overflow="hidden">
       {metadata.picture && <Image height="100%" src={metadata.picture} />}
     </Box>
   );


### PR DESCRIPTION
Group avatars use inset box shadows instead of borders. This sort of has the effect of not showing any border at all. Is this on purpose? I don't know. @g-a-v-i-n Please confirm!

<img width="305" alt="image" src="https://user-images.githubusercontent.com/20846414/109570472-116f2580-7ab8-11eb-9045-d588a071bdb4.png">

Fixes urbit/landscape#492.