### PR TITLE
MentionText: update for new contacts

### DIFF
--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -42,7 +42,7 @@ export function Mention(props: {
 }) {
   const { contacts, ship, scrollWindow, first, ...rest } = props;
   let { contact } = props;
-  contact = contact?.color ? contact : contacts?.[ship];
+  contact = contact?.color ? contact : contacts?.[`~${ship}`];
   const history = useHistory();
   const showNickname = useShowNickname(contact);
   const name = showNickname ? contact?.nickname : cite(ship);


### PR DESCRIPTION
Fixes an unfiled bug where mentions in comments had no contact information.

MentionText is written to work regardless of whether it's passed _one_ contact or _the whole object_; this was a performance change I wrote a few months ago, but in some cases where we couldn't avoid passing the whole object into the component we access the contact through the object. I presume state hooks will remedy this.

Anyway, _that_ assignment didn't have a sig prepended, as contact-store now has, so all contacts weren't matching in mentions within comments sections.