### PR TITLE
settings: add 'hide utility tiles'

### DIFF
--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -12,6 +12,7 @@ export interface LocalState {
   remoteContentPolicy: RemoteContentPolicy;
   tutorialProgress: TutorialProgress;
   hideGroups: boolean;
+  hideUtilities: boolean;
   tutorialRef: HTMLElement | null,
   hideTutorial: () => void;
   nextTutStep: () => void;
@@ -28,7 +29,7 @@ export interface LocalState {
 
 type LocalStateZus = LocalState & State;
 
-export const selectLocalState = 
+export const selectLocalState =
   <K extends keyof LocalState>(keys: K[]) => f.pick<LocalState, K>(keys);
 
 const useLocalState = create<LocalStateZus>(persist((set, get) => ({
@@ -38,6 +39,7 @@ const useLocalState = create<LocalStateZus>(persist((set, get) => ({
   hideNicknames: false,
   hideLeapCats: [],
   hideGroups: false,
+  hideUtilities: false,
   tutorialProgress: 'hidden',
   tutorialRef: null,
   setTutorialRef: (el: HTMLElement | null) => set(produce((state) => {

--- a/pkg/interface/src/logic/state/settings.tsx
+++ b/pkg/interface/src/logic/state/settings.tsx
@@ -17,6 +17,7 @@ export interface SettingsState {
     hideAvatars: boolean;
     hideUnreads: boolean;
     hideGroups: boolean;
+    hideUtilities: boolean;
   };
   remoteContentPolicy: RemoteContentPolicy;
   leap: {
@@ -42,7 +43,8 @@ const useSettingsState = create<SettingsStateZus>((set) => ({
     hideNicknames: false,
     hideAvatars: false,
     hideUnreads: false,
-    hideGroups: false
+    hideGroups: false,
+    hideUtilities: false
   },
   remoteContentPolicy: {
     imageShown: true,

--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -83,6 +83,7 @@ export default function LaunchApp(props) {
     }
   }, [query]);
 
+  const { hideUtilities } = useSettingsState(selectCalmState);
   const { tutorialProgress, nextTutStep } = useLocalState(tutSelector);
   let { hideGroups } = useLocalState(tutSelector);
   !hideGroups ? { hideGroups } = useSettingsState(selectCalmState) : null;
@@ -161,6 +162,7 @@ export default function LaunchApp(props) {
           p={2}
           pt={0}
         >
+        {!hideUtilities && <>
           <Tile
             bg="white"
             color="scales.black20"
@@ -201,6 +203,7 @@ export default function LaunchApp(props) {
           >
             <JoinGroup {...props} />
           </ModalButton>
+          </>}
           {!hideGroups &&
             (<Groups unreads={props.unreads} groups={props.groups} associations={props.associations} />)
           }

--- a/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
@@ -18,6 +18,7 @@ interface FormSchema {
   hideNicknames: boolean;
   hideUnreads: boolean;
   hideGroups: boolean;
+  hideUtilities: boolean;
   imageShown: boolean;
   audioShown: boolean;
   oembedShown: boolean;
@@ -35,7 +36,8 @@ export function CalmPrefs(props: {
       hideAvatars,
       hideNicknames,
       hideUnreads,
-      hideGroups
+      hideGroups,
+      hideUtilities
     },
     remoteContentPolicy: {
       imageShown,
@@ -51,6 +53,7 @@ export function CalmPrefs(props: {
     hideNicknames,
     hideUnreads,
     hideGroups,
+    hideUtilities,
     imageShown,
     videoShown,
     oembedShown,
@@ -63,6 +66,7 @@ export function CalmPrefs(props: {
       api.settings.putEntry('calm', 'hideNicknames', v.hideNicknames),
       api.settings.putEntry('calm', 'hideUnreads', v.hideUnreads),
       api.settings.putEntry('calm', 'hideGroups', v.hideGroups),
+      api.settings.putEntry('calm', 'hideUtilities', v.hideUtilities),
       api.settings.putEntry('remoteContentPolicy', 'imageShown', v.imageShown),
       api.settings.putEntry('remoteContentPolicy', 'videoShown', v.videoShown),
       api.settings.putEntry('remoteContentPolicy', 'audioShown', v.audioShown),
@@ -89,6 +93,11 @@ export function CalmPrefs(props: {
             label="Hide unread counts"
             id="hideUnreads"
             caption="Do not show unread counts on group tiles"
+          />
+          <Toggle
+            label="Hide utility tiles"
+            id="hideUtilities"
+            caption="Do not show home screen utilities"
           />
           <Toggle
             label="Hide group tiles"


### PR DESCRIPTION
Adds a setting within the CalmEngine to hide the top-level tiles separately from group tiles (so you can choose both, neither, one or the other, with and without unread counts).

Requested by @urcades, presuming design stamp.

<img width="905" alt="Screen Shot 2021-03-02 at 12 58 00 AM" src="https://user-images.githubusercontent.com/20846414/109605132-b73f8600-7af2-11eb-96e0-63b13def3665.png">
<img width="905" alt="Screen Shot 2021-03-02 at 12 58 05 AM" src="https://user-images.githubusercontent.com/20846414/109605137-b870b300-7af2-11eb-8826-eca8269cab37.png">
