### PR TITLE
meta: publish interface packages when available

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -2,7 +2,7 @@ name: publish-npm-packages
 on:
   push:
     branches:
-      - 'jt/npm-publish'
+      - 'master'
 jobs:
   publish-api:
     runs-on: ubuntu-latest
@@ -19,7 +19,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true
-          dry-run: true
           package: './pkg/npm/api/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 
@@ -38,7 +37,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true
-          dry-run: true
           package: './pkg/npm/http-api/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 
@@ -57,7 +55,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true
-          dry-run: true
           package: './pkg/npm/eslint-config/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,66 @@
+name: publish-npm-packages
+on:
+  push:
+    branches:
+      - 'jt/npm-publish'
+jobs:
+  publish-api:
+    runs-on: ubuntu-latest
+    name: "Publish '@urbit/api' if a new version is available"
+    defaults:
+      run:
+        working-directory: 'pkg/npm/api'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: 'npm install'
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          check-version: true
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}
+
+  publish-http-api:
+    runs-on: ubuntu-latest
+    name: "Publish '@urbit/http-api' if a new version is available"
+    defaults:
+      run:
+        working-directory: 'pkg/npm/http-api'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: 'npm install'
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          check-version: true
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}
+
+  publish-eslint-config:
+    runs-on: ubuntu-latest
+    name: "Publish '@urbit/eslint-config' if a new version is available"
+    defaults:
+      run:
+        working-directory: 'pkg/npm/eslint-config'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: 'npm install'
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          check-version: true
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -7,9 +7,6 @@ jobs:
   publish-api:
     runs-on: ubuntu-latest
     name: "Publish '@urbit/api' if a new version is available"
-    defaults:
-      run:
-        working-directory: 'pkg/npm/api'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,6 +15,7 @@ jobs:
         with:
           node-version: '14'
       - run: 'npm install'
+        working-directory: 'pkg/npm/api'
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true
@@ -28,9 +26,6 @@ jobs:
   publish-http-api:
     runs-on: ubuntu-latest
     name: "Publish '@urbit/http-api' if a new version is available"
-    defaults:
-      run:
-        working-directory: 'pkg/npm/http-api'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,6 +34,7 @@ jobs:
         with:
           node-version: '14'
       - run: 'npm install'
+        working-directory: 'pkg/npm/http-api'
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true
@@ -49,9 +45,6 @@ jobs:
   publish-eslint-config:
     runs-on: ubuntu-latest
     name: "Publish '@urbit/eslint-config' if a new version is available"
-    defaults:
-      run:
-        working-directory: 'pkg/npm/eslint-config'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -60,6 +53,7 @@ jobs:
         with:
           node-version: '14'
       - run: 'npm install'
+        working-directory: 'pkg/npm/eslint-config'
       - uses: JS-DevTools/npm-publish@v1
         with:
           check-version: true

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           check-version: true
           dry-run: true
+          package: './pkg/npm/api/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 
   publish-http-api:
@@ -42,6 +43,7 @@ jobs:
         with:
           check-version: true
           dry-run: true
+          package: './pkg/npm/http-api/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 
   publish-eslint-config:
@@ -62,5 +64,6 @@ jobs:
         with:
           check-version: true
           dry-run: true
+          package: './pkg/npm/eslint-config/package.json'
           token: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Adds a workflow that, on every push to master, will publish new versions of interface subpackages to the NPM registry if any are available (i.e., if version numbers have been incremented in any of the respective package.json files).

cc @tylershuster 