### PR TITLE
publish: use backgroundImage for images

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -68,7 +68,15 @@ export function NotePreview(props: NotePreviewProps) {
               unwrapDisallowed
               allowedTypes={['text', 'root', 'break', 'paragraph', 'image']}
               renderers={{
-                image: props => <Image src={props.src} maxHeight='300px' style={{ objectFit: 'cover' }} />
+                image: props => (
+                  <Box
+                    backgroundImage={`url(${props.src})`}
+                    style={{ backgroundSize: 'cover',
+                      backgroundPosition: "center" }}
+                  >
+                    <Image src={props.src} opacity="0" maxHeight="300px"/>
+                  </Box>
+                )
               }}
               source={snippet}
             />


### PR DESCRIPTION
Chrome's `object-fit` scaling logic differs from its `background-image` logic. In some cases, [portrait images stretch](https://stackoverflow.com/questions/63019769/css-object-fit-cover-is-stretching-a-particular-image-in-chrome-on-mac) if the file is malformed in some way. 

This PR shims that by using the `background-image` scaling in a box that encloses an invisible copy of the image (otherwise, an empty box gets flexed closed and requires way more shims all the way up the tree).

<img width="724" alt="Screenshot 2021-03-02 at 4 36 57 PM" src="https://user-images.githubusercontent.com/20846414/109718904-e519de80-7b75-11eb-9086-d6a6395d2711.png">


Makes you love the web.

Fixes urbit/landscape#495