### PR TITLE
tally: be safer wrt mangled metadata

### DIFF
--- a/pkg/arvo/gen/tally.hoon
+++ b/pkg/arvo/gen/tally.hoon
@@ -61,14 +61,24 @@
   ::NOTE  we only count graphs for now
   ?.  &(=(%graph app-name.m) =(our creator.metadatum))  ~
   `[module.metadatum resource.m]
+::  for sanity checks
+::
+=/  real=(set resource:re)
+  =/  upd=update:ga
+    %+  scry  update:ga
+    [%x %graph-store /keys/graph-update]
+  ?>  ?=(%keys -.q.upd)
+  resources.q.upd
 ::  count activity per channel
 ::
 =/  activity=(list [resource:re members=@ud (list [resource:re mod=term week=@ud authors=@ud])])
   %+  turn  crowds
   |=  [g=resource:re m=@ud]
   :+  g  m
-  %+  turn  (~(got by channels) g)
+  %+  murn  (~(got by channels) g)
   |=  [m=term r=resource:re]
+  ?.  (~(has in real) r)  ~
+  %-  some
   :+  r  m
   ::NOTE  graph-store doesn't use the full resource-style path here!
   =/  upd=update:ga


### PR DESCRIPTION
Previously, if metadata-store said a graph existed, we'd unconditionally scry
for it. Now, we make sure the graph _actually_ exists, to avoid risking a crash.

I think `/app/sane` can catch/fix such cases, but it's not guaranteed to have run on a user's ship, so we need to do a sanity-check here too.