### PR TITLE
landscape: destyle anchors

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -47,10 +47,6 @@ const Root = withSettingsState(styled.div`
   display: flex;
   flex-flow: column nowrap;
 
-  a {
-    text-decoration: none;
-  }
-
   * {
     scrollbar-width: thin;
     scrollbar-color: ${ p => p.theme.colors.gray } transparent;

--- a/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
@@ -78,9 +78,9 @@ export function CalmPrefs(props: {
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
       <Form>
+        <BackButton/>
         <Col borderBottom="1" borderBottomColor="washedGray" p="5" pt="4" gapY="5">
-          <BackButton/>
-          <Col gapY="1">
+            <Col gapY="1" mt="0">
             <Text color="black" fontSize={2} fontWeight="medium">
               CalmEngine
             </Text>

--- a/pkg/interface/src/views/apps/settings/components/lib/DisplayForm.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/DisplayForm.tsx
@@ -94,9 +94,9 @@ export default function DisplayForm(props: DisplayFormProps) {
     >
       {(props) => (
         <Form>
+          <BackButton/>
           <Col p="5" pt="4" gapY="5">
-            <BackButton/>
-            <Col gapY="2">
+              <Col gapY="1" mt="0">
               <Text color="black" fontSize={2} fontWeight="medium">
                 Display Preferences
               </Text>

--- a/pkg/interface/src/views/apps/settings/components/lib/LeapSettings.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/LeapSettings.tsx
@@ -74,9 +74,10 @@ export function LeapSettings(props: { api: GlobalApi; }) {
   };
 
   return (
+    <>
+    <BackButton/>
     <Col p="5" pt="4" gapY="5">
-      <BackButton/>
-      <Col gapY="1">
+      <Col gapY="1" mt="0">
         <Text fontSize="2" fontWeight="medium">
           Leap
         </Text>
@@ -97,5 +98,6 @@ export function LeapSettings(props: { api: GlobalApi; }) {
         </Form>
       </FormikOnBlur>
     </Col>
+    </>
   );
 }

--- a/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
@@ -51,9 +51,10 @@ export function NotificationPreferences(props: {
   }, [api]);
 
   return (
+    <>
+    <BackButton/>
     <Col p="5" pt="4" gapY="5">
-      <BackButton/>
-      <Col gapY="1">
+      <Col gapY="1" mt="0">
         <Text fontSize="2" fontWeight="medium">
           Notification Preferences
         </Text>
@@ -84,5 +85,6 @@ export function NotificationPreferences(props: {
         </Form>
       </FormikOnBlur>
     </Col>
+    </>
   );
 }

--- a/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
@@ -64,9 +64,9 @@ export default function S3Form(props: S3FormProps): ReactElement {
           onSubmit={onSubmit}
         >
           <Form>
+            <BackButton/>
             <Col maxWidth="600px" gapY="5">
-              <BackButton/>
-              <Col gapY="1">
+              <Col gapY="1" mt="0">
                 <Text color="black" fontSize={2} fontWeight="medium">
                   S3 Storage Setup
                 </Text>

--- a/pkg/interface/src/views/apps/settings/components/lib/Security.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/Security.tsx
@@ -17,9 +17,10 @@ interface SecuritySettingsProps {
 export default function SecuritySettings({ api }: SecuritySettingsProps) {
   const [allSessions, setAllSessions] = useState(false);
   return (
+    <>
+    <BackButton/>
     <Col gapY="5" p="5" pt="4">
-      <BackButton/>
-      <Col gapY="1">
+      <Col gapY="1" mt="0">
         <Text fontSize={2} fontWeight="medium">
           Security Preferences
         </Text>
@@ -56,5 +57,6 @@ export default function SecuritySettings({ api }: SecuritySettingsProps) {
         </form>
       </Col>
     </Col>
+    </>
   );
 }

--- a/pkg/interface/src/views/components/RichText.js
+++ b/pkg/interface/src/views/components/RichText.js
@@ -3,7 +3,7 @@ import RemoteContent from '~/views/components/RemoteContent';
 import { hasProvider } from 'oembed-parser';
 import ReactMarkdown from 'react-markdown';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
-import { BaseAnchor, Text } from '@tlon/indigo-react';
+import { Anchor, Text } from '@tlon/indigo-react';
 import { isValidPatp } from 'urbit-ob';
 
 import { deSig } from '~/logic/lib/util';
@@ -37,7 +37,7 @@ const RichText = React.memo(({ disableRemoteContent, ...props }) => (
           return <RemoteContent className="mw-100" url={linkProps.href} />;
         }
 
-        return <BaseAnchor target='_blank' rel='noreferrer noopener' borderBottom='1px solid' remoteContentPolicy={remoteContentPolicy} {...linkProps}>{linkProps.children}</BaseAnchor>;
+        return <Anchor target='_blank' rel='noreferrer noopener' borderBottom='1px solid' remoteContentPolicy={remoteContentPolicy} {...linkProps}>{linkProps.children}</Anchor>;
       },
       linkReference: (linkProps) => {
         const linkText = String(linkProps.children[0].props.children);

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
@@ -161,7 +161,7 @@ export function GraphPermissions(props: GraphPermissionsProps) {
     >
       <Form style={{ display: 'contents' }}>
         <Col mt="4" flexShrink={0} gapY="5">
-          <Col gapY="1">
+          <Col gapY="1" mt="0">
             <Text id="permissions" fontWeight="bold" fontSize="2">
               Permissions
             </Text>

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
@@ -6,7 +6,8 @@ import {
   Box,
   ManagedTextInputField as Input,
   ManagedToggleSwitchField as Checkbox,
-  Col
+  Col,
+  Text
 } from '@tlon/indigo-react';
 import { Enc } from '@urbit/api';
 import { Group, GroupPolicy } from '@urbit/api/groups';
@@ -104,7 +105,7 @@ return null;
       onSubmit={onSubmit}
     >
       <Form>
-        <Box p="4" fontWeight="600" fontSize="2" id="group-details">Group Details</Box>
+        <Box p="4" id="group-details"><Text fontWeight="600" fontSize="2">Group Details</Text></Box>
         <Col pb="4" px="4" maxWidth="384px" gapY={4}>
           <Input
             id="title"

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
@@ -4,7 +4,7 @@ import {
   Col,
   Label,
   BaseLabel,
-  BaseAnchor
+  Text
 } from '@tlon/indigo-react';
 import { GroupNotificationsConfig } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
@@ -28,7 +28,7 @@ export function GroupPersonalSettings(props: {
 
   return (
     <Col px="4" pb="4" gapY="4">
-      <BaseAnchor pt="4" fontWeight="600" id="notifications" fontSize="2">Group Notifications</BaseAnchor>
+      <Text pt="4" fontWeight="600" id="notifications" fontSize="2">Group Notifications</Text>
       <BaseLabel
         htmlFor="asyncToggle"
         display="flex"

--- a/pkg/interface/src/views/landscape/css/custom.css
+++ b/pkg/interface/src/views/landscape/css/custom.css
@@ -5,3 +5,7 @@
 .m0a {
   margin: 0 auto;
 }
+
+a, a:any-link {
+  text-decoration: none;
+}


### PR DESCRIPTION
- Use Anchor instead of BaseAnchor to restyle rich text links (https://github.com/urbit/landscape/issues/516)
- Place anchor css reset inside custom CSS instead of the styled Root component so that objects in portals get the CSS applied (like group switcher, etc.)