### PR TITLE
LinkResource: fix changing channels

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -68,6 +68,7 @@ export function LinkResource(props: LinkResourceProps) {
           render={(props) => {
             return (
               <LinkWindow
+                key={rid}
                 s3={s3}
                 association={resource}
                 contacts={contacts}


### PR DESCRIPTION
Forcibly destroys and recreates a linkwindow when the channel changes. This is necessary to prevent the virtualscroller from acting upon stale state.

Fixes urbit/landscape#508