### PR TITLE
Rename ++html to ++encoding

### DIFF
--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -7,11 +7,11 @@
 ::  +en-base64url: url-safe base64 encoding, without padding
 ::
 ++  en-base64url
-  ~(en base64:mimes:html | &)
+  ~(en base64:mimes:encoding | &)
 ::  +de-base64url: url-safe base64 decoding, without padding
 ::
 ++  de-base64url
-  ~(de base64:mimes:html | &)
+  ~(de base64:mimes:encoding | &)
 ::  +join-turf
 ::
 ++  join-turf
@@ -19,7 +19,7 @@
   ^-  cord
   %+  rap  3
   %-  (bake join ,[cord wain])
-  [', ' (turn hot en-turf:html)]
+  [', ' (turn hot en-turf:encoding)]
 ::  |octn: encode/decode unsigned atoms as big-endian octet stream
 ::
 ++  octn
@@ -60,7 +60,7 @@
   |%
   ::  +json-purl: parse url
   ::
-  ++  json-purl  (su auri:de-purl:html)
+  ++  json-purl  (su auri:de-purl:encoding)
   ::  +json-date: parse iso-8601
   ::
   ::    XX actually parse
@@ -114,7 +114,7 @@
         --
     ^-  $-(json auth:body)
     %-  ot
-    :~  'identifier'^(cu iden (ot type+so value+(su thos:de-purl:html) ~))
+    :~  'identifier'^(cu iden (ot type+so value+(su thos:de-purl:encoding) ~))
         'status'^so
         'expires'^json-date
         'challenges'^(cu trial (ar challenge))
@@ -391,7 +391,7 @@
 ::  directory-base: LetsEncrypt service directory url
 ::
 =/  directory-base=purl
-  =-  (need (de-purl:html -))
+  =-  (need (de-purl:encoding -))
   'https://acme-v02.api.letsencrypt.org/directory'
 ::  cards: list of outgoing moves for the current transaction
 ::
@@ -449,7 +449,7 @@
 ++  request
   |=  [wir=wire req=hiss]
   ^-  card
-  [%pass wir %arvo %i %request (hiss-to-request:html req) *outbound-config:iris]
+  [%pass wir %arvo %i %request (hiss-to-request:encoding req) *outbound-config:iris]
 ::  +signed-request: JWS JSON POST
 ::
 ++  signed-request
@@ -460,10 +460,10 @@
   :-  ~
   ^-  octs
   =;  pro=json
-    (as-octt:mimes:html (en-json:html (sign:jws key.act pro bod)))
+    (as-octt:mimes:encoding (en-json:encoding (sign:jws key.act pro bod)))
   :-  %o  %-  my  :~
     nonce+s+non
-    url+s+(crip (en-purl:html url))
+    url+s+(crip (en-purl:encoding url))
     ?^  reg.act
       kid+s+kid.u.reg.act
     jwk+(pass:en:jwk key.act)
@@ -487,7 +487,7 @@
   ::
   ?.  =(400 p.rep)  |
   ?~  r.rep  |
-  =/  jon=(unit json)  (de-json:html q.u.r.rep)
+  =/  jon=(unit json)  (de-json:encoding q.u.r.rep)
   ?~  jon  |
   =('urn:ietf:params:acme:error:badNonce' type:(error:grab u.jon))
 ::  +rate-limited: handle Acme service rate-limits
@@ -496,7 +496,7 @@
   |=  [try=@ud act=@tas spur=wire bod=(unit octs)]
   ^+  this
   =/  jon=(unit json)
-    ?~(bod ~ (de-json:html q.u.bod))
+    ?~(bod ~ (de-json:encoding q.u.bod))
   ?~  jon
     ::  no details, back way off
     ::  XX specifically based on wire
@@ -520,7 +520,7 @@
           ?~  rod
             ::  XX shouldn't happen
             ::
-            (en-turf:html /network/arvo/(crip +:(scow %p our.bow)))
+            (en-turf:encoding /network/arvo/(crip +:(scow %p our.bow)))
           (join-turf ~(tap in dom.u.rod))
           '. retrying in ~d7.'
       ==
@@ -537,7 +537,7 @@
           ' too many certificates issued for '
           ::  XX get from detail
           ::
-          (en-turf:html /network/arvo)
+          (en-turf:encoding /network/arvo)
           '. retrying in '
           (scot %dr lul)  '.'
       ==
@@ -559,7 +559,7 @@
   ^-  cord
   %+  rap  3
   :~  'unable to reach '
-      (crip (en-purl:html purl))  '. '
+      (crip (en-purl:encoding purl))  '. '
       'please confirm your urbit has network connectivity.'
   ==
 ::  |effect: send moves to advance
@@ -651,7 +651,7 @@
         :-  %a
         %+  turn
           ~(tap in ~(key by `(map turf *)`dom.u.next-order))
-        |=(a=turf [%o (my type+s+'dns' value+s+(en-turf:html a) ~)])
+        |=(a=turf [%o (my type+s+'dns' value+s+(en-turf:encoding a) ~)])
       ==
     =/  wire-params  [try %new-order /(scot %da now.bow)]
     (stateful-request wire-params new-order.dir json)
@@ -824,7 +824,7 @@
       =/  msg=cord
         %+  rap  3
         :~  'unable to reach '  (scot %p our.bow)
-            ' via http at '  (en-turf:html turf.i.item)  ':80'
+            ' via http at '  (en-turf:encoding turf.i.item)  ':80'
         ==
       (emil(next-order ~) (notify msg [(sell !>(rep)) ~]))
     ?:  ?=(~ (skip ~(val by dom.u.next-order) |=([@ud valid=?] valid)))
@@ -839,7 +839,7 @@
       ?:  (lth try 10)
         (retry:effect try %directory / (min ~m30 (backoff try)))
       (emil (notify (failure-message directory-base) [(sell !>(rep)) ~]))
-    =.  dir  (directory:grab (need (de-json:html q:(need r.rep))))
+    =.  dir  (directory:grab (need (de-json:encoding q:(need r.rep))))
     ?~(reg.act register:effect this)
   ::  +nonce: accept new nonce and trigger next effect
   ::
@@ -883,7 +883,7 @@
       ?~  r.rep
         (scot %da now.bow)
       =/  bod=acct:body
-        (acct:grab (need (de-json:html q.u.r.rep)))
+        (acct:grab (need (de-json:encoding q.u.r.rep)))
       ?>  ?=(%valid sas.bod)
       wen.bod
     =.  reg.act  `[wen loc]
@@ -908,12 +908,12 @@
     ?>  ?=(^ next-order)
     =/  loc=@t
       q:(head (skim q.rep |=((pair @t @t) ?=(%location p))))
-    =/  ego=purl  (need (de-purl:html loc))
+    =/  ego=purl  (need (de-purl:encoding loc))
     ::  XX parse identifiers, confirm equal to pending domains
     ::  XX check status
     ::
     =/  bod=order:body
-      (order:grab (need (de-json:html q:(need r.rep))))
+      (order:grab (need (de-json:encoding q:(need r.rep))))
     =/  dom=(set turf)  ~(key by dom.u.next-order)
     ::  XX maybe generate key here?
     ::
@@ -956,7 +956,7 @@
       ::
       (emil (notify (failure-message ego.u.rod) [(sell !>(rep)) ~]))
     =/  bod=order:body
-      (order:grab (need (de-json:html q:(need r.rep))))
+      (order:grab (need (de-json:encoding q:(need r.rep))))
     ?+  sas.bod
       ~&  [%check-order-status-unknown sas.bod]
       this
@@ -1063,7 +1063,7 @@
       ::
       (emil (notify (failure-message i.pending.aut.u.rod) [(sell !>(rep)) ~]))
     =/  bod=auth:body
-      (auth:grab (need (de-json:html q:(need r.rep))))
+      (auth:grab (need (de-json:encoding q:(need r.rep))))
     =/  cal=trial
        ::  XX parse token to verify url-safe base64?
        ::
@@ -1103,12 +1103,12 @@
       =/  msg=cord
         %+  rap  3
         :~  'unable to retrieve self-hosted domain validation token '
-            'via '  (en-turf:html dom.aut)  '. '
+            'via '  (en-turf:encoding dom.aut)  '. '
             'please confirm your urbit has network connectivity.'
         ==
       (emil (notify msg [(sell !>(rep)) ~]))
     =/  bod
-      %-  as-octs:mimes:html
+      %-  as-octs:mimes:encoding
       (rap 3 [tok.cal.aut '.' (pass:thumb:jwk key.act) ~])
     ?.  ?&  ?=(^ r.rep)
             =(bod u.r.rep)
@@ -1147,7 +1147,7 @@
       ::  XX get challenge, confirm urn:ietf:params:acme:error:connection
       ::
       ::  =/  err=error:body
-      ::    (error:grab (need (de-json:html q:(need r.rep))))
+      ::    (error:grab (need (de-json:encoding q:(need r.rep))))
       ::  ?:  =('urn:ietf:params:acme:error:malformed' status.err)
       ::
       =<  cancel-order:effect
@@ -1155,7 +1155,7 @@
        'unable to finalize domain validation challenge'
       (emil (notify msg [(sell !>(rep)) ~]))
     =/  bod=challenge:body
-      (challenge:grab (need (de-json:html q:(need r.rep))))
+      (challenge:grab (need (de-json:encoding q:(need r.rep))))
     ::  XX check for other possible values in 200 response
     ::  note: may have already been validated
     ::

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -740,8 +740,8 @@
       =/  =rift  rut.life-rift
       =/  =pass
         %^    pass-from-eth:azimuth
-            (as-octs:mimes:html (get-public:aqua-azimuth ship life %crypt))
-          (as-octs:mimes:html (get-public:aqua-azimuth ship life %auth))
+            (as-octs:mimes:encoding (get-public:aqua-azimuth ship life %crypt))
+          (as-octs:mimes:encoding (get-public:aqua-azimuth ship life %auth))
         1
       :^    ship
           *[address address address address]:azimuth
@@ -759,7 +759,7 @@
       get-czars
       ~[~['arvo' 'netw' 'ork']]
       0
-      `(need (de-purl:html 'http://localhost:8545'))
+      `(need (de-purl:encoding 'http://localhost:8545'))
   ==
 ::
 ::  Should only do galaxies
@@ -775,7 +775,7 @@
   %-  some
   :^  who  rut  lyfe
   %^    pass-from-eth:azimuth
-      (as-octs:mimes:html (get-public:aqua-azimuth who lyfe %crypt))
-    (as-octs:mimes:html (get-public:aqua-azimuth who lyfe %auth))
+      (as-octs:mimes:encoding (get-public:aqua-azimuth who lyfe %crypt))
+    (as-octs:mimes:encoding (get-public:aqua-azimuth who lyfe %auth))
   1
 --

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -642,7 +642,7 @@
       =-  (sear - text)
       |=  t=cord
       ^-  (unit cord)
-      ?~((rush t aurf:de-purl:html) ~ `t)
+      ?~((rush t aurf:de-purl:encoding) ~ `t)
     ::  +text: text message body
     ::
     ++  text
@@ -1129,7 +1129,7 @@
       =.  wyd  (sub wyd 2)
       :-  '_'
       =-  (weld - "_")
-      =+  prl=(rust ful aurf:de-purl:html)
+      =+  prl=(rust ful aurf:de-purl:encoding)
       ?~  prl  (scag wyd ful)
       =+  hok=r.p.p.u.prl
       =;  domain=tape

--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -264,7 +264,7 @@
   |=  reg=cord
   ^-  (list [=ship rights])
   ~|  %registration-json-insane
-  =+  jon=(need (de-json:html reg))
+  =+  jon=(need (de-json:encoding reg))
   ~|  %registration-json-invalid
   ?>  ?=(%o -.jon)
   =.  p.jon  (~(del by p.jon) 'idCode')

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -410,7 +410,7 @@
     ==
   ?.  .^(? %cu path)  ~
   %-  some
-  %-  as-octs:mimes:html
+  %-  as-octs:mimes:encoding
   .^(@ %cx path)
 ::
 ::  applications

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -255,12 +255,12 @@
   ++  parse-iden-url
     %+  cook
       |=([a=(unit knot) b=purl:eyre] [`(fall a *knot) b])
-    auru:de-purl:html
+    auru:de-purl:encoding
   ::
   ++  parse-url
     %+  cook
-      |=(a=purl:eyre (crip (en-purl:html a)))
-    auri:de-purl:html
+      |=(a=purl:eyre (crip (en-purl:encoding a)))
+    auri:de-purl:encoding
   ::
   ++  parse-model   ;~(plug parse-server parse-config)
   ++  parse-server  (stag 0 (most fas sym))
@@ -577,7 +577,7 @@
         %+  dy-request  /show
         :*  ?:(=(%put p.p.mad) %'PUT' %'POST')
             r.p.mad
-            ~[['content-type' (en-mite:mimes:html p.mim)]]
+            ~[['content-type' (en-mite:mimes:encoding p.mim)]]
             `q.mim
         ==
       ::
@@ -1137,7 +1137,7 @@
           %+  rash  pax.source.com
           rood:(vang | /(scot %p our.hid)/home/(scot %da now.hid))
         ::
-            %url         [%ur (crip (en-purl:html url.source.com))]
+            %url         [%ur (crip (en-purl:encoding url.source.com))]
             %api         !!
             %get-api
           :-  %ex
@@ -1184,7 +1184,7 @@
           %output-file  $(sink.com [%command (cat 3 '@' pax.sink.com)])
           %output-pill  $(sink.com [%command (cat 3 '.' pax.sink.com)])
           %output-clay  [%file (need (de-beam pax.sink.com))]
-          %url          [%http %post (crip (en-purl:html url.sink.com))]
+          %url          [%http %post (crip (en-purl:encoding url.sink.com))]
           %to-api       !!
           %send-api     [%poke our.hid api.sink.com]
           %command      (rash command.sink.com parse-sink:he-parser)

--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -189,7 +189,7 @@
       %+  require-authorization-simple:app
         inbound-request
       %-  js-response:gen
-      (as-octt:mimes:html "window.ship = '{+:(scow %p our.bowl)}';")
+      (as-octt:mimes:encoding "window.ship = '{+:(scow %p our.bowl)}';")
     ::
     =/  [payload=simple-payload:http public=?]  (get-file req-line is-file)
     ?:  public  payload
@@ -216,7 +216,7 @@
         ?:  ?=([~ %woff2] ext.req-line)
           :_  public.u.content
           [[200 [['content-type' '/font/woff2'] ~]] `.^(octs %cx scry-path)]
-        =/  file  (as-octs:mimes:html .^(@ %cx scry-path))
+        =/  file  (as-octs:mimes:encoding .^(@ %cx scry-path))
         :_  public.u.content
         ?+  ext.req-line  not-found:gen
             [~ %js]    (js-response:gen file)

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -72,7 +72,7 @@
     ^-  card:agent:gall
     [%pass /import-all %agent [our.bowl app] %poke %import !>(data)]
   =/  jon=json
-    (need (de-json:html body))
+    (need (de-json:encoding body))
   =/  com=command:lens
     (json:grab:lens-mark jon)
   ::
@@ -85,7 +85,7 @@
     [%pass /export %agent [our.bowl app.source.com] %watch /export]~
   ::
       %import
-    ?~  enc=(de:base64:mimes:html base64-jam.source.com)
+    ?~  enc=(de:base64:mimes:encoding base64-jam.source.com)
       !!
     ::
     =/  c=*  (cue q.u.enc)
@@ -98,7 +98,7 @@
     =/  jon
       =/  =atom  (jam (export-all our.bowl now.bowl))
       =/  =octs  [(met 3 atom) atom]
-      =/  enc    (en:base64:mimes:html octs)
+      =/  enc    (en:base64:mimes:encoding octs)
       (pairs:enjs:format file+s+output data+s+enc ~)
     :_  this
     %+  give-simple-payload:app  eyre-id
@@ -106,7 +106,7 @@
   ::
       %import-all
     ~&  %import-all
-    =/  enc  (de:base64:mimes:html base64-jam.source.com)
+    =/  enc  (de:base64:mimes:encoding base64-jam.source.com)
     ?~  enc  !!
     =/  by-app  ;;((list [@tas *]) (cue q.u.enc))
     :_  this
@@ -142,7 +142,7 @@
     ?>  ?=(^ job.state)
     :_  this(job.state ~)
     %+  give-simple-payload:app  eyre-id.u.job.state
-    [[200 ~] `(as-octt:mimes:html "\"Imported data\"")]
+    [[200 ~] `(as-octt:mimes:encoding "\"Imported data\"")]
   ::
       [%export ~]
     ?+    -.sign  (on-agent:def wire sign)
@@ -194,7 +194,7 @@
     =/  jon=json
       =/  =atom  (jam data)
       =/  =octs  [(met 3 atom) atom]
-      =/  enc  (en:base64:mimes:html octs)
+      =/  enc  (en:base64:mimes:encoding octs)
       (pairs:enjs:format file+s+output data+s+enc ~)
     ::
     :_  this
@@ -221,14 +221,14 @@
       ::
           %sag
         %-  some
-        [%mime p.fec (as-octs:mimes:html (jam q.fec))]
+        [%mime p.fec (as-octs:mimes:encoding (jam q.fec))]
       ::
           %sav
         %-  some
         :-  %json
         %-  pairs:enjs:format
         :~  file+s+(crip <`path`p.fec>)
-            data+s+(en:base64:mimes:html (met 3 q.fec) q.fec)
+            data+s+(en:base64:mimes:encoding (met 3 q.fec) q.fec)
         ==
       ::
           %mor

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -291,7 +291,7 @@
     ==
   ?>  ?=(^ body.request.inbound-request)
   =/  body=json
-    (need (de-json:html q.u.body.request.inbound-request))
+    (need (de-json:encoding q.u.body.request.inbound-request))
   =/  input=vase
     (slop !>(~) (tube !>(body)))
   =/  =start-args

--- a/pkg/arvo/app/weather.hoon
+++ b/pkg/arvo/app/weather.hoon
@@ -120,7 +120,7 @@
   ?~  data
     :: data is null
     [~ state]
-  =/  ujon=(unit json)  (de-json:html q.data.u.data)
+  =/  ujon=(unit json)  (de-json:encoding q.data.u.data)
   ?~  ujon
      [~ state]
   ?>  ?=(%o -.u.ujon)

--- a/pkg/arvo/gen/acme/domain-validation.hoon
+++ b/pkg/arvo/gen/acme/domain-validation.hoon
@@ -5,7 +5,7 @@
 ^-  simple-payload:http
 =/  url=(unit (pair pork:eyre quay:eyre))
   %+  rush  url.request
-  ;~(plug ;~(pose apat:de-purl:html (easy *pork:eyre)) yque:de-purl:html)
+  ;~(plug ;~(pose apat:de-purl:encoding (easy *pork:eyre)) yque:de-purl:encoding)
 ::
 ::  url doesn't match expected binding from :acme
 ::
@@ -30,4 +30,4 @@
 ?~  response
   [[%404 ~] ~]
 :-  [200 ['content-type' 'text/html']~]
-(some (as-octs:mimes:html u.response))
+(some (as-octs:mimes:encoding u.response))

--- a/pkg/arvo/gen/aqua/file.hoon
+++ b/pkg/arvo/gen/aqua/file.hoon
@@ -6,6 +6,6 @@
 ^-  aqua-event:aquarium
 :+  %event  her
 ?>  ?=([@ @ @ *] pax)
-=/  file  [/text/plain (as-octs:mimes:html .^(@ %cx pax))]
+=/  file  [/text/plain (as-octs:mimes:encoding .^(@ %cx pax))]
 :-  //sync/0v1n.2m9vh
 [%into `desk`i.t.pax | `mode:clay`[t.t.t.pax `file]~]

--- a/pkg/arvo/gen/dns-bind/authority.hoon
+++ b/pkg/arvo/gen/dns-bind/authority.hoon
@@ -26,7 +26,7 @@
     (fun.q.q [%& dom.arg])
 %+  prompt
   [%& %dns-domain "dns domain: "]
-%+  parse  thos:de-purl:html
+%+  parse  thos:de-purl:encoding
 |=  hot=host:eyre
 ?:  ?=(%| -.hot)
   ~|(%ips-unsupported !!)

--- a/pkg/arvo/gen/frontpage.hoon
+++ b/pkg/arvo/gen/frontpage.hoon
@@ -9,9 +9,9 @@
 ^-  simple-payload:http
 :-  [200 ['content-type' 'text/html']~]
 :-  ~
-%-  as-octs:mimes:html
+%-  as-octs:mimes:encoding
 %-  crip
-%-  en-xml:html
+%-  en-xml:encoding
 ^-  manx
 ;html
   ;head

--- a/pkg/arvo/gen/hood/init-oauth2.hoon
+++ b/pkg/arvo/gen/hood/init-oauth2.hoon
@@ -19,7 +19,7 @@
     (fun.q.q [%& dom.arg])
 %+  prompt
   [%& %oauth-hostname "api hostname: https://"]
-%+  parse  thos:de-purl:html
+%+  parse  thos:de-purl:encoding
 |=  hot=host:eyre
 ?:  ?=(%| -.hot)
   ~|(%ips-unsupported !!)

--- a/pkg/arvo/gen/hood/init-oauth2/google.hoon
+++ b/pkg/arvo/gen/hood/init-oauth2/google.hoon
@@ -9,7 +9,7 @@
 ::::
   ::
 =,  generators
-=,  html
+=,  encoding
 =,  format
 :-  %ask
 |=  $:  [now=@da eny=@uvJ bec=beak]

--- a/pkg/arvo/gen/who.hoon
+++ b/pkg/arvo/gen/who.hoon
@@ -5,7 +5,7 @@
 |=  [authorized=? =request:http]
 ^-  simple-payload:http
 =/  url=(unit pork:eyre)
-  (rush url.request apat:de-purl:html)
+  (rush url.request apat:de-purl:encoding)
 ::
 ::  url doesn't match expected binding from :launch
 ::

--- a/pkg/arvo/lib/aqua-azimuth.hoon
+++ b/pkg/arvo/lib/aqua-azimuth.hoon
@@ -57,7 +57,7 @@
   ++  get-single-req
     |=  req=@t
     =/  batch
-      ((ar:dejs:format same) (need (de-json:html req)))
+      ((ar:dejs:format same) (need (de-json:encoding req)))
     ?>  ?=([* ~] batch)
     i.batch
   ::
@@ -111,7 +111,7 @@
     ^-  card:agent:gall
     =/  resp
       %-  crip
-      %-  en-json:html
+      %-  en-json:encoding
       :-  %a  :_  ~
       %-  pairs
       :~  id+s+(get-id req)
@@ -125,7 +125,7 @@
           //http-client/0v1n.2m9vh
           %receive
           num.u.ask
-          [%start [200 ~] `(as-octs:mimes:html resp) &]
+          [%start [200 ~] `(as-octs:mimes:encoding resp) &]
       ==
     :*  %pass  /aqua-events
         %agent  [our %aqua]

--- a/pkg/arvo/lib/azimuthio.hoon
+++ b/pkg/arvo/lib/azimuthio.hoon
@@ -43,8 +43,8 @@
         url=url
         header-list=['Content-Type'^'application/json' ~]
         ^=  body
-        %-  some  %-  as-octt:mimes:html
-        %-  en-json:html
+        %-  some  %-  as-octt:mimes:encoding
+        %-  en-json:encoding
         (request-to-json:rpc:ethereum id req)
     ==
   ;<  ~  bind:m  (send-request:strandio request)
@@ -62,7 +62,7 @@
     ?~  full-file.client-response
       (pure:m ~)
     =/  body=@t  q.data.u.full-file.client-response
-    =/  jon=(unit json)  (de-json:html body)
+    =/  jon=(unit json)  (de-json:encoding body)
     ?~  jon
       (pure:m ~)
     =,  dejs-soft:format

--- a/pkg/arvo/lib/bip32.hoon
+++ b/pkg/arvo/lib/bip32.hoon
@@ -200,7 +200,7 @@
 ::
 ++  en-b58c-bip32
   |=  [v=@ k=@]
-  %-  en-base58:mimes:html
+  %-  en-base58:mimes:encoding
   (en-base58check [4 v] [74 k])
 ::
 ::  base58check
@@ -217,7 +217,7 @@
 ++  de-base58check
   ::  vw: amount of version bytes
   |=  [vw=@u t=tape]
-  =+  x=(de-base58:mimes:html t)
+  =+  x=(de-base58:mimes:encoding t)
   =+  hash=(sha-256l:sha 32 (sha-256:sha (rsh [3 4] x)))
   ?>  =((end [3 4] x) (rsh [3 28] hash))
   (cut 3 [vw (sub (met 3 x) (add 4 vw))] x)

--- a/pkg/arvo/lib/ethereum.hoon
+++ b/pkg/arvo/lib/ethereum.hoon
@@ -212,7 +212,7 @@
             [%bytes p=octs]
         ==
       --
-  =,  mimes:html
+  =,  mimes:encoding
   |%
   ::  encoding
   ::
@@ -557,7 +557,7 @@
     %+  scag  8
     %+  render-hex-bytes  32
     %-  keccak-256:keccak:crypto
-    (as-octs:mimes:html function)
+    (as-octs:mimes:encoding function)
   ::
   ::  building requests
   ::
@@ -568,7 +568,7 @@
     :^  url  %post
       %-  ~(gas in *math)
       ~['Content-Type'^['application/json']~]
-    (some (as-octt (en-json:html jon)))
+    (some (as-octt (en-json:encoding jon)))
   ::  +light-json-request: like json-request, but for %l
   ::
   ::    TODO: Exorcising +purl from our system is a much longer term effort;
@@ -579,9 +579,9 @@
     ^-  request:http
     ::
     :*  %'POST'
-        (crip (en-purl:html url))
+        (crip (en-purl:encoding url))
         ~[['content-type' 'application/json']]
-        (some (as-octt (en-json:html jon)))
+        (some (as-octt (en-json:encoding jon)))
     ==
   ::
   ++  batch-read-request
@@ -824,7 +824,7 @@
   ?:  =(0 n)
     "0"
   %-  render-hex-bytes
-  (as-octs:mimes:html n)
+  (as-octs:mimes:encoding n)
 ::
 ++  address-to-hex
   |=  a=address

--- a/pkg/arvo/lib/ethio.hoon
+++ b/pkg/arvo/lib/ethio.hoon
@@ -76,8 +76,8 @@
           header-list=['Content-Type'^'application/json' ~]
         ::
           ^=  body
-          %-  some  %-  as-octt:mimes:html
-          %-  en-json:html
+          %-  some  %-  as-octt:mimes:encoding
+          %-  en-json:encoding
           a+(turn reqs request-to-json:rpc:ethereum)
       ==
     ;<  ~  bind:m
@@ -96,7 +96,7 @@
     ?~  full-file.client-response
       (pure:m ~)
     =/  body=@t  q.data.u.full-file.client-response
-    =/  jon=(unit json)  (de-json:html body)
+    =/  jon=(unit json)  (de-json:encoding body)
     ?~  jon
       (pure:m ~)
     =/  array=(unit (list response:rpc))

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -69,7 +69,7 @@
   =-  abet:(emit %pass /write %arvo %c %info -)
   =/  byk=path  (en-beam byk.bowl(r da+now.bowl) ~)
   =+  .^(=tube:clay cc+(welp byk /mime/atom))
-  =/  =cage  atom+(tube !>([/ (as-octs:mimes:html dat)]))
+  =/  =cage  atom+(tube !>([/ (as-octs:mimes:encoding dat)]))
   (foal:space:userlib :(welp byk sec+p.hot /atom) cage)
 ::
 ++  poke-moon                                        ::  rotate moon keys

--- a/pkg/arvo/lib/jose.hoon
+++ b/pkg/arvo/lib/jose.hoon
@@ -4,11 +4,11 @@
 ::  +en-base64url: url-safe base64 encoding, without padding
 ::
 ++  en-base64url
-  ~(en base64:mimes:html | &)
+  ~(en base64:mimes:encoding | &)
 ::  +de-base64url: url-safe base64 decoding, without padding
 ::
 ++  de-base64url
-  ~(de base64:mimes:html | &)
+  ~(de base64:mimes:encoding | &)
 ::  |octn: encode/decode unsigned atoms as big-endian octet stream
 ::
 ++  octn
@@ -31,9 +31,9 @@
 ::
 ++  en-json-sort                                 ::  XX rename
   |^  |=([sor=$-(^ ?) val=json] (apex val sor ""))
-  ::                                                  ::  ++apex:en-json:html
+  ::                                                  ::  ++apex:en-json:encoding
   ++  apex
-    =,  en-json:html
+    =,  en-json:encoding
     |=  [val=json sor=$-(^ ?) rez=tape]
     ^-  tape
     ?~  val  (weld "null" rez)
@@ -194,7 +194,7 @@
     ++  encode
       |=  jon=json
       %-  en-base64url
-      %-  as-octt:mimes:html
+      %-  as-octt:mimes:encoding
       (en-json-sort aor jon)
     ::  +sign:sign:jws: compute signature
     ::

--- a/pkg/arvo/lib/json/rpc.hoon
+++ b/pkg/arvo/lib/json/rpc.hoon
@@ -10,8 +10,8 @@
     %-  ~(gas in *math:eyre)
     ~['Content-Type'^['application/json']~]
   %-  some
-  %-  as-octt:mimes:html
-  (en-json:html (request-to-json req))
+  %-  as-octt:mimes:encoding
+  (en-json:encoding (request-to-json req))
 ::
 ++  request-to-json
   |=  request

--- a/pkg/arvo/lib/ph/util.hoon
+++ b/pkg/arvo/lib/ph/util.hoon
@@ -51,7 +51,7 @@
   =/  input
     %+  turn  files
     |=  [=path txt=@t]
-    [path ~ /text/plain (as-octs:mimes:html txt)]
+    [path ~ /text/plain (as-octs:mimes:encoding txt)]
   %+  send-events-to  who
   :~
     [//sync/0v1n.2m9vh %into des | input]

--- a/pkg/arvo/lib/pill.hoon
+++ b/pkg/arvo/lib/pill.hoon
@@ -92,11 +92,11 @@
       ?-    tyl
           [%json *]
         =/  dat  .^(json %cx pax)
-        (as-octt:mimes:html (en-json:html dat))
+        (as-octt:mimes:encoding (en-json:encoding dat))
       ::
           [?(%md %txt) *]
         =/  dat  .^(wain %cx pax)
-        (as-octs:mimes:html (of-wain:format dat))
+        (as-octs:mimes:encoding (of-wain:format dat))
       ::
           *
         =/  dat  .^(@t %cx pax)

--- a/pkg/arvo/lib/pkcs.hoon
+++ b/pkg/arvo/lib/pkcs.hoon
@@ -58,7 +58,7 @@
     ^-  wain
     :: XX validate label?
     :-  (rap 3 ['-----BEGIN ' lab '-----' ~])
-    =/  a  (en:base64:mimes:html len `@`der)
+    =/  a  (en:base64:mimes:encoding len `@`der)
     |-  ^-  wain
     ?~  a
       [(rap 3 ['-----END ' lab '-----' ~]) ~]
@@ -74,7 +74,7 @@
     ?.  =((rap 3 ['-----BEGIN ' lab '-----' ~]) i.mep)  ~
     ?.  =((rap 3 ['-----END ' lab '-----' ~]) (snag a t.mep))  ~
     ^-  (unit [@ @])
-    (de:base64:mimes:html (rap 3 (scag a t.mep)))
+    (de:base64:mimes:encoding (rap 3 (scag a t.mep)))
   --
 ::  |pkcs1: RSA asymmetric cryptography (rfc3447)
 ::
@@ -354,7 +354,7 @@
         %+  turn  hot
         :: implicit, context-specific tag #2 (IA5String)
         :: XX sanitize string?
-        |=(=turf [%con `bespoke:asn1`[& 2] (trip (en-turf:html turf))])
+        |=(=turf [%con `bespoke:asn1`[& 2] (trip (en-turf:encoding turf))])
       --
     ::  |de:spec:pkcs10: ASN.1 decoding for certificate signing requests
     ++  de  !!

--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -9,17 +9,17 @@
 ++  parse-request-line
   |=  url=@t
   ^-  request-line
-  (fall (rush url ;~(plug apat:de-purl:html yque:de-purl:html)) [[~ ~] ~])
+  (fall (rush url ;~(plug apat:de-purl:encoding yque:de-purl:encoding)) [[~ ~] ~])
 ::
 ++  manx-to-octs
   |=  man=manx
   ^-  octs
-  (as-octt:mimes:html (en-xml:html man))
+  (as-octt:mimes:encoding (en-xml:encoding man))
 ::
 ++  json-to-octs
   |=  jon=json
   ^-  octs
-  (as-octt:mimes:html (en-json:html jon))
+  (as-octt:mimes:encoding (en-json:encoding jon))
 ::
 ++  app
   |%

--- a/pkg/arvo/lib/strandio.hoon
+++ b/pkg/arvo/lib/strandio.hoon
@@ -430,7 +430,7 @@
   =/  m  (strand ,json)
   ^-  form:m
   ;<  =cord  bind:m  (fetch-cord url)
-  =/  json=(unit json)  (de-json:html cord)
+  =/  json=(unit json)  (de-json:encoding cord)
   ?~  json
     (strand-fail %json-parse-error ~)
   (pure:m u.json)
@@ -439,7 +439,7 @@
   |=  =hiss:eyre
   =/  m  (strand ,(unit httr:eyre))
   ^-  form:m
-  ;<  ~  bind:m  (send-request (hiss-to-request:html hiss))
+  ;<  ~  bind:m  (send-request (hiss-to-request:encoding hiss))
   take-maybe-sigh
 ::
 ::  +build-fail: build the source file at the specified $beam

--- a/pkg/arvo/lib/vere.hoon
+++ b/pkg/arvo/lib/vere.hoon
@@ -52,8 +52,8 @@
     ::
     ++  bloq
       ^-  octs
-      %-  as-octt:mimes:html
-      %-  en-json:html
+      %-  as-octt:mimes:encoding
+      %-  en-json:encoding
       %+  request-to-json
         `~.0
       [%eth-block-number ~]
@@ -62,8 +62,8 @@
     ++  czar
       |=  boq=@ud
       ^-  octs
-      %-  as-octt:mimes:html
-      %-  en-json:html
+      %-  as-octt:mimes:encoding
+      %-  en-json:encoding
       :-  %a
       %+  turn  (gulf 0 255)
       |=  gal=@
@@ -78,8 +78,8 @@
     ++  point
       |=  [boq=@ud who=ship]
       ^-  octs
-      %-  as-octt:mimes:html
-      %-  en-json:html
+      %-  as-octt:mimes:encoding
+      %-  en-json:encoding
       %+  request-to-json
         `~.0
       :+  %eth-call
@@ -91,8 +91,8 @@
     ++  turf
       |=  boq=@ud
       ^-  octs
-      %-  as-octt:mimes:html
-      %-  en-json:html
+      %-  as-octt:mimes:encoding
+      %-  en-json:encoding
       :-  %a
       %+  turn  (gulf 0 2)
       |=  idx=@
@@ -116,7 +116,7 @@
     ++  bloq
       |=  rep=octs
       ^-  (unit @ud)
-      =/  jon=(unit json)  (de-json:html q.rep)
+      =/  jon=(unit json)  (de-json:encoding q.rep)
       ?~  jon
         ~&([%bloq-take-dawn %invalid-json] ~)
       =/  res=(unit cord)  ((ot result+so ~) u.jon)
@@ -133,7 +133,7 @@
     ++  czar
       |=  rep=octs
       ^-  (unit (map ship [=rift =life =pass]))
-      =/  jon=(unit json)  (de-json:html q.rep)
+      =/  jon=(unit json)  (de-json:encoding q.rep)
       ?~  jon
         ~&([%czar-take-dawn %invalid-json] ~)
       =/  res=(unit (list [@t @t]))
@@ -170,7 +170,7 @@
     ++  point
       |=  [who=ship rep=octs]
       ^-  (unit point:azimuth)
-      =/  jon=(unit json)  (de-json:html q.rep)
+      =/  jon=(unit json)  (de-json:encoding q.rep)
       ?~  jon
         ~&([%point-take-dawn %invalid-json] ~)
       =/  res=(unit cord)  ((ot result+so ~) u.jon)
@@ -193,7 +193,7 @@
     ++  turf
       |=  rep=octs
       ^-  (unit (list ^turf))
-      =/  jon=(unit json)  (de-json:html q.rep)
+      =/  jon=(unit json)  (de-json:encoding q.rep)
       ?~  jon
         ~&([%turf-take-dawn %invalid-json] ~)
       =/  res=(unit (list [@t @t]))
@@ -210,7 +210,7 @@
         =/  dom=tape
           (decode-results result [%string]~)
         =/  hot=host:eyre
-          (scan dom thos:de-purl:html)
+          (scan dom thos:de-purl:encoding)
         ?>(?=(%& -.hot) p.hot)
       ?~  dat
         ~&([%turf-take-dawn %invalid-domains] ~)

--- a/pkg/arvo/mar/atom.hoon
+++ b/pkg/arvo/mar/atom.hoon
@@ -5,7 +5,7 @@
 ::
 ::::  A minimal atom mark
   ::
-=,  mimes:html
+=,  mimes:encoding
 |_  ato=@
 ++  grab  |%
           ++  noun  @

--- a/pkg/arvo/mar/blit.hoon
+++ b/pkg/arvo/mar/blit.hoon
@@ -28,13 +28,13 @@
         %sag
       %-  pairs
       :~  'path'^(path p.blit)
-          'file'^s+(en:base64:mimes:html (as-octs:mimes:html (jam q.blit)))
+          'file'^s+(en:base64:mimes:encoding (as-octs:mimes:encoding (jam q.blit)))
       ==
     ::
         %sav
       %-  pairs
       :~  'path'^(path p.blit)
-          'file'^s+(en:base64:mimes:html (as-octs:mimes:html q.blit))
+          'file'^s+(en:base64:mimes:encoding (as-octs:mimes:encoding q.blit))
       ==
     ::
         %klr

--- a/pkg/arvo/mar/css.hoon
+++ b/pkg/arvo/mar/css.hoon
@@ -3,7 +3,7 @@
   ::
 /?    310
 =,  eyre
-=,  mimes:html
+=,  mimes:encoding
 |_  mud=@t
 ++  grow                                                ::  convert to
   |%  ++  mime  [/text/css (as-octs mud)]               ::  convert to %mime

--- a/pkg/arvo/mar/elem.hoon
+++ b/pkg/arvo/mar/elem.hoon
@@ -2,8 +2,8 @@
 ::::  /hoon/elem/mar
   ::
 /?    310
-=,  mimes:html
-=,  html
+=,  mimes:encoding
+=,  encoding
 |_  own=manx
 ::
 ++  grad  %mime

--- a/pkg/arvo/mar/eth/txs.hoon
+++ b/pkg/arvo/mar/eth/txs.hoon
@@ -3,7 +3,7 @@
 /+  *ethereum
 =,  format
 =,  rpc
-=,  mimes:html
+=,  mimes:encoding
 ::
 |_  txs=(list transaction)
 ++  u-parser

--- a/pkg/arvo/mar/graph/update.hoon
+++ b/pkg/arvo/mar/graph/update.hoon
@@ -1,5 +1,5 @@
 /+  *graph-store
-=*  as-octs  as-octs:mimes:html
+=*  as-octs  as-octs:mimes:encoding
 ::
 |_  upd=update
 ++  grad  %noun

--- a/pkg/arvo/mar/helm-hi.hoon
+++ b/pkg/arvo/mar/helm-hi.hoon
@@ -2,7 +2,7 @@
 ::::  /hoon/helm-hi/mar
   ::
 /?    310
-=,  mimes:html
+=,  mimes:encoding
 =,  format
 |_  txt=cord
 ::

--- a/pkg/arvo/mar/hoon.hoon
+++ b/pkg/arvo/mar/hoon.hoon
@@ -7,7 +7,7 @@
 ::
 ++  grow                                                ::  convert to
   |%
-  ++  mime  `^mime`[/text/x-hoon (as-octs:mimes:html own)] ::  convert to %mime
+  ++  mime  `^mime`[/text/x-hoon (as-octs:mimes:encoding own)] ::  convert to %mime
   ++  elem                                              ::  convert to %html
     ;div:pre(urb_codemirror "", mode "hoon"):"{(trip own)}"
     :: =+  gen-id="src-{<`@ui`(mug own)>}"

--- a/pkg/arvo/mar/html.hoon
+++ b/pkg/arvo/mar/html.hoon
@@ -5,7 +5,7 @@
   ::
 ::::  compute
   ::
-=,  html
+=,  encoding
 ^|
 |_  htm=@t
 ++  grow                                                ::  convert to

--- a/pkg/arvo/mar/httr.hoon
+++ b/pkg/arvo/mar/httr.hoon
@@ -5,7 +5,7 @@
 ::
 =,  eyre
 =,  format
-=,  html
+=,  encoding
 |_  hit=httr
 ++  grad  %noun
 ++  grow  |%  ++  wall  (turn wain trip)

--- a/pkg/arvo/mar/hymn.hoon
+++ b/pkg/arvo/mar/hymn.hoon
@@ -2,8 +2,8 @@
 ::::  /hoon/hymn/mar
   ::
 /?    310
-=,  mimes:html
-=,  html
+=,  mimes:encoding
+=,  encoding
 |_  own=manx
 ::
 ++  grad  %mime

--- a/pkg/arvo/mar/import.hoon
+++ b/pkg/arvo/mar/import.hoon
@@ -1,4 +1,4 @@
-=,  mimes:html
+=,  mimes:encoding
 |_  non=*
 ++  grab
   |%

--- a/pkg/arvo/mar/jam.hoon
+++ b/pkg/arvo/mar/jam.hoon
@@ -3,7 +3,7 @@
   ::
 /?    310
 ::
-=,  mimes:html
+=,  mimes:encoding
 |_  mud=@
 ++  grow
   |%

--- a/pkg/arvo/mar/js.hoon
+++ b/pkg/arvo/mar/js.hoon
@@ -7,7 +7,7 @@
 |_  mud=@
 ++  grow
   |%
-  ++  mime  [/application/javascript (as-octs:mimes:html (@t mud))]
+  ++  mime  [/application/javascript (as-octs:mimes:encoding (@t mud))]
   ++  elem  ;script
               ;-  (trip (@t mud))
             ==

--- a/pkg/arvo/mar/json.hoon
+++ b/pkg/arvo/mar/json.hoon
@@ -7,7 +7,7 @@
   ::
 =,  eyre
 =,  format
-=,  html
+=,  encoding
 |_  jon=json
 ::
 ++  grow                                                ::  convert to

--- a/pkg/arvo/mar/json/rpc/response.hoon
+++ b/pkg/arvo/mar/json/rpc/response.hoon
@@ -16,7 +16,7 @@
     ^-  response
     ~|  hit
     ?:  ?=(%2 (div p.hit 100))
-      =,  html
+      =,  encoding
       %-  json
       ?~  r.hit
         a+~

--- a/pkg/arvo/mar/lens/command.hoon
+++ b/pkg/arvo/mar/lens/command.hoon
@@ -31,7 +31,7 @@
         data+so
         dojo+so
         clay+so
-        url+(su auri:de-purl:html)
+        url+(su auri:de-purl:encoding)
         api+(su ;~(plug sym ;~(pfix col prn)))
         :-  %get-api
         %-  su
@@ -55,7 +55,7 @@
         output-file+so
         output-pill+so
         output-clay+(su (easy /sentinel/path))
-        url+(su auri:de-purl:html)
+        url+(su auri:de-purl:encoding)
         to-api+(su ;~(plug sym ;~(pfix col prn)))
         :-  %send-api
         %-  su

--- a/pkg/arvo/mar/map.hoon
+++ b/pkg/arvo/mar/map.hoon
@@ -7,7 +7,7 @@
 |_  mud=@
 ++  grow
   |%
-  ++  mime  [/application/octet-stream (as-octs:mimes:html (@t mud))]
+  ++  mime  [/application/octet-stream (as-octs:mimes:encoding (@t mud))]
   --
 ++  grab
   |%                                                    ::  convert from

--- a/pkg/arvo/mar/md.hoon
+++ b/pkg/arvo/mar/md.hoon
@@ -4,7 +4,7 @@
 /?    310
 ::
 =,  format
-=,  mimes:html
+=,  mimes:encoding
 |_  txt=wain
 ::
 ++  grab                                                ::  convert from

--- a/pkg/arvo/mar/mime.hoon
+++ b/pkg/arvo/mar/mime.hoon
@@ -16,7 +16,7 @@
   |%
   +$  noun  mime                                  ::  clam from %noun
   ++  tape
-    |=(a=_"" [/application/x-urb-unknown (as-octt:mimes:html a)])
+    |=(a=_"" [/application/x-urb-unknown (as-octt:mimes:encoding a)])
   --
 ++  grad
   ^?

--- a/pkg/arvo/mar/pem.hoon
+++ b/pkg/arvo/mar/pem.hoon
@@ -1,7 +1,7 @@
 ::  .pem file to list of lines
 ::
 =,  format
-=,  mimes:html
+=,  mimes:encoding
 |_  pem=wain
 ::
 ++  grab                                                ::  convert from

--- a/pkg/arvo/mar/pill.hoon
+++ b/pkg/arvo/mar/pill.hoon
@@ -3,7 +3,7 @@
   ::
 /-  aquarium
 =,  aquarium
-=,  mimes:html
+=,  mimes:encoding
 |_  pil=pill
 ++  grow
   |%

--- a/pkg/arvo/mar/png.hoon
+++ b/pkg/arvo/mar/png.hoon
@@ -1,7 +1,7 @@
 |_  dat=@t
 ++  grow
   |%
-  ++  mime  [/image/png (as-octs:mimes:html dat)]
+  ++  mime  [/image/png (as-octs:mimes:encoding dat)]
   --
 ++  grab
   |%

--- a/pkg/arvo/mar/snip.hoon
+++ b/pkg/arvo/mar/snip.hoon
@@ -2,7 +2,7 @@
 ::::  /hoon/snip/mar
   ::
 /?    310
-=,  html
+=,  encoding
 |%
   ++  words  1
   ++  hedtal
@@ -41,7 +41,7 @@
 --
 ::
 ::
-=,  mimes:html
+=,  mimes:encoding
 |_  [hed=marl tal=marl]
 ++  grad  %mime
 ::

--- a/pkg/arvo/mar/txt.hoon
+++ b/pkg/arvo/mar/txt.hoon
@@ -6,7 +6,7 @@
 =,  clay
 =,  differ
 =,  format
-=,  mimes:html
+=,  mimes:encoding
 |_  txt=wain
 ::
 ++  grab                                                ::  convert from

--- a/pkg/arvo/mar/udon.hoon
+++ b/pkg/arvo/mar/udon.hoon
@@ -6,7 +6,7 @@
 |_  mud=@t
 ++  grow
   |%
-  ++  mime  [/text/x-unmark (as-octs:mimes:html mud)]
+  ++  mime  [/text/x-unmark (as-octs:mimes:encoding mud)]
   ++  txt
     (to-wain:format mud)
   ++  elem

--- a/pkg/arvo/mar/umd.hoon
+++ b/pkg/arvo/mar/umd.hoon
@@ -6,7 +6,7 @@
 |_  mud=@t
 ++  grow
   |%
-  ++  mime  [/text/x-unmark (as-octs:mimes:html mud)]
+  ++  mime  [/text/x-unmark (as-octs:mimes:encoding mud)]
   ++  txt
     (to-wain:format mud)
   ++  elem

--- a/pkg/arvo/mar/urb.hoon
+++ b/pkg/arvo/mar/urb.hoon
@@ -2,8 +2,8 @@
 ::::  /hoon/elem/urb/mar
   ::
 /?    310
-=,  mimes:html
-=,  html
+=,  mimes:encoding
+=,  encoding
 |_  own=manx
 ::
 ++  grad  %mime

--- a/pkg/arvo/mar/xml.hoon
+++ b/pkg/arvo/mar/xml.hoon
@@ -5,8 +5,8 @@
   ::
 ::::  compute
   ::
-=,  mimes:html
-=,  html
+=,  mimes:encoding
+=,  encoding
 |_  xml=@t
 ::
 ++  grad  %mime

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -312,7 +312,7 @@
     ::
     ++  token                                         ::  7230 token
       %+  cook  crip
-      ::NOTE  this is ptok:de-purl:html, but can't access that here
+      ::NOTE  this is ptok:de-purl:encoding, but can't access that here
       %-  plus
       ;~  pose
         aln  zap  hax  buc  cen  pam  soq  tar  lus

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -231,9 +231,9 @@
   |=  [redirect-url=(unit @t) our=@p failed=?]
   ^-  octs
   =+  redirect-str=?~(redirect-url "" (trip u.redirect-url))
-  %-  as-octs:mimes:html
+  %-  as-octs:mimes:encoding
   %-  crip
-  %-  en-xml:html
+  %-  en-xml:encoding
   =/  favicon  %+
     weld  "<svg width='10' height='10' viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'>"
           "<circle r='3.09' cx='5' cy='5' /></svg>"
@@ -423,7 +423,7 @@
     ~
   ::
   :-  ~
-  %-  as-octs:mimes:html
+  %-  as-octs:mimes:encoding
   %-  crip
   %-  zing
   %+  turn  wall
@@ -434,9 +434,9 @@
 ++  internal-server-error
   |=  [authorized=? url=@t t=tang]
   ^-  octs
-  %-  as-octs:mimes:html
+  %-  as-octs:mimes:encoding
   %-  crip
-  %-  en-xml:html
+  %-  en-xml:encoding
   ;html
     ;head
       ;title:"500 Internal Server Error"
@@ -467,9 +467,9 @@
       %500  "Internal Server Error"
     ==
   ::
-  %-  as-octs:mimes:html
+  %-  as-octs:mimes:encoding
   %-  crip
-  %-  en-xml:html
+  %-  en-xml:encoding
   ;html
     ;head
       ;title:"{code-as-tape} {message}"
@@ -853,7 +853,7 @@
         (return-static-data-on-duct 400 'text/html' (login-page ~ our %.n))
       ::
       =/  parsed=(unit (list [key=@t value=@t]))
-        (rush q.u.body.request yquy:de-purl:html)
+        (rush q.u.body.request yquy:de-purl:encoding)
       ?~  parsed
         (return-static-data-on-duct 400 'text/html' (login-page ~ our %.n))
       ::
@@ -940,7 +940,7 @@
           ?~  body.request  |
           =-  ?=(^ -)
           %+  get-header:http  'all'
-          (fall (rush q.u.body.request yquy:de-purl:html) ~)
+          (fall (rush q.u.body.request yquy:de-purl:encoding) ~)
         ?.  all
           :_  (~(del by sessions) u.session-id)
           %~  tap  in
@@ -975,7 +975,7 @@
         ~
       ::  is the cookie line is valid?
       ::
-      ?~  cookies=(rush u.cookie-header cock:de-purl:html)
+      ?~  cookies=(rush u.cookie-header cock:de-purl:encoding)
         ~
       ::  is there an urbauth cookie?
       ::
@@ -1302,7 +1302,7 @@
         (error-page 400 %.y url.request "no put body")
       ::  if the incoming body isn't json, this is a bad request, 400.
       ::
-      ?~  maybe-json=(de-json:html q.u.body.request)
+      ?~  maybe-json=(de-json:encoding q.u.body.request)
         %^  return-static-data-on-duct  400  'text/html'
         (error-page 400 %.y url.request "put body not json")
       ::  parse the json into an array of +channel-request items
@@ -1680,7 +1680,7 @@
       |=  [event-id=@ud =json]
       ^-  wall
       :~  (weld "id: " (format-ud-as-integer event-id))
-          (weld "data: " (en-json:html json))
+          (weld "data: " (en-json:encoding json))
           ""
       ==
     ::
@@ -1691,7 +1691,7 @@
       =/  res
         %-  handle-response
         :*  %continue
-            data=(some (as-octs:mimes:html '\0a'))
+            data=(some (as-octs:mimes:encoding '\0a'))
             complete=%.n
         ==
       =/  http-moves  -.res
@@ -2046,7 +2046,7 @@
 ++  parse-request-line
   |=  url=@t
   ^-  [[ext=(unit @ta) site=(list @t)] args=(list [key=@t value=@t])]
-  (fall (rush url ;~(plug apat:de-purl:html yque:de-purl:html)) [[~ ~] ~])
+  (fall (rush url ;~(plug apat:de-purl:encoding yque:de-purl:encoding)) [[~ ~] ~])
 ::
 ++  insert-binding
   |=  [[=binding =duct =action] bindings=(list [=binding =duct =action])]

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -208,7 +208,7 @@
         app
         %poke
         %azimuth-tracker-poke
-        !>([%watch (crip (en-purl:html purl))])
+        !>([%watch (crip (en-purl:encoding purl))])
     ==
   ::
   ++  sein                                              ::  sponsor
@@ -261,7 +261,7 @@
       ::
       =.  nod.own.pki
         %+  fall  node.tac
-        (need (de-purl:html 'http://eth-mainnet.urbit.org:8545'))
+        (need (de-purl:encoding 'http://eth-mainnet.urbit.org:8545'))
       ::  save our parent signature (only for moons)
       ::
       =.  sig.own.pki  sig.seed.tac

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1948,7 +1948,7 @@
     ::  TODO: as-octs and hmc are outside of jet parent
     =>  :+  ..part
           hmc=hmac-sha256l:hmac:crypto
-        as-octs=as-octs:mimes:html
+        as-octs=as-octs:mimes:encoding
     ~%  %secp  +<  ~
     |%
     +$  jacobian   [x=@ y=@ z=@]                    ::  jacobian point
@@ -3857,26 +3857,27 @@
     --  ::
   --  ::differ
 ::                                                      ::
-::::                      ++html                        ::  (2e) text encodings
+::::                      ++encoding                    ::  (2e) encodings
   ::                                                    ::::
-++  html  ^?  ::  XX rename to web-txt
+++  html  encoding                                      ::  deprecated name
+++  encoding  ^?
   =,  eyre
   |%
   ::                                                    ::
-  ::::                    ++mimes:html                  ::  (2e1) MIME
+  ::::                    ++mimes:encoding              ::  (2e1) MIME
     ::                                                  ::::
   ++  mimes  ^?
     ~%  %mimes  ..part  ~
     |%
-    ::                                                  ::  ++as-octs:mimes:html
+    ::                                                  ::  ++as-octs:mimes:encoding
     ++  as-octs                                         ::  atom to octstream
       |=  tam=@  ^-  octs
       [(met 3 tam) tam]
-    ::                                                  ::  ++as-octt:mimes:html
+    ::                                                  ::  ++as-octt:mimes:encoding
     ++  as-octt                                         ::  tape to octstream
       |=  tep=tape  ^-  octs
       (as-octs (rap 3 tep))
-    ::                                                  ::  ++en-mite:mimes:html
+    ::                                                  ::  ++en-mite:mimes:encoding
     ++  en-mite                                         ::  mime type to text
       |=  myn=mite
       %-  crip
@@ -4063,10 +4064,10 @@
         (cook |=(a=@ (sub a 49)) (shim '1' '9'))
       ==
     --  ::mimes
-  ::                                                    ::  ++en-json:html
+  ::                                                    ::  ++en-json:encoding
   ++  en-json                                           ::  print json
     |^  |=(val=json (apex val ""))
-    ::                                                  ::  ++apex:en-json:html
+    ::                                                  ::  ++apex:en-json:encoding
     ++  apex
       |=  [val=json rez=tape]
       ^-  tape
@@ -4106,7 +4107,7 @@
         =.  rez  [',' $(viz t.viz)]
         ^$(val [%s p.i.viz], rez [':' ^$(val q.i.viz)])
       ==
-    ::                                                  ::  ++jesc:en-json:html
+    ::                                                  ::  ++jesc:en-json:encoding
     ++  jesc                                            ::  escaped
       =+  utf=|=(a=@ ['\\' 'u' ((x-co 4):co a)])
       |=  a=@  ^-  tape
@@ -4116,15 +4117,15 @@
         %92  "\\\\"
       ==
     --  ::en-json
-  ::                                                    ::  ++de-json:html
+  ::                                                    ::  ++de-json:encoding
   ++  de-json                                           ::  parse JSON
     =<  |=(a=cord `(unit json)`(rush a apex))
     |%
-    ::                                                  ::  ++abox:de-json:html
+    ::                                                  ::  ++abox:de-json:encoding
     ++  abox                                            ::  array
       %+  stag  %a
       (ifix [sel (wish ser)] (more (wish com) apex))
-    ::                                                  ::  ++apex:de-json:html
+    ::                                                  ::  ++apex:de-json:encoding
     ++  apex                                            ::  any value
       %+  knee  *json  |.  ~+
       %+  ifix  [spac spac]
@@ -4136,16 +4137,16 @@
         abox
         obox
       ==
-    ::                                                  ::  ++bool:de-json:html
+    ::                                                  ::  ++bool:de-json:encoding
     ++  bool                                            ::  boolean
       ;~  pose
         (cold & (jest 'true'))
         (cold | (jest 'false'))
       ==
-    ::                                                  ::  ++digs:de-json:html
+    ::                                                  ::  ++digs:de-json:encoding
     ++  digs                                            ::  digits
       (star (shim '0' '9'))
-    ::                                                  ::  ++esca:de-json:html
+    ::                                                  ::  ++esca:de-json:encoding
     ++  esca                                            ::  escaped character
       ;~  pfix  bas
         =*  loo
@@ -4157,23 +4158,23 @@
         =*  tuf  ;~(pfix (just 'u') (cook tuft qix:ab))
         ;~(pose doq fas soq bas loo tuf)
       ==
-    ::                                                  ::  ++expo:de-json:html
+    ::                                                  ::  ++expo:de-json:encoding
     ++  expo                                            ::  exponent
       ;~  (comp twel)
         (piec (mask "eE"))
         (mayb (piec (mask "+-")))
         digs
       ==
-    ::                                                  ::  ++frac:de-json:html
+    ::                                                  ::  ++frac:de-json:encoding
     ++  frac                                            ::  fraction
       ;~(plug dot digs)
-    ::                                                  ::  ++jcha:de-json:html
+    ::                                                  ::  ++jcha:de-json:encoding
     ++  jcha                                            ::  string character
       ;~(pose ;~(less doq bas prn) esca)
-    ::                                                  ::  ++mayb:de-json:html
+    ::                                                  ::  ++mayb:de-json:encoding
     ++  mayb                                            ::  optional
       |*(bus=rule ;~(pose bus (easy ~)))
-    ::                                                  ::  ++numb:de-json:html
+    ::                                                  ::  ++numb:de-json:encoding
     ++  numb                                            ::  number
       ;~  (comp twel)
         (mayb (piec hep))
@@ -4184,41 +4185,41 @@
         (mayb frac)
         (mayb expo)
       ==
-    ::                                                  ::  ++obje:de-json:html
+    ::                                                  ::  ++obje:de-json:encoding
     ++  obje                                            ::  object list
       %+  ifix  [(wish kel) (wish ker)]
       (more (wish com) pear)
-    ::                                                  ::  ++obox:de-json:html
+    ::                                                  ::  ++obox:de-json:encoding
     ++  obox                                            ::  object
       (stag %o (cook malt obje))
-    ::                                                  ::  ++pear:de-json:html
+    ::                                                  ::  ++pear:de-json:encoding
     ++  pear                                            ::  key-value
       ;~(plug ;~(sfix (wish stri) (wish col)) apex)
-    ::                                                  ::  ++piec:de-json:html
+    ::                                                  ::  ++piec:de-json:encoding
     ++  piec                                            ::  listify
       |*  bus=rule
       (cook |=(a=@ [a ~]) bus)
-    ::                                                  ::  ++stri:de-json:html
+    ::                                                  ::  ++stri:de-json:encoding
     ++  stri                                            ::  string
       (cook crip (ifix [doq doq] (star jcha)))
-    ::                                                  ::  ++tops:de-json:html
+    ::                                                  ::  ++tops:de-json:encoding
     ++  tops                                            ::  strict value
       ;~(pose abox obox)
-    ::                                                  ::  ++spac:de-json:html
+    ::                                                  ::  ++spac:de-json:encoding
     ++  spac                                            ::  whitespace
       (star (mask [`@`9 `@`10 `@`13 ' ' ~]))
-    ::                                                  ::  ++twel:de-json:html
+    ::                                                  ::  ++twel:de-json:encoding
     ++  twel                                            ::  tape weld
       |=([a=tape b=tape] (weld a b))
-    ::                                                  ::  ++wish:de-json:html
+    ::                                                  ::  ++wish:de-json:encoding
     ++  wish                                            ::  with whitespace
       |*(sef=rule ;~(pfix spac sef))
     --  ::de-json
-  ::                                                    ::  ++en-xml:html
+  ::                                                    ::  ++en-xml:encoding
   ++  en-xml                                            ::  xml printer
     =<  |=(a=manx `tape`(apex a ~))
     |_  _[unq=`?`| cot=`?`|]
-    ::                                                  ::  ++apex:en-xml:html
+    ::                                                  ::  ++apex:en-xml:encoding
     ++  apex                                            ::  top level
       |=  [mex=manx rez=tape]
       ^-  tape
@@ -4236,7 +4237,7 @@
         [' ' '/' '>' rez]
       :-  '>'
       (many c.mex :(weld "</" tam ">" rez))
-    ::                                                  ::  ++attr:en-xml:html
+    ::                                                  ::  ++attr:en-xml:encoding
     ++  attr                                            ::  attributes to tape
       |=  [tat=mart rez=tape]
       ^-  tape
@@ -4247,7 +4248,7 @@
         "=\""
         (escp(unq |) v.i.tat '"' ?~(t.tat rez [' ' rez]))
       ==
-    ::                                                  ::  ++escp:en-xml:html
+    ::                                                  ::  ++escp:en-xml:encoding
     ++  escp                                            ::  escape for xml
       |=  [tex=tape rez=tape]
       ?:  unq
@@ -4267,18 +4268,18 @@
                *    [i.xet rez]
              ==
       ==
-    ::                                                  ::  ++many:en-xml:html
+    ::                                                  ::  ++many:en-xml:encoding
     ++  many                                            ::  nodelist to tape
       |=  [lix=(list manx) rez=tape]
       |-  ^-  tape
       ?~  lix  rez
       (apex i.lix $(lix t.lix))
-    ::                                                  ::  ++name:en-xml:html
+    ::                                                  ::  ++name:en-xml:encoding
     ++  name                                            ::  name to tape
       |=  man=mane  ^-  tape
       ?@  man  (trip man)
       (weld (trip -.man) `tape`[':' (trip +.man)])
-    ::                                                  ::  ++clot:en-xml:html
+    ::                                                  ::  ++clot:en-xml:encoding
     ++  clot  ~+                                        ::  self-closing tags
       %~  has  in
       %-  silt  ^-  (list term)  :~
@@ -4286,11 +4287,11 @@
         %keygen  %link  %meta  %param     %source   %track  %wbr
       ==
     --  ::en-xml
-  ::                                                    ::  ++de-xml:html
+  ::                                                    ::  ++de-xml:encoding
   ++  de-xml                                            ::  xml parser
     =<  |=(a=cord (rush a apex))
     |_  ent=_`(map term @t)`[[%apos '\''] ~ ~]
-    ::                                                  ::  ++apex:de-xml:html
+    ::                                                  ::  ++apex:de-xml:encoding
     ++  apex                                            ::  top level
       =+  spa=;~(pose comt whit)
       %+  knee  *manx  |.  ~+
@@ -4301,7 +4302,7 @@
           ;~(plug head many tail)
         empt
       ==
-    ::                                                  ::  ++attr:de-xml:html
+    ::                                                  ::  ++attr:de-xml:encoding
     ++  attr                                            ::  attributes
       %+  knee  *mart  |.  ~+
       %-  star
@@ -4321,7 +4322,7 @@
           (easy ~)
         ==
       ==
-    ::                                                  ::  ++cdat:de-xml:html
+    ::                                                  ::  ++cdat:de-xml:encoding
     ++  cdat                                            ::  CDATA section
       %+  cook
         |=(a=tape ^-(mars ;/(a)))
@@ -4329,11 +4330,11 @@
         [(jest '<![CDATA[') (jest ']]>')]
       %-  star
       ;~(less (jest ']]>') next)
-    ::                                                  ::  ++chrd:de-xml:html
+    ::                                                  ::  ++chrd:de-xml:encoding
     ++  chrd                                            ::  character data
       %+  cook  |=(a=tape ^-(mars ;/(a)))
       (plus ;~(less doq ;~(pose (just `@`10) escp)))
-    ::                                                  ::  ++comt:de-xml:html
+    ::                                                  ::  ++comt:de-xml:encoding
     ++  comt                                            ::  comments
       =-  (ifix [(jest '<!--') (jest '-->')] (star -))
       ;~  pose
@@ -4342,15 +4343,15 @@
         ;~(less (jest '-->') hep)
       ==
     ::
-    ++  decl                                            ::  ++decl:de-xml:html
+    ++  decl                                            ::  ++decl:de-xml:encoding
       %+  ifix                                          ::  XML declaration
         [(jest '<?xml') (jest '?>')]
       %-  star
       ;~(less (jest '?>') prn)
-    ::                                                  ::  ++escp:de-xml:html
+    ::                                                  ::  ++escp:de-xml:encoding
     ++  escp                                            ::
       ;~(pose ;~(less gal gar pam prn) enty)
-    ::                                                  ::  ++enty:de-xml:html
+    ::                                                  ::  ++enty:de-xml:encoding
     ++  enty                                            ::  entity
       %+  ifix  pam^mic
       ;~  pose
@@ -4362,17 +4363,17 @@
         :-  (bass 10 (stun 1^8 dit))
         (bass 16 ;~(pfix (mask "xX") (stun 1^8 hit)))
       ==
-    ::                                                  ::  ++empt:de-xml:html
+    ::                                                  ::  ++empt:de-xml:encoding
     ++  empt                                            ::  self-closing tag
       %+  ifix  [gal (jest '/>')]
       ;~(plug ;~(plug name attr) (cold ~ (star whit)))
-    ::                                                  ::  ++head:de-xml:html
+    ::                                                  ::  ++head:de-xml:encoding
     ++  head                                            ::  opening tag
       (ifix [gal gar] ;~(plug name attr))
-    ::                                                  ::  ++many:de-xml:html
+    ::                                                  ::  ++many:de-xml:encoding
     ++  many                                            ::  contents
       ;~(pfix (star comt) (star ;~(sfix ;~(pose apex chrd cdat) (star comt))))
-    ::                                                  ::  ++name:de-xml:html
+    ::                                                  ::  ++name:de-xml:encoding
     ++  name                                            ::  tag name
       =+  ^=  chx
           %+  cook  crip
@@ -4381,14 +4382,14 @@
               (star ;~(pose cab dot alp))
           ==
       ;~(pose ;~(plug ;~(sfix chx col) chx) chx)
-    ::                                                  ::  ++tail:de-xml:html
+    ::                                                  ::  ++tail:de-xml:encoding
     ++  tail                                            ::  closing tag
       (ifix [(jest '</') gar] name)
-    ::                                                  ::  ++whit:de-xml:html
+    ::                                                  ::  ++whit:de-xml:encoding
     ++  whit                                            ::  whitespace
       (mask ~[' ' `@`0x9 `@`0xa])
     --  ::de-xml
-  ::                                                    ::  ++en-urlt:html
+  ::                                                    ::  ++en-urlt:encoding
   ++  en-urlt                                           ::  url encode
     |=  tep=tape
     ^-  tape
@@ -4406,7 +4407,7 @@
         ==
       [tap ~]
     ['%' (xen (rsh [0 4] tap)) (xen (end [0 4] tap)) ~]
-  ::                                                    ::  ++de-urlt:html
+  ::                                                    ::  ++de-urlt:encoding
   ++  de-urlt                                           ::  url decode
     |=  tep=tape
     ^-  (unit tape)
@@ -4420,22 +4421,22 @@
       ?~(nex ~ [~ [`@`u.val u.nex]])
     =+  nex=$(tep t.tep)
     ?~(nex ~ [~ i.tep u.nex])
-  ::                                                    ::  ++en-purl:html
+  ::                                                    ::  ++en-purl:encoding
   ++  en-purl                                           ::  print purl
     =<  |=(pul=purl `tape`(apex %& pul))
     |%
-    ::                                                  ::  ++apex:en-purl:html
+    ::                                                  ::  ++apex:en-purl:encoding
     ++  apex                                            ::
       |=  qur=quri  ^-  tape
       ?-  -.qur
         %&  (weld (head p.p.qur) `tape`$(qur [%| +.p.qur]))
         %|  ['/' (weld (body p.qur) (tail q.qur))]
       ==
-    ::                                                  ::  ++apix:en-purl:html
+    ::                                                  ::  ++apix:en-purl:encoding
     ++  apix                                            ::  purf to tape
       |=  purf
       (weld (apex %& p) ?~(q "" `tape`['#' (trip u.q)]))
-    ::                                                  ::  ++body:en-purl:html
+    ::                                                  ::  ++body:en-purl:encoding
     ++  body                                            ::
       |=  pok=pork  ^-  tape
       ?~  q.pok  ~
@@ -4444,7 +4445,7 @@
       ?~  t.q.pok
         ?~(p.pok seg (welp seg '.' (trip u.p.pok)))
       (welp seg '/' $(q.pok t.q.pok))
-    ::                                                  ::  ++head:en-purl:html
+    ::                                                  ::  ++head:en-purl:encoding
     ++  head                                            ::
       |=  har=hart
       ^-  tape
@@ -4461,7 +4462,7 @@
       ::
         ?~(q.har ~ `tape`[':' ((d-co:co 1) u.q.har)])
       ==
-    ::                                                  ::  ++tail:en-purl:html
+    ::                                                  ::  ++tail:en-purl:encoding
     ++  tail                                            ::
       |=  kay=quay
       ^-  tape
@@ -4475,11 +4476,11 @@
         ?~(t.kay ~ `tape`['&' $(kay t.kay)])
       ==
     --  ::
-  ::                                                    ::  ++de-purl:html
+  ::                                                    ::  ++de-purl:encoding
   ++  de-purl                                           ::  url+header parser
     =<  |=(a=cord `(unit purl)`(rush a auri))
     |%
-    ::                                                  ::  ++deft:de-purl:html
+    ::                                                  ::  ++deft:de-purl:encoding
     ++  deft                                            ::  parse url extension
       |=  rax=(list @t)
       |-  ^-  pork
@@ -4500,21 +4501,21 @@
       =+  `[ext=term [@ @] fyl=tape]`u.q.raf
       :-  `ext
       ?:(=(~ fyl) ~ [(crip (flop fyl)) ~])
-    ::                                                  ::  ++apat:de-purl:html
+    ::                                                  ::  ++apat:de-purl:encoding
     ++  apat                                            ::  2396 abs_path
       %+  cook  deft
       ;~(pfix fas (more fas smeg))
-    ::                                                  ::  ++aurf:de-purl:html
+    ::                                                  ::  ++aurf:de-purl:encoding
     ++  aurf                                            ::  2396 with fragment
       %+  cook  |~(a=purf a)
       ;~(plug auri (punt ;~(pfix hax (cook crip (star pque)))))
-    ::                                                  ::  ++auri:de-purl:html
+    ::                                                  ::  ++auri:de-purl:encoding
     ++  auri                                            ::  2396 URL
       ;~  plug
         ;~(plug htts thor)
         ;~(plug ;~(pose apat (easy *pork)) yque)
       ==
-    ::                                                  ::  ++auru:de-purl:html
+    ::                                                  ::  ++auru:de-purl:encoding
     ++  auru                                            ::  2396 with maybe user
       %+  cook
         |=  $:  a=[p=? q=(unit user) r=[(unit @ud) host]]
@@ -4527,84 +4528,84 @@
         ;~(plug htts (punt ;~(sfix urt:ab pat)) thor)
         ;~(plug ;~(pose apat (easy *pork)) yque)
       ==
-    ::                                                  ::  ++htts:de-purl:html
+    ::                                                  ::  ++htts:de-purl:encoding
     ++  htts                                            ::  scheme
       %+  sear  ~(get by (malt `(list (pair term ?))`[http+| https+& ~]))
       ;~(sfix scem ;~(plug col fas fas))
-    ::                                                  ::  ++cock:de-purl:html
+    ::                                                  ::  ++cock:de-purl:encoding
     ++  cock                                            ::  cookie
       %+  most  ;~(plug mic ace)
       ;~(plug toke ;~(pfix tis tosk))
-    ::                                                  ::  ++dlab:de-purl:html
+    ::                                                  ::  ++dlab:de-purl:encoding
     ++  dlab                                            ::  2396 domainlabel
       %+  sear
         |=  a=@ta
         ?.(=('-' (rsh [3 (dec (met 3 a))] a)) [~ u=a] ~)
       %+  cook  |=(a=tape (crip (cass a)))
       ;~(plug aln (star alp))
-    ::                                                  ::  ++fque:de-purl:html
+    ::                                                  ::  ++fque:de-purl:encoding
     ++  fque                                            ::  normal query field
       (cook crip (plus pquo))
-    ::                                                  ::  ++fquu:de-purl:html
+    ::                                                  ::  ++fquu:de-purl:encoding
     ++  fquu                                            ::  optional query field
       (cook crip (star pquo))
-    ::                                                  ::  ++pcar:de-purl:html
+    ::                                                  ::  ++pcar:de-purl:encoding
     ++  pcar                                            ::  2396 path char
       ;~(pose pure pesc psub col pat)
-    ::                                                  ::  ++pcok:de-purl:html
+    ::                                                  ::  ++pcok:de-purl:encoding
     ++  pcok                                            ::  cookie char
       ;~(less bas mic com doq prn)
-    ::                                                  ::  ++pesc:de-purl:html
+    ::                                                  ::  ++pesc:de-purl:encoding
     ++  pesc                                            ::  2396 escaped
       ;~(pfix cen mes)
-    ::                                                  ::  ++pold:de-purl:html
+    ::                                                  ::  ++pold:de-purl:encoding
     ++  pold                                            ::
       (cold ' ' (just '+'))
-    ::                                                  ::  ++pque:de-purl:html
+    ::                                                  ::  ++pque:de-purl:encoding
     ++  pque                                            ::  3986 query char
       ;~(pose pcar fas wut)
-    ::                                                  ::  ++pquo:de-purl:html
+    ::                                                  ::  ++pquo:de-purl:encoding
     ++  pquo                                            ::  normal query char
       ;~(pose pure pesc pold fas wut col com)
-    ::                                                  ::  ++pure:de-purl:html
+    ::                                                  ::  ++pure:de-purl:encoding
     ++  pure                                            ::  2396 unreserved
       ;~(pose aln hep cab dot zap sig tar soq pal par)
-    ::                                                  ::  ++psub:de-purl:html
+    ::                                                  ::  ++psub:de-purl:encoding
     ++  psub                                            ::  3986 sub-delims
       ;~  pose
         zap  buc  pam  soq  pal  par
         tar  lus  com  mic  tis
       ==
-    ::                                                  ::  ++ptok:de-purl:html
+    ::                                                  ::  ++ptok:de-purl:encoding
     ++  ptok                                            ::  2616 token
       ;~  pose
         aln  zap  hax  buc  cen  pam  soq  tar  lus
         hep  dot  ket  cab  tic  bar  sig
       ==
-    ::                                                  ::  ++scem:de-purl:html
+    ::                                                  ::  ++scem:de-purl:encoding
     ++  scem                                            ::  2396 scheme
       %+  cook  |=(a=tape (crip (cass a)))
       ;~(plug alf (star ;~(pose aln lus hep dot)))
-    ::                                                  ::  ++smeg:de-purl:html
+    ::                                                  ::  ++smeg:de-purl:encoding
     ++  smeg                                            ::  2396 segment
       (cook crip (star pcar))
-    ::                                                  ::  ++tock:de-purl:html
+    ::                                                  ::  ++tock:de-purl:encoding
     ++  tock                                            ::  6265 raw value
       (cook crip (plus pcok))
-    ::                                                  ::  ++tosk:de-purl:html
+    ::                                                  ::  ++tosk:de-purl:encoding
     ++  tosk                                            ::  6265 quoted value
       ;~(pose tock (ifix [doq doq] tock))
-    ::                                                  ::  ++toke:de-purl:html
+    ::                                                  ::  ++toke:de-purl:encoding
     ++  toke                                            ::  2616 token
       (cook crip (plus ptok))
-    ::                                                  ::  ++thor:de-purl:html
+    ::                                                  ::  ++thor:de-purl:encoding
     ++  thor                                            ::  2396 host+port
       %+  cook  |*([* *] [+<+ +<-])
       ;~  plug
         thos
         ;~((bend) (easy ~) ;~(pfix col dim:ag))
       ==
-    ::                                                  ::  ++thos:de-purl:html
+    ::                                                  ::  ++thos:de-purl:encoding
     ++  thos                                            ::  2396 host, no local
       ;~  plug
         ;~  pose
@@ -4623,13 +4624,13 @@
           ;~(plug tod (stun [3 3] ;~(pfix dot tod)))
         ==
       ==
-    ::                                                  ::  ++yque:de-purl:html
+    ::                                                  ::  ++yque:de-purl:encoding
     ++  yque                                            ::  query ending
       ;~  pose
         ;~(pfix wut yquy)
         (easy ~)
       ==
-    ::                                                  ::  ++yquy:de-purl:html
+    ::                                                  ::  ++yquy:de-purl:encoding
     ++  yquy                                            ::  query
       ;~  pose
         ::  proper query
@@ -4644,7 +4645,7 @@
           |=(a=tape [[%$ (crip a)] ~])
         (star pque)
       ==
-    ::                                                  ::  ++zest:de-purl:html
+    ::                                                  ::  ++zest:de-purl:encoding
     ++  zest                                            ::  2616 request-uri
       ;~  pose
         (stag %& (cook |=(a=purl a) auri))
@@ -4666,10 +4667,10 @@
     %+  sear
       |=  =host:eyre
       ?.(?=(%& -.host) ~ (some p.host))
-    thos:de-purl:html
+    thos:de-purl:encoding
   ::
   ::  MOVEME
-  ::                                                    ::  ++fuel:html
+  ::                                                    ::  ++fuel:encoding
   ++  fuel                                              ::  parse urbit fcgi
       |=  [bem=beam ced=noun:cred quy=quer]
       ^-  epic
@@ -4691,7 +4692,7 @@
           %trac  %'TRACE'
         ==
     ::
-      (crip (en-purl:html p.hiss))
+      (crip (en-purl:encoding p.hiss))
     ::
       ^-  header-list:http
       ~!  q.q.hiss
@@ -4703,7 +4704,7 @@
     ::
       r.q.hiss
     ==
-  --  ::  html
+  --  ::  encoding
 ::                                                      ::
 ::::                      ++wired                       ::  wire formatting
   ::                                                    ::::

--- a/pkg/arvo/ted/aqua/eyre-azimuth.hoon
+++ b/pkg/arvo/ted/aqua/eyre-azimuth.hoon
@@ -114,7 +114,7 @@
   ++  get-single-req
     |=  req=@t
     =/  batch
-      ((ar:dejs:format same) (need (de-json:html req)))
+      ((ar:dejs:format same) (need (de-json:encoding req)))
     ?>  ?=([* ~] batch)
     i.batch
   ::
@@ -168,7 +168,7 @@
     ^-  card:agent:gall
     =/  resp
       %-  crip
-      %-  en-json:html
+      %-  en-json:encoding
       :-  %a  :_  ~
       %-  pairs
       :~  id+s+(get-id req)
@@ -182,7 +182,7 @@
           //http-client/0v1n.2m9vh
           %receive
           num.u.ask
-          [%start [200 ~] `(as-octs:mimes:html resp) &]
+          [%start [200 ~] `(as-octs:mimes:encoding resp) &]
       ==
     :*  %pass  /aqua-events
         %agent  [our %aqua]
@@ -312,8 +312,8 @@
       =/  =rift  rut.life-rift
       =/  =pass
         %^    pass-from-eth:azimuth
-            (as-octs:mimes:html (get-public ship life %crypt))
-          (as-octs:mimes:html (get-public ship life %auth))
+            (as-octs:mimes:encoding (get-public ship life %crypt))
+          (as-octs:mimes:encoding (get-public ship life %auth))
         1
       :^    ship
           *[address address address address]:azimuth
@@ -333,7 +333,7 @@
       get-czars
       ~[~['arvo' 'netw' 'ork']]
       0
-      `(need (de-purl:html 'http://localhost:8545'))
+      `(need (de-purl:encoding 'http://localhost:8545'))
   ==
 ::
 ::  Should only do galaxies
@@ -349,8 +349,8 @@
   %-  some
   :^  who  rut  lyfe
   %^    pass-from-eth:azimuth
-      (as-octs:mimes:html (get-public who lyfe %crypt))
-    (as-octs:mimes:html (get-public who lyfe %auth))
+      (as-octs:mimes:encoding (get-public who lyfe %crypt))
+    (as-octs:mimes:encoding (get-public who lyfe %auth))
   1
 ::
 ++  spawn

--- a/pkg/arvo/ted/aqua/eyre.hoon
+++ b/pkg/arvo/ted/aqua/eyre.hoon
@@ -64,7 +64,7 @@
           %arvo
           %i
           %request
-          (hiss-to-request:html u.req)
+          (hiss-to-request:encoding u.req)
           *outbound-config:iris
       ==
     ..abet-pe

--- a/pkg/arvo/ted/dns/address.hoon
+++ b/pkg/arvo/ted/dns/address.hoon
@@ -51,8 +51,8 @@
   ;<  good=?    bind:m  (turf-confirm-install:libdns turf.binding)
   =/  msg=(pair cord tang)
     ?:  good
-      [(cat 3 'confirmed access via ' (en-turf:html turf.binding)) ~]
-    :-  (cat 3 'unable to access via ' (en-turf:html turf.binding))
+      [(cat 3 'confirmed access via ' (en-turf:encoding turf.binding)) ~]
+    :-  (cat 3 'unable to access via ' (en-turf:encoding turf.binding))
     :~  leaf+"XX check via nslookup"
         leaf+"XX confirm port 80"
     ==

--- a/pkg/arvo/ted/dns/auto.hoon
+++ b/pkg/arvo/ted/dns/auto.hoon
@@ -24,8 +24,8 @@
 ;<  good=?   bind:m  (turf-confirm-install:dns turf)
 =/  msg=(pair cord tang)
   ?:  good
-    [(cat 3 'confirmed access via ' (en-turf:html turf)) ~]
-  :-  (cat 3 'unable to access via ' (en-turf:html turf))
+    [(cat 3 'confirmed access via ' (en-turf:encoding turf)) ~]
+  :-  (cat 3 'unable to access via ' (en-turf:encoding turf))
   :~  leaf+"XX check via nslookup"
       leaf+"XX confirm port 80"
   ==

--- a/pkg/arvo/ted/ph/migrate/commit-home.hoon
+++ b/pkg/arvo/ted/ph/migrate/commit-home.hoon
@@ -20,7 +20,7 @@
     ?.  =((snag (dec (lent pat)) pat) %hoon)
       ~
     =/  clay-pax=path  (weld /(scot %p our)/home/(scot %da now) pat)
-    =/  file  [/text/plain (as-octs:mimes:html .^(@ %cx clay-pax))]
+    =/  file  [/text/plain (as-octs:mimes:encoding .^(@ %cx clay-pax))]
     `[pat `file]
   :-  //sync/0v1n.2m9vh
   [%into %home | mod]

--- a/pkg/arvo/tests/lib/ethereum/encoding.hoon
+++ b/pkg/arvo/tests/lib/ethereum/encoding.hoon
@@ -27,8 +27,8 @@
     !>  %-  encode-args:abi:ethereum
         :~  [%uint `@ud`0x123]
             [%array [%uint `@ud`0x456] [%uint `@ud`0x789] ~]
-            [%bytes-n (as-octt:mimes:html (flop "1234567890"))]
-            [%bytes (as-octt:mimes:html (flop "Hello, world!"))]
+            [%bytes-n (as-octt:mimes:encoding (flop "1234567890"))]
+            [%bytes (as-octt:mimes:encoding (flop "Hello, world!"))]
         ==
     !>  %-  zing
         :~  "0000000000000000000000000000000000000000000000000000000000000123"

--- a/pkg/arvo/tests/lib/jose.hoon
+++ b/pkg/arvo/tests/lib/jose.hoon
@@ -119,12 +119,12 @@
   ::
     %+  expect-eq
       !>  hedt
-      !>  (en-base64url (as-octt:mimes:html (en-json-sort aor hed)))
+      !>  (en-base64url (as-octt:mimes:encoding (en-json-sort aor hed)))
   ::
     %+  expect-eq
       !>  lodt
       !>  %-  en-base64url
-          (as-octt:mimes:html (en-json-sort (eor lte lod-order) lod))
+          (as-octt:mimes:encoding (en-json-sort (eor lte lod-order) lod))
   ::
     %+  expect-eq
       !>  exp-ws
@@ -180,7 +180,7 @@
   =/  protected-header=json
     :-  %o  %-  my  :~
       nonce+s+non
-      url+s+(crip (en-purl:html url))
+      url+s+(crip (en-purl:encoding url))
       kid+s+kid
     ==
   =/  bod=json

--- a/pkg/arvo/tests/lib/vere/dawn.hoon
+++ b/pkg/arvo/tests/lib/vere/dawn.hoon
@@ -31,7 +31,7 @@
 ::
 ++  test-give-bloq
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     '{"params":[],"id":"0","jsonrpc":"2.0","method":"eth_blockNumber"}'
   %+  expect-eq
     !>  oct
@@ -47,7 +47,7 @@
 ::
 ++  test-give-point
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     %+  rap  3
     :~  '{"params":[{"to":"'  azimuth  '","data":"'
         '0x63fa9a87'
@@ -60,7 +60,7 @@
 ::
 ++  test-give-turf
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     %+  rap  3
     :~  '[{"params":[{"to":"'  azimuth  '","data":"'
         '0xeccc8ff1'
@@ -81,7 +81,7 @@
 ::
 ++  test-take-bloq
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     '{"id":"0","jsonrpc":"2.0","result":"0x20"}'
   =/  boq  32
   %+  expect-eq
@@ -90,7 +90,7 @@
 ::
 ++  test-take-czar
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     %+  rap  3
     :~  '[{"id":"gal-0","jsonrpc":"2.0","result":"'
         '0xb69b6818b17b7cc22f8e0a2291f58e4aa840cbf44cb2f1c94dc3d71e3cda0d94'
@@ -144,7 +144,7 @@
 ::
 ++  test-take-point
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     %+  rap  3
     :~  '{"jsonrpc":"2.0","result":"'
         '0xb69b6818b17b7cc22f8e0a2291f58e4aa840cbf44cb2f1c94dc3d71e3cda0d94'
@@ -165,7 +165,7 @@
 ::
 ++  test-take-turf
   =/  oct
-    %-  as-octs:mimes:html
+    %-  as-octs:mimes:encoding
     %+  rap  3
     :~  '[{"id":"turf-0","jsonrpc":"2.0","result":"'
         '0x0000000000000000000000000000000000000000000000000000000000000020'

--- a/pkg/arvo/tests/sys/vane/eyre.hoon
+++ b/pkg/arvo/tests/sys/vane/eyre.hoon
@@ -512,7 +512,7 @@
             ^-  sign:eyre-gate
             :*  %gall  %unto  %fact
                 %http-response-data
-                !>(`(as-octs:mimes:html 'ya!'))
+                !>(`(as-octs:mimes:encoding 'ya!'))
             ==
          ==
       ^=  expected-move
@@ -756,12 +756,12 @@
     %+  expect-eq
       !>  `[%ack 5]~
       !>  %-  parse-channel-request:eyre-gate
-          (need (de-json:html '[{"action": "ack", "event-id": 5}]'))
+          (need (de-json:encoding '[{"action": "ack", "event-id": 5}]'))
   ::
     %+  expect-eq
       !>  `[%poke 0 ~nec %app1 %app-type [%n '5']]~
       !>  %-  parse-channel-request:eyre-gate
-          %-  need  %-  de-json:html
+          %-  need  %-  de-json:encoding
           '''
           [{"action": "poke",
             "id": 0,
@@ -774,7 +774,7 @@
     %+  expect-eq
       !>  `[%subscribe 1 ~sampyl-sipnym %hall /this/path]~
       !>  %-  parse-channel-request:eyre-gate
-          %-  need  %-  de-json:html
+          %-  need  %-  de-json:encoding
           '''
           [{"action": "subscribe",
             "id": 1,
@@ -786,7 +786,7 @@
     %+  expect-eq
       !>  `[%unsubscribe 2 1]~
       !>  %-  parse-channel-request:eyre-gate
-          %-  need  %-  de-json:html
+          %-  need  %-  de-json:encoding
           '''
           [{"action": "unsubscribe",
             "id": 2,
@@ -796,19 +796,19 @@
       %+  expect-eq
         !>  ~
         !>  %-  parse-channel-request:eyre-gate
-            %-  need  %-  de-json:html
+            %-  need  %-  de-json:encoding
             '[{"noaction": "noaction"}]'
   ::
       %+  expect-eq
         !>  ~
         !>  %-  parse-channel-request:eyre-gate
-            %-  need  %-  de-json:html
+            %-  need  %-  de-json:encoding
             '[{"action": "bad-action"}]'
   ::
       %+  expect-eq
         !>  ~
         !>  %-  parse-channel-request:eyre-gate
-            %-  need  %-  de-json:html
+            %-  need  %-  de-json:encoding
             '[{"action": "ack", "event-id": 5}, {"action": "bad-action"}]'
   ::
       %+  expect-eq
@@ -817,7 +817,7 @@
                 [%poke 3 ~bud %wut %wut-type [%a [%n '2'] [%n '1'] ~]]
             ==
         !>  %-  parse-channel-request:eyre-gate
-            %-  need  %-  de-json:html
+            %-  need  %-  de-json:encoding
             '''
             [{"action": "ack", "event-id": 9},
              {"action": "poke",
@@ -996,7 +996,7 @@
                 ==
               ::
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 id: 0
                 data: {"ok":"ok","id":0,"response":"poke"}
@@ -1076,7 +1076,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "poke",
               "id": 2,
@@ -1175,7 +1175,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "unsubscribe",
               "id": 2,
@@ -1275,7 +1275,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "subscribe",
               "id": 2,
@@ -1384,7 +1384,7 @@
                 ==
               ::
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 id: 0
                 data: {"ok":"ok","id":0,"response":"poke"}
@@ -1426,7 +1426,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "unsubscribe",
               "id": 3,
@@ -1477,7 +1477,7 @@
         %+  expect-eq
           !>  :*  ~[/http-get-open]  %give  %response  %continue
                   :-  ~
-                  %-  as-octs:mimes:html
+                  %-  as-octs:mimes:encoding
                   '''
                   id: 4
                   data: {"json":[1,2],"id":2,"response":"diff"}
@@ -1593,7 +1593,7 @@
                 ==
               ::
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 id: 0
                 data: {"ok":"ok","id":0,"response":"poke"}
@@ -1632,7 +1632,7 @@
                 %response
                 %continue
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 id: 2
                 data: {"json":[1],"id":1,"response":"diff"}
@@ -1660,7 +1660,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "ack",
               "event-id": 1}
@@ -1754,7 +1754,7 @@
                 ==
               ::
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 id: 2
                 data: {"json":[1],"id":1,"response":"diff"}
@@ -1871,7 +1871,7 @@
               %response
               %continue
               :-  ~
-              %-  as-octt:mimes:html
+              %-  as-octt:mimes:encoding
               """
               id: {((d-co:co 1) +(clog-threshold:eyre-gate))}
               data: \{"json":[1],"id":1,"response":"diff"}
@@ -1889,7 +1889,7 @@
                 %response
                 %continue
                 :-  ~
-                %-  as-octt:mimes:html
+                %-  as-octt:mimes:encoding
                 """
                 id: {((d-co:co 1) (add 2 clog-threshold:eyre-gate))}
                 data: \{"id":1,"response":"quit"}
@@ -2225,7 +2225,7 @@
             '/~/login'
             ~
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             'password=lidlut-tabwed-pillex-ridrup&redirect=/~landscape'
         ==
       ^=  expected-moves
@@ -2290,7 +2290,7 @@
             ['cookie' cookie-value]~
         ::
             :-  ~
-            %-  as-octs:mimes:html
+            %-  as-octs:mimes:encoding
             '''
             [{"action": "poke",
               "id": 0,

--- a/pkg/arvo/tests/sys/vane/iris.hoon
+++ b/pkg/arvo/tests/sys/vane/iris.hoon
@@ -69,7 +69,7 @@
                 ==
             ::
                 :-  ~
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 <html><body>Response</body></html>
                 '''
@@ -90,7 +90,7 @@
             ::
                 :-  ~
                 :-  'text/html'
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 <html><body>Response</body></html>
                 '''
@@ -163,7 +163,7 @@
                 :~  ['content-type' 'text/html']
                     ['content-length' '34']
                 ==
-                [~ (as-octs:mimes:html '<html><body>')]
+                [~ (as-octs:mimes:encoding '<html><body>')]
                 complete=%.n
         ==  ==
       ^=  expected-moves
@@ -180,7 +180,7 @@
             ::
                 bytes-read=12
                 expected-size=`34
-                [~ (as-octs:mimes:html '<html><body>')]
+                [~ (as-octs:mimes:encoding '<html><body>')]
     ==  ==  ==
   ::  returns the second 1/3 of the payload
   ::
@@ -196,7 +196,7 @@
             id=0
             ^-  http-event:http
             :*  %continue
-                [~ (as-octs:mimes:html 'Response')]
+                [~ (as-octs:mimes:encoding 'Response')]
                 complete=%.n
         ==  ==
       ^=  expected-moves
@@ -213,7 +213,7 @@
             ::
                 bytes-read=20
                 expected-size=`34
-                [~ (as-octs:mimes:html 'Response')]
+                [~ (as-octs:mimes:encoding 'Response')]
     ==  ==  ==
   ::  returns the last part
   ::
@@ -229,7 +229,7 @@
             id=0
             ^-  http-event:http
             :*  %continue
-                [~ (as-octs:mimes:html '</body></html>')]
+                [~ (as-octs:mimes:encoding '</body></html>')]
                 complete=%.y
         ==  ==
       ^=  expected-moves
@@ -246,7 +246,7 @@
             ::
                 :-  ~
                 :-  'text/html'
-                %-  as-octs:mimes:html
+                %-  as-octs:mimes:encoding
                 '''
                 <html><body>Response</body></html>
                 '''
@@ -320,7 +320,7 @@
                 :~  ['content-type' 'text/html']
                     ['content-length' '34']
                 ==
-                [~ (as-octs:mimes:html '<html><body>')]
+                [~ (as-octs:mimes:encoding '<html><body>')]
                 complete=%.n
         ==  ==
       ^=  expected-moves
@@ -337,7 +337,7 @@
             ::
                 bytes-read=12
                 expected-size=`34
-                [~ (as-octs:mimes:html '<html><body>')]
+                [~ (as-octs:mimes:encoding '<html><body>')]
     ==  ==  ==
   ::  lol, now we don't care about the rest so send a cancel to vere
   ::

--- a/pkg/arvo/tests/sys/zuse/html.hoon
+++ b/pkg/arvo/tests/sys/zuse/html.hoon
@@ -1,9 +1,9 @@
 ::   tests for html
 ::
 /+  *test
-=,  html
-=,  de-xml:html
-=,  en-xml:html
+=,  encoding
+=,  de-xml:encoding
+=,  en-xml:encoding
 |%
 ::  de-xml takes a cord but en-xml returns a tape?
 ::
@@ -12,7 +12,7 @@
     ::  Basic use
     ::
     %+  expect-eq
-      !>  ^-  manx  +:(de-xml:html (crip "<html><head><title>My first webpage</title></head><body><h1>Welcome!</h1>Hello, world! We are on the web.\0a<div></div><script src=\"http://unsafely.tracking.you/cookiemonster.js\"></script></body></html>"))
+      !>  ^-  manx  +:(de-xml:encoding (crip "<html><head><title>My first webpage</title></head><body><h1>Welcome!</h1>Hello, world! We are on the web.\0a<div></div><script src=\"http://unsafely.tracking.you/cookiemonster.js\"></script></body></html>"))
     !>  ^-  manx
     ;html
         ;head
@@ -29,7 +29,7 @@
     ::
     %+  expect-eq
       !>  ^-  manx
-      +:(de-xml:html (crip "<elem><![CDATA[text]]></elem>"))
+      +:(de-xml:encoding (crip "<elem><![CDATA[text]]></elem>"))
     !>  ^-  manx
     ;elem: text
     ::  comments
@@ -37,23 +37,23 @@
     %+  expect-eq
       !>  ^-  manx
       ;elem: text
-    !>  +:(de-xml:html (crip "<elem>text<!-- comment --></elem>"))
+    !>  +:(de-xml:encoding (crip "<elem>text<!-- comment --></elem>"))
     %+  expect-eq
       !>  ^-  manx
       ;elem;
-    !>  +:(de-xml:html (crip "<elem><!-- comment --></elem>"))
+    !>  +:(de-xml:encoding (crip "<elem><!-- comment --></elem>"))
     ::  entities
     ::
     %+  expect-eq
       !>  ^-  manx
-      +:(de-xml:html (crip "<elem>&#62;</elem>"))
+      +:(de-xml:encoding (crip "<elem>&#62;</elem>"))
       !>  ^-  manx
       ;elem: >
     :: self-closing tag
     ::
     %+  expect-eq
       !>  ^-  manx
-      +:(de-xml:html (crip "<img />"))
+      +:(de-xml:encoding (crip "<img />"))
       !>  ^-  manx
       ;img;
 
@@ -66,12 +66,12 @@
     ::
     %+  expect-eq
       !>  "<elem>&gt;</elem>"
-    !>  %-  en-xml:html
+    !>  %-  en-xml:encoding
     ;elem: >
     ::  Basic use
     ::
     %+  expect-eq
-      !>   %-  en-xml:html
+      !>   %-  en-xml:encoding
       ;html
         ;head
           ;title: My first webpage
@@ -89,7 +89,7 @@
     ::
     %+  expect-eq
       !>  "<input type=\"submit\">Submit</input>"
-      !>  %-  en-xml:html
+      !>  %-  en-xml:encoding
       ;input(type "submit"): Submit
   ==
 ::  JSON encoding/decoding
@@ -114,7 +114,7 @@
   :-  specs
   |=  spec=json-parse-spec
   ^-  tang
-  =+  result=(expect-eq !>(`expected.spec) !>((de-json:html input.spec)))
+  =+  result=(expect-eq !>(`expected.spec) !>((de-json:encoding input.spec)))
   ?~  result  ~
   `tang`[[%leaf "in {name.spec}:"] result]
 ::  Checks that a list of examples all fail to parse
@@ -126,7 +126,7 @@
   :-  specs
   |=  spec=json-parse-rejection-spec
   ^-  tang
-  =+  result=(expect-eq !>(~) !>((de-json:html input.spec)))
+  =+  result=(expect-eq !>(~) !>((de-json:encoding input.spec)))
   ?~  result  ~
   `tang`[[%leaf "in {name.spec}:"] result]
 ::  example values used in tests
@@ -260,7 +260,7 @@
     ::  [{}, 4, [[], [{foo: {"4": 4, "true": true}}]]]
     ::
     !>  "[\{},4,[[],[\{\"foo\":\{\"4\":4,\"true\":true}}]]]"
-    !>  %-  en-json:html
+    !>  %-  en-json:encoding
         :-  %a
         :~  [%o ~]
             [%n '4']
@@ -276,7 +276,7 @@
 ::  decoding naked values
 ::
 ++  test-de-json-simple-values
-  =,  html
+  =,  encoding
   ;:  weld
     %+  expect-eq
       !>  `~

--- a/pkg/arvo/tests/sys/zuse/mimes.hoon
+++ b/pkg/arvo/tests/sys/zuse/mimes.hoon
@@ -1,7 +1,7 @@
-::  tests for |mimes:html
+::  tests for |mimes:encoding
 ::
 /+  *test
-=,  mimes:html
+=,  mimes:encoding
 ::  helpers
 ::
 |%
@@ -120,7 +120,7 @@
     :: echo "hello" | base64
     %+  expect-eq
       !>  'aGVsbG8K'
-      !>  (en:base64 (as-octs:mimes:html 'hello\0a'))
+      !>  (en:base64 (as-octs:mimes:encoding 'hello\0a'))
   ::
     %+  expect-eq
       !>  'hello\0a'

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -250,7 +250,7 @@ _dawn_purl(u3_noun rac)
   else {
     //  XX call de-purl directly
     //
-    u3_noun par = u3v_wish("auru:de-purl:html");
+    u3_noun par = u3v_wish("auru:de-purl:encoding");
     u3_noun lur = u3i_string(u3_Host.ops_u.eth_c);
     u3_noun rul = u3dc("rush", u3k(lur), u3k(par));
 
@@ -264,7 +264,7 @@ _dawn_purl(u3_noun rac)
     }
     else {
       //  XX revise for de-purl
-      //  auru:de-purl:html parses to (pair user purl)
+      //  auru:de-purl:encoding parses to (pair user purl)
       //  we need (unit purl)
       //
       url = u3nc(u3_nul, u3k(u3t(u3t(rul))));
@@ -283,7 +283,7 @@ _dawn_turf(c3_c* dns_c)
 {
   u3_noun tuf;
 
-  u3_noun par = u3v_wish("thos:de-purl:html");
+  u3_noun par = u3v_wish("thos:de-purl:encoding");
   u3_noun dns = u3i_string(dns_c);
   u3_noun rul = u3dc("rush", u3k(dns), u3k(par));
 

--- a/pkg/urbit/vere/io/cttp.c
+++ b/pkg/urbit/vere/io/cttp.c
@@ -560,7 +560,7 @@ _cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
   }
 
   // Parse the url out of the new style url passed to us.
-  u3_noun unit_pul = u3do("de-purl:html", u3k(url));
+  u3_noun unit_pul = u3do("de-purl:encoding", u3k(url));
   if (c3n == u3r_du(unit_pul)) {
     u3l_log("cttp: url parsing failed\n");
     u3z(hes);


### PR DESCRIPTION
Zuse has a core named ++html implementing various encodings, which are largely unrelated to HTML.  Rectify this name by renaming the core to ++encoding, leaving a compatibility shim in place for userspace.

Anton (in 2016) suggests ++web-txt, but these arms are not really web or text related either.