### PR TITLE
ChatInput, Author: fix "removed avatar" case

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -128,12 +128,12 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
 
     const avatar = (
         props.ourContact &&
-        ((props.ourContact.avatar !== null) && !props.hideAvatars)
+        ((props.ourContact?.avatar) && !props.hideAvatars)
       )
-      ? <BaseImage 
-          src={props.ourContact.avatar} 
-          height={16} 
-          width={16} 
+      ? <BaseImage
+          src={props.ourContact.avatar}
+          height={16}
+          width={16}
           style={{ objectFit: 'cover' }}
           display='inline-block'
         />

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -7,6 +7,7 @@ import { Contacts } from '@urbit/api/contacts';
 import { Group } from '@urbit/api';
 
 import { uxToHex, cite, useShowNickname, deSig } from '~/logic/lib/util';
+import useSettingsState, {selectCalmState} from "~/logic/state/settings";
 import OverlaySigil from './OverlaySigil';
 import { Sigil } from '~/logic/lib/sigil';
 import GlobalApi from '~/logic/api/global';
@@ -33,6 +34,7 @@ export default function Author(props: AuthorProps): ReactElement {
   }
   const color = contact?.color ? `#${uxToHex(contact?.color)}` : '#000000';
   const showNickname = useShowNickname(contact);
+  const { hideAvatars } = useSettingsState(selectCalmState);
   const name = showNickname ? contact.nickname : cite(ship);
   const stamp = moment(date);
 
@@ -43,7 +45,7 @@ export default function Author(props: AuthorProps): ReactElement {
   };
 
   const img =
-    contact && contact.avatar !== null ? (
+    contact?.avatar && !hideAvatars ? (
       <BaseImage
         display='inline-block'
         src={contact.avatar}


### PR DESCRIPTION
Both were using older logic that checked for `null` but if you remove an avatar, it becomes an empty string; we instead ask if it's truthy, matching the fix in #4460.