### PR TITLE
landscape: avatars use borderRadius '1'

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -130,11 +130,12 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
         props.ourContact &&
         ((props.ourContact.avatar !== null) && !props.hideAvatars)
       )
-      ? <BaseImage 
-          src={props.ourContact.avatar} 
-          height={16} 
-          width={16} 
+      ? <BaseImage
+          src={props.ourContact.avatar}
+          height={16}
+          width={16}
           style={{ objectFit: 'cover' }}
+          borderRadius={1}
           display='inline-block'
         />
       : <Sigil

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -298,6 +298,7 @@ export const MessageAuthor = ({
         src={contact.avatar}
         height={16}
         width={16}
+        borderRadius={1}
       />
     ) : (
       <Sigil

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -50,6 +50,7 @@ export default function Author(props: AuthorProps): ReactElement {
         style={{ objectFit: 'cover' }}
         height={16}
         width={16}
+        borderRadius={1}
       />
     ) : (
       <Sigil ship={ship} size={16} color={color} icon padding={2} />


### PR DESCRIPTION
As per @urcades, we style avatars to match sigils' rounding.