### PR TITLE
build: amend dependencies for big sur

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": null,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "166ab9d237409c4b74b1f8ca31476ead35e8fe53",
-        "sha256": "13i43kvbkdl3dh8b986j6mxbn355mqjhcxrd8cni8zfx1z0wrscr",
+        "rev": "29ec4bb3ab38ac0229213197471133770702140e",
+        "sha256": "0q73yi4x5sjzkzak589jzwgfw0pd0byrs6lhsx3asrcff7c9afzy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/166ab9d237409c4b74b1f8ca31476ead35e8fe53.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/29ec4bb3ab38ac0229213197471133770702140e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "softfloat3": {


### PR DESCRIPTION
Applies @joemfb's local fix in https://github.com/urbit/urbit/issues/4214#issuecomment-778443916 to sources.json.

**Reason for the changes**
- Because you straight up can't build the binary on Big Sur otherwise and it's been months
- Janeway aggressively desires to use the binary it builds itself so no one can deploy if they use Big Sur

**Concerns**
- I don't know if patching sources.json is a thing you do
- @brendanhay help

Fixes #4214