### PR TITLE
landscape: two css regressions

### DIFF
--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -156,7 +156,8 @@ h2 {
 blockquote {
   padding: 0 0 0 16px;
   margin: 0;
-  border-left: 1px solid black;
+  color: inherit;
+  border-left: 1px solid;
 }
 
 :root {
@@ -173,6 +174,7 @@ blockquote {
   height: 100% !important;
   width: 100% !important;
   cursor: text;
+  color: inherit;
   background: transparent;
 }
 
@@ -308,9 +310,6 @@ pre.CodeMirror-placeholder.CodeMirror-line-like {
 /* dark */
 
 @media (prefers-color-scheme: dark) {
-  blockquote {
-    border-left: 1px solid inherit;
-  }
 
   /* codemirror */
   .chat .cm-s-tlon.CodeMirror {

--- a/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
@@ -28,6 +28,7 @@ export const MarkdownField = ({
       width="100%"
       display="flex"
       flexDirection="column"
+      color="black"
       {...rest}
     >
       <MarkdownEditor

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Text, Col } from '@tlon/indigo-react';
+import { Box, Text, Col, Anchor } from '@tlon/indigo-react';
 import ReactMarkdown from 'react-markdown';
 import bigInt from 'big-integer';
 
@@ -31,6 +31,14 @@ export function Note(props: NoteProps & RouteComponentProps) {
 
   const { notebook, note, contacts, ship, book, api, rootUrl, baseUrl, group } = props;
   const editCommentId = props.match.params.commentId;
+
+  const renderers = {
+    link: ({ href, children }) => {
+      return (
+        <Anchor display="inline" target="_blank" href={href}>{children}</Anchor>
+      )
+    }
+  };
 
   const deletePost = async () => {
     setDeleting(true);
@@ -107,7 +115,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
         </Box>
       </Col>
       <Box color="black" className="md" style={{ overflowWrap: 'break-word', overflow: 'hidden' }}>
-        <ReactMarkdown source={body} linkTarget={'_blank'} />
+        <ReactMarkdown source={body} linkTarget={'_blank'} renderers={renderers} />
       </Box>
       <NoteNavigation
         notebook={notebook}

--- a/pkg/interface/src/views/apps/publish/css/custom.css
+++ b/pkg/interface/src/views/apps/publish/css/custom.css
@@ -41,6 +41,8 @@
   cursor: text;
   font-size: 12px;
   line-height: 20px;
+  background: inherit;
+  color: inherit;
 }
 
 .publish .CodeMirror * {


### PR DESCRIPTION
- Fixes link colour on Publish render (urbit/landscape#521)
- Fixes chat / publish input and renderer theming on specific client + Indigo setting combinations