### PR TITLE
term: flex history container width

### DIFF
--- a/pkg/interface/src/views/apps/term/app.js
+++ b/pkg/interface/src/views/apps/term/app.js
@@ -67,6 +67,7 @@ export default class TermApp extends Component {
                     backgroundColor='white'
                     width='100%'
                     minHeight='0'
+                    minWidth='0'
                     color='washedGray'
                     borderRadius='2'
                     mx={['0','3']}

--- a/pkg/interface/src/views/apps/term/components/history.js
+++ b/pkg/interface/src/views/apps/term/components/history.js
@@ -13,6 +13,7 @@ export class History extends Component {
       <Box
         height='100%'
         minHeight='0'
+        minWidth='0'
         display='flex'
         flexDirection='column-reverse'
         overflowY='scroll'


### PR DESCRIPTION
Try running `.` in webterm at half your screen width — the history container overflows off screen. This is because you need `min-width: 0` to flex child containers when they try to overflow. We apply that here.