### PR TITLE
gall: add $foot to kick sign

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec80a42446a1d80974f32bf87283435547441cb7ea3fcd340711df2ce6cbec81
-size 9146390
+oid sha256:a59df8c0a721f5daae01967db29a3d61b26a320bae2513d193c85a2fc1b917cc
+size 10135909

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1653,6 +1653,7 @@
                   byk=beak                              ::  load source
           ==  ==                                        ::
   +$  dude  term                                        ::  server identity
+  +$  foot  ?(%mark %gone %fail)                        ::  reason for kick  
   +$  gill  (pair ship term)                            ::  general contact
   +$  scar                                              ::  opaque duct
     $:  p=@ud                                           ::  bone sequence
@@ -1698,7 +1699,7 @@
       $%  [%poke-ack p=(unit tang)]
           [%watch-ack p=(unit tang)]
           [%fact =cage]
-          [%kick ~]
+          [%kick p=(unit foot)]
       ==
     ++  form
       $_  ^|

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1112,14 +1112,14 @@
         ?-    sky
             ?(~ [~ ~])
           %-  (slog leaf+"watch-as fact conversion find-fail" >sky< ~)
-          (ap-kill-up-slip duct)
+          (ap-kill-up-slip duct `%mark)
         ::
             [~ ~ *]
           =+  !<(=tube:clay q.u.u.sky)
           =/  res  (mule |.((tube q.cage)))
           ?:  ?=(%| -.res)
             %-  (slog leaf+"watch-as fact conversion failure" p.res)
-            (ap-kill-up-slip duct)
+            (ap-kill-up-slip duct `%mark)
           :~  [duct %pass /nowhere %c %warp our %home ~ %sing %c case mars-path]
               [duct %give %unto %fact b.mars p.res]
           ==
@@ -1167,7 +1167,7 @@
         =/  core
           =.  agent-duct  system-duct.state
           =/  way  [%out (scot %p ship) term.i.out wire.i.out]
-          (ap-specific-take way %kick ~)
+          (ap-specific-take way %kick `%gone)
         core(agent-duct agent-duct)
       $(out t.out)
     ::  +ap-clog: handle %clog notification from ames
@@ -1518,11 +1518,11 @@
     ::  Should probably call +ap-error with error message
     ::
     ++  ap-kill-up-slip
-      |=  =duct
+      |=  [=duct fot=(unit foot)]
       ^-  (list move)
       ::
       :~  [duct %slip %g %deal [our our] agent-name %leave ~]
-          [duct %give %unto %kick ~]
+          [duct %give %unto %kick fot]
       ==
     ::  +ap-kill-down: 2-sided kill from subscriber side
     ::
@@ -1534,7 +1534,7 @@
       ::
       =.  ap-core
         (ap-pass wire %agent dock %leave ~)
-      (ap-pass wire %huck dock %b %huck `sign-arvo`[%gall %unto %kick ~])
+      (ap-pass wire %huck dock %b %huck `sign-arvo`[%gall %unto %kick `%fail])
     ::  +ap-mule: run virtualized with intercepted scry, preserving type
     ::
     ::    Compare +mute and +mule.  Those pass through scry, which


### PR DESCRIPTION
Changes the type of %kick to include `p=(unit foot)`, where foot is a
union of symbols describing the reason for the kick.
%gone: Publisher breached
%mark: Mark validation or conversion failed
%fail: Subscriber failed to process fact

If there is no foot for the kick, then it's either a %clog-triggered
kick or manually by the publisher. We do not distinguish between these
as that would require a new version of the ames protocol, which is out
of scope for now, given that this work is largely motiviated by
versioned subscriptions.