### PR TITLE
interface: p1 hotfixes

### DIFF
--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -167,7 +167,7 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
           style={{ cursor: node.post.pending ? 'default' : 'pointer' }}>
         <Box display='flex'>
           <Icon color={commColor} icon='Chat' />
-          <Text color={commColor} ml={1}>{node.children.size}</Text>
+          <Text color={commColor} ml={1}>{size}</Text>
         </Box>
       </Link>
         </Box>

--- a/pkg/interface/src/views/apps/settings/components/lib/RemoteContent.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/RemoteContent.tsx
@@ -8,7 +8,7 @@ import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
 
 import GlobalApi from '~/logic/api/global';
-import useLocalState from '~/logic/state/local';
+import useSettingsState, {selectSettingsState} from '~/logic/state/settings';
 
 const formSchema = Yup.object().shape({
   imageShown: Yup.boolean(),
@@ -27,11 +27,11 @@ interface FormSchema {
 interface RemoteContentFormProps {
   api: GlobalApi;
 }
+const selState = selectSettingsState(['remoteContentPolicy', 'set']);
 
 export default function RemoteContentForm(props: RemoteContentFormProps) {
   const { api } = props;
-  const remoteContentPolicy = useLocalState(state => state.remoteContentPolicy);
-  const setRemoteContentPolicy = useLocalState(state => state.set);
+  const { remoteContentPolicy, set: setRemoteContentPolicy} = useSettingsState(selState);
   const imageShown = remoteContentPolicy.imageShown;
   const audioShown = remoteContentPolicy.audioShown;
   const videoShown = remoteContentPolicy.videoShown;

--- a/pkg/interface/src/views/components/RemoteContent.tsx
+++ b/pkg/interface/src/views/components/RemoteContent.tsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { BaseAnchor, BaseImage, Box, Button, Text } from '@tlon/indigo-react';
 import { hasProvider } from 'oembed-parser';
 import EmbedContainer from 'react-oembed-container';
-import { withLocalState } from '~/logic/state/local';
+import { withSettingsState } from '~/logic/state/settings';
 import { RemoteContentPolicy } from '~/types/local-update';
 import { VirtualContextProps, withVirtual } from "~/logic/lib/virtualContext";
 import { IS_IOS } from '~/logic/lib/platform';
@@ -268,4 +268,4 @@ return;
   }
 }
 
-export default withLocalState(withVirtual(RemoteContent), ['remoteContentPolicy']);
+export default withSettingsState(withVirtual(RemoteContent), ['remoteContentPolicy']);


### PR DESCRIPTION
LinkItem: safely access size

Fixes urbit/landscape#542

RemoteContent: use settings instead of local state

Fixes urbit/landscape#544
