### PR TITLE
hooks: versioned subscriptions

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb221ce7316346bfaf1ddd953927c0f2afe7eaf5b160bed545f67ec7e5ccb005
-size 9410487
+oid sha256:a8b19cbe89f770f8d6c1e05972be7a3a01545b93b0f2d4523809e7df18635f3c
+size 9462938

--- a/pkg/arvo/app/chat-cli.hoon
+++ b/pkg/arvo/app/chat-cli.hoon
@@ -169,7 +169,7 @@
       ::
           %fact
         ?+  p.cage.sign  ~|([dap.bowl %bad-sub-mark wire p.cage.sign] !!)
-            %graph-update
+            %graph-update-0
           %-  on-graph-update:tc
           !<(update:graph q.cage.sign)
         ==
@@ -758,7 +758,7 @@
       ::TODO  move creation into lib?
       %^  act  %out-message
         %graph-push-hook
-      :-  %graph-update
+      :-  %graph-update-0
       !>  ^-  update:graph
       :+  %0  now.bowl
       :+  %add-nodes  audience

--- a/pkg/arvo/app/chat-hook.hoon
+++ b/pkg/arvo/app/chat-hook.hoon
@@ -154,7 +154,7 @@
   ++  poke-graph-store
     |=  =update:graph-store
     ^-  card
-    (poke-our %graph-store %graph-update !>(update))
+    (poke-our %graph-store %graph-update-0 !>(update))
   ::
   ++  nobody
     ^-  @p

--- a/pkg/arvo/app/chat-store.hoon
+++ b/pkg/arvo/app/chat-store.hoon
@@ -293,12 +293,12 @@
   |=  group=resource
   ^-  card
   =-  [%pass / %agent [our.bol %group-store] %poke -]
-  group-update+!>([%remove-group group ~])
+  group-update-0+!>([%remove-group group ~])
 ::
 ++  poke-graph-store
   |=  =update:graph-store
   ^-  card
-  [%pass / %agent [our.bol %graph-store] %poke %graph-update !>(update)]
+  [%pass / %agent [our.bol %graph-store] %poke %graph-update-0 !>(update)]
 ::
 ++  letter-to-contents
   |=  =letter:store

--- a/pkg/arvo/app/contact-pull-hook.hoon
+++ b/pkg/arvo/app/contact-pull-hook.hoon
@@ -10,6 +10,7 @@
       update:store
       %contact-update
       %contact-push-hook
+      0  0
       %.y  :: necessary to enable p2p
   ==
 --

--- a/pkg/arvo/app/contact-push-hook.hoon
+++ b/pkg/arvo/app/contact-push-hook.hoon
@@ -11,6 +11,7 @@
       update:store
       %contact-update
       %contact-pull-hook
+      0  0
   ==
 ::
 +$  agent  (push-hook:push-hook config)

--- a/pkg/arvo/app/contact-store.hoon
+++ b/pkg/arvo/app/contact-store.hoon
@@ -71,7 +71,7 @@
   ++  give
     |=  =update:store
     ^-  (list card)
-    [%give %fact ~ [%contact-update !>(update)]]~
+    [%give %fact ~ [%contact-update-0 !>(update)]]~
   --
 ::
 ++  on-poke
@@ -81,7 +81,7 @@
   |^
   =^  cards  state
     ?+  mark  (on-poke:def mark vase)
-      %contact-update  (update !<(update:store vase))
+      %contact-update-0  (update !<(update:store vase))
       %import          (import q.vase)
     ==
   [cards this]
@@ -203,7 +203,7 @@
         ?:  our
           [/updates /our /all ~]
         [/updates /all ~]
-      [%give %fact paths %contact-update !>(update)]~
+      [%give %fact paths %contact-update-0 !>(update)]~
     --
   ::
   ++  import
@@ -223,7 +223,7 @@
     =/  =ship  (slav %p i.t.t.path)
     =/  contact=(unit contact:store)  (~(get by rolodex) ship)
     ?~  contact  [~ ~]
-    :-  ~  :-  ~  :-  %contact-update
+    :-  ~  :-  ~  :-  %contact-update-0
     !>  ^-  update:store
     [%add ship u.contact]
   ::

--- a/pkg/arvo/app/demo-pull-hook.hoon
+++ b/pkg/arvo/app/demo-pull-hook.hoon
@@ -42,6 +42,8 @@
 ++  on-pull-nack
   |=   [=resource =tang]
   ^-  (quip card _this)
+  ~&  "{<resource>}: nacked"
+  %-  (slog tang)
   `this
 ::
 ++  on-pull-kick

--- a/pkg/arvo/app/demo-pull-hook.hoon
+++ b/pkg/arvo/app/demo-pull-hook.hoon
@@ -1,0 +1,58 @@
+/-  store=demo
+/+  default-agent, verb, dbug, pull-hook, agentio, resource
+~%  %demo-pull-hook-top  ..part  ~
+|%
++$  card  card:agent:gall
+::
+++  config
+  ^-  config:pull-hook
+  :*  %demo-store
+      update:store
+      %demo-update
+      %demo-push-hook
+      ::  do not change spacing, required by tests
+      0  
+      0
+      %.n
+  ==
+::
+--
+::
+::
+%-  agent:dbug
+%+  verb  |
+^-  agent:gall
+%-  (agent:pull-hook config)
+^-  (pull-hook:pull-hook config)
+|_  =bowl:gall
++*  this        .
+    def         ~(. (default-agent this %|) bowl)
+    dep         ~(. (default:pull-hook this config) bowl)
+::
+++  on-init  on-init:def
+++  on-save  !>(~)
+++  on-load  on-load:def
+++  on-poke  on-poke:def
+++  on-agent  on-agent:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+++  on-pull-nack
+  |=   [=resource =tang]
+  ^-  (quip card _this)
+  `this
+::
+++  on-pull-kick
+  |=  =resource
+  ^-  (unit path)
+  ~&  "{<resource>}: kicked"
+  `/
+::
+++  resource-for-update  
+  |=  =vase
+  =+  !<(=update:store vase)
+  ~[p.update]
+--
+

--- a/pkg/arvo/app/demo-push-hook.hoon
+++ b/pkg/arvo/app/demo-push-hook.hoon
@@ -1,0 +1,65 @@
+/-  store=demo
+/+  default-agent, verb, dbug, push-hook, resource, agentio
+|%
++$  card  card:agent:gall
+::
+++  config
+  ^-  config:push-hook
+  :*  %demo-store
+      /updates
+      update:store
+      %demo-update
+      %demo-pull-hook
+      ::
+      0  
+      0
+  ==
+::
++$  agent  (push-hook:push-hook config)
+--
+::
+::
+%-  agent:dbug
+%+  verb  |
+^-  agent:gall
+%-  (agent:push-hook config)
+^-  agent
+|_  =bowl:gall
++*  this        .
+    def         ~(. (default-agent this %|) bowl)
+    grp       ~(. grpl bowl)
+    io        ~(. agentio bowl)
+::
+++  on-init  on-init:def
+++  on-save  !>(~)
+++  on-load    on-load:def
+++  on-poke   on-poke:def
+++  on-agent  on-agent:def
+++  on-watch    on-watch:def
+++  on-leave    on-leave:def
+++  on-peek   on-peek:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+::
+++  transform-proxy-update
+  |=  vas=vase
+  ^-  (unit vase)
+  `vas
+::
+++  resource-for-update  
+  |=  =vase
+  =+  !<(=update:store vase)
+  ~[p.update]
+::
+++  take-update
+  |=   =vase
+  ^-  [(list card) agent]
+  `this
+::
+++  initial-watch
+  |=  [=path rid=resource]
+  ^-  vase
+  =+  .^(=update:store %gx (scry:io %demo-store (snoc `^path`log+(en-path:resource rid) %noun)))
+  !>(update)
+::
+--

--- a/pkg/arvo/app/demo-store.hoon
+++ b/pkg/arvo/app/demo-store.hoon
@@ -1,0 +1,100 @@
+/-  store=demo
+/+  default-agent, verb, dbug, resource, agentio
+|%
++$  card  card:agent:gall
++$  state-0
+  [%0 log=(jar resource update:store) counters=(map resource @ud)]
+--
+=|  state-0
+=*  state  -
+::
+%-  agent:dbug
+%+  verb  |
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+    io    ~(. agentio bowl)
+++  on-init
+  `this
+::
+++  on-save
+  !>(state)
+::
+++  on-load
+  |=  =vase
+  =+  !<(old=state-0 vase)
+  `this(state old)
+::
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  ?.  =(%demo-update-0 mark)
+    (on-poke:def mark vase)
+  ~&  mark
+  =+  !<(=update:store vase)
+  |^ 
+  =.  log
+    (~(add ja log) p.update update)
+  =^  cards  state
+    (upd update)
+  [cards this]
+  ::
+  ++  upd
+    |=  up=update:store
+    ^-  (quip card _state)
+    ?-  -.up
+      %ini  (upd-ini +.up)
+      %add  (upd-add +.up)
+      %sub  (upd-sub +.up)
+      %run  (upd-run +.up)
+    ==
+  ::
+  ++  upd-ini
+   |=  [rid=resource ~]
+   :-  (fact:io mark^!>([%ini +<]) /updates ~)^~
+   state(counters (~(put by counters) rid 0))
+  ::
+  ++  upd-add
+    |=  [rid=resource count=@ud]
+    :-  (fact:io mark^!>([%add +<]) /updates ~)^~
+    state(counters (~(jab by counters) rid (cury add count)))
+  ::
+  ++  upd-sub
+    |=  [rid=resource count=@ud]
+    :-  (fact:io mark^!>([%sub +<]) /updates ~)^~
+    state(counters (~(jab by counters) rid (cury sub count)))
+  ::
+  ++  upd-run
+    =|  cards=(list card)
+    |=  [rid=resource =(list update:store)]
+    ?~  list  [cards state]
+    =^  caz  state  
+      (upd i.list)
+    $(list t.list, cards (weld cards caz))
+  --
+::
+++  on-watch
+  |=  =path
+  ?.  ?=([%updates ~] path)
+    (on-watch:def path)
+  `this
+::
+++  on-peek  
+  |=  =path
+  ?.  ?=([%x %log @ @ @ ~] path)
+    (on-peek:def path)
+  =/  rid=resource
+    (de-path:resource t.t.path)
+  =/  =update:store
+    [%run rid (flop (~(get ja log) rid))]
+  ``noun+!>(update)
+::
+++  on-agent  on-agent:def
+::
+++  on-arvo  on-arvo:def
+::
+++  on-leave  on-leave:def
+::
+++  on-fail  on-fail:def
+--

--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -9,6 +9,7 @@
       update:store
       %graph-update
       %graph-push-hook
+      0  0
       %.n
   ==
 --

--- a/pkg/arvo/app/graph-pull-hook.hoon
+++ b/pkg/arvo/app/graph-pull-hook.hoon
@@ -41,7 +41,7 @@
   %-  (slog leaf+"nacked {<resource>}" tang)
   :_  this
   ?.  (~(has in get-keys:gra) resource)  ~
-  =-  [%pass /pull-nack %agent [our.bowl %graph-store] %poke %graph-update -]~
+  =-  [%pass /pull-nack %agent [our.bowl %graph-store] %poke %graph-update-0 -]~
   !>  ^-  update:store
   [%0 now.bowl [%archive-graph resource]]
 ::

--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -12,6 +12,7 @@
       update:store
       %graph-update
       %graph-pull-hook
+      0  0
   ==
 ::
 +$  agent  (push-hook:push-hook config)

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -207,7 +207,7 @@
   ++  give
     |=  =update-0:store
     ^-  (list card)
-    [%give %fact ~ [%graph-update !>([%0 now.bowl update-0])]]~
+    [%give %fact ~ [%graph-update-0 !>([%0 now.bowl update-0])]]~
   --
 ::
 ++  on-poke
@@ -218,7 +218,7 @@
   ?>  (team:title our.bowl src.bowl)
   =^  cards  state
     ?+  mark           (on-poke:def mark vase)
-        %graph-update  (graph-update !<(update:store vase))
+        %graph-update-0  (graph-update !<(update:store vase))
         %noun          (debug !<(debug-input vase))
         %import        (poke-import q.vase)
     ==
@@ -646,7 +646,7 @@
         [cards state]
       =*  update  upd.i.updates
       =^  crds  state
-        %-  graph-update 
+        %-  graph-update
         ^-  update:store
         ?-  -.q.update
             %add-graph          update(resource.q resource)
@@ -660,7 +660,7 @@
     ++  give
       |=  [paths=(list path) update=update-0:store]
       ^-  (list card)
-      [%give %fact paths [%graph-update !>([%0 now.bowl update])]]~
+      [%give %fact paths [%graph-update-0 !>([%0 now.bowl update])]]~
     --
   ::
   ++  debug
@@ -862,15 +862,15 @@
     ``noun+!>(q.u.result)
   ::
       [%x %keys ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>(`update:store`[%0 now.bowl [%keys ~(key by graphs)]])
   ::
       [%x %tags ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>(`update:store`[%0 now.bowl [%tags ~(key by tag-queries)]])
   ::
       [%x %tag-queries ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>(`update:store`[%0 now.bowl [%tag-queries tag-queries]])
   ::
       [%x %graph @ @ ~]
@@ -879,7 +879,7 @@
     =/  result=(unit marked-graph:store)
       (~(get by graphs) [ship term])
     ?~  result  [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0
       now.bowl
@@ -895,7 +895,7 @@
     ?~  result
       ~&  no-archived-graph+[ship term]
       [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0
       now.bowl
@@ -912,7 +912,7 @@
     =/  graph=(unit marked-graph:store)
       (~(get by graphs) [ship term])
     ?~  graph  [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0  now.bowl
     :+  %add-nodes
@@ -939,7 +939,7 @@
       (turn t.t.t.t.path (cury slav %ud))
     =/  node=(unit node:store)  (get-node ship term index)
     ?~  node  [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0
       now.bowl
@@ -959,7 +959,7 @@
     =/  graph
       (get-node-children ship term parent)
     ?~  graph  [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0
       now.bowl
@@ -990,7 +990,7 @@
     =/  children
       (get-node-children ship term index)
     ?~  children  [~ ~]
-    :-  ~  :-  ~  :-  %graph-update
+    :-  ~  :-  ~  :-  %graph-update-0
     !>  ^-  update:store
     :+  %0
       now.bowl
@@ -1017,7 +1017,7 @@
     ?-  -.children.u.node
         %empty  [~ ~]
         %graph
-      :-  ~  :-  ~  :-  %graph-update
+      :-  ~  :-  ~  :-  %graph-update-0
       !>  ^-  update:store
       :+  %0
         now.bowl

--- a/pkg/arvo/app/group-pull-hook.hoon
+++ b/pkg/arvo/app/group-pull-hook.hoon
@@ -48,7 +48,7 @@
   %-  (slog tang)
   :_  this
   =-  [%pass / %agent [our.bowl %group-store] %poke -]~
-  group-update+!>([%remove-group resource ~])
+  group-update-0+!>([%remove-group resource ~])
 ::
 ++  on-pull-kick
   |=  =resource

--- a/pkg/arvo/app/group-pull-hook.hoon
+++ b/pkg/arvo/app/group-pull-hook.hoon
@@ -14,6 +14,7 @@
       update:store
       %group-update
       %group-push-hook
+      0  0
       %.n
   ==
 ::
@@ -44,6 +45,7 @@
 ++  on-pull-nack
   |=   [=resource =tang]
   ^-  (quip card _this)
+  %-  (slog tang)
   :_  this
   =-  [%pass / %agent [our.bowl %group-store] %poke -]~
   group-update+!>([%remove-group resource ~])

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -86,7 +86,7 @@
   ++  poke-store
     |=  =update:store
     ^-  card
-    =+  group-update+!>(update)
+    =+  group-update-0+!>(update)
     [%pass /sane %agent [our.bowl %group-store] %poke -]
   ::
   ++  get-subscribers-for-group

--- a/pkg/arvo/app/group-push-hook.hoon
+++ b/pkg/arvo/app/group-push-hook.hoon
@@ -17,6 +17,7 @@
       update:store
       %group-update
       %group-pull-hook
+      0  0
   ==
 ::
 +$  agent  (push-hook:push-hook config)

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -234,8 +234,8 @@
     sane+(en-path:resource rid)
   =*  poke-self  ~(poke-self pass:io wire)
   %+  weld  out
-  :~  (poke-self group-update+!>([%add-members rid (silt our.bol ~)]))
-      (poke-self group-update+!>([%add-tag rid %admin (silt our.bol ~)]))
+  :~  (poke-self group-update-0+!>([%add-members rid (silt our.bol ~)]))
+      (poke-self group-update-0+!>([%add-tag rid %admin (silt our.bol ~)]))
   ==
 ::
 ++  poke-import

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -113,7 +113,7 @@
       ?+    mark  (on-poke:def mark vase)
         %sane  (poke-sane:gc !<(?(%check %fix) vase))
       ::
-          ?(%group-update %group-action)
+          ?(%group-update-0 %group-action)
         (poke-group-update:gc !<(update:store vase))
       ::
           %import
@@ -127,7 +127,7 @@
     ?>  (team:title our.bowl src.bowl)
     ?>  ?=([%groups ~] path)
     :_  this
-    [%give %fact ~ %group-update !>([%initial groups])]~
+    [%give %fact ~ %group-update-0 !>([%initial groups])]~
   ::
   ++  on-leave  on-leave:def
   ::
@@ -298,7 +298,7 @@
   |=  [rid=resource nack-count=@ud]
   ^-  card
   =/  =cage
-    :-  %group-update
+    :-  %group-update-0
     !>  ^-  update:store
     [%add-members rid (sy our.bol ~)]
   =/  =wire
@@ -583,6 +583,6 @@
 ++  send-diff
   |=  =update:store
   ^-  (list card)
-  [%give %fact ~[/groups] %group-update !>(update)]~
+  [%give %fact ~[/groups] %group-update-0 !>(update)]~
 ::
 --

--- a/pkg/arvo/app/group-view.hoon
+++ b/pkg/arvo/app/group-view.hoon
@@ -166,7 +166,7 @@
       %-  emit
       %+  poke:(jn-pass-io /add)
         [ship %group-push-hook]
-      group-update+!>([%add-members rid (silt our.bowl ~)])
+      group-update-0+!>([%add-members rid (silt our.bowl ~)])
     =.  jn-core  (tx-progress %start)
     =>  watch-md
     watch-groups

--- a/pkg/arvo/app/group-view.hoon
+++ b/pkg/arvo/app/group-view.hoon
@@ -227,7 +227,7 @@
     ::
     ++  groups-fact
       |=  =cage
-      ?.  ?=(%group-update p.cage)  jn-core
+      ?.  ?=(%group-update-0 p.cage)  jn-core
       =+  !<(=update:group-store q.cage)
       ?.  ?=(%initial-group -.update)  jn-core
       ?.  =(rid resource.update)  jn-core
@@ -246,7 +246,7 @@
     ::
     ++  md-fact
       |=  [=mark =vase]
-      ?.  ?=(%metadata-update mark)    jn-core
+      ?.  ?=(%metadata-update-0 mark)    jn-core
       =+  !<(=update:metadata vase)
       ?.  ?=(%initial-group -.update)  jn-core
       ?.  =(group.update rid)          jn-core

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -182,7 +182,7 @@
     ~[watch-graph:ha]
   ::
       %fact
-    ?.  ?=(%graph-update p.cage.sign)
+    ?.  ?=(%graph-update-0 p.cage.sign)
       (on-agent:def wire sign)
     =^  cards  state
       (graph-update !<(update:graph-store q.cage.sign))

--- a/pkg/arvo/app/hark-group-hook.hoon
+++ b/pkg/arvo/app/hark-group-hook.hoon
@@ -108,7 +108,7 @@
   ::
       %fact
     ?+  p.cage.sign  (on-agent:def wire sign)
-        %group-update
+        %group-update-0
       =^  cards  state
         (group-update !<(update:group-store q.cage.sign))
       [cards this]

--- a/pkg/arvo/app/hark-group-hook.hoon
+++ b/pkg/arvo/app/hark-group-hook.hoon
@@ -113,7 +113,7 @@
         (group-update !<(update:group-store q.cage.sign))
       [cards this]
     ::
-        %metadata-update
+        %metadata-update-0
       =^  cards  state
         (metadata-update !<(update:metadata q.cage.sign))
       [cards this]

--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -15,6 +15,7 @@
       update:metadata
       %metadata-update
       %metadata-push-hook
+      0  0
       %.n
   ==
 +$  state-zero
@@ -151,7 +152,7 @@
         %kick  [watch-store^~ state]
         ::
           %fact
-        ?>  ?=(%metadata-update p.cage.sign)
+        ?>  ?=(%metadata-update-0 p.cage.sign)
         =+  !<(=update:metadata q.cage.sign)
         ?.  ?=(%initial-group -.update)  `state
         `state(previews (~(del by previews) group.update))
@@ -255,7 +256,7 @@
   %+  turn  ~(tap by associations)
   |=  [=md-resource:metadata =association:metadata]
   %+  poke-our:pass:io  %metadata-store
-  :-  %metadata-update
+  :-  %metadata-update-0
   !>  ^-   update:metadata
   [%remove resource md-resource]
 ::

--- a/pkg/arvo/app/metadata-pull-hook.hoon
+++ b/pkg/arvo/app/metadata-pull-hook.hoon
@@ -83,7 +83,7 @@
         %kick  [~[watch-contacts] state]
         ::
           %fact
-        ?>  ?=(%contact-update p.cage.sign)
+        ?>  ?=(%contact-update-0 p.cage.sign)
         =+  !<(=update:contact q.cage.sign)
         ?+  -.update  `state
             %add

--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -14,6 +14,7 @@
       update:store
       %metadata-update
       %metadata-pull-hook
+      0  0
   ==
 ::
 +$  agent  (push-hook:push-hook config)

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -126,7 +126,7 @@
     ?>  (team:title our.bowl src.bowl)
     =^  cards  state
       ?+  mark  (on-poke:def mark vase)
-          ?(%metadata-action %metadata-update)
+          ?(%metadata-action %metadata-update-0)
         (poke-metadata-update:mc !<(update:store vase))
       ::
           %import
@@ -144,7 +144,7 @@
     =/  cards=(list card)
       ?+  path  (on-watch:def path)
           [%all ~]
-        (give %metadata-update !>([%associations associations]))
+        (give %metadata-update-0 !>([%associations associations]))
       ::
           [%updates ~]
         ~
@@ -152,7 +152,7 @@
           [%app-name @ ~]
         =/  =app-name:store  i.t.path
         =/  app-indices  (metadata-for-app:mc app-name)
-        (give %metadata-update !>([%associations app-indices]))
+        (give %metadata-update-0 !>([%associations app-indices]))
       ==
     [cards this]
     ::
@@ -443,6 +443,6 @@
   ++  update-subscribers
     |=  [pax=path =update:store]
     ^-  (list card)
-    [%give %fact ~[pax] %metadata-update !>(update)]~
+    [%give %fact ~[pax] %metadata-update-0 !>(update)]~
   --
 --

--- a/pkg/arvo/gen/demo/add.hoon
+++ b/pkg/arvo/gen/demo/add.hoon
@@ -1,0 +1,8 @@
+/-  *demo
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[ver=@ud =term count=@ud ~] ~]
+    ==
+:-  (cat 3 %demo-update- (scot %ud ver))
+^-  update
+[%add [p.beak term] count]

--- a/pkg/arvo/gen/demo/ini.hoon
+++ b/pkg/arvo/gen/demo/ini.hoon
@@ -1,0 +1,8 @@
+/-  *demo
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=term ~] ~]
+    ==
+:-  %demo-update-0
+^-  update
+[%ini [p.beak term] ~]

--- a/pkg/arvo/gen/demo/run.hoon
+++ b/pkg/arvo/gen/demo/run.hoon
@@ -1,0 +1,8 @@
+/-  *demo
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=term lst=(list action) ~] ~]
+    ==
+:-  %demo-update-0
+^-  action
+[%run [p.beak term] lst]

--- a/pkg/arvo/gen/demo/run.hoon
+++ b/pkg/arvo/gen/demo/run.hoon
@@ -1,8 +1,8 @@
 /-  *demo
 :-  %say
 |=  $:  [now=@da eny=@uvJ =beak]
-        [[=term lst=(list action) ~] ~]
+        [[=term lst=(list update) ~] ~]
     ==
 :-  %demo-update-0
-^-  action
+^-  update
 [%run [p.beak term] lst]

--- a/pkg/arvo/gen/demo/sub.hoon
+++ b/pkg/arvo/gen/demo/sub.hoon
@@ -1,0 +1,8 @@
+/-  *demo
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=term count=@ud ~] ~]
+    ==
+:-  %demo-update-0
+^-  update
+[%sub [p.beak term] count]

--- a/pkg/arvo/gen/graph-store/add-graph.hoon
+++ b/pkg/arvo/gen/graph-store/add-graph.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=resource mark=(unit mark) overwrite=? ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%add-graph resource (gas:orm ~ ~) mark overwrite]]

--- a/pkg/arvo/gen/graph-store/add-post.hoon
+++ b/pkg/arvo/gen/graph-store/add-post.hoon
@@ -12,7 +12,7 @@
     contents.post   contents
 ==
 ::
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 :+  %0  now
 :+  %add-nodes  [our name]

--- a/pkg/arvo/gen/graph-store/add-signatures.hoon
+++ b/pkg/arvo/gen/graph-store/add-signatures.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[[=resource =index] =signatures ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%add-signatures [resource index] signatures]]

--- a/pkg/arvo/gen/graph-store/add-tag.hoon
+++ b/pkg/arvo/gen/graph-store/add-tag.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=term =resource ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%add-tag term resource]]

--- a/pkg/arvo/gen/graph-store/archive-graph.hoon
+++ b/pkg/arvo/gen/graph-store/archive-graph.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=resource ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%archive-graph resource]]

--- a/pkg/arvo/gen/graph-store/export-graph.hoon
+++ b/pkg/arvo/gen/graph-store/export-graph.hoon
@@ -4,7 +4,7 @@
 |=  $:  [now=@da eny=@uvJ bec=beak]
         [[=ship graph=term ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 =/  our  (scot %p p.bec)
 =/  wen  (scot %da now)
 =/  who  (scot %p ship)

--- a/pkg/arvo/gen/graph-store/import-graph.hoon
+++ b/pkg/arvo/gen/graph-store/import-graph.hoon
@@ -4,6 +4,6 @@
 |=  $:  [now=@da eny=@uvJ bec=beak]
         [[graph=term =path ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 =-  ~&  update=-  -
 .^(=update:graph-store %cx path)

--- a/pkg/arvo/gen/graph-store/remove-graph.hoon
+++ b/pkg/arvo/gen/graph-store/remove-graph.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=resource ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%remove-graph resource]]

--- a/pkg/arvo/gen/graph-store/remove-nodes.hoon
+++ b/pkg/arvo/gen/graph-store/remove-nodes.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=resource indices=(set index) ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%remove-nodes resource indices]]

--- a/pkg/arvo/gen/graph-store/remove-signatures.hoon
+++ b/pkg/arvo/gen/graph-store/remove-signatures.hoon
@@ -6,6 +6,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[[=resource =index] =signatures ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%remove-signatures [resource index] signatures]]

--- a/pkg/arvo/gen/graph-store/remove-tag.hoon
+++ b/pkg/arvo/gen/graph-store/remove-tag.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=term =resource ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%remove-tag term resource]]

--- a/pkg/arvo/gen/graph-store/unarchive-graph.hoon
+++ b/pkg/arvo/gen/graph-store/unarchive-graph.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=resource ~] ~]
     ==
-:-  %graph-update
+:-  %graph-update-0
 ^-  update
 [%0 now [%unarchive-graph resource]]

--- a/pkg/arvo/gen/group-store/allow-ranks.hoon
+++ b/pkg/arvo/gen/group-store/allow-ranks.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=ship =term ranks=(list rank:title) ~] ~]
     ==
-:-  %group-update
+:-  %group-update-0
 ^-  action
 [%change-policy [ship term] %open %allow-ranks (sy ranks)]

--- a/pkg/arvo/gen/group-store/allow-ships.hoon
+++ b/pkg/arvo/gen/group-store/allow-ships.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=ship =term ships=(list ship) ~] ~]
     ==
-:-  %group-update
+:-  %group-update-0
 ^-  action
 [%change-policy [ship term] %open %allow-ships (sy ships)]

--- a/pkg/arvo/gen/group-store/ban-ranks.hoon
+++ b/pkg/arvo/gen/group-store/ban-ranks.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=ship =term ranks=(list rank:title) ~] ~]
     ==
-:-  %group-update
+:-  %group-update-0
 ^-  action
 [%change-policy [ship term] %open %ban-ranks (sy ranks)]

--- a/pkg/arvo/gen/group-store/ban-ships.hoon
+++ b/pkg/arvo/gen/group-store/ban-ships.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=ship =term ships=(list ship) ~] ~]
     ==
-:-  %group-update
+:-  %group-update-0
 ^-  action
 [%change-policy [ship term] %open %ban-ships (sy ships)]

--- a/pkg/arvo/gen/group-store/create.hoon
+++ b/pkg/arvo/gen/group-store/create.hoon
@@ -5,6 +5,6 @@
 |=  $:  [now=@da eny=@uvJ =beak]
         [[=term ~] ~]
     ==
-:-  %group-update
+:-  %group-action
 ^-  action
 [%add-group [p.beak term] *open:policy %.n]

--- a/pkg/arvo/gen/pull/add.hoon
+++ b/pkg/arvo/gen/pull/add.hoon
@@ -1,0 +1,8 @@
+/-  *pull-hook
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=ship =term ~] ~]
+    ==
+:-  %pull-hook-action
+^-  action
+[%add ship ship term]

--- a/pkg/arvo/gen/push/add.hoon
+++ b/pkg/arvo/gen/push/add.hoon
@@ -1,0 +1,8 @@
+/-  *push-hook
+:-  %say
+|=  $:  [now=@da eny=@uvJ =beak]
+        [[=term ~] ~]
+    ==
+:-  %push-hook-action
+^-  action
+[%add p.beak term]

--- a/pkg/arvo/gen/tally.hoon
+++ b/pkg/arvo/gen/tally.hoon
@@ -66,7 +66,7 @@
 =/  real=(set resource:re)
   =/  upd=update:ga
     %+  scry  update:ga
-    [%x %graph-store /keys/graph-update]
+    [%x %graph-store /keys/graph-update-0]
   ?>  ?=(%keys -.q.upd)
   resources.q.upd
 ::  count activity per channel

--- a/pkg/arvo/lib/agentio.hoon
+++ b/pkg/arvo/lib/agentio.hoon
@@ -5,12 +5,10 @@
 ::
 |_  =bowl:gall
 ++  scry
-  |*  [desk=@tas =path]
-  ?>  ?=(^ path)
-  ?>  ?=(^ t.path)
+  |=  [desk=@tas =path]
   %+  weld
     /(scot %p our.bowl)/[desk]/(scot %da now.bowl)
-  t.t.path
+  path
 ::
 ++  pass
   |_  =wire

--- a/pkg/arvo/lib/agentio.hoon
+++ b/pkg/arvo/lib/agentio.hoon
@@ -103,6 +103,13 @@
   ^-  card
   [%give %fact ~ cage]
 ::
+++  fact-init-kick
+  |=  =cage
+  ^-  (list card)
+  :~  (fact cage ~)
+      (kick ~)
+  ==
+::
 ++  fact
   |=  [=cage paths=(list path)]
   ^-  card

--- a/pkg/arvo/lib/pull-hook-virt.hoon
+++ b/pkg/arvo/lib/pull-hook-virt.hoon
@@ -29,10 +29,10 @@
   ``.^(* u.pax)
 ::
 ++  kick-mule
-  |=  [rid=resource =trap]
+  |=  [rid=resource trp=(trap *)]
   ^-  (unit (unit path))
   =/  res=toon
-    (mock [trap %9 2 %0 1] mule-scry)
+    (mock [trp %9 2 %0 1] mule-scry)
   =/  pax=(unit path)
     !<  (unit path) 
     :-  -:!>(*(unit path)) 

--- a/pkg/arvo/lib/pull-hook-virt.hoon
+++ b/pkg/arvo/lib/pull-hook-virt.hoon
@@ -1,0 +1,52 @@
+::  pull-hook-virt: virtualisation for pull-hook
+/-  *resource
+|_  =bowl:gall
+++  mule-scry
+  |=  [ref=* raw=*]
+  =/  pax=(unit path)
+    ((soft path) raw)
+  ?~  pax  ~
+  ?.  ?=([@ @ @ @ *] u.pax)  ~
+  =/  ship
+    (slaw %p i.t.u.pax)
+  =/  ved
+    (slay i.t.t.t.u.pax)
+  =/  dat
+    ?~  ved  now.bowl
+    =/  cas=(unit case)
+      ((soft case) p.u.ved)
+    ?~  cas  now.bowl
+    ?:  ?=(%da -.u.cas)
+      p.u.cas
+    now.bowl
+  ::  catch bad gall scries early
+  ?:  ?&  =((end 3 i.u.pax) %g)
+          ?|  !=(`our.bowl ship)
+              !=(dat now.bowl)
+          ==
+      ==
+    ~
+  ``.^(* u.pax)
+::
+++  kick-mule
+  |=  [rid=resource =trap]
+  ^-  (unit (unit path))
+  =/  res=toon
+    (mock [trap %9 2 %0 1] mule-scry)
+  =/  pax=(unit path)
+    !<  (unit path) 
+    :-  -:!>(*(unit path)) 
+    ?:(?=(%0 -.res) p.res ~)
+  ?:  !?=(%0 -.res)
+    =/  =tang
+      :+  leaf+"failed kick handler, please report" 
+        leaf+"{<rid>} in {(trip dap.bowl)}"
+      ?:  ?=(%2 -.res)
+        p.res
+      ?>  ?=(%1 -.res)
+      =/  maybe-path=(unit path)  ((soft path) p.res)
+      ?~  maybe-path  ~
+      [(smyt u.maybe-path) ~]
+    ((slog tang) ~)
+  `pax
+--

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -423,7 +423,7 @@
     ::
     ++  tr-fact
       |=  =cage
-      ?:  ?=(%hook-meta-update p.cage)
+      ?:  ?=(%version p.cage)
         (tr-suspend-sub-ver !<(@ud q.cage))
       ?>  (is-root:ver p.cage)
       =/  fact-ver=@ud

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -317,12 +317,14 @@
           (take-version:hc src.bowl sign)
         =.  pull-hook  hook
         [cards this]
-      ?.  ?=([%pull %resource *] t.t.wire)
+      ?.  ?=([%pull ?(%unver-resource %resource) *] t.t.wire)
         (on-agent:def wire sign)
       =/  rid=resource
         (de-path:resource t.t.t.t.wire)
+      =/  versioned=?
+        ?=(%resource i.t.t.t.wire)
       =^  [cards=(list card) hook=_pull-hook]  state
-        tr-abet:(tr-sign:(tr-abed:track-engine:hc rid) sign)
+        tr-abet:(tr-sign:(tr-abed:track-engine:hc rid) sign versioned)
       =.  pull-hook  hook
       [cards this]
     ::
@@ -399,18 +401,24 @@
     ::
     ::
     ++  tr-sign
-      |=  =sign:agent:gall
+      |=  [=sign:agent:gall versioned=?]
       ?+   -.sign  !!
         %kick       tr-kick
-        %watch-ack  (tr-wack +.sign)
+        %watch-ack  (tr-wack +.sign versioned)
         %fact       (tr-fact +.sign)
       ==
     ::
     ::
     ++  tr-wack
-      |=  tan=(unit tang)
+      |=  [tan=(unit tang) versioned=?]
       ?~  tan  tr-core
-      (tr-ap-og:tr-cleanup |.((on-pull-nack:og rid u.tan)))
+      ?.  versioned
+        (tr-ap-og:tr-cleanup |.((on-pull-nack:og rid u.tan)))
+      =/  pax
+        (kick-mule:virt rid |.((on-pull-kick:og rid)))
+      ?~  pax  tr-failed-kick
+      ?~  u.pax  tr-cleanup
+      (tr-watch-unver u.u.pax)
     ::
     ++  tr-kick
       ?.  ?=(%active -.status)  tr-core
@@ -516,6 +524,8 @@
       (tr-emit (~(leave pass tr-ver-wire) tr-sub-dock))
     ++  tr-sub-wire
       (make-wire pull+resource+(en-path:resource rid))
+    ++  tr-unver-sub-wire
+      (make-wire pull+unver-resource+(en-path:resource rid))
     ::
     ++  tr-sub-dock
       ^-  dock
@@ -525,6 +535,13 @@
       ?:  (~(has by wex.bowl) [tr-sub-wire tr-sub-dock])
         tr-core
       tr-kick
+    ::
+    ++  tr-watch-unver
+      |=  pax=path
+      =/  =path
+        :-  %resource
+        (weld (en-path:resource rid) pax)
+      (tr-emit (~(watch pass tr-unver-sub-wire) tr-sub-dock path))
     ::
     ++  tr-watch
       |=  pax=path

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -365,7 +365,7 @@
         ?:  gone
           (~(del by tracking) rid)
         (~(put by tracking) rid [ship status])
-      [(flop cards) state]
+      [[(flop cards) pull-hook] state]
     ::
     ++  tr-emit
       |=  =card

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -82,8 +82,8 @@
 +$  status
   $%  [%active ~]
       [%failed-kick ~]
-      [%pub-ver @ud]
-      [%sub-ver @ud]
+      [%pub-ver ver=@ud]
+      [%sub-ver ver=@ud]
   ==
 ::
 +$  base-state-2
@@ -303,6 +303,11 @@
         =^  cards  pull-hook
           (on-agent:og wire sign)
         [cards this]
+      ?:  ?=([%version ~] t.t.wire)
+        =^  [cards=(list card) hook=_pull-hook]  state
+          (take-version:hc src.bowl sign)
+        =.  pull-hook  hook
+        [cards this]
       ?.  ?=([%pull %resource *] t.t.wire)
         (on-agent:def wire sign)
       =/  rid=resource
@@ -483,7 +488,7 @@
       (make-wire /version)
     ::
     ++  tr-watch-ver
-      (tr-emit (~(watch pass tr-ver-wire) tr-sub-dock /version))
+      (tr-emit (watch-version ship))
     ::
     ++  tr-leave-ver
       (tr-emit (~(leave pass tr-ver-wire) tr-sub-dock))
@@ -509,6 +514,61 @@
     ++  tr-leave
       (tr-emit (~(leave pass tr-sub-wire) tr-sub-dock))
     --
+  ::
+  ++  take-version
+    |=  [who=ship =sign:agent:gall]
+    ^-  [[(list card) _pull-hook] _state]
+    ?+  -.sign  !!
+        %watch-ack
+      ?~  p.sign  [~^pull-hook state]
+      =/  =tank  leaf+"subscribe failed from {<dap.bowl>} on wire {<wire>}"
+      %-  (slog tank u.p.sign)
+      [~^pull-hook state]
+      ::
+        %kick
+      :_  state
+      [(watch-version who)^~ pull-hook]
+      ::
+        %fact
+      ?.  =(%version p.cage.sign)
+        [~^pull-hook state]
+      =+  !<(version=@ud q.cage.sign)
+      =/  tracks=(list [rid=resource =track])
+        ~(tap by tracking)
+      =|  cards=(list card)
+      =|  leave=_|
+      |-
+      ?~  tracks
+        =?  cards  leave
+          :_(cards (leave-version who))
+        [[cards pull-hook] state]
+      ?.  ?=(%pub-ver -.status.track.i.tracks)
+        $(tracks t.tracks)
+      ~!  -.status.track.i.tracks
+      ?.  =(who ship.track.i.tracks)
+        $(tracks t.tracks)
+      ?.  =(ver.status.track.i.tracks version)
+        =.  leave  %.y
+        $(tracks t.tracks)
+      =^  [caz=(list card) hook=_pull-hook]  state
+        tr-abet:tr-restart:(tr-abed:track-engine rid.i.tracks)
+      =.  pull-hook  hook
+      $(tracks t.tracks, cards (weld cards caz))
+    ==
+  ::
+  ++  version-wir 
+    (make-wire /version)
+  ::
+  ++  watch-version
+    |=  =ship
+    (~(watch pass version-wir) [ship push-hook-name.config] /version)
+  ::
+  ++  leave-version
+    |=  =ship
+    (~(leave pass version-wir) [ship push-hook-name.config])
+
+
+
   ++  poke-sane
     ^-  (quip card:agent:gall _state)
     =/  cards

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -427,7 +427,7 @@
         (tr-suspend-sub-ver !<(@ud q.cage))
       ?>  (is-root:ver p.cage)
       =/  fact-ver=@ud
-        (parse:ver p.cage)
+        (read-version:ver p.cage)
       ?.  (gte fact-ver min-version.config)
         (tr-suspend-pub-ver fact-ver)
       =/  =vase

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -19,7 +19,7 @@
 ::   %pull-hook-action: Add/remove a resource from pulling.
 ::
 /-  *pull-hook
-/+  default-agent, resource
+/+  default-agent, resource, versioning
 |%
 ::  JSON conversions
 ++  dejs
@@ -44,7 +44,8 @@
 ::  $config: configuration for the pull hook
 ::
 ::    .store-name: name of the store to send subscription updates to.
-::    .update-mark: mark that updates will be tagged with
+::    .update-mark: mark that updates will be tagged with, without
+::    version number
 ::    .push-hook-name: name of the corresponding push-hook
 ::    .no-validate: If true, don't validate that resource/wire/src match
 ::    up
@@ -54,6 +55,7 @@
       update=mold
       update-mark=term
       push-hook-name=term
+      version=@ud
       no-validate=_|
   ==
 ::  
@@ -185,6 +187,7 @@
         og   ~(. pull-hook bowl)
         hc   ~(. +> bowl)
         def  ~(. (default-agent this %|) bowl)
+        ver  ~(. versioning [bowl update-mark.config version.config])
     ::
     ++  on-init
       ^-  [(list card:agent:gall) agent:gall]
@@ -316,10 +319,12 @@
         [give-update cards]
       ::
           %fact
-        ?.  =(update-mark.config p.cage.sign)
+        ?.  (is-root:ver p.cage.sign)
           =^  cards  pull-hook
             (on-agent:og wire sign)
           [cards this]
+        =/  =vase
+          (convert:ver cage.sign)
         :_  this
         ~[(update-store:hc rid q.cage.sign)]
       ==
@@ -487,7 +492,7 @@
       (~(get by tracking) rid)
     ?~  ship  ~
     =/  =path
-      (welp resource+(en-path:resource rid) pax)
+      (welp (snoc resource+(en-path:resource rid) (scot %ud version.config)) pax)
     =/  =wire
       (make-wire pull+resource+(en-path:resource rid))
     [%pass wire %agent [u.ship push-hook-name.config] %watch path]~

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -207,7 +207,7 @@
         og   ~(. pull-hook bowl)
         hc   ~(. +> bowl)
         def  ~(. (default-agent this %|) bowl)
-        ver  ~(. versioning [bowl update-mark.config version.config])
+        ver  ~(. versioning [bowl [update-mark version min-version]:config])
     ::
     ++  on-init
       ^-  [(list card:agent:gall) agent:gall]
@@ -230,6 +230,7 @@
           retry-failed-kicks
         :_  this
         :(weld cards og-cards retry-cards) 
+          %2  !!
         ::
           %1  $(old [%2 +.old ~])
         ::
@@ -260,7 +261,7 @@
       ^-  vase
       =.  inner-state
         on-save:og
-      !>(-.state)
+      !>(state)
     ::
     ++  on-poke
       |=  [=mark =vase]
@@ -279,7 +280,7 @@
           %pull-hook-action
         ?>  (team:title [our src]:bowl)
         =^  [cards=(list card) hook=_pull-hook]  state
-          tr-abet:(tr-hook-act:track-engine:hc action)
+          tr-abet:(tr-hook-act:track-engine:hc !<(action vase))
         =.  pull-hook  hook
         [cards this]
       ==
@@ -346,7 +347,7 @@
       io   ~(. agentio bowl)
       pass  pass:io
       virt  ~(. pull-hook-virt bowl)
-      ver  ~(. versioning [bowl update-mark.config version.config])
+      ver  ~(. versioning [bowl [update-mark version min-version]:config])
   ::
   ++  track-engine
     |_  [cards=(list card) rid=resource =ship =status gone=_|]
@@ -376,8 +377,9 @@
       tr-core(cards (welp (flop cards) cards))
     ::
     ++  tr-ap-og
-      |=  [caz=(list card) hook=_pull-hook]
-      =.  pull-hook  hook
+      |=  ap=_^?(|.(*(quip card _pull-hook)))
+      =^  caz  pull-hook
+        (ap)
       (tr-emis caz)
     ::  +|  %sign: sign handling
     ::
@@ -390,14 +392,16 @@
         %fact       (tr-fact +.sign)
       ==
     ::
+    ::
     ++  tr-wack
       |=  tan=(unit tang)
       ?~  tan  tr-core
-      (tr-ap-og:tr-cleanup (on-pull-nack:og rid u.tan))
+      (tr-ap-og:tr-cleanup |.((on-pull-nack:og rid u.tan)))
     ::
     ++  tr-kick
       ?.  ?=(%active -.status)  tr-core
-      =/  pax=(unit (unit path))
+      =/  pax
+        ~!  kick-mule
         (kick-mule:virt rid |.((on-pull-kick:og rid)))
       ?~  pax  tr-failed-kick
       ?~  u.pax  tr-cleanup
@@ -410,7 +414,7 @@
       ?>  (is-root:ver p.cage)
       =/  fact-ver=@ud
         (parse:ver p.cage)
-      ?.  (lth fact-ver min-version.config)
+      ?.  (gte fact-ver min-version.config)
         (tr-suspend-pub-ver fact-ver)
       =/  =vase
         (convert-to:ver cage)
@@ -421,7 +425,9 @@
           ?&  (check-src resources)
               (~(has in resources) rid)
           ==  ==
-      (tr-emit (~(poke-our pass wire) store-name.config update-mark.config vase))
+      =/  =mark
+        (append-version:ver version.config)
+      (tr-emit (~(poke-our pass wire) store-name.config mark vase))
     ::  +|  %lifecycle: lifecycle management for tracked resource
     ::
     ::
@@ -497,7 +503,7 @@
       |=  pax=path
       ^+  tr-core
       =/  =path
-        (welp (snoc resource+(en-path:resource rid) (scot %ud version.config)) pax)
+        (weld (snoc `path`resource+(en-path:resource rid) (scot %ud version.config)) pax)
       (tr-emit (~(watch pass tr-sub-wire) tr-sub-dock path))
     ::
     ++  tr-leave
@@ -543,8 +549,8 @@
     %+  roll  ~(tap in resources)
     |=  [rid=resource out=_|]
     ?:  out  %.y
-    ?~  ship=(~(get by tracking) rid)
+    ?~  status=(~(get by tracking) rid)
       %.n
-    =(src.bowl u.ship)
+    =(src.bowl ship.u.status)
   --
 --

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -530,7 +530,10 @@
       |=  pax=path
       ^+  tr-core
       =/  =path
-        (weld (snoc `path`resource+(en-path:resource rid) (scot %ud version.config)) pax)
+        :+  %resource  %ver
+        %+  weld
+          (snoc (en-path:resource rid) (scot %ud version.config))
+        pax
       (tr-emit (~(watch pass tr-sub-wire) tr-sub-dock path))
     ::
     ++  tr-leave

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -25,7 +25,7 @@
 ::   foreign push-hook
 ::
 /-  *push-hook
-/+  default-agent, resource, verb
+/+  default-agent, resource, verb, versioning
 |%
 +$  card  card:agent:gall
 ::
@@ -43,6 +43,7 @@
       update=mold
       update-mark=term
       pull-hook-name=term
+      version=@ud
   ==
 ::
 ::  $base-state-0: state for the push hook
@@ -299,6 +300,7 @@
     --
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)
+      ver  ~(. versioning [bowl update-mark.config version.config])
   ::
   ++  poke-update
     |=  vas=vase
@@ -378,7 +380,7 @@
     [%pass wire %agent [our.bowl store-name.config] %watch store-path.config]
   ::
   ++  push-updates
-    |=  =vase
+    |=  =cage
     ^-  (list card:agent:gall)
     =/  rids=(list resource)  (resource-for-update vase)
     =|  cards=(list card:agent:gall)
@@ -386,16 +388,24 @@
     ?~  rids  cards
     =/  prefix=path
       resource+(en-path:resource i.rids)
-    =/  paths=(list path)
-      %~  tap  in
-      %-  silt
-      %+  turn
+    =/  paths=(jug @ud path)
+      %+  roll
         (incoming-subscriptions prefix)
-      |=([ship pax=path] pax)
+      |=  [[ship =path] out=(jug @ud path)]
+      ?>  ?=(^ path)
+      =/  path-ver
+        (slaw %ud i.path)
+      (~(put ju out) path-ver path)
+    =/  caz=(list card)
+      %+  turn  ~(tap by paths)
+      |=  [fact-ver=@ud paths=(set path)]
+      =/  =mark
+        (append-version:ver fact-ver)
+      [%give %fact ~(tap in paths) mark (convert-from:ver mark q.cage)]
     ?~  paths  $(rids t.rids)
     %_  $
       rids   t.rids
-      cards  (snoc cards [%give %fact paths update-mark.config vase])
+      cards  (welp cards caz)
     ==
   ::
   ++  forward-update

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -342,6 +342,8 @@
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)
       ver  ~(. versioning [bowl [update-mark version min-version]:config])
+      io   ~(. agentio bowl)
+      pass  pass:io
   ::
   ++  poke-hook-action
     |=  =action
@@ -414,40 +416,43 @@
   ++  push-updates
     |=  =cage
     ^-  (list card:agent:gall)
-    =/  rids=(list resource)  (resource-for-update q.cage)
-    =|  cards=(list card:agent:gall)
-    |-
-    ?~  rids  cards
-    =/  prefix=path
-      resource+ver+(en-path:resource i.rids)
-    =/  unversioned=(set path)
-      %-  ~(gas in *(set path))
-      =/  pfix=path
-        resource+(en-path:resource i.rids)
-      (turn (incoming-subscriptions pfix) tail)
-    =/  paths=(jug @ud path)
-      %+  roll
-        (incoming-subscriptions prefix)
-      |=  [[ship =path] out=(jug @ud path)]
-      =/  path-ver=@ud
-        (ver-from-path path)
-      (~(put ju out) path-ver path)
-    =/  caz=(list card)
+    %+  roll  (resource-for-update q.cage)
+    |=  [rid=resource cards=(list card)]
+    |^
+    :(weld cards versioned unversioned)
+    ::
+    ++  versioned
+      ^-  (list card:agent:gall)
+      =/  prefix=path
+        resource+ver+(en-path:resource rid)
+      =/  paths=(jug @ud path)
+        %+  roll
+          (incoming-subscriptions prefix)
+        |=  [[ship =path] out=(jug @ud path)]
+        =/  path-ver=@ud
+          (ver-from-path path)
+        (~(put ju out) path-ver path)
       %+  turn  ~(tap by paths)
       |=  [fact-ver=@ud paths=(set path)]
       =/  =mark
         (append-version:ver fact-ver)
-      [%give %fact ~(tap in paths) mark (convert-to:ver mark q.cage)]
-    =?  caz  !=(0 ~(wyt in unversioned))
-      =/  =vase
-        (convert-to:ver update-mark.config q.cage)
-      :_  caz
-      [%give %fact ~(tap in unversioned) update-mark.config vase]
-    ?~  paths  $(rids t.rids)
-    %_  $
-      rids   t.rids
-      cards  (welp cards caz)
-    ==
+      =/  =^cage
+        :-  mark
+        (convert-from:ver mark q.cage)
+      (fact:io cage ~(tap in paths))
+    ::  TODO: deprecate
+    ++  unversioned
+      =/  prefix=path
+        resource+(en-path:resource rid)
+      =/  unversioned=(set path)
+        %-  ~(gas in *(set path))
+        (turn (incoming-subscriptions prefix) tail)
+      ?:  =(0 ~(wyt in unversioned))  ~
+      =/  =^cage
+        :-  update-mark.config
+        (convert-from:ver update-mark.config q.cage)
+      (fact:io cage ~(tap in unversioned))^~
+    --
   ::
   ++  ver-from-path
     |=  =path
@@ -455,28 +460,20 @@
       (slag 5 path)
     ?>  ?=(^ extra)
     (slav %ud i.extra)
-
   ::
   ++  forward-update
-    |=  =vase
+    |=  =cage
     ^-  (list card:agent:gall)
-    =/  rids=(list resource)  (resource-for-update vase)
-    =|  cards=(list card:agent:gall)
-    |-
-    ?~  rids  cards
-    =/  =path
-      resource+(en-path:resource i.rids)
+    =/  =vase
+      (need (transform-proxy-update:og (convert-to:ver cage)))
+    %+  roll  (resource-for-update vase)
+    |=  [rid=resource cards=(list card:agent:gall)]
     =/  =wire
-      (make-wire resource+(en-path:resource i.rids))
-    =/  dap=term
-      ?:(=(our.bowl entity.i.rids) store-name.config dap.bowl)
-    %_  $
-      rids  t.rids
-    ::
-        cards
-      %+  snoc  cards
-      [%pass wire %agent [entity.i.rids dap] %poke update-mark.config vase]
-    ==
+      (make-wire resource+(en-path:resource rid))
+    =/  =dock:agent:gall
+      :-  entity.rid
+      ?:(=(our.bowl entity.rid) store-name.config dap.bowl)
+    :_(cards (~(poke pass wire) dock current-version:ver vase))
   ::
   ++  resource-for-update
     |=  =vase

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -25,7 +25,7 @@
 ::   foreign push-hook
 ::
 /-  *push-hook
-/+  default-agent, resource, verb, versioning
+/+  default-agent, resource, verb, versioning, agentio
 |%
 +$  card  card:agent:gall
 ::
@@ -44,6 +44,7 @@
       update-mark=term
       pull-hook-name=term
       version=@ud
+      min-version=@ud
   ==
 ::
 ::  $base-state-0: state for the push hook
@@ -161,6 +162,8 @@
         og   ~(. push-hook bowl)
         hc   ~(. +> bowl)
         def  ~(. (default-agent this %|) bowl)
+        io   ~(. agentio bowl)
+        pass  pass:io
     ::
     ++  on-init
       =^  cards  push-hook
@@ -178,7 +181,9 @@
           %1  
         =^  og-cards   push-hook
           (on-load:og inner-state.old)
-        [(weld cards og-cards) this(state old)]
+        =/  version=(list card)
+          (fact:io version+!>(version.config) /version ~)^~
+        [:(weld cards og-cards version) this(state old)]
         ::
           %0
         %_    $
@@ -234,15 +239,23 @@
     ++  on-watch
       |=  =path
       ^-  (quip card:agent:gall agent:gall)
+      ?:  ?=([%version ~] path)
+        :_  this
+        (fact-init:io version+!>(version.config))^~
       ?.  ?=([%resource *] path)
         =^  cards  push-hook
           (on-watch:og path)
         [cards this]
-      ?>  ?=([%ship @ @ *] t.path)
+      ?>  ?=([%ship @ @ @ *] t.path)
       =/  =resource
         (de-path:resource t.path)
+      =/  sub-ver=@ud
+        (slav %ud i.t.t.t.t.path)
+      ?.  (gte sub-ver min-version.config)
+        :_  this
+        (fact-init-kick:io hook-meta-update+!>(min-version.config))^~
       =/  =vase
-        (initial-watch:og t.t.t.t.path resource)
+        (initial-watch:og t.t.t.t.t.path resource)
       :_  this
       [%give %fact ~ update-mark.config vase]~
     ::
@@ -392,9 +405,11 @@
       %+  roll
         (incoming-subscriptions prefix)
       |=  [[ship =path] out=(jug @ud path)]
-      ?>  ?=(^ path)
+      =/  extra=^path
+        (scag 4 path)
+      ?>  ?=(^ extra)
       =/  path-ver
-        (slaw %ud i.path)
+        (slaw %ud i.extra)
       (~(put ju out) path-ver path)
     =/  caz=(list card)
       %+  turn  ~(tap by paths)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -244,12 +244,8 @@
         [cards this]
       ::
       ?:  (is-root:ver mark)
-        ?:  (team:title [our src]:bowl)
-          :_  this
-          (forward-update:hc vase)
-        =^  cards  state
-          (poke-update:hc mark vase)
-        [cards this]
+        :_  this
+        (forward-update:hc mark vase)
       ::
       =^  cards  push-hook
         (on-poke:og mark vase)
@@ -265,7 +261,6 @@
         =^  cards  push-hook
           (on-watch:og path)
         [cards this]
-      ~&  t.path
       |^
       ?.  ?=([%ver %ship @ @ @ *] t.path)
         unversioned
@@ -282,12 +277,12 @@
       [%give %fact ~ mark vase]~
       ::
       ++  unversioned
-        ?>  ?=([%ship @ @ @ *] t.path)
+        ?>  ?=([%ship @ @ *] t.path)
         =/  =resource
           (de-path:resource t.path)
         =/  =vase
           %+  convert-to:ver  update-mark.config
-          (initial-watch:og t.t.t.t.t.path resource)
+          (initial-watch:og t.t.t.t.path resource)
         :_  this
         [%give %fact ~ update-mark.config vase]~
       --
@@ -347,17 +342,6 @@
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)
       ver  ~(. versioning [bowl [update-mark version min-version]:config])
-  ::
-  ++  poke-update
-    |=  =cage
-    ^-  (quip card:agent:gall _state)
-    =/  vas=vase
-      (convert-to:ver cage)
-    =/  vax=(unit vase)  (transform-proxy-update:og vas)
-    ?>  ?=(^ vax)
-    =/  wire  (make-wire /store)
-    :_  state
-    [%pass wire %agent [our.bowl store-name.config] %poke update-mark.config u.vax]~
   ::
   ++  poke-hook-action
     |=  =action

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -231,7 +231,7 @@
           :_  this
           (forward-update:hc vase)
         =^  cards  state
-          (poke-update:hc vase)
+          (poke-update:hc mark vase)
         [cards this]
       ::
       =^  cards  push-hook
@@ -318,8 +318,10 @@
       ver  ~(. versioning [bowl [update-mark version min-version]:config])
   ::
   ++  poke-update
-    |=  vas=vase
+    |=  =cage
     ^-  (quip card:agent:gall _state)
+    =/  vas=vase
+      (convert-to:ver cage)
     =/  vax=(unit vase)  (transform-proxy-update:og vas)
     ?>  ?=(^ vax)
     =/  wire  (make-wire /store)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -164,6 +164,7 @@
         def  ~(. (default-agent this %|) bowl)
         io   ~(. agentio bowl)
         pass  pass:io
+        ver  ~(. versioning [bowl [update-mark version min-version]:config])
     ::
     ++  on-init
       =^  cards  push-hook
@@ -184,6 +185,7 @@
         =/  version=(list card)
           (fact:io version+!>(version.config) /version ~)^~
         [:(weld cards og-cards version) this(state old)]
+        ::
         ::
           %0
         %_    $
@@ -224,7 +226,7 @@
           (poke-hook-action:hc !<(action vase))
         [cards this]
       ::
-      ?:  =(mark update-mark.config)
+      ?:  (is-root:ver mark)
         ?:  (team:title [our src]:bowl)
           :_  this
           (forward-update:hc vase)
@@ -253,11 +255,11 @@
         (slav %ud i.t.t.t.t.path)
       ?.  (gte sub-ver min-version.config)
         :_  this
-        (fact-init-kick:io hook-meta-update+!>(min-version.config))^~
+        (fact-init-kick:io hook-meta-update+!>(min-version.config))
       =/  =vase
         (initial-watch:og t.t.t.t.t.path resource)
       :_  this
-      [%give %fact ~ update-mark.config vase]~
+      [%give %fact ~ (append-version:ver sub-ver) vase]~
     ::
     ++  on-agent
       |=  [=wire =sign:agent:gall]
@@ -272,7 +274,7 @@
         %kick  [~[watch-store:hc] this]
       ::
           %fact
-        ?.  =(update-mark.config p.cage.sign)
+        ?.  (is-root:ver p.cage.sign)
           =^  cards  push-hook
             (on-agent:og wire sign)
           [cards this]
@@ -280,7 +282,7 @@
           (take-update:og q.cage.sign)
         :_  this
         %+  weld
-          (push-updates:hc q.cage.sign)
+          (push-updates:hc cage.sign)
         cards
       ==
       ::
@@ -313,7 +315,7 @@
     --
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)
-      ver  ~(. versioning [bowl update-mark.config version.config])
+      ver  ~(. versioning [bowl [update-mark version min-version]:config])
   ::
   ++  poke-update
     |=  vas=vase
@@ -395,7 +397,7 @@
   ++  push-updates
     |=  =cage
     ^-  (list card:agent:gall)
-    =/  rids=(list resource)  (resource-for-update vase)
+    =/  rids=(list resource)  (resource-for-update q.cage)
     =|  cards=(list card:agent:gall)
     |-
     ?~  rids  cards
@@ -409,7 +411,7 @@
         (scag 4 path)
       ?>  ?=(^ extra)
       =/  path-ver
-        (slaw %ud i.extra)
+        (slav %ud i.extra)
       (~(put ju out) path-ver path)
     =/  caz=(list card)
       %+  turn  ~(tap by paths)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -210,6 +210,8 @@
           ~(val by sup.bowl)
         |=  [[=ship =path] out=(set path)]
         ?.  ?=([%resource *] path)  out
+        ?.  ?=([%resource %ver] path)
+          (~(put in out) path)
         =/  path-ver=@ud
           (ver-from-path:hc path)
         ?:  (supported:ver (append-version:ver path-ver))  out
@@ -263,18 +265,32 @@
         =^  cards  push-hook
           (on-watch:og path)
         [cards this]
-      ?>  ?=([%ship @ @ @ *] t.path)
+      ~&  t.path
+      |^
+      ?.  ?=([%ver %ship @ @ @ *] t.path)
+        unversioned
       =/  =resource
-        (de-path:resource t.path)
-      =/  sub-ver=@ud
-        (slav %ud i.t.t.t.t.path)
-      ?.  (supported:ver (append-version:ver sub-ver))
+        (de-path:resource t.t.path)
+      =/  =mark
+        (append-version:ver (slav %ud i.t.t.t.t.t.path))
+      ?.  (supported:ver mark)
         :_  this
         (fact-init-kick:io version+!>(min-version.config))
       =/  =vase
-        (initial-watch:og t.t.t.t.t.path resource)
+        (convert-to:ver mark (initial-watch:og t.t.t.t.t.t.path resource))
       :_  this
-      [%give %fact ~ (append-version:ver sub-ver) vase]~
+      [%give %fact ~ mark vase]~
+      ::
+      ++  unversioned
+        ?>  ?=([%ship @ @ @ *] t.path)
+        =/  =resource
+          (de-path:resource t.path)
+        =/  =vase
+          %+  convert-to:ver  update-mark.config
+          (initial-watch:og t.t.t.t.t.path resource)
+        :_  this
+        [%give %fact ~ update-mark.config vase]~
+      --
     ::
     ++  on-agent
       |=  [=wire =sign:agent:gall]
@@ -419,7 +435,12 @@
     |-
     ?~  rids  cards
     =/  prefix=path
-      resource+(en-path:resource i.rids)
+      resource+ver+(en-path:resource i.rids)
+    =/  unversioned=(set path)
+      %-  ~(gas in *(set path))
+      =/  pfix=path
+        resource+(en-path:resource i.rids)
+      (turn (incoming-subscriptions pfix) tail)
     =/  paths=(jug @ud path)
       %+  roll
         (incoming-subscriptions prefix)
@@ -432,7 +453,12 @@
       |=  [fact-ver=@ud paths=(set path)]
       =/  =mark
         (append-version:ver fact-ver)
-      [%give %fact ~(tap in paths) mark (convert-from:ver mark q.cage)]
+      [%give %fact ~(tap in paths) mark (convert-to:ver mark q.cage)]
+    =?  caz  !=(0 ~(wyt in unversioned))
+      =/  =vase
+        (convert-to:ver update-mark.config q.cage)
+      :_  caz
+      [%give %fact ~(tap in unversioned) update-mark.config vase]
     ?~  paths  $(rids t.rids)
     %_  $
       rids   t.rids
@@ -442,7 +468,7 @@
   ++  ver-from-path
     |=  =path
     =/  extra=^path
-      (slag 4 path)
+      (slag 5 path)
     ?>  ?=(^ extra)
     (slav %ud i.extra)
 

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -182,9 +182,13 @@
           %1  
         =^  og-cards   push-hook
           (on-load:og inner-state.old)
-        =/  version=(list card)
-          (fact:io version+!>(version.config) /version ~)^~
-        [:(weld cards og-cards version) this(state old)]
+        =/  old-subs
+          find-old-subs
+        =/  version-cards
+          :-  (fact:io version+!>(version.config) /version ~)
+          ?~  old-subs  ~
+          (kick:io old-subs)^~
+        [:(weld cards og-cards version-cards) this(state old)]
         ::
         ::
           %0
@@ -199,6 +203,17 @@
           [%give %kick paths ~]
         ==
       ==
+      ::
+      ++  find-old-subs
+        %~  tap  in
+        %+  roll
+          ~(val by sup.bowl)
+        |=  [[=ship =path] out=(set path)]
+        ?.  ?=([%resource *] path)  out
+        =/  path-ver=@ud
+          (ver-from-path:hc path)
+        ?:  (supported:ver (append-version:ver path-ver))  out
+        (~(put in out) path)
       ::
       ++  kicked-watches
         ^-  (list path)
@@ -243,7 +258,7 @@
       ^-  (quip card:agent:gall agent:gall)
       ?:  ?=([%version ~] path)
         :_  this
-        (fact-init:io version+!>(version.config))^~
+        (fact-init:io version+!>(min-version.config))^~
       ?.  ?=([%resource *] path)
         =^  cards  push-hook
           (on-watch:og path)
@@ -253,9 +268,9 @@
         (de-path:resource t.path)
       =/  sub-ver=@ud
         (slav %ud i.t.t.t.t.path)
-      ?.  (gte sub-ver min-version.config)
+      ?.  (supported:ver (append-version:ver sub-ver))
         :_  this
-        (fact-init-kick:io hook-meta-update+!>(min-version.config))
+        (fact-init-kick:io version+!>(min-version.config))
       =/  =vase
         (initial-watch:og t.t.t.t.t.path resource)
       :_  this
@@ -409,11 +424,8 @@
       %+  roll
         (incoming-subscriptions prefix)
       |=  [[ship =path] out=(jug @ud path)]
-      =/  extra=^path
-        (scag 4 path)
-      ?>  ?=(^ extra)
-      =/  path-ver
-        (slav %ud i.extra)
+      =/  path-ver=@ud
+        (ver-from-path path)
       (~(put ju out) path-ver path)
     =/  caz=(list card)
       %+  turn  ~(tap by paths)
@@ -426,6 +438,14 @@
       rids   t.rids
       cards  (welp cards caz)
     ==
+  ::
+  ++  ver-from-path
+    |=  =path
+    =/  extra=^path
+      (slag 4 path)
+    ?>  ?=(^ extra)
+    (slav %ud i.extra)
+
   ::
   ++  forward-update
     |=  =vase

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -3,19 +3,16 @@
 +*  io  ~(. agentio bowl)
 ++  is-root
   |=  =mark
-  =/  tape-mark
-    (trip mark)
-  =/  tape-version
-    (trip root)
-  =((scag (lent tape-version) tape-mark) tape-version)
+  ?~  (rush mark mark-parser)
+    %.n
+  %.y
 ::
-++  parse
+++  mark-parser
+  ;~(pfix (jest root) ;~(pose ;~(pfix hep dum:ag) (easy `@ud`0)))
+::
+++  read-version
   |=  =mark
-  %+  slav  %ud
-  %-  crip
-  =/  txt
-    ((star nud) [1 1] (trip (swp 3 mark)))
-  p:(need q.txt)
+  (rash mark mark-parser)
 ::
 ++  append-version
   |=  ver=@ud
@@ -27,8 +24,8 @@
 ++  supported
   |=  =mark
   =/  ver
-    (parse mark)
-  &((gte min ver) (lte version ver))
+    (read-version mark)
+  &((gte ver min) (lte ver version))
 ::
 ++  convert-to
   |=  =cage

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -1,5 +1,5 @@
 /+  agentio
-|_  [=bowl:gall root=mark version=@ud]
+|_  [=bowl:gall root=mark version=@ud min=@ud]
 +*  io  ~(. agentio bowl)
 ++  is-root
   |=  =mark
@@ -22,6 +22,12 @@
 ++  current-version
   (append-version version)
 ::
+++  supported
+  |=  =mark
+  =/  ver
+    (parse mark)
+  &((gte min ver) (lte version ver))
+::
 ++  convert-to
   |=  =cage
   ^-  vase
@@ -43,6 +49,5 @@
   ?:  =(p.cage current-version)
     q.cage
   ((tube-from p.cage) q.cage)
-  
 --
 

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -19,6 +19,7 @@
   :((cury cat 3) root '-' (scot %ud ver))
 ::
 ++  current-version
+  ^-  mark
   (append-version version)
 ::
 ++  supported

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -13,7 +13,9 @@
   |=  =mark
   %+  slav  %ud
   %-  crip
-  (rash (swp 3 mark) (star nud))
+  =/  txt
+    ((star nud) [1 1] (trip (swp 3 mark)))
+  p:(need q.txt)
 ::
 ++  append-version
   |=  ver=@ud

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -1,0 +1,48 @@
+/+  agentio
+|_  [=bowl:gall root=mark version=@ud]
++*  io  ~(. agentio bowl)
+++  is-root
+  |=  =mark
+  =/  tape-mark
+    (trip mark)
+  =/  tape-version
+    (trip root)
+  =((scag (lent tape-version) tape-mark) tape-version)
+::
+++  parse
+  |=  =mark
+  %+  slav  %ud
+  %-  crip
+  (rash (swp 3 mark) (star nud))
+::
+++  append-version
+  |=  ver=@ud
+  :((cury cat 3) root '-' (scot %ud ver))
+::
+++  current-version
+  (append-version version)
+::
+++  convert-to
+  |=  =cage
+  ^-  vase
+  ?:  =(p.cage current-version)
+    q.cage
+  ((tube-to p.cage) q.cage)
+::
+++  tube-to
+  |=  =mark
+  .^(tube:clay %cc (scry:io %home /[mark]/[current-version]))
+::
+++  tube-from
+  |=  =mark
+  .^(tube:clay %cc (scry:io %home /[current-version]/[mark]))
+::
+++  convert-from
+  |=  =cage
+  ^-  vase
+  ?:  =(p.cage current-version)
+    q.cage
+  ((tube-from p.cage) q.cage)
+  
+--
+

--- a/pkg/arvo/mar/contact/update-0.hoon
+++ b/pkg/arvo/mar/contact/update-0.hoon
@@ -5,6 +5,7 @@
 ++  grow
   |%
   ++  noun  upd
+  ++  contact-update  upd
   ++  json  (update:enjs upd)
   --
 ::

--- a/pkg/arvo/mar/contact/update-0.hoon
+++ b/pkg/arvo/mar/contact/update-0.hoon
@@ -1,0 +1,16 @@
+/+  *contact-store
+::
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  json  (update:enjs upd)
+  --
+::
+++  grab
+  |%
+  ++  noun  update
+  ++  json  update:dejs
+  --
+--

--- a/pkg/arvo/mar/contact/update.hoon
+++ b/pkg/arvo/mar/contact/update.hoon
@@ -5,6 +5,7 @@
 ++  grow
   |%
   ++  noun  upd
+  ++  contact-update-0  upd
   ++  json  (update:enjs upd)
   --
 ::

--- a/pkg/arvo/mar/demo/update-0.hoon
+++ b/pkg/arvo/mar/demo/update-0.hoon
@@ -1,0 +1,15 @@
+/-  *demo
+::
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  demo-update-1  upd
+  --
+::
+++  grab
+  |%
+  ++  noun  update
+  --
+--

--- a/pkg/arvo/mar/demo/update-0.hoon
+++ b/pkg/arvo/mar/demo/update-0.hoon
@@ -6,6 +6,7 @@
   |%
   ++  noun  upd
   ++  demo-update-1  upd
+  ++  demo-update  upd
   --
 ::
 ++  grab

--- a/pkg/arvo/mar/demo/update-1.hoon
+++ b/pkg/arvo/mar/demo/update-1.hoon
@@ -1,0 +1,15 @@
+/-  *demo
+::
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  demo-update-0  upd
+  --
+::
+++  grab
+  |%
+  ++  noun  update
+  --
+--

--- a/pkg/arvo/mar/demo/update.hoon
+++ b/pkg/arvo/mar/demo/update.hoon
@@ -1,0 +1,16 @@
+/-  *demo
+::
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  demo-update-1  upd
+  ++  demo-update-0  upd
+  --
+::
+++  grab
+  |%
+  ++  noun  update
+  --
+--

--- a/pkg/arvo/mar/graph/update-0.hoon
+++ b/pkg/arvo/mar/graph/update-0.hoon
@@ -1,0 +1,19 @@
+/+  *graph-store
+=*  as-octs  as-octs:mimes:html
+::
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  json  (update:enjs upd)
+  ++  mime  [/application/x-urb-graph-update (as-octs (jam upd))]
+  --
+::
+++  grab
+  |%
+  ++  noun  update
+  ++  json  update:dejs
+  ++  mime  |=([* =octs] ;;(update (cue q.octs)))
+  --
+--

--- a/pkg/arvo/mar/graph/update-0.hoon
+++ b/pkg/arvo/mar/graph/update-0.hoon
@@ -7,6 +7,7 @@
   |%
   ++  noun  upd
   ++  json  (update:enjs upd)
+  ++  graph-update  upd
   ++  mime  [/application/x-urb-graph-update (as-octs (jam upd))]
   --
 ::

--- a/pkg/arvo/mar/graph/update.hoon
+++ b/pkg/arvo/mar/graph/update.hoon
@@ -7,6 +7,7 @@
   |%
   ++  noun  upd
   ++  json  (update:enjs upd)
+  ++  graph-update-0  upd
   ++  mime  [/application/x-urb-graph-update (as-octs (jam upd))]
   --
 ::

--- a/pkg/arvo/mar/group/update-0.hoon
+++ b/pkg/arvo/mar/group/update-0.hoon
@@ -1,0 +1,16 @@
+/+  *group-store
+|_  upd=update
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  upd
+  ++  json
+    %+  frond:enjs:format  'groupUpdate'
+    (update:enjs upd)
+  --
+++  grab
+  |%
+  ++  noun  update
+  ++  json  update:dejs
+  --
+--

--- a/pkg/arvo/mar/group/update-0.hoon
+++ b/pkg/arvo/mar/group/update-0.hoon
@@ -4,6 +4,7 @@
 ++  grow
   |%
   ++  noun  upd
+  ++  group-update  upd
   ++  json
     %+  frond:enjs:format  'groupUpdate'
     (update:enjs upd)

--- a/pkg/arvo/mar/group/update.hoon
+++ b/pkg/arvo/mar/group/update.hoon
@@ -4,6 +4,7 @@
 ++  grow
   |%
   ++  noun  upd
+  ++  group-update-0  upd
   ++  json
     %+  frond:enjs:format  'groupUpdate'
     (update:enjs upd)

--- a/pkg/arvo/mar/metadata/update-0.hoon
+++ b/pkg/arvo/mar/metadata/update-0.hoon
@@ -4,6 +4,7 @@
 ++  grow
   |%
   ++  noun  update
+  ++  metadata-update  update
   ++  json  (update:enjs:store update)
   --
 ::

--- a/pkg/arvo/mar/metadata/update-0.hoon
+++ b/pkg/arvo/mar/metadata/update-0.hoon
@@ -1,0 +1,15 @@
+/+  store=metadata-store
+|_  =update:store
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  update
+  ++  json  (update:enjs:store update)
+  --
+::
+++  grab
+  |%
+  ++  noun  update:store
+  ++  json  action:dejs:store
+  --
+--

--- a/pkg/arvo/mar/metadata/update.hoon
+++ b/pkg/arvo/mar/metadata/update.hoon
@@ -4,6 +4,7 @@
 ++  grow
   |%
   ++  noun  update
+  ++  metadata-update-0  update
   ++  json  (update:enjs:store update)
   --
 ::

--- a/pkg/arvo/mar/version.hoon
+++ b/pkg/arvo/mar/version.hoon
@@ -1,0 +1,11 @@
+|_  ver=@ud
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  ver
+  --
+++  grab
+  |%
+  ++  noun  @ud
+  --
+--

--- a/pkg/arvo/sur/demo.hoon
+++ b/pkg/arvo/sur/demo.hoon
@@ -1,0 +1,10 @@
+/+  resource
+|%
++$  update
+  $~  [%add *resource 0]
+  $%  [%add p=resource q=@ud]
+      [%sub p=resource q=@ud]
+      [%ini p=resource ~]
+      [%run p=resource q=(list update)]
+  ==
+--

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1006,7 +1006,7 @@
     |=  suffix=@tas
     ^-  (list path)
     =/  parser
-      (most hep (cook crip ;~(plug low (star ;~(pose low nud)))))
+      (most hep (cook crip ;~(plug ;~(pose low nud) (star ;~(pose low nud)))))
     =/  torn=(list @tas)  (fall (rush suffix parser) ~[suffix])
     %-  flop
     |-  ^-  (list (list @tas))

--- a/pkg/arvo/ted/graph/add-nodes.hoon
+++ b/pkg/arvo/ted/graph/add-nodes.hoon
@@ -33,7 +33,7 @@
 =/  hashes  (nodes-to-pending-indices nodes.q.update)
 ;<  ~  bind:m
   %^  poke-our  %graph-push-hook
-    %graph-update
+    %graph-update-0
   !>(update)
 (pure:m !>(`action:graph-view`[%pending-indices hashes]))
 ::

--- a/pkg/arvo/ted/graph/create.hoon
+++ b/pkg/arvo/ted/graph/create.hoon
@@ -54,7 +54,7 @@
 =/  =update:graph
   [%0 now.bowl %add-graph rid.action *graph:graph mark.action overwrite]
 ;<  ~  bind:m
-  (poke-our %graph-store graph-update+!>(update))
+  (poke-our %graph-store graph-update-0+!>(update))
 ;<  ~  bind:m
   (poke-our %graph-push-hook %push-hook-action !>([%add rid.action]))
 ::

--- a/pkg/arvo/ted/graph/create.hoon
+++ b/pkg/arvo/ted/graph/create.hoon
@@ -25,12 +25,12 @@
     (poke-our %metadata-push-hook push-hook-act)
   ;<  ~  bind:m
      %+  poke-our  %group-store
-     :-  %group-update
+     :-  %group-update-0
      !>  ^-  update:group-store
      [%add-group rid policy.associated %.y]
   ;<  =bowl:spider  bind:m  get-bowl:strandio
   ;<  ~  bind:m
-    (poke-our %group-store group-update+!>([%add-members rid (sy our.bowl ~)]))
+    (poke-our %group-store group-update-0+!>([%add-members rid (sy our.bowl ~)]))
   ;<  ~  bind:m
     (poke-our %group-push-hook push-hook-act)
   (pure:m rid)
@@ -77,7 +77,7 @@
 =/  met-action=action:met
   [%add group graph+rid.action metadatum]
 ;<  ~  bind:m
-  (poke-our %metadata-push-hook metadata-update+!>(met-action))
+  (poke-our %metadata-push-hook metadata-update-0+!>(met-action))
 ::
 ::  Send invites
 ::

--- a/pkg/arvo/ted/graph/delete.hoon
+++ b/pkg/arvo/ted/graph/delete.hoon
@@ -41,7 +41,7 @@
     (poke-our %graph-push-hook %push-hook-action !>([%remove rid]))
   ;<  ~  bind:m
     %+  poke-our  %metadata-push-hook
-    :-  %metadata-update
+    :-  %metadata-update-0
     !>  ^-  action:metadata
     [%remove group-rid [%graph rid]]
   (pure:m ~)

--- a/pkg/arvo/ted/graph/delete.hoon
+++ b/pkg/arvo/ted/graph/delete.hoon
@@ -36,7 +36,7 @@
   ^-  form:m
   ;<  =bowl:spider  bind:m  get-bowl:strandio
   ;<  ~  bind:m
-    (poke-our %graph-store %graph-update !>([%0 now.bowl %remove-graph rid]))
+    (poke-our %graph-store %graph-update-0 !>([%0 now.bowl %remove-graph rid]))
   ;<  ~  bind:m
     (poke-our %graph-push-hook %push-hook-action !>([%remove rid]))
   ;<  ~  bind:m

--- a/pkg/arvo/ted/graph/delete.hoon
+++ b/pkg/arvo/ted/graph/delete.hoon
@@ -63,7 +63,7 @@
     (pure:m ~)
   ;<  ~  bind:m
     %+  poke  [entity.grp-rid %group-push-hook]
-    :-  %group-update
+    :-  %group-update-0
     !>  ^-  update:group-store
     [%remove-tag grp-rid tag.i.tags tagged.i.tags]
   loop(tags t.tags)

--- a/pkg/arvo/ted/graph/groupify.hoon
+++ b/pkg/arvo/ted/graph/groupify.hoon
@@ -69,5 +69,5 @@
   !>  ^-  action:met
   [%remove rid.action [%graph rid.action]]
 ;<  ~  bind:m
-  (poke-our %group-store %group-update !>([%remove-group rid.action ~]))
+  (poke-our %group-store %group-update-0 !>([%remove-group rid.action ~]))
 (pure:m !>(~))

--- a/pkg/arvo/ted/graph/leave.hoon
+++ b/pkg/arvo/ted/graph/leave.hoon
@@ -39,7 +39,7 @@
   ;<  ~  bind:m
     (poke-our %graph-pull-hook %pull-hook-action !>([%remove rid]))
   ;<  ~  bind:m
-    (poke-our %graph-store %graph-update !>([%0 now [%remove-graph rid]]))
+    (poke-our %graph-store %graph-update-0 !>([%0 now [%remove-graph rid]]))
   (pure:m ~)
 --
 ::

--- a/pkg/arvo/ted/graph/restore.hoon
+++ b/pkg/arvo/ted/graph/restore.hoon
@@ -17,7 +17,7 @@
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ::  unarchive graph and share it
 ;<  ~  bind:m
-  (poke-our %graph-store %graph-update !>([%0 now.bowl %unarchive-graph rid]))
+  (poke-our %graph-store %graph-update-0 !>([%0 now.bowl %unarchive-graph rid]))
 ;<  ~  bind:m
   (poke-our %graph-push-hook %push-hook-action !>([%add rid]))
 ::

--- a/pkg/arvo/ted/group/delete.hoon
+++ b/pkg/arvo/ted/group/delete.hoon
@@ -24,7 +24,7 @@
   !>  ^-  action:push-hook
   [%remove resource.action]
 ;<  ~  bind:m  (cleanup-md:view rid)
-;<  ~  bind:m  (poke-our %group-store %group-update !>([%remove-group rid ~]))
+;<  ~  bind:m  (poke-our %group-store %group-update-0 !>([%remove-group rid ~]))
 ;<  ~  bind:m  (poke-our %metadata-push-hook push-hook-act)
 ;<  ~  bind:m  (poke-our %contact-push-hook push-hook-act)
 ;<  ~  bind:m  (poke-our %group-push-hook push-hook-act)

--- a/pkg/arvo/ted/group/invite.hoon
+++ b/pkg/arvo/ted/group/invite.hoon
@@ -36,7 +36,7 @@
   ^-  form:m
   =/  =action:store
     [%change-policy rid %invite %add-invites ships]
-  ;<  ~  bind:m  (poke-our %group-push-hook %group-update !>(action))
+  ;<  ~  bind:m  (poke-our %group-push-hook %group-update-0 !>(action))
   (pure:m ~)
 --
 ^-  thread:spider

--- a/pkg/arvo/ted/group/leave.hoon
+++ b/pkg/arvo/ted/group/leave.hoon
@@ -25,6 +25,6 @@
 ;<  ~  bind:m  (poke-our %contact-pull-hook pull-hook-act)
 ;<  ~  bind:m  (poke-our %metadata-pull-hook pull-hook-act)
 ;<  ~  bind:m  (poke-our %group-pull-hook pull-hook-act)
-;<  ~  bind:m  (poke-our %group-store %group-update !>([%remove-group rid ~]))
+;<  ~  bind:m  (poke-our %group-store %group-update-0 !>([%remove-group rid ~]))
 ;<  ~  bind:m  (cleanup-md:view rid)
 (pure:m !>(~))

--- a/pkg/arvo/ted/group/on-leave.hoon
+++ b/pkg/arvo/ted/group/on-leave.hoon
@@ -19,7 +19,7 @@
 ;<  ~  bind:m
   %+  raw-poke
     [entity.resource.update %group-push-hook]
-  :-  %group-update
+  :-  %group-update-0
   !>  ^-  update:grp
   [%remove-members resource.update (silt [our.bowl ~])]
 ::  stop serving or syncing group updates
@@ -70,7 +70,7 @@
 ;<  ~  bind:m
   %+  raw-poke
     [our.bowl %graph-store]
-  :-  %graph-update
+  :-  %graph-update-0
   !>  ^-  update:gra
   [%0 now.bowl [%archive-graph app-resource]]
 ;<  ~  bind:m

--- a/pkg/arvo/ted/ph/migrate/make-graphs.hoon
+++ b/pkg/arvo/ted/ph/migrate/make-graphs.hoon
@@ -14,7 +14,7 @@
   =/  =post:post  [our index wen [%text body]~ ~ ~]
   =/  =node:graph-store  [post %empty ~]
   =/  act=update:graph-store  [%0 wen %add-nodes rid (my [index node] ~)]
-  (poke-app our %graph-push-hook %graph-update act)
+  (poke-app our %graph-push-hook %graph-update-0 act)
 --
 ::
 ^-  thread:spider

--- a/pkg/arvo/ted/ph/migrate/post-import-graphs.hoon
+++ b/pkg/arvo/ted/ph/migrate/post-import-graphs.hoon
@@ -14,7 +14,7 @@
   =/  =post:post  [our index wen [%text body]~ ~ ~]
   =/  =node:graph-store  [post %empty ~]
   =/  act=update:graph-store  [%0 wen %add-nodes rid (my [index node] ~)]
-  (poke-app our %graph-push-hook %graph-update act)
+  (poke-app our %graph-push-hook %graph-update-0 act)
 --
 ::
 ^-  thread:spider

--- a/pkg/arvo/tests/lib/pull-hook-virt.hoon
+++ b/pkg/arvo/tests/lib/pull-hook-virt.hoon
@@ -1,0 +1,43 @@
+/+  pull-hook-virt, *test, resource
+|%
+++  bowl  *bowl:gall
+::
+++  virt  ~(. pull-hook-virt bowl)
+::
+++  test-mule-scry-bad-time
+  %+  expect-eq  !>(~)
+  !>  %+  mule-scry:virt  **
+  /gx/(scot %p ~zod)/graph-store/(scot %da ~2010.1.1)/keys/noun
+::
+++  test-mule-scry-bad-ship
+  %+  expect-eq  !>(~)
+  !>  %+  mule-scry:virt  **
+  /gx/(scot %p ~bus)/graph-store/(scot %da *time)/keys/noun
+::
+++  test-kick-mule
+  =/  rid=resource
+    [~zod %test]
+  =/  pax=path
+    /gx/(scot %p ~zod)/graph-store/(scot %da *time)/keys/noun
+  =/  test-trp=(trap *)
+    |.
+    :-  ~
+    .^(path pax)
+  =/  harness-trp=(trap *)
+    |.((kick-mule:virt rid test-trp))
+  %+  expect-eq  !>(``/foo)
+  !>  
+  =/  res=toon
+    %+  mock  [harness-trp %9 2 %0 1]
+    |=  [ref=* raw=*]
+    =/  pox=(unit path)
+      ((soft path) raw)
+    ?~  pox  ~
+    ?:  =(u.pox pax)
+      ``/foo
+    ``.^(* u.pox)
+  ?>  ?=(%0 -.res)
+  ;;((unit (unit path)) p.res)
+::
+--
+    

--- a/pkg/arvo/tests/lib/versioning.hoon
+++ b/pkg/arvo/tests/lib/versioning.hoon
@@ -1,0 +1,49 @@
+/+  versioning, *test
+|%
+++  ver  ~(. versioning [*bowl:gall %update 2 1])
+++  test-is-root
+  ;:  weld
+    %+  expect-eq  !>  %.y
+    !>  (is-root:ver %update-0)
+    ::
+    %+  expect-eq  !>  %.y
+    !>  (is-root:ver %update)
+
+    ::
+    %+  expect-eq  !>  %.n
+    !>  (is-root:ver %not-update-0)
+  ==
+::
+++  test-read-version
+  ;:  weld
+    %+  expect-eq  !>  0
+    !>  (read-version:ver %update-0)
+    ::
+    %+  expect-eq  !>  0
+    !>  (read-version:ver %update)
+    ::
+    %+  expect-eq  !>  1
+    !>  (read-version:ver %update-1)
+  ==
+::
+++  test-append-version
+  ;:  weld
+    %+  expect-eq  !>  %update-0
+    !>  (append-version:ver 0)
+    ::
+    %+  expect-eq  !>  %update-1
+    !>  (append-version:ver 1)
+  ==
+::
+++  test-current-version
+  %+  expect-eq  !>  %update-2
+  !>  current-version:ver
+::
+++  test-supported
+  ;:  weld
+    (expect !>((supported:ver %update-2)))
+    (expect !>((supported:ver %update-1)))
+    (expect !>(!(supported:ver %update-0)))
+  ==
+--
+

--- a/pkg/interface/src/logic/api/contacts.ts
+++ b/pkg/interface/src/logic/api/contacts.ts
@@ -84,7 +84,7 @@ export default class ContactsApi extends BaseApi<StoreState> {
   }
 
   private storeAction(action: any): Promise<any> {
-    return this.action('contact-store', 'contact-update', action);
+    return this.action('contact-store', 'contact-update-0', action);
   }
 
   private viewAction(threadName: string, action: any) {
@@ -92,6 +92,6 @@ export default class ContactsApi extends BaseApi<StoreState> {
   }
 
   private hookAction(ship: Patp, action: any): Promise<any> {
-    return this.action('contact-push-hook', 'contact-update', action);
+    return this.action('contact-push-hook', 'contact-update-0', action);
   }
 }

--- a/pkg/interface/src/logic/api/graph.ts
+++ b/pkg/interface/src/logic/api/graph.ts
@@ -83,7 +83,7 @@ export default class GraphApi extends BaseApi<StoreState> {
   joiningGraphs = new Set<string>();
 
   private storeAction(action: any): Promise<any> {
-    return this.action('graph-store', 'graph-update', action);
+    return this.action('graph-store', 'graph-update-0', action);
   }
 
   private viewAction(threadName: string, action: any) {
@@ -91,7 +91,7 @@ export default class GraphApi extends BaseApi<StoreState> {
   }
 
   private hookAction(ship: Patp, action: any): Promise<any> {
-    return this.action('graph-push-hook', 'graph-update', action);
+    return this.action('graph-push-hook', 'graph-update-0', action);
   }
 
   createManagedGraph(
@@ -227,7 +227,7 @@ export default class GraphApi extends BaseApi<StoreState> {
     };
 
     const pendingPromise = this.spider(
-      'graph-update',
+      'graph-update-0',
       'graph-view-action',
       'graph-add-nodes',
       action

--- a/pkg/interface/src/logic/api/groups.ts
+++ b/pkg/interface/src/logic/api/groups.ts
@@ -79,11 +79,11 @@ export default class GroupsApi extends BaseApi<StoreState> {
   }
 
   private proxyAction(action: GroupAction) {
-    return this.action('group-push-hook', 'group-update', action);
+    return this.action('group-push-hook', 'group-update-0', action);
   }
 
   private storeAction(action: GroupAction) {
-    return this.action('group-store', 'group-update', action);
+    return this.action('group-store', 'group-update-0', action);
   }
 
   private viewThread(thread: string, action: any) {

--- a/pkg/interface/src/logic/api/metadata.ts
+++ b/pkg/interface/src/logic/api/metadata.ts
@@ -103,6 +103,6 @@ export default class MetadataApi extends BaseApi<StoreState> {
   }
 
   private metadataAction(data) {
-    return this.action('metadata-push-hook', 'metadata-update', data);
+    return this.action('metadata-push-hook', 'metadata-update-0', data);
   }
 }

--- a/sh/test-hook
+++ b/sh/test-hook
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+reset_ship() {
+  ship=$1
+  pier=../../$ship
+
+  downgrade $ship
+
+  herb ./$pier -p hood -d "+hood/fade %demo-store"
+  herb ./$pier -p hood -d "+hood/fade %demo-pull-hook"
+  herb ./$pier -p hood -d "+hood/fade %demo-push-hook"
+
+  herb ./$pier -p hood -d "+hood/start %demo-store"
+  herb ./$pier -p hood -d "+hood/start %demo-pull-hook"
+  herb ./$pier -p hood -d "+hood/start %demo-push-hook"
+
+  #herb ./$pier -p demo-store -d "+verb"
+  #herb ./$pier -p demo-push-hook -d "+verb"
+  #herb ./$pier -p demo-pull-hook -d "+verb"
+
+}
+
+start() {
+  ship=$1
+  pier=../../$ship
+
+  herb ./$pier -p demo-store -d "+demo/ini %foo"
+  herb ./$pier -p demo-push-hook -d "+push/add %foo"
+  herb ./$pier -p demo-store -d "+demo/add 0 %foo 3"
+}
+
+poke_store() {
+  ship=$1
+  num=$2
+  ver=$3
+  pier=../../$ship
+  herb ./$pier -p demo-store -d "+demo/add $ver %foo $num"
+}
+sub() {
+  us=$1
+  them=$2
+  
+  pier=../../$us
+
+  herb ./$pier -p demo-pull-hook -d "+pull/add ~$them %foo"
+}
+
+print() {
+  ship=$1
+  pier=../../$ship
+
+  herb ./$pier -p demo-store -d "+dbug"
+  herb ./$pier -p demo-push-hook -d "+dbug"
+  herb ./$pier -p demo-pull-hook -d "+dbug"
+}
+
+
+
+upgrade() {
+  ship=$1
+  pier=../../$ship
+  desk=$pier/home
+  gsed --in-place "s/demo-update-0/demo-update-1/g" $desk/app/demo-store.hoon
+  gsed --in-place "14s/.*/1/" $desk/app/demo-pull-hook.hoon
+  gsed --in-place "14s/.*/1/" $desk/app/demo-push-hook.hoon
+  herb ./$pier -p hood -d "+hood/commit %home"
+}
+
+upgrade_incompat() {
+  ship=$1
+  pier=../../$ship
+  desk=$pier/home
+  gsed --in-place "s/demo-update-0/demo-update-1/g" $desk/app/demo-store.hoon
+  gsed --in-place "14s/.*/1/" $desk/app/demo-pull-hook.hoon
+  gsed --in-place "15s/.*/1/" $desk/app/demo-pull-hook.hoon
+  gsed --in-place "14s/.*/1/" $desk/app/demo-push-hook.hoon
+  gsed --in-place "15s/.*/1/" $desk/app/demo-push-hook.hoon
+  herb ./$pier -p hood -d "+hood/commit %home"
+}
+
+downgrade() {
+  ship=$1
+  pier=../../$ship
+  desk=$pier/home
+  gsed --in-place "s/demo-update-1/demo-update-0/g" $desk/app/demo-store.hoon
+  gsed --in-place "14s/.*/0/" $desk/app/demo-pull-hook.hoon
+  gsed --in-place "15s/.*/0/" $desk/app/demo-pull-hook.hoon
+  gsed --in-place "14s/.*/0/" $desk/app/demo-push-hook.hoon
+  gsed --in-place "15s/.*/0/" $desk/app/demo-push-hook.hoon
+  herb ./$pier -p hood -d "+hood/commit %home"
+}
+
+
+sub_ahead() {
+  echo "subscriber ahead"
+  reset_ship "zod"
+  reset_ship "bus"
+  start "zod"
+  sub "bus" "zod"
+  sleep 2
+  print "zod"
+  print "bus"
+  sleep 2
+  upgrade "zod"
+  sleep 1
+  poke_store "zod" 5 1
+  sleep 2
+  print "zod"
+  print "bus"
+}
+
+
+sub_ahead_incompat() {
+  echo "subscriber ahead, incompatible"
+  reset_ship "zod"
+  reset_ship "bus"
+  start "zod"
+  sub "bus" "zod"
+  sleep 2
+  print "zod"
+  print "bus"
+  sleep 2
+  upgrade_incompat "bus"
+  sleep 1
+  print "bus"
+  poke_store "zod" 5 0
+  sleep 2
+  upgrade_incompat "zod"
+  sleep 3
+  print "zod"
+  print "bus"
+}
+
+pub_ahead() {
+  echo "publisher ahead"
+  reset_ship "zod"
+  reset_ship "bus"
+  start "zod"
+  sub "bus" "zod"
+  sleep 2
+  print "zod"
+  print "bus"
+  sleep 2
+  upgrade "zod"
+  sleep 1
+  poke_store "zod" 5 1
+  sleep 2
+  print "zod"
+  print "bus"
+}
+
+
+pub_ahead_incompat() {
+  echo "publisher ahead, incompatible"
+  reset_ship "zod"
+  reset_ship "bus"
+  start "zod"
+  sub "bus" "zod"
+  sleep 2
+  print "zod"
+  print "bus"
+  sleep 2
+  upgrade_incompat "zod"
+  sleep 1
+  poke_store "zod" 5 1
+  sleep 2
+  upgrade_incompat "bus"
+  sleep 3
+  print "zod"
+  print "bus"
+}
+
+pub_ahead_incompat


### PR DESCRIPTION
A draft of versioned subscriptions.

There are four cases that we care about with versioning

#### Publisher ahead, compatible
If the publisher is ahead and the requested version is convertible to the publisher's current version, then publisher does mark conversion to the requested version and gives it on the subscription

#### Subscriber ahead, compatible
If the subscriber is ahead and the received version is convertible to the subscriber's current version, then the subscriber does a mark conversion to the requested version before proxying it to the store

##### Subscriber ahead, incompatible
If the subscriber is ahead and the received version is not convertible, then we suspend the connection and subscribe to the /versions path. We then resume the connection when the publisher gives us a version that is convertible

##### Publisher ahead, incompatible
If the publisher is ahead and the requested version is not convertible, then we suspend the connection and wait to learn about the version that the publisher is on. 

I'd note that I'm concerned about the publisher ahead & compatible case. We need to ensure that there's no possible loss of information in this conversion

TODO:

- [x] Proxied pokes should be converted
- [x] Restart subscription logic
- [x] A functioning +on-load
- [x] Groups
- [x] Graph
- [x] Metadata
- [x] Contacts