### PR TITLE
settings: sidebar same width as groups

### DIFF
--- a/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
@@ -4,8 +4,16 @@ import { Text } from '@tlon/indigo-react';
 
 export function BackButton(props: {}) {
   return (
-    <Link to="/~settings">
-      <Text display={["block", "none"]} fontSize="2" fontWeight="medium">{"<- Back to System Preferences"}</Text>
+    <Link to='/~settings'>
+      <Text
+        display={['block', 'none']}
+        fontSize='2'
+        fontWeight='medium'
+        p={4}
+        pb={0}
+      >
+        {'<- Back to System Preferences'}
+      </Text>
     </Link>
   );
 }

--- a/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
@@ -11,12 +11,12 @@ import {
   Anchor
 } from '@tlon/indigo-react';
 
-import GlobalApi from "~/logic/api/global";
-import { BucketList } from "./BucketList";
+import GlobalApi from '~/logic/api/global';
+import { BucketList } from './BucketList';
 import { S3State } from '~/types/s3-update';
 import useS3State from '~/logic/state/storage';
 import { BackButton } from './BackButton';
-import {StorageState} from '~/types';
+import { StorageState } from '~/types';
 import useStorageState from '~/logic/state/storage';
 
 interface FormSchema {
@@ -33,7 +33,7 @@ interface S3FormProps {
 
 export default function S3Form(props: S3FormProps): ReactElement {
   const { api } = props;
-  const s3 = useStorageState(state => state.s3);
+  const s3 = useStorageState((state) => state.s3);
 
   const onSubmit = useCallback(
     (values: FormSchema) => {
@@ -54,7 +54,8 @@ export default function S3Form(props: S3FormProps): ReactElement {
 
   return (
     <>
-      <Col p="5" pt="4" borderBottom="1" borderBottomColor="washedGray">
+      <BackButton />
+      <Col p='5' pt='4' borderBottom='1' borderBottomColor='washedGray'>
         <Formik
           initialValues={
             {
@@ -68,42 +69,42 @@ export default function S3Form(props: S3FormProps): ReactElement {
           onSubmit={onSubmit}
         >
           <Form>
-            <BackButton/>
-            <Col maxWidth="600px" gapY="5">
-              <Col gapY="1" mt="0">
-                <Text color="black" fontSize={2} fontWeight="medium">
+            <Col maxWidth='600px' gapY='5'>
+              <Col gapY='1' mt='0'>
+                <Text color='black' fontSize={2} fontWeight='medium'>
                   S3 Storage Setup
                 </Text>
                 <Text gray>
                   Store credentials for your S3 object storage buckets on your
                   Urbit ship, and upload media freely to various modules.
                   <Anchor
-                    target="_blank"
+                    target='_blank'
                     style={{ textDecoration: 'none' }}
-                    borderBottom="1"
-                    ml="1"
-                    href="https://urbit.org/using/operations/using-your-ship/#bucket-setup">
+                    borderBottom='1'
+                    ml='1'
+                    href='https://urbit.org/using/operations/using-your-ship/#bucket-setup'
+                  >
                     Learn more
                   </Anchor>
                 </Text>
               </Col>
-              <Input label="Endpoint" id="s3endpoint" />
-              <Input label="Access Key ID" id="s3accessKeyId" />
+              <Input label='Endpoint' id='s3endpoint' />
+              <Input label='Access Key ID' id='s3accessKeyId' />
               <Input
-                type="password"
-                label="Secret Access Key"
-                id="s3secretAccessKey"
+                type='password'
+                label='Secret Access Key'
+                id='s3secretAccessKey'
               />
-              <Button style={{ cursor: "pointer" }} type="submit">
+              <Button style={{ cursor: 'pointer' }} type='submit'>
                 Submit
               </Button>
             </Col>
           </Form>
         </Formik>
       </Col>
-      <Col maxWidth="600px" p="5" gapY="4">
-        <Col gapY="1">
-          <Text color="black" mb={4} fontSize={2} fontWeight="medium">
+      <Col maxWidth='600px' p='5' gapY='4'>
+        <Col gapY='1'>
+          <Text color='black' mb={4} fontSize={2} fontWeight='medium'>
             S3 Buckets
           </Text>
           <Text gray>

--- a/pkg/interface/src/views/apps/settings/settings.tsx
+++ b/pkg/interface/src/views/apps/settings/settings.tsx
@@ -77,50 +77,49 @@ export default function SettingsScreen(props: any) {
         <title>Landscape - Settings</title>
       </Helmet>
       <Skeleton>
-        <Row height='100%' overflow='auto'>
-          <Col
-            height='100%'
-            borderRight='1'
-            borderRightColor='washedGray'
-            display={hash === '' ? 'flex' : ['none', 'flex']}
-            width='100%'
-          >
-            <Text display='block' my='4' mx='3' fontSize='2' fontWeight='700'>
-              System Preferences
-            </Text>
-            <Col gapY='1'>
-              <SidebarItem
-                icon='Inbox'
-                text='Notifications'
-                hash='notifications'
-              />
-              <SidebarItem icon='Image' text='Display' hash='display' />
-              <SidebarItem icon='Upload' text='Remote Storage' hash='s3' />
-              <SidebarItem icon='LeapArrow' text='Leap' hash='leap' />
-              <SidebarItem icon='Node' text='CalmEngine' hash='calm' />
-              <SidebarItem
-                icon='Locked'
-                text='Devices + Security'
-                hash='security'
-              />
-            </Col>
+        <Col
+          height='100%'
+          borderRight='1'
+          borderRightColor='washedGray'
+          display={hash === '' ? 'flex' : ['none', 'flex']}
+          width='100%'
+          overflowY='auto'
+        >
+          <Text display='block' my='4' mx='3' fontSize='2' fontWeight='700'>
+            System Preferences
+          </Text>
+          <Col gapY='1'>
+            <SidebarItem
+              icon='Inbox'
+              text='Notifications'
+              hash='notifications'
+            />
+            <SidebarItem icon='Image' text='Display' hash='display' />
+            <SidebarItem icon='Upload' text='Remote Storage' hash='s3' />
+            <SidebarItem icon='LeapArrow' text='Leap' hash='leap' />
+            <SidebarItem icon='Node' text='CalmEngine' hash='calm' />
+            <SidebarItem
+              icon='Locked'
+              text='Devices + Security'
+              hash='security'
+            />
           </Col>
-          <Col flexGrow={1} overflowY='auto'>
-            <SettingsItem>
-              {hash === 'notifications' && (
-                <NotificationPreferences
-                  {...props}
-                  graphConfig={props.notificationsGraphConfig}
-                />
-              )}
-              {hash === 'display' && <DisplayForm api={props.api} />}
-              {hash === 's3' && <S3Form api={props.api} />}
-              {hash === 'leap' && <LeapSettings api={props.api} />}
-              {hash === 'calm' && <CalmPrefs api={props.api} />}
-              {hash === 'security' && <SecuritySettings api={props.api} />}
-            </SettingsItem>
-          </Col>
-        </Row>
+        </Col>
+        <Col flexGrow={1} overflowY='auto'>
+          <SettingsItem>
+            {hash === 'notifications' && (
+              <NotificationPreferences
+                {...props}
+                graphConfig={props.notificationsGraphConfig}
+              />
+            )}
+            {hash === 'display' && <DisplayForm api={props.api} />}
+            {hash === 's3' && <S3Form api={props.api} />}
+            {hash === 'leap' && <LeapSettings api={props.api} />}
+            {hash === 'calm' && <CalmPrefs api={props.api} />}
+            {hash === 'security' && <SecuritySettings api={props.api} />}
+          </SettingsItem>
+        </Col>
       </Skeleton>
     </>
   );

--- a/pkg/interface/src/views/apps/settings/settings.tsx
+++ b/pkg/interface/src/views/apps/settings/settings.tsx
@@ -1,35 +1,42 @@
-import React, { ReactNode } from "react";
-import { useLocation } from "react-router-dom";
-import Helmet from "react-helmet";
+import React, { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import Helmet from 'react-helmet';
 
 import { Text, Box, Col, Row } from '@tlon/indigo-react';
 
-import { NotificationPreferences } from "./components/lib/NotificationPref";
-import DisplayForm from "./components/lib/DisplayForm";
-import S3Form from "./components/lib/S3Form";
-import { CalmPrefs } from "./components/lib/CalmPref";
-import SecuritySettings from "./components/lib/Security";
-import { LeapSettings } from "./components/lib/LeapSettings";
-import { useHashLink } from "~/logic/lib/useHashLink";
-import { SidebarItem as BaseSidebarItem } from "~/views/landscape/components/SidebarItem";
-import { PropFunc } from "~/types";
+import { NotificationPreferences } from './components/lib/NotificationPref';
+import DisplayForm from './components/lib/DisplayForm';
+import S3Form from './components/lib/S3Form';
+import { CalmPrefs } from './components/lib/CalmPref';
+import SecuritySettings from './components/lib/Security';
+import { LeapSettings } from './components/lib/LeapSettings';
+import { useHashLink } from '~/logic/lib/useHashLink';
+import { SidebarItem as BaseSidebarItem } from '~/views/landscape/components/SidebarItem';
+import { PropFunc } from '~/types';
 
 export const Skeleton = (props: { children: ReactNode }) => (
-  <Box height="100%" width="100%" px={[0, 3]} pb={[0, 3]} borderRadius={1}>
+  <Box height='100%' width='100%' px={[0, 3]} pb={[0, 3]} borderRadius={1}>
     <Box
-      height="100%"
-      width="100%"
-      borderRadius={1}
-      bg="white"
+      display='grid'
+      gridTemplateColumns={[
+        '100%',
+        'minmax(150px, 1fr) 3fr',
+        'minmax(250px, 1fr) 4fr'
+      ]}
+      gridTemplateRows='100%'
+      height='100%'
+      width='100%'
+      borderRadius={2}
+      bg='white'
       border={1}
-      borderColor="washedGray"
+      borderColor='washedGray'
     >
       {props.children}
     </Box>
   </Box>
 );
 
-type ProvSideProps = "to" | "selected";
+type ProvSideProps = 'to' | 'selected';
 type BaseProps = PropFunc<typeof BaseSidebarItem>;
 function SidebarItem(props: { hash: string } & Omit<BaseProps, ProvSideProps>) {
   const { hash, icon, text, ...rest } = props;
@@ -54,16 +61,15 @@ function SettingsItem(props: { children: ReactNode }) {
   const { children } = props;
 
   return (
-    <Box borderBottom="1" borderBottomColor="washedGray">
+    <Box borderBottom='1' borderBottomColor='washedGray'>
       {children}
     </Box>
   );
 }
 
 export default function SettingsScreen(props: any) {
-
   const location = useLocation();
-  const hash = location.hash.slice(1)
+  const hash = location.hash.slice(1);
 
   return (
     <>
@@ -71,65 +77,47 @@ export default function SettingsScreen(props: any) {
         <title>Landscape - Settings</title>
       </Helmet>
       <Skeleton>
-        <Row height="100%" overflow="hidden">
+        <Row height='100%' overflow='auto'>
           <Col
-            height="100%"
-            borderRight="1"
-            borderRightColor="washedGray"
-            display={hash === "" ? "flex" : ["none", "flex"]}
-            minWidth="250px"
-            width="100%"
-            maxWidth={["100vw", "350px"]}
+            height='100%'
+            borderRight='1'
+            borderRightColor='washedGray'
+            display={hash === '' ? 'flex' : ['none', 'flex']}
+            width='100%'
           >
-            <Text
-              display="block"
-              my="4"
-              mx="3"
-              fontSize="2"
-              fontWeight="medium"
-            >
+            <Text display='block' my='4' mx='3' fontSize='2' fontWeight='700'>
               System Preferences
             </Text>
-            <Col gapY="1">
+            <Col gapY='1'>
               <SidebarItem
-                icon="Inbox"
-                text="Notifications"
-                hash="notifications"
+                icon='Inbox'
+                text='Notifications'
+                hash='notifications'
               />
-              <SidebarItem icon="Image" text="Display" hash="display" />
-              <SidebarItem icon="Upload" text="Remote Storage" hash="s3" />
-              <SidebarItem icon="LeapArrow" text="Leap" hash="leap" />
-              <SidebarItem icon="Node" text="CalmEngine" hash="calm" />
+              <SidebarItem icon='Image' text='Display' hash='display' />
+              <SidebarItem icon='Upload' text='Remote Storage' hash='s3' />
+              <SidebarItem icon='LeapArrow' text='Leap' hash='leap' />
+              <SidebarItem icon='Node' text='CalmEngine' hash='calm' />
               <SidebarItem
-                icon="Locked"
-                text="Devices + Security"
-                hash="security"
+                icon='Locked'
+                text='Devices + Security'
+                hash='security'
               />
             </Col>
           </Col>
-          <Col flexGrow={1} overflowY="auto">
+          <Col flexGrow={1} overflowY='auto'>
             <SettingsItem>
-              {hash === "notifications" && (
+              {hash === 'notifications' && (
                 <NotificationPreferences
                   {...props}
                   graphConfig={props.notificationsGraphConfig}
                 />
               )}
-              {hash === "display" && (
-                <DisplayForm api={props.api} />
-              )}
-              {hash === "s3" && (
-                <S3Form api={props.api} />
-              )}
-              {hash === "leap" && (
-                <LeapSettings api={props.api} />
-              )}
-              {hash === "calm" && (
-                <CalmPrefs api={props.api} />
-              )}
-              {hash === "security" && (
-                <SecuritySettings api={props.api} />
-              )}
+              {hash === 'display' && <DisplayForm api={props.api} />}
+              {hash === 's3' && <S3Form api={props.api} />}
+              {hash === 'leap' && <LeapSettings api={props.api} />}
+              {hash === 'calm' && <CalmPrefs api={props.api} />}
+              {hash === 'security' && <SecuritySettings api={props.api} />}
             </SettingsItem>
           </Col>
         </Row>


### PR DESCRIPTION
Adjusts the System Preferences layout to be the same (CSS grid-based) as Groups and Messages.

The sidebar in both instances is flexible. The proportions match, therefore so do the pixel measurements at various window widths.

![Frame 1 (1)](https://user-images.githubusercontent.com/748181/110707852-e4152c80-81c7-11eb-9d0d-16e801259270.png)

An easy way to test is to visit the System Preferences, Leap to a Group, then use browser keyboard shortcuts to quickly flip back and forth between pages.

Fixes urbit/landscape#541