### PR TITLE
GroupsPane: restore channel counts on summaries

### DIFF
--- a/pkg/interface/src/views/components/UnjoinedResource.tsx
+++ b/pkg/interface/src/views/components/UnjoinedResource.tsx
@@ -9,15 +9,13 @@ import {
   StatelessAsyncButton as AsyncButton,
   StatelessAsyncButton
 } from './StatelessAsyncButton';
-import { Notebooks, Graphs, Inbox } from '@urbit/api';
+import { Graphs } from '@urbit/api';
 import useGraphState from '~/logic/state/graph';
 
 interface UnjoinedResourceProps {
   association: Association;
   api: GlobalApi;
   baseUrl: string;
-  notebooks: Notebooks;
-  inbox: Inbox;
 }
 
 function isJoined(path: string) {
@@ -31,7 +29,7 @@ function isJoined(path: string) {
 }
 
 export function UnjoinedResource(props: UnjoinedResourceProps) {
-  const { api, notebooks, inbox } = props;
+  const { api } = props;
   const history = useHistory();
   const rid = props.association.resource;
   const appName = props.association['app-name'];
@@ -52,7 +50,7 @@ export function UnjoinedResource(props: UnjoinedResourceProps) {
     if (isJoined(rid)({ graphKeys })) {
       history.push(`${props.baseUrl}/resource/${app}${rid}`);
     }
-  }, [props.association, inbox, graphKeys, notebooks]);
+  }, [props.association, graphKeys]);
 
   return (
     <Center p={6}>

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -158,8 +158,6 @@ export function GroupsPane(props: GroupsPaneProps) {
                 baseUrl={baseUrl}
               >
                 <UnjoinedResource
-                  notebooks={props.notebooks}
-                  inbox={props.inbox}
                   baseUrl={baseUrl}
                   api={api}
                   association={association}
@@ -191,9 +189,8 @@ export function GroupsPane(props: GroupsPaneProps) {
       <Route
         path={relativePath('')}
         render={(routeProps) => {
-          const hasDescription = groupAssociation?.metadata?.description;
-          const channelCount = Object.keys(props?.associations?.graph ?? {}).filter((e) => {
-            return props?.associations?.graph?.[e]?.['group'] === groupPath;
+          const channelCount = Object.keys(associations?.graph ?? {}).filter((e) => {
+            return associations?.graph?.[e]?.['group'] === groupPath;
           }).length;
           let summary: ReactNode;
           if(groupAssociation?.group) {

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -37,7 +37,6 @@ interface SidebarProps {
   api: GlobalApi;
   selected?: string;
   selectedGroup?: string;
-  includeUnmanaged?: boolean;
   apps: SidebarAppConfigs;
   baseUrl: string;
   mobileHide?: boolean;

--- a/pkg/interface/src/views/landscape/components/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Skeleton.tsx
@@ -5,7 +5,6 @@ import { Associations } from '@urbit/api/metadata';
 
 import { Sidebar } from './Sidebar/Sidebar';
 import GlobalApi from '~/logic/api/global';
-import GlobalSubscription from '~/logic/subscription/global';
 import { useGraphModule } from './Sidebar/Apps';
 import { Body } from '~/views/components/Body';
 import { Workspace } from '~/types/workspace';
@@ -16,14 +15,11 @@ import ErrorBoundary from '~/views/components/ErrorBoundary';
 interface SkeletonProps {
   children: ReactNode;
   recentGroups: string[];
-  linkListening: Set<Path>;
   selected?: string;
   selectedApp?: AppName;
   baseUrl: string;
   mobileHide?: boolean;
   api: GlobalApi;
-  subscription: GlobalSubscription;
-  includeUnmanaged: boolean;
   workspace: Workspace;
 }
 


### PR DESCRIPTION
We were referencing `props.associations` where we no longer received associations from props.