### PR TITLE
interface: added tool to track unneeded renders

### DIFF
--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -94,7 +94,11 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env', '@babel/typescript', '@babel/preset-react'],
+            presets: ['@babel/preset-env', '@babel/typescript', ['@babel/preset-react', {
+              runtime: 'automatic',
+              development: true,
+              importSource: '@welldone-software/why-did-you-render',
+            }]],
             plugins: [
               '@babel/transform-runtime',
               '@babel/plugin-proposal-object-rest-spread',

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -1995,6 +1995,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@welldone-software/why-did-you-render": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-6.1.0.tgz",
+      "integrity": "sha512-0s+PuKQ4v9VV1SZSM6iS7d2T7X288T3DF+K8yfkFAhI31HhJGGH1SY1ssVm+LqjSMyrVWT60ZF5r0qUsO0Z9Lw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -71,6 +71,7 @@
     "@types/yup": "^0.29.11",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@urbit/eslint-config": "file:../npm/eslint-config",
+    "@welldone-software/why-did-you-render": "^6.1.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-lodash": "^3.3.4",

--- a/pkg/interface/src/index.js
+++ b/pkg/interface/src/index.js
@@ -1,3 +1,4 @@
+import './wdyr';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 

--- a/pkg/interface/src/logic/api/metadata.ts
+++ b/pkg/interface/src/logic/api/metadata.ts
@@ -77,7 +77,6 @@ export default class MetadataApi extends BaseApi<StoreState> {
           tempChannel.delete();
         },
         (ev: any) => {
-          console.log(ev);
           if ('metadata-hook-update' in ev) {
             done = true;
             tempChannel.delete();

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -40,7 +40,6 @@ export function Notebook(props: NotebookProps & RouteComponentProps): ReactEleme
   const contacts = useContactState(state => state.contacts);
 
   const contact = contacts?.[`~${ship}`];
-  console.log(association.resource);
 
   const showNickname = useShowNickname(contact);
 

--- a/pkg/interface/src/views/components/RemoteContent.tsx
+++ b/pkg/interface/src/views/components/RemoteContent.tsx
@@ -51,7 +51,6 @@ class RemoteContent extends Component<RemoteContentProps, RemoteContentState> {
   }
 
   save = () => {
-    console.log(`saving for: ${this.props.url}`);
     if(this.saving) {
       return;
     }
@@ -60,7 +59,6 @@ class RemoteContent extends Component<RemoteContentProps, RemoteContentState> {
   };
 
   restore = () => {
-    console.log(`restoring for: ${this.props.url}`);
     this.saving = false;
     this.props.restore();
   }

--- a/pkg/interface/src/views/components/useTutorialModal.tsx
+++ b/pkg/interface/src/views/components/useTutorialModal.tsx
@@ -16,9 +16,7 @@ export function useTutorialModal(
       setTutorialRef(anchorRef.current);
     }
 
-    return () => {
-      console.log(tutorialProgress);
-    }
+    return () => {}
   }, [tutorialProgress, show, anchorRef]);
 
   return show && onProgress === tutorialProgress;

--- a/pkg/interface/src/wdyr.js
+++ b/pkg/interface/src/wdyr.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+if (process.env.NODE_ENV === 'development') {
+  const whyDidYouRender = require('@welldone-software/why-did-you-render');
+  whyDidYouRender(React, {
+    trackAllPureComponents: true,
+  });
+}


### PR DESCRIPTION
As per a discussion with @liam-fitzgerald a while back, adds `why-did-you-render` during development to check for unneeded renders. Seems to be pretty clean already, but it looks like it doesn't track functional components by default (only PureComponents), but might aid in future debugging.

Also removes some unnecessary `console.log`s