### PR TITLE
publish: allow admins to delete posts, comments

### DIFF
--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -148,17 +148,13 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
           </Anchor>
         </Text>
       </Box>
-
       <Row minWidth='0' flexShrink={0} width="100%" justifyContent="space-between" py={3} bg="white">
-
       <Author
         showImage
         ship={author}
         date={node.post['time-sent']}
         group={group}
-        api={api}
-      ></Author>
-
+      />
       <Box ml="auto">
         <Link
           to={node.post.pending ? '#' : `${baseUrl}/${index}`}

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Text, Col, Anchor } from '@tlon/indigo-react';
+import { Box, Text, Col, Anchor, Row } from '@tlon/indigo-react';
 import ReactMarkdown from 'react-markdown';
 import bigInt from 'big-integer';
 
@@ -9,6 +9,7 @@ import { Comments } from '~/views/components/Comments';
 import { NoteNavigation } from './NoteNavigation';
 import GlobalApi from '~/logic/api/global';
 import { getLatestRevision, getComments } from '~/logic/lib/publish';
+import { roleForShip } from '~/logic/lib/group';
 import Author from '~/views/components/Author';
 import { Contacts, GraphNode, Graph, Association, Unreads, Group } from '@urbit/api';
 
@@ -54,29 +55,37 @@ export function Note(props: NoteProps & RouteComponentProps) {
     api.hark.markEachAsRead(props.association, '/',`/${index[1]}/1/1`, 'note', 'publish');
   }, [props.association, props.note]);
 
-  let adminLinks: JSX.Element | null = null;
+  let adminLinks: JSX.Element[] = [];
+  const ourRole = roleForShip(group, window.ship);
   if (window.ship === note?.post?.author) {
-    adminLinks = (
-      <Box display="inline-block" verticalAlign="middle">
-        <Link to={`${baseUrl}/edit`}>
-        <Text
-          color="green"
-          ml={2}
+    adminLinks.push(
+        <Link
+          style={{ 'display': 'inline-block' }}
+          to={`${baseUrl}/edit`}
         >
-          Update
-        </Text>
+          <Text
+            color="blue"
+            ml={2}
+          >
+            Update
+          </Text>
       </Link>
-        <Text
-          color="red"
-          ml={2}
-          onClick={deletePost}
-          style={{ cursor: 'pointer' }}
-        >
-          Delete
-        </Text>
-      </Box>
-    );
-  }
+    )
+  };
+
+  if (window.ship === note?.post?.author || ourRole === "admin") {
+    adminLinks.push(
+      <Text
+        color="red"
+        display='inline-block'
+        ml={2}
+        onClick={deletePost}
+        style={{ cursor: 'pointer' }}
+      >
+        Delete
+      </Text>
+    )
+  };
 
   const windowRef = React.useRef(null);
   useEffect(() => {
@@ -103,13 +112,14 @@ export function Note(props: NoteProps & RouteComponentProps) {
       </Link>
       <Col>
         <Text display="block" mb={2}>{title || ''}</Text>
-        <Box display="flex">
+        <Row alignItems="center">
           <Author
             ship={post?.author}
             date={post?.['time-sent']}
+            group={group}
           />
-          <Text ml={2}>{adminLinks}</Text>
-        </Box>
+          <Text ml={1}>{adminLinks}</Text>
+        </Row>
       </Col>
       <Box color="black" className="md" style={{ overflowWrap: 'break-word', overflow: 'hidden' }}>
         <ReactMarkdown source={body} linkTarget={'_blank'} renderers={renderers} />

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -114,6 +114,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
         <Text display="block" mb={2}>{title || ''}</Text>
         <Row alignItems="center">
           <Author
+            showImage
             ship={post?.author}
             date={post?.['time-sent']}
             group={group}

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -12,7 +12,6 @@ import {
   getSnippet
 } from '~/logic/lib/publish';
 import { Unreads } from '@urbit/api';
-import GlobalApi from '~/logic/api/global';
 import ReactMarkdown from 'react-markdown';
 import useHarkState from '~/logic/state/hark';
 
@@ -21,7 +20,6 @@ interface NotePreviewProps {
   book: string;
   node: GraphNode;
   baseUrl: string;
-  api: GlobalApi;
   group: Group;
 }
 
@@ -96,7 +94,6 @@ export function NotePreview(props: NotePreviewProps) {
           date={post?.['time-sent']}
           group={group}
           unread={isUnread}
-          api={props.api}
         />
         <Box ml="auto" mr={1}>
           <Link to={url}>

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -5,13 +5,11 @@ import { Col, Box, Text, Row } from '@tlon/indigo-react';
 import { Contacts, Rolodex, Groups, Associations, Graph, Association, Unreads } from '@urbit/api';
 
 import { NotebookPosts } from './NotebookPosts';
-import GlobalApi from '~/logic/api/global';
 import { useShowNickname } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
 
 interface NotebookProps {
-  api: GlobalApi;
   ship: string;
   book: string;
   graph: Graph;
@@ -40,7 +38,6 @@ export function Notebook(props: NotebookProps & RouteComponentProps): ReactEleme
   const contacts = useContactState(state => state.contacts);
 
   const contact = contacts?.[`~${ship}`];
-  console.log(association.resource);
 
   const showNickname = useShowNickname(contact);
 
@@ -61,7 +58,6 @@ export function Notebook(props: NotebookProps & RouteComponentProps): ReactEleme
         host={ship}
         book={book}
         baseUrl={props.baseUrl}
-        api={props.api}
         group={group}
       />
     </Col>

--- a/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
@@ -11,7 +11,6 @@ interface NotebookPostsProps {
   baseUrl: string;
   hideAvatars?: boolean;
   hideNicknames?: boolean;
-  api: GlobalApi;
   group: Group;
 }
 
@@ -29,7 +28,6 @@ export function NotebookPosts(props: NotebookPostsProps) {
               contact={contacts[`~${node.post.author}`]}
               node={node}
               baseUrl={props.baseUrl}
-              api={props.api}
               group={props.group}
             />
           )

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -11,7 +11,6 @@ import useSettingsState, {selectCalmState} from "~/logic/state/settings";
 import useLocalState from "~/logic/state/local";
 import OverlaySigil from './OverlaySigil';
 import { Sigil } from '~/logic/lib/sigil';
-import GlobalApi from '~/logic/api/global';
 import Timestamp from './Timestamp';
 import useContactState from '~/logic/state/contact';
 
@@ -22,7 +21,6 @@ interface AuthorProps {
   children?: ReactNode;
   unread?: boolean;
   group: Group;
-  api?: GlobalApi;
 }
 
 // eslint-disable-next-line max-lines-per-function

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -10,6 +10,7 @@ import { Group } from '@urbit/api';
 import GlobalApi from '~/logic/api/global';
 import Author from '~/views/components/Author';
 import { MentionText } from '~/views/components/MentionText';
+import { roleForShip } from '~/logic/lib/group';
 import { getLatestCommentRevision } from '~/logic/lib/publish';
 
 const ClickBox = styled(Box)`
@@ -31,7 +32,7 @@ interface CommentItemProps {
 export function CommentItem(props: CommentItemProps): ReactElement {
   const { ship, name, api, comment, group } = props;
   const [, post] = getLatestCommentRevision(comment);
-  const disabled = props.pending || window.ship !== post?.author;
+  const disabled = props.pending;
 
   const onDelete = async () => {
     await api.graph.removeNodes(ship, name, [comment.post?.index]);
@@ -40,6 +41,29 @@ export function CommentItem(props: CommentItemProps): ReactElement {
   const commentIndexArray = (comment.post?.index || '/').split('/');
   const commentIndex = commentIndexArray[commentIndexArray.length - 1];
   const updateUrl = `${props.baseUrl}/${commentIndex}`;
+
+  const adminLinks: JSX.Element[] = [];
+  const ourRole = roleForShip(group, window.ship);
+  if (window.ship == post?.author && !disabled) {
+    adminLinks.push(
+      <Link to={updateUrl}>
+        <Text
+          color="blue"
+          ml={2}
+        >
+          Update
+        </Text>
+      </Link>
+    )
+  };
+
+  if ((window.ship == post?.author || ourRole == "admin") && !disabled) {
+    adminLinks.push(
+      <ClickBox display="inline-block" color="red" onClick={onDelete}>
+        <Text color='red'>Delete</Text>
+      </ClickBox>
+    )
+  };
 
   return (
     <Box mb={4} opacity={post?.pending ? '60%' : '100%'}>
@@ -52,21 +76,9 @@ export function CommentItem(props: CommentItemProps): ReactElement {
           group={group}
           api={api}
         >
-          {!disabled && (
-            <Box display="inline-block" verticalAlign="middle">
-              <Link to={updateUrl}>
-                <Text
-                  color="green"
-                  ml={2}
-                >
-                  Update
-                </Text>
-              </Link>
-              <ClickBox display="inline-block" color="red" onClick={onDelete}>
-                <Text color='red'>Delete</Text>
-              </ClickBox>
-            </Box>
-          )}
+          <Row alignItems="center">
+            {adminLinks}
+          </Row>
         </Author>
       </Row>
       <Box mb={2}>

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -74,7 +74,6 @@ export function CommentItem(props: CommentItemProps): ReactElement {
           date={post?.['time-sent']}
           unread={props.unread}
           group={group}
-          api={api}
         >
           <Row alignItems="center">
             {adminLinks}


### PR DESCRIPTION
- Checks for our role in notes and comments, allows admins to delete them.
- Changes the update colour to blue to match the rest of the interface, moves to flexbox to just center the line height properly
- Shows the author's sigil on notes now so you can DM them if you want
- Removes a bunch of unnecessary api prop weaving since the Author component doesn't use the api for anything

<img width="535" alt="image" src="https://user-images.githubusercontent.com/20846414/110831546-59383e80-8268-11eb-93d6-ecc158707dbb.png">
