### PR TITLE
interface: small grab-bag

### DIFF
--- a/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
@@ -85,7 +85,7 @@ export function ProfileHeaderImageEdit(props: any): ReactElement {
 
 export function EditProfile(props: any): ReactElement {
   const { contact, ship, api } = props;
-  const isPublic = useContactState(state => state.isContactPublic);
+  const isPublic = useContactState((state) => state.isContactPublic);
   const [hideCover, setHideCover] = useState(false);
 
   const handleHideCover = (value) => {
@@ -150,7 +150,7 @@ export function EditProfile(props: any): ReactElement {
           <Form width='100%' height='100%'>
             <ProfileHeader>
               <ProfileControls>
-                <Row>
+                <Row alignItems='baseline'>
                   <Button
                     type='submit'
                     display='inline'
@@ -178,7 +178,11 @@ export function EditProfile(props: any): ReactElement {
                 </Row>
                 <ProfileStatus contact={contact} />
               </ProfileControls>
-              <ProfileImages hideCover={hideCover} contact={contact} ship={ship}>
+              <ProfileImages
+                hideCover={hideCover}
+                contact={contact}
+                ship={ship}
+              >
                 <ProfileHeaderImageEdit
                   contact={contact}
                   setFieldValue={setFieldValue}
@@ -203,11 +207,7 @@ export function EditProfile(props: any): ReactElement {
               <MarkdownField id='bio' mb={3} />
             </Col>
             <Checkbox mb={3} id='isPublic' label='Public Profile' />
-            <GroupSearch
-              label='Pinned Groups'
-              id='groups'
-              publicOnly
-            />
+            <GroupSearch label='Pinned Groups' id='groups' publicOnly />
             <AsyncButton primary loadingText='Updating...' border mt={3}>
               Submit
             </AsyncButton>

--- a/pkg/interface/src/views/components/StatusBar.js
+++ b/pkg/interface/src/views/components/StatusBar.js
@@ -9,6 +9,7 @@ import {
   Button,
   BaseImage
 } from '@tlon/indigo-react';
+
 import ReconnectButton from './ReconnectButton';
 import { Dropdown } from './Dropdown';
 import { StatusBarItem } from './StatusBarItem';
@@ -19,6 +20,7 @@ import { useTutorialModal } from './useTutorialModal';
 
 import useHarkState from '~/logic/state/hark';
 import useInviteState from '~/logic/state/invite';
+import useContactState from '~/logic/state/contact';
 import { useHistory } from 'react-router-dom';
 import useLocalState, { selectLocalState } from '~/logic/state/local';
 import useSettingsState, { selectCalmState } from '~/logic/state/settings';
@@ -60,6 +62,8 @@ const StatusBar = (props) => {
 
   const floatLeap =
     leapHighlight && window.matchMedia('(max-width: 550px)').matches;
+
+  const contact = useContactState((state) => state.contacts[`~${ship}`]);
 
   return (
     <Box
@@ -176,11 +180,7 @@ const StatusBar = (props) => {
                 <Text color='gray' fontWeight='500' mb='1'>
                   Set Status:
                 </Text>
-                <ProfileStatus
-                  contact={ourContact}
-                  ship={`~${ship}`}
-                  api={api}
-                />
+                <ProfileStatus contact={contact} ship={`~${ship}`} api={api} />
               </Row>
             </Col>
           }

--- a/pkg/interface/src/views/components/StatusBar.js
+++ b/pkg/interface/src/views/components/StatusBar.js
@@ -28,8 +28,9 @@ import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 const localSel = selectLocalState(['toggleOmnibox']);
 
 const StatusBar = (props) => {
-  const { ourContact, api, ship } = props;
+  const { api, ship } = props;
   const history = useHistory();
+  const ourContact = useContactState((state) => state.contacts[`~${ship}`]);
   const notificationsCount = useHarkState((state) => state.notificationsCount);
   const doNotDisturb = useHarkState((state) => state.doNotDisturb);
   const inviteState = useInviteState((state) => state.invites);
@@ -40,7 +41,7 @@ const StatusBar = (props) => {
   const { toggleOmnibox } = useLocalState(localSel);
   const { hideAvatars } = useSettingsState(selectCalmState);
 
-  const color = !!ourContact ? `#${uxToHex(props.ourContact.color)}` : '#000';
+  const color = !!ourContact ? `#${uxToHex(ourContact.color)}` : '#000';
   const xPadding = !hideAvatars && ourContact?.avatar ? '0' : '2';
   const bgColor = !hideAvatars && ourContact?.avatar ? '' : color;
   const profileImage =
@@ -62,8 +63,6 @@ const StatusBar = (props) => {
 
   const floatLeap =
     leapHighlight && window.matchMedia('(max-width: 550px)').matches;
-
-  const contact = useContactState((state) => state.contacts[`~${ship}`]);
 
   return (
     <Box
@@ -180,7 +179,11 @@ const StatusBar = (props) => {
                 <Text color='gray' fontWeight='500' mb='1'>
                   Set Status:
                 </Text>
-                <ProfileStatus contact={contact} ship={`~${ship}`} api={api} />
+                <ProfileStatus
+                  contact={ourContact}
+                  ship={`~${ship}`}
+                  api={api}
+                />
               </Row>
             </Col>
           }


### PR DESCRIPTION
- Correctly references `contacts` from the Zustand store in the header dropdown status-setter (the old one came from app root, which never refreshed and would result in out-of-sync statuses).
- Correctly aligns the "Save Profile" button to the text baseline of the other profile actions.

![image](https://user-images.githubusercontent.com/748181/110863185-4cc6dc80-828e-11eb-86ea-5fd9c90544db.png)
