### PR TITLE
graph-store signatures: turn them on and correctly validate them

### DIFF
--- a/pkg/arvo/lib/signatures.hoon
+++ b/pkg/arvo/lib/signatures.hoon
@@ -30,7 +30,7 @@
   ?~  lyf  %.y
   =+  %:  jael-scry
         ,deed=[a=life b=pass c=(unit @ux)]
-        our  %deed  now  /(scot %p q.signature)/(scot %ud p.signature)
+        our  %deed  now  /(scot %p q.signature)/(scot %ud r.signature)
       ==
   ?.  =(a.deed r.signature)  %.y
   ::  verify signature from ship at life

--- a/pkg/arvo/ted/graph/add-nodes.hoon
+++ b/pkg/arvo/ted/graph/add-nodes.hoon
@@ -88,10 +88,9 @@
   %_  node
     hash.post  `hash
   ::
-  ::  TODO: enable signing our own post as soon as we're ready
-  ::    signatures.post
-  ::  %-  ~(gas in *signatures:store)
-  ::  [(sign:sig our.bowl now.bowl hash)]~
+      signatures.post
+    %-  ~(gas in *signatures:store)
+    [(sign:sig our.bowl now.bowl hash)]~
   ::
       children
     ?:  ?=(%empty -.children.node)


### PR DESCRIPTION
As per @matildepark, waiting to put this in until closer to end of sprint. Can confirm that this works. I tested it on `~bolbex-fogdys` and `~tacryt-socryp` on livenet.