### PR TITLE
zuse: fix time fix regression

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5535,7 +5535,8 @@
     ::                                                  ::  ++unm:chrono:userlib
     ++  unm                                             ::  Urbit to Unix ms
       |=  a=@da
-      (div (mul (sub a ~1970.1.1) 1.000) ~s1)
+      =-  (div (mul - 1.000) ~s1)
+      (sub (add a (div ~s1 2.000)) ~1970.1.1)
     ::                                                  ::  ++unt:chrono:userlib
     ++  unt                                             ::  Urbit to Unix time
       |=  a=@da

--- a/pkg/arvo/tests/sys/zuse/format.hoon
+++ b/pkg/arvo/tests/sys/zuse/format.hoon
@@ -179,6 +179,11 @@
     %+  expect-eq
       !>  [%n '1000']
       !>  (time ~1970.1.1..0.0.1)
+    ::  timestamps should invert
+    ::
+    %+  expect-eq
+      !>  [%n '1001']
+      !>  (time (from-unix-ms:chrono:userlib 1.001))
     :: ship - store ship identity as a string
     ::
     %+  expect-eq


### PR DESCRIPTION
Fixes #4598.

#4474 made the JSON time conversion no longer invertible, which caused
problems for chat, which uses message timestamp in milliseconds as a key
— so chat would send a message with ms timestamp x, it would get
encoded as @da x, but then when it went back through the conversion to
milliseconds, it would often (not always) get encoded as x-1.

I still do not fully understand why this is — and why it doesn't seem
to be a problem with seconds based on cursory testing — but integer
multiplication and division generally do not invert. And adding a half a
millisecond to the input date before converting it resolves the issue
and makes the functions invertible.

I added a regression test, so hopefully the next courageous adventurer
who winds up here after wondering why `+unm` looks funny will have a
safeguard against some of the mistakes I made.