### PR TITLE
landscape profiles: tiny tweaks to visual elements

### DIFF
--- a/pkg/interface/src/views/apps/profile/components/Profile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/Profile.tsx
@@ -15,8 +15,8 @@ export function ProfileHeader(props: any): ReactElement {
   return (
     <Box
       border='1px solid'
-      borderColor='lightGray'
-      borderRadius='2'
+      borderColor='washedGray'
+      borderRadius='3'
       overflow='hidden'
       marginBottom='calc(64px + 2rem)'
     >
@@ -65,7 +65,7 @@ export function ProfileImages(props: any): ReactElement {
 
   return (
     <>
-      <Row ref={anchorRef} width='100%' height='300px' position='relative'>
+      <Row ref={anchorRef} width='100%' height='400px' position='relative'>
         {cover}
         <Center position='absolute' width='100%' height='100%'>
           {props.children}
@@ -74,7 +74,7 @@ export function ProfileImages(props: any): ReactElement {
       <Box
         height='128px'
         width='128px'
-        borderRadius='2'
+        borderRadius='3'
         overflow='hidden'
         position='absolute'
         left='50%'

--- a/pkg/interface/src/views/apps/profile/components/ViewProfile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/ViewProfile.tsx
@@ -39,7 +39,7 @@ export function ViewProfile(props: any): ReactElement {
       </ProfileHeader>
       <Row pb={2} alignItems='center' width='100%'>
         <Center width='100%'>
-          <Text>
+          <Text fontWeight='500'>
             {!hideNicknames && contact?.nickname ? contact.nickname : ''}
           </Text>
         </Center>
@@ -51,7 +51,7 @@ export function ViewProfile(props: any): ReactElement {
           </Text>
         </Center>
       </Row>
-      <Col pb={2} alignItems='center' justifyContent='center' width='100%'>
+      <Col pb={2} mt='3' alignItems='center' justifyContent='center' width='100%'>
         <Center flexDirection='column' maxWidth='32rem'>
           <RichText width='100%' disableRemoteContent>
             {contact?.bio ? contact.bio : ''}


### PR DESCRIPTION
Made a few tweaks to the current interface, some closer to designs, some just "better":

<img width="774" alt="Screen Shot 2021-03-12 at 6 40 14 PM" src="https://user-images.githubusercontent.com/1195363/111010285-0d6abf80-8364-11eb-8c40-1ed4c9ab15da.png">

List of Tweaks:

1. Increased Height of Header
2. Larger radii on header + avatar/sigil
3. UI-weight font weight for user-set name
4. Spacing between patp and bio matches space between username + avatar/sigil

Caveats:

I need to check out how these end up being applied to the mobile version of the interface. For example, I want to eliminate the border radii and border stroke on small viewports so the header is edge-to-edge.