### PR TITLE
ed: sidebar group avatar fix

### DIFF
--- a/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
+++ b/pkg/interface/src/views/landscape/components/MetadataIcon.tsx
@@ -15,7 +15,7 @@ export function MetadataIcon(props: MetadataIconProps) {
   const bgColor = metadata.picture ? {} : { bg: `#${uxToHex(metadata.color)}` };
 
   return (
-    <Box {...bgColor} {...rest} borderRadius={2} boxShadow="inset 0 0 0 1px" color="lightGray" overflow="hidden">
+    <Box {...bgColor} {...rest} borderRadius={1} boxShadow="inset 0 0 0 1px" color="lightGray" overflow="hidden">
       {metadata.picture && <Image height="100%" src={metadata.picture} />}
     </Box>
   );


### PR DESCRIPTION
This is a one character/variable change — editing the group avatar radius from `2` to `1`.

Whenever we have two radii'd elements near one another, in a nested manner, we want to always attempt to "drill down" from largest corner radius on the outside, with increasingly smaller radii applied to inner elements.