### PR TITLE
build: patch lmdb to use F_FULLFSYNC on darwin

### DIFF
--- a/nix/overlays/native.nix
+++ b/nix/overlays/native.nix
@@ -25,4 +25,15 @@ in {
     ldapSupport = false;
     brotliSupport = false;
   };
+
+  lmdb = prev.lmdb.overrideAttrs (attrs: {
+    patches =
+      if builtins.currentSystem != "x86_64-darwin"
+      then
+        attrs.patches
+      else
+        optionalList attrs.patches ++ [
+          ../pkgs/lmdb/darwin-fsync.patch
+        ];
+  });
 }

--- a/nix/overlays/native.nix
+++ b/nix/overlays/native.nix
@@ -28,12 +28,8 @@ in {
 
   lmdb = prev.lmdb.overrideAttrs (attrs: {
     patches =
-      if builtins.currentSystem != "x86_64-darwin"
-      then
-        attrs.patches
-      else
-        optionalList attrs.patches ++ [
-          ../pkgs/lmdb/darwin-fsync.patch
-        ];
+      optionalList attrs.patches ++ prev.lib.optional prev.stdenv.isDarwin [
+        ../pkgs/lmdb/darwin-fsync.patch
+      ];
   });
 }

--- a/nix/pkgs/lmdb/darwin-fsync.patch
+++ b/nix/pkgs/lmdb/darwin-fsync.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index fe65e30..0070215 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -2526,7 +2526,7 @@ mdb_env_sync(MDB_env *env, int force)
+ 					rc = ErrCode();
+ 			} else
+ #endif
+-			if (MDB_FDATASYNC(env->me_fd))
++			if (fcntl(env->me_fd, F_FULLFSYNC, 0))
+ 				rc = ErrCode();
+ 		}
+ 	}


### PR DESCRIPTION
This is a (presumed) fix for the (presumed) event log corruption observed in #4605 (see the [fsync man page for MacOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fsync.2.html)).

@brendanhay, plz review for general nix sanity.

Also, do you have any idea how i would apply a platform-specific patch to  `pkg/hs/lmdb-static/cbits/`? (Alternately, we could just warn people off of `urbit-king` on MacOS until the log is moved.)