### PR TITLE
king: commit seppuku when server is out of fds, also setrlimit allowing for more fds

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -704,9 +704,13 @@ main = do
       Sys.installHandler sig (Sys.Catch onKillSig) Nothing
 
   setRLimits = do
-    nofiles <- Sys.getResourceLimit Sys.ResourceOpenFiles
+    openFiles <- Sys.getResourceLimit Sys.ResourceOpenFiles
+    let soft = case Sys.hardLimit openFiles of
+          Sys.ResourceLimit lim     -> Sys.ResourceLimit lim
+          Sys.ResourceLimitInfinity -> Sys.ResourceLimit 10240  -- macOS
+          Sys.ResourceLimitUnknown  -> Sys.ResourceLimit 10240
     Sys.setResourceLimit Sys.ResourceOpenFiles
-      nofiles { Sys.softLimit = Sys.ResourceLimit 10240 }
+      openFiles { Sys.softLimit = soft }
 
   verboseLogging :: CLI.Cmd -> Bool
   verboseLogging = \case

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
@@ -363,7 +363,7 @@ eyre env who plan isFake stderr sub = (initialEvents, runHttpServer)
     logInfo "Restarting http server"
     let onFatal = runRIO env $ do
           -- XX instead maybe restart following logic under HSESetConfig below
-          stderr "You've been DDoSed. Please restart your ship."
+          stderr "A web server problem has occurred. Please restart your ship."
           view killKingActionL >>= atomically
     let startAct = startServ who isFake conf plan stderr onFatal sub
     res <- fromEither =<< restartService var startAct kill

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre.hs
@@ -11,7 +11,11 @@ where
 import Urbit.Prelude hiding (Builder)
 
 import Urbit.Arvo                hiding (ServerId, reqUrl)
-import Urbit.King.App            (HasKingId(..), HasMultiEyreApi(..), HasPierEnv(..))
+import Urbit.King.App            ( killKingActionL
+                                 , HasKingId(..)
+                                 , HasMultiEyreApi(..)
+                                 , HasPierEnv(..)
+                                 )
 import Urbit.King.Config
 import Urbit.Vere.Eyre.Multi
 import Urbit.Vere.Eyre.PortsFile
@@ -177,9 +181,10 @@ startServ
   -> HttpServerConf
   -> (EvErr -> STM ())
   -> (Text -> RIO e ())
+  -> IO ()
   -> KingSubsite
   -> RIO e Serv
-startServ who isFake conf plan stderr sub = do
+startServ who isFake conf plan stderr onFatal sub = do
   logInfo (displayShow ("EYRE", "startServ"))
 
   multi <- view multiEyreApiL
@@ -228,7 +233,7 @@ startServ who isFake conf plan stderr sub = do
   atomically (joinMultiEyre multi who mCre onReq onKilReq sub)
 
   logInfo $ displayShow ("EYRE", "Starting loopback server")
-  lop <- serv vLive $ ServConf
+  lop <- serv vLive onFatal $ ServConf
     { scHost = soHost (pttLop ptt)
     , scPort = soWhich (pttLop ptt)
     , scRedi = Nothing
@@ -240,7 +245,7 @@ startServ who isFake conf plan stderr sub = do
     }
 
   logInfo $ displayShow ("EYRE", "Starting insecure server")
-  ins <- serv vLive $ ServConf
+  ins <- serv vLive onFatal $ ServConf
     { scHost = soHost (pttIns ptt)
     , scPort = soWhich (pttIns ptt)
     , scRedi = secRedi
@@ -253,7 +258,7 @@ startServ who isFake conf plan stderr sub = do
 
   mSec <- for mTls $ \tls -> do
     logInfo "Starting secure server"
-    serv vLive $ ServConf
+    serv vLive onFatal $ ServConf
       { scHost = soHost (pttSec ptt)
       , scPort = soWhich (pttSec ptt)
       , scRedi = Nothing
@@ -356,7 +361,11 @@ eyre env who plan isFake stderr sub = (initialEvents, runHttpServer)
   restart :: Drv -> HttpServerConf -> RIO e Serv
   restart (Drv var) conf = do
     logInfo "Restarting http server"
-    let startAct = startServ who isFake conf plan stderr sub
+    let onFatal = runRIO env $ do
+          -- XX instead maybe restart following logic under HSESetConfig below
+          stderr "You've been DDoSed. Please restart your ship."
+          view killKingActionL >>= atomically
+    let startAct = startServ who isFake conf plan stderr onFatal sub
     res <- fromEither =<< restartService var startAct kill
     logInfo "Done restating http server"
     pure res

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Eyre/Multi.hs
@@ -75,8 +75,8 @@ leaveMultiEyre MultiEyreApi {..} who = do
   modifyTVar' meaTlsC (deleteMap who)
   modifyTVar' meaSite (deleteMap who)
 
-multiEyre :: HasLogFunc e => MultiEyreConf -> RIO e MultiEyreApi
-multiEyre conf@MultiEyreConf {..} = do
+multiEyre :: HasLogFunc e => IO () -> MultiEyreConf -> RIO e MultiEyreApi
+multiEyre onFatal conf@MultiEyreConf {..} = do
   logInfo (displayShow ("EYRE", "MULTI", conf))
 
   vLive <- io emptyLiveReqs >>= newTVarIO
@@ -108,7 +108,7 @@ multiEyre conf@MultiEyreConf {..} = do
 
   mIns <- for mecHttpPort $ \por -> do
     logInfo (displayShow ("EYRE", "MULTI", "HTTP", por))
-    serv vLive $ ServConf
+    serv vLive onFatal $ ServConf
       { scHost = host
       , scPort = SPChoices $ singleton $ fromIntegral por
       , scRedi = Nothing -- TODO
@@ -121,7 +121,7 @@ multiEyre conf@MultiEyreConf {..} = do
 
   mSec <- for mecHttpsPort $ \por -> do
     logInfo (displayShow ("EYRE", "MULTI", "HTTPS", por))
-    serv vLive $ ServConf
+    serv vLive onFatal $ ServConf
       { scHost = host
       , scPort = SPChoices $ singleton $ fromIntegral por
       , scRedi = Nothing


### PR DESCRIPTION
Following joe's suggested response to #4530, we shut down the king when the http server is saturated with requests, as an alternative to getting the server permanently stuck in a state where it cannot accept new connections.

To make this condition far less likely, we increase the resource cap on file descriptors from 256 to 10240 (the value of OPEN_MAX, at least on darwin).

In the long run, we should probably try to restart the http server rather than shut down the king, or selectively go through and terminate specific requests.