### PR TITLE
interface: remove referrer headers from img tags

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -370,8 +370,8 @@ export const MessageAuthor = ({
     .unix(msg['time-sent'] / 1000)
     .format(DATESTAMP_FORMAT);
   const contact =
-    ( ( (msg.author === window.ship && showOurContact) || 
-         msg.author !== window.ship) && 
+    ( ( (msg.author === window.ship && showOurContact) ||
+         msg.author !== window.ship) &&
       `~${msg.author}` in contacts
     ) ? contacts[`~${msg.author}`] : false;
 
@@ -416,6 +416,7 @@ export const MessageAuthor = ({
     contact?.avatar && !hideAvatars ? (
       <BaseImage
         display='inline-block'
+        referrerPolicy="no-referrer"
         style={{ objectFit: 'cover' }}
         src={contact.avatar}
         height={24}

--- a/pkg/interface/src/views/apps/profile/components/Profile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/Profile.tsx
@@ -40,6 +40,7 @@ export function ProfileImages(props: any): ReactElement {
         src={contact.cover}
         width='100%'
         height='100%'
+        referrerPolicy="no-referrer"
         style={{ objectFit: 'cover' }}
       />
     ) : (
@@ -57,6 +58,7 @@ export function ProfileImages(props: any): ReactElement {
         src={contact.avatar}
         width='100%'
         height='100%'
+        referrerPolicy="no-referrer"
         style={{ objectFit: 'cover' }}
       />
     ) : (

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -52,6 +52,7 @@ export default function Author(props: AuthorProps): ReactElement {
   const img =
     contact?.avatar && !hideAvatars ? (
       <BaseImage
+        referrerPolicy="no-referrer"
         display='inline-block'
         src={contact.avatar}
         style={{ objectFit: 'cover' }}

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -82,6 +82,7 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
     const img =
       contact?.avatar && !hideAvatars ? (
         <BaseImage
+          referrerPolicy="no-referrer"
           display='inline-block'
           style={{ objectFit: 'cover' }}
           src={contact.avatar}

--- a/pkg/interface/src/views/components/RemoteContent.tsx
+++ b/pkg/interface/src/views/components/RemoteContent.tsx
@@ -168,6 +168,7 @@ return;
       return this.wrapInLink(
         <BaseImage
           {...(noCors ? {} : { crossOrigin: "anonymous" })}
+          referrerPolicy="no-referrer"
           flexShrink={0}
           src={url}
           style={style}

--- a/pkg/interface/src/views/components/RichText.js
+++ b/pkg/interface/src/views/components/RichText.js
@@ -37,7 +37,7 @@ const RichText = React.memo(({ disableRemoteContent, ...props }) => (
           return <RemoteContent className="mw-100" url={linkProps.href} />;
         }
 
-        return <Anchor display="inline" target='_blank' rel='noreferrer noopener' borderBottom='1px solid' remoteContentPolicy={remoteContentPolicy} {...linkProps}>{linkProps.children}</Anchor>;
+        return <Anchor display="inline" target='_blank' referrerPolicy='noreferrer noopener' borderBottom='1px solid' remoteContentPolicy={remoteContentPolicy} {...linkProps}>{linkProps.children}</Anchor>;
       },
       linkReference: (linkProps) => {
         const linkText = String(linkProps.children[0].props.children);

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -88,7 +88,7 @@ export function SidebarItem(props: {
 
   if (urbitOb.isValidPatp(title)) {
     if (contacts?.[title]?.avatar && !hideAvatars) {
-      img = <BaseImage src={contacts[title].avatar} width='16px' height='16px' borderRadius={2} />;
+      img = <BaseImage referrerPolicy="no-referrer" src={contacts[title].avatar} width='16px' height='16px' borderRadius={2} />;
     } else {
       img = <Sigil ship={title} color={`#${uxToHex(contacts?.[title]?.color || '0x0')}`} icon padding={2} size={16} />;
     }


### PR DESCRIPTION
In response to an unfiled bug on display in UC last weekend.

<img width="366" alt="image" src="https://user-images.githubusercontent.com/20846414/111391377-e295a980-868a-11eb-934b-f7e30e4d3da2.png">
