### PR TITLE
hoon: update seminoun bunt to be fully blocked

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6627,7 +6627,7 @@
 +$  seminoun
   ::  partial noun; blocked subtrees are ~
   ::
-  $~  [[%full ~] ~]
+  $~  [[%full / ~ ~] ~]
   [mask=stencil data=noun]
 ::
 ::  +stencil: noun knowledge map


### PR DESCRIPTION
The current default `seminoun` is wrong, given the pattern of bunting batteries in `+play:ut`.