### PR TITLE
hoon: strip faces in =^

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -944,8 +944,9 @@
           =^  lab  sac  (~(spot wa sac) 7 vax)
           $(vax lab)
         ::
-        ?>  ?=(?(%pass %give) -.p.bal)
-        [[%hurl goof p.bal] sac]
+        ~!  bal
+        ?>  ?=(?(%pass %give) -.bal)
+        [[%hurl goof bal] sac]
       ==
     ::  +refine-card: card from vase
     ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8637,12 +8637,12 @@
       [%tsdt p.gen [%wtcl q.gen r.gen [%wing p.gen]] s.gen]
     ::
         [%tskt *]                                       ::                  =^
-      =+  wuy=(weld q.gen `wing`[%v ~])                 ::
       :+  %tsgr  [%ktts %v %$ 1]                        ::  =>  v=.
       :+  %tsls  [%ktts %a %tsgr [%limb %v] r.gen]      ::  =+  a==>(v \r.gen)
-      :^  %tsdt  wuy  [%tsgl [%$ 3] [%limb %a]]
+      :^  %tsdt  (weld q.gen `wing`[%v ~])
+        [%tsgr [%limb %a] [%wing [|+[0 ~] &+3 ~]]]
       :+  %tsgr  :-  :+  %ktts  [%over [%v ~] p.gen]
-                     [%tsgl [%$ 2] [%limb %a]]
+                     [%tsgr [%limb %a] [%wing [|+[0 ~] &+2 ~]]]
                  [%limb %v]
       s.gen
     ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3141,7 +3141,7 @@
     ^+  message-sink
     ::
     =^  pending  pending-vane-ack.state  ~(get to pending-vane-ack.state)
-    =/  =message-num  message-num.p.pending
+    =/  =message-num  message-num.pending
     ::
     =.  last-acked.state  +(last-acked.state)
     =?  nax.state  !ok  (~(put in nax.state) message-num)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1224,7 +1224,7 @@
         ?:  =(~ queue)
           events
         =^  head  queue  ~(get to queue)
-        =,  p.head
+        =,  head
         ::NOTE  these will only fail if the mark and/or json types changed,
         ::      since conversion failure also gets caught during first receive.
         ::      we can't do anything about this, so consider it unsupported.


### PR DESCRIPTION
This PR is a proposal for a minor behavior change in the `=^` rune.

The current macro expansion has something like:

```
=>  a=foo
=^  b  a  bar
baz
```

```
=>  a=foo
=/  x=bar
=/  b  -.x
=.  a  +.x
baz
=
```

The use of `=.` means that any outer face in the tail of (the product of) `bar` is stripped -- `=.` expands to `%_` which uses a cast-by-example (`^+`). But the outer face  of the head of (the product of) `bar` is preserved inside `b`.

With this change, both faces are stripped (if present). This PR is a draft, as the proposal has been more controversial than anticipated.