### PR TITLE
king: remove the "hardware femtosecond clock"

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
@@ -604,7 +604,7 @@ processWork serf maxSize q onResp spin = do
       Nothing -> do
         atomically (writeTVar vDone True)
       Just evErr@(EvErr ev _) -> do
-        now <- Time.now
+        now <- Time.chop <$> Time.now
         let cb = onResp now evErr
         atomically $ modifyTVar' vInFlight (:|> (ev, cb))
         sendWrit serf (WWork 0 now ev)

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Serf/IPC.hs
@@ -604,7 +604,7 @@ processWork serf maxSize q onResp spin = do
       Nothing -> do
         atomically (writeTVar vDone True)
       Just evErr@(EvErr ev _) -> do
-        now <- Time.chop <$> Time.now
+        now <- Time.now
         let cb = onResp now evErr
         atomically $ modifyTVar' vInFlight (:|> (ev, cb))
         sendWrit serf (WWork 0 now ev)

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Time.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Time.hs
@@ -149,3 +149,9 @@ gap (Wen x) (Wen y) | x > y     = x - y
 
 addGap :: Wen -> Gap -> Wen
 addGap (Wen x) y = Wen (x+y)
+
+-- | Produce a Wen with precision compatible to that from vere's time.c
+chop :: Wen -> Wen
+chop (Wen (Gap g)) = Wen (Gap (mop g))
+  where
+      mop n = shiftL (shiftR n 48) 48


### PR DESCRIPTION
Fix for #4562.

Although hardware does not have a femtosecond clock, it does have a nanosecond clock (or at least that's the precision that Haskell purports to give). The problem is that, while nanoseconds are by definition given as a decimal fraction of seconds, urbit's "fractoseconds" are given as a *binary* fraction, and decimal fractions do not divide evenly into binary fractions. The result is that one nanosecond after 1970 is

```
~1970.1.1..00.00.00..0000.0004.4b82.fa09
```

as a `@da`. Arguably, this is the most accurate way to represent the time data coming out of the king, so, in my view, that level of precision should be kept internally in the `Gap` type, and any transformation we do for compatibility should be done at the interface between Haskell and the serf (which is what I do in this pr).

If we wanted to be "scientific" about our decimal (well really, hexidecimal) point, we'd truncate the above date to

```
~1970.1.1..00.00.00..0000.0004
```

but for compatibility with vere, I'm happy to chop off the 0004 too.

Now time.c effects the transformation from microseconds (yes) to fractoseconds via

```
((usc_d * 65536ULL) / 1000000ULL) << 48ULL
```

but Time.hs effects the transformation from *seconds to fractoseconds via

```
(shiftL ds 64) `div` denom
```

where denom is e.g. 1_000_000_000 for nanos. So the function for loosing the extra bits is

\n -> shiftL (shiftR n 48) 48