### PR TITLE
hark: eliminate chatmessage hover backgrounds

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -207,7 +207,7 @@ const MessageWrapper = (props) => {
     <Box
       py='1'
       backgroundColor={
-        hovering && props.hoverMarker !== false ? 'washedGray' : 'transparent'
+        hovering && !props.hideHover ? 'washedGray' : 'transparent'
       }
       position='relative'
       {...bind}
@@ -235,7 +235,7 @@ interface ChatMessageProps {
   api: GlobalApi;
   highlighted?: boolean;
   renderSigil?: boolean;
-  hoverMarker?: boolean;
+  hideHover?: boolean;
   innerRef: (el: HTMLDivElement | null) => void;
 }
 
@@ -268,7 +268,7 @@ class ChatMessage extends Component<ChatMessageProps> {
       highlighted,
       showOurContact,
       fontSize,
-      hoverMarker
+      hideHover
     } = this.props;
 
     let { renderSigil } = this.props;
@@ -306,7 +306,7 @@ class ChatMessage extends Component<ChatMessageProps> {
       scrollWindow,
       highlighted,
       fontSize,
-      hoverMarker
+      hideHover
     };
 
     const unreadContainerStyle = {

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -206,7 +206,9 @@ const MessageWrapper = (props) => {
   return (
     <Box
       py='1'
-      backgroundColor={hovering ? 'washedGray' : 'transparent'}
+      backgroundColor={
+        hovering && props.hoverMarker !== false ? 'washedGray' : 'transparent'
+      }
       position='relative'
       {...bind}
     >
@@ -233,6 +235,7 @@ interface ChatMessageProps {
   api: GlobalApi;
   highlighted?: boolean;
   renderSigil?: boolean;
+  hoverMarker?: boolean;
   innerRef: (el: HTMLDivElement | null) => void;
 }
 
@@ -264,7 +267,8 @@ class ChatMessage extends Component<ChatMessageProps> {
       api,
       highlighted,
       showOurContact,
-      fontSize
+      fontSize,
+      hoverMarker
     } = this.props;
 
     let { renderSigil } = this.props;
@@ -301,7 +305,8 @@ class ChatMessage extends Component<ChatMessageProps> {
       api,
       scrollWindow,
       highlighted,
-      fontSize
+      fontSize,
+      hoverMarker
     };
 
     const unreadContainerStyle = {
@@ -370,10 +375,11 @@ export const MessageAuthor = ({
     .unix(msg['time-sent'] / 1000)
     .format(DATESTAMP_FORMAT);
   const contact =
-    ( ( (msg.author === window.ship && showOurContact) ||
-         msg.author !== window.ship) &&
-      `~${msg.author}` in contacts
-    ) ? contacts[`~${msg.author}`] : false;
+    ((msg.author === window.ship && showOurContact) ||
+      msg.author !== window.ship) &&
+    `~${msg.author}` in contacts
+      ? contacts[`~${msg.author}`]
+      : false;
 
   const showNickname = useShowNickname(contact);
   const { hideAvatars } = useSettingsState(selectCalmState);
@@ -416,7 +422,7 @@ export const MessageAuthor = ({
     contact?.avatar && !hideAvatars ? (
       <BaseImage
         display='inline-block'
-        referrerPolicy="no-referrer"
+        referrerPolicy='no-referrer'
         style={{ objectFit: 'cover' }}
         src={contact.avatar}
         height={24}

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -32,7 +32,7 @@ const FilterBox = styled(Box)`
   background: linear-gradient(
     to bottom,
     transparent,
-    ${p => p.theme.colors.white}
+    ${(p) => p.theme.colors.white}
   );
 `;
 
@@ -81,9 +81,7 @@ const GraphNodeContent = ({
       const [{ text }, { url }] = contents;
       return <GraphUrl title={text} url={url} />;
     } else if (idx.length === 3) {
-      return (
-        <MentionText content={contents} group={group} />
-      );
+      return <MentionText content={contents} group={group} />;
     }
     return null;
   }
@@ -138,6 +136,7 @@ const GraphNodeContent = ({
           msg={post}
           fontSize='0'
           pt='2'
+          hoverMarker={false}
         />
       </Row>
     );
@@ -182,11 +181,11 @@ const GraphNode = ({
   group,
   read,
   onRead,
-  showContact = false,
+  showContact = false
 }) => {
   author = deSig(author);
   const history = useHistory();
-  const contacts = useContactState(state => state.contacts);
+  const contacts = useContactState((state) => state.contacts);
 
   const nodeUrl = getNodeUrl(mod, group?.hidden, groupPath, graph, index);
 
@@ -198,17 +197,15 @@ const GraphNode = ({
   }, [read, onRead]);
 
   const showNickname = useShowNickname(contacts?.[`~${author}`]);
-  const nickname = (contacts?.[`~${author}`]?.nickname && showNickname) ? contacts[`~${author}`].nickname : cite(author);
+  const nickname =
+    contacts?.[`~${author}`]?.nickname && showNickname
+      ? contacts[`~${author}`].nickname
+      : cite(author);
   return (
     <Row onClick={onClick} gapX='2' pt={showContact ? 2 : 0}>
       <Col flexGrow={1} alignItems='flex-start'>
         {showContact && (
-          <Author
-            showImage
-            ship={author}
-            date={time}
-            group={group}
-          />
+          <Author showImage ship={author} date={time} group={group} />
         )}
         <Row width='100%' p='1' flexDirection='column'>
           <GraphNodeContent
@@ -249,7 +246,7 @@ export function GraphNotification(props: {
     return api.hark['read'](timebox, { graph: index });
   }, [api, timebox, index, read]);
 
-  const groups = useGroupState(state => state.groups);
+  const groups = useGroupState((state) => state.groups);
 
   return (
     <>

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -136,7 +136,7 @@ const GraphNodeContent = ({
           msg={post}
           fontSize='0'
           pt='2'
-          hoverMarker={false}
+          hideHover={true}
         />
       </Row>
     );


### PR DESCRIPTION
Adds an optional `hoverMarker` prop to `ChatMessage`. When set, this hides the washedGray hover background. We then use this in the Notifications view, where we want to prevent the gray background from appearing until we get through the detailed refactor coming from @g-a-v-i-n.

Pointed out by @matildepark , no corresponding Landscape issue.