### PR TITLE
hark: kill incorrect count reporting

### DIFF
--- a/pkg/arvo/app/hark-store.hoon
+++ b/pkg/arvo/app/hark-store.hoon
@@ -293,7 +293,7 @@
       ~(tap by unreads-count)
     |=  [=stats-index:store count=@ud]
     :*  stats-index
-        ~(wyt in (~(gut by by-index) stats-index ~))
+        (~(gut by by-index) stats-index ~)
         [%count count]
         (~(gut by last-seen) stats-index *time)
     ==
@@ -304,7 +304,7 @@
       ~(tap by unreads-each)
     |=  [=stats-index:store indices=(set index:graph-store)]
     :*  stats-index
-        ~(wyt in (~(gut by by-index) stats-index ~))
+        (~(gut by by-index) stats-index ~)
         [%each indices]
         (~(gut by last-seen) stats-index *time)
     ==
@@ -317,7 +317,7 @@
       ~
     :-  ~
     :*  stats-index
-        ~(wyt in nots)
+        nots
         [%count 0]
         *time
     ==

--- a/pkg/arvo/lib/hark/store.hoon
+++ b/pkg/arvo/lib/hark/store.hoon
@@ -151,7 +151,7 @@
       ^-  json
       %-  pairs
       :~  unreads+(unread unreads.s)
-          notifications+(numb notifications.s)
+          notifications+a+(turn ~(tap in notifications.s) notif-ref)
           last+(time last-seen.s)
       ==
     ++  added

--- a/pkg/arvo/sur/hark-store.hoon
+++ b/pkg/arvo/sur/hark-store.hoon
@@ -150,7 +150,7 @@
   [index notification]
 ::
 +$  stats
-  [notifications=@ud =unreads last-seen=@da]
+  [notifications=(set [time index]) =unreads last-seen=@da]
 ::
 +$  unreads
   $%  [%count num=@ud]

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -9855,6 +9855,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -9921,6 +9922,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }

--- a/pkg/npm/api/hark/types.ts
+++ b/pkg/npm/api/hark/types.ts
@@ -1,13 +1,19 @@
 import { Post } from "../graph/types";
 import { GroupUpdate } from "../groups/types";
 import BigIntOrderedMap from "../lib/BigIntOrderedMap";
+import {BigInteger} from "big-integer";
 
 export type GraphNotifDescription = "link" | "comment" | "note" | "mention" | "message";
 
 export interface UnreadStats {
   unreads: Set<string> | number;
-  notifications: number;
+  notifications: NotifRef[];
   last: number;
+}
+
+interface NotifRef {
+  time: BigInteger;
+  index: NotifIndex;
 }
 
 export interface GraphNotifIndex {


### PR DESCRIPTION
When we receive a notification, it might not affect our count because
it’ll get merged on the server side, but we unconditionally increment
our count on the client if the notification hasn’t been loaded yet.
Addresses this by storing a set of time, index so we can compute whether
or not the notification is merged or unloaded and change the count
accordingly. Calculates the notificationsCount as derived state, instead of independently updated state

Fixes urbit/landscape#276
