### PR TITLE
u3: reallocate hot jet state before gc in meld and cram

### DIFF
--- a/pkg/urbit/noun/urth.c
+++ b/pkg/urbit/noun/urth.c
@@ -401,13 +401,16 @@ _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
   //
   _cu_all_to_loom(rot_u, ken, &cod_u);
 
+  //  allocate new hot jet state
+  //
+  u3j_boot(c3y);
+
   //  establish correct refcounts via tracing
   //
   u3m_grab(u3_none);
 
-  //  allocate new hot jet state; re-establish warm
+  //  re-establish warm jet state
   //
-  u3j_boot(c3y);
   u3j_ream();
 
   //  restore event number


### PR DESCRIPTION
This PR fixes a (possible) crash in `|meld` and `urbit-worker cram pier`. Both operations involve reallocating all persistent state off-loom, and then copying it back onto the loom (which btw, is unnecessary in the case of `cram`). Loom refcounts are fixed-up by a gc pass, but that includes a read of uninitialized memory (the hot jet state) due to the order of operations.