### PR TITLE
metadata-push-hook: do not crash on new hidden metadata

### DIFF
--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -65,7 +65,7 @@
   =/  role=(unit (unit role-tag))
     (role-for-ship:grp group.update src.bowl)
   =/  =metadatum:store
-    (need (peek-metadatum:met %groups group.update))
+    (fall (peek-metadatum:met %groups group.update) *metadatum:store)
   ?~  role  ~
   ?^  u.role  
     ?:  ?=(?(%admin %moderator) u.u.role)


### PR DESCRIPTION
If we were creating a DM, for which no %groups metadata exists, the
+transform-proxy-update arm would crash, preventing the creation of new
DMs.