### PR TITLE
interface/gcp: stop polling for gcp store config

### DIFF
--- a/pkg/interface/src/logic/lib/gcpManager.ts
+++ b/pkg/interface/src/logic/lib/gcpManager.ts
@@ -76,7 +76,8 @@ class GcpManager {
           if (this.isConfigured()) {
             this.refreshLoop();
           } else {
-            this.refreshAfter(10_000);
+            console.log('GcpManager: GCP storage not configured; stopping.');
+            this.stop();
           }
         })
         .catch((reason) => {


### PR DESCRIPTION
We polled on -gcp-is-configured before, so that if the store got
configured, Landscape would get a token without needing a browser
refresh. But the resulting POSTs were bothersome, so now we only check
once and stop if GCP store doesn't seem to be configured.

We could check 0 times (and delete -gcp-is-configured), but this has
problems. Mainly:

- there would be no way to tell whether GCP store was unconfigured or
  misconfigured

- if -gcp-get-token failed intermittently (e.g. the token-uri was down
  for a moment), we would not get a token for that session.

We may want to make GCP store into a Gall app of its own, so we can get
updates from it for free. Or else perhaps key off of the presence of the
store config in settings-store or something. But for now, this
fixes urbit/landscape#583.