### PR TITLE
meta: only build ci if changing arvo, vere, king

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,17 @@
 
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'pkg/arvo'
+      - 'pkg/hs'
+      - 'pkg/urbit'
+  pull_request:
+    paths:
+      - 'pkg/arvo'
+      - 'pkg/hs'
+      - 'pkg/urbit'
 
 jobs:
   urbit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,15 @@ on:
       - 'pkg/arvo'
       - 'pkg/hs'
       - 'pkg/urbit'
+      - 'bin'
+      - 'nix'
   pull_request:
     paths:
       - 'pkg/arvo'
       - 'pkg/hs'
       - 'pkg/urbit'
+      - 'bin'
+      - 'nix'
 
 jobs:
   urbit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,22 @@ on:
   push:
     paths:
       - 'pkg/arvo'
+      - 'pkg/docker-image'
+      - 'pkg/ent'
+      - 'pkg/ge-additions'
       - 'pkg/hs'
+      - 'pkg/libaes_siv'
       - 'pkg/urbit'
       - 'bin'
       - 'nix'
   pull_request:
     paths:
       - 'pkg/arvo'
+      - 'pkg/docker-image'
+      - 'pkg/ent'
+      - 'pkg/ge-additions'
       - 'pkg/hs'
+      - 'pkg/libaes_siv'
       - 'pkg/urbit'
       - 'bin'
       - 'nix'


### PR DESCRIPTION
Part 1 of a "CI specificity" series — 

In userspace we often have JS-specific changes that are just hanging on CI for a long period of time. They don't need to be in CI, and they clog up the queue. This only runs the build CI if we're changing files in pkg/arvo, pkg/hs or pkg/urbit in the push.

Could use a looksee because I am unsure how to test the change, though I noticed the first time I pushed this change there was a fail because of a typo, and I fixed the typo and it just didn't run on the force push, so presumably it worked.