### PR TITLE
eyre: clean up connection in ++discard-channel

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec80a42446a1d80974f32bf87283435547441cb7ea3fcd340711df2ce6cbec81
-size 9146390
+oid sha256:3ede4eb20efd43173d4027c9353bb5c0e0135af638ce97a50b5f2ea6f1ff446d
+size 9197174

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1706,7 +1706,8 @@
       (snoc http-moves (set-heartbeat-move channel-id heartbeat-time))
     ::  +discard-channel: remove a channel from state
     ::
-    ::    cleans up state, timers, and gall subscriptions of the channel
+    ::    cleans up state, timers, gall subscriptions, and connection
+    ::    of the channel
     ::
     ++  discard-channel
       |=  [channel-id=@t expired=?]
@@ -1725,6 +1726,9 @@
               duct-to-key.channel-state
             ?.  ?=(%| -.state.session)  duct-to-key.channel-state.state
             (~(del by duct-to-key.channel-state.state) p.state.session)
+          ::
+              connections
+            (~(del by connections.state) p.state.session)
           ==
       =/  heartbeat-cancel=(list move)
         ?~  heartbeat.session  ~


### PR DESCRIPTION
Fixes #4617.

The next step is to do some `+load` magic in eyre to get rid of all the outstanding connections people have because of this bug.