### PR TITLE
chat: prevent input overflow offscreen

### DIFF
--- a/pkg/interface/src/views/apps/chat/css/custom.css
+++ b/pkg/interface/src/views/apps/chat/css/custom.css
@@ -168,6 +168,7 @@ blockquote {
 }
 .chat .react-codemirror2 {
   width: 100%;
+  height: 100%;
 }
 
 .chat .CodeMirror {
@@ -184,6 +185,18 @@ blockquote {
 
 .chat .cm-s-tlon.CodeMirror {
   font-size: 14px;
+}
+
+.chat .CodeMirror-scroll {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
+.chat .CodeMirror-sizer {
+  min-height: 0 !important;
+  max-height: 100%;
 }
 
 .chat.code .react-codemirror2 .CodeMirror * {


### PR DESCRIPTION
Overrides CodeMirror defaults in custom CSS to prevent its sizer from min-heighting offscreen and uses flexbox to keep the text input vertically centred.

![Mar-25-2021 12-28-10](https://user-images.githubusercontent.com/20846414/112508125-a4bd1300-8d65-11eb-87ef-c6f69ee1b0fd.gif)

Please please please try to break it with long long input. Tested on Firefox.

Fixes urbit/landscape#632