### PR TITLE
push-hook: add version scries

### DIFF
--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -335,9 +335,11 @@
         ^-  (unit (unit cage))
         ?:  =(/x/dbug/state path)
           ``noun+(slop !>(state(inner-state *vase)) on-save:og)
-        ?.  =(/x/sharing path)
-          (on-peek:og path)
-        ``noun+!>(sharing)
+        ?+  path  (on-peek:og path)
+          [%x %sharing ~]  ``noun+!>(sharing)
+          [%x %version ~]  ``version+!>(version.config)
+          [%x %min-version ~]  ``version+!>(version.config)
+        ==
     --
   |_  =bowl:gall
   +*  og   ~(. push-hook bowl)

--- a/pkg/arvo/mar/version.hoon
+++ b/pkg/arvo/mar/version.hoon
@@ -3,6 +3,7 @@
 ++  grow
   |%
   ++  noun  ver
+  ++  json  (numb:enjs:format ver)
   --
 ++  grab
   |%


### PR DESCRIPTION
Allows airlock libraries and other local stores to negotiate versioning better