### PR TITLE
vere: add -b to specify http server bind ip

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -99,7 +99,7 @@ _main_getopt(c3_i argc, c3_c** argv)
   u3_Host.ops_u.kno_w = DefaultKernel;
 
   while ( -1 != (ch_i=getopt(argc, argv,
-                 "X:Y:G:J:B:K:A:H:I:C:w:u:e:F:k:n:p:r:i:Z:LljacdgqstvxPDRS")) )
+                 "X:Y:G:J:B:b:K:A:H:I:C:w:u:e:F:k:n:p:r:i:Z:LljacdgqstvxPDRS")) )
   {
     switch ( ch_i ) {
       case 'X': {
@@ -120,6 +120,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 'B': {
         u3_Host.ops_u.pil_c = strdup(optarg);
+        break;
+      }
+      case 'b': {
+        u3_Host.ops_u.bin_c = strdup(optarg);
         break;
       }
       case 'G': {
@@ -302,6 +306,12 @@ _main_getopt(c3_i argc, c3_c** argv)
     return c3n;
   }
 
+  struct sockaddr_in t;
+  if ( u3_Host.ops_u.bin_c != 0 && inet_aton(u3_Host.ops_u.bin_c, &t.sin_addr) == 0 ) {
+    fprintf(stderr, "-b invalid IP address\n");
+    return c3n;
+  }
+
   if ( u3_Host.ops_u.nuu != c3y && u3_Host.ops_u.dns_c != 0) {
     fprintf(stderr, "-H only makes sense when bootstrapping a new instance\n");
     return c3n;
@@ -402,6 +412,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "\n",
     "-A dir        Use dir for initial clay sync\n",
     "-B pill       Bootstrap from this pill\n",
+    "-b ip         Bind HTTP server to this IP address\n",
     "-C limit      Set memo cache max size; 0 means uncapped\n",
     "-c pier       Create a new urbit in pier/\n",
     "-D            Recompute from events\n",

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -256,6 +256,7 @@
         c3_c*   arv_c;                      //  -A, initial sync from
         c3_o    abo;                        //  -a, abort aggressively
         c3_c*   pil_c;                      //  -B, bootstrap from
+        c3_c*   bin_c;                      //  -b, http server bind ip
         c3_o    nuu;                        //  -c, new pier
         c3_o    dry;                        //  -D, dry compute, no checkpoint
         c3_o    dem;                        //  -d, daemon

--- a/pkg/urbit/vere/io/http.c
+++ b/pkg/urbit/vere/io/http.c
@@ -1467,6 +1467,10 @@ _http_serv_start(u3_http* htp_u)
                           htonl(INADDR_LOOPBACK) :
                           INADDR_ANY;
 
+  if ( 0 != u3_Host.ops_u.bin_c && c3n == htp_u->lop ) {
+    inet_aton(u3_Host.ops_u.bin_c, &adr_u.sin_addr);
+  }
+
   uv_tcp_init(u3L, &htp_u->wax_u);
 
   /*  Try ascending ports.
@@ -1480,6 +1484,10 @@ _http_serv_start(u3_http* htp_u)
                                    (const struct sockaddr*)&adr_u, 0)) ||
          0 != (sas_i = uv_listen((uv_stream_t*)&htp_u->wax_u,
                                  TCP_BACKLOG, _http_serv_listen_cb)) ) {
+      if ( UV_EADDRNOTAVAIL == sas_i ) {
+        u3l_log("http: ip address not available\n");
+        u3_king_bail();
+      }
       if ( (UV_EADDRINUSE == sas_i) || (UV_EACCES == sas_i) ) {
         if ( (c3y == htp_u->sec) && (443 == htp_u->por_s) ) {
           htp_u->por_s = 8443;


### PR DESCRIPTION
Fixes #4638

Note that this prints `http: listen: address not available` when we get `UV_EADDRNOTAVAIL` and continues with no http server, should we crash instead?