### PR TITLE
interface: unify back button

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -16,6 +16,7 @@ import { Association } from '@urbit/api/metadata';
 import useGraphState from '~/logic/state/graph';
 import useMetadataState from '~/logic/state/metadata';
 import useGroupState from '../../../logic/state/group';
+import BackButton from '~/views/components/BackButton';
 
 const emptyMeasure = () => {};
 
@@ -98,8 +99,8 @@ export function LinkResource(props: LinkResourceProps) {
             }
             return (
               <Col alignItems="center" overflowY="auto" width="100%">
-              <Col width="100%" p={3} maxWidth="768px">
-                <Link to={resourceUrl}><Text px={3} bold>{'<- Back'}</Text></Link>
+                <Col width="100%" p={3} maxWidth="768px">
+                  <BackButton to={resourceUrl} mx={3} />
                 <LinkItem
                   key={node.post.index}
                   resource={resourcePath}

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -12,6 +12,7 @@ import { getLatestRevision, getComments } from '~/logic/lib/publish';
 import { roleForShip } from '~/logic/lib/group';
 import Author from '~/views/components/Author';
 import { Contacts, GraphNode, Graph, Association, Unreads, Group } from '@urbit/api';
+import BackButton from '~/views/components/BackButton';
 
 interface NoteProps {
   ship: string;
@@ -107,9 +108,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
       mx="auto"
       ref={windowRef}
     >
-      <Link to={rootUrl}>
-        <Text>{'<- Notebook Index'}</Text>
-      </Link>
+      <BackButton text="Notebook Index" to={rootUrl} />
       <Col>
         <Text display="block" mb={2}>{title || ''}</Text>
         <Row alignItems="center">

--- a/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
@@ -1,19 +1,14 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Text } from '@tlon/indigo-react';
+import React, { ReactElement } from 'react';
+import { default as GenericBackButton } from '~/views/components/BackButton';
 
-export function BackButton(props: {}) {
+export function BackButton(): ReactElement {
   return (
-    <Link to='/~settings'>
-      <Text
-        display={['block', 'none']}
-        fontSize='2'
-        fontWeight='medium'
-        p={4}
-        pb={0}
-      >
-        {'<- Back to System Preferences'}
-      </Text>
-    </Link>
+    <GenericBackButton
+      to='/~settings'
+      text="Back to System Preferences"
+      display={['flex', 'none']}
+      p={4}
+      pb={0}
+    />
   );
 }

--- a/pkg/interface/src/views/components/BackButton.tsx
+++ b/pkg/interface/src/views/components/BackButton.tsx
@@ -1,0 +1,20 @@
+import { Box, BoxProps, Icon, Text } from '@tlon/indigo-react';
+import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+
+type BackButtonProps = BoxProps & {
+  text?: string;
+  to: string;
+}
+const BackButton = ({ text = 'Back', to, ...rest }: BackButtonProps): ReactElement => {
+  return (
+    <Link to={to}>
+      <Box display="flex" alignItems="center" {...rest}>
+        <Icon icon="ChevronWest" bg="washedGray" borderRadius="50%" p={1} size="12px" mr={1}></Icon>
+        <Text bold>{text}</Text>
+      </Box>
+    </Link>
+  );
+};
+
+export default BackButton;

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
@@ -19,6 +19,7 @@ import { useHistory, Link } from 'react-router-dom';
 import { ChannelNotifications } from './Notifications';
 import { StatelessAsyncButton } from '~/views/components/StatelessAsyncButton';
 import { isChannelAdmin, isHost } from '~/logic/lib/group';
+import BackButton from '~/views/components/BackButton';
 
 interface ChannelPopoverRoutesProps {
   baseUrl: string;
@@ -74,9 +75,7 @@ export function ChannelPopoverRoutes(props: ChannelPopoverRoutesProps) {
         height="100%"
       >
         <Box pt="4" px="4" display={['block', 'none']}>
-          <Link to={props.baseUrl}>
-            <Text fontSize="1">{'<- Back'}</Text>
-          </Link>
+          <BackButton to={props.baseUrl} />
         </Box>
         <ChannelPopoverRoutesSidebar
           isAdmin={canAdmin}

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -23,6 +23,7 @@ import { IconRadio } from '~/views/components/IconRadio';
 import { ChannelWriteFieldSchema, ChannelWritePerms } from './ChannelWritePerms';
 import { Workspace } from '~/types/workspace';
 import useGroupState from '~/logic/state/group';
+import BackButton from '~/views/components/BackButton';
 
 type FormSchema = {
   name: string;
@@ -114,13 +115,11 @@ export function NewChannel(props: NewChannelProps & RouteComponentProps): ReactE
 
   return (
     <Col overflowY="auto" p={3} backgroundColor="white">
-      <Box
-        pb='3'
-        display={workspace?.type === 'messages' ? 'none' : ['block', 'none']}
-        onClick={() => history.push(props.baseUrl)}
-      >
-        <Text>{'<- Back'}</Text>
-      </Box>
+      <BackButton
+        pb={3}
+        display={workspace?.type === 'messages' ? 'none' : ['flex', 'none']}
+        to={props.baseUrl}
+      />
       <Box>
         <Text fontSize={2} bold>{workspace?.type === 'messages' ? 'Direct Message' : 'New Channel'}</Text>
       </Box>

--- a/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
+++ b/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
@@ -16,6 +16,7 @@ import { resourceFromPath } from '~/logic/lib/group';
 import { ModalOverlay } from '~/views/components/ModalOverlay';
 import { SidebarItem } from '~/views/landscape/components/SidebarItem';
 import { StorageState } from '~/types';
+import BackButton from '~/views/components/BackButton';
 
 export function PopoverRoutes(
   props: {
@@ -112,9 +113,7 @@ export function PopoverRoutes(
                   p={2}
                   display={['auto', 'none']}
                 >
-                  <Link to={view ? relativeUrl('') : props.baseUrl}>
-                    <Text>{'<- Back'}</Text>
-                  </Link>
+                  <BackButton to={view ? relativeUrl('') : props.baseUrl} />
                 </Box>
                 <Box overflow="hidden">
                   {view === 'settings' && (

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -13,6 +13,7 @@ import { isWriter } from '~/logic/lib/group';
 import { getItemTitle } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
+import BackButton from '~/views/components/BackButton';
 
 const TruncatedText = styled(RichText)`
   white-space: pre;
@@ -91,7 +92,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
           display={['block', 'none']}
           flexShrink={0}
         >
-          <Link to={`/~landscape${workspace}`}><Text>{'<- Back'}</Text></Link>
+          <BackButton to={`/~landscape${workspace}`} />
         </Box>
         <Box px={1} mr={2} minWidth={0} display="flex" flexShrink={[1, 0]}>
           <Text


### PR DESCRIPTION
fixes urbit/landscape#647

As you can see, it's not exactly like the mockups. The size of the caret is kind of small. @g-a-v-i-n any ideas on how to make this match the correct size? `size={2}` is too big

<img width="469" alt="image" src="https://user-images.githubusercontent.com/3999320/112663006-90385380-8e15-11eb-9ea7-20f919b99637.png">
