### PR TITLE
launch: get tutorial state from zustand

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -178,6 +178,7 @@ class App extends React.Component {
                 ship={this.ship}
                 api={this.api}
                 subscription={this.subscription}
+                connection={this.state.connection}
               />
             </ErrorBoundary>
           </Router>

--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -46,13 +46,14 @@ const ScrollbarLessBox = styled(Box)`
 const tutSelector = f.pick(['tutorialProgress', 'nextTutStep', 'hideGroups']);
 
 export default function LaunchApp(props) {
+  const connection = { props };
   const baseHash = useLaunchState(state => state.baseHash);
   const [hashText, setHashText] = useState(baseHash);
   const [exitingTut, setExitingTut] = useState(false);
   const seen = useSettingsState(s => s?.tutorial?.seen) ?? true;
   const associations = useMetadataState(s => s.associations);
   const contacts = useContactState(state => state.contacts);
-  const hasLoaded = useMemo(() => Object.keys(contacts).length > 0, [contacts]);
+  const hasLoaded = useMemo(() => Boolean(connection === "connected"), [connection]);
   const notificationsCount = useHarkState(state => state.notificationsCount);
   const calmState = useSettingsState(selectCalmState);
   const { hideUtilities } = calmState;


### PR DESCRIPTION
The check for rendering the tutorial modal was relying on a passed prop that does not exist now.

(I also move all the hooks to the top of the function as per best practice.)