### PR TITLE
chat: adjust unread banner corners

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/unread-notice.js
+++ b/pkg/interface/src/views/apps/chat/components/unread-notice.js
@@ -35,7 +35,7 @@ export const UnreadNotice = (props) => {
       className='unread-notice'
     >
       <Center>
-        <Box backgroundColor='white' borderRadius='2'>
+        <Box backgroundColor='white' borderRadius='3' overflow='hidden'>
           <Box
             backgroundColor='washedBlue'
             display='flex'


### PR DESCRIPTION
Adjusts the border-radius of both elements to match and hides the overflow.

![2021-03-27_22-47](https://user-images.githubusercontent.com/748181/112740928-e230c480-8f4e-11eb-9907-79142d2cac58.png)

fixes urbit/landscape#657