### PR TITLE
sys: Speed up things used in Landscape

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5455,9 +5455,10 @@
   ~%  %co  ..co  ~
   =<  |_  lot=coin
       ++  rear  |=(rom=tape rend(rep rom))
-      ++  rent  `@ta`(rap 3 rend)
+      ++  rent  ~+  `@ta`(rap 3 rend)
       ++  rend
         ^-  tape
+        ~+
         ?:  ?=(%blob -.lot)
           ['~' '0' ((v-co 1) (jam p.lot))]
         ?:  ?=(%many -.lot)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -3962,8 +3962,10 @@
         ruf=raft                                      ::  revision tree
     ==                                                ::
 |=  [now=@da eny=@uvJ rof=roof]                       ::  current invocation
+~%  %clay-top  ..part  ~
 |%                                                    ::
 ++  call                                              ::  handle request
+  ~/  %clay-call
   |=  $:  hen=duct
           dud=(unit goof)
           wrapped-task=(hobo task)
@@ -4273,6 +4275,7 @@
   --
 ::
 ++  scry                                              ::  inspect
+  ~/  %clay-scry
   ^-  roon
   |=  [lyc=gang car=term bem=beam]
   ^-  (unit (unit cage))
@@ -4334,6 +4337,7 @@
   ==
 ::
 ++  take                                              ::  accept response
+  ~/  %clay-take
   |=  [tea=wire hen=duct dud=(unit goof) hin=sign]
   ^+  [*(list move) ..^$]
   ?^  dud

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1597,6 +1597,7 @@
     ::  +channel-event-to-sign: attempt to recover a sign from a channel-event
     ::
     ++  channel-event-to-sign
+      ~%  %eyre-channel-event-to-sign  ..part  ~
       |=  event=channel-event
       ^-  (unit sign:agent:gall)
       ?.  ?=(%fact -.event)  `event
@@ -1677,6 +1678,7 @@
       ==
     ::
     ++  event-json-to-wall
+      ~%  %eyre-json-to-wall  ..part  ~
       |=  [event-id=@ud =json]
       ^-  wall
       :~  (weld "id: " (format-ud-as-integer event-id))
@@ -2094,6 +2096,7 @@
 ~%  %http-server  ..part  ~
 |%
 ++  call
+  ~/  %eyre-call
   |=  [=duct dud=(unit goof) wrapped-task=(hobo task)]
   ^-  [(list move) _http-server-gate]
   ::
@@ -2296,6 +2299,7 @@
   ==
 ::
 ++  take
+  ~/  %eyre-take
   |=  [=wire =duct dud=(unit goof) =sign]
   ^-  [(list move) _http-server-gate]
   ?^  dud
@@ -2483,6 +2487,7 @@
 ::  +scry: request a path in the urbit namespace
 ::
 ++  scry
+  ~/  %eyre-scry
   ^-  roon
   |=  [lyc=gang car=term bem=beam]
   ^-  (unit (unit cage))

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -425,10 +425,12 @@
   :-  ~
   %-  as-octs:mimes:html
   %-  crip
-  %-  zing
+  %-  zing  ^-  ^wall
+  %-  zing  ^-  (list ^wall)
   %+  turn  wall
   |=  t=tape
-  "{t}\0a"
+  ^-  ^wall
+  ~[t "\0a"]
 ::  +internal-server-error: 500 page, with a tang
 ::
 ++  internal-server-error

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3286,7 +3286,7 @@
     ++  ship                                            ::  string from ship
       |=  a=^ship
       ^-  json
-      [%n (rap 3 '"' (scot %p a) '"' ~)]
+      [%n (rap 3 '"' (rsh [3 1] (scot %p a)) '"' ~)]
     ::                                                  ::  ++numb:enjs:format
     ++  numb                                            ::  number from unsigned
       |=  a=@u

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3286,7 +3286,7 @@
     ++  ship                                            ::  string from ship
       |=  a=^ship
       ^-  json
-      (tape (slag 1 (scow %p a)))
+      [%n (rap 3 '"' (scot %p a) '"' ~)]
     ::                                                  ::  ++numb:enjs:format
     ++  numb                                            ::  number from unsigned
       |=  a=@u


### PR DESCRIPTION
Four separate changes aimed at improving landscape initial load time, with notes in the individual commit messages.  I also determined that we're compiling marks on every refresh.  In my opinion, we should keep all marks "warm", but in the meantime you can run `-test %/mar ~` to warm them up until they're invalidated by a dependency changing (for example zuse).

Combined, these changes take my initial landscape load from 28 seconds to 6.3 seconds (under profiling; a bit faster in real-world).  Still far too long!

With marks warmed up (by running `-test %/mar ~`) it takes 12 seconds even without any other changes, so that's the most important thing.  The changes in this PR cut that time in half again.

The majority of the remaining time (3.5 seconds) is spent in mark conversion to json (largely in `(scot %p)`), and a significant other portion (1.8 seconds) is spent in +en-json.  See:
![Screen Shot 2021-03-28 at 1 14 59 AM](https://user-images.githubusercontent.com/5553176/112746361-131af480-8f63-11eb-9745-813770db0db3.png)
