### PR TITLE
interface: truncate channel names & descriptions in header

### DIFF
--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, useRef, useState } from 'react';
 import { Icon, Box, Col, Row, Text } from '@tlon/indigo-react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
@@ -15,7 +15,7 @@ import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
 
 const TruncatedText = styled(RichText)`
-  white-space: pre;
+  white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 `;
@@ -36,6 +36,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
   const groups = useGroupState(state => state.groups);
   const group = groups[association.group];
   let workspace = association.group;
+  const actionsRef = useRef(null);
 
   if (group?.hidden && app === 'chat') {
     workspace = '/messages';
@@ -69,74 +70,113 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
     canWrite = isOwn;
   }
 
+  const BackLink = () => (
+    <Box
+      borderRight={1}
+      borderRightColor='gray'
+      pr={3}
+      fontSize='1'
+      mr='12px'
+      my='1'
+      flexShrink='0'
+      display={['block','none']}
+    >
+      <Link to={`/~landscape${workspace}`}>
+        <Text>{'<- Back'}</Text>
+      </Link>
+    </Box>
+  );
+
+  const Title = () => (
+    <Text
+      mono={urbitOb.isValidPatp(title)}
+      fontSize='2'
+      fontWeight='700'
+      textOverflow='ellipsis'
+      overflow='hidden'
+      whiteSpace='nowrap'
+      minWidth='0'
+      maxWidth={association?.metadata?.description ? ['100%', '50%'] : 'none'}
+      mr='2'
+      ml='1'
+      flexShrink={['1', '0']}
+    >
+      {title}
+    </Text>
+  );
+
+  const Description = () => (
+    <TruncatedText
+      display={['none','inline']}
+      mono={workspace === '/messages' && !urbitOb.isValidPatp(title)}
+      color='gray'
+      mb='0'
+      minWidth='0'
+      maxWidth='50%'
+      flexShrink='1'
+      disableRemoteContent
+    >
+      {workspace === '/messages'
+        ? recipient
+        : association?.metadata?.description}
+    </TruncatedText>
+  );
+
+  const WriterControls = () => (
+    <Link to={resourcePath('/new')}>
+      <Text bold pr='3' color='blue'>
+        + New Post
+      </Text>
+    </Link>
+  );
+
+  const MenuControl = () => (
+    <Link to={`${baseUrl}/settings`}>
+      <Icon icon='Menu' color='gray' pr='2' />
+    </Link>
+  );
+
+  const actRef = actionsRef.current;
+  let actionsWidth = 0;
+
+  if (actRef) {
+    actionsWidth = actRef.clientWidth;
+  }
+  
+
   return (
-    <Col width="100%" height="100%" overflowY="hidden">
+    <Col width='100%' height='100%' overflow='hidden'>
       <Box
-        flexShrink="0"
+        flexShrink='0'
         height='48px'
-        py="2"
-        px="2"
-        display="flex"
-        alignItems="center"
+        py='2'
+        px='2'
         borderBottom={1}
-        borderBottomColor="washedGray"
+        borderBottomColor='washedGray'
+        display='flex'
+        justifyContent='space-between'
+        alignItems='center'
       >
         <Box
-          borderRight={1}
-          borderRightColor="gray"
-          pr={3}
-          fontSize='1'
-          mr={3}
-          my="1"
-          display={['block', 'none']}
-          flexShrink={0}
+          display='flex'
+          alignItems='baseline'
+          width={`calc(100% - ${actionsWidth}px - 16px)`}
+          flexShrink='0'
         >
-          <Link to={`/~landscape${workspace}`}><Text>{'<- Back'}</Text></Link>
+          <BackLink />
+          <Title />
+          <Description />
         </Box>
-        <Box px={1} mr={2} minWidth={0} display="flex" flexShrink={[1, 0]}>
-          <Text
-            mono={urbitOb.isValidPatp(title)}
-            fontSize='2'
-            fontWeight='700'
-            display="inline-block"
-            verticalAlign="middle"
-            textOverflow="ellipsis"
-            overflow="hidden"
-            whiteSpace="pre"
-            minWidth={0}
-            flexShrink={1}
-          >
-            {title}
-          </Text>
-        </Box>
-        <Row
-          display={['none', 'flex']}
-          verticalAlign="middle"
-          flexShrink={2}
-          minWidth={0}
-          title={association?.metadata?.description}
+        <Box
+          ml={3}
+          display='flex'
+          alignItems='center'
+          flexShrink='0'
+          ref={actionsRef}
         >
-          <TruncatedText
-            display={(workspace === '/messages' && (urbitOb.isValidPatp(title))) ? 'none' : 'inline-block'}
-            mono={(workspace === '/messages' && !(urbitOb.isValidPatp(title)))}
-            color="gray"
-            minWidth={0}
-            width="100%"
-            mb="0"
-            disableRemoteContent
-          >
-            {(workspace === '/messages') ? recipient : association?.metadata?.description}
-          </TruncatedText>
-        </Row>
-        <Box flexGrow={1} flexShrink={0} />
-        {canWrite && (
-          <Link to={resourcePath('/new')} style={{ flexShrink: '0' }}>
-            <Text bold pr='3' color='blue'>+ New Post</Text>
-          </Link>
-      )}
-      <Link to={`${baseUrl}/settings`}>
-        <Icon icon="Menu" color="gray" pr="2" />
-      </Link>
+          {canWrite && <WriterControls />}
+          <MenuControl />
+        </Box>
       </Box>
       {children}
     </Col>

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -1,11 +1,10 @@
-import React, { ReactElement, ReactNode, useRef, useState } from 'react';
-import { Icon, Box, Col, Row, Text } from '@tlon/indigo-react';
+import React, { ReactElement, ReactNode, useRef } from 'react';
+import { Icon, Box, Col, Text } from '@tlon/indigo-react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import urbitOb from 'urbit-ob';
 
 import { Association } from '@urbit/api/metadata';
-import { Groups, Rolodex } from '@urbit/api';
 
 import RichText from '~/views/components/RichText';
 import GlobalApi from '~/logic/api/global';
@@ -143,7 +142,6 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
     actionsWidth = actRef.clientWidth;
   }
   
-
   return (
     <Col width='100%' height='100%' overflow='hidden'>
       <Box


### PR DESCRIPTION
Proposes a more dynamic way of handling layout of channel titles and descriptions while making room for additional actions.

For small viewports, don't show the description at all. Show a back button, and truncate the channel name to fit the available space, including any right-hand actions or icons in the header.

For larger viewports, remove the back button, and show the channel description while making room for any right-hand actions. 
- Truncate both the title and description if both exceed half the allotted space. 
- Truncate the title if the title is longer than the description.
- If the channel does not have a description, or if the title is shorter than the description, do not truncate the title, and truncate the description if it exists. 

Small viewport, short title:
![image](https://user-images.githubusercontent.com/748181/112780402-c2fd6a00-9016-11eb-8574-e4aec1ccd585.png)

Small viewport, long title:
![image](https://user-images.githubusercontent.com/748181/112780340-a4976e80-9016-11eb-8b4a-0654f21e7693.png)

Small viewport, posting rights:
![image](https://user-images.githubusercontent.com/748181/112780448-da3c5780-9016-11eb-98f1-cd31fa92872b.png)

Large viewport, short title, no description, no posting rights:
![image](https://user-images.githubusercontent.com/748181/112780578-212a4d00-9017-11eb-8e50-84b7f4154fb2.png)

Large viewport, short title, no description, posting rights:
![image](https://user-images.githubusercontent.com/748181/112780523-06f06f00-9017-11eb-8ad8-77f9e70c9262.png)

Large viewport, short title, long description, no posting rights:
![image](https://user-images.githubusercontent.com/748181/112780675-5cc51700-9017-11eb-8bde-1779d983928e.png)

Large viewport, short title, long description, posting rights:
![image](https://user-images.githubusercontent.com/748181/112780697-69496f80-9017-11eb-9d40-ba02855b1753.png)

Large viewport, long title, short description, no posting rights:
![image](https://user-images.githubusercontent.com/748181/112780869-baf1fa00-9017-11eb-90f0-f4f491801b24.png)

Large viewport, long title, short description, posting rights:
![image](https://user-images.githubusercontent.com/748181/112780938-dfe66d00-9017-11eb-965e-21c661db9003.png)

Large viewport, long title, long description, no posting rights:
![image](https://user-images.githubusercontent.com/748181/112780719-76fef500-9017-11eb-9686-2e20b36a5a2f.png)

Large viewport, long title, long description, posting rights:
![image](https://user-images.githubusercontent.com/748181/112780783-9007a600-9017-11eb-9650-5cec7833f7c5.png)

DMs follow the same rules; since 'participants' are effectively the channel 'description.'

1:1 DM:
![image](https://user-images.githubusercontent.com/748181/112781030-158b5600-9018-11eb-84b7-3a1cb50bf889.png)

Group DM with 3+ participants:
![image](https://user-images.githubusercontent.com/748181/112781146-44a1c780-9018-11eb-9f5b-2a88cba44e9f.png)



fixes urbit/landscape#587, fixes urbit/landscape#512