### PR TITLE
landscape: don't build serviceworker in dev

### DIFF
--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -64,12 +64,12 @@ if(urbitrc.URL) {
           return '/index.js'
         }
       },
-      '/~landscape/js/serviceworker.js': {
-        target: 'http://localhost:9000',
-        pathRewrite: (req, path) => {
-          return '/serviceworker.js'
-        }
-      },
+      // '/~landscape/js/serviceworker.js': {
+      //   target: 'http://localhost:9000',
+      //   pathRewrite: (req, path) => {
+      //     return '/serviceworker.js'
+      //   }
+      // },
       '**': {
         changeOrigin: true,
         target: urbitrc.URL,
@@ -85,7 +85,7 @@ module.exports = {
   mode: 'development',
   entry: {
     app: './src/index.js',
-    serviceworker: './src/serviceworker.js'
+    // serviceworker: './src/serviceworker.js'
   },
   module: {
     rules: [

--- a/pkg/interface/src/register-sw.js
+++ b/pkg/interface/src/register-sw.js
@@ -1,6 +1,4 @@
-
-
-if ("serviceWorker" in navigator) {
+if ("serviceWorker" in navigator && process.env.NODE_ENV !== 'development') {
   window.addEventListener("load", () => {
     navigator.serviceWorker.register("/~landscape/js/bundle/serviceworker.js", {
       scope: "/",


### PR DESCRIPTION
This is tripping us up like the old days — serviceworker caches the JS so that changes stick across hot reloads, making it hard to tell whether changes are being reflected as we work. We just don't build the serviceworker for dev.

If you are developing on Safari, you will have to run the following after this is on next-userspace:

```
navigator.serviceWorker.getRegistrations().then(function(registrations) {
 for(let registration of registrations) {
  registration.unregister()
} })
```

cc @tylershuster 