### PR TITLE
u3: jets +fein:ob and +fynd:ob

### DIFF
--- a/pkg/urbit/include/jets/q.h
+++ b/pkg/urbit/include/jets/q.h
@@ -151,6 +151,7 @@
     u3_noun u3qe_sha1(u3_atom, u3_atom);
 
     u3_atom u3qe_fein_ob(u3_atom pyn);
+    u3_atom u3qe_fynd_ob(u3_atom pyn);
 
     u3_noun u3qe_hmac(u3_noun, u3_atom, u3_atom,
                       u3_atom, u3_atom, u3_atom, u3_atom);

--- a/pkg/urbit/include/jets/q.h
+++ b/pkg/urbit/include/jets/q.h
@@ -150,6 +150,8 @@
     u3_noun u3qe_shal(u3_atom, u3_atom);
     u3_noun u3qe_sha1(u3_atom, u3_atom);
 
+    u3_atom u3qe_fein_ob(u3_atom pyn);
+
     u3_noun u3qe_hmac(u3_noun, u3_atom, u3_atom,
                       u3_atom, u3_atom, u3_atom, u3_atom);
 

--- a/pkg/urbit/include/jets/w.h
+++ b/pkg/urbit/include/jets/w.h
@@ -176,6 +176,7 @@
     u3_noun u3we_sha1(u3_noun);
 
     u3_noun u3we_fein_ob(u3_noun);
+    u3_noun u3we_fynd_ob(u3_noun);
 
     u3_noun u3weo_raw(u3_noun);
 

--- a/pkg/urbit/include/jets/w.h
+++ b/pkg/urbit/include/jets/w.h
@@ -175,6 +175,8 @@
     u3_noun u3we_shal(u3_noun);
     u3_noun u3we_sha1(u3_noun);
 
+    u3_noun u3we_fein_ob(u3_noun);
+
     u3_noun u3weo_raw(u3_noun);
 
     u3_noun u3wee_puck(u3_noun);

--- a/pkg/urbit/jets/e/fein_ob.c
+++ b/pkg/urbit/jets/e/fein_ob.c
@@ -1,0 +1,82 @@
+/* j/3/fein.c
+**
+*/
+#include "all.h"
+#include <murmur3.h>
+
+//  +feis:ob constant parameters to +fe:ob
+//
+static const c3_w a_w =     0xffff;
+static const c3_w b_w =    0x10000;
+static const c3_w k_w = 0xffff0000;
+
+//  +raku:ob
+//
+static const c3_w rak_w[4] = { 0xb76d5eed, 0xee281300, 0x85bcae01, 0x4b387af7 };
+
+static c3_w
+_feis_fe(c3_w m_w)
+{
+  c3_w l_w = m_w % a_w;
+  c3_w r_w = m_w / a_w;
+  c3_w f_w, tmp_w;
+  c3_d tmp_d;
+  c3_y k_y[2];
+  c3_y j_y;
+
+  for ( j_y = 0; j_y < 4; j_y++ ) {
+    k_y[0] = r_w & 0xff;
+    k_y[1] = (r_w >> 8) & 0xff;
+
+    MurmurHash3_x86_32(k_y, 2, rak_w[j_y], &f_w);
+
+    tmp_d = (c3_d)f_w + l_w;
+    tmp_w = tmp_d % (!(j_y & 1) ? a_w: b_w);
+    l_w   = r_w;
+    r_w   = tmp_w;
+  }
+
+  return ( a_w == r_w ) ? (r_w * a_w) + l_w : (l_w * a_w) + r_w;
+}
+
+static c3_w
+_feis(c3_w m_w)
+{
+  c3_w c_w = _feis_fe(m_w);
+  return ( c_w < k_w ) ? c_w : _feis_fe(c_w);
+}
+
+u3_atom
+u3qe_fein_ob(u3_atom pyn)
+{
+  c3_w sor_w = u3r_met(4, pyn);
+
+  if ( (sor_w < 2) || (sor_w > 4) ) {
+    return u3k(pyn);
+  }
+
+  if ( 2 == sor_w ) {
+    c3_w pyn_w = u3r_word(0, pyn);
+    c3_w out_w = b_w + _feis(pyn_w - b_w);
+
+    return u3i_word(out_w);
+  }
+  else {
+    c3_w pyn_w[2];
+    u3r_words(0, 2, pyn_w, pyn);
+
+    if ( pyn_w[0] < b_w ) {
+      return u3k(pyn);
+    }
+    else {
+      pyn_w[0] = b_w + _feis(pyn_w[0] - b_w);
+      return u3i_words(2, pyn_w);
+    }
+  }
+}
+
+u3_noun
+u3we_fein_ob(u3_noun cor)
+{
+  return u3qe_fein_ob(u3x_atom(u3x_at(u3x_sam, cor)));
+}

--- a/pkg/urbit/jets/e/fein_ob.c
+++ b/pkg/urbit/jets/e/fein_ob.c
@@ -14,15 +14,16 @@ static const c3_w k_w = 0xffff0000;
 //
 static const c3_w rak_w[4] = { 0xb76d5eed, 0xee281300, 0x85bcae01, 0x4b387af7 };
 
+/* _fe_ob(): +fe:ob, with constant parameters factored out.
+**           correct over the domain [0x0, 0xfffe.ffff]
+*/
 static c3_w
-_feis_fe(c3_w m_w)
+_fe_ob(c3_w m_w)
 {
   c3_w l_w = m_w % a_w;
   c3_w r_w = m_w / a_w;
-  c3_w f_w, tmp_w;
-  c3_d tmp_d;
-  c3_y k_y[2];
-  c3_y j_y;
+  c3_w f_w, t_w;
+  c3_y j_y, k_y[2];
 
   for ( j_y = 0; j_y < 4; j_y++ ) {
     k_y[0] = r_w & 0xff;
@@ -30,20 +31,28 @@ _feis_fe(c3_w m_w)
 
     MurmurHash3_x86_32(k_y, 2, rak_w[j_y], &f_w);
 
-    tmp_d = (c3_d)f_w + l_w;
-    tmp_w = tmp_d % (!(j_y & 1) ? a_w: b_w);
-    l_w   = r_w;
-    r_w   = tmp_w;
+    //  NB: this addition can overflow a c3_w (before mod)
+    //
+    t_w = ((c3_d)f_w + l_w) % (!(j_y & 1) ? a_w : b_w);
+    l_w = r_w;
+    r_w = t_w;
   }
 
-  return ( a_w == r_w ) ? (r_w * a_w) + l_w : (l_w * a_w) + r_w;
+  //  legendary @max19
+  //
+  return ( a_w == r_w )
+         ? (r_w * a_w) + l_w
+         : (l_w * a_w) + r_w;
 }
 
+/* _feis_ob(): +feis:ob, also offsetting by 0x1.000 (as in +fein:ob).
+**             correct over the domain [0x1.0000, 0xffff.ffff]
+*/
 static c3_w
-_feis(c3_w m_w)
+_feis_ob(c3_w m_w)
 {
-  c3_w c_w = _feis_fe(m_w);
-  return ( c_w < k_w ) ? c_w : _feis_fe(c_w);
+  c3_w c_w = _fe_ob(m_w - b_w);
+  return b_w + (( c_w < k_w ) ? c_w : _fe_ob(c_w));
 }
 
 u3_atom
@@ -56,10 +65,7 @@ u3qe_fein_ob(u3_atom pyn)
   }
 
   if ( 2 == sor_w ) {
-    c3_w pyn_w = u3r_word(0, pyn);
-    c3_w out_w = b_w + _feis(pyn_w - b_w);
-
-    return u3i_word(out_w);
+    return u3i_word(_feis_ob(u3r_word(0, pyn)));
   }
   else {
     c3_w pyn_w[2];
@@ -69,7 +75,7 @@ u3qe_fein_ob(u3_atom pyn)
       return u3k(pyn);
     }
     else {
-      pyn_w[0] = b_w + _feis(pyn_w[0] - b_w);
+      pyn_w[0] = _feis_ob(pyn_w[0]);
       return u3i_words(2, pyn_w);
     }
   }

--- a/pkg/urbit/jets/e/fynd_ob.c
+++ b/pkg/urbit/jets/e/fynd_ob.c
@@ -1,0 +1,88 @@
+/* j/3/fein.c
+**
+*/
+#include "all.h"
+#include <murmur3.h>
+
+//  +tail:ob constant parameters to +fe:ob
+//
+static const c3_w a_w =     0xffff;
+static const c3_w b_w =    0x10000;
+static const c3_w k_w = 0xffff0000;
+
+//  +raku:ob
+//
+static const c3_w rak_w[4] = { 0xb76d5eed, 0xee281300, 0x85bcae01, 0x4b387af7 };
+
+static c3_w
+_tail_fen(c3_w m_w)
+{
+  c3_w l_w = m_w / a_w;
+  c3_w r_w = m_w % a_w;
+  c3_w f_w, tmp_w;
+  c3_y k_y[2];
+  c3_y j_y;
+
+  if ( a_w == l_w ) {
+    tmp_w = l_w;
+    l_w = r_w;
+    r_w = tmp_w;
+  }
+
+  for ( j_y = 4; j_y > 0; j_y-- ) {
+    k_y[0] = l_w & 0xff;
+    k_y[1] = (l_w >> 8) & 0xff;
+
+    MurmurHash3_x86_32(k_y, 2, rak_w[j_y - 1], &f_w);
+
+    tmp_w = ( j_y & 1 )
+            ? ((r_w + a_w) - (f_w % a_w)) % a_w
+            : ((r_w + b_w) - (f_w % b_w)) % b_w;
+    r_w = l_w;
+    l_w = tmp_w;
+  }
+
+  return (r_w * a_w) + l_w;
+}
+
+static c3_w
+_tail(c3_w m_w)
+{
+  c3_w c_w = _tail_fen(m_w);
+  return ( c_w < k_w ) ? c_w : _tail_fen(c_w);
+}
+
+u3_atom
+u3qe_fynd_ob(u3_atom pyn)
+{
+  c3_w sor_w = u3r_met(4, pyn);
+
+  if ( (sor_w < 2) || (sor_w > 4) ) {
+    return u3k(pyn);
+  }
+
+  if ( 2 == sor_w ) {
+    c3_w pyn_w = u3r_word(0, pyn);
+    c3_w out_w = b_w + _tail(pyn_w - b_w);
+
+    return u3i_word(out_w);
+  }
+  else {
+    c3_w pyn_w[2];
+    u3r_words(0, 2, pyn_w, pyn);
+
+    if ( pyn_w[0] < b_w ) {
+      return u3k(pyn);
+    }
+    else {
+      pyn_w[0] = b_w + _tail(pyn_w[0] - b_w);
+      return u3i_words(2, pyn_w);
+    }
+  }
+}
+
+u3_noun
+u3we_fynd_ob(u3_noun cor)
+{
+  return u3qe_fynd_ob(u3x_atom(u3x_at(u3x_sam, cor)));
+}

--- a/pkg/urbit/jets/e/fynd_ob.c
+++ b/pkg/urbit/jets/e/fynd_ob.c
@@ -10,46 +10,53 @@ static const c3_w a_w =     0xffff;
 static const c3_w b_w =    0x10000;
 static const c3_w k_w = 0xffff0000;
 
-//  +raku:ob
+//  (flop raku:ob)
 //
-static const c3_w rak_w[4] = { 0xb76d5eed, 0xee281300, 0x85bcae01, 0x4b387af7 };
+static const c3_w kar_w[4] = { 0x4b387af7, 0x85bcae01, 0xee281300, 0xb76d5eed };
 
+/* _fen_ob(): +fen:ob, with constant parameters factored out.
+**           correct over the domain [0x0 ... 0xfffe.ffff]
+*/
 static c3_w
-_tail_fen(c3_w m_w)
+_fen_ob(c3_w m_w)
 {
   c3_w l_w = m_w / a_w;
   c3_w r_w = m_w % a_w;
-  c3_w f_w, tmp_w;
-  c3_y k_y[2];
-  c3_y j_y;
+  c3_w f_w, t_w;
+  c3_y j_y, k_y[2];
 
+  //  legendary @max19
+  //
   if ( a_w == l_w ) {
-    tmp_w = l_w;
+    t_w = l_w;
     l_w = r_w;
-    r_w = tmp_w;
+    r_w = t_w;
   }
 
-  for ( j_y = 4; j_y > 0; j_y-- ) {
+  for ( j_y = 0; j_y < 4; j_y++ ) {
     k_y[0] = l_w & 0xff;
     k_y[1] = (l_w >> 8) & 0xff;
 
-    MurmurHash3_x86_32(k_y, 2, rak_w[j_y - 1], &f_w);
+    MurmurHash3_x86_32(k_y, 2, kar_w[j_y], &f_w);
 
-    tmp_w = ( j_y & 1 )
-            ? ((r_w + a_w) - (f_w % a_w)) % a_w
-            : ((r_w + b_w) - (f_w % b_w)) % b_w;
+    t_w = ( j_y & 1 )
+          ? ((r_w + a_w) - (f_w % a_w)) % a_w
+          : ((r_w + b_w) - (f_w % b_w)) % b_w;
     r_w = l_w;
-    l_w = tmp_w;
+    l_w = t_w;
   }
 
   return (r_w * a_w) + l_w;
 }
 
+/* _tail_ob(): +feis:ob, also offsetting by 0x1.000 (as in +fynd:ob).
+**             correct over the domain [0x1.0000, 0xffff.ffff]
+*/
 static c3_w
-_tail(c3_w m_w)
+_tail_ob(c3_w m_w)
 {
-  c3_w c_w = _tail_fen(m_w);
-  return ( c_w < k_w ) ? c_w : _tail_fen(c_w);
+  c3_w c_w = _fen_ob(m_w - b_w);
+  return b_w + (( c_w < k_w ) ? c_w : _fen_ob(c_w));
 }
 
 u3_atom
@@ -62,10 +69,7 @@ u3qe_fynd_ob(u3_atom pyn)
   }
 
   if ( 2 == sor_w ) {
-    c3_w pyn_w = u3r_word(0, pyn);
-    c3_w out_w = b_w + _tail(pyn_w - b_w);
-
-    return u3i_word(out_w);
+    return u3i_word(_tail_ob(u3r_word(0, pyn)));
   }
   else {
     c3_w pyn_w[2];
@@ -75,7 +79,7 @@ u3qe_fynd_ob(u3_atom pyn)
       return u3k(pyn);
     }
     else {
-      pyn_w[0] = b_w + _tail(pyn_w[0] - b_w);
+      pyn_w[0] = _tail_ob(pyn_w[0]);
       return u3i_words(2, pyn_w);
     }
   }

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -1389,8 +1389,21 @@ static c3_c* _140_tri_shal_ha[] = {
   0
 };
 
-static u3j_core _140_ob_d[] =
-{ {}
+static u3j_harm _140_ob_fein_a[] = {{".2", u3we_fein_ob}, {}};
+static c3_c* _140_ob_fein_ha[] = {
+  0
+};
+
+static u3j_harm _140_ob_fynd_a[] = {{".2", u3we_fynd_ob}, {}};
+static c3_c* _140_ob_fynd_ha[] = {
+  0
+};
+
+
+static u3j_core _140_ob_d[] = {
+  { "fein", 7, _140_ob_fein_a, 0, _140_ob_fein_ha },
+  { "fynd", 7, _140_ob_fynd_a, 0, _140_ob_fynd_ha },
+  {}
 };
 static c3_c* _140_ob_ha[] = {
   "13ebfbdee69396bc1d980fc4dcbcdaa9cc3fb9c011e6cf188e71311a8bffc8e6",

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -290,11 +290,106 @@ _test_fein_ob(void)
   return ret_i;
 }
 
+static c3_w
+_fynd_ob_w(c3_w inp_w)
+{
+  u3_atom inp = u3i_word(inp_w);
+  u3_atom act = u3qe_fynd_ob(inp);
+  c3_w  act_w = u3r_word(0, act);
+  u3z(inp); u3z(act);
+  return act_w;
+}
+
+static c3_i
+_expect_fynd_ob_w(c3_w exp_w, c3_w inp_w)
+{
+  c3_w act_w = _fynd_ob_w(inp_w);
+
+  if ( act_w != exp_w ) {
+    fprintf(stderr, "fynd: inp=0x%08x exp=0x%08x act=0x%08x\n",
+                    inp_w, exp_w, act_w);
+    return 0;
+  }
+
+  return 1;
+}
+
+static c3_i
+_test_fynd_ob(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _expect_fynd_ob_w(0, 0);
+  ret_i &= _expect_fynd_ob_w(0xffff, 0xffff);
+  ret_i &= _expect_fynd_ob_w(0x10000, 0x423e60bf);
+  ret_i &= _expect_fynd_ob_w(0x10001, 0xd4400acb);
+  ret_i &= _expect_fynd_ob_w(0x10002, 0xf429043);
+  ret_i &= _expect_fynd_ob_w(0x10000000, 0xa04bc7fa);
+  ret_i &= _expect_fynd_ob_w(0x1234abcd, 0x686f6c25);
+  ret_i &= _expect_fynd_ob_w(0xabcd1234, 0x4a220c8);
+  ret_i &= _expect_fynd_ob_w(0xdeadbeef, 0x909bc4a9);
+  ret_i &= _expect_fynd_ob_w(0xfffff, 0x6746b96b);
+  ret_i &= _expect_fynd_ob_w(0xffffffff, 0xbba4dcce);
+
+  return ret_i;
+}
+
+static c3_i
+_exhaust_roundtrip_fein_fynd_ob(void)
+{
+  c3_i ret_i = 1;
+  c3_w fyn_w, i_w;
+
+  {
+    u3_atom fen, fyn;
+
+    for ( i_w = 0x10000; i_w < 0x80000000; i_w++ ) {
+      fen   = u3qe_fein_ob(i_w);
+      fyn   = u3qe_fynd_ob(fen);
+      fyn_w = u3r_word(0, fyn);
+
+      if ( i_w != fyn_w ) {
+        fprintf(stderr, "fein/fynd: inp=0x%08x fein=0x%08x fynd=0x%08x\n",
+                        i_w, u3r_word(0, fen), fyn_w);
+        ret_i = 0;
+      }
+      u3z(fen); u3z(fyn);
+
+      if ( !(i_w % 0x1000000) ) {
+        fprintf(stderr, "fein/fynd: 0x%x done\n", i_w);
+      }
+    }
+  }
+
+  {
+    c3_w fen_w;
+
+    do {
+      fen_w = _fein_ob_w(i_w);
+      fyn_w = _fynd_ob_w(fen_w);
+      if ( i_w != fyn_w ) {
+        fprintf(stderr, "fein/fynd: inp=0x%08x fein=0x%08x fynd=0x%08x\n",
+                        i_w, fen_w, fyn_w);
+        ret_i = 0;
+      }
+
+      if ( !(i_w % 0x1000000) ) {
+        fprintf(stderr, "fein/fynd: 0x%x done\n", i_w);
+      }
+    }
+    while ( ++i_w );
+  }
+
+  return ret_i;
+}
+
 static c3_i
 _test_ob(void)
 {
   c3_i ret_i = 1;
   ret_i &= _test_fein_ob();
+  ret_i &= _test_fynd_ob();
+  // ret_i &= _exhaust_roundtrip_fein_fynd_ob();
   return ret_i;
 }
 

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -389,6 +389,8 @@ _test_ob(void)
   c3_i ret_i = 1;
   ret_i &= _test_fein_ob();
   ret_i &= _test_fynd_ob();
+  //  disabled, takes almost ~m15
+  //
   // ret_i &= _exhaust_roundtrip_fein_fynd_ob();
   return ret_i;
 }

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -245,6 +245,59 @@ _test_base16(void)
   return ret_i;
 }
 
+static c3_w
+_fein_ob_w(c3_w inp_w)
+{
+  u3_atom inp = u3i_word(inp_w);
+  u3_atom act = u3qe_fein_ob(inp);
+  c3_w  act_w = u3r_word(0, act);
+  u3z(inp); u3z(act);
+  return act_w;
+}
+
+static c3_i
+_expect_fein_ob_w(c3_w inp_w, c3_w exp_w)
+{
+  c3_w act_w = _fein_ob_w(inp_w);
+
+  if ( act_w != exp_w ) {
+    fprintf(stderr, "fein: inp=0x%08x exp=0x%08x act=0x%08x\n",
+                    inp_w, exp_w, act_w);
+    return 0;
+  }
+
+  return 1;
+}
+
+static c3_i
+_test_fein_ob(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _expect_fein_ob_w(0, 0);
+  ret_i &= _expect_fein_ob_w(0xffff, 0xffff);
+  ret_i &= _expect_fein_ob_w(0x1b08f, 0x76b920e5);
+  ret_i &= _expect_fein_ob_w(0x10000, 0x423e60bf);
+  ret_i &= _expect_fein_ob_w(0x10001, 0xd4400acb);
+  ret_i &= _expect_fein_ob_w(0x10002, 0xf429043);
+  ret_i &= _expect_fein_ob_w(0x10000000, 0xa04bc7fa);
+  ret_i &= _expect_fein_ob_w(0x1234abcd, 0x686f6c25);
+  ret_i &= _expect_fein_ob_w(0xabcd1234, 0x4a220c8);
+  ret_i &= _expect_fein_ob_w(0xdeadbeef, 0x909bc4a9);
+  ret_i &= _expect_fein_ob_w(0xfffff, 0x6746b96b);
+  ret_i &= _expect_fein_ob_w(0xffffffff, 0xbba4dcce);
+
+  return ret_i;
+}
+
+static c3_i
+_test_ob(void)
+{
+  c3_i ret_i = 1;
+  ret_i &= _test_fein_ob();
+  return ret_i;
+}
+
 static c3_i
 _test_jets(void)
 {
@@ -252,6 +305,11 @@ _test_jets(void)
 
   if ( !_test_base16() ) {
     fprintf(stderr, "test jets: base16: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_ob() ) {
+    fprintf(stderr, "test jets: ob: failed\r\n");
     ret_i = 0;
   }
 


### PR DESCRIPTION
I was inspired to add these after seeing @philipcmonk's performance measurements in #4677. I've added some sparse unit tests for both jets, and a (disabled) exhaustive 32-bit roundtrip test, all of which pass.

I intend to add some nock/jet result-comparison testing from the arvo side (something like `=((f i) =>(f(+6 i) .*(. -)))`), and the implementations could use a little cleanup (and comments where they appear to differ from the hoon). But I wanted to open this PR ASAP so anyone who was interested could play around or take measurements.