### PR TITLE
graph-validators: speed up validators by adding type casts

### DIFF
--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -1,4 +1,4 @@
-/-  *post, met=metadata-store
+/-  *post, met=metadata-store, graph=graph-store, hark=hark-graph-hook
 |_  i=indexed-post
 ++  grow
   |%
@@ -6,17 +6,20 @@
   ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     ?+  index.p.i  !!
       [@ ~]  [%yes %yes %no]
     ==
   ::
   ++  graph-permissions-remove
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     ?+  index.p.i  !!
       [@ ~]  [%self %self %no]
     ==
   ::
   ++  notification-kind
+    ^-  (unit notif-kind:hark)
     ?+  index.p.i  ~
       [@ ~]  `[%message [0 1] %count %none]
     ==

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -1,4 +1,4 @@
-/-  *post, met=metadata-store
+/-  *post, met=metadata-store, graph=graph-store, hark=hark-graph-hook
 |_  i=indexed-post
 ++  grow
   |%
@@ -6,6 +6,7 @@
   ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     =/  reader
       ?=(%reader-comments vip)
     ?+  index.p.i  !!
@@ -16,6 +17,7 @@
   ::
   ++  graph-permissions-remove
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     =/  reader
       ?=(%reader-comments vip)
     ?+  index.p.i  !!
@@ -25,6 +27,7 @@
     ==
   ::
   ++  notification-kind
+    ^-  (unit notif-kind:hark)
     ?+  index.p.i  ~
       [@ ~]       `[%link [0 1] %each %children]
       [@ @ %1 ~]  `[%comment [1 2] %count %siblings]

--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -1,20 +1,23 @@
-/-  *post, met=metadata-store
+/-  *post, met=metadata-store, graph=graph-store, hark=hark-graph-hook
 |_  i=indexed-post
 ++  grow
   |%
   ++  noun  i
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     ?:  ?=([@ ~] index.p.i)
       [%yes %yes %no]
     [%yes %yes ?:(?=(%reader-comments vip) %yes %no)]
   ::
   ++  graph-permissions-remove
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     [%yes %self %self]
   ::  +notification-kind: don't track unreads, notify on replies
   ::
   ++  notification-kind  
+    ^-  (unit notif-kind:hark)
     =/  len  (lent index.p.i)
     ?:  =(1 len)  ~
     `[%post [(dec len) len] %none %children]

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -1,10 +1,11 @@
-/-  *post, met=metadata-store
+/-  *post, met=metadata-store, graph=graph-store, hark=hark-graph-hook
 |_  i=indexed-post
 ++  grow
   |%
   ++  noun  i
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     ?+  index.p.i  !!
       [@ ~]            [%yes %yes %no]  :: new note
       [@ %1 @ ~]       [%self %self %no]
@@ -14,6 +15,7 @@
   ::
   ++  graph-permissions-remove
     |=  vip=vip-metadata:met
+    ^-  permissions:graph
     ?+  index.p.i  !!
       [@ ~]            [%yes %self %self]
       [@ %1 @ @ ~]     [%yes %self %self]
@@ -24,6 +26,7 @@
   ::    ignore all containers, only notify on content
   ::
   ++  notification-kind
+    ^-  (unit notif-kind:hark)
     ?+  index.p.i   ~
       [@ %1 %1 ~]    `[%note [0 1] %each %children]
       [@ %2 @ %1 ~]  `[%comment [1 3] %count %siblings]


### PR DESCRIPTION
All validators (and uses of `!>` and `!<`) should have type-casts to avoid expensive nest-checking.

Please put into `prerelease` @matildepark 