### PR TITLE
build: only run publish-npm-packages on pkg/npm

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - 'master'
+    paths:
+      - 'pkg/npm/**'
 jobs:
   publish-api:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's a little aggressive on the attempted publish, causing constant fails.