### PR TITLE
graph-store: speed up +validate-graph by using +turn and no longer virtualizing

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -676,12 +676,13 @@
     |=  [=graph:store mark=(unit mark:store)]
     ^-  ?
     ?~  mark   %.y
-    ?~  graph  %.y
     =/  =dais:clay
       .^  =dais:clay
           %cb
           /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[u.mark]
       ==
+    |-  ^-  ?
+    ?~  graph  %.y
     %+  roll  (tap:orm graph)
     |=  [[=atom =node:store] out=?]
     ^-  ?

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -259,6 +259,7 @@
               ?&  !(~(has by archive) resource)
                   !(~(has by graphs) resource)
           ==  ==
+      ~|  "validation of graph {<resource>} failed using mark {<mark>}"
       ?>  (validate-graph graph mark)
       =/  =logged-update:store
         [%0 time %add-graph resource graph mark overwrite]
@@ -681,15 +682,16 @@
           %cb
           /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[u.mark]
       ==
-    %+  roll  (tap:orm graph)
-    |=  [[=atom =node:store] out=?]
-    ?&  out
-        =(%& -:(mule |.((vale:dais [atom post.node]))))
-        ?-  -.children.node
-            %empty  %.y
-            %graph  ^$(graph p.children.node)
-        ==
-    ==
+    =/  unused
+      %+  turn  (tap:orm graph)
+      |=  [=atom =node:store]
+      ^-  ?
+      =/  side  (vale:dais [atom post.node])
+      ?-  -.children.node
+          %empty  %.y
+          %graph  ^$(graph p.children.node)
+      ==
+    %.y
   ::
   ++  poke-import
     |=  arc=*

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -682,16 +682,14 @@
           %cb
           /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[u.mark]
       ==
-    =/  unused
-      %+  turn  (tap:orm graph)
-      |=  [=atom =node:store]
-      ^-  ?
-      =/  side  (vale:dais [atom post.node])
-      ?-  -.children.node
+    %+  roll  (tap:orm graph)
+    |=  [[=atom =node:store] out=?]
+    ^-  ?
+    ?&  ?=(^ (vale:dais [atom post.node]))
+        ?-  -.children.node
           %empty  %.y
           %graph  ^$(graph p.children.node)
-      ==
-    %.y
+    ==  ==
   ::
   ++  poke-import
     |=  arc=*


### PR DESCRIPTION
In my test, the time to validate a graph went from 56 seconds to 1 second when joining UC General.

Perf Before:

<img width="1260" alt="Screen Shot 2021-03-31 at 11 45 12 AM" src="https://user-images.githubusercontent.com/1377557/113180688-a3349480-9216-11eb-9c4c-71c01616053b.png">

Perf After:
<img width="1061" alt="Screen Shot 2021-03-31 at 11 28 09 AM" src="https://user-images.githubusercontent.com/1377557/113179417-340a7080-9215-11eb-851c-43b608733d0c.png">
