### PR TITLE
gall: print on missing request for ack

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -646,6 +646,7 @@
           ::  cleared queue in +load 3-to-4 or +load-4-to-5
           ::
           =?  stand  ?=(~ stand)
+            ~&  [%gall-missing wire hen]
             (~(put to *(qeu remote-request)) %missing)
           ~|  [full-wire=full-wire hen=hen stand=stand]
           =^  rr  stand  ~(get to stand)


### PR DESCRIPTION
Following @philipcmonk's recommendation in https://github.com/urbit/urbit/issues/4687.  Should help clarify problem with Gall request queueing.