### PR TITLE
ViewProfile: clone contact groups array

### DIFF
--- a/pkg/interface/src/views/apps/profile/components/ViewProfile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/ViewProfile.tsx
@@ -62,7 +62,7 @@ export function ViewProfile(props: any): ReactElement {
         <Col gapY='3' mb='3' mt='6' alignItems='flex-start'>
           <Text gray>Pinned Groups</Text>
           <Col>
-            {contact?.groups.sort(lengthOrder).map((g) => (
+            {contact?.groups.slice().sort(lengthOrder).map((g) => (
               <GroupLink
                 api={api}
                 resource={g}


### PR DESCRIPTION
Fixes urbit/landscape#682.

For whatever reason we can't mutate these arrays in place when using immer. See [this StackOverflow thread](https://stackoverflow.com/questions/53420055/error-while-sorting-array-of-objects-cannot-assign-to-read-only-property-2-of/53420326), this fixes the crash by copying the array we're rendering.