### PR TITLE
u3: adds bitwidth short-circuit to atom comparison jets

### DIFF
--- a/pkg/urbit/jets/a/gte.c
+++ b/pkg/urbit/jets/a/gte.c
@@ -3,42 +3,40 @@
 */
 #include "all.h"
 
-
-/* functions
-*/
-  u3_noun
-  u3qa_gte(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      return __(a >= b);
-    }
-    else {
-      mpz_t   a_mp, b_mp;
-      u3_noun cmp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      cmp = (mpz_cmp(a_mp, b_mp) >= 0) ? c3y : c3n;
-
-      mpz_clear(a_mp);
-      mpz_clear(b_mp);
-
-      return cmp;
-    }
+u3_noun
+u3qa_gte(u3_atom a, u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    return __(a >= b);
   }
-  u3_noun
-  u3wa_gte(u3_noun cor)
-  {
-    u3_noun a, b;
+  else {
+    mpz_t   a_mp, b_mp;
+    u3_noun cmp;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_gte(a, b);
-    }
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
+
+    cmp = (mpz_cmp(a_mp, b_mp) >= 0) ? c3y : c3n;
+
+    mpz_clear(a_mp);
+    mpz_clear(b_mp);
+
+    return cmp;
   }
+}
+
+u3_noun
+u3wa_gte(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b)) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_gte(a, b);
+  }
+}

--- a/pkg/urbit/jets/a/gte.c
+++ b/pkg/urbit/jets/a/gte.c
@@ -9,6 +9,12 @@ u3qa_gte(u3_atom a, u3_atom b)
   if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
     return __(a >= b);
   }
+  else if ( 0 == a ) {
+    return c3n;
+  }
+  else if ( 0 == b ) {
+    return c3y;
+  }
   else {
     c3_w a_w = u3r_met(0, a);
     c3_w b_w = u3r_met(0, b);
@@ -38,9 +44,9 @@ u3wa_gte(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-       (c3n == u3ud(a)) ||
-       (c3n == u3ud(b)) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0))
+     || (c3n == u3ud(b) && 0 != a)
+     || (c3n == u3ud(a) && 0 != b) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/urbit/jets/a/gte.c
+++ b/pkg/urbit/jets/a/gte.c
@@ -10,18 +10,26 @@ u3qa_gte(u3_atom a, u3_atom b)
     return __(a >= b);
   }
   else {
-    mpz_t   a_mp, b_mp;
-    u3_noun cmp;
+    c3_w a_w = u3r_met(0, a);
+    c3_w b_w = u3r_met(0, b);
 
-    u3r_mp(a_mp, a);
-    u3r_mp(b_mp, b);
+    if ( a_w != b_w ) {
+      return __(a_w >= b_w);
+    }
+    else {
+      mpz_t   a_mp, b_mp;
+      u3_noun cmp;
 
-    cmp = (mpz_cmp(a_mp, b_mp) >= 0) ? c3y : c3n;
+      u3r_mp(a_mp, a);
+      u3r_mp(b_mp, b);
 
-    mpz_clear(a_mp);
-    mpz_clear(b_mp);
+      cmp = (mpz_cmp(a_mp, b_mp) >= 0) ? c3y : c3n;
 
-    return cmp;
+      mpz_clear(a_mp);
+      mpz_clear(b_mp);
+
+      return cmp;
+    }
   }
 }
 

--- a/pkg/urbit/jets/a/gth.c
+++ b/pkg/urbit/jets/a/gth.c
@@ -3,52 +3,48 @@
 */
 #include "all.h"
 
-
-/* functions
-*/
-  u3_noun
-  u3qa_gth(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      return __(a > b);
-    }
-    else {
-      mpz_t   a_mp, b_mp;
-      u3_noun cmp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      cmp = (mpz_cmp(a_mp, b_mp) > 0) ? c3y : c3n;
-
-      mpz_clear(a_mp);
-      mpz_clear(b_mp);
-
-      return cmp;
-    }
+u3_noun
+u3qa_gth(u3_atom a, u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    return __(a > b);
   }
-  u3_noun
-  u3wa_gth(u3_noun cor)
-  {
-    u3_noun a, b;
+  else {
+    mpz_t   a_mp, b_mp;
+    u3_noun cmp;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_gth(a, b);
-    }
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
+
+    cmp = (mpz_cmp(a_mp, b_mp) > 0) ? c3y : c3n;
+
+    mpz_clear(a_mp);
+    mpz_clear(b_mp);
+
+    return cmp;
   }
+}
 
-  u3_noun
-  u3ka_gth(u3_noun a,
-           u3_noun b)
+u3_noun
+u3wa_gth(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b)) )
   {
-    u3_noun c = u3qa_gth(a, b);
-
-    u3z(a); u3z(b);
-    return c;
+    return u3m_bail(c3__exit);
   }
+  else {
+    return u3qa_gth(a, b);
+  }
+}
+
+u3_noun
+u3ka_gth(u3_noun a, u3_noun b)
+{
+  u3_noun c = u3qa_gth(a, b);
+  u3z(a); u3z(b);
+  return c;
+}

--- a/pkg/urbit/jets/a/gth.c
+++ b/pkg/urbit/jets/a/gth.c
@@ -9,6 +9,12 @@ u3qa_gth(u3_atom a, u3_atom b)
   if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
     return __(a > b);
   }
+  else if ( 0 == a ) {
+    return c3n;
+  }
+  else if ( 0 == b ) {
+    return c3y;
+  }
   else {
     c3_w a_w = u3r_met(0, a);
     c3_w b_w = u3r_met(0, b);
@@ -38,9 +44,9 @@ u3wa_gth(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-       (c3n == u3ud(a)) ||
-       (c3n == u3ud(b)) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0))
+     || (c3n == u3ud(b) && 0 != a)
+     || (c3n == u3ud(a) && 0 != b) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/urbit/jets/a/gth.c
+++ b/pkg/urbit/jets/a/gth.c
@@ -10,18 +10,26 @@ u3qa_gth(u3_atom a, u3_atom b)
     return __(a > b);
   }
   else {
-    mpz_t   a_mp, b_mp;
-    u3_noun cmp;
+    c3_w a_w = u3r_met(0, a);
+    c3_w b_w = u3r_met(0, b);
 
-    u3r_mp(a_mp, a);
-    u3r_mp(b_mp, b);
+    if ( a_w != b_w ) {
+      return __(a_w > b_w);
+    }
+    else {
+      mpz_t   a_mp, b_mp;
+      u3_noun cmp;
 
-    cmp = (mpz_cmp(a_mp, b_mp) > 0) ? c3y : c3n;
+      u3r_mp(a_mp, a);
+      u3r_mp(b_mp, b);
 
-    mpz_clear(a_mp);
-    mpz_clear(b_mp);
+      cmp = (mpz_cmp(a_mp, b_mp) > 0) ? c3y : c3n;
 
-    return cmp;
+      mpz_clear(a_mp);
+      mpz_clear(b_mp);
+
+      return cmp;
+    }
   }
 }
 

--- a/pkg/urbit/jets/a/lte.c
+++ b/pkg/urbit/jets/a/lte.c
@@ -3,51 +3,48 @@
 */
 #include "all.h"
 
-
-/* functions
-*/
-  u3_noun
-  u3qa_lte(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      return __(a <= b);
-    }
-    else {
-      mpz_t   a_mp, b_mp;
-      u3_noun cmp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      cmp = (mpz_cmp(a_mp, b_mp) <= 0) ? c3y : c3n;
-
-      mpz_clear(a_mp);
-      mpz_clear(b_mp);
-
-      return cmp;
-    }
+u3_noun
+u3qa_lte(u3_atom a, u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    return __(a <= b);
   }
-  u3_noun
-  u3wa_lte(u3_noun cor)
-  {
-    u3_noun a, b;
+  else {
+    mpz_t   a_mp, b_mp;
+    u3_noun cmp;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_lte(a, b);
-    }
-  }
-  u3_noun
-  u3ka_lte(u3_noun a,
-           u3_noun b)
-  {
-    u3_noun c = u3qa_lte(a, b);
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
 
-    u3z(a); u3z(b);
-    return c;
+    cmp = (mpz_cmp(a_mp, b_mp) <= 0) ? c3y : c3n;
+
+    mpz_clear(a_mp);
+    mpz_clear(b_mp);
+
+    return cmp;
   }
+}
+
+u3_noun
+u3wa_lte(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b)) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_lte(a, b);
+  }
+}
+
+u3_noun
+u3ka_lte(u3_noun a, u3_noun b)
+{
+  u3_noun c = u3qa_lte(a, b);
+  u3z(a); u3z(b);
+  return c;
+}

--- a/pkg/urbit/jets/a/lte.c
+++ b/pkg/urbit/jets/a/lte.c
@@ -10,18 +10,26 @@ u3qa_lte(u3_atom a, u3_atom b)
     return __(a <= b);
   }
   else {
-    mpz_t   a_mp, b_mp;
-    u3_noun cmp;
+    c3_w a_w = u3r_met(0, a);
+    c3_w b_w = u3r_met(0, b);
 
-    u3r_mp(a_mp, a);
-    u3r_mp(b_mp, b);
+    if ( a_w != b_w ) {
+      return __(a_w <= b_w);
+    }
+    else {
+      mpz_t   a_mp, b_mp;
+      u3_noun cmp;
 
-    cmp = (mpz_cmp(a_mp, b_mp) <= 0) ? c3y : c3n;
+      u3r_mp(a_mp, a);
+      u3r_mp(b_mp, b);
 
-    mpz_clear(a_mp);
-    mpz_clear(b_mp);
+      cmp = (mpz_cmp(a_mp, b_mp) <= 0) ? c3y : c3n;
 
-    return cmp;
+      mpz_clear(a_mp);
+      mpz_clear(b_mp);
+
+      return cmp;
+    }
   }
 }
 

--- a/pkg/urbit/jets/a/lte.c
+++ b/pkg/urbit/jets/a/lte.c
@@ -9,6 +9,12 @@ u3qa_lte(u3_atom a, u3_atom b)
   if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
     return __(a <= b);
   }
+  else if ( 0 == a ) {
+    return c3y;
+  }
+  else if ( 0 == b ) {
+    return c3n;
+  }
   else {
     c3_w a_w = u3r_met(0, a);
     c3_w b_w = u3r_met(0, b);
@@ -38,9 +44,9 @@ u3wa_lte(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-       (c3n == u3ud(a)) ||
-       (c3n == u3ud(b)) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0))
+     || (c3n == u3ud(b) && 0 != a)
+     || (c3n == u3ud(a) && 0 != b) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/urbit/jets/a/lth.c
+++ b/pkg/urbit/jets/a/lth.c
@@ -16,18 +16,26 @@ u3qa_lth(u3_atom a, u3_atom b)
     return c3n;
   }
   else {
-    mpz_t   a_mp, b_mp;
-    u3_noun cmp;
+    c3_w a_w = u3r_met(0, a);
+    c3_w b_w = u3r_met(0, b);
 
-    u3r_mp(a_mp, a);
-    u3r_mp(b_mp, b);
+    if ( a_w != b_w ) {
+      return __(a_w < b_w);
+    }
+    else {
+      mpz_t   a_mp, b_mp;
+      u3_noun cmp;
 
-    cmp = (mpz_cmp(a_mp, b_mp) < 0) ? c3y : c3n;
+      u3r_mp(a_mp, a);
+      u3r_mp(b_mp, b);
 
-    mpz_clear(a_mp);
-    mpz_clear(b_mp);
+      cmp = (mpz_cmp(a_mp, b_mp) < 0) ? c3y : c3n;
 
-    return cmp;
+      mpz_clear(a_mp);
+      mpz_clear(b_mp);
+
+      return cmp;
+    }
   }
 }
 

--- a/pkg/urbit/jets/a/lth.c
+++ b/pkg/urbit/jets/a/lth.c
@@ -44,9 +44,9 @@ u3wa_lth(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-       (c3n == u3ud(b) && a != 0) ||
-       (c3n == u3ud(a) && b != 0) )
+  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0))
+     || (c3n == u3ud(b) && 0 != a)
+     || (c3n == u3ud(a) && 0 != b) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/urbit/jets/a/lth.c
+++ b/pkg/urbit/jets/a/lth.c
@@ -3,48 +3,46 @@
 */
 #include "all.h"
 
-
-/* functions
-*/
-  u3_noun
-  u3qa_lth(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      return __(a < b);
-    }
-    else if ( 0 == a ) {
-      return c3y;
-    }
-    else if ( 0 == b ) {
-      return c3n;
-    }
-    else {
-      mpz_t   a_mp, b_mp;
-      u3_noun cmp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      cmp = (mpz_cmp(a_mp, b_mp) < 0) ? c3y : c3n;
-
-      mpz_clear(a_mp);
-      mpz_clear(b_mp);
-
-      return cmp;
-    }
+u3_noun
+u3qa_lth(u3_atom a, u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    return __(a < b);
   }
-  u3_noun
-  u3wa_lth(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(b) && a != 0) ||
-         (c3n == u3ud(a) && b != 0) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_lth(a, b);
-    }
+  else if ( 0 == a ) {
+    return c3y;
   }
+  else if ( 0 == b ) {
+    return c3n;
+  }
+  else {
+    mpz_t   a_mp, b_mp;
+    u3_noun cmp;
+
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
+
+    cmp = (mpz_cmp(a_mp, b_mp) < 0) ? c3y : c3n;
+
+    mpz_clear(a_mp);
+    mpz_clear(b_mp);
+
+    return cmp;
+  }
+}
+
+u3_noun
+u3wa_lth(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(b) && a != 0) ||
+       (c3n == u3ud(a) && b != 0) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_lth(a, b);
+  }
+}

--- a/pkg/urbit/noun/jets.c
+++ b/pkg/urbit/noun/jets.c
@@ -918,12 +918,11 @@ _cj_kick_z(u3_noun cor, u3j_core* cop_u, u3j_harm* ham_u, u3_atom axe)
                u3r_mug(pro));
         ham_u->liv = c3n;
 
-        c3_assert(0);
         return u3m_bail(c3__fail);
       }
       else {
 
-#if 1
+#if 0
         u3l_log("test: %s %s\r\n",
                cop_u->cos_c,
                (!strcmp(".2", ham_u->fcs_c)) ? "$" : ham_u->fcs_c);


### PR DESCRIPTION
Our atom comparison jets (`+gth`, `+lth`, &c) use GMP when either argument is an indirect atom. This is expensive, as we have to allocate to GMP integers. This PR updates the jets to only use GMP when the arguments have the same bitwidth.

This PR was inspired by the (very slow) exhaustive test I'm performing for #4692 (and seeing the jets in stack samples). I'll try to whip up a quick benchmark to measure the impact.