### PR TITLE
build: only run 'push' build on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ name: build
 
 on:
   push:
+    branches:
+      - 'release/**'
+      - 'na-release/**'
+      - 'pre-release/**'
     paths:
       - 'pkg/arvo/**'
       - 'pkg/docker-image/**'


### PR DESCRIPTION
Part of the increasingly inaccurately named "CI specificity" trilogy.

If someone pushes a commit onto an open PR, the CI runs twice: once for the push trigger, once for the pull request trigger. To remedy this, we now only run the push CI when pushing to a release/, na-release/, or pre-release/ branch.

cc @joemfb — how often do we want builds to process? Pre-existing behaviour was "any commit on any branch," which may have been intentional, but kept the queue busy.

Fixes #4657 