### PR TITLE
metadata-push-hook: fixes issue with adding unmanaged metadata

### DIFF
--- a/pkg/arvo/app/metadata-push-hook.hoon
+++ b/pkg/arvo/app/metadata-push-hook.hoon
@@ -65,16 +65,25 @@
     ~
   =/  role=(unit (unit role-tag))
     (role-for-ship:grp group.update src.bowl)
-  =/  =metadatum:store
-    (need (peek-metadatum:met %groups group.update))
   ?~  role  ~
+  =/  metadatum=(unit metadatum:store)
+    (peek-metadatum:met %groups group.update)
+  ?:  ?&  ?=(~ metadatum)
+          (is-managed:grp group.update)
+      ==
+    ~
+  ?:  ?&  ?=(^ metadatum)
+          !(is-managed:grp group.update)
+      ==
+    ~
   ?^  u.role  
     ?:  ?=(?(%admin %moderator) u.u.role)
       `vas
     ~
   ?.  ?=(%add -.update)  ~
-  ?:  ?&  =(src.bowl entity.resource.resource.update)
-          ?=(%member-metadata vip.metadatum)
+  ?:  ?&  ?=(^ metadatum)
+          =(src.bowl entity.resource.resource.update)
+          ?=(%member-metadata vip.u.metadatum)
       ==
     `vas
   ~


### PR DESCRIPTION
There was an erroneous assertion that had been around for the past month or more that *should* have prevented all unmanaged channel creation, but mysteriously did not. I have talked through this with Isaac and Matilde and we all agree that this should have been broken for a long time, but was *not*.

This now works and has been tested on `~tacryt-socryp` on livenet.

@liam-fitzgerald Can you think of why this could have possibly worked prior?