### PR TITLE
push-hook: nack unversioned subscriptions when unsupported

### DIFF
--- a/pkg/arvo/lib/metadata-store.hoon
+++ b/pkg/arvo/lib/metadata-store.hoon
@@ -189,9 +189,12 @@
     ^-  md-config
     ?~  jon
       [%group ~]
-    ?:  ?=(%s -.jon)
-      [%graph p.jon]
     ?>  ?=(%o -.jon)
+    ?:  (~(has by p.jon) %graph)
+      =/  mod
+        (~(got by p.jon) %graph)
+      ?>  ?=(%s -.mod)
+      [%graph p.mod]
     =/  jin=json
       (~(got by p.jon) %group)
     ?>  ?=(%o -.jin)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -446,6 +446,7 @@
       (fact:io cage ~(tap in paths))
     ::  TODO: deprecate
     ++  unversioned
+      ?.  =(min-version.config 0)  ~
       =/  prefix=path
         resource+(en-path:resource rid)
       =/  unversioned=(set path)

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -277,6 +277,9 @@
       ::
       ++  unversioned
         ?>  ?=([%ship @ @ *] t.path)
+        ?.  =(min-version.config 0)
+           ~&  >>>  "unversioned req from: {<src.bowl>}, nooping"
+           `this
         =/  =resource
           (de-path:resource t.path)
         =/  =vase

--- a/pkg/arvo/mar/metadata/update-1.hoon
+++ b/pkg/arvo/mar/metadata/update-1.hoon
@@ -4,7 +4,6 @@
 ++  grow
   |%
   ++  noun               update
-  ++  metadata-update    update
   ++  json               (update:enjs:store update)
   --
 ::

--- a/pkg/interface/src/logic/lib/virtualContext.tsx
+++ b/pkg/interface/src/logic/lib/virtualContext.tsx
@@ -3,7 +3,10 @@ import React, {
   useState,
   useCallback,
   useLayoutEffect,
+  useRef,
+  useEffect,
 } from "react";
+import usePreviousValue from "./usePreviousValue";
 
 export interface VirtualContextProps {
   save: () => void;
@@ -44,4 +47,19 @@ export function useVirtualResizeState(s: boolean) {
   }, [state]);
 
   return [state, setState] as const;
+}
+
+export function useVirtualResizeProp<T>(prop: T) {
+  const { save, restore } = useVirtual();
+  const oldProp = usePreviousValue(prop)
+
+  if(prop !== oldProp) {
+    save();
+  }
+
+  useLayoutEffect(() => {
+    restore();
+  }, [prop]);
+
+
 }

--- a/pkg/interface/src/logic/subscription/global.ts
+++ b/pkg/interface/src/logic/subscription/global.ts
@@ -49,12 +49,6 @@ export default class GlobalSubscription extends BaseSubscription<StoreState> {
   }
 
   restart() {
-    for (let key in Object.keys(this.openSubscriptions)) {
-      let val = this.openSubscriptions[key];
-
-      this.unsubscribe(val.id);
-    }
-
     this.start();
   }
 }

--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -42,8 +42,20 @@ const MARKDOWN_CONFIG = {
 // we need to hack this into a regular input that has some funny behaviors
 const inputProxy = (input) => new Proxy(input, {
   get(target, property) {
+    if(property === 'focus') {
+      return () => {
+        target.focus();
+      }
+    }
     if (property in target) {
       return target[property];
+    }
+    if (property === 'execCommand') {
+      return () => {
+        target.setSelectionRange(target.value.length, target.value.length);
+        input.blur();
+        input.focus();
+      }
     }
     if (property === 'setOption') {
       return () => {};
@@ -108,7 +120,9 @@ export default class ChatEditor extends Component {
     if (prevProps.message !== props.message) {
       this.editor.setValue(props.message);
       this.editor.setOption('mode', MARKDOWN_CONFIG);
-      this.editor?.element?.focus();
+      this.editor?.focus();
+      this.editor.execCommand('goDocEnd');
+      this.editor?.focus();
       return;
     }
 

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -23,6 +23,7 @@ import { Link } from "react-router-dom";
 import useGraphState from "~/logic/state/graph";
 import { GraphNodeContent } from "../notifications/graph";
 import { TranscludedNode } from "./TranscludedNode";
+import {useVirtualResizeProp} from "~/logic/lib/virtualContext";
 
 function GroupPermalink(props: { group: string; api: GlobalApi }) {
   const { group, api } = props;
@@ -61,13 +62,15 @@ function GraphPermalink(
       graph,
     ])
   );
+
+  useVirtualResizeProp(node)
   useEffect(() => {
     (async () => {
       if (pending || !index) {
         return;
       }
       try {
-        await api.graph.getNode(ship, name, index);
+        api.graph.getNode(ship, name, index);
       } catch (e) {
         console.log(e);
         setErrored(true);

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -70,7 +70,7 @@ function GraphPermalink(
         return;
       }
       try {
-        api.graph.getNode(ship, name, index);
+        await api.graph.getNode(ship, name, index);
       } catch (e) {
         console.log(e);
         setErrored(true);

--- a/pkg/interface/src/views/components/RemoteContent.tsx
+++ b/pkg/interface/src/views/components/RemoteContent.tsx
@@ -217,6 +217,7 @@ return;
             src={url}
             style={style}
             onLoad={onLoad}
+            objectFit="contain"
             {...audioProps}
             {...props}
           />
@@ -235,6 +236,7 @@ return;
             src={url}
             style={style}
             onLoad={onLoad}
+            objectFit="contain"
             {...videoProps}
             {...props}
           />

--- a/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
@@ -24,9 +24,9 @@ export function DeleteGroup(props: {
 return;
     }
     if(props.owner) {
-      await props.api.groups.deleteGroup(ship, name);
+      props.api.groups.deleteGroup(ship, name);
     } else {
-      await props.api.groups.leaveGroup(ship, name);
+      props.api.groups.leaveGroup(ship, name);
     }
     history.push('/');
   };

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
@@ -66,7 +66,7 @@ export function GroupFeedSettings(props: {
               </Label>
             </Col>
           </BaseLabel>
-          {isEnabled && false && (
+          {isEnabled && (
             <>
               <GroupFeedPermsInput id="permissions" />
               <FormSubmit start>Update Permissions</FormSubmit>


### PR DESCRIPTION
Mainnet is currently experiencing undue load due to a watch-kick loop.
If the watch is unsupported, it will be kicked due to a mark mismatch,
which will be interpreted by the unversioned hooks as a network pressure
kick, prompting a resub and continuing the loop. Instead, we now no-op
on unversioned, unsupported watches, waiting for the subscriber to
rewatch after it processes the versioning OTA. This will silently break
groups for the subscriber until the reach the latest OTA, but is
preferable to nacking, and kicking them permanently