### PR TITLE
extras: emacs syntax highlighting

### DIFF
--- a/extras/hoon-mode.el/hoon-mode.el
+++ b/extras/hoon-mode.el/hoon-mode.el
@@ -63,6 +63,7 @@
     ("\\(%\\w\\(-\\|\\w\\)*\\)" (1 font-lock-keyword-face))
     ("\\(\\(-\\|\\w\\)+\\)=" (1 font-lock-variable-name-face))
     ("[=,]\\(\\(-\\|\\w\\)+\\|@\\(-\\|\\w\\)*\\)" (1 font-lock-type-face))
+    ("\\+\\$  \\(\\(-\\|\\w\\)+\\)" (1 font-lock-function-name-face))
     )
   "Keyword highlighting specification for `hoon-mode'.")
 

--- a/extras/hoon-mode.el/hoon-mode.el
+++ b/extras/hoon-mode.el/hoon-mode.el
@@ -59,10 +59,10 @@
 
 (defvar hoon-font-lock-keywords
   '(
-    ("\\+\\+  \\(\\w+\\)" (1 font-lock-function-name-face))
-    ("\\(%\\w+\\)" (1 font-lock-keyword-face))
-    ("\\(\\w+\\)=" (1 font-lock-variable-name-face))
-    ("[=,]\\(\\w+\\|@\\w*\\)" (1 font-lock-type-face))
+    ("\\+\\+  \\(\\(-\\|\\w\\)+\\)" (1 font-lock-function-name-face))
+    ("\\(%\\w\\(-\\|\\w\\)*\\)" (1 font-lock-keyword-face))
+    ("\\(\\(-\\|\\w\\)+\\)=" (1 font-lock-variable-name-face))
+    ("[=,]\\(\\(-\\|\\w\\)+\\|@\\(-\\|\\w\\)*\\)" (1 font-lock-type-face))
     )
   "Keyword highlighting specification for `hoon-mode'.")
 


### PR DESCRIPTION
From the style guide:

> Modern Hoon naming is *verbose*.

As such, hoon tends to have hyphenated names, but these names are only partially matched by the current font-lock regex.