### PR TITLE
landscape: restore profile overlays on mention clicks

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -610,6 +610,7 @@ export const Message = ({
                   scrollWindow={scrollWindow}
                   ship={content.mention}
                   contact={contacts?.[`~${content.mention}`]}
+                  api={api}
                 />
               );
             default:

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -4,7 +4,7 @@ import { Text, Box } from '@tlon/indigo-react';
 import { Contact, Contacts, Content, Group } from '@urbit/api';
 import RichText from '~/views/components/RichText';
 import { cite, useShowNickname, uxToHex } from '~/logic/lib/util';
-import OverlaySigil from '~/views/components/OverlaySigil';
+import ProfileOverlay from '~/views/components/ProfileOverlay';
 import { useHistory } from 'react-router-dom';
 import useContactState from '~/logic/state/contact';
 import {referenceToPermalink} from '~/logic/lib/permalinks';
@@ -45,8 +45,9 @@ export function Mention(props: {
   scrollWindow?: HTMLElement;
   ship: string;
   first?: Boolean;
+  api: any;
 }) {
-  const { ship, scrollWindow, first, ...rest } = props;
+  const { ship, scrollWindow, first, api, ...rest } = props;
   let { contact } = props;
   const contacts = useContactState(state => state.contacts);
   contact = contact?.color ? contact : contacts?.[`~${ship}`];
@@ -62,30 +63,23 @@ export function Mention(props: {
 
   return (
     <Box position='relative' display='inline-block' cursor='pointer' {...rest}>
-      <Text
-        onClick={() => toggleOverlay()}
-        marginLeft={first? 0 : 1}
-        marginRight={1}
-        px={1}
-        bg='washedBlue'
-        color='blue'
-        fontSize={showNickname ? 1 : 0}
-        mono={!showNickname}
-      >
-        {name}
-      </Text>
-      {showOverlay && (
-        <OverlaySigil
+        <ProfileOverlay
           ship={ship}
-          contact={contact}
-          color={`#${uxToHex(contact?.color ?? '0x0')}`}
-          group={group}
-          onDismiss={() => toggleOverlay()}
-          history={history}
-          className='relative'
-          scrollWindow={scrollWindow}
-        />
-      )}
+          api={api}
+        >
+          <Text
+            onClick={() => toggleOverlay()}
+            marginLeft={first? 0 : 1}
+            marginRight={1}
+            px={1}
+            bg='washedBlue'
+            color='blue'
+            fontSize={showNickname ? 1 : 0}
+            mono={!showNickname}
+          >
+          {name}
+        </Text>
+      </ProfileOverlay>
     </Box>
   );
 }

--- a/pkg/interface/src/views/components/RichText.js
+++ b/pkg/interface/src/views/components/RichText.js
@@ -52,7 +52,7 @@ const RichText = React.memo(({ disableRemoteContent, api, ...props }) => (
       linkReference: (linkProps) => {
         const linkText = String(linkProps.children[0].props.children);
         if (isValidPatp(linkText)) {
-          return <Mention contact={props.contact || {}} group={props.group} ship={deSig(linkText)} />;
+          return <Mention contact={props.contact || {}} group={props.group} ship={deSig(linkText)} api={api} />;
         } else if(linkText.startsWith('web+urbitgraph://')) {
           return (
             <PermalinkEmbed


### PR DESCRIPTION
After https://github.com/urbit/urbit/commit/60b7b5df442496468b5fa3f2ed4a8abc11aa83d7 refactored the profile overlay everything that referenced it was updated, except MentionText. This fixes that and passes the api prop through each place where we use MentionText, so that your status can be sent, etc.