### PR TITLE
landscape: fix 'my channels' sidebar logic

### DIFF
--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarList.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarList.tsx
@@ -64,6 +64,7 @@ export function SidebarList(props: {
           assoc.group === group &&
           !assoc.metadata.hidden
         ) : (
+          !(assoc.group in associationState.groups) &&
           'graph' in assoc.metadata.config &&
           assoc.metadata.config.graph !== 'chat' &&
           !assoc.metadata.hidden


### PR DESCRIPTION
When we changed metadata.module to metadata.config, we amended the logic for parsing through group paths in the DM workspace, but not in the My Channels workspace.