### PR TITLE
pull-hook: noop on unsupported, unversioned facts

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -440,6 +440,11 @@
         =/  fact-ver=@ud
           (read-version:ver p.cage)
         ?.  (gte fact-ver min-version.config)
+          ?.  versioned
+            ::  don't process unversioned, unsupported facts
+            ::  just wait for publisher to upgrade and kick the
+            ::  subscription
+            tr-core
           (tr-suspend-pub-ver min-version.config)
         =/  =vase
           (convert-to:ver cage)

--- a/pkg/arvo/mar/metadata/update-0.hoon
+++ b/pkg/arvo/mar/metadata/update-0.hoon
@@ -1,5 +1,5 @@
 /+  store=metadata-store
-|_  =update:store
+|_  =update:zero:store
 ++  grad  %noun
 ++  grow
   |%
@@ -9,7 +9,6 @@
 ::
 ++  grab
   |%
-  ++  noun  update:store
-  ++  json  action:dejs:store
+  ++  noun  update:zero:store
   --
 --

--- a/pkg/arvo/mar/metadata/update.hoon
+++ b/pkg/arvo/mar/metadata/update.hoon
@@ -1,17 +1,14 @@
 /+  store=metadata-store
-|_  =update:store
+|_  =update:zero:store
 ++  grad  %noun
 ++  grow
   |%
   ++  noun  update
   ++  metadata-update-0  update
-  ++  metadata-update-1  update
-  ++  json  (update:enjs:store update)
   --
 ::
 ++  grab
   |%
-  ++  noun  update:store
-  ++  json  action:dejs:store
+  ++  noun  update:zero:store
   --
 --

--- a/pkg/arvo/sur/metadata-store.hoon
+++ b/pkg/arvo/sur/metadata-store.hoon
@@ -78,4 +78,38 @@
           =metadatum
       ==
   ==
+::  historical
+++  zero
+  |%
+  ::
+  +$  association   [group=resource =metadatum]
+  ::
+  +$  associations  (map md-resource association)
+  ::
+  +$  metadatum
+    $:  title=cord
+        description=cord
+        =color
+        date-created=time
+        creator=ship
+        module=term
+        picture=url
+        preview=?
+        vip=vip-metadata
+    ==
+  ::
+  +$  update
+    $%  [%add group=resource resource=md-resource =metadatum]
+        [%remove group=resource resource=md-resource]
+        [%initial-group group=resource =associations]
+        [%associations =associations]
+        $:  %updated-metadata 
+            group=resource
+            resource=md-resource 
+            before=metadatum
+            =metadatum
+        ==
+    ==
+  ::
+  --
 --


### PR DESCRIPTION
Pull-hook side of the previous change to push-hook
(479fbfd). Noop on unsupported
unversioned marks, waiting for the publisher to upgrade and kick. Same
tradeoffs as previous change apply. Restores the historical marks to their correct types so that clamming will no longer fail