### PR TITLE
observe-hook: upgrade to keep marks warm

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -46,19 +46,8 @@
       %0  
     %_    $
       -.old  %1
-    ::
-        validators.old
-      (~(put in validators.old) %graph-validator-link)
-    ::
-        cards
-      %+  weld  cards
-      %+  turn
-        ~(tap in (~(put in validators.old) %graph-validator-link))
-      |=  validator=@t
-      ^-  card
-      =/  =wire  /validator/[validator]
-      =/  =rave:clay  [%sing %b [%da now.bowl] /[validator]]
-      [%pass wire %arvo %c %warp our.bowl [%home `rave]]
+      cards  cards
+      validators.old  validators.old
     ::
         graphs.old
       %-  ~(run by graphs.old)
@@ -285,19 +274,10 @@
               graphs       (~(put by graphs) resource [graph mark])
               update-logs  (~(put by update-logs) resource update-log)
               archive      (~(del by archive) resource)
-            ::
-              validators
-            ?~  mark  validators
-            (~(put in validators) u.mark)
           ==
       %-  zing
       :~  (give [/keys ~] %keys (~(put in ~(key by graphs)) resource))
           (give [/updates ~] %add-graph resource *graph:store mark overwrite)
-          ?~  mark  ~
-          ?:  (~(has in validators) u.mark)  ~
-          =/  wire  /validator/[u.mark]
-          =/  =rave:clay  [%sing %b [%da now.bowl] /[u.mark]]
-          [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
       ==
     ::
     ++  remove-graph
@@ -1119,13 +1099,8 @@
   ?+  wire  (on-arvo:def wire sign-arvo)
   ::
   ::  old wire, do nothing 
-      [%graph *]  [~ this]
-  ::
-      [%validator @ ~]
-    :_  this
-    =*  validator  i.t.wire
-    =/  =rave:clay  [%next %b [%da now.bowl] /[validator]]
-    [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
+      [%graph *]        [~ this]
+      [%validator @ ~]  [~ this]
   ::
       [%try-rejoin @ *]
     =/  rid=resource:store  (de-path:res t.t.wire)

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -162,8 +162,7 @@
   ++  warm-cache-all
     ?:  warm-cache
       ~|('cannot warm up cache that is already warm' !!)
-    :::_  this(warm-cache %.y)
-    :_  this
+    :_  this(warm-cache %.y)
     =/  =mood:clay  [%t da+now.bowl /mar]
     [%pass /warm-cache %arvo %c %warp our.bowl %home `[%sing mood]]~
   ::
@@ -325,7 +324,6 @@
     =*  mark  t.wire
     ?~  riot
       ~|('mark build failed for {<mark>}' !!)
-    ~&  mark
     :_  this
     =/  =rave:clay  [%next %b [%da now.bowl] mark]
     [%pass wire %arvo %c %warp our.bowl [%home `rave]]~

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -163,8 +163,8 @@
     ?:  warm-cache
       ~|('cannot warm up cache that is already warm' !!)
     :_  this(warm-cache %.y)
-    =/  =mood:clay  [%t da+now.bowl /mar]
-    [%pass /warm-cache %arvo %c %warp our.bowl %home `[%sing mood]]~
+    =/  =rave:clay  [%sing [%t da+now.bowl /mar]]
+    [%pass /warm-cache %arvo %c %warp our.bowl %home `rave]~
   ::
   ++  cool-cache-all
     ?.  warm-cache
@@ -291,17 +291,18 @@
 ++  on-arvo
   |=  [=wire =sign-arvo]
   ^-  (quip card _this)
+  :_  this
   ?+    wire  (on-arvo:def wire sign-arvo)
       [%warm-cache ~]
     ?.  warm-cache
-      [~ this]
+      ~
     ?>  ?=([%clay %writ *] sign-arvo)
-    :_  this
-    :-  =/  =rave:clay  [%next [%t da+now.bowl /mar]]
-        [%pass /warm-cache %arvo %c %warp our.bowl %home `rave]
     =*  riot  p.sign-arvo
     ?~  riot
-      ~
+      =/  =rave:clay  [%next [%t da+now.bowl /mar]]
+      [%pass /warm-cache %arvo %c %warp our.bowl %home `rave]~
+    :-  =/  =rave:clay  [%next [%t q.p.u.riot /mar]]
+        [%pass /warm-cache %arvo %c %warp our.bowl %home `rave]
     %+  turn  !<((list path) q.r.u.riot)
     |=  pax=path
     ^-  card
@@ -311,26 +312,20 @@
       |=  [=term mark=term]
       ?:  =(0 (lent (trip mark)))
         term
-      %-  crip
-      %-  zing
-      :~  (trip mark)
-          "-"
-          (trip term)
-      ==
-    =/  =rave:clay  [%sing %b [%da now.bowl] [mark ~]]
+      :((cury cat 3) mark '-' term)
+    =/  =rave:clay  [%sing %b da+now.bowl /[mark]]
     [%pass [%mar mark ~] %arvo %c %warp our.bowl %home `rave]
   ::
       [%mar ^]
     ?.  warm-cache
-      [~ this]
+      ~
     ?>  ?=([%clay %writ *] sign-arvo)
     =*  riot  p.sign-arvo
     =*  mark  t.wire
     ?~  riot
-      ~|('mark build failed for {<mark>}' !!)
-    :_  this
-    =/  =rave:clay  [%next %b [%da now.bowl] mark]
-    [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
+      ~
+    =/  =rave:clay  [%next %b q.p.u.riot mark]
+    [%pass wire %arvo %c %warp our.bowl %home `rave]~
   ==
 ::
 ++  on-watch  on-watch:def

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -14,6 +14,7 @@
       [%2 observers=(map serial observer:sur)]
       [%3 observers=(map serial observer:sur)]
       [%4 observers=(map serial observer:sur)]
+      [%5 observers=(map serial observer:sur) warm-cache=_|]
   ==
 ::
 +$  serial   @uv
@@ -27,7 +28,7 @@
 --
 ::
 %-  agent:dbug
-=|  [%4 observers=(map serial observer:sur)]
+=|  [%5 observers=(map serial observer:sur) warm-cache=_|]
 =*  state  -
 ::
 ^-  agent:gall
@@ -66,8 +67,13 @@
   =|  cards=(list card)
   |-
   ?-  -.old-state
-      %4
+      %5
     [cards this(state old-state)]
+      %4
+    =.  cards
+      :_  cards
+      (act [%warm-cache-all ~])
+    $(old-state [%5 observers.old-state %.n])
   ::
       %3
     =.  cards
@@ -110,11 +116,19 @@
   ?>  (team:title our.bowl src.bowl)
   ?.  ?=(%observe-action mark)
     (on-poke:def mark vase)
+  |^
   =/  =action:sur  !<(action:sur vase)
   =*  observer  observer.action
   =/  vals  (silt ~(val by observers))
   ?-  -.action
-      %watch
+    %watch           (watch observer vals)
+    %ignore          (ignore observer vals)
+    %warm-cache-all  warm-cache-all
+    %cool-cache-all  cool-cache-all
+  ==
+  ::
+  ++  watch
+    |=  [=observer:sur vals=(set observer:sur)]
     ?:  ?|(=(app.observer %spider) =(app.observer %observe-hook)) 
       ~|('we avoid infinite loops' !!)
     ?:  (~(has in vals) observer)
@@ -129,7 +143,8 @@
         path.observer
     == 
   ::
-      %ignore
+  ++  ignore
+    |=  [=observer:sur vals=(set observer:sur)]
     ?.  (~(has in vals) observer)
       ~|('cannot remove nonexistent observer' !!)
     =/  key  (got-by-val observers observer)
@@ -142,7 +157,20 @@
         %leave
         ~
     == 
-  ==
+  ::
+  ++  warm-cache-all
+    ?:  warm-cache
+      ~|('cannot warm up cache that is already warm' !!)
+    :::_  this(warm-cache %.y)
+    :_  this
+    =/  =mood:clay  [%t da+now.bowl /mar]
+    [%pass /warm-cache %arvo %c %warp our.bowl %home `[%sing mood]]~
+  ::
+  ++  cool-cache-all
+    ?.  warm-cache
+      ~|('cannot cool down cache that is already cool' !!)
+    [~ this(warm-cache %.n)]
+  --
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]
@@ -260,9 +288,50 @@
     ==  == 
   --
 ::
+++  on-arvo
+  |=  [=wire =sign-arvo]
+  ^-  (quip card _this)
+  ?+    wire  (on-arvo:def wire sign-arvo)
+      [%warm-cache ~]
+    ?>  ?=([%clay %writ *] sign-arvo)
+    =*  riot  p.sign-arvo
+    ?~  riot
+      ~|('should always have data in %/mar directory' !!)
+    :_  this
+    %+  turn  !<((list path) q.r.u.riot)
+    |=  pax=path
+    ^-  card
+    =.  pax  `path`(snip (slag 1 `(list @)`pax))
+    =/  mark=@ta
+      %+  roll  pax
+      |=  [=term mark=term]
+      ?:  =(0 (lent (trip mark)))
+        term
+      %-  crip
+      %-  zing
+      :~  (trip mark)
+          "-"
+          (trip term)
+      ==
+    =/  =rave:clay  [%sing %b [%da now.bowl] [mark ~]]
+    [%pass [%mar mark ~] %arvo %c %warp our.bowl [%home `rave]]
+  ::
+      [%mar ^]
+    ?.  warm-cache
+      [~ this]
+    ?>  ?=([%clay %writ *] sign-arvo)
+    =*  riot  p.sign-arvo
+    =*  mark  t.wire
+    ?~  riot
+      ~|('mark build failed for {<mark>}' !!)
+    ~&  mark
+    :_  this
+    =/  =rave:clay  [%next %b [%da now.bowl] mark]
+    [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
+  ==
+::
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
 ++  on-peek   on-peek:def
-++  on-arvo   on-arvo:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -43,6 +43,7 @@
       (act [%watch %group-store /groups %group-on-leave])
       (act [%watch %group-store /groups %group-on-remove-member])
       (act [%watch %metadata-store /updates %md-on-add-group-feed])
+      (act [%warm-cache-all ~])
   ==
   ::
   ++  act

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -293,11 +293,15 @@
   ^-  (quip card _this)
   ?+    wire  (on-arvo:def wire sign-arvo)
       [%warm-cache ~]
+    ?.  warm-cache
+      [~ this]
     ?>  ?=([%clay %writ *] sign-arvo)
+    :_  this
+    :-  =/  =rave:clay  [%next [%t da+now.bowl /mar]]
+        [%pass /warm-cache %arvo %c %warp our.bowl %home `rave]
     =*  riot  p.sign-arvo
     ?~  riot
-      ~|('should always have data in %/mar directory' !!)
-    :_  this
+      ~
     %+  turn  !<((list path) q.r.u.riot)
     |=  pax=path
     ^-  card
@@ -314,7 +318,7 @@
           (trip term)
       ==
     =/  =rave:clay  [%sing %b [%da now.bowl] [mark ~]]
-    [%pass [%mar mark ~] %arvo %c %warp our.bowl [%home `rave]]
+    [%pass [%mar mark ~] %arvo %c %warp our.bowl %home `rave]
   ::
       [%mar ^]
     ?.  warm-cache

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -306,11 +306,11 @@
     %+  turn  !<((list path) q.r.u.riot)
     |=  pax=path
     ^-  card
-    =.  pax  `path`(snip (slag 1 `(list @)`pax))
+    =.  pax  (snip (slag 1 pax))
     =/  mark=@ta
       %+  roll  pax
       |=  [=term mark=term]
-      ?:  =(0 (lent (trip mark)))
+      ?:  ?=(%$ mark)
         term
       :((cury cat 3) mark '-' term)
     =/  =rave:clay  [%sing %b da+now.bowl /[mark]]

--- a/pkg/arvo/sur/observe-hook.hoon
+++ b/pkg/arvo/sur/observe-hook.hoon
@@ -1,7 +1,14 @@
 |%
 +$  observer  [app=term =path thread=term]
 +$  action
-  $%  [%watch =observer]
+  $%  ::  %gall actions
+      ::
+      [%watch =observer]
       [%ignore =observer]
+    ::
+      ::  %clay actions
+      ::
+      [%warm-cache-all ~]
+      [%cool-cache-all ~]
   ==
 --


### PR DESCRIPTION
Keep all marks warm so as to never need to build a mark on demand. Can confirm that on a livenet comet, this stops all marks from rebuilding, whereas some marks (ex: `%hark-update`) would rebuild continually before this.