### PR TITLE
Group Feed: unread counts

### DIFF
--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -22,8 +22,9 @@
   ++  notification-kind  
     ^-  (unit notif-kind:hark)
     =/  len  (lent index.p.i)
-    ?:  =(1 len)  ~
-    `[%post [(dec len) len] %none %children]
+    =/  =mode:hark
+      ?:(=(1 len) %count %none)
+    `[%post [(dec len) len] mode %children]
   ::
   ++  transform-add-nodes
     |=  [=index =post =atom was-parent-modified=?]

--- a/pkg/interface/src/views/landscape/components/Home/GroupFeed.js
+++ b/pkg/interface/src/views/landscape/components/Home/GroupFeed.js
@@ -54,6 +54,7 @@ function GroupFeed(props) {
       return;
     }
     api.graph.getNewest(graphResource.ship, graphResource.name, 100);
+    api.hark.markCountAsRead(association, '/', 'post');
   }, [graphPath]);
 
   if (!graphPath) {

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -24,6 +24,7 @@ import { Workspace } from '~/types/workspace';
 import useGroupState from '~/logic/state/group';
 import useMetadataState from '~/logic/state/metadata';
 import {IS_SAFARI} from '~/logic/lib/platform';
+import useHarkState from '~/logic/state/hark';
 
 export function SidebarListHeader(props: {
   api: GlobalApi;
@@ -54,15 +55,15 @@ export function SidebarListHeader(props: {
 
   const noun = (props.workspace?.type === 'messages') ? 'Messages' : 'Channels';
 
-  const isFeedEnabled =
-    metadata &&
-    metadata.config &&
-    metadata.config.group &&
-    'resource' in metadata.config.group;
+  const feedPath = metadata?.config?.group?.resource;
+
+  const unreadCount = useHarkState(
+    s => s.unreads?.graph?.[feedPath ?? ""]?.["/"]?.unreads as number ?? 0
+  );
 
   return (
     <Box>
-    {( isFeedEnabled ) ? (
+    {( !!feedPath) ? (
        <Row
          flexShrink="0"
          alignItems="center"
@@ -87,7 +88,7 @@ export function SidebarListHeader(props: {
            props.history.push(`/~landscape${groupPath}/feed`);
          }}
        >
-         <Text>
+         <Text color={unreadCount > 0 ? 'blue' : 'black'}>
            Group Feed
          </Text>
        </Row>

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -88,8 +88,11 @@ export function SidebarListHeader(props: {
            props.history.push(`/~landscape${groupPath}/feed`);
          }}
        >
-         <Text color={unreadCount > 0 ? 'blue' : 'black'}>
+         <Text>
            Group Feed
+         </Text>
+         <Text mr="1" color="blue">
+           { unreadCount > 0 && unreadCount}
          </Text>
        </Row>
      ) : null


### PR DESCRIPTION
Keeps track of an unread count for group feeds, and displays the link as blue if the group feed has unreads. In lieu of better specified behaviour the unread count is reset upon navigation to the page.