### PR TITLE
groups: forward to already-joined group from GroupLink

### DIFF
--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState, useLayoutEffect, ReactElement } from 'react';
-
+import { useHistory } from 'react-router-dom';
 import { Box, Text, Row, Col } from '@tlon/indigo-react';
 import { Associations, Groups } from '@urbit/api';
-
 import GlobalApi from '~/logic/api/global';
 import { MetadataIcon } from '../landscape/components/MetadataIcon';
 import { JoinGroup } from '../landscape/components/JoinGroup';
@@ -23,27 +22,12 @@ export function GroupLink(
   const name = resource.slice(6);
   const [preview, setPreview] = useState<MetadataUpdatePreview | null>(null);
   const associations = useMetadataState(state => state.associations);
-
+  const { save, restore } = useVirtual();
+  const history = useHistory();
   const joined = resource in associations.groups;
 
-  const { save, restore } = useVirtual();
-
   const { modal, showModal } = useModal({
-    modal:
-      joined && preview ? (
-        <Box width="fit-content" p="4">
-          <GroupSummary
-            metadata={preview.metadata}
-            memberCount={preview.members}
-            channelCount={preview?.['channel-count']}
-          />
-        </Box>
-      ) : (
-        <JoinGroup
-          api={api}
-          autojoin={name}
-        />
-      )
+    modal: <JoinGroup api={api} autojoin={name} />
   });
 
   useEffect(() => {
@@ -72,7 +56,9 @@ export function GroupLink(
         alignItems="center"
         py="2"
         pr="2"
-        onClick={showModal}
+        onClick={
+          joined ? () => history.push(`/~landscape/ship/${name}`) : showModal
+        }
         cursor='pointer'
         opacity={preview ? '1' : '0.6'}
       >


### PR DESCRIPTION
Forwards users directly to groups they have already joined when they click a GroupLink.

Video attached; I belong to the "Clack" group and not the "Areological Fermentation" group:

https://user-images.githubusercontent.com/748181/114098922-087c2b80-9890-11eb-8a5a-a0de17f8cc08.mp4

Fixes urbit/landscape#593