### PR TITLE
king: fix lanes yet again, also reuse udp port

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
@@ -25,7 +25,6 @@ module Urbit.Arvo.Common
 import Urbit.Prelude
 
 import Control.Monad.Fail (fail)
-import Data.Bits
 import Data.Serialize
 
 import qualified Network.HTTP.Types.Method as H
@@ -185,9 +184,9 @@ newtype Ipv4 = Ipv4 { unIpv4 :: N.HostAddress }
   deriving newtype (Eq, Ord, Enum)
 
 instance Serialize Ipv4 where
-  get = Ipv4 <$> N.tupleToHostAddress
-    <$> ((,,,) <$> getWord8 <*> getWord8 <*> getWord8 <*> getWord8)
-  put (Ipv4 (N.hostAddressToTuple -> (a, b, c, d))) = for_ [a, b, c, d] putWord8
+  get = (\a b c d -> Ipv4 $ N.tupleToHostAddress $ (d, c, b, a))
+    <$> getWord8 <*> getWord8 <*> getWord8 <*> getWord8
+  put (Ipv4 (N.hostAddressToTuple -> (a, b, c, d))) = for_ [d, c, b, a] putWord8
 
 instance ToNoun Ipv4 where
   toNoun = serializeToNoun
@@ -196,11 +195,11 @@ instance FromNoun Ipv4 where
   parseNoun = serializeParseNoun "Ipv4" 4
 
 instance Show Ipv4 where
-  show (Ipv4 i) =
-    show ((shiftR i 24) .&. 0xff) ++ "." ++
-    show ((shiftR i 16) .&. 0xff) ++ "." ++
-    show ((shiftR i  8) .&. 0xff) ++ "." ++
-    show (i .&. 0xff)
+  show (Ipv4 (N.hostAddressToTuple -> (a, b, c, d))) =
+    show a ++ "." ++
+    show b ++ "." ++
+    show c ++ "." ++
+    show d
 
 -- @is
 -- should probably use hostAddress6ToTuple here, but no one uses it right now

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/Packet.hs
@@ -80,10 +80,6 @@ data ShipClass
 muk :: ByteString -> Word20
 muk bs = mugBS bs .&. (2 ^ 20 - 1)
 
--- XX check this
-getAmesAddress :: Get AmesAddress
-getAmesAddress = AAIpv4 <$> (Ipv4 <$> getWord32le) <*> (Port <$> getWord16le)
-
 putAmesAddress :: Putter AmesAddress
 putAmesAddress = \case
   AAIpv4 (Ipv4 ip) (Port port) -> putWord32le ip >> putWord16le port
@@ -104,7 +100,7 @@ instance Serialize Packet where
     guard isAmes
 
     pktOrigin <- if isRelayed
-      then Just <$> getAmesAddress
+      then Just <$> get
       else pure Nothing
 
     -- body
@@ -157,9 +153,10 @@ instance Serialize Packet where
 
     putWord32le head
     case pktOrigin of
-      Just o  -> putAmesAddress o
+      Just o  -> put o
       Nothing -> pure ()
     putByteString body
+    
     where
       putShipGetRank s@(Ship (LargeKey p q)) = case () of
         _ | s < 2 ^ 16 -> (0, putWord16le $ fromIntegral s)    -- lord

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -4,7 +4,7 @@
   1. Opens a UDP socket and makes sure that it stays open.
 
     - If can't open the port, wait and try again repeatedly.
-    - If there is an error reading or writting from the open socket,
+    - If there is an error reading to or writing from the open socket,
       close it and open another, making sure, however, to reuse the
       same port
         NOTE: It's not clear what, if anything, closing and reopening

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Ames/UDP.hs
@@ -7,6 +7,9 @@
     - If there is an error reading or writting from the open socket,
       close it and open another, making sure, however, to reuse the
       same port
+        NOTE: It's not clear what, if anything, closing and reopening
+      the socket does. We're keeping this behavior out of conservatism
+      until we understand it better.
 
   2. Receives packets from the socket.
 


### PR DESCRIPTION
In king haskell, it seems, the "lane" is more of a poorly lit alley, an alley I hope I don't have to walk through ever again.

This time around, it seems I got the byte order of the ip address wrong. According to https://hackage.haskell.org/package/network-3.1.2.1/docs/Network-Socket.html#t:HostAddress, the ip address in haskell is represented as a Word32, of which it is said, confusingly, that "[t]he raw network byte order number is read using host byte order." On real computers, this means it's reversed, which, apparently, is not what the corresponding c function does. So we fix that here. Hopefully.

We also add code to guarantee that when your UDP port is closed and reopened due to a problem, it is opened at the same port. Previously, if you hadn't explicitly specified a port, we'd ask the OS for the next available one, which would be different each time. Because not explicitly specifying a port is represented as "port 0" in the code, however, a naive read-through of the code suggests that this was always the behavior, which it was not.

Fixes #4707