### PR TITLE
clay: add /~ ford rune, as /= for directories

### DIFF
--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -23,6 +23,9 @@
     %+  rune  tis
     ;~(plug sym ;~(pfix gap stap))
   ::
+    %+  rune  sig
+    ;~(plug sym ;~(pfix gap stap))
+  ::
     %+  rune  cen
     ;~(plug sym ;~(pfix gap ;~(pfix cen sym)))
   ::

--- a/pkg/arvo/lib/language-server/parser.hoon
+++ b/pkg/arvo/lib/language-server/parser.hoon
@@ -24,7 +24,7 @@
     ;~(plug sym ;~(pfix gap stap))
   ::
     %+  rune  sig
-    ;~(plug sym ;~(pfix gap stap))
+    ;~((glue gap) sym wyde:vast stap)
   ::
     %+  rune  cen
     ;~(plug sym ;~(pfix gap ;~(pfix cen sym)))

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -928,6 +928,7 @@
   ::    /-  sur-file            ::  surface imports from /sur
   ::    /+  lib-file            ::  library imports from /lib
   ::    /=  face  /path         ::  imports built hoon file at path
+  ::    /~  face  /path         ::  imports built hoon files from directory
   ::    /%  face  %mark         ::  imports mark definition from /mar
   ::    /$  face  %from  %to    ::  imports mark converter from /mar
   ::    /*  face  %mark  /path  ::  unbuilt file imports, as mark
@@ -936,6 +937,7 @@
     $:  sur=(list taut)
         lib=(list taut)
         raw=(list [face=term =path])
+        raz=(list [face=term =path])
         maz=(list [face=term =mark])
         caz=(list [face=term =mars])
         bar=(list [face=term =mark =path])

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -928,7 +928,7 @@
   ::    /-  sur-file            ::  surface imports from /sur
   ::    /+  lib-file            ::  library imports from /lib
   ::    /=  face  /path         ::  imports built hoon file at path
-  ::    /~  face  /path         ::  imports built hoon files from directory
+  ::    /~  face  type   /path  ::  imports built hoon files from directory
   ::    /%  face  %mark         ::  imports mark definition from /mar
   ::    /$  face  %from  %to    ::  imports mark converter from /mar
   ::    /*  face  %mark  /path  ::  unbuilt file imports, as mark
@@ -937,7 +937,7 @@
     $:  sur=(list taut)
         lib=(list taut)
         raw=(list [face=term =path])
-        raz=(list [face=term =path])
+        raz=(list [face=term =spec =path])
         maz=(list [face=term =mark])
         caz=(list [face=term =mars])
         bar=(list [face=term =mark =path])

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -932,7 +932,7 @@
         ;~(plug sym ;~(pfix gap stap))
       ::
         %+  rune  sig
-        ;~(plug sym ;~(pfix gap stap))
+        ;~((glue gap) sym wyde:vast stap)
       ::
         %+  rune  cen
         ;~(plug sym ;~(pfix gap ;~(pfix cen sym)))
@@ -995,7 +995,7 @@
       $(sut (slop pin sut), raw t.raw)
     ::
     ++  run-raz
-      |=  [sut=vase raz=(list [face=term =path])]
+      |=  [sut=vase raz=(list [face=term =spec =path])]
       ^-  [vase state]
       ?~  raz  [sut nub]
       =^  res=(map path vase)  nub
@@ -1003,20 +1003,23 @@
       =;  pin=vase
         =.  p.pin  [%face face.i.raz p.pin]
         $(sut (slop pin sut), raz t.raz)
-      ::  convert the (map path vase) into a vase of (map @ta *),
-      ::  with paths hyphenated into names and the .hoon cut off
       ::
       =/  lap=@ud  (lent path.i.raz)
-      |-  ^-  vase
-      ?~  res  [[%atom %n `0] 0]
-      %+  slop
-        %+  slop
-          :-  [%atom %ta ~]
-          %+  rap  3
-          %+  join  '-'
-          (snip (slag lap p.n.res))
-        q.n.res
-      (slop $(res l.res) $(res r.res))
+      =/  =type  (~(play ut p.sut) [%kttr spec.i.raz])
+      ::  ensure results nest in the specified type,
+      ::  and produce a homogenous map containing that type.
+      ::
+      :-  %-  ~(play ut p.sut)
+          [%kttr %make [%wing ~[%map]] ~[[%base %atom %ta] spec.i.raz]]
+      |-
+      ?~  res  ~
+      ~|  [%nest-fail path.i.raz p.n.res]
+      ?>  (~(nest ut type) | p.q.n.res)
+      :_  [$(res l.res) $(res r.res)]
+      :_  q.q.n.res
+      %+  rap  3
+      %+  join  '-'
+      (snip (slag lap p.n.res))
     ::
     ++  run-maz
       |=  [sut=vase maz=(list [face=term =mark])]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -810,9 +810,11 @@
       =^  res=vase  nub  (run-pile pile)
       res
     ::
-    ++  build-file
-      |=  =path
+    ++  build-dependency
+      |=  dep=(each [dir=path fil=path] path)
       ^-  [vase state]
+      =/  =path
+        ?:(?=(%| -.dep) p.dep fil.p.dep)
       ~|  %error-building^path
       ?^  got=(~(get by files.cache.nub) path)
         =?  stack.nub  ?=(^ stack.nub)
@@ -821,7 +823,9 @@
       ?:  (~(has in cycle.nub) file+path)
         ~|(cycle+file+path^stack.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) file+path)
-      =.  stack.nub  [(sy [| path] ~) stack.nub]
+      =.  stack.nub
+        =-  [(sy - ~) stack.nub]
+        ?:(?=(%| -.dep) dep [& dir.p.dep])
       =^  cag=cage  nub  (read-file path)
       ?>  =(%hoon p.cag)
       =/  tex=tape  (trip !<(@t q.cag))
@@ -830,6 +834,10 @@
       =^  top  stack.nub  pop-stack
       =.  files.cache.nub  (~(put by files.cache.nub) path [res top])
       [res nub]
+    ::
+    ++  build-file
+      |=  =path
+      (build-dependency |+path)
     ::  +build-directory: builds files in top level of a directory
     ::
     ::    this excludes files directly at /path/hoon,
@@ -854,24 +862,7 @@
         [rez nub]
       =*  nom=@ta    i.fiz
       =/  pax=^path  (weld path nom %hoon ~)
-      ::
-      ::TODO  deduplicate with +build-file
-      ?^  got=(~(get by files.cache.nub) pax)
-        =?  stack.nub  ?=(^ stack.nub)
-          stack.nub(i (~(uni in i.stack.nub) dez.u.got))
-        $(fiz t.fiz, rez (~(put by rez) nom res.u.got))
-      ?:  (~(has in cycle.nub) file+pax)
-        ~|(cycle+file+pax^stack.nub !!)
-      =.  cycle.nub  (~(put in cycle.nub) file+pax)
-      =.  stack.nub  [(sy [& path] ~) stack.nub]
-      =^  cag=cage  nub  (read-file pax)
-      ?>  =(%hoon p.cag)
-      =/  tex=tape  (trip !<(@t q.cag))
-      =/  =pile  (parse-pile pax tex)
-      =^  res=vase  nub  (run-pile pile)
-      =^  top  stack.nub  pop-stack
-      =.  files.cache.nub  (~(put by files.cache.nub) pax [res top])
-      ::
+      =^  res  nub   (build-dependency &+[path pax])
       $(fiz t.fiz, rez (~(put by rez) nom res))
     ::
     ++  run-pile

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1655,11 +1655,11 @@
       |-  ^+  cache
       ?~  builds
         ~
-      ?:  %+  lien  ~(tap in dez.i.builds)
+      ?:  %-  ~(any in dez.i.builds)
           |=  [dir=? =path]
           ?.  dir  (~(has in invalid) path)
           =+  l=(lent path)
-          %+  lien  ~(tap in invalid)
+          %-  ~(any in invalid)
           |=  i=^path
           &(=(path (scag l i)) ?=([@ %hoon ~] (slag l i)))
         $(builds t.builds)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -992,8 +992,9 @@
           [%kttr %make [%wing ~[%map]] ~[[%base %atom %ta] spec.i.raz]]
       |-
       ?~  res  ~
-      ~|  [%nest-fail path.i.raz p.n.res]
-      ?>  (~(nest ut type) | p.q.n.res)
+      ?.  (~(nest ut type) | p.q.n.res)
+        ~|  [%nest-fail path.i.raz p.n.res]
+        !!
       :-  [p.n.res q.q.n.res]
       [$(res l.res) $(res r.res)]
     ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1669,8 +1669,7 @@
           =+  l=(lent path)
           %+  lien  ~(tap in invalid)
           |=  i=^path
-          =+  j=(lent i)
-          &((gth j +(l)) =(path (scag l i)))
+          &(=(path (scag l i)) ?=([@ %hoon ~] (slag l i)))
         $(builds t.builds)
       (~(put by $(builds t.builds)) i.builds)
     ::


### PR DESCRIPTION
Hoon files may want to import nouns from all files in a given directory.
`/~` lets you do so, importing as a noun structured like a `(map @ta *)`.

Note the description as "directories" here, instead of "path prefix".
The behavior, as implemented, will not include `/path/hoon` for `/~  /path`, instead only including `/path/more/hoon` and more deeply nested files.
This seems to be, generally, the behavior you want, for example when importing from `/app/myapp/*` for use in `/app/myapp/hoon`.
It's a bit out of line compared to general clay semantics though, so RFC.

Also, the map keying by `@ta` seems more ergonomic than `path` for most cases, but does run into the usual hyphenation-ambiguity problem, where `/path/a/b/hoon` and `/path/a-b/hoon` would conflict with each other. Again, RFC.

From my testing, using the resulting map requires manual casting, which is not ideal. Not sure how to solve for this besides adding `/^` back in as well, but perhaps there's some wizardry to be done here. RFC the third!

Internally, in addition to implementing the logic for `/~` by itself, we update the `ford-cache` to be able to tell whether a dependency is a single file, or the path of a directory whose contents we depend on. Without this, we would not rebuild for file additions.

This code isn't gonna win any beauty contests yet (`+build-directory` and `+invalidate` in particular need some love), but I wanted to go ahead and start getting eyes on this. Maybe the ideal refactoring will come to me in a dream...