### PR TITLE
eyre + interface: use font-display: swap; to reduce time to paint text

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -249,6 +249,7 @@
                  font-family: "Source Code Pro";
                  src: url("https://storage.googleapis.com/media.urbit.org/fonts/scp-regular.woff");
                  font-weight: 400;
+                 font-display: swap;
              }
              :root {
                --red05: rgba(255,65,54,0.05);

--- a/pkg/interface/src/views/css/fonts.css
+++ b/pkg/interface/src/views/css/fonts.css
@@ -2,6 +2,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 400;
+  font-display: swap;
   src: url("/~landscape/fonts/inter-regular.woff2") format("woff2"),
        url("https://media.urbit.org/fonts/Inter-Regular.woff2") format("woff2");
 }
@@ -10,6 +11,7 @@
   font-family: 'Inter';
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url("https://media.urbit.org/fonts/Inter-Medium.woff2") format("woff2");
 }
 
@@ -17,6 +19,7 @@
   font-family: 'Inter';
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url("https://media.urbit.org/fonts/Inter-SemiBold.woff2") format("woff2");
 }
 
@@ -24,6 +27,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 400;
+  font-display: swap;
   src: url("/~landscape/fonts/inter-italic.woff2") format("woff2"),
        url("https://media.urbit.org/fonts/Inter-Italic.woff2") format("woff2");
 }
@@ -32,6 +36,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 700;
+  font-display: swap;
   src: url("/~landscape/fonts/inter-bold.woff2") format("woff2"),
        url("https://media.urbit.org/fonts/Inter-Bold.woff2") format("woff2");
 }
@@ -39,6 +44,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 700;
+  font-display: swap;
   src: url("/~landscape/fonts/inter-bolditalic.woff2") format("woff2"),
        url("https://media.urbit.org/fonts/Inter-BoldItalic.woff2") format("woff2");
 }
@@ -48,6 +54,7 @@
   src: url("/~landscape/fonts/sourcecodepro-extralight.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-extralight.woff");
   font-weight: 200;
+  font-display: swap;
 }
 
 @font-face {
@@ -55,6 +62,7 @@
   src: url("/~landscape/fonts/sourcecodepro-light.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-light.woff");
   font-weight: 300;
+  font-display: swap;
 }
 
 @font-face {
@@ -62,6 +70,7 @@
   src: url("/~landscape/fonts/sourcecodepro-regular.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-regular.woff");
   font-weight: 400;
+  font-display: swap;
 }
 
 @font-face {
@@ -69,6 +78,7 @@
   src: url("(/~landscape/fonts/sourcecodepro-medium.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-medium.woff");
   font-weight: 500;
+  font-display: swap;
 }
 
 @font-face {
@@ -76,6 +86,7 @@
   src: url("/~landscape/fonts/sourcecodepro-semibold.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-semibold.woff");
   font-weight: 600;
+  font-display: swap;
 }
 
 @font-face {
@@ -83,5 +94,6 @@
   src: url("/~landscape/fonts/sourcecodepro-bold.woff2"),
        url("https://storage.googleapis.com/media.urbit.org/fonts/scp-bold.woff");
   font-weight: 700;
+  font-display: swap;
 }
 


### PR DESCRIPTION
https://web.dev/font-display/?utm_source=lighthouse&utm_medium=unknown

Fixes https://github.com/urbit/landscape/issues/762