### PR TITLE
MentionText: inline mentions

### DIFF
--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -50,7 +50,7 @@ export function Mention(props: {
   const name = showNickname ? contact?.nickname : cite(ship);
 
   return (
-    <ProfileOverlay ship={ship} api={api}>
+    <ProfileOverlay ship={ship} api={api} display="inline">
       <Text
         marginLeft={first? 0 : 1}
         marginRight={1}


### PR DESCRIPTION
Mentions are wrapped in ProfileOverlay, which defaults to using a `Box`, which is a `block`, so we pass an inline prop which corrects the issue. Overlays still work.

Fixes urbit/landscape#763