### PR TITLE
leap: deduplicate selection with mouse+keys

### DIFF
--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -62,7 +62,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
   const contacts = useMemo(() => {
     const maybeShip = `~${deSig(query)}`;
     const selflessContactState = omit(contactState, `~${window.ship}`);
-    return ob.isValidPatp(maybeShip)
+    return ob.isValidPatp(maybeShip) && maybeShip !== `~${window.ship}`
       ? { ...selflessContactState, [maybeShip]: {} }
       : selflessContactState;
   }, [contactState, query]);

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -210,6 +210,10 @@ export function Omnibox(props: OmniboxProps): ReactElement {
     }
   }, [selected, results]);
 
+  const setSelection = (app, link) => {
+    setSelected([app, link]);
+  };
+
   const control = useCallback(
     (evt) => {
       if (evt.key === 'Escape') {
@@ -288,12 +292,6 @@ export function Omnibox(props: OmniboxProps): ReactElement {
     return 0;
   };
 
-  // Handler to set selection on mouse hover
-  const setSelection = (app, link) => {
-    // TODO: Cancel this event if we are navigating by keyboard
-    setSelected([app, link]);
-  };
-
   const renderResults = useCallback(() => {
     return (
       <Box
@@ -366,7 +364,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
               ref={(el) => {
                 inputRef.current = el;
               }}
-              control={(e) => control(e)}
+              control={e => control(e)}
               search={search}
               query={query}
             />

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -3,15 +3,13 @@ import React, {
   useRef,
   useCallback,
   useEffect,
-  useState,
+  useState
 } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import * as ob from 'urbit-ob';
 import Mousetrap from 'mousetrap';
 
 import { Box, Row, Text } from '@tlon/indigo-react';
-import { Associations, Contacts, Groups, Invites } from '@urbit/api';
-
 import makeIndex from '~/logic/lib/omnibox';
 import OmniboxInput from './OmniboxInput';
 import OmniboxResult from './OmniboxResult';
@@ -22,7 +20,6 @@ import defaultApps from '~/logic/lib/default-apps';
 import { useOutsideClick } from '~/logic/lib/useOutsideClick';
 import { Portal } from '../Portal';
 import useSettingsState, { SettingsState } from '~/logic/state/settings';
-import { Tile } from '~/types';
 import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
 import useHarkState from '~/logic/state/hark';
@@ -46,7 +43,7 @@ const SEARCHED_CATEGORIES = [
 ];
 const settingsSel = (s: SettingsState) => s.leap;
 
-export function Omnibox(props: OmniboxProps) {
+export function Omnibox(props: OmniboxProps): ReactElement {
   const location = useLocation();
   const history = useHistory();
   const leapConfig = useSettingsState(settingsSel);
@@ -55,10 +52,10 @@ export function Omnibox(props: OmniboxProps) {
 
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<[] | [string, string]>([]);
-  const contactState = useContactState((state) => state.contacts);
-  const notifications = useHarkState((state) => state.notifications);
-  const invites = useInviteState((state) => state.invites);
-  const tiles = useLaunchState((state) => state.tiles);
+  const contactState = useContactState(state => state.contacts);
+  const notifications = useHarkState(state => state.notifications);
+  const invites = useInviteState(state => state.invites);
+  const tiles = useLaunchState(state => state.tiles);
 
   const contacts = useMemo(() => {
     const maybeShip = `~${deSig(query)}`;
@@ -67,8 +64,8 @@ export function Omnibox(props: OmniboxProps) {
       : contactState;
   }, [contactState, query]);
 
-  const groups = useGroupState((state) => state.groups);
-  const associations = useMetadataState((state) => state.associations);
+  const groups = useGroupState(state => state.groups);
+  const associations = useMetadataState(state => state.associations);
 
   const selectedGroup = useMemo(
     () =>
@@ -256,14 +253,14 @@ export function Omnibox(props: OmniboxProps) {
       props.show,
       results,
       setPreviousSelected,
-      setNextSelected,
+      setNextSelected
     ]
   );
 
   useEffect(() => {
     const flattenedResultLinks = Array.from(results.values())
       .flat()
-      .map((result) => [result.app, result.link]);
+      .map(result => [result.app, result.link]);
     if (!flattenedResultLinks.includes(selected)) {
       setSelected(flattenedResultLinks[0] || []);
     }
@@ -291,6 +288,12 @@ export function Omnibox(props: OmniboxProps) {
     return 0;
   };
 
+  // Handler to set selection on mouse hover
+  const setSelection = (app, link) => {
+    // TODO: Cancel this event if we are navigating by keyboard
+    setSelected([app, link]);
+  };
+
   const renderResults = useCallback(() => {
     return (
       <Box
@@ -300,10 +303,10 @@ export function Omnibox(props: OmniboxProps) {
         borderBottomLeftRadius='2'
         borderBottomRightRadius='2'
       >
-        {SEARCHED_CATEGORIES.map((category) =>
+        {SEARCHED_CATEGORIES.map(category =>
           Object({ category, categoryResults: results.get(category) })
         )
-          .filter((category) => category.categoryResults.length > 0)
+          .filter(category => category.categoryResults.length > 0)
           .map(({ category, categoryResults }, i) => {
             const categoryTitle =
               category === 'other' ? null : (
@@ -325,6 +328,7 @@ export function Omnibox(props: OmniboxProps) {
                     subtext={result.host}
                     link={result.link}
                     navigate={() => navigate(result.app, result.link)}
+                    setSelection={() => setSelection(result.app, result.link)}
                     selected={sel}
                   />
                 ))}

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useLocation, useHistory } from 'react-router-dom';
 import * as ob from 'urbit-ob';
 import Mousetrap from 'mousetrap';
+import { omit } from 'lodash';
 
 import { Box, Row, Text } from '@tlon/indigo-react';
 import makeIndex from '~/logic/lib/omnibox';
@@ -60,9 +61,10 @@ export function Omnibox(props: OmniboxProps): ReactElement {
 
   const contacts = useMemo(() => {
     const maybeShip = `~${deSig(query)}`;
+    const selflessContactState = omit(contactState, `~${window.ship}`);
     return ob.isValidPatp(maybeShip)
-      ? { ...contactState, [maybeShip]: {} }
-      : contactState;
+      ? { ...selflessContactState, [maybeShip]: {} }
+      : selflessContactState;
   }, [contactState, query]);
 
   const groups = useGroupState(state => state.groups);
@@ -144,9 +146,6 @@ export function Omnibox(props: OmniboxProps): ReactElement {
         })
       );
     });
-    resultsMap.set('ships', resultsMap.get('ships').filter(ship => (
-      ship.title === `~${window.ship}` ? null : (ship)
-    )));
     return resultsMap;
   }, [query, index]);
 

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -39,7 +39,7 @@ const SEARCHED_CATEGORIES = [
   'other',
   'groups',
   'subscriptions',
-  'apps',
+  'apps'
 ];
 const settingsSel = (s: SettingsState) => s.leap;
 
@@ -56,6 +56,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
   const notifications = useHarkState(state => state.notifications);
   const invites = useInviteState(state => state.invites);
   const tiles = useLaunchState(state => state.tiles);
+  const [leapCursor, setLeapCursor] = useState('pointer');
 
   const contacts = useMemo(() => {
     const maybeShip = `~${deSig(query)}`;
@@ -113,7 +114,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
         if (category === 'other') {
           return [
             'other',
-            index.get('other').filter(({ app }) => app !== 'tutorial'),
+            index.get('other').filter(({ app }) => app !== 'tutorial')
           ];
         }
         return [category, []];
@@ -211,6 +212,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
   }, [selected, results]);
 
   const setSelection = (app, link) => {
+    setLeapCursor('pointer');
     setSelected([app, link]);
   };
 
@@ -228,11 +230,13 @@ export function Omnibox(props: OmniboxProps): ReactElement {
       if (evt.key === 'ArrowUp' || (evt.shiftKey && evt.key === 'Tab')) {
         evt.preventDefault();
         setPreviousSelected();
+        setLeapCursor('none');
         return;
       }
       if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
         evt.preventDefault();
         setNextSelected();
+        setLeapCursor('none');
         return;
       }
       if (evt.key === 'Enter') {
@@ -325,6 +329,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
                     text={result.title}
                     subtext={result.host}
                     link={result.link}
+                    cursor={leapCursor}
                     navigate={() => navigate(result.app, result.link)}
                     setSelection={() => setSelection(result.app, result.link)}
                     selected={sel}

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -1,4 +1,10 @@
-import React, { useMemo, useRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  useMemo,
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import * as ob from 'urbit-ob';
 import Mousetrap from 'mousetrap';
@@ -13,9 +19,9 @@ import { deSig } from '~/logic/lib/util';
 import { withLocalState } from '~/logic/state/local';
 
 import defaultApps from '~/logic/lib/default-apps';
-import {useOutsideClick} from '~/logic/lib/useOutsideClick';
-import {Portal} from '../Portal';
-import useSettingsState, {SettingsState} from '~/logic/state/settings';
+import { useOutsideClick } from '~/logic/lib/useOutsideClick';
+import { Portal } from '../Portal';
+import useSettingsState, { SettingsState } from '~/logic/state/settings';
 import { Tile } from '~/types';
 import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
@@ -30,22 +36,29 @@ interface OmniboxProps {
   notifications: number;
 }
 
-const SEARCHED_CATEGORIES = ['commands', 'ships', 'other', 'groups', 'subscriptions', 'apps'];
+const SEARCHED_CATEGORIES = [
+  'commands',
+  'ships',
+  'other',
+  'groups',
+  'subscriptions',
+  'apps',
+];
 const settingsSel = (s: SettingsState) => s.leap;
 
 export function Omnibox(props: OmniboxProps) {
   const location = useLocation();
   const history = useHistory();
   const leapConfig = useSettingsState(settingsSel);
-  const omniboxRef = useRef<HTMLDivElement | null>(null)
+  const omniboxRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<[] | [string, string]>([]);
-  const contactState = useContactState(state => state.contacts);
-  const notifications = useHarkState(state => state.notifications);
-  const invites = useInviteState(state => state.invites);
-  const tiles = useLaunchState(state => state.tiles);
+  const contactState = useContactState((state) => state.contacts);
+  const notifications = useHarkState((state) => state.notifications);
+  const invites = useInviteState((state) => state.invites);
+  const tiles = useLaunchState((state) => state.tiles);
 
   const contacts = useMemo(() => {
     const maybeShip = `~${deSig(query)}`;
@@ -54,13 +67,14 @@ export function Omnibox(props: OmniboxProps) {
       : contactState;
   }, [contactState, query]);
 
-  const groups = useGroupState(state => state.groups);
-  const associations = useMetadataState(state => state.associations);
+  const groups = useGroupState((state) => state.groups);
+  const associations = useMetadataState((state) => state.associations);
 
-  const selectedGroup =  useMemo(
-    () => location.pathname.startsWith('/~landscape/ship/')
-      ? '/' + location.pathname.split('/').slice(2,5).join('/')
-      : null,
+  const selectedGroup = useMemo(
+    () =>
+      location.pathname.startsWith('/~landscape/ship/')
+        ? '/' + location.pathname.split('/').slice(2, 5).join('/')
+        : null,
     [location.pathname]
   );
 
@@ -71,16 +85,9 @@ export function Omnibox(props: OmniboxProps) {
       tiles,
       selectedGroup,
       groups,
-      leapConfig,
+      leapConfig
     );
-  }, [
-    selectedGroup,
-    leapConfig,
-    contacts,
-    associations,
-    groups,
-    tiles
-  ]);
+  }, [selectedGroup, leapConfig, contacts, associations, groups, tiles]);
 
   const onOutsideClick = useCallback(() => {
     props.show && props.toggle();
@@ -90,7 +97,7 @@ export function Omnibox(props: OmniboxProps) {
 
   //  handle omnibox show
   useEffect(() => {
-    if(!props.show) {
+    if (!props.show) {
       return;
     }
     Mousetrap.bind('escape', props.toggle);
@@ -104,29 +111,37 @@ export function Omnibox(props: OmniboxProps) {
   }, [props.show]);
 
   const initialResults = useMemo(() => {
-    return new Map(SEARCHED_CATEGORIES.map((category) => {
-     if (category === 'other') {
-       return ['other', index.get('other').filter(({ app }) => app !== 'tutorial')];
-     }
-     return [category, []];
-    }));
+    return new Map(
+      SEARCHED_CATEGORIES.map((category) => {
+        if (category === 'other') {
+          return [
+            'other',
+            index.get('other').filter(({ app }) => app !== 'tutorial'),
+          ];
+        }
+        return [category, []];
+      })
+    );
   }, [index]);
 
   const results = useMemo(() => {
-    if(query.length <= 1) {
+    if (query.length <= 1) {
       return initialResults;
     }
     const q = query.toLowerCase();
     const resultsMap = new Map();
     SEARCHED_CATEGORIES.map((category) => {
       const categoryIndex = index.get(category);
-      resultsMap.set(category,
+      resultsMap.set(
+        category,
         categoryIndex.filter((result) => {
           return (
             result.title.toLowerCase().includes(q) ||
             result.link.toLowerCase().includes(q) ||
             result.app.toLowerCase().includes(q) ||
-            (result.host !== null ? result.host.toLowerCase().includes(q) : false)
+            (result.host !== null
+              ? result.host.toLowerCase().includes(q)
+              : false)
           );
         })
       );
@@ -134,21 +149,26 @@ export function Omnibox(props: OmniboxProps) {
     return resultsMap;
   }, [query, index]);
 
-  const navigate = useCallback((app: string, link: string) => {
-    props.toggle();
-    if (defaultApps.includes(app.toLowerCase())
-        || app === 'profile'
-        || app === 'messages'
-        || app === 'tutorial'
-        || app === 'Links'
-        || app === 'Terminal'
-        || app === 'home'
-        || app === 'inbox') {
-      history.push(link);
-    } else {
-      window.location.href = link;
-    }
-  }, [history, props.toggle]);
+  const navigate = useCallback(
+    (app: string, link: string) => {
+      props.toggle();
+      if (
+        defaultApps.includes(app.toLowerCase()) ||
+        app === 'profile' ||
+        app === 'messages' ||
+        app === 'tutorial' ||
+        app === 'Links' ||
+        app === 'Terminal' ||
+        app === 'home' ||
+        app === 'inbox'
+      ) {
+        history.push(link);
+      } else {
+        window.location.href = link;
+      }
+    },
+    [history, props.toggle]
+  );
 
   const setPreviousSelected = useCallback(() => {
     const flattenedResults = Array.from(results.values()).flat();
@@ -193,55 +213,57 @@ export function Omnibox(props: OmniboxProps) {
     }
   }, [selected, results]);
 
-  const control = useCallback((evt) => {
-    if (evt.key === 'Escape') {
-      if (query.length > 0) {
-        setQuery('');
-        return;
-      } else if (props.show) {
-        props.toggle();
-        return;
+  const control = useCallback(
+    (evt) => {
+      if (evt.key === 'Escape') {
+        if (query.length > 0) {
+          setQuery('');
+          return;
+        } else if (props.show) {
+          props.toggle();
+          return;
+        }
       }
-    }
-    if (
-      evt.key === 'ArrowUp' ||
-      (evt.shiftKey && evt.key === 'Tab')) {
+      if (evt.key === 'ArrowUp' || (evt.shiftKey && evt.key === 'Tab')) {
         evt.preventDefault();
-      setPreviousSelected();
-      return;
-    }
-    if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
-      evt.preventDefault();
-      setNextSelected();
-      return;
-    }
-    if (evt.key === 'Enter') {
-      evt.preventDefault();
-      if (selected.length) {
-        navigate(selected[0], selected[1]);
-      } else if (Array.from(results.values()).flat().length === 0) {
+        setPreviousSelected();
         return;
-      } else {
-        navigate(
-          Array.from(results.values()).flat()[0].app,
-          Array.from(results.values()).flat()[0].link);
       }
-    }
-  }, [
-    props.toggle,
-    selected,
-    navigate,
-    query,
-    props.show,
-    results,
-    setPreviousSelected,
-    setNextSelected
-  ]);
+      if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
+        evt.preventDefault();
+        setNextSelected();
+        return;
+      }
+      if (evt.key === 'Enter') {
+        evt.preventDefault();
+        if (selected.length) {
+          navigate(selected[0], selected[1]);
+        } else if (Array.from(results.values()).flat().length === 0) {
+          return;
+        } else {
+          navigate(
+            Array.from(results.values()).flat()[0].app,
+            Array.from(results.values()).flat()[0].link
+          );
+        }
+      }
+    },
+    [
+      props.toggle,
+      selected,
+      navigate,
+      query,
+      props.show,
+      results,
+      setPreviousSelected,
+      setNextSelected,
+    ]
+  );
 
   useEffect(() => {
     const flattenedResultLinks = Array.from(results.values())
       .flat()
-      .map(result => [result.app, result.link]);
+      .map((result) => [result.app, result.link]);
     if (!flattenedResultLinks.includes(selected)) {
       setSelected(flattenedResultLinks[0] || []);
     }
@@ -252,88 +274,104 @@ export function Omnibox(props: OmniboxProps) {
   }, []);
 
   // Sort Omnibox results alphabetically
-  const sortResults = (a: Record<'title', string>, b: Record<'title', string>) => {
+  const sortResults = (
+    a: Record<'title', string>,
+    b: Record<'title', string>
+  ) => {
     // Do not sort unless searching (preserves order of menu actions)
-    if (query === '') { return 0 };
-    if (a.title < b.title) { return -1 };
-    if (a.title > b.title) { return 1 };
+    if (query === '') {
+      return 0;
+    }
+    if (a.title < b.title) {
+      return -1;
+    }
+    if (a.title > b.title) {
+      return 1;
+    }
     return 0;
-  }
+  };
 
   const renderResults = useCallback(() => {
-    return <Box
-            maxHeight={['200px', '400px']}
-            overflowY="auto"
-            overflowX="hidden"
-            borderBottomLeftRadius='2'
-            borderBottomRightRadius='2'
-           >
-      {SEARCHED_CATEGORIES
-        .map(category => Object({ category, categoryResults: results.get(category) }))
-        .filter(category => category.categoryResults.length > 0)
-        .map(({ category, categoryResults }, i) => {
-          const categoryTitle = (category === 'other')
-            ? null : <Row pl='2' height='5' alignItems='center' bg='washedGray'><Text gray bold>{category.charAt(0).toUpperCase() + category.slice(1)}</Text></Row>;
-          const sel = selected?.length ? selected[1] : '';
-          return (<Box key={i} width='max(50vw, 300px)' maxWidth='600px'>
-            {categoryTitle}
-            {categoryResults
-              .sort(sortResults)
-              .map((result, i2) => (
-                <OmniboxResult
-                  key={i2}
-                  icon={result.app}
-                  text={result.title}
-                  subtext={result.host}
-                  link={result.link}
-                  navigate={() => navigate(result.app, result.link)}
-                  selected={sel}
-                />
-            ))}
-          </Box>
-        );
-      })
-      }
-    </Box>;
+    return (
+      <Box
+        maxHeight={['200px', '400px']}
+        overflowY='auto'
+        overflowX='hidden'
+        borderBottomLeftRadius='2'
+        borderBottomRightRadius='2'
+      >
+        {SEARCHED_CATEGORIES.map((category) =>
+          Object({ category, categoryResults: results.get(category) })
+        )
+          .filter((category) => category.categoryResults.length > 0)
+          .map(({ category, categoryResults }, i) => {
+            const categoryTitle =
+              category === 'other' ? null : (
+                <Row pl='2' height='5' alignItems='center' bg='washedGray'>
+                  <Text gray bold>
+                    {category.charAt(0).toUpperCase() + category.slice(1)}
+                  </Text>
+                </Row>
+              );
+            const sel = selected?.length ? selected[1] : '';
+            return (
+              <Box key={i} width='max(50vw, 300px)' maxWidth='600px'>
+                {categoryTitle}
+                {categoryResults.sort(sortResults).map((result, i2) => (
+                  <OmniboxResult
+                    key={i2}
+                    icon={result.app}
+                    text={result.title}
+                    subtext={result.host}
+                    link={result.link}
+                    navigate={() => navigate(result.app, result.link)}
+                    selected={sel}
+                  />
+                ))}
+              </Box>
+            );
+          })}
+      </Box>
+    );
   }, [results, navigate, selected, contactState, notifications, invites]);
 
   return (
     <Portal>
-        <Box
-          backgroundColor='scales.black30'
-          width='100%'
-          height='100%'
-          position='absolute'
-          top='0'
-          right='0'
-          zIndex={11}
-          display={props.show ? 'block' : 'none'}
-        >
-          <Row justifyContent='center'>
-            <Box
-              mt={['10vh', '20vh']}
-              width='max(50vw, 300px)'
-              maxWidth='600px'
-              borderRadius='2'
-              backgroundColor='white'
+      <Box
+        backgroundColor='scales.black30'
+        width='100%'
+        height='100%'
+        position='absolute'
+        top='0'
+        right='0'
+        zIndex={11}
+        display={props.show ? 'block' : 'none'}
+      >
+        <Row justifyContent='center'>
+          <Box
+            mt={['10vh', '20vh']}
+            width='max(50vw, 300px)'
+            maxWidth='600px'
+            borderRadius='2'
+            backgroundColor='white'
+            ref={(el) => {
+              omniboxRef.current = el;
+            }}
+          >
+            <OmniboxInput
               ref={(el) => {
- omniboxRef.current = el;
-}}
-            >
-              <OmniboxInput
-                ref={(el) => {
- inputRef.current = el;
-}}
-                control={e => control(e)}
-                search={search}
-                query={query}
-              />
-              {renderResults()}
-            </Box>
-          </Row>
-        </Box>
-      </Portal>
-    );
-  }
+                inputRef.current = el;
+              }}
+              control={(e) => control(e)}
+              search={search}
+              query={query}
+            />
+            {renderResults()}
+          </Box>
+        </Row>
+      </Box>
+    </Portal>
+  );
+}
 
 export default withLocalState(Omnibox, ['toggleOmnibox', 'omniboxShown']);

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -144,6 +144,9 @@ export function Omnibox(props: OmniboxProps): ReactElement {
         })
       );
     });
+    resultsMap.set('ships', resultsMap.get('ships').filter(ship => (
+      ship.title === `~${window.ship}` ? null : (ship)
+    )));
     return resultsMap;
   }, [query, index]);
 

--- a/pkg/interface/src/views/components/leap/OmniboxInput.js
+++ b/pkg/interface/src/views/components/leap/OmniboxInput.js
@@ -1,4 +1,3 @@
-
 import React, { Component } from 'react';
 import { BaseInput } from '@tlon/indigo-react';
 
@@ -6,33 +5,31 @@ export class OmniboxInput extends Component {
   render() {
     const { props } = this;
     return (
-    <BaseInput
-      ref={(el) => {
-        this.input = el;
+      <BaseInput
+        ref={(el) => {
+          this.input = el;
           if (el && document.activeElement.isSameNode(el)) {
             el.blur();
             el.focus();
           }
-        }
-      }
-      width='100%'
-      p='2'
-      backgroundColor='white'
-      color='black'
-      border='1px solid transparent'
-      borderRadius='2'
-      maxWidth='calc(600px - 1.15rem)'
-      fontSize='1'
-      style={{ boxSizing: 'border-box' }}
-      placeholder='Search...'
-      onKeyDown={props.control}
-      onChange={props.search}
-      spellCheck={false}
-      value={props.query}
-    />
+        }}
+        width='100%'
+        p='2'
+        backgroundColor='white'
+        color='black'
+        border='1px solid transparent'
+        borderRadius='2'
+        maxWidth='calc(600px - 1.15rem)'
+        fontSize='1'
+        style={{ boxSizing: 'border-box' }}
+        placeholder='Search...'
+        onKeyDown={props.control}
+        onChange={props.search}
+        spellCheck={false}
+        value={props.query}
+      />
     );
   }
 }
 
 export default OmniboxInput;
-

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -173,6 +173,7 @@ export class OmniboxResult extends Component {
       text,
       subtext,
       link,
+      cursor,
       navigate,
       selected,
       invites,
@@ -198,7 +199,7 @@ export class OmniboxResult extends Component {
       <Row
         py='2'
         px='2'
-        cursor='pointer'
+        cursor={cursor}
         onMouseMove={() => setSelection()}
         onMouseLeave={() => this.setHover(false)}
         backgroundColor={

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -13,7 +13,7 @@ export class OmniboxResult extends Component {
     super(props);
     this.state = {
       isSelected: false,
-      hovered: false
+      hovered: false,
     };
     this.setHover = this.setHover.bind(this);
     this.result = React.createRef();
@@ -21,52 +21,143 @@ export class OmniboxResult extends Component {
 
   componentDidUpdate(prevProps) {
     const { props, state } = this;
-    if (prevProps &&
+    if (
+      prevProps &&
       !state.hovered &&
       prevProps.selected !== props.selected &&
       props.selected === props.link
-      ) {
-        this.result.current.scrollIntoView({ block: 'nearest' });
-      }
+    ) {
+      this.result.current.scrollIntoView({ block: 'nearest' });
+    }
   }
 
   getIcon(icon, selected, link, invites, notifications, text, color) {
-    const iconFill = (this.state.hovered || (selected === link)) ? 'white' : 'black';
-    const bulletFill = (this.state.hovered || (selected === link)) ? 'white' : 'blue';
+    const iconFill =
+      this.state.hovered || selected === link ? 'white' : 'black';
+    const bulletFill =
+      this.state.hovered || selected === link ? 'white' : 'blue';
 
-    const inviteCount = [].concat(...Object.values(invites).map(obj => Object.values(obj)));
+    const inviteCount = [].concat(
+      ...Object.values(invites).map((obj) => Object.values(obj))
+    );
 
     let graphic = <div />;
-    if (defaultApps.includes(icon.toLowerCase())
-        || icon.toLowerCase() === 'links'
-        || icon.toLowerCase() === 'terminal')
-    {
-      icon = (icon === 'Link')     ? 'Collection' :
-             (icon === 'Terminal') ? 'Dojo'  : icon;
-      graphic = <Icon display="inline-block" verticalAlign="middle" icon={icon} mr='2' size='18px' color={iconFill} />;
+    if (
+      defaultApps.includes(icon.toLowerCase()) ||
+      icon.toLowerCase() === 'links' ||
+      icon.toLowerCase() === 'terminal'
+    ) {
+      icon =
+        icon === 'Link' ? 'Collection' : icon === 'Terminal' ? 'Dojo' : icon;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon={icon}
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
     } else if (icon === 'inbox') {
-      graphic = <Box display='flex' verticalAlign='middle' position="relative">
-        <Icon display='inline-block' verticalAlign='middle' icon='Inbox' mr='2' size='18px' color={iconFill} />
-        {(notifications > 0 || inviteCount.length > 0) && (
-          <Icon display='inline-block' icon='Bullet' style={{ position: 'absolute', top: -5, left: 5 }} color={bulletFill} />
-        )}
-      </Box>;
+      graphic = (
+        <Box display='flex' verticalAlign='middle' position='relative'>
+          <Icon
+            display='inline-block'
+            verticalAlign='middle'
+            icon='Inbox'
+            mr='2'
+            size='18px'
+            color={iconFill}
+          />
+          {(notifications > 0 || inviteCount.length > 0) && (
+            <Icon
+              display='inline-block'
+              icon='Bullet'
+              style={{ position: 'absolute', top: -5, left: 5 }}
+              color={bulletFill}
+            />
+          )}
+        </Box>
+      );
     } else if (icon === 'logout') {
-      graphic = <Icon display="inline-block" verticalAlign="middle" icon='SignOut' mr='2' size='18px' color={iconFill} />;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon='SignOut'
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
     } else if (icon === 'profile') {
       text = text.startsWith('Profile') ? window.ship : text;
-      graphic = <Sigil color={color} classes='dib flex-shrink-0 v-mid mr2' ship={text} size={18} icon padding={2} />;
+      graphic = (
+        <Sigil
+          color={color}
+          classes='dib flex-shrink-0 v-mid mr2'
+          ship={text}
+          size={18}
+          icon
+          padding={2}
+        />
+      );
     } else if (icon === 'home') {
-      graphic = <Icon display='inline-block' verticalAlign='middle' icon='Home' mr='2' size='18px' color={iconFill} />;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon='Home'
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
     } else if (icon === 'notifications') {
-      graphic = <Icon display='inline-block' verticalAlign='middle' icon='Inbox' mr='2' size='18px' color={iconFill} />;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon='Inbox'
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
     } else if (icon === 'messages') {
-      graphic = <Icon display='inline-block' verticalAlign='middle' icon='Users' mr='2' size='18px' color={iconFill} />;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon='Users'
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
     } else if (icon === 'tutorial') {
-      graphic = <Icon display='inline-block' verticalAlign='middle' icon='Tutorial' mr='2' size='18px' color={iconFill} />;
-    }
-    else {
-      graphic = <Icon display='inline-block' icon='NullIcon' verticalAlign="middle" mr='2' size="16px" color={iconFill} />;
+      graphic = (
+        <Icon
+          display='inline-block'
+          verticalAlign='middle'
+          icon='Tutorial'
+          mr='2'
+          size='18px'
+          color={iconFill}
+        />
+      );
+    } else {
+      graphic = (
+        <Icon
+          display='inline-block'
+          icon='NullIcon'
+          verticalAlign='middle'
+          mr='2'
+          size='16px'
+          color={iconFill}
+        />
+      );
     }
 
     return graphic;
@@ -77,53 +168,79 @@ export class OmniboxResult extends Component {
   }
 
   render() {
-    const { icon, text, subtext, link, navigate, selected, invites, notificationsCount, contacts } = this.props;
+    const {
+      icon,
+      text,
+      subtext,
+      link,
+      navigate,
+      selected,
+      invites,
+      notificationsCount,
+      contacts,
+    } = this.props;
 
-    const color = contacts?.[text] ? `#${uxToHex(contacts[text].color)}` : "#000000";
-    const graphic = this.getIcon(icon, selected, link, invites, notificationsCount, text, color);
+    const color = contacts?.[text]
+      ? `#${uxToHex(contacts[text].color)}`
+      : '#000000';
+    const graphic = this.getIcon(
+      icon,
+      selected,
+      link,
+      invites,
+      notificationsCount,
+      text,
+      color
+    );
 
     return (
       <Row
-      py='2'
-      px='2'
-      cursor='pointer'
-      onMouseEnter={() => this.setHover(true)}
-      onMouseLeave={() => this.setHover(false)}
-      backgroundColor={
-        this.state.hovered || selected === link ? 'blue' : 'white'
-      }
-      onClick={navigate}
-      width="100%"
-      justifyContent="space-between"
-      ref={this.result}
+        py='2'
+        px='2'
+        cursor='pointer'
+        onMouseEnter={() => this.setHover(true)}
+        onMouseLeave={() => this.setHover(false)}
+        backgroundColor={
+          this.state.hovered || selected === link ? 'blue' : 'white'
+        }
+        onClick={navigate}
+        width='100%'
+        justifyContent='space-between'
+        ref={this.result}
       >
-      <Box display="flex" verticalAlign="middle" maxWidth="60%" flexShrink={0}>
-        {graphic}
-        <Text
-        mono={(icon == 'profile' && text.startsWith('~'))}
-        color={this.state.hovered || selected === link ? 'white' : 'black'}
-        display='inline-block'
-        verticalAlign='middle'
-        width='100%'
-        overflow='hidden'
-        textOverflow='ellipsis'
-        whiteSpace='pre'
-        mr='1'
+        <Box
+          display='flex'
+          verticalAlign='middle'
+          maxWidth='60%'
+          flexShrink={0}
         >
-          {text.startsWith("~") ? cite(text) : text}
-        </Text>
+          {graphic}
+          <Text
+            mono={icon == 'profile' && text.startsWith('~')}
+            color={this.state.hovered || selected === link ? 'white' : 'black'}
+            display='inline-block'
+            verticalAlign='middle'
+            width='100%'
+            overflow='hidden'
+            textOverflow='ellipsis'
+            whiteSpace='pre'
+            mr='1'
+          >
+            {text.startsWith('~') ? cite(text) : text}
+          </Text>
         </Box>
-        <Text pr='2'
-        display="inline-block"
-        verticalAlign="middle"
-        color={this.state.hovered || selected === link ? 'white' : 'black'}
-        width='100%'
-        minWidth={0}
-        textOverflow="ellipsis"
-        whiteSpace="pre"
-        overflow="hidden"
-        maxWidth="40%"
-        textAlign='right'
+        <Text
+          pr='2'
+          display='inline-block'
+          verticalAlign='middle'
+          color={this.state.hovered || selected === link ? 'white' : 'black'}
+          width='100%'
+          minWidth={0}
+          textOverflow='ellipsis'
+          whiteSpace='pre'
+          overflow='hidden'
+          maxWidth='40%'
+          textAlign='right'
         >
           {subtext}
         </Text>

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -13,7 +13,7 @@ export class OmniboxResult extends Component {
     super(props);
     this.state = {
       isSelected: false,
-      hovered: false,
+      hovered: false
     };
     this.setHover = this.setHover.bind(this);
     this.result = React.createRef();
@@ -199,7 +199,7 @@ export class OmniboxResult extends Component {
         py='2'
         px='2'
         cursor='pointer'
-        onMouseEnter={() => this.setHover(true), setSelection}
+        onMouseMove={() => setSelection()}
         onMouseLeave={() => this.setHover(false)}
         backgroundColor={
           this.state.hovered || selected === link ? 'blue' : 'white'

--- a/pkg/interface/src/views/components/leap/OmniboxResult.js
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.js
@@ -178,6 +178,7 @@ export class OmniboxResult extends Component {
       invites,
       notificationsCount,
       contacts,
+      setSelection
     } = this.props;
 
     const color = contacts?.[text]
@@ -198,7 +199,7 @@ export class OmniboxResult extends Component {
         py='2'
         px='2'
         cursor='pointer'
-        onMouseEnter={() => this.setHover(true)}
+        onMouseEnter={() => this.setHover(true), setSelection}
         onMouseLeave={() => this.setHover(false)}
         backgroundColor={
           this.state.hovered || selected === link ? 'blue' : 'white'


### PR DESCRIPTION
This PR proposes we unify the selection in Leap between hovered (mouse) and keyboard selections by doing the following:
- Set the active selection, not just hover treatment, by mouse among leap results
- Determine an item's selection-eligibility by mouseMove event (not hover) to account for items scrolling into view under the cursor
- Hide the mouse cursor while navigating results by keyboard; restore the cursor on mouse move

Reformatting handled in a separate commit.

Video demonstrating behavior attached.

https://user-images.githubusercontent.com/748181/114450025-7d5aa880-9ba3-11eb-9cf8-5deb200cabb9.mp4

Fixes urbit/landscape#598