### PR TITLE
ProfileOverlay: restore DM button

### DIFF
--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -151,6 +151,16 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
         padding={3}
         justifyContent='center'
       >
+        <Row color='black' padding={3} position='absolute' top={0} left={0}>
+           {!isOwn && (
+             <Icon
+               icon='Chat'
+               size={16}
+               cursor='pointer'
+               onClick={() => history.push(`/~landscape/dm/${ship}`)}
+             />
+           )}
+         </Row>
         <Box
           alignSelf='center'
           height='72px'


### PR DESCRIPTION
Dropped in a merge conflict resolution (https://github.com/urbit/urbit/commit/7fd4928d96fbac5e0ca680c11179c3737847a3d4).

Fixes urbit/landscape#757