### PR TITLE
landscape: sidebar uses black100 for all synced

### DIFF
--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -86,11 +86,7 @@ export function SidebarItem(props: {
   let color = 'lightGray';
 
   if (isSynced) {
-    if (hasUnread || hasNotification) {
       color = 'black';
-    } else {
-      color = 'gray';
-    }
   }
 
   const fontWeight = (hasUnread || hasNotification) ? '500' : 'normal';


### PR DESCRIPTION
Fixes urbit/landscape#678