### PR TITLE
file-server: lowercase headers for http2

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -243,7 +243,7 @@
         =/  headers
           :~  content-type+mime-type 
               max-1-da:gen 
-              'Service-Worker-Allowed'^'/'
+              'service-worker-allowed'^'/'
           ==
         [[200 headers] `q.u.data]
       ==


### PR DESCRIPTION
Ported from the HTTP2 branch, to avoid strange release flows. 