### PR TITLE
metadata-store: fix OTA 2

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -247,7 +247,7 @@
       %+  murn  ~(tap in ~(key by groups))
       |=  group=resource
       ^-  (unit card)
-      =/  =association:store  (~(got by associations) [%groups group])
+      =/  =association:store  (~(got by associations.old) [%groups group])
       =*  met  metadatum.association
       ?.  ?=([%group [~ [~ [@ [@ @]]]]] config.met)
         ~


### PR DESCRIPTION
Fixes `got` crashing in +on-load