### PR TITLE
docker: add exec to final urbit invocation

### DIFF
--- a/nix/pkgs/docker-image/default.nix
+++ b/nix/pkgs/docker-image/default.nix
@@ -42,7 +42,7 @@ let
     dirs=( $dirnames )
     dirname=''${dirnames[0]}
 
-    urbit $ttyflag -p ${toString amesPort} $dirname
+    exec urbit $ttyflag -p ${toString amesPort} $dirname
     '';
     
     


### PR DESCRIPTION
This lets docker's SIGTERM pass through to urbit so it stops cleanly.

Previously it was taking 7-8 seconds to stop and occasionally left a `.vere.lock` file behind when it did. After adding `exec` it stops in <1 sec and seems to clear the lock properly. I also think the lack of this might have been truncating the error messages during some crashes I was having in the past week.