### PR TITLE
publish: tokenise content

### DIFF
--- a/pkg/interface/src/logic/lib/publish.ts
+++ b/pkg/interface/src/logic/lib/publish.ts
@@ -3,6 +3,7 @@ import { buntPost } from '~/logic/lib/post';
 import { unixToDa } from '~/logic/lib/util';
 import { BigIntOrderedMap } from './BigIntOrderedMap';
 import bigInt, { BigInteger } from 'big-integer';
+import tokenizeMessage from './tokenizeMessage';
 
 export function newPost(
   title: string,
@@ -19,13 +20,15 @@ export function newPost(
     signatures: []
   };
 
+  const tokenisedBody = tokenizeMessage(body);
+
   const revContainer: Post = { ...root, index: root.index + '/1' };
   const commentsContainer = { ...root, index: root.index + '/2' };
 
   const firstRevision: Post = {
     ...revContainer,
     index: revContainer.index + '/1',
-    contents: [{ text: title }, { text: body }]
+    contents: [{ text: title }, ...tokenisedBody]
   };
 
   const nodes = {
@@ -54,11 +57,12 @@ export function newPost(
 
 export function editPost(rev: number, noteId: BigInteger, title: string, body: string) {
   const now = Date.now();
+  const tokenisedBody = tokenizeMessage(body);
   const newRev: Post = {
     author: `~${window.ship}`,
     index: `/${noteId.toString()}/1/${rev}`,
     'time-sent': now,
-    contents: [{ text: title }, { text: body }],
+    contents: [{ text: title }, ...tokenisedBody],
     hash: null,
     signatures: []
   };
@@ -72,7 +76,7 @@ export function editPost(rev: number, noteId: BigInteger, title: string, body: s
   return nodes;
 }
 
-export function getLatestRevision(node: GraphNode): [number, string, string, Post] {
+export function getLatestRevision(node: GraphNode): [number, string, any, Post] {
   const revs = node.children.get(bigInt(1));
   const empty = [1, '', '', buntPost()] as [number, string, string, Post];
   if(!revs) {
@@ -82,8 +86,9 @@ export function getLatestRevision(node: GraphNode): [number, string, string, Pos
   if(!rev) {
     return empty;
   }
-  const [title, body] = rev.post.contents as TextContent[];
-  return [revNum.toJSNumber(), title.text, body.text, rev.post];
+  const title = rev.post.contents[0];
+  const body = rev.post.contents.slice(1);
+  return [revNum.toJSNumber(), title.text, body, rev.post];
 }
 
 export function getLatestCommentRevision(node: GraphNode): [number, Post] {
@@ -106,10 +111,11 @@ export function getComments(node: GraphNode): GraphNode {
   return comments;
 }
 
-export function getSnippet(body: string) {
-  const newlineIdx = body.indexOf('\n', 2);
-  const end = newlineIdx > -1 ? newlineIdx : body.length;
-  const start = body.substr(0, end);
+export function getSnippet(body: any) {
+  const firstContent = Object.values(body[0])[0];
+  const newlineIdx = firstContent.indexOf('\n', 2);
+  const end = newlineIdx > -1 ? newlineIdx : firstContent.length;
+  const start = firstContent.substr(0, end);
 
-  return (start === body || start.startsWith('![')) ? start : `${start}...`;
+  return (start === firstContent || firstContent.startsWith('![')) ? start : `${start}...`;
 }

--- a/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
+++ b/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
@@ -31,7 +31,7 @@ function TranscludedLinkNode(props: {
         return <PermalinkEmbed transcluded={transcluded + 1} api={api} link={permalink} association={assoc} />
 
       }
-      
+
       return (
         <Box borderRadius="2" p="2" bg="scales.black05">
           <Anchor underline={false} target="_blank" color="black" href={link.url}>
@@ -113,7 +113,7 @@ function TranscludedPublishNode(props: {
           </Text>
           <Box p="2">
             <NotePreviewContent
-              snippet={getSnippet(post?.post.contents[1]?.text)}
+              snippet={getSnippet(post?.post.contents.slice(1))}
             />
           </Box>
         </Col>
@@ -200,8 +200,8 @@ export function TranscludedNode(props: {
       <TranscludedPost
         api={props.api}
         post={node.post}
-        group={group} 
-        transcluded={transcluded} 
+        group={group}
+        transcluded={transcluded}
       />)
       ;
     default:

--- a/pkg/interface/src/views/apps/publish/components/EditPost.tsx
+++ b/pkg/interface/src/views/apps/publish/components/EditPost.tsx
@@ -9,6 +9,7 @@ import { PostFormSchema, PostForm } from './NoteForm';
 import GlobalApi from '~/logic/api/global';
 import { getLatestRevision, editPost } from '~/logic/lib/publish';
 import { useWaitForProps } from '~/logic/lib/useWaitForProps';
+import { referenceToPermalink } from '~/logic/lib/permalinks';
 
 interface EditPostProps {
   ship: string;
@@ -23,10 +24,27 @@ export function EditPost(props: EditPostProps & RouteComponentProps): ReactEleme
   const [revNum, title, body] = getLatestRevision(note);
   const location = useLocation();
 
+  let editContent = null;
+  editContent = body.reduce((val, curr) => {
+      if ('text' in curr) {
+        val = val + curr.text;
+      } else if ('mention' in curr) {
+        val = val + `~${curr.mention}`;
+      } else if ('url' in curr) {
+        val = val + curr.url;
+      } else if ('code' in curr) {
+        val = val + curr.code.expression;
+      } else if ('reference' in curr) {
+        val = `${val}${referenceToPermalink(curr).link}`;
+      }
+
+      return val;
+    }, '');
+
   const waiter = useWaitForProps(props);
   const initial: PostFormSchema = {
     title,
-    body
+    body: editContent
   };
 
   const onSubmit = async (

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, Col, Anchor, Row, Action } from '@tlon/indigo-react';
-import ReactMarkdown from 'react-markdown';
+import { GraphContentWide } from "~/views/landscape/components/Graph/GraphContentWide";
 import bigInt from 'big-integer';
 
 import { Link, RouteComponentProps } from 'react-router-dom';
@@ -11,7 +11,7 @@ import GlobalApi from '~/logic/api/global';
 import { getLatestRevision, getComments } from '~/logic/lib/publish';
 import { roleForShip } from '~/logic/lib/group';
 import Author from '~/views/components/Author';
-import { Contacts, GraphNode, Graph, Association, Unreads, Group } from '@urbit/api';
+import { Contacts, GraphNode, Graph, Association, Unreads, Group, Post } from '@urbit/api';
 import {useCopy} from '~/logic/lib/useCopy';
 import { getPermalinkForGraph } from '~/logic/lib/permalinks';
 import {useQuery} from '~/logic/lib/useQuery';
@@ -28,22 +28,11 @@ interface NoteProps {
   group: Group;
 }
 
-const renderers = {
-  link: ({ href, children }) => {
-    return (
-      <Anchor display="inline" target="_blank" href={href}>{children}</Anchor>
-    )
-  }
-};
-
-export function NoteContent({ body }) {
+export function NoteContent({ body, api }) {
+  const post = { contents: Object.values(body) };
   return (
-
-      <Box color="black" className="md" style={{ overflowWrap: 'break-word', overflow: 'hidden' }}>
-        <ReactMarkdown source={body} linkTarget={'_blank'} renderers={renderers} />
-      </Box>
+        <GraphContentWide transcluded={0} post={post} api={api} showOurContact={false} allowHeaders allowLists />
   );
-
 }
 
 export function Note(props: NoteProps & RouteComponentProps) {
@@ -126,7 +115,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
           </Author>
         </Row>
       </Col>
-      <NoteContent body={body} />
+      <NoteContent body={body} api={api} />
       <NoteNavigation
         notebook={notebook}
         noteId={noteId}

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContentWide.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContentWide.tsx
@@ -17,9 +17,11 @@ function GraphContentWideInner(
     post: Post;
     api: GlobalApi;
     showOurContact: boolean;
+    allowHeaders?: boolean;
+    allowLists?: boolean;
   } & PropFunc<typeof Box>
 ) {
-  const { post, transcluded = 0, showOurContact, api, ...rest } = props;
+  const { post, transcluded = 0, showOurContact, api, allowHeaders, allowLists, ...rest } = props;
 
   return (
     <Box {...rest}>
@@ -33,6 +35,8 @@ function GraphContentWideInner(
                 fontSize={1}
                 lineHeight={"20px"}
                 content={content}
+                allowHeaders={allowHeaders}
+                allowLists={allowLists}
               />
             );
           case "code":

--- a/pkg/interface/src/views/landscape/components/Graph/content/text.js
+++ b/pkg/interface/src/views/landscape/components/Graph/content/text.js
@@ -77,20 +77,38 @@ const renderers = {
   },
   link: (props) => {
     return <Anchor src={props.href} borderBottom="1" color="black">{props.children}</Anchor>
+  },
+  list: ({depth, children}) => {
+    return <Text my='2' display='block' fontSize='1' ml={depth ? (2 * depth) : 0} lineHeight={'20px'}>{children}</Text>
   }
 };
 
 const MessageMarkdown = React.memo((props) => {
-  const { source, ...rest } = props;
+  const { source, allowHeaders, allowLists, ...rest } = props;
   const blockCode = source.split('```');
   const codeLines = blockCode.map((codes) => codes.split('\n'));
-  const lines = codeLines.reduce((acc, val, i) => {
-    if (i % 2 === 1) {
-      return [...acc, `\`\`\`${val.join('\n')}\`\`\``];
-    } else {
-      return [...acc, ...val];
+  let lines = [];
+  if (allowLists) {
+    lines.push(source);
+  } else {
+    lines = codeLines.reduce((acc, val, i) => {
+        if (i % 2 === 1) {
+          return [...acc, `\`\`\`${val.join('\n')}\`\`\``];
+        } else {
+          return [...acc, ...val];
+        }
+      }, []);
+  }
+
+  const modifiedBlockTokens = DISABLED_BLOCK_TOKENS.filter(e => {
+    if (allowHeaders && allowLists) {
+      return (e in ["setextHeading", "atxHeading", "list"])
+    } else if (allowHeaders) {
+      return (e in ["setextHeading", "atxHeading"])
+    } else if (allowLists) {
+      return (e  === "list")
     }
-  }, []);
+  })
 
   return lines.map((line, i) => (
     <React.Fragment key={i}>
@@ -119,7 +137,7 @@ const MessageMarkdown = React.memo((props) => {
           [
             RemarkDisableTokenizers,
             {
-              block: DISABLED_BLOCK_TOKENS,
+              block: modifiedBlockTokens,
               inline: DISABLED_INLINE_TOKENS
             }
           ]
@@ -131,23 +149,26 @@ const MessageMarkdown = React.memo((props) => {
 
 export default function TextContent(props) {
   const content = props.content;
+  const allowHeaders = props.allowHeaders;
+  const allowLists = props.allowLists;
 
-  const group = content.text.match(
+  const group = content.text.trim().match(
     /([~][/])?(~[a-z]{3,6})(-[a-z]{6})?([/])(([a-z0-9-])+([/-])?)+/
   );
   const isGroupLink =
     group !== null && // matched possible chatroom
     group[2].length > 2 && // possible ship?
     urbitOb.isValidPatp(group[2]) && // valid patp?
-    group[0] === content.text; // entire message is room name?
+    group[0] === content.text.trim(); // entire message is room name?
 
   if (isGroupLink) {
-    const resource = `/ship/${content.text}`;
+    const resource = `/ship/${content.text.trim()}`;
     return (
       <GroupLink
         resource={resource}
         api={props.api}
         pl='2'
+        my='2'
         border='1'
         borderRadius='2'
         borderColor='washedGray'
@@ -162,7 +183,7 @@ export default function TextContent(props) {
         lineHeight={props.lineHeight ? props.lineHeight : '20px'}
         style={{ overflowWrap: 'break-word' }}
       >
-        <MessageMarkdown source={content.text} />
+        <MessageMarkdown source={content.text} allowHeaders={allowHeaders} allowLists={allowLists} />
       </Text>
     );
   }


### PR DESCRIPTION
- Moves Publish to using `tokenizeMessage` when creating or editing posts
- Moves Publish to using `GraphContentWide`
- Modifies `GraphContentWide` with `allowHeaders` and `allowLists` props

Enables the use of transclusions, group links, mentions, etc. in notes.

<img width="516" alt="Screen Shot 2021-04-14 at 3 20 44 PM" src="https://user-images.githubusercontent.com/20846414/114767345-83808e80-9d35-11eb-9226-293f5a58ffc7.png">

**What works**
- Pre-existing publish content looks normal
- Chat still looks normal
- You can still embed images in snippets
- Transcluded notes look normal too
- Nested lists work (with the change I made to not chop up the lines when `allowLists` is true, so that we know we're inside another list)

**What doesn't**
- There are no margins between paragraphs. Using `gap-y` to remedy this cuts up mentions into their own line?
- The last list item treats the next paragraph, and the following header, as a part of the list, and I don't know why?
- Headers probably need a design pass because we aren't using the markdown CSS at all now, just indigo-react renderers and I haven't configured a renderer for headers yet (cc @urcades)

@liam-fitzgerald would you be able to help me take this one home?

Fixes urbit/landscape#284