### PR TITLE
sidebar: typesafe notifications check

### DIFF
--- a/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
@@ -18,7 +18,11 @@ export function useGraphModule(
       }
 
       const notifications = graphUnreads?.[s]?.['/']?.notifications;
-      if ( notifications > 0 ) {
+      if (
+        notifications &&
+        ((typeof notifications === 'number' && notifications > 0)
+        || notifications.length)
+      ) {
         return 'notification';
       }
 


### PR DESCRIPTION
Fixes a bug where the "this channel has notifications" dot would not appear when it should have