### PR TITLE
imageInput: adds clear button

### DIFF
--- a/pkg/interface/src/views/components/ImageInput.tsx
+++ b/pkg/interface/src/views/components/ImageInput.tsx
@@ -8,7 +8,8 @@ import {
   Button,
   Label,
   BaseInput,
-  Text
+  Text,
+  Icon
 } from '@tlon/indigo-react';
 
 import useStorage from '~/logic/lib/useStorage';
@@ -84,6 +85,31 @@ const errorRetry = (meta, uploading, clickUploadButton) => {
   return null;
 };
 
+const clearButton = (field, uploading, clearEvt) => {
+  if (field.value && !uploading) {
+    return (
+      <Box
+        position='absolute'
+        right={0}
+        top={0}
+        px={1}
+        height='100%'
+        cursor='pointer'
+        onClick={clearEvt}
+        backgroundColor='white'
+        display='flex'
+        alignItems='center'
+        borderRadius='0 4px 4px 0'
+        border='1px solid'
+        borderColor='lightGray'
+      >
+        <Icon icon='X' />
+      </Box>
+    );
+  }
+  return null;
+};
+
 export function ImageInput(props: ImageInputProps): ReactElement {
   const { id, label, caption } = props;
   const { uploadDefault, canUpload, uploading } = useStorage();
@@ -107,6 +133,11 @@ export function ImageInput(props: ImageInputProps): ReactElement {
   const clickUploadButton = useCallback(() => {
     ref.current?.click();
   }, [ref]);
+
+  const clearEvt = useCallback(() => {
+    setValue('');
+  }, []);
+
   return (
     <Box display="flex" flexDirection="column" {...props}>
       <Label htmlFor={id}>{label}</Label>
@@ -117,6 +148,7 @@ export function ImageInput(props: ImageInputProps): ReactElement {
       ) : null}
       <Row mt="2" alignItems="flex-end" position='relative' width='100%'>
         {prompt(field, uploading, meta, clickUploadButton)}
+        {clearButton(field, uploading, clearEvt)}
         {uploadingStatus(uploading, meta)}
         {errorRetry(meta, uploading, clickUploadButton)}
         <Box background='white' borderRadius={2} width='100%'>


### PR DESCRIPTION
Adds a clear affordance to zero out the ImageInput field.

![image](https://user-images.githubusercontent.com/748181/114801404-a331aa00-9d69-11eb-9588-0704ce27fb18.png)

Respects darkmode as well.

![image](https://user-images.githubusercontent.com/748181/114801431-af1d6c00-9d69-11eb-9d33-d99828df2e2b.png)

Clicking this button restores the uploading prompt.

![image](https://user-images.githubusercontent.com/748181/114801468-be041e80-9d69-11eb-9056-3a9fa44b2507.png)

Fixes urbit/landscape#785