### PR TITLE
docker: allow setting Ames port via docker run argument

### DIFF
--- a/nix/pkgs/docker-image/default.nix
+++ b/nix/pkgs/docker-image/default.nix
@@ -13,7 +13,7 @@ let
     do
     case $i in
         -p=*|--port=*)
-            amesPort="${i#*=}"
+            amesPort="''${i#*=}"
             shift
             ;;
     esac

--- a/nix/pkgs/docker-image/default.nix
+++ b/nix/pkgs/docker-image/default.nix
@@ -5,6 +5,20 @@ let
 
     set -eu
 
+    # set defaults
+    amesPort=${toString amesPort}
+
+    # check args
+    for i in "$@"
+    do
+    case $i in
+        -p=*|--port=*)
+            amesPort="${i#*=}"
+            shift
+            ;;
+    esac
+    done
+
     # If the container is not started with the `-i` flag
     # then STDIN will be closed and we need to start
     # Urbit/vere with the `-t` flag.
@@ -23,7 +37,7 @@ let
       mv $keyname /tmp
 
       # Boot urbit with the key, exit when done booting
-      urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p ${toString amesPort} -x
+      urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p $amesPort -x
 
       # Remove the keyfile for security
       rm /tmp/$keyname
@@ -34,7 +48,7 @@ let
       cometname=''${comets[0]}
       rm *.comet
 
-      urbit $ttyflag -c $(basename $cometname .comet) -p ${toString amesPort} -x
+      urbit $ttyflag -c $(basename $cometname .comet) -p $amesPort -x
     fi
 
     # Find the first directory and start urbit with the ship therein
@@ -42,7 +56,7 @@ let
     dirs=( $dirnames )
     dirname=''${dirnames[0]}
 
-    exec urbit $ttyflag -p ${toString amesPort} $dirname
+    exec urbit $ttyflag -p $amesPort $dirname
     '';
     
     


### PR DESCRIPTION
This allows the docker container Ames port to be optionally overridden by passing a `--port=xxx` argument along with the `docker run` command. If no port argument is passed the default 34343 is still used instead.

Example: 
```
docker run -p 80:80 -p 13436:13436/udp \
     --mount type=volume,source=/home/user/urbit/galaxy,destination=/urbit \
     tloncorp/urbit --port=13436
```

This is fairly edge case and probably not needed by many users but adds a little flexibility and it can suppress the warnings galaxies get:
```
ames: czar: overriding port 13436 with -p 34343
ames: czar: WARNING: 13436 required for discoverability
```