### PR TITLE
meta/interface: re-integrate preinstall script with clean install

### DIFF
--- a/pkg/interface/CONTRIBUTING.md
+++ b/pkg/interface/CONTRIBUTING.md
@@ -32,7 +32,7 @@ same (if [developing on a local development ship][local]). Then, from
 'pkg/interface':
 
 ```
-npm install
+npm ci
 npm run start
 ```
 
@@ -59,7 +59,7 @@ module.exports = {
 ```
 
 The dev environment will attempt to match the subdomain against the keys of this
-object, and if matched will proxy to the corresponding URL. For example, the 
+object, and if matched will proxy to the corresponding URL. For example, the
 above config will proxy `zod.localhost:9000` to `http://localhost:8080`,
 `bus.localhost:9000` to `http://localhost:8081` and so on and so forth. If no
 match is found, then it will fallback to the `URL` property.
@@ -71,7 +71,7 @@ linter and for usage through the command, do the following:
 
 ```bash
 $ cd ./pkg/interface
-$ npm install
+$ npm ci
 $ npm run lint
 ```
 

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -100,7 +100,7 @@
     "tsc:watch": "tsc --watch",
     "preinstall": "./preinstall.sh",
     "build:dev": "cross-env NODE_ENV=development webpack --config config/webpack.dev.js",
-    "build:prod": "cross-env NODE_ENV=production webpack --config config/webpack.prod.js",
+    "build:prod": "cd ../npm/api && npm ci && cd ../../interface && cross-env NODE_ENV=production webpack --config config/webpack.prod.js",
     "start": "webpack-dev-server --config config/webpack.dev.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -98,8 +98,9 @@
     "lint-file": "eslint",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
+    "preinstall": "./preinstall.sh",
     "build:dev": "cross-env NODE_ENV=development webpack --config config/webpack.dev.js",
-    "build:prod": "cd ../npm/api && npm i && cd ../../interface && cross-env NODE_ENV=production webpack --config config/webpack.prod.js",
+    "build:prod": "cross-env NODE_ENV=production webpack --config config/webpack.prod.js",
     "start": "webpack-dev-server --config config/webpack.dev.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/pkg/interface/preinstall.sh
+++ b/pkg/interface/preinstall.sh
@@ -6,7 +6,7 @@ for i in $(find . -type d -maxdepth 1) ; do
     if [ -f "${packageJson}" ]; then
         echo "installing ${i}..."
         cd ./${i}
-        npm install
+        npm ci
         cd ..
     fi
 done

--- a/pkg/interface/preinstall.sh
+++ b/pkg/interface/preinstall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+cd ../npm
+
+for i in $(find . -type d -maxdepth 1) ; do
+    packageJson="${i}/package.json"
+    if [ -f "${packageJson}" ]; then
+        echo "installing ${i}..."
+        cd ./${i}
+        npm install
+        cd ..
+    fi
+done


### PR DESCRIPTION
The original commit was reverted hot on next-js because the auto-deploy script was crashing on some uncompiled `../npm/api` files, in the wake of package-lock requiring it to actually grab the `../npm/api` folder. 

This is because the npm in the docker instance we use to auto-deploy can't leave its pwd in an automated mode, we will need to amend docker or the package.json to let npm do that for installing these local dependencies. [See here](https://stackoverflow.com/questions/18136746/npm-install-failed-with-cannot-run-in-wd).

However with and without this preinstall script there's an ongoing issue in developing on Landscape where the npm cache across these four packages can get into some wild desynchronisation, requiring some [truly silly incantations](https://github.com/urbit/indigo-react/issues/101) to clear those caches afterward and try again. I believe this is because all the node_modules in the script are changing on the fly.

By using `npm ci` instead of `npm i` we prevent touching those package-locks or package.json files, which has, at least in some brief testing, resolved those errors, but we'll have to see after this. I also amend contributing docs to also advise toward `npm ci` unless changing dependencies.