### PR TITLE
MentionText: pass all ships with sigs

### DIFF
--- a/pkg/interface/src/logic/state/contact.ts
+++ b/pkg/interface/src/logic/state/contact.ts
@@ -8,12 +8,6 @@ export interface ContactState extends BaseState<ContactState> {
   isContactPublic: boolean;
   nackedContacts: Set<Patp>;
   // fetchIsAllowed: (entity, name, ship, personal) => Promise<boolean>;
-};
-
-export function useContact(ship: string) { 
-  return useContactState(
-    useCallback(s => s.contacts[ship] as Contact | null, [ship])
-  );
 }
 
 const useContactState = createState<ContactState>('Contact', {
@@ -34,5 +28,11 @@ const useContactState = createState<ContactState>('Contact', {
   //   });
   // },
 }, ['nackedContacts']);
+
+export function useContact(ship: string) {
+  return useContactState(
+    useCallback(s => s.contacts[ship] as Contact | null, [ship])
+  );
+}
 
 export default useContactState;

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { Text, Box } from '@tlon/indigo-react';
 import { Contact, Contacts, Content, Group } from '@urbit/api';
 import RichText from '~/views/components/RichText';
-import { cite, useShowNickname, uxToHex } from '~/logic/lib/util';
+import { cite, useShowNickname, uxToHex, deSig } from '~/logic/lib/util';
 import ProfileOverlay from '~/views/components/ProfileOverlay';
 import { useHistory } from 'react-router-dom';
 import useContactState, {useContact} from '~/logic/state/contact';
@@ -45,7 +45,7 @@ export function Mention(props: {
   api: any;
 }) {
   const { ship, first, api, ...rest } = props;
-  const contact = useContact(ship);
+  const contact = useContact(`~${deSig(ship)}`);
   const showNickname = useShowNickname(contact);
   const name = showNickname ? contact?.nickname : cite(ship);
 


### PR DESCRIPTION
Mentions currently don't show nicknames ever right now; this is because the new hook introduced in #4738, `useContact`, is passed with whatever ship string we give it, which, in graph-store, doesn't include a sig, but in contact-store, is referenced with a sig. We just deSig and prepend a sig in all cases now.