### PR TITLE
ed: visual tweaks to notifications and sidebar 

### DIFF
--- a/pkg/interface/src/views/components/Invite/Group.tsx
+++ b/pkg/interface/src/views/components/Invite/Group.tsx
@@ -64,7 +64,7 @@ function Elbow(
     >
       <Box
         border="2px solid"
-        borderRadius={2}
+        borderRadius={3}
         borderColor={color}
         position="absolute"
         left="0px"

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -86,7 +86,11 @@ export function SidebarItem(props: {
   let color = 'lightGray';
 
   if (isSynced) {
+    if (hasUnread || hasNotification) {
       color = 'black';
+    } else {
+      color = 'gray';
+    }
   }
 
   const fontWeight = (hasUnread || hasNotification) ? '500' : 'normal';
@@ -132,7 +136,7 @@ export function SidebarItem(props: {
         {DM ? img : (
               <Icon
                 display="block"
-                color={isSynced ? 'black' : 'gray'}
+                color={isSynced ? 'black' : 'lightGray'}
                 icon={getModuleIcon(mod) as any}
               />
             )


### PR DESCRIPTION
contained in this PR:

Purely visual fixes to two small issues:

1. Incorrect border radius in notification items (the little "reference elbow" that shows were an invite is coming from)
2. Sidebar coloration: After actually trying out `black80`, it's still too subtle. I think what we had before was good, in that no one was complaining about sidebar contrast. It looks a little dull/inactive at first, but you quickly get acclimated.

Reference Elbow Before:

<img width="299" alt="Screen Shot 2021-04-16 at 6 51 53 PM" src="https://user-images.githubusercontent.com/1195363/115154797-b59e3300-a04a-11eb-9110-b62802d862f2.png">

<img width="505" alt="Screen Shot 2021-04-16 at 6 50 15 PM" src="https://user-images.githubusercontent.com/1195363/115154818-cbabf380-a04a-11eb-92ad-707f8e77f96a.png">

Reference Elbow After:

<img width="411" alt="Screen Shot 2021-04-18 at 1 35 19 PM" src="https://user-images.githubusercontent.com/1195363/115154858-feee8280-a04a-11eb-8946-c9872d7bd799.png">

~

Sidebar Before:

<img width="352" alt="Screen Shot 2021-04-18 at 1 35 02 PM" src="https://user-images.githubusercontent.com/1195363/115154864-06159080-a04b-11eb-832c-8848e0b838c9.png">

Sidebar After:

<img width="343" alt="Screen Shot 2021-04-18 at 1 34 55 PM" src="https://user-images.githubusercontent.com/1195363/115154870-0e6dcb80-a04b-11eb-870d-a3aa79621836.png">

