### PR TITLE
interface: correctly scroll lock document

### DIFF
--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -53,6 +53,7 @@ const Root = withState(styled.div`
   }
   display: flex;
   flex-flow: column nowrap;
+  touch-action: none;
 
   * {
     scrollbar-width: thin;


### PR DESCRIPTION
Even if overflow is hidden, certain mobile browsers may interpret a
scroll event to be on the document root, leading to strange and
inconsistent scrolling behaviours. Addresses this by adding
touch-action: none, which explicitly instructs browers to ignore this
element in scroll calculations.