### PR TITLE
launch: fix reversed destructure

### DIFF
--- a/pkg/interface/src/views/apps/launch/app.js
+++ b/pkg/interface/src/views/apps/launch/app.js
@@ -46,7 +46,7 @@ const ScrollbarLessBox = styled(Box)`
 const tutSelector = f.pick(['tutorialProgress', 'nextTutStep', 'hideGroups']);
 
 export default function LaunchApp(props) {
-  const connection = { props };
+  const { connection } = props;
   const baseHash = useLaunchState(state => state.baseHash);
   const [hashText, setHashText] = useState(baseHash);
   const [exitingTut, setExitingTut] = useState(false);


### PR DESCRIPTION
This was causing the tutorial to never be shown. This change should be
deployed with a new pill, to ensure comets show the tutorial.