### PR TITLE
settings: default tutorial to seen

### DIFF
--- a/pkg/interface/src/logic/state/settings.ts
+++ b/pkg/interface/src/logic/state/settings.ts
@@ -58,7 +58,7 @@ const useSettingsState = createState<SettingsState>('Settings', {
     categories: leapCategories,
   },
   tutorial: {
-    seen: false,
+    seen: true,
     joined: undefined
   }
 });


### PR DESCRIPTION
Prevents a race condition where the tutorial prompt will always show