### PR TITLE
king: do not commit files starting with a dot

### DIFF
--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
@@ -37,12 +37,12 @@ textPlain = Path [(MkKnot "text"), (MkKnot "plain")]
 
 -- | Filter for dotfiles, tempfiles and backup files.
 validClaySyncPath :: FilePath -> Bool
-validClaySyncPath fp = hasPeriod && notTildeFile && notDotHash && notDoubleHash
+validClaySyncPath fp = hasPeriod && notTildeFile && notDotFile && notDoubleHash
   where
     fileName = takeFileName fp
     hasPeriod = elem '.' fileName
     notTildeFile = not $ "~" `isSuffixOf` fileName
-    notDotHash = not $ "." `isPrefixOf` fileName
+    notDotFile = not $ "." `isPrefixOf` fileName
     notDoubleHash =
       not $ ("#" `isPrefixOf` fileName) && ("#" `isSuffixOf` fileName)
 

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Clay.hs
@@ -42,7 +42,7 @@ validClaySyncPath fp = hasPeriod && notTildeFile && notDotHash && notDoubleHash
     fileName = takeFileName fp
     hasPeriod = elem '.' fileName
     notTildeFile = not $ "~" `isSuffixOf` fileName
-    notDotHash = not $ ".#" `isPrefixOf` fileName
+    notDotHash = not $ "." `isPrefixOf` fileName
     notDoubleHash =
       not $ ("#" `isPrefixOf` fileName) && ("#" `isSuffixOf` fileName)
 


### PR DESCRIPTION
Brings the haskell king inline with the C king (see: https://github.com/urbit/urbit/blob/268677e74412d80eb5ebc9eed4c3add20a274f91/pkg/urbit/vere/io/unix.c#L845)
This discrepancy in behaviour breaks janeway. 

(Also, is this against the right branch?)