### PR TITLE
hooks: don't kick every reload

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -90,7 +90,12 @@
   $:  tracking=(map resource track)
       inner-state=vase
   ==
-      
+::
++$  base-state-3
+  $:  prev-version=@ud
+      prev-min-version=@ud
+      base-state-2
+  ==
 ::
 +$  state-0  [%0 base-state-0]
 ::
@@ -100,11 +105,14 @@
 ::
 +$  state-3  [%3 base-state-2]
 ::
++$  state-4  [%4 base-state-3]
+::
 +$  versioned-state 
   $%  state-0
       state-1
       state-2
       state-3
+      state-4
   ==
 ::
 ++  default
@@ -198,7 +206,7 @@
 ++  agent
   |*  =config
   |=  =(pull-hook config)
-  =|  state-3
+  =|  state-4
   =*  state  -
   ^-  agent:gall
   =<
@@ -224,13 +232,20 @@
       =|  cards=(list card:agent:gall)
       |^ 
       ?-  -.old
-          %3  
+          %4
         =^  og-cards   pull-hook
           (on-load:og inner-state.old)
         =.  state  old
+        =/  kick=(list card)
+          ?:  ?&  =(min-version.config prev-min-version.old)
+                  =(version.config prev-version.old)
+              ==
+            ~
+          (poke-self:pass kick+!>(%kick))^~
         :_  this
-        :(weld cards og-cards (poke-self:pass kick+!>(%kick))^~)
+        :(weld cards og-cards kick)
        ::
+          %3  $(old [%4 0 0 +.old])
           %2  $(old (state-to-3 old))
           %1  $(old [%2 +.old ~])
           %0  !!  :: pre-breach
@@ -257,6 +272,10 @@
       ^-  vase
       =.  inner-state
         on-save:og
+      =.  prev-min-version
+        min-version.config
+      =.  prev-version
+        version.config
       !>(state)
     ::
     ++  on-poke

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -491,6 +491,7 @@
     ::
     ++  tr-add
       |=  [s=^ship r=resource]
+      ?<  =(s our.bowl)
       =:  ship  s
           rid   r
           status  [%active ~]

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -270,12 +270,10 @@
     ::
     ++  on-save
       ^-  vase
-      =.  inner-state
-        on-save:og
-      =.  prev-min-version
-        min-version.config
-      =.  prev-version
-        version.config
+      =:  inner-state       on-save:og
+          prev-min-version  min-version.config
+          prev-version      version.config
+        ==
       !>(state)
     ::
     ++  on-poke

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -249,12 +249,10 @@
       --
     ::
     ++  on-save
-      =.  inner-state
-        on-save:og
-      =.  prev-version
-        version.config
-      =.  prev-min-version
-        min-version.config
+      =:  prev-version      version.config
+          prev-min-version  min-version.config
+          inner-state       on-save:og
+        ==
       !>(state)
     ::
     ++  on-poke

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -57,13 +57,21 @@
       inner-state=vase
   ==
 ::
++$  base-state-1
+  $:  prev-version=@ud
+      prev-min-version=@ud
+      base-state-0
+  ==
+::
 +$  state-0  [%0 base-state-0]
 ::
 +$  state-1  [%1 base-state-0]
++$  state-2  [%2 base-state-1]
 ::
 +$  versioned-state
   $%  state-0
       state-1
+      state-2
   ==
 ++  push-hook
   |*  =config
@@ -153,7 +161,7 @@
 ++  agent
   |*  =config
   |=  =(push-hook config)
-  =|  state-1
+  =|  state-2
   =*  state  -
   ^-  agent:gall
   =<
@@ -179,16 +187,21 @@
       =|  cards=(list card:agent:gall)
       |^ 
       ?-  -.old
-          %1  
+          %2
         =^  og-cards   push-hook
           (on-load:og inner-state.old)
         =/  old-subs
-          find-old-subs
+          (find-old-subs [prev-version prev-min-version]:old)
         =/  version-cards
           :-  (fact:io version+!>(version.config) /version ~)
           ?~  old-subs  ~
           (kick:io old-subs)^~
         [:(weld cards og-cards version-cards) this(state old)]
+        ::
+          %1
+        %_    $
+          old  [%2 0 0 +.old]
+        ==
         ::
         ::
           %0
@@ -205,6 +218,12 @@
       ==
       ::
       ++  find-old-subs
+        |=  [prev-min-version=@ud prev-version=@ud]
+        ?:  ?&  =(min-version.config prev-min-version)
+                =(prev-version version.config)
+            ==
+          ::  bail on kick if we didn't change versions
+          ~
         %~  tap  in
         %+  roll
           ~(val by sup.bowl)
@@ -232,6 +251,10 @@
     ++  on-save
       =.  inner-state
         on-save:og
+      =.  prev-version
+        version.config
+      =.  prev-min-version
+        min-version.config
       !>(state)
     ::
     ++  on-poke


### PR DESCRIPTION
Prevents undue network pressure due to spurious kicking. Also prevents the looped pull-hook add issue at the source. 
