### PR TITLE
graph-store, metadata-store lib: skip trip and crip, use rap

### DIFF
--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -145,18 +145,17 @@
     ==
   ::
   ++  index
-    |=  i=^index
+    |=  ind=^index
     ^-  json
-    ?:  =(~ i)  s+'/'
-    =/  j=^tape  ""
-    |-
-    ?~  i  [%s (crip j)]
-    =/  k=json  (numb i.i)
-    ?>  ?=(%n -.k)
-    %_  $
-        i  t.i
-        j  (weld j (weld "/" (trip +.k)))
-    ==
+    :-  %s
+    ?:  =(~ ind)
+      '/'
+    %+  roll  ind
+    |=  [cur=@ acc=@t]
+    ^-  @t
+    =/  num  (numb cur)
+    ?>  ?=(%n -.num)
+    (rap 3 acc '/' p.num ~) 
   ::
   ++  uid
     |=  u=^uid

--- a/pkg/arvo/lib/metadata-store.hoon
+++ b/pkg/arvo/lib/metadata-store.hoon
@@ -23,13 +23,13 @@
     %+  turn  ~(tap by associations)
     |=  [=md-resource [group=resource =^metadatum]]
     ^-  [cord json]
-    :-
-    %-  crip
-    ;:  weld
-        (trip (spat (en-path:resource group)))
-        (weld "/" (trip app-name.md-resource))
-        (trip (spat (en-path:resource resource.md-resource)))
-    ==
+    :-  %:  rap  3
+            (spat (en-path:resource group))
+            '/'
+            app-name.md-resource
+            (spat (en-path:resource resource.md-resource))
+            ~
+        ==
     %-  pairs
     :~  [%group s+(enjs-path:resource group)]
         [%app-name s+app-name.md-resource]


### PR DESCRIPTION
Attempting to remove all uses of `+trip` and `+crip` from the hotpath that Landscape data moves through. These arms make quite a few allocations and can be replaced with `+rap` for better performance.

The change to the `%graph-store` lib is likely to have a larger effect.