### PR TITLE
u3: propagate bail:meme

### DIFF
--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -98,28 +98,22 @@ _cm_punt(u3_noun tax)
 }
 #endif
 
-static void _write(int  fd,  const  void  *buf,  size_t count)
-{
-  if (count != write(fd,  buf, count)){
-    u3l_log("write failed\r\n");
-    c3_assert(0);
-  }
-}
-
-
 /* _cm_emergency(): write emergency text to stderr, never failing.
 */
 static void
 _cm_emergency(c3_c* cap_c, c3_l sig_l)
 {
-  _write(2, "\r\n", 2);
-  _write(2, cap_c, strlen(cap_c));
+  c3_i ret_i;
+
+  ret_i = write(2, "\r\n", 2);
+  ret_i = write(2, cap_c, strlen(cap_c));
 
   if ( sig_l ) {
-    _write(2, ": ", 2);
-    _write(2, &sig_l, 4);
+    ret_i = write(2, ": ", 2);
+    ret_i = write(2, &sig_l, 4);
   }
-  _write(2, "\r\n", 2);
+
+  ret_i = write(2, "\r\n", 2);
 }
 
 static void _cm_overflow(void *arg1, void *arg2, void *arg3)

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -127,7 +127,7 @@ static void _cm_overflow(void *arg1, void *arg2, void *arg3)
   (void)(arg1);
   (void)(arg2);
   (void)(arg3);
-  siglongjmp(u3_Signal, c3__over);
+  u3m_signal(c3__over);
 }
 
 /* _cm_signal_handle(): handle a signal in general.
@@ -139,7 +139,7 @@ _cm_signal_handle(c3_l sig_l)
     sigsegv_leave_handler(_cm_overflow, NULL, NULL, NULL);
   }
   else {
-    siglongjmp(u3_Signal, sig_l);
+    u3m_signal(sig_l);
   }
 }
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -688,7 +688,6 @@ u3m_bail(u3_noun how)
   //
   switch ( how ) {
     case c3__foul:
-    case c3__meme:
     case c3__oops: {
       fprintf(stderr, "bailing out\r\n");
       abort();

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -661,7 +661,10 @@ u3m_dump(void)
 c3_i
 u3m_bail(u3_noun how)
 {
-  if ( (c3__exit == how) && (u3R == &u3H->rod_u) ) {
+  if ( &(u3H->rod_u) == u3R ) {
+    //  XX set exit code
+    //
+    fprintf(stderr, "home: bailing out\r\n");
     abort();
   }
 
@@ -689,6 +692,8 @@ u3m_bail(u3_noun how)
   switch ( how ) {
     case c3__foul:
     case c3__oops: {
+      //  XX set exit code
+      //
       fprintf(stderr, "bailing out\r\n");
       abort();
     }
@@ -698,6 +703,9 @@ u3m_bail(u3_noun how)
     //  For top-level errors, which shouldn't happen often, we have no
     //  choice but to use the signal process; and we require the flat
     //  form of how.
+    //
+    //    XX JB: these seem unrecoverable, at least wrt memory management,
+    //    so they've been disabled above for now
     //
     c3_assert(_(u3a_is_cat(how)));
     u3m_signal(how);


### PR DESCRIPTION
This PR updates the u3 exception mechanism (bail) to no longer treat `bail:meme` (OOM on the loom) as a fatal error.

I've been hesitant to make this change, as I'm not confident that I completely understand all scenarios. So I've additionally made all top-level bails fatal. This was already explicitly the case for `bail:exit` (deterministic nock reduction failure), and appeared to be implicitly the case for most other errors. There is still code that tries to recover from some top-level bails (see `recover: top`), but I don't see how it could maintain our invariants with regards to memory management. I'm leaving it for now until this implementation can be more thoroughly cleaned up.

Additionally, I've cherry-picked a cleanup commit from #4675, and removed assertions from the emergency printf function. Those were added to suppress compiler warnings, but they're counterproductive.