### PR TITLE
landscape: pass background colors to actions

### DIFF
--- a/pkg/interface/src/views/apps/notifications/notifications.tsx
+++ b/pkg/interface/src/views/apps/notifications/notifications.tsx
@@ -92,6 +92,7 @@ export default function NotificationsScreen(props: any): ReactElement {
                       <StatelessAsyncAction
                         overflow="hidden"
                         color="black"
+                        backgroundColor="white"
                         onClick={onReadAll}
                       >
                         Mark All Read
@@ -106,7 +107,7 @@ export default function NotificationsScreen(props: any): ReactElement {
                   {!view && <Inbox
                     pendingJoin={pendingJoin}
                     {...props}
-                    filter={filter.groups} 
+                    filter={filter.groups}
                     />}
                 </Col>
               </Body>

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -73,14 +73,14 @@ export function Note(props: NoteProps & RouteComponentProps) {
   if (window.ship === note?.post?.author) {
     adminLinks.push(
       <Link to={`${baseUrl}/edit`}>
-        <Action>Update</Action>
+        <Action backgroundColor="white">Update</Action>
       </Link>
     )
   };
 
   if (window.ship === note?.post?.author || ourRole === "admin") {
     adminLinks.push(
-      <Action destructive onClick={deletePost}>
+      <Action backgroundColor="white" destructive onClick={deletePost}>
         Delete
       </Action>
     )


### PR DESCRIPTION
While indigo-react 1.2.20 passes background colors to actions for us, it doesn't yet, so these are still whited out unnecessarily. Patching for now.

Fixes urbit/landscape#802