### PR TITLE
ColorInput: remove "#" from input value

### DIFF
--- a/pkg/interface/src/views/components/ColorInput.tsx
+++ b/pkg/interface/src/views/components/ColorInput.tsx
@@ -73,7 +73,7 @@ export function ColorInput(props: ColorInputProps) {
             height='100%'
             alignSelf='stretch'
             onChange={onChange}
-            value={`#${padded}`}
+            value={padded}
             disabled={disabled || false}
             type='color'
             opacity={0}


### PR DESCRIPTION
ColorInput sets its value to `#{value}` but we skim off that prepended pound onChange and basically everywhere else. However, if you set a different value on the same page (like theme) and resubmit without actually typing into the ColorInput, the component will return `#{value}`, which gets duplicate prepended and submitted to the ship as `##{value}`, breaking the background color.

Fixes urbit/landscape#803