### PR TITLE
u3: rewrites %ud parser

### DIFF
--- a/pkg/urbit/include/noun/serial.h
+++ b/pkg/urbit/include/noun/serial.h
@@ -65,3 +65,13 @@
       */
         u3_noun
         u3s_cue_atom(u3_atom a);
+
+      /* u3s_sift_ud_bytes: parse @ud.
+      */
+        u3_weak
+        u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y);
+
+      /* u3s_sift_ud: parse @ud.
+      */
+        u3_weak
+        u3s_sift_ud(u3_atom a);

--- a/pkg/urbit/jets/e/slaw.c
+++ b/pkg/urbit/jets/e/slaw.c
@@ -5,49 +5,16 @@
 
 #include <ctype.h>
 
-/* functions
- */
-u3_noun
-_parse_ud(u3_noun txt) {
-  c3_c* c = u3a_string(txt);
+static inline u3_noun
+_parse_ud(u3_noun a)
+{
+  u3_weak pro;
 
-  // First character must represent a digit
-  c3_c* cur = c;
-  if (cur[0] > '9' || cur[0] < '0') {
-    u3a_free(c);
-    return u3_none;
-  }
-  u3_atom total = cur[0] - '0';
-  cur++;
-
-  int since_last_period = 0;
-  while (cur[0] != 0) {
-    since_last_period++;
-    if (cur[0] == '.') {
-      since_last_period = 0;
-      cur++;
-      continue;
-    }
-
-    if (cur[0] > '9' || cur[0] < '0') {
-      u3a_free(c);
-      u3z(total);
-      return u3_none;
-    }
-
-    total = u3ka_mul(total, 10);
-    total = u3ka_add(total, cur[0] - '0');
-    cur++;
-
-    if (since_last_period > 3) {
-      u3a_free(c);
-      u3z(total);
-      return u3_none;
-    }
+  if ( u3_none == (pro = u3s_sift_ud(u3x_atom(a))) ) {
+    return u3_nul;
   }
 
-  u3a_free(c);
-  return u3nc(0, total);
+  return u3nc(u3_nul, pro);
 }
 
 static

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -313,12 +313,17 @@ u3i_word(c3_w dat_w)
 u3_atom
 u3i_chub(c3_d dat_d)
 {
-  c3_w dat_w[2] = {
-    dat_d & 0xffffffffULL,
-    dat_d >> 32
-  };
+  if ( c3y == u3a_is_cat(dat_d) ) {
+    return (u3_atom)dat_d;
+  }
+  else {
+    c3_w dat_w[2] = {
+      dat_d & 0xffffffffULL,
+      dat_d >> 32
+    };
 
-  return u3i_words(2, dat_w);
+    return u3i_words(2, dat_w);
+  }
 }
 
 /* u3i_bytes(): Copy [a] bytes from [b] to an LSB first atom.

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1205,16 +1205,11 @@ u3r_mp(mpz_t   a_mp,
   else {
     u3a_atom* b_u = u3a_to_ptr(b);
     c3_w    len_w = b_u->len_w;
+    c3_d    bit_d = (c3_d)len_w << 5;
 
     //  avoid reallocation on import, if possible
     //
-    if ( (len_w >> 27) ) {
-      mpz_init(a_mp);
-    }
-    else {
-      mpz_init2(a_mp, len_w << 5);
-    }
-
+    mpz_init2(a_mp, (c3_w)c3_min(bit_d, UINT32_MAX));
     mpz_import(a_mp, len_w, -1, sizeof(c3_w), 0, 0, b_u->buf_w);
   }
 }

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -922,7 +922,7 @@ tid_ab:
       if (  ('.' != byt_y[0])
          || NOT_DEC(byt_y[1])
          || NOT_DEC(byt_y[2])
-         || NOT_DEC(byt_y[1]) )
+         || NOT_DEC(byt_y[3]) )
       {
         return u3_none;
       }
@@ -952,7 +952,7 @@ tid_ab:
       if (  ('.' != byt_y[0])
          || NOT_DEC(byt_y[1])
          || NOT_DEC(byt_y[2])
-         || NOT_DEC(byt_y[1]) )
+         || NOT_DEC(byt_y[3]) )
       {
         mpz_clear(a_mp);
         return u3_none;

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -857,92 +857,90 @@ u3s_cue_atom(u3_atom a)
   return u3s_cue_bytes((c3_d)len_w, byt_y);
 }
 
-#define NONZERO(a) ( ((a) >= '1') && ((a) <= '9') )
-#define DIGIT(a)   ( ((a) >= '0') && ((a) <= '9') )
+#define NOT_DEC(a) ( ((a) < '0') || ((a) > '9') )
 
 /* u3s_sift_ud_bytes: parse @ud
 */
 u3_weak
 u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
 {
-  //  +ape:ag: just 0 or
+  c3_s val_s;
+
+  if ( !len_w ) return u3_none;
+
+  //  +ape:ag: just 0
   //
-  if ( (1 == len_w) && ('0' == *byt_y) ) {
-    return (u3_noun)0;
+  if ( '0' == *byt_y ) {
+    return ( 1 == len_w ) ? (u3_noun)0 : u3_none;
   }
+
+  // if ( (1 == len_w) && ('0' == *byt_y) ) return (u3_noun)val_s;
 
   //  +ted:ab: leading nonzero, 0-2 digits
   //
-  if ( len_w && NONZERO(*byt_y) ) {
-    c3_s val_s = *byt_y++ - '0';
+  if ( NOT_DEC(*byt_y) ) return u3_none;
 
-    //  0 digits
+  val_s = *byt_y++ - '0';
+  if ( 0 == --len_w )    return (u3_noun)val_s;
+
+  //  1 digit
+  //
+  if ( '.' == *byt_y )   goto tid_ab;
+  if ( NOT_DEC(*byt_y) ) return u3_none;
+
+  val_s *= 10;
+  val_s += *byt_y++ - '0';
+  if ( 0 == --len_w )    return (u3_noun)val_s;
+
+  //  2 digits
+  //
+  if ( '.' == *byt_y )   goto tid_ab;
+  if ( NOT_DEC(*byt_y) ) return u3_none;
+
+  val_s *= 10;
+  val_s += *byt_y++ - '0';
+  if ( 0 == --len_w )    return (u3_noun)val_s;
+
+tid_ab:
+  //  +tid:ab: dot-prefixed 3-digit blocks
+  //
+  if ( len_w % 4 ) return u3_none;
+
+  {
+    //  XX estimate size, allocate once
     //
-    if ( 0 == --len_w ) return (u3_noun)val_s;
+    mpz_t a_mp;
+    mpz_init_set_ui(a_mp, val_s);
 
-    //  1 digit
-    //
-    if ( !DIGIT(*byt_y) ) goto fail;
-
-    val_s *= 10;
-    val_s += *byt_y++ - '0';
-
-    if ( 0 == --len_w ) return (u3_noun)val_s;
-
-    //  2  digits
-    //
-    if ( !DIGIT(*byt_y) ) goto fail;
-
-    val_s *= 10;
-    val_s += *byt_y++ - '0';
-
-    if ( 0 == --len_w ) return (u3_noun)val_s;
-
-    //  +tid:ab: dot-prefixed 3-digit blocks
-    //
-    if ( 0 != (len_w % 4) ) goto fail;
-
-    {
-      //  XX estimate size, allocate once
-      //
-      mpz_t a_mp;
-      mpz_init_set_ui(a_mp, val_s);
-
-      while ( len_w ) {
-        if (  ('.' != byt_y[0])
-           || !DIGIT(byt_y[1])
-           || !DIGIT(byt_y[2])
-           || !DIGIT(byt_y[1]) )
-        {
-          mpz_clear(a_mp);
-          goto fail;
-        }
-
-        byt_y++;
-
-        val_s  = *byt_y++ - '0';
-        val_s *= 10;
-        val_s += *byt_y++ - '0';
-        val_s *= 10;
-        val_s += *byt_y++ - '0';
-
-        mpz_mul_ui(a_mp, a_mp, 1000);
-        mpz_add_ui(a_mp, a_mp, val_s);
-
-        len_w -= 4;
+    while ( len_w ) {
+      if (  ('.' != byt_y[0])
+         || NOT_DEC(byt_y[1])
+         || NOT_DEC(byt_y[2])
+         || NOT_DEC(byt_y[1]) )
+      {
+        mpz_clear(a_mp);
+        return u3_none;
       }
 
-      return u3i_mp(a_mp);
-    }
-  }
+      byt_y++;
 
-fail:
-  return u3_none;
+      val_s  = *byt_y++ - '0';
+      val_s *= 10;
+      val_s += *byt_y++ - '0';
+      val_s *= 10;
+      val_s += *byt_y++ - '0';
+
+      mpz_mul_ui(a_mp, a_mp, 1000);
+      mpz_add_ui(a_mp, a_mp, val_s);
+
+      len_w -= 4;
+    }
+
+    return u3i_mp(a_mp);
+  }
 }
 
-#undef DIGIT
-#undef NONZERO
-
+#undef NOT_DEC
 
 /* u3s_sift_ud: parse @ud.
 */

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -873,8 +873,8 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
 
   //  +ape:ag: just 0
   //
-  if      ( !len_w )        return u3_none;
-  else if ( '0' == *byt_y ) return ( 1 == len_w ) ? (u3_noun)0 : u3_none;
+  if ( !len_w )        return u3_none;
+  if ( '0' == *byt_y ) return ( 1 == len_w ) ? (u3_noun)0 : u3_none;
 
   //  +ted:ab: leading nonzero (checked above), plus up to 2 digits
   //

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -878,22 +878,20 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
 
   //  +ted:ab: leading nonzero (checked above), plus up to 2 digits
   //
+#define NEXT()  do {                          \
+    if ( !DIGIT(*byt_y) ) return u3_none;     \
+    val_s *= 10;                              \
+    val_s += *byt_y++ - '0';                  \
+  } while (0)
+
   switch ( num_y ) {
-    case 3:  if ( !DIGIT(*byt_y) ) return u3_none;
-             val_s *= 10;
-             val_s += *byt_y++ - '0';
-
-    case 2:  if ( !DIGIT(*byt_y) ) return u3_none;
-             val_s *= 10;
-             val_s += *byt_y++ - '0';
-
-    case 1:  if ( !DIGIT(*byt_y) ) return u3_none;
-             val_s *= 10;
-             val_s += *byt_y++ - '0';
-             break;
-
-    case 0:  return u3_none;
+    case 3: NEXT();
+    case 2: NEXT();
+    case 1: NEXT(); break;
+    case 0: return u3_none;
   }
+
+#undef NEXT
 
   len_w -= num_y;
 

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -875,9 +875,7 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
     return ( 1 == len_w ) ? (u3_noun)0 : u3_none;
   }
 
-  // if ( (1 == len_w) && ('0' == *byt_y) ) return (u3_noun)val_s;
-
-  //  +ted:ab: leading nonzero, 0-2 digits
+  //  +ted:ab: leading nonzero, 0-2 additional digits
   //
   if ( NOT_DEC(*byt_y) ) return u3_none;
 
@@ -885,7 +883,7 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
   val_s = *byt_y++ - '0';
   if ( 0 == --len_w )    return (u3_noun)val_s;
 
-  //  1 digit
+  //  1 additional digit
   //
   if ( '.' == *byt_y )   goto tid_ab;
   if ( NOT_DEC(*byt_y) ) return u3_none;
@@ -895,7 +893,7 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
   val_s += *byt_y++ - '0';
   if ( 0 == --len_w )    return (u3_noun)val_s;
 
-  //  2 digits
+  //  2 additional digits
   //
   if ( '.' == *byt_y )   goto tid_ab;
   if ( NOT_DEC(*byt_y) ) return u3_none;

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -876,9 +876,9 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
   if      ( !len_w )        return u3_none;
   else if ( '0' == *byt_y ) return ( 1 == len_w ) ? (u3_noun)0 : u3_none;
 
-  //  +ted:ab: leading nonzero (checked above), plus 0-2 digits
+  //  +ted:ab: leading nonzero (checked above), plus up to 2 digits
   //
-  switch (num_y) {
+  switch ( num_y ) {
     case 3:  if ( !DIGIT(*byt_y) ) return u3_none;
              val_s *= 10;
              val_s += *byt_y++ - '0';
@@ -890,6 +890,9 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
     case 1:  if ( !DIGIT(*byt_y) ) return u3_none;
              val_s *= 10;
              val_s += *byt_y++ - '0';
+             break;
+
+    case 0:  return u3_none;
   }
 
   len_w -= num_y;

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -925,10 +925,14 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
   }
 
   {
-    //  XX estimate size, allocate once
+    //  avoid gmp realloc if possible
     //
     mpz_t a_mp;
-    mpz_init_set_ui(a_mp, val_s);
+    {
+      c3_d bit_d = (c3_d)(len_w / 4) * 10;
+      mpz_init2(a_mp, (c3_w)c3_min(bit_d, UINT32_MAX));
+      mpz_set_ui(a_mp, val_s);
+    }
 
     while ( len_w ) {
       if ( !BLOCK(byt_y) ) {

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -67,6 +67,7 @@ _test_sift_ud(void)
   ret_i &= _ud_fail("1234.567.8");
   ret_i &= _ud_fail("1234.56..78.");
   ret_i &= _ud_fail("123.45a");
+  ret_i &= _ud_fail(".123.456");
 
   {
     c3_c* num_c = "4.294.967.296";

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -9,6 +9,107 @@ _setup(void)
   u3m_pave(c3y);
 }
 
+static inline c3_i
+_ud_good(c3_w num_w, const c3_c* num_c)
+{
+  u3_weak out;
+  if ( num_w != (out = u3s_sift_ud_bytes(strlen(num_c), (c3_y*)num_c)) ) {
+    if ( u3_none == out ) {
+      fprintf(stderr, "sift_ud: %s fail; expected %u\r\n", num_c, num_w);
+    }
+    else {
+      fprintf(stderr, "sift_ud: %s wrong; expected %u: actual %u\r\n", num_c, num_w, out);
+    }
+    return 0;
+  }
+
+  return 1;
+}
+
+static inline c3_i
+_ud_fail(const c3_c* num_c)
+{
+  u3_weak out;
+  if ( u3_none != (out = u3s_sift_ud_bytes(strlen(num_c), (c3_y*)num_c)) ) {
+    u3m_p("out", out);
+    fprintf(stderr, "sift_ud: %s expected fail\r\n", num_c);
+    return 0;
+  }
+
+  return 1;
+}
+
+static c3_i
+_test_sift_ud(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _ud_good(0, "0");
+  ret_i &= _ud_good(1, "1");
+  ret_i &= _ud_good(12, "12");
+  ret_i &= _ud_good(123, "123");
+  ret_i &= _ud_good(1234, "1.234");
+  ret_i &= _ud_good(12345, "12.345");
+  ret_i &= _ud_good(123456, "123.456");
+  ret_i &= _ud_good(1234567, "1.234.567");
+  ret_i &= _ud_good(12345678, "12.345.678");
+  ret_i &= _ud_good(123456789, "123.456.789");
+  ret_i &= _ud_good(100000000, "100.000.000");
+  ret_i &= _ud_good(101101101, "101.101.101");
+  ret_i &= _ud_good(201201201, "201.201.201");
+  ret_i &= _ud_good(302201100, "302.201.100");
+
+  ret_i &= _ud_fail("01");
+  ret_i &= _ud_fail("02");
+  ret_i &= _ud_fail("003");
+  ret_i &= _ud_fail("1234");
+  ret_i &= _ud_fail("1234.5");
+  ret_i &= _ud_fail("1234.567.8");
+  ret_i &= _ud_fail("1234.56..78.");
+  ret_i &= _ud_fail("123.45a");
+
+  {
+    c3_c* num_c = "4.294.967.296";
+    u3_weak out = u3s_sift_ud_bytes(strlen(num_c), (c3_y*)num_c);
+    u3_atom pro = u3qc_bex(32);
+
+    if ( u3_none == out ) {
+      fprintf(stderr, "sift_ud: (bex 32) fail\r\n");
+      ret_i = 0;
+    }
+
+    if ( c3n == u3r_sing(pro, out) ) {
+      u3m_p("out", out);
+      fprintf(stderr, "sift_ud: (bex 32) wrong\r\n");
+      ret_i = 0;
+    }
+
+    u3z(out); u3z(pro);
+  }
+
+
+  {
+    c3_c* num_c = "340.282.366.920.938.463.463.374.607.431.768.211.456";
+    u3_weak out = u3s_sift_ud_bytes(strlen(num_c), (c3_y*)num_c);
+    u3_atom pro = u3qc_bex(128);
+
+    if ( u3_none == out ) {
+      fprintf(stderr, "sift_ud: (bex 128) fail\r\n");
+      ret_i = 0;
+    }
+
+    if ( c3n == u3r_sing(pro, out) ) {
+      u3m_p("out", out);
+      fprintf(stderr, "sift_ud: (bex 128) wrong\r\n");
+      ret_i = 0;
+    }
+
+    u3z(out); u3z(pro);
+  }
+
+  return ret_i;
+}
+
 static c3_i
 _test_en_base16(void)
 {
@@ -399,6 +500,11 @@ static c3_i
 _test_jets(void)
 {
   c3_i ret_i = 1;
+
+  if ( !_test_sift_ud() ) {
+    fprintf(stderr, "test jets: sift_ud: failed\r\n");
+    ret_i = 0;
+  }
 
   if ( !_test_base16() ) {
     fprintf(stderr, "test jets: base16: failed\r\n");


### PR DESCRIPTION
Fixes #4767, and improves performance.

There was a jet mismatch in `+slaw`; the `@ud` parser mistakenly allowed leading zeros, and less-than-3-digit blocks between `.` separators. Those bugs have been corrected in a new implementation.

To test the performance, I parsed a big `@ud` in a loop.

```
> =do |*([max=@ud arg=* fun=gate] =|(i=@ud |-(?:(=(max i) ~ =+((fun arg) $(i +(i)))))))
> |start %time
```

The raw parser combinator:

```
> :time (do 1.000 (rap 3 ['123.456.789' (reap 200 '.123.456.789')]) |=(a=@t (rush a dem:ag)))
[%took ~s21..438a]
```

The old, overly-lenient jet:

```
> :time (do 1.000 (rap 3 ['123.456.789' (reap 200 '.123.456.789')]) |=(a=@t (slaw %ud a)))
[%took ~s5..697e]
```

The new jet:

```
> :time (do 1.000 (rap 3 ['123.456.789' (reap 200 '.123.456.789')]) |=(a=@t (slaw %ud a)))
[%took ~s0..226a]
> :time (do 10.000 (rap 3 ['123.456.789' (reap 200 '.123.456.789')]) |=(a=@t (slaw %ud a)))
[%took ~s0..769a]
> :time (do 100.000 (rap 3 ['123.456.789' (reap 200 '.123.456.789')]) |=(a=@t (slaw %ud a)))
[%took ~s3..dd65]
```