### PR TITLE
group-timer: fix mark assertion

### DIFF
--- a/pkg/arvo/app/group-timer.hoon
+++ b/pkg/arvo/app/group-timer.hoon
@@ -87,7 +87,7 @@
     ::
         %fact
       ?:  ?=(%group-initial p.cage.sign)  [~ this]
-      ?>  ?=(%group-update p.cage.sign)
+      ?>  ?=(%group-update-0 p.cage.sign)
       =+  !<(=update:gr q.cage.sign)
       ?.  ?=(%add-members -.update)     [~ this]
       =|  cards=(list card)


### PR DESCRIPTION
Fixes an infinite loop of kick and resubscribes. Already deployed to ~difmex-passed