### PR TITLE
VirtualScroller: fix race conditions and excessive scroll adjusting

### DIFF
--- a/pkg/interface/src/logic/lib/virtualContext.tsx
+++ b/pkg/interface/src/logic/lib/virtualContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
 } from "react";
 import usePreviousValue from "./usePreviousValue";
+import {Primitive} from "~/types";
 
 export interface VirtualContextProps {
   save: () => void;
@@ -49,7 +50,7 @@ export function useVirtualResizeState(s: boolean) {
   return [state, setState] as const;
 }
 
-export function useVirtualResizeProp<T>(prop: T) {
+export function useVirtualResizeProp(prop: Primitive) {
   const { save, restore } = useVirtual();
   const oldProp = usePreviousValue(prop)
 
@@ -58,7 +59,7 @@ export function useVirtualResizeProp<T>(prop: T) {
   }
 
   useLayoutEffect(() => {
-    restore();
+    requestAnimationFrame(restore);
   }, [prop]);
 
 

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -18,7 +18,7 @@ import { GroupLink } from "~/views/components/GroupLink";
 import GlobalApi from "~/logic/api/global";
 import { getModuleIcon } from "~/logic/lib/util";
 import useMetadataState from "~/logic/state/metadata";
-import { Association, resourceFromPath } from "@urbit/api";
+import { Association, resourceFromPath, GraphNode } from "@urbit/api";
 import { Link } from "react-router-dom";
 import useGraphState from "~/logic/state/graph";
 import { GraphNodeContent } from "../notifications/graph";
@@ -51,7 +51,7 @@ function GraphPermalink(
   const { full = false, showOurContact, pending, link, graph, group, index, api, transcluded } = props;
   const { ship, name } = resourceFromPath(graph);
   const node = useGraphState(
-    useCallback((s) => s.looseNodes?.[`${ship.slice(1)}/${name}`]?.[index], [
+    useCallback((s) => s.looseNodes?.[`${ship.slice(1)}/${name}`]?.[index] as GraphNode, [
       graph,
       index,
     ])
@@ -63,7 +63,7 @@ function GraphPermalink(
     ])
   );
 
-  useVirtualResizeProp(node)
+  useVirtualResizeProp(!!node)
   useEffect(() => {
     (async () => {
       if (pending || !index) {


### PR DESCRIPTION
VirtualScroller: fix race condition in ref deletion

A callback ref is called after the component is mounted, but before the
component is unmounted. However, we might still be adjusting scroll
position based on a component that is going to be remounted. Previously,
we delayed the deletion until the next tick with setTimeout. With the
faster ordered map implementation, the component may be remounted
before the next tick, leading to the deletion of a ref that is still
mounted. To work around this, we store a set of 'orphans' and clear the
map of orphans on an interval, and only clear the map if we are not
currently adjusting our scroll position. Also includes fixes for jumpy
scroll behaviour on initial mount.

virtualContext: fix useVirtualResizeProp
