### PR TITLE
landscape: restore timestamps across interface

### DIFF
--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -19,7 +19,7 @@ interface LinkItemProps {
   node: GraphNode;
   association: Association;
   resource: string; api: GlobalApi; group: Group; path: string; }
-export const LinkItem = (props: LinkItemProps): ReactElement => { 
+export const LinkItem = (props: LinkItemProps): ReactElement => {
   const {
     association,
     node,
@@ -86,7 +86,7 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
     permalink,
     'Copy reference'
   );
-  
+
   const deleteLink = () => {
     if (confirm('Are you sure you want to delete this link?')) {
       api.graph.removeNodes(`~${ship}`, name, [node.post.index]);
@@ -167,9 +167,11 @@ export const LinkItem = (props: LinkItemProps): ReactElement => {
       <Row minWidth='0' flexShrink={0} width="100%" justifyContent="space-between" py={3} bg="white">
       <Author
         showImage
+        isRelativeTime
         ship={author}
         date={node.post['time-sent']}
         group={group}
+        lineHeight="1"
       />
       <Box ml="auto">
         <Link

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -115,11 +115,12 @@ export function Note(props: NoteProps & RouteComponentProps) {
         <Row alignItems="center">
           <Author
             showImage
+            isRelativeTime
             ship={post?.author}
             date={post?.['time-sent']}
             group={group}
           >
-            <Row px="2" gapX="2" alignItems="flex-end">
+            <Row px="2" gapX="2" alignItems="flex-end" height="14px">
               <Action bg="white" onClick={doCopy}>{copyDisplay}</Action>
               {adminLinks}
             </Row>

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -24,6 +24,7 @@ interface AuthorProps {
   unread?: boolean;
   api?: GlobalApi;
   size?: number;
+  lineHeight?: string;
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -38,10 +39,11 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
     group,
     isRelativeTime,
     dontShowTime,
+    lineHeight = 'tall',
     ...rest
   } = props;
 
-  const time = props.time || false;
+  const time = props.time || props.date || false;
   const size = props.size || 16;
   const sigilPadding = props.sigilPadding || 2;
 
@@ -89,7 +91,7 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
     ) : sigil;
 
   return (
-    <Row height="20px" {...rest} alignItems='center' width='auto'>
+    <Row {...rest} alignItems='center' width='auto'>
       <Box
         onClick={(e) => {
           e.stopPropagation();
@@ -110,7 +112,7 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
         color='black'
         fontSize='1'
         cursor='pointer'
-        lineHeight='tall'
+        lineHeight={lineHeight}
         fontFamily={showNickname ? 'sans' : 'mono'}
         fontWeight={showNickname ? '500' : '400'}
         mr={showNickname ? 0 : "2px"}
@@ -121,6 +123,7 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
       </Box>
       { !dontShowTime && time && (
         <Timestamp
+          height="fit-content"
           relative={isRelativeTime}
           stamp={stamp}
           fontSize={1}

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -95,6 +95,7 @@ export function CommentItem(props: CommentItemProps): ReactElement {
           date={post?.['time-sent']}
           unread={props.unread}
           group={group}
+          isRelativeTime
         >
           <Row px="2" gapX="2" height="18px">
             <Action bg="white" onClick={doCopy}>{copyDisplay}</Action>

--- a/pkg/interface/src/views/components/Timestamp.tsx
+++ b/pkg/interface/src/views/components/Timestamp.tsx
@@ -12,6 +12,7 @@ export type TimestampProps = BoxProps & {
   date?: boolean;
   time?: boolean;
   relative?: boolean;
+  height?: string;
 };
 
 const Timestamp = (props: TimestampProps): ReactElement | null => {

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostHeader.js
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostHeader.js
@@ -46,6 +46,7 @@ export function PostHeader(props) {
         isRelativeTime={true}
         showTime={false}
         time={true}
+        lineHeight='1'
       />
       <Dropdown
         dropWidth="200px"


### PR DESCRIPTION
Somewhere in there we lost timestamps on comment items, notes, links, etc. etc. I use `props.date` as a fallback in `Timestamp` and also add a prop to set line-height to force Author and Timestamp to line up across all instances it's used (Links, Publish, Group Feed, etc etc) — the `tall` line-height breaks `align-items` otherwise.