### PR TITLE
VirtualScroller: performance, memory leaks

### DIFF
--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -75,7 +75,14 @@ export function ChatResource(props: ChatResourceProps) {
   );
 
   const clearUnsent = useCallback(
-    () => setUnsent(s => _.omit(s, station)),
+    () => {
+      setUnsent(s => {
+        if(station in s) {
+          return _.omit(s, station);
+        }
+        return s;
+      });
+    },
     [station]
   );
 

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -210,7 +210,9 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
 
     if(size !== prevProps.size || pendingSize !== prevProps.pendingSize) {
       if(this.scrollLocked) {
-        this.updateVisible(0);
+        if(!this.state.visibleItems.peekLargest()![0].eq(this.props.data.peekLargest()![0])) {
+          this.updateVisible(0);
+        }     
         this.resetScroll();
 
       }

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -222,9 +222,8 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
     if(this.cleanupRefInterval) {
       clearInterval(this.cleanupRefInterval);
     }
-    if(this.initScroll) {
-      clearTimeout(this.initScroll);
-    }
+    this.cleanupRefs();
+    this.childRefs.clear();
   }
 
   startOffset() {

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -146,8 +146,6 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
 
   private cleanupRefInterval: NodeJS.Timeout | null = null;
 
-  private initScroll: NodeJS.Timeout | null = null;
-
   constructor(props: VirtualScrollerProps<T>) {
     super(props);
     this.state = {
@@ -170,15 +168,9 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
 
   componentDidMount() {
     this.updateVisible(0);
-    this.resetScroll();
     this.loadTop();
     this.loadBottom();
     this.cleanupRefInterval = setInterval(this.cleanupRefs, 5000);
-    this.initScroll = setTimeout(() => {
-      log('scroll', 'initialised scroll');
-      this.restore();
-      this.initScroll = null;
-    }, 100);
   }
 
 
@@ -429,8 +421,11 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
       log('bail', 'Deep restore');
       return;
     }
-    if(this.initScroll) {
-      log('bail', 'still initialising scroll');
+    if(this.scrollLocked) {
+      this.resetScroll();
+      this.savedIndex = null;
+      this.savedDistance = 0;
+      this.saveDepth--;
       return;
     }
 

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -361,10 +361,6 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
       // bail if we're going to adjust scroll anyway
       return;
     }
-    if(this.initScroll) {
-      clearTimeout(this.initScroll);
-      this.initScroll = null;
-    }
     if(this.saveDepth > 0) {
       log('bail', 'deep scroll queue');
       return;
@@ -376,17 +372,15 @@ export default class VirtualScroller<T> extends Component<VirtualScrollerProps<T
     const startOffset = this.startOffset();
     if (scrollTop < ZONE_SIZE) {
       log('scroll', `Entered start zone ${scrollTop}`);
-      if (startOffset === 0 && onStartReached) {
-        onStartReached();
+      if (startOffset === 0) {
+        onStartReached && onStartReached();
+        this.scrollLocked = true;
       }
       const newOffset = Math.max(0, startOffset - this.pageDelta);
       if(newOffset < 10) {
         this.loadBottom();
       }
 
-      if(newOffset === 0) {
-        this.scrollLocked = true;
-      }
       if(newOffset !== startOffset) {
         this.updateVisible(newOffset);
       }


### PR DESCRIPTION
ChatResource: prevent unnecessary state update

VirtualScroller: only rerender on scroll lock if necessary

VirtualScroller: lock scroll less aggressively

Prevents incorrect scroll adjustment

VirtualScroller: aggressively cleanup refs

Prevents a memory leak, as it appears React holds onto the class
instance after unmounting

VirtualScroller: rework scroll initialisation

Calling restore if the scroll is locked simply resets the scroll,
instead of using the usual adjustment algorithm
