### PR TITLE
landscape: highlight content mentioning our ship

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -264,6 +264,7 @@ class ChatMessage extends Component<ChatMessageProps> {
   componentDidMount() {}
 
   render() {
+    let { highlighted } = this.props;
     const {
       msg,
       previousMsg,
@@ -279,11 +280,20 @@ class ChatMessage extends Component<ChatMessageProps> {
       unreadMarkerRef,
       history,
       api,
-      highlighted,
       showOurContact,
       fontSize,
       hideHover
     } = this.props;
+
+    const ourMention = msg?.contents?.some((e) => {
+      return e?.mention && e?.mention === window.ship;
+    });
+
+    if (!highlighted) {
+      if (ourMention) {
+        highlighted = true;
+      }
+    }
 
     let onReply = this.props?.onReply ?? (() => {});
     const transcluded = this.props?.transcluded ?? 0;

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -35,6 +35,7 @@ interface CommentItemProps {
 }
 
 export function CommentItem(props: CommentItemProps): ReactElement {
+  let { highlighted } = props;
   const { ship, name, api, comment, group } = props;
   const association = useMetadataState(
     useCallback(s => s.associations.graph[`/ship/${ship}/${name}`], [ship,name])
@@ -46,6 +47,16 @@ export function CommentItem(props: CommentItemProps): ReactElement {
   const onDelete = async () => {
     await api.graph.removeNodes(ship, name, [comment.post?.index]);
   };
+
+  const ourMention = post?.contents?.some((e) => {
+      return e?.mention && e?.mention === window.ship;
+    });
+
+  if (!highlighted) {
+    if (ourMention) {
+      highlighted = true;
+    }
+  }
 
   const commentIndexArray = (comment.post?.index || '/').split('/');
   const commentIndex = commentIndexArray[commentIndexArray.length - 1];
@@ -106,7 +117,7 @@ export function CommentItem(props: CommentItemProps): ReactElement {
         borderRadius="1"
         p="1"
         mb="1"
-        backgroundColor={props.highlighted ? 'washedBlue' : 'white'}
+        backgroundColor={highlighted ? 'washedBlue' : 'white'}
         transcluded={0}
         api={api}
         post={post}


### PR DESCRIPTION
Was using Landscape and was just thinking "we should probably have this"...

cc @urcades — how's this look (it's just using our already-defined highlight styles) and do you approve of the feature?
![comparison](https://user-images.githubusercontent.com/20846414/116007662-ec41f380-a5de-11eb-9109-95fe08a42ca2.png)

@liam-fitzgerald @tacryt-socryp I don't think this is that expensive, is it?