### PR TITLE
chat: persist submit button

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -44,7 +44,7 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
       inCodeMode: false,
       submitFocus: false,
       uploadingPaste: false,
-      currentInput: props.message,
+      currentInput: props.message
     };
 
     this.chatEditor = React.createRef();
@@ -124,10 +124,6 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
         .catch(this.uploadError);
     });
   }
-  
-  toggleFocus(value) {
-    this.setState({ submitFocus: value });
-  }
 
   eventHandler(value) {
     this.setState({ currentInput: value });
@@ -194,8 +190,6 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
           onUnmount={props.onUnmount}
           message={props.message}
           onPaste={this.onPaste.bind(this)}
-          focusEvent={() => this.toggleFocus(true)}
-          blurEvent={() => this.toggleFocus(false)}
           changeEvent={this.eventHandler}
           placeholder='Message...'
         />
@@ -224,9 +218,7 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
             )
           ) : null}
         </Box>
-        {(MOBILE_BROWSER_REGEX.test(navigator.userAgent) &&
-          state.submitFocus) ||
-        state.currentInput !== "" ? (
+        {MOBILE_BROWSER_REGEX.test(navigator.userAgent) ?
           <Box
             ml={2}
             mr="12px"
@@ -237,13 +229,13 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
             width="24px"
             height="24px"
             borderRadius="50%"
-            backgroundColor={state.currentInput !== "" ? "blue" : "gray"}
-            cursor={state.currentInput !== "" ? "pointer" : "default"}
+            backgroundColor={state.currentInput !== '' ? 'blue' : 'gray'}
+            cursor={state.currentInput !== '' ? 'pointer' : 'default'}
             onClick={() => this.chatEditor.current.submit()}
           >
             <Icon icon="ArrowEast" color="white" />
           </Box>
-        ) : null}
+          : null}
       </Row>
     );
   }

--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -181,8 +181,6 @@ export default class ChatEditor extends Component {
       inCodeMode,
       placeholder,
       message,
-      focusEvent,
-      blurEvent,
       ...props
     } = this.props;
 
@@ -242,8 +240,6 @@ export default class ChatEditor extends Component {
               rows="1"
               style={{ width: '100%', background: 'transparent', color: 'currentColor' }}
               placeholder={inCodeMode ? "Code..." : "Message..."}
-              onFocus={focusEvent}
-              onBlur={blurEvent}
               onChange={event => {
                 this.messageChange(null, null, event.target.value);
               }}
@@ -271,8 +267,6 @@ export default class ChatEditor extends Component {
             this.editor = editor;
             editor.focus();
           }}
-          onFocus={focusEvent}
-          onBlur={blurEvent}
           {...props}
         />
         }


### PR DESCRIPTION
Discovered some inconsistent and frustrating event behavior with #4801 where the act of clicking the disabled Send button in ChatInput would blur the field, thereby hiding the button you just tapped. This persists the Send button regardless of input focus, and turns the button blue if the user has entered some text.

![image](https://user-images.githubusercontent.com/748181/116141862-3c848880-a6a7-11eb-9325-cfcf630c5a55.png)

Default experience otherwise:
![image](https://user-images.githubusercontent.com/748181/116141884-44442d00-a6a7-11eb-9f49-89cd9e2b30c4.png)
