### PR TITLE
vere: fix cttp tls crash from (bad) fix for synchronous error callback 

### DIFF
--- a/pkg/urbit/vere/io/cttp.c
+++ b/pkg/urbit/vere/io/cttp.c
@@ -36,26 +36,26 @@
 /* u3_creq: outgoing http request.
 */
   typedef struct _u3_creq {             //  client request
-    c3_l             num_l;             //  request number
+    c3_l               num_l;           //  request number
     h2o_http1client_t* cli_u;           //  h2o client
-    u3_csat          sat_e;             //  connection state
-    c3_o             sec;               //  yes == https
-    c3_w             ipf_w;             //  IP
-    c3_c*            ipf_c;             //  IP (string)
-    c3_c*            hot_c;             //  host
-    c3_s             por_s;             //  port
-    c3_c*            por_c;             //  port (string)
-    c3_c*            met_c;             //  method
-    c3_c*            url_c;             //  url
-    u3_hhed*         hed_u;             //  headers
-    u3_hbod*         bod_u;             //  body
-    u3_hbod*         rub_u;             //  exit of send queue
-    u3_hbod*         bur_u;             //  entry of send queue
-    h2o_iovec_t*     vec_u;             //  send-buffer array
-    u3_cres*         res_u;             //  nascent response
-    struct _u3_creq* nex_u;             //  next in list
-    struct _u3_creq* pre_u;             //  previous in list
-    struct _u3_cttp* ctp_u;             //  cttp backpointer
+    u3_csat            sat_e;           //  connection state
+    c3_o               sec;             //  yes == https
+    c3_w               ipf_w;           //  IP
+    c3_c*              ipf_c;           //  IP (string)
+    c3_c*              hot_c;           //  host
+    c3_s               por_s;           //  port
+    c3_c*              por_c;           //  port (string)
+    c3_c*              met_c;           //  method
+    c3_c*              url_c;           //  url
+    u3_hhed*           hed_u;           //  headers
+    u3_hbod*           bod_u;           //  body
+    u3_hbod*           rub_u;           //  exit of send queue
+    u3_hbod*           bur_u;           //  entry of send queue
+    h2o_iovec_t*       vec_u;           //  send-buffer array
+    u3_cres*           res_u;           //  nascent response
+    struct _u3_creq*   nex_u;           //  next in list
+    struct _u3_creq*   pre_u;           //  previous in list
+    struct _u3_cttp*   ctp_u;           //  cttp backpointer
   } u3_creq;
 
 /* u3_cttp: http client.


### PR DESCRIPTION
This PR fixes a crash introduced by #4766. That PR fixed a longstanding, rare crash in the http-client driver, caused by a surprising synchronous call to a normally async callback, which would result in a use-after-free. The fix introduced a new, deterministic crash for every TLS request, due to my misunderstanding of the code (which I had written).

`cttp.c` always connects by ip/port, to avoid synchronous `getaddrinfo()` calls in the library (we use libuv's threadpool at call sites). In order to correctly negotiate TLS sessions, we must also synchronously patch the SNI data, but only after successful `connect()` calls. This PR extends the client request state machine to correctly cover these edge cases.