### PR TITLE
king: ensure lmdb is statically linked on osx

### DIFF
--- a/nix/pkgs/hs/default.nix
+++ b/nix/pkgs/hs/default.nix
@@ -82,6 +82,8 @@ haskell-nix.stackProject {
 
       urbit-king.components.tests.urbit-king-tests.testFlags =
         [ "--brass-pill=${brass.lfs}" ];
+
+      lmdb.components.library.libs = lib.mkForce [ lmdb ];
     };
   }];
 }


### PR DESCRIPTION
By way of ensuring the lmdb package's cabal extra-libraries field is ignored and our lmdb overlay is used. 🤷🏽