### PR TITLE
Chat: refactor to strip associations prop

### DIFF
--- a/pkg/interface/src/logic/api/contacts.ts
+++ b/pkg/interface/src/logic/api/contacts.ts
@@ -2,6 +2,7 @@ import BaseApi from './base';
 import { StoreState } from '../store/type';
 import { Patp } from '@urbit/api';
 import { ContactEdit } from '@urbit/api/contacts';
+import _ from 'lodash';
 
 export default class ContactsApi extends BaseApi<StoreState> {
   add(ship: Patp, contact: any) {
@@ -70,6 +71,28 @@ export default class ContactsApi extends BaseApi<StoreState> {
     return this.scry<any>(
       'contact-store',
       `/is-allowed/${entity}/${name}/${ship}/${isPersonal}`
+    );
+  }
+
+  async disallowedShipsForOurContact(ships: string[]): Promise<string[]> {
+    return _.compact(
+      await Promise.all(
+        ships.map(
+          async s => {
+            const ship = `~${s}`;
+            if(s === window.ship) {
+              return null
+            }
+            const allowed = await this.fetchIsAllowed(
+              `~${window.ship}`,
+              'personal',
+              ship,
+              true
+            )
+            return allowed ? null : ship;
+          }
+        )
+      )
     );
   }
 

--- a/pkg/interface/src/logic/state/contact.ts
+++ b/pkg/interface/src/logic/state/contact.ts
@@ -35,4 +35,8 @@ export function useContact(ship: string) {
   );
 }
 
+export function useOurContact() {
+  return useContact(`~${window.ship}`)
+}
+
 export default useContactState;

--- a/pkg/interface/src/logic/state/graph.ts
+++ b/pkg/interface/src/logic/state/graph.ts
@@ -1,4 +1,5 @@
-import { Graphs, decToUd, numToUd, GraphNode } from "@urbit/api";
+import { Graphs, decToUd, numToUd, GraphNode, deSig, Association, resourceFromPath } from "@urbit/api";
+import {useCallback} from "react";
 
 import { BaseState, createState } from "./base";
 
@@ -129,6 +130,18 @@ const useGraphState = createState<GraphState>('Graph', {
   //   graphReducer(node);
   // },
 }, ['graphs', 'graphKeys', 'looseNodes', 'graphTimesentMap']);
+
+export function useGraph(ship: string, name: string) {
+  return useGraphState(
+    useCallback(s => s.graphs[`${deSig(ship)}/${name}`], [ship, name])
+  );
+}
+
+export function useGraphForAssoc(association: Association) {
+  const { resource } = association;
+  const { ship, name } = resourceFromPath(resource);
+  return useGraph(ship, name);
+}
 
 window.useGraphState = useGraphState;
 

--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -90,8 +90,8 @@ const useLocalState = create<LocalStateZus>(persist((set, get) => ({
   name: 'localReducer'
 }));
 
-function withLocalState<P, S extends keyof LocalState>(Component: any, stateMemberKeys?: S[]) {
-  return React.forwardRef((props: Omit<P, S>, ref) => {
+function withLocalState<P, S extends keyof LocalState, C extends React.ComponentType<P>>(Component: C, stateMemberKeys?: S[]) {
+  return React.forwardRef<C, Omit<P, S>>((props, ref) => {
     const localState = stateMemberKeys ? useLocalState(
       state => stateMemberKeys.reduce(
         (object, key) => ({ ...object, [key]: state[key] }), {}

--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -1,8 +1,14 @@
-import React, { useRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+} from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Col } from '@tlon/indigo-react';
 import _ from 'lodash';
-import bigInt from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 
 import { Association } from '@urbit/api/metadata';
 import { StoreState } from '~/logic/store/type';
@@ -16,13 +22,20 @@ import { useLocalStorageState } from '~/logic/lib/useLocalStorageState';
 import { Loading } from '~/views/components/Loading';
 import { isWriter, resourceFromPath } from '~/logic/lib/group';
 
-import './css/custom.css';
 import useContactState from '~/logic/state/contact';
-import useGraphState from '~/logic/state/graph';
-import useGroupState from '~/logic/state/group';
+import useGraphState, { useGraphForAssoc } from '~/logic/state/graph';
+import useGroupState, { useGroupForAssoc } from '~/logic/state/group';
 import useHarkState from '~/logic/state/hark';
-import {Post} from '@urbit/api';
-import {getPermalinkForGraph} from '~/logic/lib/permalinks';
+import { Content, createPost, Post } from '@urbit/api';
+import { getPermalinkForGraph } from '~/logic/lib/permalinks';
+import { ChatPane } from './components/ChatPane';
+
+const getCurrGraphSize = (ship: string, name: string) => {
+  const { graphs } = useGraphState.getState();
+  const graph = graphs[`${ship}/${name}`];
+  return graph?.size ?? 0;
+};
+
 
 type ChatResourceProps = StoreState & {
   association: Association;
@@ -31,172 +44,126 @@ type ChatResourceProps = StoreState & {
 };
 
 function ChatResource(props: ChatResourceProps) {
-  const station = props.association.resource;
-  const groupPath = props.association.group;
-  const groups = useGroupState(state => state.groups);
-  const group = groups[groupPath];
-  const contacts = useContactState(state => state.contacts);
-  const graphs = useGraphState(state => state.graphs);
-  const graphPath = station.slice(7);
-  const graph = graphs[graphPath];
-  const unreads = useHarkState(state => state.unreads);
-  const unreadCount = unreads.graph?.[station]?.['/']?.unreads as number || 0;
-  const graphTimesentMap = useGraphState(state => state.graphTimesentMap);
-  const [,, owner, name] = station.split('/');
-  const ourContact = contacts?.[`~${window.ship}`];
-  const chatInput = useRef<ChatInput>();
-  const canWrite = isWriter(group, station);
+  const { association, api } = props;
+  const { resource } = association;
+  const [toShare, setToShare] = useState<string[] | string | undefined>();
+  const group = useGroupForAssoc(association)!;
+  const graph = useGraphForAssoc(association);
+  const unreads = useHarkState((state) => state.unreads);
+  const unreadCount =
+    (unreads.graph?.[resource]?.['/']?.unreads as number) || 0;
+  const canWrite = group ? isWriter(group, resource) : false;
 
   useEffect(() => {
     const count = Math.min(400, 100 + unreadCount);
-    props.api.graph.getNewest(owner, name, count);
-  }, [station]);
-
-  const onFileDrag = useCallback(
-    (files: FileList | File[]) => {
-      if (!chatInput.current) {
-        return;
-      }
-      chatInput.current?.uploadFiles(files);
-    },
-    [chatInput.current]
-  );
-
-  const { bind, dragging } = useFileDrag(onFileDrag);
-
-  const [unsent, setUnsent] = useLocalStorageState<Record<string, string>>(
-    'chat-unsent',
-    {}
-  );
-
-  const appendUnsent = useCallback(
-    (u: string) => setUnsent(s => ({ ...s, [station]: u })),
-    [station]
-  );
-
-  const clearUnsent = useCallback(
-    () => {
-      setUnsent(s => {
-        if(station in s) {
-          return _.omit(s, station);
-        }
-        return s;
-      });
-    },
-    [station]
-  );
-
-  const scrollTo = new URLSearchParams(location.search).get('msg');
-
-  const [showBanner, setShowBanner] = useState(false);
-  const [hasLoadedAllowed, setHasLoadedAllowed] = useState(false);
-  const [recipients, setRecipients] = useState([]);
-
-  const res = resourceFromPath(groupPath);
-  const onReply = useCallback((msg: Post) => {
-    const url = getPermalinkForGraph(
-      props.association.group,
-      props.association.resource,
-      msg.index
-    );
-    const message = `${url}\n~${msg.author} : `;
-    setUnsent(s => ({...s, [props.association.resource]: message }));
-  }, [props.association, group, setUnsent]);
-
-  useEffect(() => {
-    (async () => {
-      if (!res) { return; }
-      if (!group) { return; }
-      if (group.hidden) {
-        const members = _.compact(await Promise.all(
+    const { ship, name } = resourceFromPath(resource);
+    props.api.graph.getNewest(ship, name, count);
+    setToShare(undefined);
+    (async function() {
+      if(group.hidden) {
+        const members = await props.api.contacts.disallowedShipsForOurContact(
           Array.from(group.members)
-            .map(s => {
-              const ship = `~${s}`;
-              if(s === window.ship) {
-                return Promise.resolve(null);
-              }
-              return props.api.contacts.fetchIsAllowed(
-                `~${window.ship}`,
-                'personal',
-                ship,
-                true
-              ).then(isAllowed => {
-                return isAllowed ? null : ship;
-              });
-            })
-        ));
-
+        );
         if(members.length > 0) {
-          setShowBanner(true);
-          setRecipients(members);
-        } else {
-          setShowBanner(false);
+          setToShare(members);
         }
       } else {
-        const groupShared = await props.api.contacts.fetchIsAllowed(
+        const { ship: groupHost } = resourceFromPath(association.group);
+        const shared = await props.api.contacts.fetchIsAllowed(
           `~${window.ship}`,
           'personal',
-          res.ship,
+          groupHost,
           true
         );
-        setShowBanner(!groupShared);
+        if(!shared) {
+          setToShare(association.group);
+        }
       }
-
-      setHasLoadedAllowed(true);
     })();
-  }, [groupPath, group]);
+  }, [resource]);
 
-  if(!graph) {
+  const onReply = useCallback(
+    (msg: Post) => {
+      const url = getPermalinkForGraph(
+        props.association.group,
+        props.association.resource,
+        msg.index
+      );
+      return `${url}\n~${msg.author} : `;
+    },
+    [association]
+  );
+
+  const isAdmin = useMemo(
+    () => (group ? group.tags.role.admin.has(`~${window.ship}`) : false),
+    [group]
+  );
+
+  const fetchMessages = useCallback(async (newer: boolean) => {
+    const { api } = props;
+    const pageSize = 100;
+
+    const [, , ship, name] = resource.split('/');
+    const graphSize = graph?.size ?? 0;
+    const expectedSize = graphSize + pageSize;
+    if (newer) {
+      const index = graph.peekLargest()?.[0];
+      if(!index) {
+        return true;
+      }
+      await api.graph.getYoungerSiblings(
+        ship,
+        name,
+        pageSize,
+        `/${index.toString()}`
+      );
+      return expectedSize !== getCurrGraphSize(ship.slice(1), name);
+    } else {
+      const index = graph.peekSmallest()?.[0];
+      if(!index) {
+        return true;
+      }
+      await api.graph.getOlderSiblings(ship, name, pageSize, `/${index.toString()}`);
+      const done = expectedSize !== getCurrGraphSize(ship.slice(1), name);
+      return done;
+    }
+  }, [graph, resource]);
+
+  const onSubmit = useCallback((contents: Content[]) => {
+    const { ship, name } = resourceFromPath(resource);
+    api.graph.addPost(ship, name, createPost(window.ship, contents))
+  }, [resource]);
+
+  const dismissUnread = useCallback(() => {
+    api.hark.markCountAsRead(association, '/', 'message');
+  }, [association]);
+
+  const getPermalink = useCallback(
+    (index: BigInteger) =>
+      getPermalinkForGraph(association.group, resource, `/${index.toString()}`),
+    [association]
+  );
+
+  if (!graph) {
     return <Loading />;
   }
 
   return (
-    <Col {...bind} height="100%" overflow="hidden" position="relative">
-      <ShareProfile
-        our={ourContact}
-        api={props.api}
-        recipient={owner}
-        recipients={recipients}
-        showBanner={showBanner}
-        setShowBanner={setShowBanner}
-        group={group}
-        groupPath={groupPath}
-      />
-      {dragging && <SubmitDragger />}
-      <ChatWindow
-        key={station}
-        graph={graph}
-        graphSize={graph.size}
-        unreadCount={unreadCount as number}
-        showOurContact={ !showBanner && hasLoadedAllowed }
-        association={props.association}
-        pendingSize={Object.keys(graphTimesentMap[graphPath] || {}).length}
-        group={group}
-        ship={owner}
-        onReply={onReply}
-        station={station}
-        api={props.api}
-        scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
-      />
-      { canWrite && (
-      <ChatInput
-        ref={chatInput}
-        api={props.api}
-        station={station}
-        ourContact={
-          (!showBanner && hasLoadedAllowed) ? ourContact : null
-        }
-        envelopes={[]}
-        onUnmount={appendUnsent}
-        placeholder="Message..."
-        message={unsent[station] || ''}
-        deleteMessage={clearUnsent}
-      /> )}
-    </Col>
+    <ChatPane
+      id={resource.slice(7)}
+      graph={graph}
+      unreadCount={unreadCount}
+      api={api}
+      canWrite={canWrite}
+      onReply={onReply}
+      fetchMessages={fetchMessages}
+      dismissUnread={dismissUnread}
+      getPermalink={getPermalink}
+      isAdmin={isAdmin}
+      onSubmit={onSubmit}
+      promptShare={toShare}
+    />
   );
 }
 
-ChatResource.whyDidYouRender = true;
-
 export { ChatResource };
-

--- a/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
@@ -1,0 +1,183 @@
+import React, { useRef, useCallback, useEffect, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { Col } from '@tlon/indigo-react';
+import _ from 'lodash';
+import bigInt, { BigInteger } from 'big-integer';
+
+import { Association } from '@urbit/api/metadata';
+import { StoreState } from '~/logic/store/type';
+import { useFileDrag } from '~/logic/lib/useDrag';
+import ChatWindow from './ChatWindow';
+import ChatInput from './ChatInput';
+import GlobalApi from '~/logic/api/global';
+import { ShareProfile } from '~/views/apps/chat/components/ShareProfile';
+import SubmitDragger from '~/views/components/SubmitDragger';
+import { useLocalStorageState } from '~/logic/lib/useLocalStorageState';
+import { Loading } from '~/views/components/Loading';
+import { isWriter, resourceFromPath } from '~/logic/lib/group';
+
+import useContactState, { useOurContact } from '~/logic/state/contact';
+import useGraphState from '~/logic/state/graph';
+import useGroupState from '~/logic/state/group';
+import useHarkState from '~/logic/state/hark';
+import { Post, Graph, Content } from '@urbit/api';
+import { getPermalinkForGraph } from '~/logic/lib/permalinks';
+
+interface ChatPaneProps {
+  /**
+   * A key to uniquely identify a ChatPane instance. Should be either the
+   * resource for group chats or the @p for DMs
+   */
+  id: string;
+  /**
+   * The graph of the chat to render
+   */
+  graph: Graph;
+  unreadCount: number;
+  /**
+   * User able to write to chat
+   */
+  canWrite: boolean;
+  api: GlobalApi;
+  /**
+   * Get contents of reply message
+   */
+  onReply: (msg: Post) => string;
+  /**
+   * Fetch more messages
+   *
+   * @param newer Get newer or older backlog
+   * @returns Whether backlog is finished loading in that direction
+   */
+  fetchMessages: (newer: boolean) => Promise<boolean>;
+  /**
+   * Dismiss unreads for chat
+   */
+  dismissUnread: () => void;
+  /**
+   * Get permalink for a node
+   */
+  getPermalink: (idx: BigInteger) => string;
+  isAdmin: boolean;
+  /**
+   * Post message with contents to channel
+   */
+  onSubmit: (contents: Content[]) => void;
+  /**
+   *
+   * Users or group we haven't shared our contact with yet
+   *
+   * string[] - array of ships
+   * string - path of group
+   */
+  promptShare?: string[] | string;
+}
+
+export function ChatPane(props: ChatPaneProps) {
+  const {
+    api,
+    graph,
+    unreadCount,
+    canWrite,
+    id,
+    getPermalink,
+    isAdmin,
+    dismissUnread,
+    onSubmit,
+    promptShare = [],
+    fetchMessages
+  } = props;
+  const graphTimesentMap = useGraphState((state) => state.graphTimesentMap);
+  const ourContact = useOurContact();
+  const chatInput = useRef<ChatInput>();
+
+  const onFileDrag = useCallback(
+    (files: FileList | File[]) => {
+      if (!chatInput.current) {
+        return;
+      }
+      chatInput.current?.uploadFiles(files);
+    },
+    [chatInput.current]
+  );
+
+  const { bind, dragging } = useFileDrag(onFileDrag);
+
+  const [unsent, setUnsent] = useLocalStorageState<Record<string, string>>(
+    'chat-unsent',
+    {}
+  );
+
+  const appendUnsent = useCallback(
+    (u: string) => setUnsent((s) => ({ ...s, [id]: u })),
+    [id]
+  );
+
+  const clearUnsent = useCallback(() => {
+    setUnsent((s) => {
+      if (id in s) {
+        return _.omit(s, id);
+      }
+      return s;
+    });
+  }, [id]);
+
+  const scrollTo = new URLSearchParams(location.search).get('msg');
+
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    setShowBanner(promptShare.length > 0);
+  }, [promptShare]);
+
+  const onReply = useCallback(
+    (msg: Post) => {
+      const message = props.onReply(msg);
+      setUnsent((s) => ({ ...s, [id]: message }));
+    },
+    [id, props.onReply]
+  );
+
+  if (!graph) {
+    return <Loading />;
+  }
+
+  return (
+    <Col {...bind} height="100%" overflow="hidden" position="relative">
+      <ShareProfile
+        our={ourContact}
+        api={api}
+        recipients={showBanner ? promptShare : []}
+        onShare={() => setShowBanner(false)}
+      />
+      {dragging && <SubmitDragger />}
+      <ChatWindow
+        key={id}
+        graph={graph}
+        graphSize={graph.size}
+        unreadCount={unreadCount}
+        showOurContact={promptShare.length === 0 && showBanner}
+        pendingSize={Object.keys(graphTimesentMap[id] || {}).length}
+        onReply={onReply}
+        dismissUnread={dismissUnread}
+        fetchMessages={fetchMessages}
+        isAdmin={isAdmin}
+        getPermalink={getPermalink}
+        api={api}
+        scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
+      />
+      {canWrite && (
+        <ChatInput
+          ref={chatInput}
+          api={props.api}
+          onSubmit={onSubmit}
+          ourContact={(promptShare.length === 0 && ourContact) || undefined}
+          onUnmount={appendUnsent}
+          placeholder="Message..."
+          message={unsent[id] || ''}
+          deleteMessage={clearUnsent}
+        />
+      )}
+    </Col>
+  );
+}

--- a/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
@@ -156,7 +156,7 @@ export function ChatPane(props: ChatPaneProps) {
         graph={graph}
         graphSize={graph.size}
         unreadCount={unreadCount}
-        showOurContact={promptShare.length === 0 && showBanner}
+        showOurContact={promptShare.length === 0 && !showBanner}
         pendingSize={Object.keys(graphTimesentMap[id] || {}).length}
         onReply={onReply}
         dismissUnread={dismissUnread}

--- a/pkg/interface/src/views/apps/chat/components/ShareProfile.js
+++ b/pkg/interface/src/views/apps/chat/components/ShareProfile.js
@@ -40,21 +40,20 @@ export const ShareProfile = (props) => {
   );
 
   const onClick = async () => {
-    if(group.hidden && recipients.length > 0) {
-      await api.contacts.allowShips(recipients);
-      await Promise.all(recipients.map(r => api.contacts.share(r)))
-      setShowBanner(false);
-    } else if (!group.hidden) {
-      const [,,ship,name] = groupPath.split('/');
+    if(typeof recipients === 'string') {
+      const [,,ship,name] = recipients.split('/');
       await api.contacts.allowGroup(ship,name);
       if(ship !== `~${window.ship}`) {
         await api.contacts.share(ship);
       }
-      setShowBanner(false);
-    }
+    } else if(recipients.length > 0) {
+      await api.contacts.allowShips(recipients);
+      await Promise.all(recipients.map(r => api.contacts.share(r)))
+    } 
+    props.onShare();
   };
 
-  return showBanner ? (
+  return props.recipients?.length > 0 ? (
     <Row
       height="48px"
       alignItems="center"

--- a/pkg/interface/src/views/components/withStorage.tsx
+++ b/pkg/interface/src/views/components/withStorage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import useStorage from '~/logic/lib/useStorage';
+import useStorage, {IuseStorage} from '~/logic/lib/useStorage';
 
-const withStorage = (Component, params = {}) => {
-  return React.forwardRef((props: any, ref) => {
+const withStorage = <P, C extends React.ComponentType<P>>(Component: C, params = {}) => {
+  return React.forwardRef<C, Omit<C, keyof IuseStorage>>((props, ref) => {
     const storage = useStorage(params);
 
     return <Component ref={ref} {...storage} {...props} />;


### PR DESCRIPTION
Paves the way for DMs, by stripping the association prop everywhere and refactoring the Chat functionality into ChatPane, which makes no assumptions about the presence of an association or group by lifting that functionality into prop callbacks. 