### PR TITLE
file-server: Added support for .ico files:

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -222,6 +222,7 @@
             [~ %js]    (js-response:gen file)
             [~ %css]   (css-response:gen file)
             [~ %png]   (png-response:gen file)
+            [~ %ico]   (ico-response:gen file)
           ::
               [~ %html]
             %.  file

--- a/pkg/arvo/lib/server.hoon
+++ b/pkg/arvo/lib/server.hoon
@@ -111,6 +111,11 @@
     ^-  simple-payload:http
     [[200 [['content-type' 'image/png'] max-1-wk ~]] `octs]
   ::
+    ++  ico-response
+    |=  =octs
+    ^-  simple-payload:http
+    [[200 [['content-type' 'image/x-icon'] max-1-wk ~]] `octs]
+  ::
   ++  woff2-response
     |=  =octs
     ^-  simple-payload:http

--- a/pkg/arvo/mar/ico.hoon
+++ b/pkg/arvo/mar/ico.hoon
@@ -1,0 +1,12 @@
+|_  dat=@
+++  grow
+  |%
+  ++  mime  [/image/x-icon (as-octs:mimes:html dat)]
+  --
+++  grab
+  |%
+  ++  mime  |=([p=mite q=octs] q.q)
+  ++  noun  @
+  --
+++  grad  %mime
+--


### PR DESCRIPTION
Adding support for .ico files makes hosting prebuilt websites on urbit easier.

This commit utilizes the following changes to effectuate .ico support:
-/mar/ico/hoon
 * Utilizes similar structure to /mar/png/hoon, w/ changed mimetype
-/lib/server
 * Added ico-response, again similar to png w/ same caching
-/app/file-server
 * Added reference to ico-response:gen

This will also rectify one complexity glossed over in [this docs addition](https://github.com/urbit/docs/pull/1067) and allow for minor simplification of the guide.