### PR TITLE
chat: input behavior quirks

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -74,6 +74,8 @@ class ChatInput extends Component<ChatInputProps, ChatInputState> {
     } else {
       onSubmit(tokenizeMessage(text));
     }
+    this.chatEditor.current.editor.focus();
+    this.setState({ currentInput: '' });
   }
 
   uploadSuccess(url: string) {

--- a/pkg/interface/src/views/apps/chat/components/chat-editor.js
+++ b/pkg/interface/src/views/apps/chat/components/chat-editor.js
@@ -240,17 +240,12 @@ export default class ChatEditor extends Component {
               rows="1"
               style={{ width: '100%', background: 'transparent', color: 'currentColor' }}
               placeholder={inCodeMode ? "Code..." : "Message..."}
-              onChange={event => {
-                this.messageChange(null, null, event.target.value);
-              }}
-              onKeyDown={event => {
-                if (event.key === 'Enter') {
-                  event.preventDefault();
-                  this.submit();
-                } else {
-                  this.messageChange(null, null, event.target.value);
-                }
-              }}
+              onChange={event =>
+                this.messageChange(null, null, event.target.value)
+              }
+              onKeyDown={event =>
+                this.messageChange(null, null, event.target.value)
+              }
               ref={input => {
                 if (!input) return;
                 this.editor = inputProxy(input);


### PR DESCRIPTION
- Clears state on submit such that the button does not stay blue
- Refocuses field on submit such that the mobile keyboard doesn't disappear
- Removes submit on enter; retains enter for linebreak insertion