### PR TITLE
graph-store: update log hotfixes

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -10,16 +10,17 @@
       [%1 network:zero:store]
       [%2 network:zero:store]
       [%3 network:one:store]
-      state-4
+      [%4 network:store]
+      state-5
   ==
 ::
-+$  state-4  [%4 network:store]
++$  state-5  [%5 network:store]
 ++  orm      orm:store
 ++  orm-log  orm-log:store
 +$  debug-input  [%validate-graph =resource:store]
 --
 ::
-=|  state-4
+=|  state-5
 =*  state  -
 ::
 %-  agent:dbug
@@ -91,7 +92,21 @@
       |=(a=* *update-log:store)
     ==
   ::
-    %4  [cards this(state old)]
+      %4
+    %_   $
+        update-logs.old
+      %-  ~(gas by *update-logs:store)
+      %+  turn  ~(tap by graphs.old)
+      |=  [=resource:store =graph:store mar=(unit mark)]
+      :-  resource
+      =/  log  (~(got by update-logs.old) resource)
+      ?.  =(~ log)  log
+      =/  =logged-update:store
+        [now.bowl %add-graph resource graph mar %.y]
+      (gas:orm-log ~ [now.bowl logged-update] ~)
+    ==
+  ::
+    %5  [cards this(state old)]
   ==
 ::
 ++  on-watch

--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -721,9 +721,9 @@
   --
 ++  import
   |=  [arc=* our=ship]
-  ^-  (quip card:agent:gall [%4 network])
+  ^-  (quip card:agent:gall [%5 network])
   |^
-  =/  sty  [%4 (remake-network ;;(tree-network +.arc))]
+  =/  sty  [%5 (remake-network ;;(tree-network +.arc))]
   :_  sty
   %+  turn  ~(tap by graphs.sty)
   |=  [rid=resource =marked-graph]

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -76,6 +76,7 @@
 ++  get-graph
   |=  res=resource
   ^-  update:store
+  =-  -(p *time)
   %+  scry-for  update:store
   /graph/(scot %p entity.res)/[name.res]
 ::


### PR DESCRIPTION
Hotfixes the lack of update log for graphs which causes frequent resetting of unreads and notifications.
The varying timestamp in the %add-graph fact from graph-push-hook was
preventing deduplication of the jammed noun in ames. Prevents
unnecessary bail: memes upon sending many %add-graph facts.