### PR TITLE
meta: rescue flow

### DIFF
--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -74,6 +74,7 @@
 ++  transform-proxy-update
   |=  vas=vase
   ^-  (unit vase)
+  ?:  =(1 1)  `this
   =/  =update:store  !<(update:store vas)
   =*  rid  resource.q.update
   =.  p.update  now.bowl

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -10,16 +10,17 @@
       [%1 network:zero:store]
       [%2 network:zero:store]
       [%3 network:one:store]
-      state-4
+      [%4 network:store]
+      state-5
   ==
 ::
-+$  state-4  [%4 network:store]
++$  state-5  [%5 network:store]
 ++  orm      orm:store
 ++  orm-log  orm-log:store
 +$  debug-input  [%validate-graph =resource:store]
 --
 ::
-=|  state-4
+=|  state-5
 =*  state  -
 ::
 %-  agent:dbug
@@ -91,7 +92,21 @@
       |=(a=* *update-log:store)
     ==
   ::
-    %4  [cards this(state old)]
+      %4
+    %_   $
+        update-logs.old
+      %-  ~(gas by *update-logs:store)
+      %+  turn  ~(tap by graphs.old)
+      |=  [=resource:store =graph:store mar=(unit mark)]
+      :-  resource
+      =/  log  (~(got by update-logs.old) resource)
+      ?.  =(~ log)  log
+      =/  =logged-update:store
+        [now.bowl %add-graph resource graph mar %.y]
+      (gas:orm-log ~ [now.bowl logged-update] ~)
+    ==
+  ::
+    %5  [cards this(state old)]
   ==
 ::
 ++  on-watch

--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -721,9 +721,9 @@
   --
 ++  import
   |=  [arc=* our=ship]
-  ^-  (quip card:agent:gall [%4 network])
+  ^-  (quip card:agent:gall [%5 network])
   |^
-  =/  sty  [%4 (remake-network ;;(tree-network +.arc))]
+  =/  sty  [%5 (remake-network ;;(tree-network +.arc))]
   :_  sty
   %+  turn  ~(tap by graphs.sty)
   |=  [rid=resource =marked-graph]

--- a/pkg/arvo/lib/graph.hoon
+++ b/pkg/arvo/lib/graph.hoon
@@ -76,6 +76,7 @@
 ++  get-graph
   |=  res=resource
   ^-  update:store
+  =-  -(p *time)
   %+  scry-for  update:store
   /graph/(scot %p entity.res)/[name.res]
 ::

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -1047,6 +1047,18 @@ _ames_try_forward(u3_ames* sam_u,
   }
 }
 
+#define SKIP_PARITY 1
+#define SKIP_MASK   0x1
+
+static c3_o _ames_skip(u3_body* bod_u) {
+  if( bod_u->sen_d[1] == 0 &&
+       ((bod_u->sen_d[0] & SKIP_MASK) == SKIP_PARITY) ) {
+    return c3y; 
+  } else {
+    return c3n;
+  }
+}
+
 /* _ames_hear(): parse a (potential) packet, dispatch appropriately.
 */
 static void
@@ -1149,10 +1161,13 @@ _ames_hear(u3_ames* sam_u,
   else {
     u3_noun msg = u3i_bytes(len_w, hun_y);
     c3_free(hun_y);
-    _ames_put_packet(sam_u, msg, *lan_u);
+    if(_ames_skip(&bod_u) == c3y ) {
+      u3z(msg);
+    } else {
+      _ames_put_packet(sam_u, msg, *lan_u);
+    }
   }
 }
-
 /* _ames_recv_cb(): udp message receive callback.
 */
 static void


### PR DESCRIPTION
PRing to document the rescue flow. While the parity is not evenly distributed, it should be enough to get memory under control and doesn't require the host to hex-convert ship names and custom build a binary. A derivative of urbit/urbit#4838 that is designed so that the user doesn't have to control, and also includes fixes to prevent the backlog from getting larger. To fix a ship that's bail: memeing
- Grab the binary for this branch
- Run the bail: memeing ship on this branch and run `|pack` in the dojo
- Commit the arvo changes to the ship
- Allow the ship to clear its queue, you may have to sporadically run `|pack` to avoid additional bail:memes
- Once the result of `|pack` is under 1.6GB, return to the unmodified binary
- `|merge %home ~sponsor %kids, =gem %take-that` to clear the temporary arvo changes