### PR TITLE
hark-graph-hook: remove unnecessary scries where possible for perf

### DIFF
--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -421,7 +421,8 @@
       update-core
     =*  pos  p.post.node
     =+  !<  notif-kind=(unit notif-kind:hook)
-        (get-conversion !>([0 pos]))
+        %-  get-conversion
+        !>(`indexed-post:graph-store`[0 pos])
     ?~  notif-kind
       update-core
     =/  desc=@t

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -124,15 +124,15 @@
   ::
   ++  poke-noun
     |=  non=*
-    ?>  ?=(%rewatch-dms non)
-    =/  graphs=(list resource)
-      ~(tap in get-keys:gra)
-    :-  ~
-    %_   state
-        watching  
-      %-  ~(gas in watching)
-      (murn graphs |=(rid=resource ?:((should-watch:ha rid) `[rid ~] ~)))
-    ==
+    [~ state]
+::    ?>  ?=(%rewatch-dms non)
+::    =/  graphs=(list resource)
+::      ~(tap in get-keys:gra)
+::    %_   state
+::        watching  
+::      %-  ~(gas in watching)
+::      (murn graphs |=(rid=resource ?:((should-watch:ha rid) `[rid ~] ~)))
+::    ==
   ::
   ++  hark-graph-hook-action
     |=  =action:hook
@@ -195,13 +195,15 @@
       ::
         ?(%remove-graph %archive-graph)  
       (remove-graph resource.q.update)
-      ::
+    ::
         %remove-posts
       (remove-posts resource.q.update indices.q.update)
-      ::
+    ::
         %add-nodes
       =*  rid  resource.q.update
-      (check-nodes ~(val by nodes.q.update) rid)
+      =/  assoc=(unit association:metadata)
+        (peek-association:met %graph rid)
+      (check-nodes ~(val by nodes.q.update) rid assoc)
     ==
   ::  this is awful, but notification kind should always switch
   ::  on the index, so hopefully doesn't matter
@@ -255,9 +257,11 @@
       (get-graph-mop:gra rid)
     =/  node=(unit node:graph-store)
       (bind (peek:orm:graph-store graph) |=([@ =node:graph-store] node))
+    =/  assoc=(unit association:metadata)
+      (peek-association:met %graph rid)
     =^  cards  state
-      (check-nodes (drop node) rid)
-    ?.  (should-watch:ha rid)
+      (check-nodes (drop node) rid assoc)
+    ?.  (should-watch:ha rid assoc)
       [cards state]
     :_   state(watching (~(put in watching) [rid ~]))
     (weld cards (give:ha ~[/updates] %listen [rid ~]))
@@ -265,20 +269,18 @@
   ++  check-nodes
     |=  $:  nodes=(list node:graph-store)
             rid=resource
+            assoc=(unit association:metadata)
         ==
-    =/  group=(unit resource)
-      (peek-group:met %graph rid)
-    ?~  group  
-      ~&  no-group+rid
+    ?~  assoc
+      ~&  no-assoc+rid
       `state
-    =/  metadatum=(unit metadatum:metadata)
-      (peek-metadatum:met %graph rid)
-    ?~  metadatum  `state
+    =*  group      group.u.assoc
+    =*  metadatum  metadatum.u.assoc
     =/  module=term
-      ?:  ?=(%empty -.config.u.metadatum)  %$
-      ?:  ?=(%group -.config.u.metadatum)  %$
-      module.config.u.metadatum
-    abet:check:(abed:handle-update:ha rid nodes u.group module)
+      ?:  ?=(%empty -.config.metadatum)  %$
+      ?:  ?=(%group -.config.metadatum)  %$
+      module.config.metadatum
+    abet:check:(abed:handle-update:ha rid nodes group module)
   --
 ::
 ++  on-peek  on-peek:def
@@ -340,12 +342,11 @@
   $(contents t.contents)
 ::
 ++  should-watch
-  |=  rid=resource
+  |=  [rid=resource assoc=(unit association:metadata)]
   ^-  ?
-  =/  group-rid=(unit resource)
-    (peek-group:met %graph rid) 
-  ?~  group-rid  %.n
-  ?|  !(is-managed:grp u.group-rid)
+  ?~  assoc
+    %.n
+  ?|  !(is-managed:grp group.u.assoc)
       &(watch-on-self =(our.bowl entity.rid))
   ==
 ::
@@ -364,7 +365,9 @@
     update-core(rid r, updates upds, group grp, module mod)
   ::
   ++  get-conversion
-    (^get-conversion rid)
+    ::  LA:  this tube should be cached in %hark-graph-hook state
+    ::  instead of just trying to keep it warm, as the scry overhead is large
+    ~+  (^get-conversion rid)
   ::
   ++  abet
     ^-  (quip card _state)


### PR DESCRIPTION
Marginal performance gains that pave the way for larger ones. (Really tiny)

Should do two fewer scries when adding a graph, and one less per %add-nodes update.

Ideally, we'll move to using %watch-as for converting %add-nodes into $notif-kind