### PR TITLE
Ames: time out direct lanes faster

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1967,20 +1967,12 @@
     ++  on-memo
       |=  [=bone payload=* valence=?(%plea %boon)]
       ^+  peer-core
-      ::  if we haven't been trying to talk to %live, reset timer
-      ::
-      =?    last-contact.qos.peer-state
-          ?&  ?=(%live -.qos.peer-state)
-              %-  ~(all by snd.peer-state)
-              |=  =message-pump-state
-              =(~ live.packet-pump-state.message-pump-state)
-          ==
-        now
-      ::
       =/  =message-blob  (dedup-message (jim payload))
       =.  peer-core  (run-message-pump bone %memo message-blob)
       ::
-      ?:  &(=(%boon valence) ?=(?(%dead %unborn) -.qos.peer-state))
+      ?:  ?&  =(%boon valence)
+              (gte now (add ~s30 last-contact.qos.peer-state))
+          ==
         check-clog
       peer-core
     ::  +dedup-message: replace with any existing copy of this message


### PR DESCRIPTION
Time out direct lanes much faster after inactivity.  Removes logic in +on-memo that reset the `last-contact` time to `now` after a period of inactivity; this caused the ship to restart the lane timeout logic from scratch on a new message after a period of inactivity.  The problem with this was that if the lane had been held open by the receiver's firewall as a pinhole that has since closed, the firewall would drop any new packets, and it would take on the order of minutes to resume connectivity between the two ships.

After this change, if the first packet times out on a direct lane that has been inactive for thirty seconds or more, the lane will be marked as indirect, causing retries to hit the peer's sponsor.  This puts marginally more relaying load on sponsors, but should improve reconnection time dramatically.  Relaying is now faster than most other parts of the system, so the extra load shouldn't be too onerous.