### PR TITLE
hooks: refactor, fix nacking, slog ghosts

### DIFF
--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -463,18 +463,18 @@
             ::  subscription
             tr-core
           (tr-suspend-pub-ver min-version.config)
-        =/  =vase
+        =/  =^cage
           (convert-to:ver cage)
         =/  =wire
           (make-wire /store)
-        =+  resources=(~(gas in *(set resource)) (resource-for-update:og vase))
+        =+  resources=(~(gas in *(set resource)) (resource-for-update:og q.cage))
         ?>  ?|  no-validate.config
             ?&  (check-src resources)
                 (~(has in resources) rid)
             ==  ==
         =/  =mark
           (append-version:ver version.config)
-        (tr-emit (~(poke-our pass wire) store-name.config mark vase))
+        (tr-emit (~(poke-our pass wire) store-name.config cage))
       --
     ::
     ++  tr-kick

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -439,6 +439,7 @@
         ?~  tan  tr-core
         ?.  versioned
           (tr-ap-og:tr-cleanup |.((on-pull-nack:og rid u.tan)))
+        %-  (slog leaf+"versioned nack for {<rid>} in {<dap.bowl>}" u.tan)
         =/  pax
           (kick-mule:virt rid |.((on-pull-kick:og rid)))
         ?~  pax  tr-failed-kick

--- a/pkg/arvo/lib/pull-hook.hoon
+++ b/pkg/arvo/lib/pull-hook.hoon
@@ -114,6 +114,15 @@
       state-3
       state-4
   ==
+::  +diplomatic: only renegotiate if versions changed
+::    
+::    If %.n please leave note as to why renegotiation necessary
+::    
+::    - Fixing incorrectly held unversioned subscriptions
+::
+++  diplomatic
+  ^-  ?
+  %.n
 ::
 ++  default
   |*  [pull-hook=* =config]
@@ -239,6 +248,7 @@
         =/  kick=(list card)
           ?:  ?&  =(min-version.config prev-min-version.old)
                   =(version.config prev-version.old)
+                  diplomatic
               ==
             ~
           (poke-self:pass kick+!>(%kick))^~

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -291,10 +291,9 @@
       ?.  (supported:ver mark)
         :_  this
         (fact-init-kick:io version+!>(min-version.config))
-      =/  =vase
-        (convert-to:ver mark (initial-watch:og t.t.t.t.t.t.path resource))
       :_  this
-      [%give %fact ~ mark vase]~
+      =-  [%give %fact ~ -]~
+      (convert-to:ver mark (initial-watch:og t.t.t.t.t.t.path resource))
       ::
       ++  unversioned
         ?>  ?=([%ship @ @ *] t.path)
@@ -303,11 +302,10 @@
            `this
         =/  =resource
           (de-path:resource t.path)
-        =/  =vase
-          %+  convert-to:ver  update-mark.config
+        =/   =vase 
           (initial-watch:og t.t.t.t.path resource)
         :_  this
-        [%give %fact ~ update-mark.config vase]~
+        [%give %fact ~ (convert-to:ver update-mark.config vase)]~
       --
     ::
     ++  on-agent
@@ -461,10 +459,7 @@
       |=  [fact-ver=@ud paths=(set path)]
       =/  =mark
         (append-version:ver fact-ver)
-      =/  =^cage
-        :-  mark
-        (convert-from:ver mark q.cage)
-      (fact:io cage ~(tap in paths))
+      (fact:io (convert-from:ver mark q.cage) ~(tap in paths))
     ::  TODO: deprecate
     ++  unversioned
       ?.  =(min-version.config 0)  ~
@@ -474,18 +469,15 @@
         %-  ~(gas in *(set path))
         (turn (incoming-subscriptions prefix) tail)
       ?:  =(0 ~(wyt in unversioned))  ~
-      =/  =^cage
-        :-  update-mark.config
-        (convert-from:ver update-mark.config q.cage)
-      (fact:io cage ~(tap in unversioned))^~
+      (fact:io (convert-from:ver update-mark.config q.cage) ~(tap in unversioned))^~
     --
   ::
   ++  forward-update
     |=  =cage
     ^-  (list card:agent:gall)
     =-  lis
-    =/  vas
-      (convert-to:ver cage)
+    =/  vas=vase
+      q:(convert-to:ver cage)
     %+  roll  (resource-for-update q.cage)
     |=  [rid=resource [lis=(list card:agent:gall) tf-vas=(unit vase)]]
     ^-  [(list card:agent:gall) (unit vase)]

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -297,14 +297,14 @@
       ::
       ++  unversioned
         ?>  ?=([%ship @ @ *] t.path)
-        ?.  =(min-version.config 0)
-           ~&  >>>  "unversioned req from: {<src.bowl>}, nooping"
-           `this
         =/  =resource
           (de-path:resource t.path)
         =/   =vase 
           (initial-watch:og t.t.t.t.path resource)
         :_  this
+        ?.  =(min-version.config 0)
+           ~&  >>>  "unversioned req from: {<src.bowl>}, nooping"
+           ~
         [%give %fact ~ (convert-to:ver update-mark.config vase)]~
       --
     ::

--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -73,6 +73,16 @@
       state-1
       state-2
   ==
+::  +diplomatic: only renegotiate if versions changed
+::    
+::    If %.n please leave note as to why renegotiation necessary
+::    
+::    - Fixing incorrectly held unversioned subscriptions
+::
+++  diplomatic
+  ^-  ?
+  %.n
+::
 ++  push-hook
   |*  =config
   $_  ^|
@@ -221,6 +231,7 @@
         |=  [prev-min-version=@ud prev-version=@ud]
         ?:  ?&  =(min-version.config prev-min-version)
                 =(prev-version version.config)
+                diplomatic
             ==
           ::  bail on kick if we didn't change versions
           ~

--- a/pkg/arvo/lib/versioning.hoon
+++ b/pkg/arvo/lib/versioning.hoon
@@ -29,11 +29,12 @@
   &((gte ver min) (lte ver version))
 ::
 ++  convert-to
-  |=  =cage
-  ^-  vase
-  ?:  =(p.cage current-version)
-    q.cage
-  ((tube-to p.cage) q.cage)
+  |=  [=mark =vase]
+  ^-  cage
+  :-  current-version
+  ?:  =(mark current-version)
+    vase
+  ((tube-to mark) vase)
 ::
 ++  tube-to
   |=  =mark
@@ -44,10 +45,11 @@
   .^(tube:clay %cc (scry:io %home /[current-version]/[mark]))
 ::
 ++  convert-from
-  |=  =cage
-  ^-  vase
-  ?:  =(p.cage current-version)
-    q.cage
-  ((tube-from p.cage) q.cage)
+  |=  [=mark =vase]
+  ^-  cage
+  :-  mark
+  ?:  =(mark current-version)
+    vase
+  ((tube-from mark) vase)
 --
 


### PR DESCRIPTION
hooks: add diplomacy flag

pull-hook: slog tank on versioned nack

Should hopefully provide more debugging info for ghost subscriptions

push-hook: hold subscription open after validating access

When we receive a watch-nack on a versioned subscription, we attempt to
resubscribe on an unversioned path. However, if we receive an unversioned
subscription request for which we are not compatible, we hold the
subscription open and never send any facts on unversioned subscriptions.
As the check for unversioned compatiblility occurs before retrieving the
initial-watch, subscriptions which are supposed to nack never do. Fixed
by moving the conditional.

Fixes urbit/landscape#795

versioning: convert gates return a cage
