### PR TITLE
gen: warn and prompt for confirmation in |code %reset

### DIFF
--- a/pkg/arvo/gen/hood/code.hoon
+++ b/pkg/arvo/gen/hood/code.hoon
@@ -32,8 +32,8 @@
   [%& %project "y/n: "]
 %+  parse
   ;~  pose
-    (cold %.y ;~(pose (just 'y') (just 'Y')))
-    (cold %.n ;~(pose (just 'n') (just 'N')))
+    (cold %.y (mask "yY"))
+    (cold %.n (mask "nN"))
   ==
 |=  reset=?
 ?.  reset

--- a/pkg/arvo/gen/hood/code.hoon
+++ b/pkg/arvo/gen/hood/code.hoon
@@ -3,15 +3,14 @@
 ::::  /hoon/code/hood/gen
   ::
 /?    310
-::
-::::
-  ::
-:-  %say
+/-  *sole
+/+  *generators
+:-  %ask
 |=  $:  [now=@da eny=@uvJ bec=beak]
         [arg=?(~ [%reset ~]) ~]
     ==
 =*  our  p.bec
-:-  %helm-code
+^-  (sole-result [%helm-code ?(~ %reset)])
 ?~  arg
   =/  code=tape
     %+  slag  1
@@ -20,11 +19,23 @@
   =/  step=tape
     %+  scow  %ud
     .^(@ud %j /(scot %p our)/step/(scot %da now)/(scot %p our))
-  %-  %-  slog
-  :~  [%leaf code]
-      [%leaf (weld "current step=" step)]
-      [%leaf "use |code %reset to invalidate this and generate a new code"]
-  ==
-  ~
+  ::
+  %+  print  'use |code %reset to invalidate this and generate a new code'
+  %+  print  leaf+(weld "current step=" step)
+  %+  print  leaf+code
+  (produce [%helm-code ~])
+::
 ?>  =(%reset -.arg)
-%reset
+%+  print  'continue?'
+%+  print  'warning: resetting your code closes all web sessions'
+%+  prompt
+  [%& %project "y/n: "]
+%+  parse
+  ;~  pose
+    (cold %.y ;~(pose (just 'y') (just 'Y')))
+    (cold %.n ;~(pose (just 'n') (just 'N')))
+  ==
+|=  reset=?
+?.  reset
+  no-product
+(produce [%helm-code %reset])


### PR DESCRIPTION
Because `|code %reset` logs out all active web sessions (and does not produce or print the new code), it causes problems if run through web terminal, without access to the actual terminal. This feature should be redesigned for compatibility without hosting.

In the meantime, this PR adds a warning and requires for confirmation before reset. Wording improvements welcome.

/cc @brendanhay 