### PR TITLE
ResourceSkeleton: always flex-shrink

### DIFF
--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -101,7 +101,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
       maxWidth={association?.metadata?.description ? ['100%', '50%'] : 'none'}
       mr='2'
       ml='1'
-      flexShrink={[1, 0]}
+      flexShrink={1}
     >
       {title}
     </Text>


### PR DESCRIPTION
Fixes urbit/landscape#842

She said, "it's literally always better to flex truncate a title than to push UI out of the container. lol. lmao"

<img width="595" alt="Screen Shot 2021-05-06 at 1 13 03 PM" src="https://user-images.githubusercontent.com/20846414/117338852-0eeccb80-ae6d-11eb-835d-8bbe608a92dc.png">
