### PR TITLE
permalinks: style deleted chat reference

### DIFF
--- a/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
+++ b/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
@@ -270,7 +270,10 @@ export function TranscludedNode(props: {
   const { node, showOurContact, assoc, transcluded } = props;
   const group = useGroupForAssoc(assoc)!;
 
-  if (typeof node?.post === 'string') {
+  if (
+    typeof node?.post === "string" &&
+    assoc.metadata.config.graph === "chat"
+  ) {
     return (
       <Box
         mx="12px"
@@ -281,7 +284,7 @@ export function TranscludedNode(props: {
       >
         <Text gray>This message has been deleted.</Text>
       </Box>
-    )
+    );
   }
 
   switch (assoc.metadata.config.graph) {

--- a/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
+++ b/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
@@ -269,6 +269,21 @@ export function TranscludedNode(props: {
 }) {
   const { node, showOurContact, assoc, transcluded } = props;
   const group = useGroupForAssoc(assoc)!;
+
+  if (typeof node?.post === 'string') {
+    return (
+      <Box
+        mx="12px"
+        mt="12px"
+        p="2"
+        backgroundColor="washedGray"
+        borderRadius="2"
+      >
+        <Text gray>This message has been deleted.</Text>
+      </Box>
+    )
+  }
+
   switch (assoc.metadata.config.graph) {
     case 'chat':
       return (


### PR DESCRIPTION
Adds styling to deleted chat references.

Deleted chat reference from the same resource:
![image](https://user-images.githubusercontent.com/748181/117486193-56d82500-af37-11eb-874c-c362bee5e975.png)

Deleted chat reference from another resource:
![image](https://user-images.githubusercontent.com/748181/117486324-7f601f00-af37-11eb-9278-6e38a6789079.png)
