### PR TITLE
GraphContent: prevent grid blowout

### DIFF
--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -376,7 +376,14 @@ const renderers = {
     );
   },
   root: ({ tall, children }) =>
-    tall ? <Col display='grid' style={{ 'row-gap': '1rem' }}>{children}</Col> : <Box>{children}</Box>,
+    tall
+      ? <Box
+          display='grid'
+          style={{ 'gridTemplateColumns': 'minmax(0,1fr)', 'rowGap': '1rem' }}
+         >
+           {children}
+        </Box>
+      : <Box>{children}</Box>,
   text: ({ value }) => value,
 };
 


### PR DESCRIPTION
Before and after:

<img width="1440" alt="Screen Shot 2021-05-08 at 12 39 08 PM" src="https://user-images.githubusercontent.com/20846414/117546862-9fa4e200-affa-11eb-8cc6-1ba35e5f425f.png">
