### PR TITLE
groups: World Privacy icon fix

### DIFF
--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -78,7 +78,11 @@ export function GroupLink(
             {preview ?
               <>
                 <Box pr='2' display='flex' alignItems='center'>
-                  <Icon icon='Public' color='gray' mr='1' />
+                  <Icon 
+                    icon={preview.metadata.hidden ? 'Locked' : 'Public'}
+                    color='gray'
+                    mr='1'
+                   />
                   <Text fontSize='0' color='gray'>
                     {preview.metadata.hidden ? 'Private' : 'Public'}
                   </Text>


### PR DESCRIPTION
Although the bug was poetic, this makes the icon in GroupLink aware of the group's hidden status and surfaces a lock icon in those cases instead of the "public" globe icon.