### PR TITLE
permalinks: minor fixes

### DIFF
--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -127,10 +127,7 @@ function GraphPermalink(
           showOurContact={showOurContact}
         />
       )}
-      {isInSameResource && (
-        <Row height='12px' />
-      )}
-      {association && !isInSameResource ? (
+      {association && !isInSameResource && (
         <PermalinkDetails
           known
           showTransclusion={showTransclusion}
@@ -138,7 +135,17 @@ function GraphPermalink(
           title={association.metadata.title}
           permalink={permalink}
         />
-      ) : null}
+      )}
+      {association && isInSameResource && transcluded === 2 && (
+        <PermalinkDetails
+          known
+          showTransclusion={showTransclusion}
+          icon={getModuleIcon(association.metadata.config.graph)}
+          title={association.metadata.title}
+          permalink={permalink}
+        />
+      )}
+      {isInSameResource && transcluded !== 2 && <Row height="12px" />}
       {!association && (
         <PermalinkDetails
           icon="Groups"

--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -90,7 +90,8 @@ export function GroupLink(
                 <Box display='flex' alignItems='center'>
                   <Icon icon='Users' color='gray' mr='1' />
                   <Text fontSize='0'color='gray' >
-                    {preview.members} peers
+                    {preview.members} 
+                    {preview.members > 1 ? 'peers' : 'peer'}
                   </Text>
                 </Box>
               </>


### PR DESCRIPTION
- Uses "peer" for a single-member GroupLink; "peers" for >1... peer.
- Avoids the problem of an empty nested embed within the same resource (I quote you, you quote me quoting you, observe blank 12px-high box). Surfaces the permalink resource in this case.