### PR TITLE
permalinks: add group peer space

### DIFF
--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -90,7 +90,8 @@ export function GroupLink(
                 <Box display='flex' alignItems='center'>
                   <Icon icon='Users' color='gray' mr='1' />
                   <Text fontSize='0'color='gray' >
-                    {preview.members} 
+                    {preview.members}
+                    {' '}
                     {preview.members > 1 ? 'peers' : 'peer'}
                   </Text>
                 </Box>


### PR DESCRIPTION
Adds a space, which I forgot in a previous PR.

![image](https://user-images.githubusercontent.com/748181/117660397-2082eb80-b16b-11eb-8fd6-1e312ee35ca3.png)
