### PR TITLE
links: remove stray semicolon

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkWindow.tsx
+++ b/pkg/interface/src/views/apps/links/LinkWindow.tsx
@@ -82,7 +82,7 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
     }
     return (
       <Box ref={ref}>
-        <LinkItem key={index.toString()} {...linkProps} />;
+        <LinkItem key={index.toString()} {...linkProps} />
       </Box>
     );
   });


### PR DESCRIPTION
Removes this:

![image](https://user-images.githubusercontent.com/748181/117733406-80a37d00-b1bf-11eb-80f6-ff47c4099814.png)
