### PR TITLE
interface: added component class names

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatEditor.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatEditor.tsx
@@ -238,7 +238,7 @@ export default class ChatEditor extends Component<ChatEditorProps, ChatEditorSta
         paddingBottom={MOBILE_BROWSER_REGEX.test(navigator.userAgent) ? '16px' : '0'}
         maxHeight='224px'
         width='calc(100% - 88px)'
-        className={inCodeMode ? 'chat code' : 'chat'}
+        className={inCodeMode ? 'chat code chat-editor' : 'chat chat-editor'}
         color="black"
         overflow='auto'
       >

--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -162,7 +162,7 @@ export class ChatInput extends Component<ChatInputProps, ChatInputState> {
         borderTop={1}
         borderTopColor='lightGray'
         backgroundColor='white'
-        className='cf'
+        className='cf chat-input'
         zIndex={0}
       >
         <Row p='12px 4px 12px 12px' flexShrink={0} alignItems='center'>

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -39,6 +39,7 @@ export const DayBreak = ({ when, shimTop = false }: DayBreakProps) => (
     justifyContent='center'
     alignItems='center'
     mt={shimTop ? '-8px' : '0'}
+    className='day-break'
   >
     <Rule borderColor='lightGray' />
     <Text
@@ -76,6 +77,7 @@ export const UnreadMarker = React.forwardRef(
         justifyContent='center'
         alignItems='center'
         width='100%'
+        className='unread-marker'
       >
         <Rule borderColor='lightBlue' />
         <VisibilitySensor onChange={setVisible}>
@@ -106,6 +108,7 @@ const MessageActionItem = (props) => {
       px={3}
       py={2}
       onClick={props.onClick}
+      className='message-action-item'
     >
       <Text fontWeight='500' color={props.color}>
         {props.children}
@@ -127,6 +130,7 @@ const MessageActions = ({ onReply, onDelete, msg, isAdmin, permalink }) => {
       position='absolute'
       top='-12px'
       right={2}
+      className='message-actions'
     >
       <Row>
         <Box
@@ -194,6 +198,7 @@ const MessageWrapper = (props) => {
         : showHover ? 'washedGray' : 'transparent'
       }
       position='relative'
+    className='message-wrapper'
       {...bind}
     >
       {props.children}
@@ -278,7 +283,7 @@ function ChatMessage(props: ChatMessageProps) {
     new Date(nextDate).getDate()
   , [nextDate, date]);
 
-  const containerClass = `${isPending ? 'o-40' : ''} ${className}`;
+  const containerClass = `${isPending ? 'o-40' : ''} ${className} chat-message`;
 
   const timestamp = useMemo(() => moment
     .unix(date / 1000)
@@ -418,7 +423,7 @@ export const MessageAuthor = ({
       </Box>
     );
   return (
-    <Box pb="1" display='flex' alignItems='center'>
+    <Box pb="1" display='flex' alignItems='center' className='message-author'>
       <Box
        height={24}
         pr={2}
@@ -483,7 +488,7 @@ export const Message = React.memo(({
 }: MessageProps) => {
   const { hovering, bind } = useHovering();
   return (
-    <Box pl="44px" pr={4} width="100%" position='relative'>
+    <Box pl="44px" pr={4} width="100%" position='relative' className='message'>
       {timestampHover ? (
         <Text
           display={hovering ? 'block' : 'none'}
@@ -530,7 +535,7 @@ export const MessagePlaceholder = ({
     pr={3}
     display='flex'
     lineHeight='tall'
-    className={className}
+    className={`${className} message-placeholder`}
     style={{ height, ...style }}
     {...props}
   >

--- a/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatPane.tsx
@@ -136,7 +136,7 @@ export function ChatPane(props: ChatPaneProps): ReactElement {
   }
 
   return (
-    <Col {...bind} height="100%" overflow="hidden" position="relative">
+    <Col {...bind} height="100%" overflow="hidden" position="relative" className='chat-pane'>
       <ShareProfile
         our={ourContact}
         api={api}

--- a/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatWindow.tsx
@@ -259,7 +259,7 @@ class ChatWindow extends Component<
     const unreadMsg = graph.get(this.state.unreadIndex);
 
     return (
-      <Col height='100%' overflow='hidden' position='relative'>
+      <Col height='100%' overflow='hidden' position='relative' className='chat-window'>
         { this.dismissedInitialUnread() &&
          (<UnreadNotice
           unreadCount={unreadCount}

--- a/pkg/interface/src/views/apps/chat/components/ShareProfile.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ShareProfile.tsx
@@ -65,6 +65,7 @@ const ShareProfile = (props: ShareProfileProps): ReactElement | null => {
       borderBottom={1}
       borderColor="lightGray"
       flexShrink={0}
+      className='share-profile'
     >
       <Row pl={3} alignItems="center">
         {image}

--- a/pkg/interface/src/views/apps/launch/App.tsx
+++ b/pkg/interface/src/views/apps/launch/App.tsx
@@ -6,13 +6,13 @@ import { Helmet } from 'react-helmet';
 import styled from 'styled-components';
 import GlobalApi from '~/logic/api/global';
 import {
-    hasTutorialGroup,
+  hasTutorialGroup,
 
-    TUTORIAL_BOOK,
-    TUTORIAL_CHAT, TUTORIAL_GROUP,
-    TUTORIAL_HOST,
+  TUTORIAL_BOOK,
+  TUTORIAL_CHAT, TUTORIAL_GROUP,
+  TUTORIAL_HOST,
 
-    TUTORIAL_LINKS
+  TUTORIAL_LINKS
 } from '~/logic/lib/tutorialModal';
 import { useModal } from '~/logic/lib/useModal';
 import { useQuery } from '~/logic/lib/useQuery';
@@ -76,6 +76,7 @@ export const LaunchApp = (props: LaunchAppProps): ReactElement | null => {
       overflow='hidden'
       fontSize={0}
       cursor="pointer"
+      className='hash-box'
       onClick={() => {
         writeText(baseHash);
         setHashText('copied');
@@ -190,6 +191,7 @@ export const LaunchApp = (props: LaunchAppProps): ReactElement | null => {
           gridGap={3}
           p={2}
           pt={0}
+          className='launch-app'
         >
         {!hideUtilities && <>
           <Tile
@@ -197,6 +199,7 @@ export const LaunchApp = (props: LaunchAppProps): ReactElement | null => {
             color="scales.black20"
             to="/~landscape/home"
             p={0}
+            className='home-tile'
           >
             <Box
               p={2}

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -96,7 +96,14 @@ function Group(props: GroupProps) {
         .diff(moment()))
     .as('days'))) || 0;
   return (
-    <Tile ref={anchorRef} position="relative" bg={isTutorialGroup ? 'lightBlue' : undefined} to={`/~landscape${path}`} gridColumnStart={first ? '1' : null}>
+    <Tile
+      ref={anchorRef}
+      position="relative"
+      bg={isTutorialGroup ? 'lightBlue' : undefined}
+      to={`/~landscape${path}`}
+      gridColumnStart={first ? '1' : null}
+      className='group-tile'
+    >
       <Col height="100%" justifyContent="space-between">
         <Text>{title}</Text>
         {!hideUnreads && (<Col>

--- a/pkg/interface/src/views/apps/launch/components/tiles/basic.tsx
+++ b/pkg/interface/src/views/apps/launch/components/tiles/basic.tsx
@@ -12,7 +12,7 @@ const BasicTile = (props: BasicTileProps): ReactElement => (
     bg={props.title === 'Terminal' ? '#000000' : 'white'}
     to={props.linkedUrl}
   >
-    <Text color={props.title === 'Terminal' ? '#ffffff' : 'black'}>
+    <Text color={props.title === 'Terminal' ? '#ffffff' : 'black'} className='basic-tile'>
       {props.title === 'Terminal'
         ? <Icon
           icon='ChevronEast'

--- a/pkg/interface/src/views/apps/launch/components/tiles/clock.tsx
+++ b/pkg/interface/src/views/apps/launch/components/tiles/clock.tsx
@@ -289,6 +289,7 @@ class Clock extends React.PureComponent<ClockProps, ClockState> {
           viewBox={`0 0 ${VIEWBOX_SIZE} ${VIEWBOX_SIZE}`}
           xmlns="http://www.w3.org/2000/svg"
           xmlnsXlink="http://www.w3.org/1999/xlink"
+          className='clock'
         >
           <defs>
             <symbol id="border">
@@ -347,7 +348,7 @@ class Clock extends React.PureComponent<ClockProps, ClockState> {
 }
 
 const ClockTile = ({ location = {} }) => (
-  <Tile p={0} border={0} bg='transparent' boxShadow='none'>
+  <Tile p={0} border={0} bg='transparent' boxShadow='none' className='clock-tile'>
     <Clock data={location} />
   </Tile>
 );

--- a/pkg/interface/src/views/apps/launch/components/tiles/custom.tsx
+++ b/pkg/interface/src/views/apps/launch/components/tiles/custom.tsx
@@ -5,7 +5,7 @@ import Tile from './tile';
 export default class CustomTile extends React.PureComponent {
   render() {
     return (
-      <Tile>
+      <Tile className='custom-tile'>
         <Box
           width='100%'
           height='100%'

--- a/pkg/interface/src/views/apps/launch/components/tiles/tile.tsx
+++ b/pkg/interface/src/views/apps/launch/components/tiles/tile.tsx
@@ -29,10 +29,11 @@ type TileProps = BoxProps & {
   children: any;
   gridColumnStart?: number;
   color?: string;
+  className?: string;
 }
 
 const Tile = React.forwardRef((props: TileProps, ref: RefObject<HTMLDivElement>) => {
-  const { bg, to, href, p, boxShadow, gridColumnStart, ...rest } = props;
+  const { bg, to, href, p, boxShadow, gridColumnStart, className = '', ...rest } = props;
 
   let childElement = (
     <Box p={typeof p === 'undefined' ? 2 : p} width="100%" height="100%">
@@ -58,6 +59,7 @@ const Tile = React.forwardRef((props: TileProps, ref: RefObject<HTMLDivElement>)
       color={props?.color || 'lightGray'}
       boxShadow={boxShadow || '0 0 0px 1px inset'}
       style={{ gridColumnStart }}
+      className={`${className} tile`}
     >
       <Box
         {...rest}

--- a/pkg/interface/src/views/apps/launch/components/tiles/weather.tsx
+++ b/pkg/interface/src/views/apps/launch/components/tiles/weather.tsx
@@ -87,7 +87,7 @@ class WeatherTile extends React.Component<WeatherTileProps, WeatherTileState> {
   renderWrapper(child, backgroundColor = 'white') {
     return (
       <ErrorBoundary>
-        <Tile bg='white' backgroundColor={backgroundColor}>
+        <Tile bg='white' backgroundColor={backgroundColor} className='weather-tile'>
           {child}
         </Tile>
       </ErrorBoundary>

--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -55,7 +55,13 @@ export function LinkResource(props: LinkResourceProps) {
   }
 
   return (
-    <Col alignItems="center" height="100%" width="100%" overflowY="hidden">
+    <Col
+      alignItems="center"
+      height="100%"
+      width="100%"
+      overflowY="hidden"
+      className='link-resource'
+    >
       <Switch>
         <Route
           exact

--- a/pkg/interface/src/views/apps/links/LinkWindow.tsx
+++ b/pkg/interface/src/views/apps/links/LinkWindow.tsx
@@ -106,6 +106,7 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
           width="100%"
           flexShrink={0}
           px={3}
+          class='link-window empty'
         >
           {this.canWrite() ? (
             <LinkSubmit
@@ -124,7 +125,7 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
     }
 
     return (
-      <Col width="100%" height="100%" position="relative">
+      <Col width="100%" height="100%" position="relative" class='link-window'>
         <VirtualScroller
           origin="top"
           offset={0}

--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -110,6 +110,7 @@ export const LinkItem = React.forwardRef((props: LinkItemProps, ref: RefObject<H
       ref={ref}
       width="100%"
       opacity={node.post.pending ? '0.5' : '1'}
+      className='link-item'
       {...rest}
     >
       <Box

--- a/pkg/interface/src/views/apps/links/components/LinkSubmit.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkSubmit.tsx
@@ -165,6 +165,7 @@ const LinkSubmit = (props: LinkSubmitProps) => {
         width='100%'
         borderRadius={2}
         {...bind}
+        className='link-submit'
       >
         {uploading && <Box
           display="flex"

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -92,7 +92,7 @@ const GraphUrl = ({ contents, api }) => {
 
 function ContentSummary({ icon, name, author, to }) {
   return (
-    <Link to={to}>
+    <Link to={to} className='content-summary'>
       <Col
         gapY={1}
         flexDirection={['column', 'row']}
@@ -224,7 +224,7 @@ const GraphNodes = (props: {
       {_.map(postsByConsecAuthor, ({ posts, author }, idx) => {
         const time = posts[0]?.['time-sent'];
         return (
-          <Col key={idx} flexGrow={1} alignItems="flex-start">
+          <Col key={idx} flexGrow={1} alignItems="flex-start" className='graph-node'>
             {!hideAuthors && (
               <Author
                 size={24}

--- a/pkg/interface/src/views/apps/notifications/group.tsx
+++ b/pkg/interface/src/views/apps/notifications/group.tsx
@@ -54,7 +54,7 @@ export function GroupNotification(props: GroupNotificationProps): ReactElement {
   const groupTitle = association?.metadata?.title ?? group;
 
   return (
-    <Col>
+    <Col className='group-notification'>
       <Header
         time={time}
         authors={authors}

--- a/pkg/interface/src/views/apps/notifications/header.tsx
+++ b/pkg/interface/src/views/apps/notifications/header.tsx
@@ -39,6 +39,7 @@ export function Header(
       alignItems={['flex-start', 'center']}
       gridArea="header"
       overflow="hidden"
+      className='notification-header'
     >
       <Row gapX={1} overflow="hidden" alignItems="center">
         {authors.length > 0 && (

--- a/pkg/interface/src/views/apps/notifications/inbox.tsx
+++ b/pkg/interface/src/views/apps/notifications/inbox.tsx
@@ -1,10 +1,10 @@
-import { Box, Center, Col, LoadingSpinner, Text, Icon } from '@tlon/indigo-react';
+import { Box, Center, Col, Icon, LoadingSpinner, Text } from '@tlon/indigo-react';
 import {
-    IndexedNotification,
+  IndexedNotification,
 
-    JoinRequests, Notifications,
+  JoinRequests, Notifications,
 
-    Timebox
+  Timebox
 } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import _ from 'lodash';
@@ -14,9 +14,9 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import GlobalApi from '~/logic/api/global';
 import { getNotificationKey } from '~/logic/lib/hark';
 import { useLazyScroll } from '~/logic/lib/useLazyScroll';
-import useLaunchState from '~/logic/state/launch';
 import { daToUnix, MOMENT_CALENDAR_DATE } from '~/logic/lib/util';
 import useHarkState from '~/logic/state/hark';
+import useLaunchState from '~/logic/state/launch';
 import { Invites } from './invites';
 import { Notification } from './notification';
 
@@ -116,7 +116,15 @@ export default function Inbox(props: {
   );
 
   return (
-    <Col p={1} ref={scrollRef} position="relative" height="100%" overflowY="auto" overflowX="hidden">
+    <Col
+      p={1}
+      ref={scrollRef}
+      position="relative"
+      height="100%"
+      overflowY="auto"
+      overflowX="hidden"
+      className='inbox'
+    >
       {runtimeLag && (
         <Box bg="yellow" borderRadius={2} p={2} m={2}>
           <Icon verticalAlign="middle" mr={2} icon="Tutorial" />

--- a/pkg/interface/src/views/apps/notifications/joining.tsx
+++ b/pkg/interface/src/views/apps/notifications/joining.tsx
@@ -1,8 +1,8 @@
 import { Box, Row, SegmentedProgressBar, Text } from '@tlon/indigo-react';
 import {
-    joinError, joinProgress,
+  joinError, joinProgress,
 
-    JoinRequest
+  JoinRequest
 } from '@urbit/api';
 import React, { useCallback } from 'react';
 import GlobalApi from '~/logic/api/global';
@@ -36,6 +36,7 @@ export function JoiningStatus(props: JoiningStatusProps) {
       alignItems="center"
       px={4}
       gapX={4}
+      className='joining-status'
     >
       <Box flexGrow={1} maxWidth="400px">
         <SegmentedProgressBar current={current + 1} segments={3} />

--- a/pkg/interface/src/views/apps/notifications/metadata.tsx
+++ b/pkg/interface/src/views/apps/notifications/metadata.tsx
@@ -25,7 +25,7 @@ export function MetadataNotification(props: any) {
   const description = getDescription(unread.unreads[0].body);
 
   return (
-    <Box p={2}>
+    <Box p={2} className='metadata-notification'>
       <Header
         authors={[]}
         description={description}

--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -101,6 +101,7 @@ export function NotificationWrapper(props: {
       m={2}
       menuWidth={100}
       disabled={!isMobile}
+      className='notification-wrapper'
       menu={
         <Button onClick={onArchive} ml={2} height="100%" width="92px" primary destructive>
           Remove

--- a/pkg/interface/src/views/apps/notifications/notifications.tsx
+++ b/pkg/interface/src/views/apps/notifications/notifications.tsx
@@ -65,7 +65,7 @@ export default function NotificationsScreen(props: any): ReactElement {
                 <title>{ notificationsCount ? `(${String(notificationsCount) }) `: '' }Landscape - Notifications</title>
               </Helmet>
               <Body>
-                <Col overflowY="hidden" height="100%">
+                <Col overflowY="hidden" height="100%" className='notification-screen'>
                   <Row
                     p={3}
                     alignItems="center"

--- a/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
+++ b/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
@@ -30,6 +30,7 @@ function TranscludedLinkNode(props: {
         p="2"
         backgroundColor="washedGray"
         borderRadius="2"
+        className='deleted-link'
       >
         <Text gray>This link has been deleted.</Text>
       </Box>
@@ -45,7 +46,7 @@ function TranscludedLinkNode(props: {
       }
 
       return (
-        <Box>
+        <Box className='transcluded-link'>
           <Author
             pt='12px'
             pl='12px'
@@ -107,6 +108,7 @@ function TranscludedComment(props: {
         p="2"
         backgroundColor="washedGray"
         borderRadius="2"
+        className='deleted-comment'
       >
         <Text gray>This comment has been deleted.</Text>
       </Box>
@@ -117,7 +119,7 @@ function TranscludedComment(props: {
 
   const comment = node.children?.peekLargest()![1]!;
   return (
-    <Col>
+    <Col className='transcluded-comment'>
       <Author
         pt='12px'
         pl='12px'
@@ -158,6 +160,7 @@ function TranscludedPublishNode(props: {
         p="2"
         backgroundColor="washedGray"
         borderRadius="2"
+        className='deleted-note'
       >
         <Text gray>This note has been deleted.</Text>
       </Box>
@@ -171,7 +174,7 @@ function TranscludedPublishNode(props: {
         ?.get(bigInt.one)
         ?.children?.peekLargest()?.[1]!;
       return (
-        <Col color="black" gapY={2}>
+        <Col color="black" gapY={2} className='transcluded-note'>
           <Author
             pl='12px'
             pt='12px'
@@ -224,6 +227,7 @@ export function TranscludedPost(props: {
         p="2"
         backgroundColor="washedGray"
         borderRadius="2"
+        className='deleted-post'
       >
         <Text gray>This post has been deleted.</Text>
       </Box>
@@ -231,7 +235,7 @@ export function TranscludedPost(props: {
   }
 
   return (
-    <Col>
+    <Col className='transcluded-post'>
       <Author
         pt='12px'
         pl='12px'
@@ -282,6 +286,7 @@ export function TranscludedNode(props: {
         p="2"
         backgroundColor="washedGray"
         borderRadius="2"
+        className='deleted-message'
       >
         <Text gray>This message has been deleted.</Text>
       </Box>
@@ -291,7 +296,13 @@ export function TranscludedNode(props: {
   switch ((assoc.metadata.config as GraphConfig).graph) {
     case 'chat':
       return (
-        <Row width="100%" flexShrink={0} flexGrow={1} flexWrap="wrap">
+        <Row
+          width="100%"
+          flexShrink={0}
+          flexGrow={1}
+          flexWrap="wrap"
+          className='transcluded-node'
+        >
           <ChatMessage
             renderSigil
             transcluded={transcluded + 1}

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -112,6 +112,7 @@ function GraphPermalink(
       borderColor="lightGray"
       borderRadius={2}
       cursor="pointer"
+      className='graph-permalink'
       onClick={(e) => {
         navigate(e);
       }}
@@ -175,6 +176,7 @@ function PermalinkDetails(props: {
       alignItems="center"
       justifyContent="space-between"
       width="100%"
+      className='permalink-details'
     >
       <Row gapX="2" alignItems="center">
         <Box width={4} height={4}>

--- a/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
@@ -1,8 +1,8 @@
 import {
-    Button, Col, ManagedCheckboxField as Checkbox, ManagedForm as Form,
-    ManagedTextInputField as Input,
+  Button, Col, ManagedCheckboxField as Checkbox, ManagedForm as Form,
+  ManagedTextInputField as Input,
 
-    Row, Text
+  Row, Text
 } from '@tlon/indigo-react';
 import { Formik } from 'formik';
 import _ from 'lodash';
@@ -18,9 +18,9 @@ import { ColorInput } from '~/views/components/ColorInput';
 import GroupSearch from '~/views/components/GroupSearch';
 import { ImageInput } from '~/views/components/ImageInput';
 import {
-    ProfileControls, ProfileHeader,
+  ProfileControls, ProfileHeader,
 
-    ProfileImages, ProfileStatus
+  ProfileImages, ProfileStatus
 } from './Profile';
 
 const formSchema = Yup.object({
@@ -138,7 +138,7 @@ export function EditProfile(props: any): ReactElement {
         onSubmit={onSubmit}
       >
         {({ setFieldValue }) => (
-          <Form width='100%' height='100%'>
+          <Form width='100%' height='100%' className='edit-profile'>
             <ProfileHeader>
               <ProfileControls>
                 <Row alignItems='baseline'>

--- a/pkg/interface/src/views/apps/profile/components/Profile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/Profile.tsx
@@ -190,7 +190,7 @@ export function Profile(props: any): ReactElement | null {
   }
 
   return (
-    <Center p={[3, 4]} height='100%' width='100%'>
+    <Center p={[3, 4]} height='100%' width='100%' className='profile'>
       <Box maxWidth='600px' width='100%' position='relative'>
         { isEdit ? (
           <EditProfile

--- a/pkg/interface/src/views/apps/profile/components/SetStatus.tsx
+++ b/pkg/interface/src/views/apps/profile/components/SetStatus.tsx
@@ -34,7 +34,7 @@ export function SetStatus(props: any) {
   };
 
   return (
-    <Row width='100%' my={3}>
+    <Row width='100%' my={3} className='set-status'>
       <Input
         ref={inputRef}
         onChange={onStatusChange}

--- a/pkg/interface/src/views/apps/publish/PublishResource.tsx
+++ b/pkg/interface/src/views/apps/publish/PublishResource.tsx
@@ -27,7 +27,7 @@ export function PublishResource(props: PublishResourceProps) {
   }, [location]);
 
   return (
-    <Box ref={scrollRef} height="100%" width="100%" overflowY="auto">
+    <Box ref={scrollRef} height="100%" width="100%" overflowY="auto" className='publish-resource'>
       <NotebookRoutes
         api={api}
         ship={ship}

--- a/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownEditor.tsx
@@ -94,7 +94,7 @@ export function MarkdownEditor(
   return (
     <Box
       position="relative"
-      className="publish"
+      className="publish markdown-editor"
       p={1}
       border={1}
       borderColor="lightGray"

--- a/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
+++ b/pkg/interface/src/views/apps/publish/components/MarkdownField.tsx
@@ -28,6 +28,7 @@ export const MarkdownField = ({
       display="flex"
       flexDirection="column"
       color="black"
+      className='markdown-field'
       {...rest}
     >
       <MarkdownEditor

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -1,4 +1,4 @@
-import { Action, Anchor, Box, Col, Row, Text } from '@tlon/indigo-react';
+import { Action, Box, Col, Row, Text } from '@tlon/indigo-react';
 import { Association, Graph, GraphNode, Group } from '@urbit/api';
 import bigInt from 'big-integer';
 import React, { useEffect, useState } from 'react';
@@ -14,7 +14,6 @@ import { Comments } from '~/views/components/Comments';
 import { Spinner } from '~/views/components/Spinner';
 import { GraphContent } from '~/views/landscape/components/Graph/GraphContent';
 import { NoteNavigation } from './NoteNavigation';
-import { Redirect } from 'react-router-dom';
 
 interface NoteProps {
   ship: string;
@@ -103,6 +102,7 @@ export function Note(props: NoteProps & RouteComponentProps) {
       width="100%"
       gridRowGap={4}
       mx="auto"
+      className='publish-note'
     >
       <Link to={rootUrl}>
         <Text>{'<- Notebook Index'}</Text>

--- a/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteForm.tsx
@@ -34,7 +34,7 @@ export function PostForm(props: PostFormProps) {
   const { initial, onSubmit, submitLabel, loadingText, cancel, history } = props;
 
   return (
-    <Col width="100%" height="100%" p={[2, 4]}>
+    <Col width="100%" height="100%" p={[2, 4]} className='post-form'>
       <Formik
         validationSchema={formSchema}
         initialValues={initial}

--- a/pkg/interface/src/views/apps/publish/components/NoteNavigation.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteNavigation.tsx
@@ -20,6 +20,7 @@ function NavigationItem(props: {
       flexDirection="column"
       justifyContent="flex-end"
       textAlign={props.prev ? 'left' : 'right'}
+      className='navigation-item'
     >
       <Link to={props.url}>
         <Text display='block' color="gray">
@@ -99,6 +100,7 @@ export function NoteNavigation(props: NoteNavigationProps): ReactElement {
       alignItems="center"
       gridTemplateColumns="1fr 1px 1fr"
       gridTemplateRows="100px"
+      className='note-navigation'
     >
       {prevComponent}
       <Box borderRight={1} borderColor="lightGray" height="100%" />

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -6,9 +6,9 @@ import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import {
-    getComments,
-    getLatestRevision,
-    getSnippet
+  getComments,
+  getLatestRevision,
+  getSnippet
 } from '~/logic/lib/publish';
 import useHarkState from '~/logic/state/hark';
 import Author from '~/views/components/Author';
@@ -78,7 +78,7 @@ export function NotePreview(props: NotePreviewProps) {
   const cursorStyle = post.pending ? 'default' : 'pointer';
 
   return (
-    <Box width='100%' opacity={post.pending ? '0.5' : '1'}>
+    <Box width='100%' opacity={post.pending ? '0.5' : '1'} className='note-preview'>
       <Link
         to={post.pending ? '#' : url}
         style={ { cursor: cursorStyle } }

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -40,7 +40,7 @@ export function Notebook(props: NotebookProps & RouteComponentProps): ReactEleme
   }
 
   return (
-    <Col gapY={4} pt={4} mx="auto" px={3} maxWidth="768px">
+    <Col gapY={4} pt={4} mx="auto" px={3} maxWidth="768px" className='notebook'>
       <Row justifyContent="space-between">
         <Box>
           <Text display='block'>{association.metadata?.title}</Text>

--- a/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotebookPosts.tsx
@@ -17,7 +17,7 @@ interface NotebookPostsProps {
 export function NotebookPosts(props: NotebookPostsProps) {
   const contacts = useContactState(state => state.contacts);
   return (
-    <Col>
+    <Col className='notebook-posts'>
       {Array.from(props.graph || []).map(
         ([date, node]) =>
           node && (

--- a/pkg/interface/src/views/apps/publish/components/Writers.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Writers.tsx
@@ -36,7 +36,7 @@ export const Writers = (props: WritersProps): ReactElement => {
     const writers = Array.from(groups?.[association?.group]?.tags.graph[association.resource]?.writers || []).map(s => `~${s}`).join(', ');
 
     return (
-      <Box maxWidth='512px'>
+      <Box maxWidth='512px' className='writers'>
         <Text display='block'>Writers</Text>
         <Text display='block' mt={2} gray>Add additional writers to this notebook</Text>
         <Formik

--- a/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 export function BackButton(props: {}) {
   return (
-    <Link to='/~settings'>
+    <Link to='/~settings' className='back-button'>
       <Text
         display={['block', 'none']}
         fontSize={2}

--- a/pkg/interface/src/views/apps/settings/components/lib/BackgroundPicker.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackgroundPicker.tsx
@@ -28,7 +28,7 @@ export function BackgroundPicker({
     width: ['100%', '288px']
   };
   return (
-    <Col>
+    <Col className='background-picker'>
       <Label>Landscape Background</Label>
       <Row flexWrap="wrap" {...rowSpace}>
         <Col {...colProps}>

--- a/pkg/interface/src/views/apps/settings/components/lib/BucketList.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BucketList.tsx
@@ -1,13 +1,13 @@
 import {
-    Box,
-    Button, ManagedForm as Form, ManagedTextInputField as Input,
+  Box,
+  Button, ManagedForm as Form, ManagedTextInputField as Input,
 
-    Menu,
-    MenuButton,
+  Menu,
+  MenuButton,
 
-    MenuItem, MenuList,
+  MenuItem, MenuList,
 
-    Row, Text
+  Row, Text
 } from '@tlon/indigo-react';
 import { Formik, FormikHelpers } from 'formik';
 import React, { ReactElement, useCallback, useState } from 'react';
@@ -59,6 +59,7 @@ export function BucketList({
         gridTemplateColumns="100%"
         gridAutoRows="auto"
         gridRowGap={2}
+        className='bucket-list'
       >
         {_buckets.map(bucket => (
           <Box

--- a/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
@@ -1,7 +1,7 @@
 import {
-    Col, ManagedToggleSwitchField as Toggle,
+  Col, ManagedToggleSwitchField as Toggle,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Form, Formik, FormikHelpers } from 'formik';
 import React, { useCallback } from 'react';
@@ -73,7 +73,7 @@ export function CalmPrefs(props: {
 
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
-      <Form>
+      <Form className='calm-prefs'>
         <BackButton />
         <Col borderBottom={1} borderBottomColor="washedGray" p={5} pt={4} gapY={5}>
           <Col gapY={1} mt={0}>

--- a/pkg/interface/src/views/apps/settings/components/lib/Debug.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/Debug.tsx
@@ -41,7 +41,7 @@ const StoreDebugger = (props: StoreDebuggerProps) => {
   }, [state, filter, text]);
 
   return (
-    <Box p={1}>
+    <Box p={1} className='store-debugger'>
       <Text cursor="pointer" onClick={() => setVisible(!visible)}>{name}</Text>
       {visible && <Box>
         <BaseInput

--- a/pkg/interface/src/views/apps/settings/components/lib/DisplayForm.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/DisplayForm.tsx
@@ -1,8 +1,8 @@
 import {
-    Col,
+  Col,
 
-    Label,
-    ManagedRadioButtonField as Radio, Text
+  Label,
+  ManagedRadioButtonField as Radio, Text
 } from '@tlon/indigo-react';
 import { Form, Formik } from 'formik';
 import React from 'react';
@@ -87,7 +87,7 @@ export default function DisplayForm(props: DisplayFormProps) {
       }}
     >
       {props => (
-        <Form>
+        <Form className='display-form'>
           <BackButton />
           <Col p={5} pt={4} gapY={5}>
               <Col gapY={1} mt={0}>

--- a/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
@@ -64,6 +64,7 @@ function GroupWithChannels(props: { association: Association }) {
       gridTemplateRows="auto"
       gridGap={2}
       gridTemplateAreas="'arrow icon title graphToggle groupToggle'"
+      className='group-with-channels'
     >
       {Object.keys(joinedGroupGraphs).length > 0 && (
         <Center

--- a/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
@@ -1,7 +1,7 @@
 import {
-    Col,
+  Col,
 
-    ManagedToggleSwitchField as Toggle, Text
+  ManagedToggleSwitchField as Toggle, Text
 } from '@tlon/indigo-react';
 import { Form, Formik, FormikHelpers } from 'formik';
 import _ from 'lodash';
@@ -83,7 +83,7 @@ export function NotificationPreferences(props: {
         </Text>
       </Col>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
+        <Form className='notification-pref'>
           <Col gapY={4}>
             <Toggle
               label="Do not disturb"

--- a/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/S3Form.tsx
@@ -1,7 +1,7 @@
 import {
-    Anchor, Col, ManagedForm as Form, ManagedTextInputField as Input,
+  Anchor, Col, ManagedForm as Form, ManagedTextInputField as Input,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Formik, FormikHelpers } from 'formik';
 import React, { ReactElement, useCallback } from 'react';
@@ -60,7 +60,7 @@ export default function S3Form(props: S3FormProps): ReactElement {
           }
           onSubmit={onSubmit}
         >
-          <Form>
+          <Form className='s3-form'>
             <Col maxWidth='600px' gapY={5}>
               <Col gapY={1} mt={0}>
                 <Text color='black' fontSize={2} fontWeight='medium'>

--- a/pkg/interface/src/views/apps/settings/components/settings.tsx
+++ b/pkg/interface/src/views/apps/settings/components/settings.tsx
@@ -28,7 +28,7 @@ export function SettingsItem(props: {
 
 export default function Settings(props: {}) {
   return (
-    <Col gapY={5} p={5}>
+    <Col gapY={5} p={5} className='settings'>
       <Col gapY={1}>
         <Text fontSize={2}>System Preferences</Text>
         <Text gray>Configure and customize Landscape</Text>

--- a/pkg/interface/src/views/apps/settings/settings.tsx
+++ b/pkg/interface/src/views/apps/settings/settings.tsx
@@ -99,6 +99,7 @@ return;
           display={hash === '' ? 'flex' : ['none', 'flex']}
           width='100%'
           overflowY='auto'
+          className='settings-screen'
         >
           <Text display='block' mt={4} mb={3} mx={3} fontSize={2} fontWeight='700'>
             System Preferences

--- a/pkg/interface/src/views/apps/term/app.tsx
+++ b/pkg/interface/src/views/apps/term/app.tsx
@@ -54,6 +54,7 @@ class TermApp extends Component {
         </Helmet>
         <Box
           height='100%'
+          className='term-app'
         >
           <Route
             exact

--- a/pkg/interface/src/views/apps/term/components/history.tsx
+++ b/pkg/interface/src/views/apps/term/components/history.tsx
@@ -17,6 +17,7 @@ export class History extends Component {
         flexDirection='column-reverse'
         overflowY='scroll'
         style={{ resize: 'none' }}
+        className='term-history'
       >
         <Box
           mt='auto'

--- a/pkg/interface/src/views/apps/term/components/input.tsx
+++ b/pkg/interface/src/views/apps/term/components/input.tsx
@@ -96,7 +96,7 @@ belt = { met: 'bac' };
       }
     }
     return (
-      <Row flexGrow={1} position='relative'>
+      <Row flexGrow={1} position='relative' className='term-input'>
         <Box flexShrink={0} width='100%' color='black' fontSize={0}>
           <BaseInput
             autoFocus

--- a/pkg/interface/src/views/apps/term/components/line.tsx
+++ b/pkg/interface/src/views/apps/term/components/line.tsx
@@ -58,7 +58,8 @@ export default React.memo(({ line }) => {
   return (
     <Text mono display='flex'
 fontSize={0}
-    style={{ overflowWrap: 'break-word', whiteSpace: 'pre-wrap' }}
+      style={{ overflowWrap: 'break-word', whiteSpace: 'pre-wrap' }}
+      className='term-line'
     >
       {text}
     </Text>

--- a/pkg/interface/src/views/components/AsyncButton.tsx
+++ b/pkg/interface/src/views/components/AsyncButton.tsx
@@ -34,6 +34,7 @@ export function AsyncButton<T = any>({
       hideDisabled={isSubmitting}
       disabled={!isValid || isSubmitting}
       type="submit"
+      className='asynct-button'
       {...rest}
     >
       {isSubmitting ? (

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -89,7 +89,7 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
     ) : sigil;
 
   return (
-    <Row {...rest} alignItems='center' width='auto'>
+    <Row className='author' {...rest} alignItems='center' width='auto'>
       <Box
         onClick={(e) => {
           e.stopPropagation();

--- a/pkg/interface/src/views/components/Body.tsx
+++ b/pkg/interface/src/views/components/Body.tsx
@@ -6,7 +6,7 @@ export function Body(
 ) {
   const { children, border, ...boxProps } = props;
   return (
-    <Box fontSize={0} px={[0, 3]} pb={[0, 3]} height="100%" width="100%">
+    <Box fontSize={0} px={[0, 3]} pb={[0, 3]} height="100%" width="100%" className='body'>
       <Box
         bg="white"
         height="100%"

--- a/pkg/interface/src/views/components/ChipInput.tsx
+++ b/pkg/interface/src/views/components/ChipInput.tsx
@@ -1,18 +1,18 @@
 import {
-    Col,
+  Col,
 
-    ErrorLabel, Label,
-    Row,
+  ErrorLabel, Label,
+  Row,
 
-    StatelessTextInput as Input
+  StatelessTextInput as Input
 } from '@tlon/indigo-react';
 import { useField } from 'formik';
 import Mousetrap from 'mousetrap';
 import React, {
-    ReactElement, ReactNode, useCallback,
+  ReactElement, ReactNode, useCallback,
 
-    useEffect,
-    useRef, useState
+  useEffect,
+  useRef, useState
 } from 'react';
 
 function Chip(props: { children: ReactNode }): ReactElement {
@@ -25,6 +25,7 @@ function Chip(props: { children: ReactNode }): ReactElement {
       p={1}
       bg="blue"
       color="white"
+      className='chip'
     >
       {props.children}
     </Row>
@@ -93,7 +94,7 @@ export function ChipInput(props: ChipInputProps): ReactElement {
   }, [inputRef.current, addNewChip, newChip]);
 
   return (
-    <Col gapY={2}>
+    <Col gapY={2} className='chip-input'>
       <Label htmlFor={id}>{label}</Label>
       {caption && <Label gray>{caption}</Label>}
       <Row

--- a/pkg/interface/src/views/components/ColorInput.tsx
+++ b/pkg/interface/src/views/components/ColorInput.tsx
@@ -1,10 +1,10 @@
 import {
-    Box, Col,
+  Box, Col,
 
-    ErrorLabel, Label,
-    Row,
+  ErrorLabel, Label,
+  Row,
 
-    StatelessTextInput as Input
+  StatelessTextInput as Input
 } from '@tlon/indigo-react';
 import { useField } from 'formik';
 import React, { FormEvent } from 'react';
@@ -37,7 +37,7 @@ export function ColorInput(props: ColorInputProps) {
   };
 
   return (
-    <Box display='flex' flexDirection='column' {...rest}>
+    <Box display='flex' flexDirection='column' className='color-input' {...rest}>
       <Label htmlFor={id}>{label}</Label>
       {caption ? (
         <Label mt={2} gray>

--- a/pkg/interface/src/views/components/CommentInput.tsx
+++ b/pkg/interface/src/views/components/CommentInput.tsx
@@ -45,7 +45,7 @@ export default function CommentInput(props: CommentInputProps) {
       validateOnBlur={false}
       validateOnChange={false}
     >
-      <Form>
+      <Form className='comment-input'>
         <SubmitTextArea
           id="comment"
           placeholder={props.placeholder || ''}

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -118,7 +118,7 @@ export function CommentItem(props: CommentItemProps) {
   }
 
   return (
-    <Box ref={ref} mb={4} opacity={post?.pending ? '60%' : '100%'}>
+    <Box ref={ref} mb={4} opacity={post?.pending ? '60%' : '100%'} className='comment-item'>
       <Row px={1} my={3}>
         <Author
           showImage

--- a/pkg/interface/src/views/components/Comments.tsx
+++ b/pkg/interface/src/views/components/Comments.tsx
@@ -128,7 +128,7 @@ export function Comments(props: CommentsProps & PropFunc<typeof Col>) {
   const canComment = isWriter(group, association.resource) || association.metadata.vip === 'reader-comments';
 
   return (
-    <Col {...rest} minWidth={0}>
+    <Col className='comments' {...rest} minWidth={0}>
       {( !editCommentId && canComment ? <CommentInput onSubmit={onSubmit} /> : null )}
       {( editCommentId ? (
         <CommentInput

--- a/pkg/interface/src/views/components/Dot.tsx
+++ b/pkg/interface/src/views/components/Dot.tsx
@@ -14,6 +14,7 @@ const Dot = ({ color, ...rest }: DotProps): ReactElement => {
         height: '4px',
         borderRadius: '50%'
       }}
+    className='dot'
       {...rest}
     />
   );

--- a/pkg/interface/src/views/components/Dropdown.tsx
+++ b/pkg/interface/src/views/components/Dropdown.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@tlon/indigo-react';
 import React, {
-    ReactElement, ReactNode,
+  ReactElement, ReactNode,
 
-    useCallback, useEffect, useRef, useState
+  useCallback, useEffect, useRef, useState
 } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -84,7 +84,12 @@ export function Dropdown(props: DropdownProps): ReactElement {
   }, []);
 
   return (
-    <Box flexShrink={flexShrink} position={open ? 'relative' : 'static'} minWidth={0} width={props?.width ? props.width : 'auto'}>
+    <Box
+      flexShrink={flexShrink}
+      position={open ? 'relative' : 'static'}
+      minWidth={0} width={props?.width ? props.width : 'auto'}
+      className='dropdown'
+    >
       <ClickBox width='100%' ref={anchorRef} onClick={onOpen}>
         {children}
       </ClickBox>

--- a/pkg/interface/src/views/components/DropdownSearch.tsx
+++ b/pkg/interface/src/views/components/DropdownSearch.tsx
@@ -1,14 +1,14 @@
 import {
-    Box,
-    StatelessTextInput as Input
+  Box,
+  StatelessTextInput as Input
 } from '@tlon/indigo-react';
 import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 import React, {
-    ChangeEvent,
-    ReactElement, useCallback,
-    useEffect, useMemo, useRef,
-    useState
+  ChangeEvent,
+  ReactElement, useCallback,
+  useEffect, useMemo, useRef,
+  useState
 } from 'react';
 import { useDropdown } from '~/logic/lib/useDropdown';
 import { PropFunc } from '~/types/util';
@@ -128,7 +128,7 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>): ReactElement {
   }, [options, props.getKey, props.renderCandidate, selected]);
 
   return (
-    <Box {...rest} position="relative" zIndex={9}>
+    <Box className='dropdown-search' {...rest} position="relative" zIndex={9}>
       <Input
         ref={textarea}
         onChange={changeCallback}

--- a/pkg/interface/src/views/components/Error.tsx
+++ b/pkg/interface/src/views/components/Error.tsx
@@ -29,7 +29,15 @@ class ErrorComponent extends Component<ErrorProps> {
       body =`\`\`\`%0A${error.stack?.replaceAll('\n', '%0A')}%0A\`\`\``;
     }
     return (
-      <Col alignItems="center" justifyContent="center" height="100%" p={4} backgroundColor="white" maxHeight="100%">
+      <Col
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+        p={4}
+        backgroundColor="white"
+        maxHeight="100%"
+        className='error'
+      >
         <Box mb={4}>
           <Text fontSize={3}>
            {code ? code : 'Error'}

--- a/pkg/interface/src/views/components/FormGroup.tsx
+++ b/pkg/interface/src/views/components/FormGroup.tsx
@@ -2,9 +2,9 @@ import { Box, Button, Row } from '@tlon/indigo-react';
 import { useFormikContext } from 'formik';
 import _ from 'lodash';
 import React, {
-    useCallback, useEffect,
+  useCallback, useEffect,
 
-    useMemo, useState
+  useMemo, useState
 } from 'react';
 import { Prompt } from 'react-router-dom';
 import { FormGroupContext, SubmitHandler } from '~/logic/lib/formGroup';
@@ -138,7 +138,7 @@ export function FormGroup(props: { onReset?: () => void; } & PropFunc<typeof Box
   usePreventWindowUnload(isDirty);
 
   return (
-    <Box {...rest} position="relative">
+    <Box className='form-group' {...rest} position="relative">
       <Prompt
         when={isDirty}
         message="Are you sure you want to leave? You have unsaved changes"

--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -50,6 +50,7 @@ export function GroupLink(
     <Box
       maxWidth="500px"
       cursor='pointer'
+      className='group-link'
       {...rest}
       onClick={(e) => {
         e.stopPropagation();

--- a/pkg/interface/src/views/components/GroupSearch.tsx
+++ b/pkg/interface/src/views/components/GroupSearch.tsx
@@ -1,10 +1,10 @@
 import {
-    Box,
+  Box,
 
-    Col,
+  Col,
 
-    ErrorLabel, Icon, Label,
-    Row, Text
+  ErrorLabel, Icon, Label,
+  Row, Text
 } from '@tlon/indigo-react';
 import { Association } from '@urbit/api/metadata';
 import { FieldArray, useFormikContext } from 'formik';
@@ -129,7 +129,7 @@ export function GroupSearch<I extends string, V extends FormValues<I>>(props: Gr
         };
 
         return (
-          <Col>
+          <Col className='group-search'>
             <Label htmlFor={id}>{label}</Label>
             {caption && (
               <Label gray mt={2}>

--- a/pkg/interface/src/views/components/HoverBox.tsx
+++ b/pkg/interface/src/views/components/HoverBox.tsx
@@ -26,7 +26,7 @@ export const HoverBoxLink = React.forwardRef<HTMLAnchorElement, HoverBoxLinkProp
   children,
   ...rest
 }, ref) => (
-  <Link ref={ref} to={to}>
+  <Link ref={ref} to={to} className='hover-box'>
     <HoverBox {...rest}>{children}</HoverBox>
   </Link>
 ));

--- a/pkg/interface/src/views/components/IconRadio.tsx
+++ b/pkg/interface/src/views/components/IconRadio.tsx
@@ -1,9 +1,9 @@
 import {
-    BaseLabel, Box,
+  BaseLabel, Box,
 
-    Col, Icon,
+  Col, Icon,
 
-    Label, Row
+  Label, Row
 } from '@tlon/indigo-react';
 import { useField } from 'formik';
 import React, { useCallback, useMemo } from 'react';
@@ -110,7 +110,7 @@ export function IconRadio(props: IconRadioProps) {
   );
 
   return (
-    <Row {...rest}>
+    <Row {...rest} className='icon-radio'>
       <BaseLabel
         htmlFor={id}
         display="flex"

--- a/pkg/interface/src/views/components/ImageInput.tsx
+++ b/pkg/interface/src/views/components/ImageInput.tsx
@@ -136,7 +136,7 @@ export function ImageInput(props: ImageInputProps): ReactElement {
   }, []);
 
   return (
-    <Box display="flex" flexDirection="column" {...props}>
+    <Box display="flex" flexDirection="column" className='image-input' {...props}>
       <Label htmlFor={id}>{label}</Label>
       {caption ? (
         <Label mt={2} gray>

--- a/pkg/interface/src/views/components/Invite/Group.tsx
+++ b/pkg/interface/src/views/components/Invite/Group.tsx
@@ -50,6 +50,7 @@ function Elbow(
       width={size}
       height={size}
       position="relative"
+      className='elbow'
     >
       <Box
         border="2px solid"
@@ -227,7 +228,7 @@ function InviteActions(props: {
 
   if (status) {
     return (
-      <Row gapX={2} alignItems="center" height={4}>
+      <Row gapX={2} alignItems="center" height={4} className='invite-actions'>
         <StatelessAsyncButton
           height={4}
           backgroundColor="white"
@@ -240,7 +241,7 @@ function InviteActions(props: {
   }
 
   return (
-    <Row gapX={2} alignItems="center" height={4}>
+    <Row gapX={2} alignItems="center" height={4} className='invite-actions'>
       <StatelessAsyncButton
         color="blue"
         height={4}

--- a/pkg/interface/src/views/components/Loading.tsx
+++ b/pkg/interface/src/views/components/Loading.tsx
@@ -7,7 +7,7 @@ interface LoadingProps {
 }
 export function Loading({ text }: LoadingProps) {
   return (
-    <Body border="0">
+    <Body border="0" className='loading'>
       <Center height="100%">
         <LoadingSpinner />
         {Boolean(text) && <Text ml={4}>{text}</Text>}

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -57,6 +57,7 @@ export function Mention(props: {
         color='blue'
         fontSize={showNickname ? 1 : 0}
         mono={!showNickname}
+        className='mention-text'
       >
         {name}
       </Text>

--- a/pkg/interface/src/views/components/ModalOverlay.tsx
+++ b/pkg/interface/src/views/components/ModalOverlay.tsx
@@ -45,6 +45,7 @@ export const ModalOverlay = (props: Props) => {
       p={spacing}
       onClick={onClick}
       onKeyDown={onKeyDown}
+      className='modal-overlay'
     >
       <Box ref={ref} {...rest} />
     </Box>

--- a/pkg/interface/src/views/components/OverlaySigil.tsx
+++ b/pkg/interface/src/views/components/OverlaySigil.tsx
@@ -28,7 +28,7 @@ interface OverlaySigilState {
 export const OverlaySigil = (props: OverlaySigilProps) => {
   const {
     api,
-    className,
+    className = '',
     color,
     contact,
     group,
@@ -81,7 +81,7 @@ export const OverlaySigil = (props: OverlaySigilProps) => {
     <Box
       cursor='pointer'
       position='relative'
-      className={className}
+      className={`${className} overlay-sigil`}
       pr={0}
       pl={0}
       ref={containerRef}

--- a/pkg/interface/src/views/components/RemoteContent.tsx
+++ b/pkg/interface/src/views/components/RemoteContent.tsx
@@ -133,7 +133,7 @@ return;
   wrapInLink(contents, textOnly = false, unfold = false, unfoldEmbed = null, embedContainer = null, flushPadding = false, noOp = false) {
     const { style } = this.props;
     return (
-      <Box borderRadius={1} backgroundColor="washedGray" maxWidth="min(100%, 20rem)">
+      <Box borderRadius={1} backgroundColor="washedGray" maxWidth="min(100%, 20rem)" className='remote-content'>
       <Row
         alignItems="center"
         gapX={1}

--- a/pkg/interface/src/views/components/ShipSearch.tsx
+++ b/pkg/interface/src/views/components/ShipSearch.tsx
@@ -1,18 +1,18 @@
 import {
-    Col,
-    ErrorLabel, Icon, Label,
+  Col,
+  ErrorLabel, Icon, Label,
 
-    Row, Text
+  Row, Text
 } from '@tlon/indigo-react';
 import { Groups, Rolodex } from '@urbit/api';
 import { FieldArray, useFormikContext } from 'formik';
 import _ from 'lodash';
 import React, {
-    ChangeEvent,
+  ChangeEvent,
 
-    ReactElement, useCallback, useMemo,
+  ReactElement, useCallback, useMemo,
 
-    useRef
+  useRef
 } from 'react';
 import ob from 'urbit-ob';
 import * as Yup from 'yup';
@@ -178,7 +178,7 @@ export function ShipSearch<I extends string, V extends Value<I>>(
         };
 
         return (
-          <Col>
+          <Col className='ship-search'>
             <Label htmlFor={id}>{label}</Label>
             {caption && (
               <Label gray mt={2}>

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -13,8 +13,8 @@ import { Sigil } from '~/logic/lib/sigil';
 import { uxToHex } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
 import useHarkState from '~/logic/state/hark';
-import useLaunchState from '~/logic/state/launch';
 import useInviteState from '~/logic/state/invite';
+import useLaunchState from '~/logic/state/launch';
 import useLocalState, { selectLocalState } from '~/logic/state/local';
 import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { Dropdown } from './Dropdown';
@@ -72,6 +72,7 @@ const StatusBar = (props) => {
       py={3}
       px={3}
       pb={3}
+      className='status-bar'
     >
       <Row collapse>
         <Button

--- a/pkg/interface/src/views/components/StatusBarItem.tsx
+++ b/pkg/interface/src/views/components/StatusBarItem.tsx
@@ -25,6 +25,7 @@ export function StatusBarItem({
       overflow='visible'
       zIndex={10}
       boxShadow="1px 1px black"
+      className='status-bar-item'
       {...props}
     >
       {children}

--- a/pkg/interface/src/views/components/SubmitDragger.tsx
+++ b/pkg/interface/src/views/components/SubmitDragger.tsx
@@ -15,6 +15,7 @@ const SubmitDragger = (): ReactElement => (
     alignItems='center'
     justifyContent='center'
     style={{ pointerEvents: 'none', zIndex: 999 }}
+    className='submit-drager'
   >
       <Text fontSize={1} color='black'>
         Drop a file to upload

--- a/pkg/interface/src/views/components/SwipeMenu.tsx
+++ b/pkg/interface/src/views/components/SwipeMenu.tsx
@@ -23,6 +23,7 @@ export function SwipeMenu(
     menu: ReactNode;
     menuWidth: number;
     threshold?: number;
+    className?: string;
   } & PropFunc<typeof Box>
 ) {
   const [open, setOpen] = useState(false);
@@ -34,6 +35,7 @@ export function SwipeMenu(
     menu,
     menuWidth,
     threshold = DEFAULT_THRESHOLD,
+    className = '',
     ...rest
   } = props;
   const [{ x, opacity }, springApi] = useSpring(() => ({
@@ -71,7 +73,7 @@ export function SwipeMenu(
   );
 
   return (
-    <NoScrollBox {...rest} position="relative">
+    <NoScrollBox {...rest} position="relative" className={className}>
       <AnimBox {...sliderBind()}>
         <AnimBox style={{ x }}>{children}</AnimBox>
       </AnimBox>

--- a/pkg/interface/src/views/components/Tab.tsx
+++ b/pkg/interface/src/views/components/Tab.tsx
@@ -12,6 +12,7 @@ export const Tab = ({ selected, id, label, setSelected }) => (
     display="flex"
     alignItems="center"
     justifyContent="center"
+    className='tab'
     onClick={() => setSelected(id)}
   >
     <Text color={selected === id ? 'black' : 'gray'}>{label}</Text>
@@ -24,6 +25,7 @@ export const Tabs = ({ children, ...rest }: Parameters<typeof Row>[0]) => (
     mb={2}
     justifyContent="stretch"
     alignItems="flex-end"
+    className='tabs'
     {...rest}
   >
     {children}

--- a/pkg/interface/src/views/components/Timestamp.tsx
+++ b/pkg/interface/src/views/components/Timestamp.tsx
@@ -62,6 +62,7 @@ return null;
       display='flex'
       flex='row'
       flexWrap='nowrap'
+      className='timestamp'
       {...rest}
       title={stamp.format(DateFormat + ' ' + TimeFormat)}
     >

--- a/pkg/interface/src/views/components/UnjoinedResource.tsx
+++ b/pkg/interface/src/views/components/UnjoinedResource.tsx
@@ -65,7 +65,7 @@ export function UnjoinedResource(props: UnjoinedResourceProps) {
   }, [query]);
 
   return (
-    <Center p={6}>
+    <Center p={6} className='unjoined-resource'>
       <Col
         maxWidth="400px"
         p={4}

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -550,7 +550,13 @@ position="absolute" width="4px"
 backgroundColor="lightGray"
                      />)}
 
-      <ScrollbarLessBox overflowY='scroll' ref={this.setWindow} onScroll={this.onScroll} style={{ ...style, ...{ transform }, 'WebkitOverflowScrolling': 'auto' }}>
+        <ScrollbarLessBox
+          overflowY='scroll'
+          ref={this.setWindow}
+          onScroll={this.onScroll}
+          style={{ ...style, ...{ transform }, 'WebkitOverflowScrolling': 'auto' }}
+          className='virtual-scroller'
+        >
         <Box style={{ transform, width: 'calc(100% - 4px)' }}>
           {(isTop ? !atStart : !atEnd) && (<Center height={5}>
             <LoadingSpinner />

--- a/pkg/interface/src/views/components/leap/Omnibox.tsx
+++ b/pkg/interface/src/views/components/leap/Omnibox.tsx
@@ -353,6 +353,7 @@ export function Omnibox(props: OmniboxProps): ReactElement {
         right={0}
         zIndex={11}
         display={props.show ? 'block' : 'none'}
+        className='omnibox'
       >
         <Row justifyContent='center'>
           <Box

--- a/pkg/interface/src/views/components/leap/OmniboxInput.tsx
+++ b/pkg/interface/src/views/components/leap/OmniboxInput.tsx
@@ -34,6 +34,7 @@ export class OmniboxInput extends Component<OmniboxInputProps> {
         onChange={props.search}
         spellCheck={false}
         value={props.query}
+        className='omnibox-input'
       />
     );
   }

--- a/pkg/interface/src/views/components/leap/OmniboxResult.tsx
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.tsx
@@ -7,8 +7,8 @@ import { cite, uxToHex } from '~/logic/lib/util';
 import withState from '~/logic/lib/withState';
 import useContactState from '~/logic/state/contact';
 import useHarkState from '~/logic/state/hark';
-import useLaunchState from '~/logic/state/launch';
 import useInviteState from '~/logic/state/invite';
+import useLaunchState from '~/logic/state/launch';
 
 interface OmniboxResultProps {
   contacts: Contacts;
@@ -255,6 +255,7 @@ export class OmniboxResult extends Component<OmniboxResultProps, OmniboxResultSt
         width='100%'
         justifyContent='space-between'
         ref={this.result}
+        className='omnibox-result'
       >
         <Box
           display='flex'

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
@@ -1,9 +1,9 @@
 import {
-    Box,
-    Col, Label,
-    ManagedToggleSwitchField as Checkbox,
+  Box,
+  Col, Label,
+  ManagedToggleSwitchField as Checkbox,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Association, Group, PermVariation } from '@urbit/api';
 import { Form, Formik } from 'formik';
@@ -157,7 +157,7 @@ export function GraphPermissions(props: GraphPermissionsProps) {
       initialValues={initialValues}
       onSubmit={onSubmit}
     >
-      <Form style={{ display: 'contents' }}>
+      <Form style={{ display: 'contents' }} className='graph-permissions'>
         <FormGroupChild id="permissions" />
         <Col mx={4} mt={4} flexShrink={0} gapY={5}>
           <Col gapY={1} mt={0}>

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Details.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Details.tsx
@@ -1,8 +1,8 @@
 import {
-    Col,
-    Label, ManagedTextInputField as Input,
+  Col,
+  Label, ManagedTextInputField as Input,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Association } from '@urbit/api';
 import { Form, Formik } from 'formik';
@@ -42,7 +42,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
 
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
-      <Form style={{ display: 'contents' }}>
+      <Form style={{ display: 'contents' }} className='channel-details'>
         <FormGroupChild id="details" />
         <Col mx={4} mb={4} flexShrink={0} gapY={4}>
           <Col mb={3}>

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Notifications.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Notifications.tsx
@@ -28,7 +28,7 @@ export function ChannelNotifications(props: ChannelNotificationsProps) {
   const anchorRef = useRef<HTMLElement | null>(null);
 
   return (
-    <Col mx={4} mb={6} gapY={4} flexShrink={0}>
+    <Col mx={4} mb={6} gapY={4} flexShrink={0} className='channel-notifications'>
       <Text ref={anchorRef} id="notifications" fontSize={2} fontWeight="bold">
         Channel Notifications
       </Text>

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/Sidebar.tsx
@@ -19,6 +19,7 @@ export function ChannelPopoverRoutesSidebar(props: {
       borderRightColor="washedGray"
       py={5}
       gapY={2}
+      className='channel-popover-routes-sidebar'
     >
       <Text mx={3} my={3} fontSize={1} fontWeight="medium">
         Channel Settings

--- a/pkg/interface/src/views/landscape/components/ChannelWritePerms.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelWritePerms.tsx
@@ -1,7 +1,7 @@
 import {
-    Col, Label,
+  Col, Label,
 
-    ManagedRadioButtonField as Radio
+  ManagedRadioButtonField as Radio
 } from '@tlon/indigo-react';
 import { useFormikContext } from 'formik';
 import React from 'react';
@@ -22,7 +22,7 @@ export function ChannelWritePerms<
   const { values, errors } = useFormikContext<T>();
 
   return (
-    <Col gapY={3}>
+    <Col gapY={3} className='channel-write-perms'>
       <Label> Write Access</Label>
       <Radio name="writePerms" id="everyone" label="All group members" />
       <Radio name="writePerms" id="self" label="Only host" />

--- a/pkg/interface/src/views/landscape/components/Content.tsx
+++ b/pkg/interface/src/views/landscape/components/Content.tsx
@@ -38,7 +38,7 @@ export const Content = (props) => {
   }, [hasProtocol]);
 
   return (
-    <Container>
+    <Container className='content'>
       <Switch>
         <Route
           exact

--- a/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
@@ -63,7 +63,7 @@ return;
       );
     } });
   return (
-    <Row px={3} py={1} onClick={showModal} cursor="pointer">
+    <Row px={3} py={1} onClick={showModal} cursor="pointer" className='delete-group'>
       {modal}
       <Icon icon={icon} color="red" mr={2} />
       <Text color="red">

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -446,7 +446,7 @@ export const GraphContent = React.memo(function GraphContent(
   } = props;
   const [, ast] = stitchAsts(contents.map(contentToMdAst(tall)));
   return (
-    <Box {...rest}>
+    <Box className='graph-content' {...rest}>
       <Graphdown transcluded={transcluded} api={api} ast={ast} tall={tall} />
     </Box>
   );

--- a/pkg/interface/src/views/landscape/components/Graph/content/code.js
+++ b/pkg/interface/src/views/landscape/components/Graph/content/code.js
@@ -28,7 +28,7 @@ export default class CodeContent extends Component {
       ) : null;
 
     return (
-      <Box my={2}>
+      <Box my={2} className='code-content'>
         <Text
           display='block'
           mono

--- a/pkg/interface/src/views/landscape/components/Graph/content/text.js
+++ b/pkg/interface/src/views/landscape/components/Graph/content/text.js
@@ -181,6 +181,7 @@ export default function TextContent(props) {
         fontSize={props.fontSize ? props.fontSize : '14px'}
         lineHeight={props.lineHeight ? props.lineHeight : '20px'}
         style={{ overflowWrap: 'break-word' }}
+        className='text-content'
       >
         <MessageMarkdown source={content.text} allowHeaders={allowHeaders} allowLists={allowLists} />
       </Text>

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
@@ -1,10 +1,10 @@
 import {
-    Box,
+  Box,
 
-    Col, ManagedTextInputField as Input,
-    ManagedToggleSwitchField as Checkbox,
+  Col, ManagedTextInputField as Input,
+  ManagedToggleSwitchField as Checkbox,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Enc } from '@urbit/api';
 import { Group, GroupPolicy } from '@urbit/api/groups';
@@ -101,7 +101,7 @@ return null;
       initialValues={initialValues}
       onSubmit={onSubmit}
     >
-      <Form>
+      <Form className='group-admin-settings'>
         <Box p={4} id="group-details"><Text fontWeight="600" fontSize={2}>Group Details</Text></Box>
         <Col pb={4} px={4} maxWidth="384px" gapY={4}>
           <Input

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Channels.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Channels.tsx
@@ -39,7 +39,7 @@ export function GroupChannelSettings(props: GroupChannelSettingsProps) {
     resourceFromPath(association.group).ship.slice(1) !== window.ship &&
     roleForShip(group, window.ship) !== 'admin';
   return (
-    <Col maxWidth="384px" width="100%">
+    <Col maxWidth="384px" width="100%" className='group-channel-settings'>
       <Text p={4} id="channels" fontWeight="600" fontSize={2}>
         Channels
       </Text>

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
@@ -7,7 +7,7 @@ import useMetadataState from '~/logic/state/metadata';
 import { FormSubmit } from '~/views/components/FormSubmit';
 import { StatelessAsyncToggle } from '~/views/components/StatelessAsyncToggle';
 import {
-    GroupFeedPermsInput
+  GroupFeedPermsInput
 } from '../Home/Post/GroupFeedPerms';
 
 interface FormSchema {
@@ -58,7 +58,7 @@ export function GroupFeedSettings(props: {
   };
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
-      <Form>
+      <Form className='group-feed-settings'>
         <Col p={4} gapY={4}>
           <Text id="feed" fontSize={2} fontWeight="medium">
             Group Feed Settings

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
@@ -36,7 +36,7 @@ export function GroupSettings(props: GroupSettingsProps) {
     isOwner || roleForShip(props.group, window.ship) === 'admin';
 
   return (
-    <Box height="100%" overflowY="auto">
+    <Box height="100%" overflowY="auto" className='group-settings'>
       <Col>
         <GroupPersonalSettings {...props} />
         <Section>

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
@@ -1,8 +1,8 @@
 import {
-    BaseLabel, Col,
-    Label,
+  BaseLabel, Col,
+  Label,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { Association } from '@urbit/api/metadata';
 import React from 'react';
@@ -26,7 +26,7 @@ export function GroupPersonalSettings(props: {
   };
 
   return (
-    <Col px={4} pb={4} gapY={4}>
+    <Col px={4} pb={4} gapY={4} className='group-personal-settings'>
       <Text pt={4} fontWeight="600" id="notifications" fontSize={2}>Group Notifications</Text>
       <BaseLabel
         htmlFor="asyncToggle"

--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -24,7 +24,7 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
     anchorRef
   );
   return (
-    <Col {...rest} ref={anchorRef} gapY={4} maxWidth={['100%', '288px']}>
+    <Col {...rest} ref={anchorRef} gapY={4} maxWidth={['100%', '288px']} className='group-summary'>
       <Row gapX={2} width="100%">
         <MetadataIcon
           width="40px"

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -1,9 +1,9 @@
 import {
-    Box,
-    Col,
+  Box,
+  Col,
 
-    Icon, Row,
-    Text
+  Icon, Row,
+  Text
 } from '@tlon/indigo-react';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -37,7 +37,7 @@ function RecentGroups(props: { recent: string[] }) {
   const associations = useMetadataState(state => state.associations);
 
   return (
-    <Col borderBottom={1} borderBottomColor="lightGray" p={1}>
+    <Col borderBottom={1} borderBottomColor="lightGray" p={1} className='recent-groups'>
       <Box fontSize={0} px={1} py={2} color="gray">
         Recent Groups
       </Box>
@@ -94,6 +94,7 @@ export function GroupSwitcher(props: {
       pl={3}
       borderBottom='1px solid'
       borderColor='lightGray'
+      className='group-switcher'
     >
       <Col
         bg="white"

--- a/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
@@ -69,7 +69,7 @@ export function GroupifyForm(props: GroupifyFormProps) {
       initialValues={initialValues}
       onSubmit={onGroupify}
     >
-      <Form>
+      <Form className='groupify-form'>
         <Col flexShrink={0} gapY={4} maxWidth="512px">
           <Box>
             <Text fontWeight="500">Groupify this channel</Text>

--- a/pkg/interface/src/views/landscape/components/Home/AddFeedBanner.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/AddFeedBanner.tsx
@@ -40,6 +40,7 @@ export const AddFeedBanner = (props) => {
       borderColor="lightGray"
       pl={2}
       pr={2}
+      className='add-feed-banner'
     >
       <Row gapX={2} flexShrink={1} minWidth={0}>
         { dismissing ? (

--- a/pkg/interface/src/views/landscape/components/Home/EmptyGroupHome.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/EmptyGroupHome.tsx
@@ -19,6 +19,7 @@ export function EmptyGroupHome(props) {
       justifyContent="center"
       alignItems="center"
       display="flex"
+      className='empty-group-home'
     >
       { groupAssociation?.group ? (
         <GroupSummary

--- a/pkg/interface/src/views/landscape/components/Home/EnableGroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/EnableGroupFeed.tsx
@@ -43,7 +43,7 @@ export function EnableGroupFeed(props: {
   return (
     <ModalOverlay spacing={[3, 5, 7]} bg="white" dismiss={dismiss}>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
+        <Form className='enable-group-feed'>
           <Col gapY={3} p={3}>
             <Col gapY={1}>
               <Text fontWeight="medium" fontSize={2}>

--- a/pkg/interface/src/views/landscape/components/Home/GroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/GroupFeed.tsx
@@ -64,6 +64,7 @@ function GroupFeed(props) {
       display="flex"
       position="relative"
       alignItems="center"
+      className='group-feed'
     >
       <GroupFeedHeader
         baseUrl={baseUrl}

--- a/pkg/interface/src/views/landscape/components/Home/GroupFeedHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/GroupFeedHeader.tsx
@@ -51,6 +51,7 @@ export function GroupFeedHeader(props) {
       alignItems="center"
       borderBottom={1}
       borderColor="lightGray"
+      className='group-feed-header'
     >
       <Box display='block'>
         { ( baseUrl !== historyLocation ) ? (

--- a/pkg/interface/src/views/landscape/components/Home/GroupHome.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/GroupHome.tsx
@@ -40,7 +40,7 @@ function GroupHome(props) {
   const graphMetadata = associations?.graph[graphPath]?.metadata;
 
   return (
-    <Box width="100%" height="100%" overflow="hidden">
+    <Box width="100%" height="100%" overflow="hidden" className='group-home'>
       <Route path={`${baseUrl}/enable`}
         render={() => {
           return (

--- a/pkg/interface/src/views/landscape/components/Home/Post/GroupFeedPerms.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/GroupFeedPerms.tsx
@@ -1,7 +1,7 @@
 import {
-    Col, ManagedRadioButtonField as Radio,
+  Col, ManagedRadioButtonField as Radio,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import React from 'react';
 import { PropFunc } from '~/types';
@@ -14,7 +14,7 @@ export function GroupFeedPermsInput(
   const { id, ...rest } = props;
 
   return (
-    <Col gapY={4} {...rest}>
+    <Col gapY={4} className='group-feed-perms-input' {...rest}>
       <Text fontWeight="medium">Permissions</Text>
       <Radio
         name={id}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostFeed.tsx
@@ -73,6 +73,7 @@ class PostFeed extends React.Component<PostFeedProps, PostFeedState> {
             mb={3}
             width="100%"
             flexShrink={0}
+            className='post-feed'
           >
             <PostItem
               key={parentNode.post.index}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostInput.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostInput.tsx
@@ -111,6 +111,7 @@ const PostInput = (props: PostInputProps): ReactElement | null => {
       borderRadius={2}
       border={1}
       borderColor="lightGray"
+      className='post-input'
     >
       <BaseTextArea
         p={2}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostContent.tsx
@@ -34,6 +34,7 @@ const PostContent = (props: PostContentProps): ReactElement => {
       truncate={isParent ? null : 8}
       textOverflow="ellipsis"
       overflow="hidden"
+      className='post-content'
     >
       <GraphContent
         transcluded={0}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostFooter.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostFooter.tsx
@@ -32,6 +32,7 @@ const PostFooter = (props: PostFooterProps): ReactElement => {
       justify-content="flex-start"
       width="100%"
       opacity={canComment ? 1 : 0}
+      className='post-footer'
     >
       <Col width="100%">
         { showTimestamp && (

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostHeader.tsx
@@ -2,10 +2,10 @@ import { Action, Col, Icon, Row } from '@tlon/indigo-react';
 import { Association, Post } from '@urbit/api';
 import React, { ReactElement } from 'react';
 import GlobalApi from '~/logic/api/global';
+import { resourceFromPath } from '~/logic/lib/group';
 import { getPermalinkForGraph } from '~/logic/lib/permalinks';
 import { useCopy } from '~/logic/lib/useCopy';
 import useContactState from '~/logic/state/contact';
-import { resourceFromPath } from '~/logic/lib/group';
 import Author from '~/views/components/Author';
 import { Dropdown } from '~/views/components/Dropdown';
 
@@ -48,6 +48,7 @@ const PostHeader = (props: PostHeaderProps): ReactElement => {
       pl={2}
       pr={2}
       justifyContent="space-between"
+      className='post-header'
       onClick={(e) => {
         e.stopPropagation();
       }}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostItem.tsx
@@ -122,6 +122,7 @@ class PostItem extends React.Component<PostItemProps, PostItemState> {
         mb={3}
         width="100%"
         alignItems="center"
+        className='post-item'
       >
         <Col
           pt={2}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostReplies.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostReplies.tsx
@@ -64,7 +64,9 @@ export default function PostReplies(props) {
         key={locationUrl}
         width="100%"
         height="100%"
-        alignItems="center" overflowY="scroll"
+        alignItems="center"
+        overflowY="scroll"
+        className='post-replies'
       >
         <Box mt={3} width="100%" alignItems="center">
           <PostItem
@@ -100,7 +102,14 @@ export default function PostReplies(props) {
   }
 
   return (
-    <Box height="calc(100% - 48px)" width="100%" alignItems="center" pl={1} pt={3}>
+    <Box
+      height="calc(100% - 48px)"
+      width="100%"
+      alignItems="center"
+      pl={1}
+      pt={3}
+      className='post-replies'
+    >
       <PostFeed
         key={locationUrl}
         graphPath={graphPath}

--- a/pkg/interface/src/views/landscape/components/JoinGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/JoinGroup.tsx
@@ -1,11 +1,11 @@
 import {
-    Box, Col,
+  Box, Col,
 
-    Icon,
+  Icon,
 
-    ManagedTextInputField as Input, Row,
+  ManagedTextInputField as Input, Row,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { MetadataUpdatePreview } from '@urbit/api';
 import { Form, Formik, FormikHelpers, useFormikContext } from 'formik';
@@ -140,7 +140,7 @@ export function JoinGroup(props: JoinGroupProps): ReactElement {
   );
 
   return (
-    <Col p={3}>
+    <Col p={3} className='join-group'>
       <Box mb={3}>
         <Text fontSize={2} fontWeight="bold">
           Join a Group

--- a/pkg/interface/src/views/landscape/components/MessageInvite.tsx
+++ b/pkg/interface/src/views/landscape/components/MessageInvite.tsx
@@ -35,7 +35,7 @@ export const MessageInvite = (props) => {
     }
   };
   return (
-    <Col p={3}>
+    <Col p={3} className='message-invite'>
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -124,6 +124,7 @@ export function NewChannel(props: NewChannelProps): ReactElement {
       overflowY='auto'
       p={3}
       backgroundColor='white'
+      className='new-channel'
       {...rest}
     >
       <Box

--- a/pkg/interface/src/views/landscape/components/NewGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/NewGroup.tsx
@@ -79,7 +79,7 @@ export function NewGroup(props: NewGroupProps & RouteComponentProps): ReactEleme
 
   return (
     <>
-      <Col overflowY="auto" p={3}>
+      <Col overflowY="auto" p={3} className='new-group'>
         <Box mb={3}>
           <Text fontWeight="bold">New Group</Text>
         </Box>

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -1,10 +1,10 @@
 import {
-    Action, Box, Col,
+  Action, Box, Col,
 
-    Icon,
-    Image, Row,
+  Icon,
+  Image, Row,
 
-    StatelessTextInput as Input, Text
+  StatelessTextInput as Input, Text
 } from '@tlon/indigo-react';
 import { Contact, Contacts } from '@urbit/api/contacts';
 import { Group, RoleTags } from '@urbit/api/groups';
@@ -12,8 +12,8 @@ import { Association } from '@urbit/api/metadata';
 import _ from 'lodash';
 import f from 'lodash/fp';
 import React, {
-    ChangeEvent,
-    ReactElement, useCallback, useMemo, useState
+  ChangeEvent,
+  ReactElement, useCallback, useMemo, useState
 } from 'react';
 import { Link } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
@@ -162,7 +162,7 @@ export function Participants(props: {
   }, []);
 
   return (
-    <Col height="100%" overflowY="scroll" p={2} position="relative">
+    <Col height="100%" overflowY="scroll" p={2} position="relative" className='participants'>
       <Row
         bg="white"
         border={1}

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -175,7 +175,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
   }, [rid]);
 
   return (
-    <Col width='100%' height='100%' overflow='hidden'>
+    <Col width='100%' height='100%' overflow='hidden' className='resource-skeleton'>
       <Box
         flexShrink={0}
         height='48px'

--- a/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import {
-    Col
+  Col
 } from '@tlon/indigo-react';
 import React, { ReactElement, useRef } from 'react';
 import styled from 'styled-components';
@@ -68,6 +68,7 @@ export function Sidebar(props: SidebarProps): ReactElement | null {
       overflowY="scroll"
       fontSize={0}
       position="relative"
+      className='sidebar'
     >
       <GroupSwitcher
         recentGroups={props.recentGroups}

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -114,7 +114,7 @@ export function SidebarItem(props: {
       pr={3}
       selected={selected}
     >
-      <Row width='100%' alignItems="center" flex='1 auto' minWidth={0}>
+      <Row width='100%' alignItems="center" flex='1 auto' minWidth={0} className='sidebar-item'>
         {hasNotification && <Text color='black' marginLeft={-2} width={2} display='flex' alignItems='center'>
           <Dot />
         </Text>}

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -1,11 +1,11 @@
 import {
-    Box,
+  Box,
 
-    Col, Icon,
+  Col, Icon,
 
-    ManagedCheckboxField as Checkbox, ManagedRadioButtonField as Radio, Row,
+  ManagedCheckboxField as Checkbox, ManagedRadioButtonField as Radio, Row,
 
-    Text
+  Text
 } from '@tlon/indigo-react';
 import { FormikHelpers } from 'formik';
 import React, { ReactElement, useCallback } from 'react';
@@ -62,7 +62,7 @@ export function SidebarListHeader(props: {
   );
 
   return (
-    <Box>
+    <Box className='sidebar-list-header'>
     {( !!feedPath) ? (
        <Row
          flexShrink={0}

--- a/pkg/interface/src/views/landscape/components/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/SidebarItem.tsx
@@ -33,7 +33,7 @@ export const SidebarItem = ({
       justifyContent="space-between"
       {...rest}
     >
-      <Row alignItems="center">
+      <Row alignItems="center" className='sidebar-item'>
         <Icon color={color} icon={icon as any} mr={2} />
         <Text color={color}>{text}</Text>
       </Row>

--- a/pkg/interface/src/views/landscape/components/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Skeleton.tsx
@@ -39,6 +39,7 @@ export function Skeleton(props: SkeletonProps): ReactElement {
         ['100%', 'minmax(150px, 1fr) 3fr', 'minmax(250px, 1fr) 4fr']
       }
       gridTemplateRows="100%"
+      className='skeleton'
     >
       <ErrorBoundary>
         <Sidebar


### PR DESCRIPTION
Where a component returned a single, sane, top-level classable element, added the name of the component as a kebab-cased class name

Frees up development time by preventing @Fang- from writing new CSS every OTA.