### PR TITLE
meta: auto-deploy release/next-userspace

### DIFF
--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -2,7 +2,7 @@ name: glob
 on:
   push:
     branches:
-      - 'release/next-js'
+      - 'release/next-userspace'
 jobs:
   glob:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -6,13 +6,13 @@ on:
 jobs:
   merge-to-next-js:
     runs-on: ubuntu-latest
-    name: "Merge master to release/next-js"
+    name: "Merge master to release/next-userspace"
     steps:
       - uses: actions/checkout@v2
       - uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
-          target_branch: release/next-js
+          target_branch: release/next-userspace
           github_token: ${{ secrets.JANEWAY_BOT_TOKEN }}
 
   merge-to-group-timer:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -309,9 +309,9 @@ the new binary, and restarting the pier with it.
 #### Continuous deployment
 
 A subset of release branches are deployed continuously to the network. Thus far
-this only includes `release/next-js`, which deploys livenet-compatible
-JavaScript changes to select QA ships. Any push to master will automatically
-merge master into `release/next-js` to keep the streams at parity.
+this only includes `release/next-userspace`, which deploys livenet-compatible
+changes to select QA ships. Any push to master will automatically
+merge master into `release/next-userspace` to keep the streams at parity.
 
 ### Announce the update
 


### PR DESCRIPTION
This PR retires next-js in favour of next-userspace, auto-deploying next-userspace to the dev stream. 

Going forward _all possible changes_ should target next-userspace for staging deployment; irrevocably breaking changes will target the next dated release branch (eg. 1.8's branch will be `release/2021-5-27`).