### PR TITLE
LinkResource: add index to baseUrl prop

### DIFF
--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -125,7 +125,7 @@ export function LinkResource(props: LinkResourceProps) {
                   api={api}
                   editCommentId={editCommentId}
                   history={props.history}
-                  baseUrl={`${resourceUrl}/${props.match.params.index}`}
+                  baseUrl={`${resourceUrl}/index/${props.match.params.index}`}
                   group={group}
                   px={3}
                 />


### PR DESCRIPTION
Conforms the `baseUrl` prop we pass to `Comments` from within `LinkResource` to fit the new `/index/:index` route used as of permalinks.

Very confused where this broke, since all related code has been the same for two months. Has editing links comments been broken that long?

Fixes urbit/landscape#873