### PR TITLE
interface: square buttons; home: squash group key squawking

### DIFF
--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -56,9 +56,9 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
         const path = group?.group;
         const unreadCount = graphUnreads(path);
         const notCount = graphNotifications(path);
-
         return (
           <Group
+            key={group.metadata.title}
             updates={notCount}
             first={index === 0}
             unreads={unreadCount}

--- a/pkg/interface/src/views/components/StatelessAsyncAction.tsx
+++ b/pkg/interface/src/views/components/StatelessAsyncAction.tsx
@@ -23,7 +23,7 @@ export function StatelessAsyncAction({
 
   return (
     <Action
-      height="18px"
+      height="16px"
       hideDisabled={!disabled}
       disabled={disabled || state === 'loading'}
       onClick={handleClick} {...rest}

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -1,12 +1,12 @@
 import {
-  BaseImage, Box,
-
-  Button, Col,
-
-  Icon, Row,
-
-  Text
-} from '@tlon/indigo-react';
+  BaseImage,
+  Box,
+  Button,
+  Col,
+  Icon,
+  Row,
+  Text,
+} from "@tlon/indigo-react";
 import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Sigil } from '~/logic/lib/sigil';
@@ -110,6 +110,7 @@ const StatusBar = (props) => {
       </Row>
       <Row justifyContent='flex-end' collapse>
         <StatusBarItem
+          width='32px'
           mr={2}
           backgroundColor='yellow'
           display={
@@ -125,7 +126,7 @@ const StatusBar = (props) => {
             )
           }
         >
-        <Icon icon="Bug" color="#000000" />
+          <Icon icon="Bug" color="#000000" />
         </StatusBarItem>
         <StatusBarItem
           width='32px'


### PR DESCRIPTION
Makes the SYB button and notification dismiss buttons square.

Also gets rid of the annoying "these iterable elements don't have unique keys" console error on the group grid view.

fixes urbit/landscape#836
fixes urbit/landscape#833