### PR TITLE
interface: changed alphabeticalOrder to ignore non-word characters

### DIFF
--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -278,8 +278,12 @@ export function cite(ship: string): string {
   return `~${patp}`;
 }
 
+export function stripNonWord(string: string): string {
+  return string.replace(/[^\p{L}\p{N}\p{Z}]/gu, '');
+}
+
 export function alphabeticalOrder(a: string, b: string) {
-  return a.toLowerCase().localeCompare(b.toLowerCase());
+  return stripNonWord(a).toLowerCase().trim().localeCompare(stripNonWord(b).toLowerCase().trim());
 }
 
 export function lengthOrder(a: string, b: string) {


### PR DESCRIPTION
~~before/after:~~ after/before:
<img width="1778" alt="Screen Shot 2021-05-13 at 2 27 00 PM" src="https://user-images.githubusercontent.com/3999320/118190079-77045a00-b3f7-11eb-9474-058e49bbcb0c.png">

Also changes the sidebar sort algorithm — doesn't seem to break anything but I don't think I'm in any groups with emoji channel names.

Fixes https://github.com/urbit/landscape/issues/875