### PR TITLE
landscape: grabbag

### DIFF
--- a/pkg/interface/src/logic/lib/useCopy.ts
+++ b/pkg/interface/src/logic/lib/useCopy.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { writeText } from './util';
 
-export function useCopy(copied: string, display?: string) {
+export function useCopy(copied: string, display?: string, replaceText?: string) {
   const [didCopy, setDidCopy] = useState(false);
   const doCopy = useCallback(() => {
     writeText(copied);
@@ -11,7 +11,7 @@ export function useCopy(copied: string, display?: string) {
     }, 2000);
   }, [copied]);
 
-  const copyDisplay = useMemo(() => (didCopy ? 'Copied' : display), [
+  const copyDisplay = useMemo(() => (didCopy ? (replaceText ?? 'Copied') : display), [
     didCopy,
     display
   ]);

--- a/pkg/interface/src/views/components/GroupLink.tsx
+++ b/pkg/interface/src/views/components/GroupLink.tsx
@@ -77,16 +77,6 @@ export function GroupLink(
           <Box pt='1' ml='2' display='flex' alignItems='center'>
             {preview ?
               <>
-                <Box pr='2' display='flex' alignItems='center'>
-                  <Icon 
-                    icon={preview.metadata.hidden ? 'Locked' : 'Public'}
-                    color='gray'
-                    mr='1'
-                   />
-                  <Text fontSize='0' color='gray'>
-                    {preview.metadata.hidden ? 'Private' : 'Public'}
-                  </Text>
-                </Box>
                 <Box display='flex' alignItems='center'>
                   <Icon icon='Users' color='gray' mr='1' />
                   <Text fontSize='0'color='gray' >

--- a/pkg/interface/src/views/components/leap/OmniboxResult.tsx
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.tsx
@@ -84,7 +84,7 @@ export class OmniboxResult extends Component<OmniboxResultProps, OmniboxResultSt
       icon.toLowerCase() === 'terminal'
     ) {
       if (icon === 'Link') {
-        link = 'Collection';
+        icon = 'Collection';
       } else if (icon === 'Terminal') {
         icon = 'Dojo';
       }

--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -25,7 +25,7 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
     resource === `/ship/${TUTORIAL_HOST}/${TUTORIAL_GROUP}`,
     anchorRef
   );
-  const { doCopy, copyDisplay } = useCopy(`web+urbitgraph://group${resource.slice(5)}`, "Copy", "Checkmark");
+  const { doCopy, copyDisplay } = useCopy(`web+urbitgraph://group${resource?.slice(5)}`, "Copy", "Checkmark");
   return (
     <Col {...rest} ref={anchorRef} gapY={4} maxWidth={['100%', '288px']}>
       <Row gapX={2} width="100%">
@@ -44,7 +44,7 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
             overflow="hidden"
           >{metadata.title}
           </Text>
-          {props.AllowCopy &&
+          {props?.AllowCopy &&
             <Icon
               color="gray"
               icon={props?.locked ? "Locked" : copyDisplay as IconRef}

--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -1,11 +1,11 @@
-import { Col, Row, Text } from '@tlon/indigo-react';
+import { Col, Row, Text, Icon } from '@tlon/indigo-react';
 import { Metadata } from '@urbit/api';
 import React, { ReactElement, ReactNode, useRef } from 'react';
 import { TUTORIAL_GROUP, TUTORIAL_HOST } from '~/logic/lib/tutorialModal';
-import { PropFunc } from '~/types';
+import { PropFunc, IconRef } from '~/types';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
 import { MetadataIcon } from './MetadataIcon';
-
+import { useCopy } from '~/logic/lib/useCopy';
 interface GroupSummaryProps {
   metadata: Metadata;
   memberCount: number;
@@ -13,6 +13,8 @@ interface GroupSummaryProps {
   resource?: string;
   children?: ReactNode;
   gray?: boolean;
+  AllowCopy?: boolean;
+  locked?: boolean;
 }
 
 export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): ReactElement {
@@ -23,6 +25,7 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
     resource === `/ship/${TUTORIAL_HOST}/${TUTORIAL_GROUP}`,
     anchorRef
   );
+  const { doCopy, copyDisplay } = useCopy(`web+urbitgraph://group${resource.slice(5)}`, "Copy", "Checkmark");
   return (
     <Col {...rest} ref={anchorRef} gapY={4} maxWidth={['100%', '288px']}>
       <Row gapX={2} width="100%">
@@ -33,13 +36,24 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
           flexShrink={0}
         />
         <Col justifyContent="space-between" flexGrow={1} overflow="hidden">
+          <Row justifyContent="space-between">
           <Text
             fontSize={1}
             textOverflow="ellipsis"
             whiteSpace="nowrap"
             overflow="hidden"
-          >{metadata.title}</Text>
-          <Row gapX={4} >
+          >{metadata.title}
+          </Text>
+          {props.AllowCopy &&
+            <Icon
+              color="gray"
+              icon={props?.locked ? "Locked" : copyDisplay as IconRef}
+              onClick={!props?.locked ? doCopy : null}
+              cursor={props?.locked ? "default" : "pointer"}
+            />
+          }
+          </Row>
+          <Row gapX={4} justifyContent="space-between">
             <Text fontSize={1} gray>
               {memberCount} participants
             </Text>

--- a/pkg/interface/src/views/landscape/components/Home/EmptyGroupHome.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/EmptyGroupHome.tsx
@@ -23,9 +23,11 @@ export function EmptyGroupHome(props) {
       { groupAssociation?.group ? (
         <GroupSummary
           memberCount={groups[groupAssociation.group].members.size}
+          locked={Boolean('invite' in groups[groupAssociation.group].policy)}
           channelCount={channelCount}
           metadata={groupAssociation.metadata}
           resource={groupAssociation.group}
+          AllowCopy
         />
       ) : (
         <Box p={4}>


### PR DESCRIPTION
- Fixes the null collection icon in Leap (urbit/landscape#876)
- Removes private/public labels from group links that don't actually reflect that information (urbit/landscape#874)
- Group Summary now displays a padlock for closed groups, and a copy icon for public groups (urbit/landscape#411). I took some liberties with the  design, please stamp @urcades:

Public

![May-14-2021 12-40-31](https://user-images.githubusercontent.com/20846414/118302560-5e0caf00-b4b2-11eb-9776-215c21a4c25d.gif)


Private

<img width="319" alt="Screen Shot 2021-05-14 at 12 41 23 PM" src="https://user-images.githubusercontent.com/20846414/118302575-62d16300-b4b2-11eb-8113-14c25797a4dd.png">

It copies the web+urbitgraph link for the group to clipboard.