### PR TITLE
dm-hook: boot fixes

### DIFF
--- a/pkg/arvo/app/dm-hook.hoon
+++ b/pkg/arvo/app/dm-hook.hoon
@@ -32,7 +32,7 @@
   :_  this
   :_  ~
   =/  dms=(list resource)
-    ?.  .^(? %gu (scry:io %home %graph-store ~))
+    ?.  .^(? %gu (scry:io %graph-store ~))
       ~
     %+  skim  ~(tap in get-keys:gra)
     |=([ship name=term] ?=(^ (rush name ;~(pfix (jest 'dm--') (star next)))))

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -2,7 +2,7 @@
 /+  drum=hood-drum, helm=hood-helm, kiln=hood-kiln
 |%
 +$  state
-  $:  %12
+  $:  %13
       drum=state:drum
       helm=state:helm
       kiln=state:kiln
@@ -15,6 +15,7 @@
       [%9 drum=state:drum helm=state:helm kiln=state:kiln]
       [%10 drum=state:drum helm=state:helm kiln=state:kiln]
       [%11 drum=state:drum helm=state:helm kiln=state:kiln]
+      [%12 drum=state:drum helm=state:helm kiln=state:kiln]
   ==
 +$  any-state-tuple
   $:  drum=any-state:drum

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -108,6 +108,7 @@
       %metadata-pull-hook
       %group-view
       %settings-store
+      %dm-hook
   ==
 ::
 ++  deft-fish                                           ::  default connects
@@ -258,6 +259,8 @@
     =>  (se-born | %home %contact-pull-hook)
     =>  (se-born | %home %settings-store)
     (se-born | %home %group-view)
+  =?  ..on-load  (lte hood-version %13)
+    (se-born | %home %dm-hook)
   ..on-load
 ::
 ++  reap-phat                                         ::  ack connect


### PR DESCRIPTION
- Autoboots dm-hook on upgrade and initialisation
- Fixes the +on-init logic scry