### PR TITLE
interface: misc grabbag

### DIFF
--- a/pkg/interface/src/logic/api/graph.ts
+++ b/pkg/interface/src/logic/api/graph.ts
@@ -328,6 +328,7 @@ export default class GraphApi extends BaseApi<StoreState> {
 
   async getNewest(ship: string, resource: string, count: number, index = '') {
     const data = await this.scry<any>('graph-store', `/newest/${ship}/${resource}/${count}${index}`);
+    data['graph-update'].fetch = true;
     this.store.handleEvent({ data });
   }
 
@@ -335,7 +336,7 @@ export default class GraphApi extends BaseApi<StoreState> {
     const idx = index.split('/').map(decToUd).join('/');
     const data = await this.scry<any>('graph-store',
        `/node-siblings/older/${ship}/${resource}/${count}${idx}`
-     );
+    );
     this.store.handleEvent({ data });
   }
 

--- a/pkg/interface/src/logic/reducers/graph-update.ts
+++ b/pkg/interface/src/logic/reducers/graph-update.ts
@@ -180,9 +180,15 @@ const addNodes = (json, state) => {
 
     const resource = data.resource.ship + '/' + data.resource.name;
     if (!(resource in state.graphs)) {
-      state.graphs[resource] = new BigIntOrderedMap();
+      if(json.fetch) {
+        state.graphs[resource] = new BigIntOrderedMap();
+      } else {
+        //  ignore updates until we load backlog deliberately, to avoid 
+        //  unnecessary memory usage
+        return state;
+      }
     }
-
+    
     if (!(resource in state.graphTimesentMap)) {
       state.graphTimesentMap[resource] = {};
     }

--- a/pkg/interface/src/views/apps/launch/components/Groups.tsx
+++ b/pkg/interface/src/views/apps/launch/components/Groups.tsx
@@ -58,7 +58,7 @@ export default function Groups(props: GroupsProps & Parameters<typeof Box>[0]) {
         const notCount = graphNotifications(path);
         return (
           <Group
-            key={group.metadata.title}
+            key={group?.group}
             updates={notCount}
             first={index === 0}
             unreads={unreadCount}

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -43,7 +43,7 @@ function RecentGroups(props: { recent: string[] }) {
       </Box>
       {props.recent.filter((e) => {
         return (e in associations?.groups);
-      }).slice(1, 5).map((g) => {
+      }).slice(0, 4).map((g) => {
         const assoc = associations.groups[g];
         const color = uxToHex(assoc?.metadata?.color || '0x0');
         return (

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -53,7 +53,9 @@ export function GroupsPane(props: GroupsPaneProps) {
     if (workspace.type !== 'group') {
       return;
     }
-    setRecentGroups(gs => _.uniq([workspace.group, ...gs]));
+    return () => {
+      setRecentGroups(gs => _.uniq([workspace.group, ...gs]));
+    }
   }, [workspace]);
 
   if (!(associations && (groupPath ? groupPath in groups : true))) {


### PR DESCRIPTION
Groups: fix keying

GroupSwitcher: update recent groups on unmount

Fixes an unfiled bug where switching to a non-group workspace would not
add the most recent group to the group switcher

graph-reducer: ignore superfluous updates

Reduces RAM usage drastically, especially in long-lived sessions
