### PR TITLE
permalinks: graph node placeholders

### DIFF
--- a/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
+++ b/pkg/interface/src/views/apps/permalinks/TranscludedNode.tsx
@@ -57,7 +57,7 @@ function TranscludedLinkNode(props: {
           />
           <Box
             borderRadius='2'
-            mt='1'
+            mt='3'
             ml='44px'
             mr='3'
             p='2'
@@ -128,7 +128,7 @@ function TranscludedComment(props: {
         date={comment.post?.['time-sent']}
         group={group}
       />
-      <Box pl="44px" pt='1'>
+      <Box pl="44px" pt='2'>
         <GraphContent
           api={api}
           transcluded={transcluded}
@@ -182,7 +182,7 @@ function TranscludedPublishNode(props: {
             date={post.post?.['time-sent']}
             group={group}
           />
-          <Text pl='44px' fontSize="2" fontWeight="medium">
+          <Text mt='3' pl='44px' fontSize="2" fontWeight="medium">
             {(post.post.contents[0] as TextContent)?.text}
           </Text>
           <Box pl="44px" pr='3'>
@@ -242,7 +242,7 @@ export function TranscludedPost(props: {
         date={post?.['time-sent']}
         group={group}
       />
-      <Box pl='44px' pt='2' pr='3'>
+      <Box pl='44px' pt='3' pr='3'>
         <MentionText
           api={api}
           transcluded={transcluded}

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -15,11 +15,21 @@ import { TranscludedNode } from "./TranscludedNode";
 
 function Placeholder() {
   return (
-    <Row margin='12px' marginBottom='0' height='4'>
-      <Box backgroundColor='washedGray' size='4' marginRight='2' borderRadius='2' />
-      <Box backgroundColor='washedGray' heigh='4' width='75%' borderRadius='2' />
+    <Row margin="12px" marginBottom="0" height="4">
+      <Box
+        backgroundColor="washedGray"
+        size="4"
+        marginRight="2"
+        borderRadius="2"
+      />
+      <Box
+        backgroundColor="washedGray"
+        height="4"
+        width="75%"
+        borderRadius="2"
+      />
     </Row>
-  )
+  );
 }
 
 function GroupPermalink(props: { group: string; api: GlobalApi }) {

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -154,7 +154,7 @@ function GraphPermalink(
         navigate(e);
       }}
     >
-      {loading && association && Placeholder(association.metadata.config.graph)}
+      {loading && association && Placeholder((association.metadata.config as GraphConfig).graph)}
       {showTransclusion && index && !loading && (
         <TranscludedNode
           api={api}

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -1,6 +1,7 @@
 import { BaseAnchor, Box, Center, Col, Icon, Row, Text } from "@tlon/indigo-react";
 import { Association, GraphNode, resourceFromPath, GraphConfig } from '@urbit/api';
 import React, { useCallback, useEffect, useState } from "react";
+import _ from 'lodash';
 import { useHistory, useLocation } from 'react-router-dom';
 import GlobalApi from '~/logic/api/global';
 import {
@@ -13,22 +14,44 @@ import useMetadataState from "~/logic/state/metadata";
 import { GroupLink } from "~/views/components/GroupLink";
 import { TranscludedNode } from "./TranscludedNode";
 
-function Placeholder() {
+function Placeholder(type) {
+  const lines = (type) => {
+    switch (type) {
+      case 'publish':
+        return 5;
+      case 'post':
+        return 3;
+      default:
+        return 1;
+    }
+  }
   return (
-    <Row margin="12px" marginBottom="0" height="4">
-      <Box
-        backgroundColor="washedGray"
-        size="4"
-        marginRight="2"
-        borderRadius="2"
-      />
-      <Box
-        backgroundColor="washedGray"
-        height="4"
-        width="75%"
-        borderRadius="2"
-      />
-    </Row>
+    <>
+      <Row mt='12px' ml='12px' mb='6px' height="4">
+        <Box
+          backgroundColor="washedGray"
+          size="4"
+          marginRight="2"
+          borderRadius="2"
+        />
+        <Box
+          backgroundColor="washedGray"
+          height="4"
+          width="25%"
+          borderRadius="2"
+        />
+      </Row>
+      {_.times(lines(type), () => (
+        <Row margin="6px" ml='44px' mr='12px' height="4">
+          <Box
+            backgroundColor="washedGray"
+            height="4"
+            width="100%"
+            borderRadius="2"
+          />
+        </Row>
+      ))}
+    </>
   );
 }
 
@@ -131,8 +154,8 @@ function GraphPermalink(
         navigate(e);
       }}
     >
-      {loading && Placeholder()}
-      {showTransclusion && index && (
+      {loading && association && Placeholder(association.metadata.config.graph)}
+      {showTransclusion && index && !loading && (
         <TranscludedNode
           api={api}
           transcluded={transcluded + 1}
@@ -141,7 +164,7 @@ function GraphPermalink(
           showOurContact={showOurContact}
         />
       )}
-      {association && !isInSameResource && (
+      {association && !isInSameResource && !loading && (
         <PermalinkDetails
           known
           showTransclusion={showTransclusion}
@@ -150,7 +173,7 @@ function GraphPermalink(
           permalink={permalink}
         />
       )}
-      {association && isInSameResource && transcluded === 2 && (
+      {association && isInSameResource && transcluded === 2 && !loading && (
         <PermalinkDetails
           known
           showTransclusion={showTransclusion}
@@ -159,8 +182,8 @@ function GraphPermalink(
           permalink={permalink}
         />
       )}
-      {isInSameResource && transcluded !== 2 && <Row height="12px" />}
-      {!association && (
+      {isInSameResource && transcluded !== 2 && <Row height='2' />}
+      {!association && !loading && (
         <PermalinkDetails
           icon="Groups"
           showDetails={false}

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -13,6 +13,15 @@ import useMetadataState from "~/logic/state/metadata";
 import { GroupLink } from "~/views/components/GroupLink";
 import { TranscludedNode } from "./TranscludedNode";
 
+function Placeholder() {
+  return (
+    <Row margin='12px' marginBottom='0' height='4'>
+      <Box backgroundColor='washedGray' size='4' marginRight='2' borderRadius='2' />
+      <Box backgroundColor='washedGray' heigh='4' width='75%' borderRadius='2' />
+    </Row>
+  )
+}
+
 function GroupPermalink(props: { group: string; api: GlobalApi }) {
   const { group, api } = props;
   return (
@@ -47,6 +56,7 @@ function GraphPermalink(
     ])
   );
   const [errored, setErrored] = useState(false);
+  const [loading, setLoading] = useState(false);
   const association = useMetadataState(
     useCallback(s => s.associations.graph[graph] as Association | null, [
       graph
@@ -60,9 +70,12 @@ function GraphPermalink(
         return;
       }
       try {
+        setLoading(true);
         await api.graph.getNode(ship, name, index);
+        setLoading(false);
       } catch (e) {
         console.log(e);
+        setLoading(false);
         setErrored(true);
       }
     })();
@@ -108,6 +121,7 @@ function GraphPermalink(
         navigate(e);
       }}
     >
+      {loading && Placeholder()}
       {showTransclusion && index && (
         <TranscludedNode
           api={api}


### PR DESCRIPTION
Adds an sigil/author skeleton loader to transcluded blocks such that the chat view doesn't dramatically jump with unloaded content. Sets a 'pending' flag in state in the async call, as it turns out this was much simpler and reliable than checking for undefined props.

https://user-images.githubusercontent.com/748181/118661351-070e1f00-b7bd-11eb-85b5-32eb5bd922a6.mp4

Also brings the author/content lines into alignment with Chat references due to the new ChatMessage line-height.