### PR TITLE
interface: all visible 'members' or 'participants' to 'peers'

### DIFF
--- a/pkg/interface/src/logic/lib/tutorialModal.ts
+++ b/pkg/interface/src/logic/lib/tutorialModal.ts
@@ -86,7 +86,7 @@ export const progressDetails: Record<TutorialProgress, StepDetail> = {
   'group-desc': {
     title: 'What\'s a group',
     description:
-      'A group contains members and tends to be centered around a topic or multiple topics.',
+      'A group contains peers and tends to be centered around a topic or multiple topics.',
     url: `/~landscape/ship/${TUTORIAL_HOST}/${TUTORIAL_GROUP}`,
     alignX: 'left',
     alignY: 'top',

--- a/pkg/interface/src/views/apps/publish/components/Writers.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Writers.tsx
@@ -59,7 +59,7 @@ export const Writers = (props: WritersProps): ReactElement => {
         <Text mt={2} display='block' mono>{writers}</Text>
         </> :
           <Text display='block' mt={2}>
-            All group members can write to this channel
+            All group peers can write to this channel
           </Text>
         }
       </Box>

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
@@ -24,7 +24,7 @@ function PermissionsSummary(props: {
 
   const description =
     writersSize === 0
-      ? 'Currently, all members of the group can write to this channel'
+      ? 'Currently, all peers in the group can write to this channel'
       : `Currently, only ${writersSize} ship${
           writersSize > 1 ? 's' : ''
         } can write to this channel`;
@@ -185,7 +185,7 @@ export function GraphPermissions(props: GraphPermissionsProps) {
             <Checkbox
               id="readerComments"
               label="Allow readers to comment"
-              caption="If enabled, all members of the group can comment on this channel"
+              caption="If enabled, all peers in the group can comment on this channel"
             />
           )}
         </Col>

--- a/pkg/interface/src/views/landscape/components/ChannelWritePerms.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelWritePerms.tsx
@@ -24,7 +24,7 @@ export function ChannelWritePerms<
   return (
     <Col gapY={3}>
       <Label> Write Access</Label>
-      <Radio name="writePerms" id="everyone" label="All group members" />
+      <Radio name="writePerms" id="everyone" label="All group peers" />
       <Radio name="writePerms" id="self" label="Only host" />
       <Radio name="writePerms" id="subset" label="Host and selected ships" />
       {values.writePerms === 'subset' && (

--- a/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/DeleteGroup.tsx
@@ -31,7 +31,7 @@ return;
 
   const action = props.owner ? 'Archive' : 'Leave';
   const description = props.owner
-    ? 'Permanently archive this group. (All current members will no longer see this group.)'
+    ? 'Permanently archive this group. (All current peers will no longer see this group.)'
     : 'You can rejoin if it is an open group, or if you are reinvited';
 
   const icon = props.owner ? 'X' : 'LogOut';

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
@@ -42,9 +42,9 @@ export function GroupSettings(props: GroupSettingsProps) {
         <Section>
           <Col p={4} maxWidth="384px">
             <Text fontSize={2} fontWeight="600">
-              Participants
+              Peers
             </Text>
-            <Text gray>View list of all group participants and statuses</Text>
+            <Text gray>View list of all group peers and statuses</Text>
             <Button primary mt={4} onClick={linkRelative('/participants')}>View List</Button>
           </Col>
         </Section>

--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -55,7 +55,7 @@ export function GroupSummary(props: GroupSummaryProps & PropFunc<typeof Col>): R
           </Row>
           <Row gapX={4} justifyContent="space-between">
             <Text fontSize={1} gray>
-              {memberCount} participants
+              {memberCount} peers
             </Text>
             <Text fontSize={1} gray>
               {channelCount} channels

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -153,7 +153,7 @@ export function GroupSwitcher(props: {
                         color="gray"
                         icon="Node"
                       />
-                      <Text> Participants</Text>
+                      <Text> Peers</Text>
                     </GroupSwitcherItem>
                     <GroupSwitcherItem to={navTo('/popover/settings')}>
                       <Icon

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -206,7 +206,7 @@ export function Participants(props: {
             color="gray"
             bg="transparent"
             border={0}
-            placeholder="Search Participants"
+            placeholder="Search Peers"
             onChange={onSearchChange}
           />
         </Row>

--- a/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
+++ b/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
@@ -76,7 +76,7 @@ export function PopoverRoutes(
                     <SidebarItem
                       icon="Users"
                       to={relativeUrl('/participants')}
-                      text="Participants"
+                      text="Peers"
                       selected={view === 'participants'}
                     ><Text gray>{groupSize}</Text>
                     </SidebarItem>


### PR DESCRIPTION
In order to reinforce that Urbit is, in fact, p2p, this change migrates all instances of 'members' or 'participants' in group contexts to 'peers,' which is harmonious with the new label in GroupLink.

![image](https://user-images.githubusercontent.com/748181/118827765-ad742600-b88a-11eb-9e75-cfbad4c8d6b3.png)
![image](https://user-images.githubusercontent.com/748181/118827809-bc5ad880-b88a-11eb-863a-b524168e45ca.png)
![image](https://user-images.githubusercontent.com/748181/118827903-cd0b4e80-b88a-11eb-800e-1587549e709b.png)
![image](https://user-images.githubusercontent.com/748181/118828217-1065bd00-b88b-11eb-99f6-0fbc0ab164a0.png)
![image](https://user-images.githubusercontent.com/748181/118828328-2b383180-b88b-11eb-8efb-a104a1544d8f.png)

Drafting this for now as I'm sure I'm going to find more.