### PR TITLE
graph-validators: hotfix broken vale:dais caused by removal of +bunt from clay

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -1,6 +1,5 @@
 ::  graph-store [landscape]
 ::
-::
 /+  store=graph-store, sigs=signatures, res=resource, default-agent, dbug, verb
 ~%  %graph-store-top  ..part  ~
 |%

--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -33,7 +33,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?>  ?=([@ ~] index.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -49,7 +49,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  ~|(index+index.p.ip !!)
         ::  top-level link post; title and url

--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -43,7 +43,7 @@
   :: +noun: validate post
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post contents.p [%text '']~)
     =/  ip  ;;(indexed-post p)
     ?>  ?=(^ contents.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -58,7 +58,7 @@
   :: +noun: validate publish note
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  !!
     ::  top level post must have no content


### PR DESCRIPTION
Introduced by lack of full mark testing on: https://github.com/urbit/urbit/pull/4554

Fixes urbit/landscape#889