### PR TITLE
eyre: send warp to warm %f cache for any mark that gets used and switch to %f from %c

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -1,6 +1,5 @@
 ::  graph-store [landscape]
 ::
-::
 /+  store=graph-store, sigs=signatures, res=resource, default-agent, dbug, verb
 ~%  %graph-store-top  ..part  ~
 |%

--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -33,7 +33,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?>  ?=([@ ~] index.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -49,7 +49,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  ~|(index+index.p.ip !!)
         ::  top-level link post; title and url

--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -43,7 +43,7 @@
   :: +noun: validate post
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post contents.p [%text '']~)
     =/  ip  ;;(indexed-post p)
     ?>  ?=(^ contents.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -58,7 +58,7 @@
   :: +noun: validate publish note
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  !!
     ::  top level post must have no content

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1642,17 +1642,16 @@
         ::
         =*  have=mark  p.cage.sign
         =*  desc=tape  "from {(trip have)} to json"
-        =/  tube=(unit tube:clay)
-          =/  tuc=(unit (unit cage))
-            (rof ~ %cc [our %home da+now] /[have]/json)
-          ?.  ?=([~ ~ *] tuc)  ~
-          `!<(tube:clay q.u.u.tuc)
-        ?~  tube
-          ((slog leaf+"eyre: no tube {desc}" ~) [~ ~])
-        ::
-        =/  res  (mule |.((u.tube q.cage.sign)))
+        =/  convert=(unit $-(* json))
+          =/  cag=(unit (unit cage))
+            (rof ~ %cf [our %home da+now] /[have]/json)
+          ?.  ?=([~ ~ *] cag)  ~
+          `!<($-(* json) q.u.u.cag)
+        ?~  convert
+          ((slog leaf+"eyre: no convert {desc}" ~) [~ ~])
+        =/  res  (mule |.((u.convert q.cage.sign)))
         ?:  ?=(%& -.res)
-          [`have `[%fact %json p.res]]
+          [`have `[%fact %json !>(p.res)]]
         ((slog leaf+"eyre: failed tube {desc}" ~) [~ ~])
       ::
       ?~  q.jsyn  ~
@@ -1660,7 +1659,7 @@
       :_  ?~  p.jsyn  ~
           :_  ~
           :^  duct  %pass  /pass/(scot %ud request-id)
-          [%c %warp our %home `[%sing %c da+now /[u.p.jsyn]/json]]
+          [%c %warp our %home `[%sing %f da+now /[u.p.jsyn]/json]]
       =*  sign  u.q.jsyn
       =,  enjs:format
       %-  pairs

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -59,7 +59,9 @@
           ::
       ==
       $:  %clay
-          $>(%writ gift:clay)
+          gift:clay
+          ::  $>(%writ gift:clay)
+          ::
   ==  ==
 --
 ::  more structures

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1238,9 +1238,9 @@
         ::NOTE  these will only fail if the mark and/or json types changed,
         ::      since conversion failure also gets caught during first receive.
         ::      we can't do anything about this, so consider it unsupported.
-        ?~  sign=(channel-event-to-sign channel-event)  $
-        ?~  json-with-moves=(sign-to-json request-id u.sign)       $
-        $(events [(event-json-to-wall id p.u.json-with-moves) events])
+        ?~  sign=(channel-event-to-sign channel-event)        $
+        ?~  json-with-moves=(sign-to-json request-id u.sign)  $
+        $(events [(event-json-to-wall id +.u.json-with-moves) events])
       ::  send the start event to the client
       ::
       =^  http-moves  state
@@ -1506,13 +1506,13 @@
       ::  if conversion succeeds, we *can* send it. if the client is actually
       ::  connected, we *will* send it immediately.
       ::
-      =/  json-with-moves=(unit (pair json (list move)))
+      =/  json-with-moves=(unit (quip move json))
         (sign-to-json request-id sign)
       =/  json=(unit json)
         ?~  json-with-moves  ~
-        `p.u.json-with-moves
+        `+.u.json-with-moves
       =?  moves  ?=(^ json-with-moves)
-        (weld moves q.u.json-with-moves)
+        (weld moves -.u.json-with-moves)
       =*  sending  &(?=([%| *] state.u.channel) ?=(^ json))
       ::
       =/  next-id  next-id.u.channel
@@ -1590,7 +1590,7 @@
             ^=  data
             %-  wall-to-octs
             %+  event-json-to-wall  next-id
-            p:(need (sign-to-json request-id %kick ~))
+            +:(need (sign-to-json request-id %kick ~))
         ::
             complete=%.n
         ==
@@ -1631,11 +1631,12 @@
     ::  +sign-to-json: render sign from request-id as json channel event
     ::
     ++  sign-to-json
+      ~%  %sign-to-json  ..part  ~
       |=  [request-id=@ud =sign:agent:gall]
-      ^-  (unit (pair json (list move)))
+      ^-  (unit (quip move json))
       ::  for facts, we try to convert the result to json
       ::
-      =/  jsyn=(pair (unit mark) (unit sign:agent:gall))
+      =/  [from=(unit mark) jsyn=(unit sign:agent:gall)]
         ?.  ?=(%fact -.sign)       [~ `sign]
         ?:  ?=(%json p.cage.sign)  [~ `sign]
         ::  find and use tube from fact mark to json
@@ -1649,15 +1650,14 @@
           `q.u.u.cag
         ?~  convert
           ((slog leaf+"eyre: no convert {desc}" ~) [~ ~])
-        [`have `[%fact %json (slam u.convert q.cage.sign)]]
-      ::
-      ?~  q.jsyn  ~
+        [`have `[%fact %json (slym u.convert q.q.cage.sign)]]
+      ?~  jsyn  ~
       %-  some
-      :_  ?~  p.jsyn  ~
+      :-  ?~  from  ~
           :_  ~
-          :^  duct  %pass  /conversion-cache/[u.p.jsyn]
-          [%c %warp our %home `[%sing %f da+now /[u.p.jsyn]/json]]
-      =*  sign  u.q.jsyn
+          :^  duct  %pass  /conversion-cache/[u.from]
+          [%c %warp our %home `[%sing %f da+now /[u.from]/json]]
+      =*  sign  u.jsyn
       =,  enjs:format
       %-  pairs
       ^-  (list [@t json])

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -32,7 +32,7 @@
       ==  ==
       $:  %c
           $>(%warp task:clay)
-      == 
+      ==
       ::  %d: to dill
       ::
       $:  %d
@@ -59,7 +59,7 @@
           ::
       ==
       $:  %clay
-          gift:clay
+          $>(%writ gift:clay)
   ==  ==
 --
 ::  more structures

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1636,8 +1636,8 @@
       ::  for facts, we try to convert the result to json
       ::
       =/  jsyn=(pair (unit mark) (unit sign:agent:gall))
-        ?.  ?=(%fact -.sign)       ``sign
-        ?:  ?=(%json p.cage.sign)  ``sign
+        ?.  ?=(%fact -.sign)       [~ `sign]
+        ?:  ?=(%json p.cage.sign)  [~ `sign]
         ::  find and use tube from fact mark to json
         ::
         =*  have=mark  p.cage.sign

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1642,17 +1642,14 @@
         ::
         =*  have=mark  p.cage.sign
         =*  desc=tape  "from {(trip have)} to json"
-        =/  convert=(unit $-(* json))
+        =/  convert=(unit vase)
           =/  cag=(unit (unit cage))
             (rof ~ %cf [our %home da+now] /[have]/json)
           ?.  ?=([~ ~ *] cag)  ~
-          `!<($-(* json) q.u.u.cag)
+          `q.u.u.cag
         ?~  convert
           ((slog leaf+"eyre: no convert {desc}" ~) [~ ~])
-        =/  res  (mule |.((u.convert q.cage.sign)))
-        ?:  ?=(%& -.res)
-          [`have `[%fact %json !>(p.res)]]
-        ((slog leaf+"eyre: failed tube {desc}" ~) [~ ~])
+        [`have `[%fact %json (slam u.convert q.cage.sign)]]
       ::
       ?~  q.jsyn  ~
       %-  some
@@ -1680,7 +1677,7 @@
             :-  'json'
             ~|  [%unexpected-fact-mark p.cage.sign]
             ?>  =(%json p.cage.sign)
-            ;;(json q.q.cage.sign)
+            !<(json q.cage.sign)
         ==
       ::
           %kick

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -56,6 +56,10 @@
       $:  %gall
           gift:gall
           ::  $>(%unto gift:gall)
+          ::
+      ==
+      $:  %clay
+          gift:clay
   ==  ==
 --
 ::  more structures
@@ -2326,6 +2330,8 @@
           sign
         sign
       ==
+  ?:  ?=([%clay *] sign)
+    [~ http-server-gate]
   ::  :wire must at least contain two parts, the type and the build
   ::
   ?>  ?=([@ *] wire)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1655,7 +1655,7 @@
       %-  some
       :_  ?~  p.jsyn  ~
           :_  ~
-          :^  duct  %pass  /pass/(scot %ud request-id)
+          :^  duct  %pass  /conversion-cache/[u.p.jsyn]
           [%c %warp our %home `[%sing %f da+now /[u.p.jsyn]/json]]
       =*  sign  u.q.jsyn
       =,  enjs:format

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1650,6 +1650,7 @@
           `q.u.u.cag
         ?~  convert
           ((slog leaf+"eyre: no convert {desc}" ~) [~ ~])
+        ~|  "conversion failed {desc}"
         [`have `[%fact %json (slym u.convert q.q.cage.sign)]]
       ?~  jsyn  ~
       %-  some

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1239,8 +1239,8 @@
         ::      since conversion failure also gets caught during first receive.
         ::      we can't do anything about this, so consider it unsupported.
         ?~  sign=(channel-event-to-sign channel-event)        $
-        ?~  json-with-moves=(sign-to-json request-id u.sign)  $
-        $(events [(event-json-to-wall id +.u.json-with-moves) events])
+        ?~  jive=(sign-to-json request-id u.sign)  $
+        $(events [(event-json-to-wall id +.u.jive) events])
       ::  send the start event to the client
       ::
       =^  http-moves  state
@@ -1506,13 +1506,12 @@
       ::  if conversion succeeds, we *can* send it. if the client is actually
       ::  connected, we *will* send it immediately.
       ::
-      =/  json-with-moves=(unit (quip move json))
+      =/  jive=(unit (quip move json))
         (sign-to-json request-id sign)
       =/  json=(unit json)
-        ?~  json-with-moves  ~
-        `+.u.json-with-moves
-      =?  moves  ?=(^ json-with-moves)
-        (weld moves -.u.json-with-moves)
+        ?~(jive ~ `+.u.jive)
+      =?  moves  ?=(^ jive)
+        (weld moves -.u.jive)
       =*  sending  &(?=([%| *] state.u.channel) ?=(^ json))
       ::
       =/  next-id  next-id.u.channel
@@ -2327,22 +2326,21 @@
           sign
         sign
       ==
-  ?:  ?=([%clay *] sign)
-    [~ http-server-gate]
   ::  :wire must at least contain two parts, the type and the build
   ::
   ?>  ?=([@ *] wire)
   ::
   |^  ^-  [(list move) _http-server-gate]
       ::
-      ?+     i.wire
-           ~|([%bad-take-wire wire] !!)
+      ?+    i.wire
+          ~|([%bad-take-wire wire] !!)
       ::
-         %run-app-request  run-app-request
-         %watch-response   watch-response
-         %sessions         sessions
-         %channel          channel
-         %acme             acme-ack
+        %run-app-request   run-app-request
+        %watch-response    watch-response
+        %sessions          sessions
+        %channel           channel
+        %acme              acme-ack
+        %conversion-cache  `http-server-gate
       ==
   ::
   ++  run-app-request


### PR DESCRIPTION
A draft of work to prime caches for any `%c` conversion that `%eyre` does to json.

Note: I don't know much about ducts or how to handle the response I get back from clay (or if I need to), but this compiles so I figured I'd push it up and get somebody to help me figure out the rest.

Edit: Can confirm that this works in practice on livenet and shaves 70ms off of a `%graph-update` event.

Given that I've tested this on my livenet ship, I'm marking this as ready, but I'd still like some comments on the duct stuff / ways to heat these caches more efficiently (getting rid of the time spent in nest checks would be ideal).

Edit: Latest version takes about 300ms per event, so this overall gives us a 40% speedup.

<img width="592" alt="Screen Shot 2021-05-20 at 2 32 57 PM" src="https://user-images.githubusercontent.com/1377557/119038053-4f257100-b978-11eb-8bbd-7b71cc68e127.png">

