### PR TITLE
[wip] interface: add math support

### DIFF
--- a/pkg/interface/config/webpack.dev.js
+++ b/pkg/interface/config/webpack.dev.js
@@ -3,18 +3,10 @@ const webpack = require('webpack');
 // const HtmlWebpackPlugin = require('html-webpack-plugin');
 // const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const urbitrc = require('./urbitrc');
-const fs = require('fs');
-const util = require('util');
 const _ = require('lodash');
 const { execSync } = require('child_process');
 
 const GIT_DESC = execSync('git describe --always', { encoding: 'utf8' }).trim();
-
-
-function copyFile(src,dest) {
-  return new Promise((res,rej) =>
-    fs.copyFile(src,dest, err => err ? rej(err) : res()));
-}
 
 class UrbitShipPlugin {
   constructor(urbitrc) {
@@ -26,7 +18,7 @@ class UrbitShipPlugin {
     compiler.hooks.afterEmit.tapPromise(
       'UrbitShipPlugin',
       async (compilation) => {
-        const src = path.resolve(compiler.options.output.path, 'index.js');
+        // const src = path.resolve(compiler.options.output.path, 'index.js');
         // uncomment to copy into all piers
         //
         // return Promise.all(this.piers.map(pier => {
@@ -64,7 +56,7 @@ if(urbitrc.URL) {
       '/~landscape/js/bundle/index.*.js': {
         target: 'http://localhost:9000',
         pathRewrite: (req, path) => {
-          return '/index.js'
+          return '/index.js';
         }
       },
       // '/~landscape/js/serviceworker.js': {
@@ -78,7 +70,7 @@ if(urbitrc.URL) {
         target: urbitrc.URL,
         router,
         // ensure proxy doesn't timeout channels
-        proxyTimeout: 0,
+        proxyTimeout: 0
      }
     }
   };
@@ -87,7 +79,7 @@ if(urbitrc.URL) {
 module.exports = {
   mode: 'development',
   entry: {
-    app: './src/index.js',
+    app: './src/index.js'
     // serviceworker: './src/serviceworker.js'
   },
   module: {
@@ -100,7 +92,7 @@ module.exports = {
             presets: ['@babel/preset-env', '@babel/typescript', ['@babel/preset-react', {
               runtime: 'automatic',
               development: true,
-              importSource: '@welldone-software/why-did-you-render',
+              importSource: '@welldone-software/why-did-you-render'
             }]],
             plugins: [
               '@babel/transform-runtime',
@@ -123,6 +115,10 @@ module.exports = {
           // Compiles Sass to CSS
           'sass-loader'
         ]
+      },
+      {
+        test: /\.(woff|woff2|ttf)$/i,
+        use: ['url-loader']
       }
     ]
   },
@@ -139,7 +135,7 @@ module.exports = {
       'process.env.TUTORIAL_GROUP': JSON.stringify('beginner-island'),
       'process.env.TUTORIAL_CHAT': JSON.stringify('introduce-yourself-7010'),
       'process.env.TUTORIAL_BOOK': JSON.stringify('guides-9684'),
-      'process.env.TUTORIAL_LINKS': JSON.stringify('community-articles-2143'),
+      'process.env.TUTORIAL_LINKS': JSON.stringify('community-articles-2143')
     })
 
     // new CleanWebpackPlugin(),

--- a/pkg/interface/config/webpack.prod.js
+++ b/pkg/interface/config/webpack.prod.js
@@ -42,6 +42,10 @@ module.exports = {
           // Compiles Sass to CSS
           'sass-loader'
         ]
+      },
+      {
+        test: /\.(woff|woff2|ttf)$/i,
+        use: ['url-loader']
       }
     ]
   },
@@ -65,8 +69,8 @@ module.exports = {
       'process.env.TUTORIAL_GROUP': JSON.stringify('beginner-island'),
       'process.env.TUTORIAL_CHAT': JSON.stringify('introduce-yourself-7010'),
       'process.env.TUTORIAL_BOOK': JSON.stringify('guides-9684'),
-      'process.env.TUTORIAL_LINKS': JSON.stringify('community-articles-2143'),
-    }),
+      'process.env.TUTORIAL_LINKS': JSON.stringify('community-articles-2143')
+    })
     // new HtmlWebpackPlugin({
     //   title: 'Hot Module Replacement',
     //   template: './public/index.html',

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -15163,6 +15163,21 @@
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
     },
+    "katex": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.13.11.tgz",
+      "integrity": "sha512-yJBHVIgwlAaapzlbvTpVF/ZOs8UkTj/sd46Fl8+qAf2/UiituPYVeapVD8ADZtqyRg/qNWUKt7gJoyYVWLrcXw==",
+      "requires": {
+        "commander": "^6.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        }
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -19184,6 +19199,11 @@
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==",
       "dev": true
+    },
+    "remark-math": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-3.0.1.tgz",
+      "integrity": "sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q=="
     },
     "remark-mdx": {
       "version": "1.6.22",

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -23,6 +23,7 @@
     "file-saver": "^2.0.5",
     "formik": "^2.1.5",
     "immer": "^9.0.2",
+    "katex": "^0.13.11",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "mousetrap": "^1.6.5",
@@ -44,6 +45,7 @@
     "remark": "^12.0.0",
     "remark-breaks": "^2.0.2",
     "remark-disable-tokenizers": "1.1.0",
+    "remark-math": "^3.0.1",
     "stacktrace-js": "^2.0.2",
     "style-loader": "^1.3.0",
     "styled-components": "^5.1.1",
@@ -101,6 +103,7 @@
     "sass-loader": "^8.0.2",
     "ts-mdast": "^1.0.0",
     "typescript": "^4.2.4",
+    "url-loader": "^4.1.1",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.2"

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -27,6 +27,7 @@ import Omnibox from './components/leap/Omnibox';
 import StatusBar from './components/StatusBar';
 import './css/fonts.css';
 import './css/indigo-static.css';
+import 'katex/dist/katex.css';
 import { Content } from './landscape/components/Content';
 import './landscape/css/custom.css';
 
@@ -78,6 +79,7 @@ class App extends React.Component {
     this.store.setStateHandler(this.setState.bind(this));
     this.state = this.store.state;
 
+    // eslint-disable-next-line
     this.appChannel = new window.channel();
     this.api = new GlobalApi(this.ship, this.appChannel, this.store);
     gcpManager.configure(this.api);
@@ -102,7 +104,7 @@ class App extends React.Component {
       this.updateTheme(this.themeWatcher);
     }, 500);
     this.api.local.getBaseHash();
-    this.api.local.getRuntimeLag();  //TODO  consider polling periodically
+    this.api.local.getRuntimeLag();  // TODO  consider polling periodically
     this.api.settings.getAll();
     gcpManager.start();
     Mousetrap.bindGlobal(['command+/', 'ctrl+/'], (e) => {

--- a/pkg/interface/src/views/landscape/components/Graph/parse.ts
+++ b/pkg/interface/src/views/landscape/components/Graph/parse.ts
@@ -1,8 +1,8 @@
 import remark from 'remark';
 import RemarkDisableTokenizers from 'remark-disable-tokenizers';
-import RemarkBreaks from 'remark-breaks';
-import ResumeParse from './resume';
 import newlines from './remark-break';
+import math from 'remark-math';
+import inlineMath from 'remark-math/inline';
 
 export interface ParserSettings {
   inList: boolean;
@@ -18,12 +18,12 @@ const DISABLED_BLOCK_TOKENS = [
   'setextHeading',
   'html',
   'definition',
-  'table',
+  'table'
 ];
 
 const DISABLED_INLINE_TOKENS = ['autoLink', 'url', 'email', 'reference', 'html'];
 
-const tallParser = remark().freeze();
+const tallParser = remark().use(math).freeze();
 
 export const parseTall = (text: string) => tallParser.parse(text);
 
@@ -33,10 +33,11 @@ const wideParser = remark()
       RemarkDisableTokenizers,
       {
         block: DISABLED_BLOCK_TOKENS,
-        inline: DISABLED_INLINE_TOKENS,
-      },
+        inline: DISABLED_INLINE_TOKENS
+      }
     ],
     newlines
   ])
+  .use(inlineMath);
 
 export const parseWide = (text: string) => wideParser.parse(text);


### PR DESCRIPTION
Adds math notation (LaTeX subset) support to GraphContent. Wide format graph content is restricted to only inline math e.g. `$x$`, where as tall format content may use display mode and environments. A demo:
<img width="584" alt="Screen Shot 2021-05-21 at 2 30 31 pm" src="https://user-images.githubusercontent.com/46801558/119082957-70529400-ba42-11eb-95b9-e626abe6bb34.png">
<img width="519" alt="Screen Shot 2021-05-21 at 2 42 57 pm" src="https://user-images.githubusercontent.com/46801558/119083205-d9d2a280-ba42-11eb-8098-9219f8ef28e3.png">

Open questions before this gets merged:
- What does design think of this?
- Usability, unless you're a madman at latex is kinda poor for longer equations. Could potentially use a preview? Maybe if we check that it parses correctly and prevent sending otherwise. 
- Absolutely ruins our bundle size with fonts and css, partly due to the (ab)use of url-loader. Should be addressed before merge.