### PR TITLE
chat: no s3, no blank space

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatInput.tsx
@@ -178,7 +178,14 @@ export class ChatInput extends Component<ChatInputProps, ChatInputState> {
           changeEvent={this.eventHandler}
           placeholder='Message...'
         />
-        <Box mx='12px' flexShrink={0} height='16px' width='16px' flexBasis='16px'>
+        <Box
+          mx='12px'
+          mr={this.props.canUpload ? '12px' : 3}
+          flexShrink={0}
+          height='16px'
+          width='16px'
+          flexBasis='16px'
+        >
           <Icon
             icon='Dojo'
             cursor='pointer'
@@ -186,9 +193,16 @@ export class ChatInput extends Component<ChatInputProps, ChatInputState> {
             color={state.inCodeMode ? 'blue' : 'black'}
           />
         </Box>
-        <Box ml='12px' mr={3} flexShrink={0} height='16px' width='16px' flexBasis='16px'>
-          {this.props.canUpload ? (
-            this.props.uploading ? (
+        {this.props.canUpload ? (
+          <Box
+            ml='12px'
+            mr={3}
+            flexShrink={0}
+            height='16px'
+            width='16px'
+            flexBasis='16px'
+          >
+            {this.props.uploading ? (
               <LoadingSpinner />
             ) : (
               <Icon
@@ -200,9 +214,9 @@ export class ChatInput extends Component<ChatInputProps, ChatInputState> {
                   this.props.promptUpload().then(this.uploadSuccess)
                 }
               />
-            )
-          ) : null}
-        </Box>
+            )}
+          </Box>
+        ) : null}
         {MOBILE_BROWSER_REGEX.test(navigator.userAgent) ?
           <Box
             ml={2}


### PR DESCRIPTION
Gets rid of a blank space in ChatInput if S3 isn't configured.

![Frame 1](https://user-images.githubusercontent.com/748181/119280722-9d4ca580-bc00-11eb-9b26-4e75b1d79b47.png)

fixes urbit/landscape#892