### PR TITLE
arvo: add +de-case to speed up +de-beam, prime cache in +settle:va

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -1,6 +1,5 @@
 ::  graph-store [landscape]
 ::
-::
 /+  store=graph-store, sigs=signatures, res=resource, default-agent, dbug, verb
 ~%  %graph-store-top  ..part  ~
 |%

--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -33,7 +33,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?>  ?=([@ ~] index.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -49,7 +49,7 @@
 ++  grab
   |%
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  ~|(index+index.p.ip !!)
         ::  top-level link post; title and url

--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -43,7 +43,7 @@
   :: +noun: validate post
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post contents.p [%text '']~)
     =/  ip  ;;(indexed-post p)
     ?>  ?=(^ contents.p.ip)
     ip

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -58,7 +58,7 @@
   :: +noun: validate publish note
   :: 
   ++  noun
-    |=  p=*
+    |:  p=`*`%*(. *indexed-post index.p [0 ~])
     =/  ip  ;;(indexed-post p)
     ?+    index.p.ip  !!
     ::  top level post must have no content

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -252,11 +252,13 @@
   ::  %what: update from files
   ::  %whey: produce $mass                    :: XX remove, scry
   ::  %verb: toggle laconicity
+  ::  %whiz: prime vane caches
   ::
   $%  [%trim p=@ud]
       [%what p=(list (pair path (cask)))]
       [%whey ~]
       [%verb p=(unit ?)]
+      [%whiz ~]
   ==
 +$  wasp
   ::  %crud: reroute $ovum with $goof
@@ -1483,6 +1485,9 @@
           %verb  ..pith(lac.fad ?~(p.waif !lac.fad u.p.waif))
           %what  ~(kel what p.waif)
           %whey  ..pith(out [[//arvo mass/whey] out])
+        ::
+            %whiz
+          ..pith(van.mod (~(run by van.mod) |=(vane (settle:va:part vase))))
         ==
       ::
       ++  peek

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -291,12 +291,13 @@
   |=(b=beam =*(s scot `path`[(s %p p.b) q.b (s r.b) s.b]))
 ::
 ++  de-beam
+  ~/  %de-beam
   |=  p=path
   ^-  (unit beam)
   ?.  ?=([@ @ @ *] p)  ~
   ?~  who=(slaw %p i.p)  ~
   ?~  des=?~(i.t.p (some %$) (slaw %tas i.t.p))  ~  :: XX +sym ;~(pose low (easy %$))
-  ?~  ved=(slay i.t.t.p)  ~
+  ?~  ved=(sloy i.t.t.p)  ~
   ?.  ?=([%$ case] u.ved)  ~
   `(unit beam)`[~ [`ship`u.who `desk`u.des `case`p.u.ved] t.t.t.p]
 ::
@@ -308,6 +309,7 @@
   ~(rent co [%many $/tas/way.vis $/tas/car.vis ~])
 ::
 ++  de-omen
+  ~/  %de-omen
   |=  pax=path
   ^-  (unit [vis=view bem=beam])
   ?~  pax  ~

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -297,9 +297,17 @@
   ?.  ?=([@ @ @ *] p)  ~
   ?~  who=(slaw %p i.p)  ~
   ?~  des=?~(i.t.p (some %$) (slaw %tas i.t.p))  ~  :: XX +sym ;~(pose low (easy %$))
-  ?~  ved=(sloy i.t.t.p)  ~
-  ?.  ?=([%$ case] u.ved)  ~
-  `(unit beam)`[~ [`ship`u.who `desk`u.des `case`p.u.ved] t.t.t.p]
+  ?~  ved=(en-case i.t.t.p)  ~
+  `(unit beam)`[~ [`ship`u.who `desk`u.des `case`u.ved] t.t.t.p]
+::
+++  en-case
+  ~/  %en-case
+  |=  =knot
+  ^-  (unit case)
+  ?^  num=(slaw %ud knot)  `[%ud u.num]
+  ?^  wen=(slaw %da knot)  `[%da u.wen]
+  ?~  lab=(slaw %tas knot)  ~
+  `[%tas u.lab]
 ::
 ++  en-omen
   |=  [vis=view bem=beam]

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -298,10 +298,10 @@
   ?~  who=(slaw %p i.p)  ~
   ?~  des=?~(i.t.p (some %$) (slaw %tas i.t.p))  ~  :: XX +sym ;~(pose low (easy %$))
   ?~  ved=(de-case i.t.t.p)  ~
-  `(unit beam)`[~ [`ship`u.who `desk`u.des `case`u.ved] t.t.t.p]
+  `[[`ship`u.who `desk`u.des u.ved] t.t.t.p]
 ::
 ++  de-case
-  ~/  %en-case
+  ~/  %de-case
   |=  =knot
   ^-  (unit case)
   ?^  num=(slaw %ud knot)  `[%ud u.num]

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -297,10 +297,10 @@
   ?.  ?=([@ @ @ *] p)  ~
   ?~  who=(slaw %p i.p)  ~
   ?~  des=?~(i.t.p (some %$) (slaw %tas i.t.p))  ~  :: XX +sym ;~(pose low (easy %$))
-  ?~  ved=(en-case i.t.t.p)  ~
+  ?~  ved=(de-case i.t.t.p)  ~
   `(unit beam)`[~ [`ship`u.who `desk`u.des `case`u.ved] t.t.t.p]
 ::
-++  en-case
+++  de-case
   ~/  %en-case
   |=  =knot
   ^-  (unit case)
@@ -1010,8 +1010,11 @@
         ++  settle
           |=  van=vase
           ^-  (pair vase worm)
-          =/  [rig=vase wor=worm]  (~(slym wa *worm) van *vane-sample)
-          [van +:(~(slap wa wor) rig [%limb %scry])]
+          =|  sac=worm
+          =^  rig=vase  sac  (~(slym wa sac) van *vane-sample)
+          =^  gat=vase  sac  (~(slap wa sac) rig [%limb %scry])
+          =^  pro=vase  sac  (~(slap wa sac) gat [%limb %$])
+          [van +:(~(mint wa sac) p.pro [%$ 7])]
         ::
         ::  XX pass identity to preserve behavior?
         ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5952,13 +5952,6 @@
     ~
   [~ p.u.q.vex]
 ::
-++  sloy
-  |=  txt=@ta  ^-  (unit coin)
-  =/  maybe-da  (rush txt ;~(pfix sig (cook year when:so)))
-  ?^  maybe-da
-    `[%$ [%da u.maybe-da]]
-  (slay txt)
-::
 ++  smyt                                                ::  pretty print path
   |=  bon=path  ^-  tank
   :+  %rose  [['/' ~] ['/' ~] ~]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5952,6 +5952,13 @@
     ~
   [~ p.u.q.vex]
 ::
+++  sloy
+  |=  txt=@ta  ^-  (unit coin)
+  =/  maybe-da  (rush txt ;~(pfix sig (cook year when:so)))
+  ?^  maybe-da
+    `[%$ [%da u.maybe-da]]
+  (slay txt)
+::
 ++  smyt                                                ::  pretty print path
   |=  bon=path  ^-  tank
   :+  %rose  [['/' ~] ['/' ~] ~]

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2102,6 +2102,7 @@
       [%g task:gall]
       [%i task:iris]
       [%j task:jael]
+      [%$ %whiz ~]
       [@tas %meta vase]
   ==
 ::  full vane names are required in vanes

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -159,7 +159,10 @@
       ~<  %slog.[0 leaf+"gall: molted"]
       ::  +molt should never notify its client about agent changes
       ::
-      =-  [(skip -< |=(move ?=([* %give %onto *] +<))) ->]
+      =-  :_  ->
+          %+  welp
+            (skip -< |=(move ?=([* %give %onto *] +<)))
+          [^duct %pass /whiz/gall %$ %whiz ~]~
       =/  adult  adult-core
       =.  state.adult
         [%7 system-duct outstanding contacts yokes=~ blocked]:spore


### PR DESCRIPTION
Made `+look` in arvo significantly faster. A trace that has the eyre performance improvements merged in already takes about 120ms less per chat message sent. Down from 300ms to 180ms.

<img width="835" alt="Screen Shot 2021-05-26 at 5 18 07 PM" src="https://user-images.githubusercontent.com/1377557/119738478-67006780-be46-11eb-939a-17d4eb40098c.png">

