### PR TITLE
tokenizeMessage: revenge

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -3,9 +3,9 @@ import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
 const URL_REGEX = new RegExp(String(/^(.*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)([\s\S]*)/.source));
 
-const PATP_REGEX = /^(.)(~[a-z_-]+)(.*)/;
+const PATP_REGEX = /^(.)(~[a-z_-]+)([\s\S]*)/;
 
-const GROUP_REGEX = new RegExp(String(/^( *)(~[-a-z_]+\/[-a-z]+)(.*)/.source));
+const GROUP_REGEX = new RegExp(String(/^( *)(~[-a-z_]+\/[-a-z]+)([\s\S]*)/.source));
 
 const convertToGroupRef = group => `web+urbitgraph://group/${group}`;
 
@@ -18,7 +18,6 @@ export const isUrl = (str) => {
 };
 
 const tokenizeMessage = (text) => {
-  console.log(text);
   const messages = [];
   // by line
   let blocks = [];
@@ -35,7 +34,6 @@ const tokenizeMessage = (text) => {
       return;
     }
     while(str.length > 0) {
-      console.log(str);
       const resetAndPush = (content) => {
         blocks.push(currBlock.join(''));
         messages.push({ text: blocks.join('`') });

--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -1,7 +1,7 @@
 import urbitOb from 'urbit-ob';
 import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
-const URL_REGEX = new RegExp(String(/^(.*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)([\s\S]*)/.source));
+const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)([\s\S]*)/.source));
 
 const PATP_REGEX = /^([\s\S]*?)(~[a-z_-]+)([\s\S]*)/;
 

--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -3,9 +3,9 @@ import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
 const URL_REGEX = new RegExp(String(/^(.*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)([\s\S]*)/.source));
 
-const PATP_REGEX = /^(.)(~[a-z_-]+)([\s\S]*)/;
+const PATP_REGEX = /^([\s\S]*?)(~[a-z_-]+)([\s\S]*)/;
 
-const GROUP_REGEX = new RegExp(String(/^( *)(~[-a-z_]+\/[-a-z]+)([\s\S]*)/.source));
+const GROUP_REGEX = new RegExp(String(/^([\s\S ]*?)(~[-a-z_]+\/[-a-z]+)([\s\S]*)/.source));
 
 const convertToGroupRef = group => `web+urbitgraph://group/${group}`;
 
@@ -78,7 +78,7 @@ const tokenizeMessage = (text) => {
     currBlock = [];
   });
   messages.push({ text: blocks.join('`') });
-
+  console.log(messages);
   return messages;
 };
 

--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -1,7 +1,7 @@
 import urbitOb from 'urbit-ob';
 import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
-const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+\w)([\s\S]*)/.source));
+const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+[\w/])([\s\S]*)/.source));
 
 const PATP_REGEX = /^([\s\S]*?)(~[a-z_-]+)([\s\S]*)/;
 

--- a/pkg/interface/src/logic/lib/tokenizeMessage.test.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.test.js
@@ -20,10 +20,10 @@ describe('tokenizeMessage', () => {
     expect(mention).toEqual('~hastuc-dibtux');
   });
   it('should parse urls', () => {
-    const example = 'this is a url: http://tlon.io';
+    const example = 'this is a url: http://tlon.io/';
     const [{ text }, { url }] = tokenizeMessage(example);
     expect(text).toEqual('this is a url: ');
-    expect(url).toEqual('http://tlon.io');
+    expect(url).toEqual('http://tlon.io/');
   });
   it('should ignore urls in codemode', () => {
     const example = 'some urls `http://ignore.me` http://urbit.org';

--- a/pkg/interface/src/logic/lib/tokenizeMessage.test.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import tokenizeMessage from './tokenizeMessage';
 
 describe('tokenizeMessage', () => {
@@ -43,5 +44,25 @@ describe('tokenizeMessage', () => {
     const example = 'test \n \n foo \n \n \n';
     const [{ text }] = tokenizeMessage(example);
     expect(text).toEqual(example);
+  });
+
+  it('should handle multiline messages with references', () => {
+    const example = 'web+urbitgraph://group/~fabled-faster/interface-testing-facility/graph/~hastuc-dibtux/test-book-7531/170141184505064871297992714192687202304\n\nlol here [is a link](https://urbit.org)';
+    const [{ text }, { reference }, { text: text2 }] = tokenizeMessage(example);
+    expect(text).toEqual('');
+    expect(reference.graph.graph).toEqual('/ship/~hastuc-dibtux/test-book-7531');
+    expect(reference.graph.index).toEqual('/170141184505064871297992714192687202304');
+    expect(text2).toEqual('\n\nlol here [is a link](https://urbit.org)');
+  });
+
+  it('should handle links on newlines after references', () => {
+    const example = 'web+urbitgraph://group/~fabled-faster/interface-testing-facility/graph/~hastuc-dibtux/test-book-7531/170141184505064871297992714192687202304\n\nhttps://urbit.org a link is here!';
+    const [{ text }, { reference }, { text: text2 }, { url }, { text: text3 }] = tokenizeMessage(example);
+    expect(text).toEqual('');
+    expect(reference.graph.graph).toEqual('/ship/~hastuc-dibtux/test-book-7531');
+    expect(reference.graph.index).toEqual('/170141184505064871297992714192687202304');
+    expect(text2).toEqual('\n\n');
+    expect(url).toEqual('https://urbit.org');
+    expect(text3).toEqual(' a link is here!');
   });
 });


### PR DESCRIPTION
- Patp regex is less flexible, only accepts one "any" character before a mention.
- Links regex parses _before_ group reference parser to prevent breaking references.
- Groups regex will only match on preceding spaces, there will never be a case where people are mingling it mid-word like `Here's a message~haddef-sigwen/mygroup`.
- All regex looks for `\s\S` now, not `.`, because `.` doesn't match on whitespace characters eg. line breaks, thus eating the remainder of a message that has line breaks after, well, any mention or URL.

You can give this a shot with a notebook's comment field, if you segregate links to groups, mentions, URLs with line breaks.