### PR TITLE
dill: support next runtime's inputs

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1070,15 +1070,15 @@
     ::
   +$  blew  [p=@ud q=@ud]                               ::  columns rows
   +$  belt                                              ::  client input
-    $%  bolt                                            ::  simple input
-        [%mod mod=?(%ctl %met %hyp) key=bolt]           ::  w/ modifier
+    $?  bolt                                            ::  simple input
+    $%  [%mod mod=?(%ctl %met %hyp) key=bolt]           ::  w/ modifier
         [%txt p=(list @c)]                              ::  utf32 text
         ::TODO  consider moving %hey, %rez, %yow here   ::
-        ::TMP  forward backwards-compatibility
-        ::
-        [%ctl p=@c]
-        [%met p=@c]
-    ==                                                  ::
+        ::TMP  forward backwards-compatibility          ::
+        ::                                              ::
+        [%ctl p=@c]                                     ::
+        [%met p=@c]                                     ::
+    ==  ==                                              ::
   +$  bolt                                              ::  simple input
     $@  @c                                              ::  simple keystroke
     $%  [%aro p=?(%d %l %r %u)]                         ::  arrow key

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1069,14 +1069,23 @@
   ::::                                                  ::  (1d2)
     ::
   +$  blew  [p=@ud q=@ud]                               ::  columns rows
-  +$  belt                                              ::  old belt
+  +$  belt                                              ::  client input
+    $%  bolt                                            ::  simple input
+        [%mod mod=?(%ctl %met %hyp) key=bolt]           ::  w/ modifier
+        [%txt p=(list @c)]                              ::  utf32 text
+        ::TODO  consider moving %hey, %rez, %yow here   ::
+        ::TMP  forward backwards-compatibility
+        ::
+        [%ctl p=@c]
+        [%met p=@c]
+    ==                                                  ::
+  +$  bolt                                              ::  simple input
+    $@  @c                                              ::  simple keystroke
     $%  [%aro p=?(%d %l %r %u)]                         ::  arrow key
         [%bac ~]                                        ::  true backspace
-        [%ctl p=@c]                                     ::  control-key
         [%del ~]                                        ::  true delete
-        [%met p=@c]                                     ::  meta-key
+        [%hit r=@ud c=@ud]                              ::  mouse click
         [%ret ~]                                        ::  return
-        [%txt p=(list @c)]                              ::  utf32 text
     ==                                                  ::
   +$  blit                                              ::  old blit
     $%  [%bel ~]                                        ::  make a noise

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -106,7 +106,6 @@
           %flow  +>
           %harm  +>
           %hail  (send %hey ~)
-          %belt  (send `dill-belt`p.kyz)
           %text  (from %out (tuba p.kyz))
           %crud  ::  (send `dill-belt`[%cru p.kyz q.kyz])
                  (crud p.kyz q.kyz)
@@ -116,6 +115,18 @@
           %pack  (dump kyz)
           %crop  (dump trim+p.kyz)
           %verb  (pass /verb %$ kyz)
+        ::
+            %belt
+          %-  send
+          ::TMP  forwards compatibility with next-dill
+          ::
+          ?@  p.kyz  [%txt p.kyz ~]
+          ?:  ?=(%hit -.p.kyz)  [%txt ~]
+          ?.  ?=(%mod -.p.kyz)  p.kyz
+          =/  =@c
+            ?@  key.p.kyz  key.p.kyz
+            ?:(?=(?(%bac %del %ret) -.key.p.kyz) `@`-.key.p.kyz ~-)
+          ?:(?=(%met mod.p.kyz) [%met c] [%ctl c])
         ==
       ::
       ++  crud


### PR DESCRIPTION
Quick and dirty forward-compatibility by pulling the new belts (from #4463) into the current dill. Intent is to send this out prior to the new dill/runtime combo as an appetizer OTA.

This, along with the new runtime doing best-effort handling of current dill's blits, will ensure that the new runtime is reasonably usable even with the old dill.