### PR TITLE
arvo: add %whiz option to  that allows one to prime the compiler cache

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -252,11 +252,13 @@
   ::  %what: update from files
   ::  %whey: produce $mass                    :: XX remove, scry
   ::  %verb: toggle laconicity
+  ::  %whiz: prime vane caches
   ::
   $%  [%trim p=@ud]
       [%what p=(list (pair path (cask)))]
       [%whey ~]
       [%verb p=(unit ?)]
+      [%whiz ~]
   ==
 +$  wasp
   ::  %crud: reroute $ovum with $goof
@@ -1483,6 +1485,9 @@
           %verb  ..pith(lac.fad ?~(p.waif !lac.fad u.p.waif))
           %what  ~(kel what p.waif)
           %whey  ..pith(out [[//arvo mass/whey] out])
+        ::
+            %whiz
+          ..pith(van.mod (~(run by van.mod) |=(vane (settle:va:part vase))))
         ==
       ::
       ++  peek

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2102,6 +2102,7 @@
       [%g task:gall]
       [%i task:iris]
       [%j task:jael]
+      [%$ %whiz ~]
       [@tas %meta vase]
   ==
 ::  full vane names are required in vanes

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -160,8 +160,9 @@
       ::  +molt should never notify its client about agent changes
       ::
       =-  :_  ->
-          :_  (skip -< |=(move ?=([* %give %onto *] +<)))
-          [^duct %pass /whiz/gall %$ %whiz ~]
+          %+  welp
+            (skip -< |=(move ?=([* %give %onto *] +<)))
+          [^duct %pass /whiz/gall %$ %whiz ~]~
       =/  adult  adult-core
       =.  state.adult
         [%7 system-duct outstanding contacts yokes=~ blocked]:spore

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -159,7 +159,9 @@
       ~<  %slog.[0 leaf+"gall: molted"]
       ::  +molt should never notify its client about agent changes
       ::
-      =-  [(skip -< |=(move ?=([* %give %onto *] +<))) ->]
+      =-  :_  ->
+          :_  (skip -< |=(move ?=([* %give %onto *] +<)))
+          [^duct %pass /whiz/gall %$ %whiz ~]
       =/  adult  adult-core
       =.  state.adult
         [%7 system-duct outstanding contacts yokes=~ blocked]:spore


### PR DESCRIPTION
This PR saves us an additional 15-20ms per event by reducing arvo scry overhead.

<img width="768" alt="Screen Shot 2021-05-27 at 1 26 28 PM" src="https://user-images.githubusercontent.com/1377557/119877926-37f20080-beef-11eb-8560-a0f3f8ad7f48.png">
<img width="768" alt="Screen Shot 2021-05-27 at 1 26 46 PM" src="https://user-images.githubusercontent.com/1377557/119877928-39232d80-beef-11eb-979d-ffacbf65d8ff.png">
