### PR TITLE
npm/http-api: changed relative dependency

### DIFF
--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": {
@@ -52,12 +52,15 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@microsoft/fetch-event-source": "^2.0.0",
-    "@urbit/api": "file:../api",
+    "@urbit/api": "^1.1.0",
     "browser-or-node": "^1.3.0",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "node-fetch": "^2.6.1",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.1.1"
+  },
+  "bundledDependencies": {
+    "@urbit/api"
   }
 }


### PR DESCRIPTION
Targeting master so it gets pushed to npm faster. LMK if there's a problem with that. Fixes https://github.com/urbit/urbit/issues/4941