### PR TITLE
leap: render custom app tiles

### DIFF
--- a/pkg/interface/src/logic/lib/omnibox.js
+++ b/pkg/interface/src/logic/lib/omnibox.js
@@ -53,16 +53,16 @@ const appIndex = function (apps) {
   const applications = [];
   Object.keys(apps)
     .filter((e) => {
-      return apps[e]?.type?.basic;
+      return !['weather','clock'].includes(e);
     })
     .sort((a, b) => {
       return a.localeCompare(b);
     })
     .map((e) => {
       const obj = result(
-        apps[e].type.basic.title,
-        apps[e].type.basic.linkedUrl,
-        apps[e].type.basic.title,
+        apps[e].type?.basic?.title || apps[e].type.custom?.tile || e,
+        apps[e]?.type.basic?.linkedUrl || apps[e]?.type.custom?.linkedUrl || '',
+        apps[e]?.type?.basic?.title || apps[e].type.custom?.tile || e,
         null
       );
       applications.push(obj);

--- a/pkg/interface/src/views/components/leap/OmniboxResult.tsx
+++ b/pkg/interface/src/views/components/leap/OmniboxResult.tsx
@@ -81,12 +81,15 @@ export class OmniboxResult extends Component<OmniboxResultProps, OmniboxResultSt
     if (
       defaultApps.includes(icon.toLowerCase()) ||
       icon.toLowerCase() === 'links' ||
-      icon.toLowerCase() === 'terminal'
+      icon.toLowerCase() === 'terminal' ||
+      icon === 'btc-wallet'
     ) {
       if (icon === 'Link') {
         icon = 'Collection';
       } else if (icon === 'Terminal') {
         icon = 'Dojo';
+      } else if (icon === 'btc-wallet') {
+        icon = 'Bitcoin';
       }
       graphic = (
         <Icon


### PR DESCRIPTION
Fixes urbit/landscape#915

<img width="756" alt="image" src="https://user-images.githubusercontent.com/20846414/120044619-32beaf80-bfdc-11eb-9465-90686340ed35.png">

- Iterates through all apps regardless of tile type when indexing; instead just filters the two tiles we don't want in the index
- Provides appropriate fallback values for custom tile cases

Leap result logic is getting a little long in the tooth, but will probably amend its index behaviour quite soon anyhow. BTC Wallet's entry has no title; it feels weirder to special case it in FE, probably should add a title to it on back-end?