### PR TITLE
push-hook: fix version negotiation

### DIFF
--- a/pkg/arvo/lib/push-hook.hoon
+++ b/pkg/arvo/lib/push-hook.hoon
@@ -300,8 +300,10 @@
         unversioned
       =/  =resource
         (de-path:resource t.t.path)
+      =/  requested=@ud
+        (slav %ud i.t.t.t.t.t.path)
       =/  =mark
-        (append-version:ver (slav %ud i.t.t.t.t.t.path))
+        (append-version:ver (min requested version.config))
       ?.  (supported:ver mark)
         :_  this
         (fact-init-kick:io version+!>(min-version.config))
@@ -476,7 +478,7 @@
       %+  turn  ~(tap by paths)
       |=  [fact-ver=@ud paths=(set path)]
       =/  =mark
-        (append-version:ver fact-ver)
+        (append-version:ver (min version.config fact-ver))
       (fact:io (convert-from:ver mark q.cage) ~(tap in paths))
     ::  TODO: deprecate
     ++  unversioned


### PR DESCRIPTION
Addresses a bug where if the publisher could not perform the fact
conversion, it would not be deferred to the subscriber, preventing the
subscriber from being ahead of the publisher