### PR TITLE
btc: stop storing bip32 core in btc-wallet state

### DIFF
--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -19,10 +19,26 @@
 ::
 +$  versioned-state
     $%  state-0
+        state-1
     ==
 ::
 +$  state-0
   $:  %0
+      prov=(unit provider)
+      walts=(map xpub:bc walt-0)
+      =btc-state
+      =history
+      curr-xpub=(unit xpub:bc)
+      =scans
+      =params
+      feybs=(map ship sats)
+      =piym
+      =poym
+      ahistorical-txs=(set txid)
+  ==
+::
++$  state-1
+  $:  %1
       prov=(unit provider)
       walts=(map xpub:bc walt)
       =btc-state
@@ -39,7 +55,7 @@
 +$  card  card:agent:gall
 ::
 --
-=|  state-0
+=|  state-1
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
@@ -69,7 +85,7 @@
       ==
   %_  this
       state
-    :*  %0
+    :*  %1
         ~
         *(map xpub:bc walt)
         *^btc-state
@@ -96,8 +112,16 @@
   =|  cards=(list card)
   |-
   ?-  -.ver
-      %0
+      %1
     [cards this(state ver)]
+  ::
+      %0
+    =/  new-walts=(map xpub:bc walt)
+      %-  ~(run by walts.ver)
+      |=  old-walt=walt-0
+      ^-  walt
+      old-walt(wilt +6:wilt.old-walt)
+    $(ver [%1 +.ver(walts new-walts)])
   ==
 ::
 ++  on-poke
@@ -790,7 +814,7 @@
     (handle-address-info address.p.upd utxos.p.upd used.p.upd)
     ::
       %tx-info
-    =/  [cards=(list card) sty=state-0]
+    =/  [cards=(list card) sty=state-1]
       (handle-tx-info info.p.upd)
     :_  sty
     [(poke-internal [%close-pym info.p.upd]) cards]

--- a/pkg/arvo/lib/btc.hoon
+++ b/pkg/arvo/lib/btc.hoon
@@ -39,7 +39,7 @@
   :*  xpub
       network
       fprint
-      (from-extended:bip32 (trip xpub))
+      +6:(from-extended:bip32 (trip xpub))
       bipt
       *wach
       [0 0]
@@ -170,7 +170,7 @@
     ^-  hexb:bc
     =/  pk=@ux
       %-  compress-point:ecc
-      pub:(derive-public:(derive-public:wilt.w (@ chyg)) idx)
+      pub:(derive-public:(~(derive-public bip32 wamp.w) chyg) idx)
     [(met 3 pk) pk]
   ::
   ++  hdkey

--- a/pkg/arvo/sur/btc-wallet.hoon
+++ b/pkg/arvo/sur/btc-wallet.hoon
@@ -59,6 +59,7 @@
 +$  wach  (map address addi)
 +$  scon  $~([max-index max-index] (pair idx idx))
 +$  wilt  _bip32
++$  wamp  [prv=@ pub=[x=@ y=@] cad=@ dep=@ud ind=@ud pif=@]
 ::
 ::  walt: wallet datastructure
 ::  scanned: whether the wallet's addresses have been checked for prior activity
@@ -66,11 +67,25 @@
 ::  max-gap: maximum number of consec blank addresses before wallet stops scanning
 ::  confs:   confirmations required (after this is hit for an address, wallet stops refreshing it)
 ::
-+$  walt
++$  walt-0
   $:  =xpub
       =network
       =fprint
       =wilt
+      =bipt
+      =wach
+      =nixt
+      scanned=?
+      scan-to=scon
+      max-gap=@ud
+      confs=@ud
+  ==
+::
++$  walt
+  $:  =xpub
+      =network
+      =fprint
+      =wamp
       =bipt
       =wach
       =nixt


### PR DESCRIPTION
Instead just store the sample that gets passed into the core