### PR TITLE
graph-push-hook: disable proxying of DM updates

### DIFF
--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -119,6 +119,9 @@
   ?-  -.q.update
       %add-nodes
     =|  cards=(list card)
+    ?:  ?=(^ (rush name.rid ;~(pfix (jest 'dm--') fed:ag)))
+      ::  block new DM messages
+      [~ ~]
     =^  allowed  cards  (is-allowed-add:hc rid nodes.q.update)
     ?.  allowed
       [cards ~]


### PR DESCRIPTION
Prevents messages from being dropped during the OTA, when there's a mismatch in deployed versions between host and subscriber. 