### PR TITLE
meta: update to janeway v0.15.2

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaredtobin/janeway:v0.15.1
+FROM jaredtobin/janeway:v0.15.2
 COPY entrypoint.sh /entrypoint.sh
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/glob/entrypoint.sh
+++ b/.github/actions/glob/entrypoint.sh
@@ -13,7 +13,7 @@ chmod 600 id_ssh.pub
 janeway release glob-all --dev --no-pill \
     --credentials service-account \
     --ssh-key id_ssh \
-    --do-it-live \
+    --ci \
   | bash
 
 SHORTHASH=$(git rev-parse --short HEAD)
@@ -21,12 +21,12 @@ SHORTHASH=$(git rev-parse --short HEAD)
 janeway release prepare-ota arvo-glob-"$SHORTHASH" "$1" \
     --credentials service-account \
     --ssh-key id_ssh \
-    --do-it-live \
+    --ci \
   | bash
 
 janeway release perform-ota "$1" \
     --credentials service-account \
     --ssh-key id_ssh \
-    --do-it-live \
+    --ci \
   | bash
 


### PR DESCRIPTION
Despite the benign-looking patch version bump, the latest version of janeway drops support for the `--do-it-live` flag in favour of `--ci` (which also does some additional CI-specific stuff).