### PR TITLE
graph-store + validators: stop using +grab:noun and switch to using a static conversion to %graph-indexed-post

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -19,7 +19,7 @@
 +$  debug-input  [%validate-graph =resource:store]
 ::
 +$  cache
-  $:  validators=(map mark dais:clay)
+  $:  validators=(map mark $-(indexed-post:store indexed-post:store))
   ==
 ::
 ::  TODO: come back to this and potentially use ford runes or otherwise
@@ -627,22 +627,27 @@
     |=  [=graph:store mark=(unit mark:store)]
     ^-  [? _state]
     ?~  mark   [%.y state]
-    =/  has-dais  (~(has by validators) u.mark)
-    =/  =dais:clay
-      ?:  has-dais
+    =/  has-validator  (~(has by validators) u.mark)
+    =/  validate=$-(indexed-post:store indexed-post:store)
+      ?:  has-validator
         (~(got by validators) u.mark)
-      .^  =dais:clay
-          %cb
-          /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[u.mark]
+      .^  $-(indexed-post:store indexed-post:store)
+          %cf
+          (scot %p our.bowl)
+          q.byk.bowl
+          (scot %da now.bowl)
+          u.mark
+          %graph-indexed-post
+          ~
       ==
-    :_  state(validators (~(put by validators) u.mark dais))
+    :_  state(validators (~(put by validators) u.mark validate))
     |-  ^-  ?
     ?~  graph  %.y
     %+  roll  (tap:orm graph)
     |=  [[=atom =node:store] out=?]
     ^-  ?
     ?&  ?|  ?=(%| -.post.node)
-            ?=(^ (vale:dais [atom p.post.node]))
+            ?=(^ (validate [atom p.post.node]))
         ==
       ::
         ?-  -.children.node

--- a/pkg/arvo/mar/graph/indexed-post.hoon
+++ b/pkg/arvo/mar/graph/indexed-post.hoon
@@ -1,0 +1,14 @@
+/-  *post
+|_  i=indexed-post
+++  grow
+  |%
+  ++  noun  i
+  --
+::
+++  grab
+  |%
+  ++  noun  indexed-post
+  --
+::
+++  grad  %noun
+--

--- a/pkg/arvo/mar/graph/validator/chat.hoon
+++ b/pkg/arvo/mar/graph/validator/chat.hoon
@@ -4,6 +4,11 @@
   |%
   ++  noun  i
   ::
+  ++  graph-indexed-post
+    ^-  indexed-post
+    ?>  ?=([@ ~] index.p.i)
+    i
+  ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
     ^-  permissions:graph
@@ -30,13 +35,10 @@
     =-  [- post(index -)]
     [atom ~]
   --
-++  grab
+::
+++  grab  
   |%
-  ++  noun
-    |:  p=`*`%*(. *indexed-post index.p [0 ~])
-    =/  ip  ;;(indexed-post p)
-    ?>  ?=([@ ~] index.p.ip)
-    ip
+  ++  noun  indexed-post
   --
 ::
 ++  grad  %noun

--- a/pkg/arvo/mar/graph/validator/dm.hoon
+++ b/pkg/arvo/mar/graph/validator/dm.hoon
@@ -3,6 +3,13 @@
 ++  grow
   |%
   ++  noun  i
+  ::
+  ++  graph-indexed-post
+    ^-  indexed-post
+    ?>  ?=(?([@ ~] [@ @ ~]) index.p.i)
+    ?>  (lth i.index.p.i (bex 128))
+    i
+  ::
   ++  notification-kind
     ^-  (unit notif-kind:hark)
     ?+  index.p.i  ~
@@ -12,12 +19,7 @@
   --
 ++  grab
   |%
-  ++  noun
-    |:  p=`*`%*(. *indexed-post index.p [0 0 ~])
-    =/  ip  ;;(indexed-post p)
-    ?>  ?=(?([@ ~] [@ @ ~]) index.p.ip)
-    ?>  (lth i.index.p.ip (bex 128))
-    ip
+  ++  noun  indexed-post
   --
 ::
 ++  grad  %noun

--- a/pkg/arvo/mar/graph/validator/link.hoon
+++ b/pkg/arvo/mar/graph/validator/link.hoon
@@ -4,6 +4,28 @@
   |%
   ++  noun  i
   ::
+  ++  graph-indexed-post
+    ^-  indexed-post
+    ?+    index.p.i  ~|(index+index.p.i !!)
+        ::  top-level link post; title and url
+        ::
+        [@ ~]
+      ?>  ?=([[%text @] $%([%url @] [%reference *]) ~] contents.p.i)
+      i
+    ::
+        ::  comment on link post; container structure
+        ::
+        [@ @ ~]
+      ?>  ?=(~ contents.p.i)
+      i
+    ::
+        ::  comment on link post; comment text
+        ::
+        [@ @ @ ~]
+      ?>  ?=(^ contents.p.i)
+      i
+    ==
+  ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
     ^-  permissions:graph
@@ -48,28 +70,7 @@
   --
 ++  grab
   |%
-  ++  noun
-    |:  p=`*`%*(. *indexed-post index.p [0 0 ~])
-    =/  ip  ;;(indexed-post p)
-    ?+    index.p.ip  ~|(index+index.p.ip !!)
-        ::  top-level link post; title and url
-        ::
-        [@ ~]
-      ?>  ?=([[%text @] $%([%url @] [%reference *]) ~] contents.p.ip)
-      ip
-    ::
-        ::  comment on link post; container structure
-        ::
-        [@ @ ~]
-      ?>  ?=(~ contents.p.ip)
-      ip
-    ::
-        ::  comment on link post; comment text
-        ::
-        [@ @ @ ~]
-      ?>  ?=(^ contents.p.ip)
-      ip
-    ==
+  ++  noun  indexed-post
   --
 ++  grad  %noun
 --

--- a/pkg/arvo/mar/graph/validator/post.hoon
+++ b/pkg/arvo/mar/graph/validator/post.hoon
@@ -3,6 +3,12 @@
 ++  grow
   |%
   ++  noun  i
+  ::
+  ++  graph-indexed-post
+    ^-  indexed-post
+    ?>  ?=(^ contents.p.i)
+    i
+  ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
     ^-  permissions:graph
@@ -40,13 +46,7 @@
   --
 ++  grab
   |%
-  :: +noun: validate post
-  :: 
-  ++  noun
-    |:  p=`*`%*(. *indexed-post contents.p [%text '']~)
-    =/  ip  ;;(indexed-post p)
-    ?>  ?=(^ contents.p.ip)
-    ip
+  ++  noun  indexed-post
   --
 ::
 ++  grad  %noun

--- a/pkg/arvo/mar/graph/validator/publish.hoon
+++ b/pkg/arvo/mar/graph/validator/publish.hoon
@@ -3,6 +3,44 @@
 ++  grow
   |%
   ++  noun  i
+  ::
+  ++  graph-indexed-post
+    ^-  indexed-post
+    ?+    index.p.i  !!
+    ::  top level post must have no content
+        [@ ~]
+      ?>  ?=(~ contents.p.i)
+      i
+    ::  container for revisions
+    ::
+        [@ %1 ~]  
+      ?>  ?=(~ contents.p.i)
+      i
+    ::  specific revision
+    ::  first content is the title
+    ::  revisions are numbered by the revision count
+    ::  starting at one
+        [@ %1 @ ~]
+      ?>  ?=([* * *] contents.p.i)
+      ?>  ?=(%text -.i.contents.p.i)
+      i
+    ::  container for comments
+    ::
+        [@ %2 ~]
+      ?>  ?=(~ contents.p.i)
+      i
+    ::  container for comment revisions
+    ::
+        [@ %2 @ ~]
+      ?>  ?=(~ contents.p.i)
+      i
+    ::  specific comment revision
+    ::
+        [@ %2 @ @ ~]
+      ?>  ?=(^ contents.p.i)
+      i
+    ==
+  ::
   ++  graph-permissions-add
     |=  vip=vip-metadata:met
     ^-  permissions:graph
@@ -55,45 +93,7 @@
   --
 ++  grab
   |%
-  :: +noun: validate publish note
-  :: 
-  ++  noun
-    |:  p=`*`%*(. *indexed-post index.p [0 ~])
-    =/  ip  ;;(indexed-post p)
-    ?+    index.p.ip  !!
-    ::  top level post must have no content
-        [@ ~]
-      ?>  ?=(~ contents.p.ip)
-      ip
-    ::  container for revisions
-    ::
-        [@ %1 ~]  
-      ?>  ?=(~ contents.p.ip)
-      ip
-    ::  specific revision
-    ::  first content is the title
-    ::  revisions are numbered by the revision count
-    ::  starting at one
-        [@ %1 @ ~]
-      ?>  ?=([* * *] contents.p.ip)
-      ?>  ?=(%text -.i.contents.p.ip)
-      ip
-    ::  container for comments
-    ::
-        [@ %2 ~]
-      ?>  ?=(~ contents.p.ip)
-      ip
-    ::  container for comment revisions
-    ::
-        [@ %2 @ ~]
-      ?>  ?=(~ contents.p.ip)
-      ip
-    ::  specific comment revision
-    ::
-        [@ %2 @ @ ~]
-      ?>  ?=(^ contents.p.ip)
-      ip
-    ==
+  ++  noun  indexed-post
   --
 ::
 ++  grad  %noun


### PR DESCRIPTION
@belisarius222  recommended I do this recently, and I tested it and it is indeed significantly faster (by about ~20ms for a single chat / publish / link / feed message). Tested to work on Chat, Publish, Links, and Feed.