### PR TITLE
graph-push-hook: speed up by getting rid of nest checks, using %cf, a…

### DIFF
--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -26,12 +26,18 @@
       state-one
   ==
 ::
++$  cached-transform
+  $-([index:store post:store atom ?] [index:store post:store])
+::
++$  cached-permission
+  $-(indexed-post:store $-(vip-metadata:metadata permissions:store))
+::
 ::  TODO: come back to this and potentially use send a %t
 ::  to be notified of validator changes
 +$  cache
   $:  graph-to-mark=(map resource:res (unit mark))
-      perm-marks=(map [mark @tas] tube:clay)
-      transform-marks=(map mark tube:clay)
+      perm-marks=(map [mark @tas] cached-permission)
+      transform-marks=(map mark cached-transform)
   ==
 ::
 +$  inflated-state
@@ -41,8 +47,8 @@
 ::
 +$  cache-action
   $%  [%graph-to-mark (pair resource:res (unit mark))]
-      [%perm-marks (pair (pair mark @tas) tube:clay)]
-      [%transform-marks (pair mark tube:clay)]
+      [%perm-marks (pair (pair mark @tas) cached-permission)]
+      [%transform-marks (pair mark cached-transform)]
   ==
 --
 ::
@@ -138,12 +144,12 @@
     ++  $
       ^-  (quip card (unit vase))
       =/  transform-cached  (~(has by transform-marks) u.mark)
-      =/  =tube:clay
+      =/  transform=cached-transform
         ?:  transform-cached
           (~(got by transform-marks) u.mark)
-        .^(tube:clay (scry:hc %cc %home /[u.mark]/transform-add-nodes))
-      =/  transform
-        !<  $-([index:store post:store atom ?] [index:store post:store])
+        =/  =tube:clay
+          .^(tube:clay (scry:hc %cc %home /[u.mark]/transform-add-nodes))
+        !<  cached-transform
         %.  !>(*indexed-post:store)
         tube
       =/  [* result=(list [index:store node:store])]
@@ -168,7 +174,7 @@
           :_  ~
           %+  poke-self:pass:io  %graph-cache-hook
           !>  ^-  cache-action
-          [%transform-marks u.mark tube]
+          [%transform-marks u.mark transform]
       ==
     ::
     ++  flatten-node-map
@@ -319,14 +325,11 @@
     [[%no %no %no] ~]
   =/  key  [u.mark (perm-mark-name perm)]
   =/  perms-cached  (~(has by perm-marks.cache) key)
-  =/  =tube:clay
+  =/  convert
     ?:  perms-cached
       (~(got by perm-marks.cache) key)
-    .^(tube:clay (scry %cc %home /[u.mark]/(perm-mark-name perm)))
-  =/  check
-    !<  $-(vip-metadata:metadata permissions:store)
-    (tube !>(indexed-post))
-  :-  (check vip)
+    .^(cached-permission (scry %cf %home /[u.mark]/(perm-mark-name perm)))
+  :-  ((convert indexed-post) vip)
   %-  zing
   :~  ?:  mark-cached   ~
       :_  ~
@@ -338,7 +341,7 @@
       :_  ~
       %+  poke-self:pass:io  %graph-cache-hook
       !>  ^-  cache-action
-      [%perm-marks [u.mark (perm-mark-name perm)] tube]
+      [%perm-marks [u.mark (perm-mark-name perm)] convert]
   ==
   ::
   ++  perm-mark-name

--- a/pkg/arvo/app/group-store.hoon
+++ b/pkg/arvo/app/group-store.hoon
@@ -136,13 +136,13 @@
     ^-  (unit (unit cage))
     ?+  path  (on-peek:def path)
         [%y %groups ~]
-      ``noun+!>(~(key by groups))
+      ``noun+!>(`(set resource)`~(key by groups))
     ::
         [%x %groups %ship @ @ ~]
       =/  rid=(unit resource)
         (de-path-soft:resource t.t.path)
       ?~  rid   ~
-      ``noun+!>((peek-group u.rid))
+      ``noun+!>(`(unit group)`(peek-group u.rid))
     ::
        [%x %groups %ship @ @ %join @ ~]
       =/  rid=(unit resource)
@@ -150,7 +150,7 @@
       =/  =ship
         (slav %p i.t.t.t.t.t.t.path)
       ?~  rid  ~
-      ``noun+!>((peek-group-join u.rid ship))
+      ``noun+!>(`?`(peek-group-join u.rid ship))
     ::
         [%x %export ~]
       ``noun+!>(state)
@@ -199,6 +199,7 @@
 ::
 ++  peek-group-join
   |=  [rid=resource =ship]
+  ^-  ?
   =/  ugroup
     (~(get by groups) rid)
   ?~  ugroup

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -200,22 +200,21 @@
         [%x %associations ~]      ``noun+!>(associations)
         [%x %app-name @ ~]
       =/  =app-name:store  i.t.t.path
-      ``noun+!>((metadata-for-app:mc app-name))
+      ``noun+!>(`associations:store`(metadata-for-app:mc app-name))
     ::
         [%x %group *]
       =/  group=resource  (de-path:resource t.t.path)
-      ``noun+!>((metadata-for-group:mc group))
+      ``noun+!>(`associations:store`(metadata-for-group:mc group))
     ::
         [%x %metadata @ @ @ @ ~]
       =/  =md-resource:store
         [i.t.t.path (de-path:resource t.t.t.path)]
-      ``noun+!>((~(get by associations) md-resource))
+      ``noun+!>(`(unit association:store)`(~(get by associations) md-resource))
     ::
         [%x %resource @ *]
       =/  app=term        i.t.t.path
       =/  rid=resource    (de-path:resource t.t.t.path)
-      ``noun+!>((~(get by resource-indices) [app rid]))
-      
+      ``noun+!>(`(unit resource)`(~(get by resource-indices) [app rid]))
     ::
         [%x %export ~]
       ``noun+!>(-.state)
@@ -501,7 +500,7 @@
 ::
 ++  metadata-for-app
   |=  =app-name:store
-  ^+  associations
+  ^-  associations:store
   %+  roll  ~(tap in (~(gut by app-indices) app-name ~))
   |=  [[group=resource rid=resource] out=associations:store]
   =/  =md-resource:store
@@ -512,6 +511,7 @@
 ::
 ++  metadata-for-group
   |=  group=resource
+  ^-  associations:store
   =/  resources=(set md-resource:store)
     (~(get ju group-indices) group)
   %+  roll

--- a/pkg/arvo/lib/group.hoon
+++ b/pkg/arvo/lib/group.hoon
@@ -34,10 +34,12 @@
 ::
 ++  scry-group
   |=  rid=resource
+  ^-  (unit group)
   %+  scry-for  ,(unit group)
   `path`groups+(en-path:resource rid)
 ::
 ++  scry-groups
+  ^-  (set resource)
   .^  ,(set resource)
     %gy
     (scot %p our.bowl)
@@ -48,6 +50,7 @@
 ::
 ++  members
   |=  rid=resource
+  ^-  (set ship)
   =;  =group
     members.group
   (fall (scry-group rid) *group)
@@ -101,6 +104,7 @@
 ::
 ++  can-join
   |=  [rid=resource =ship]
+  ^-  ?
   %+  scry-for  ,?
   ^-  path
   :-  %groups
@@ -121,6 +125,7 @@
 ::
 ++  is-managed
   |=  rid=resource
+  ^-  ?
   =/  group=(unit group)
     (scry-group rid)
   ?~  group  %.n

--- a/pkg/arvo/lib/metadata.hoon
+++ b/pkg/arvo/lib/metadata.hoon
@@ -53,6 +53,7 @@
 ::
 ++  app-metadata-for-group
   |=  [group=resource =app-name:store]
+  ^-  associations:store
   =/  =associations:store
     (metadata-for-group group)
   %-  ~(gas by *associations:store)
@@ -62,6 +63,7 @@
 ::
 ++  metadata-for-group
   |=  group=resource
+  ^-  associations:store
   .^  associations:store
     %gx  (scot %p our.bowl)  %metadata-store  (scot %da now.bowl)
     %group  (snoc (en-path:resource group) %noun)
@@ -69,6 +71,7 @@
 ::
 ++  md-resources-from-group
   |=  group=resource
+  ^-  (set md-resource:store)
   =-  (~(get ju -) group)
   .^  (jug resource md-resource:store)
     %gy
@@ -80,6 +83,7 @@
 ::
 ++  peek-association
   |=  [app-name=term rid=resource]
+  ^-  (unit association:store)
   .^  (unit association:store)
     %gx  (scot %p our.bowl)  %metadata-store  (scot %da now.bowl)
     %metadata  app-name  (snoc (en-path:resource rid) %noun)
@@ -87,6 +91,7 @@
 ::
 ++  peek-metadatum
   |=  =md-resource:store
+  ^-  (unit metadatum:store)
   %+  bind  (peek-association md-resource)
   |=(association:store metadatum)
 ::


### PR DESCRIPTION
…nd storing gates instead of tubes

We now spend only 4ms (!!!) in `%graph-push-hook`.