### PR TITLE
groups: prevents group names starting with digits

### DIFF
--- a/pkg/interface/src/views/landscape/components/NewGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/NewGroup.tsx
@@ -17,7 +17,7 @@ import { AsyncButton } from '~/views/components/AsyncButton';
 
 const formSchema = Yup.object({
   title: Yup.string()
-    .matches(/^(\D).+$/, 'Group names may not start with a number')
+    .matches(/^(\D).*$/, 'Group names may not start with a number')
     .required('Group must have a name'),
   description: Yup.string(),
   isPrivate: Yup.boolean()

--- a/pkg/interface/src/views/landscape/components/NewGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/NewGroup.tsx
@@ -17,7 +17,7 @@ import { AsyncButton } from '~/views/components/AsyncButton';
 
 const formSchema = Yup.object({
   title: Yup.string()
-    .matches(/^(\D).*$/, 'Group names may not start with a number')
+    .matches(/^([a-zA-Z]|[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|\ud83c[\ude32-\ude3a]|\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff]).*$/, 'Group names must start with letters or emoji')
     .required('Group must have a name'),
   description: Yup.string(),
   isPrivate: Yup.boolean()

--- a/pkg/interface/src/views/landscape/components/NewGroup.tsx
+++ b/pkg/interface/src/views/landscape/components/NewGroup.tsx
@@ -6,7 +6,7 @@ import {
 import { Enc, GroupPolicy } from '@urbit/api';
 import { Form, Formik, FormikHelpers } from 'formik';
 import React, { ReactElement, useCallback } from 'react';
-import { RouteComponentProps, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import * as Yup from 'yup';
 import GlobalApi from '~/logic/api/global';
 import { useWaitForProps } from '~/logic/lib/useWaitForProps';
@@ -16,7 +16,9 @@ import useMetadataState from '~/logic/state/metadata';
 import { AsyncButton } from '~/views/components/AsyncButton';
 
 const formSchema = Yup.object({
-  title: Yup.string().required('Group must have a name'),
+  title: Yup.string()
+    .matches(/^(\D).+$/, 'Group names may not start with a number')
+    .required('Group must have a name'),
   description: Yup.string(),
   isPrivate: Yup.boolean()
 });
@@ -94,7 +96,7 @@ export function NewGroup(props: NewGroupProps): ReactElement {
                 id="title"
                 label="Name"
                 caption="Provide a name for your group"
-                placeholder="eg. My Channel"
+                placeholder="eg. My Group"
               />
               <Input
                 id="description"


### PR DESCRIPTION
Implements some very simple form validation preventing group names that begin with digits. Emoji and symbols are still permitted.

fixes urbit/landscape#906