### PR TITLE
interface: consistent  titles for mentions, authors with nicknames

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -159,7 +159,7 @@ export const MessageAuthor = ({
             fontWeight={nameMono ? '400' : '500'}
             cursor='pointer'
             onClick={doCopy}
-            title={`~${msg.author}`}
+            title={showNickname ? `~${msg.author}` : contact?.nickname}
           >
             {copyDisplay}
           </Text>

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -1,4 +1,4 @@
-import { BaseImage, Box, Row } from '@tlon/indigo-react';
+import { BaseImage, Box, Row, Text } from '@tlon/indigo-react';
 import moment from 'moment';
 import React, { ReactElement, ReactNode } from 'react';
 import GlobalApi from '~/logic/api/global';
@@ -94,7 +94,7 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
         )}
       </Box>
       <Box display='flex' alignItems='baseline'>
-        <Box
+        <Text
           ml={showImage ? 2 : 0}
           color='black'
           fontSize='1'
@@ -104,10 +104,11 @@ export default function Author(props: AuthorProps & PropFunc<typeof Box>): React
           fontWeight={showNickname ? '500' : '400'}
           mr={showNickname ? 0 : '2px'}
           mt={showNickname ? 0 : '0px'}
+          title={showNickname ? cite(ship) : contact?.nickname}
           onClick={doCopy}
         >
           {copyDisplay}
-        </Box>
+        </Text>
         { !dontShowTime && time && (
           <Timestamp
             height="fit-content"

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -46,7 +46,6 @@ export function Mention(props: {
   const contact = useContact(`~${deSig(ship)}`);
   const showNickname = useShowNickname(contact);
   const name = showNickname ? contact?.nickname : cite(ship);
-
   return (
     <ProfileOverlay ship={ship} api={api} display="inline">
       <Text
@@ -57,6 +56,8 @@ export function Mention(props: {
         color='blue'
         fontSize={showNickname ? 1 : 0}
         mono={!showNickname}
+        title={showNickname ? cite(ship) : contact?.nickname}
+        {...rest}
       >
         {name}
       </Text>


### PR DESCRIPTION
My understanding of urbit/landscape#65 is that the tooltip over any sort of ship text (mention, author, chat byline) should display the inverse of whatever logic is showing it.

- If I have nicknames set to show, I should naturally see ships' nicknames (if set), and see their ~patps on hover
- If I have nicknames set to not show, I should naturally see ships' ~patps, and their nicknames on hover (if set)
- Regardless of my settings, if others have not set nicknames, they should not show and I should naturally see their ~patps with no hover text otherwise.

I may have misinterpreted the issue, since this seems inconsistent with our rule about never showing nicknames if the pilot truly does not want to see them. It's an easy enough fix to back out the second behavior above, but just need some clarity.