### PR TITLE
tokenizeMessage: fix urls that end in punctuation

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -1,7 +1,7 @@
 import urbitOb from 'urbit-ob';
 import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
-const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)([\s\S]*)/.source));
+const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+[-a-zA-Z0-9:@;?&=\/%\+\*!'\(\)\$_\{\}\^~\[\]`#|])([\s\S]*)/.source));
 
 const PATP_REGEX = /^([\s\S]*?)(~[a-z_-]+)([\s\S]*)/;
 

--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -1,7 +1,7 @@
 import urbitOb from 'urbit-ob';
 import { parsePermalink, permalinkToReference } from '~/logic/lib/permalinks';
 
-const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+[\w/])([\s\S]*)/.source));
+const URL_REGEX = new RegExp(String(/^([^[\]]*?)(([\w\-\+]+:\/\/)[-a-zA-Z0-9:@;?&=\/%\+\.\*!'\(\),\$_\{\}\^~\[\]`#|]+)([\s\S]*)/.source));
 
 const PATP_REGEX = /^([\s\S]*?)(~[a-z_-]+)([\s\S]*)/;
 

--- a/pkg/interface/src/logic/lib/tokenizeMessage.test.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.test.js
@@ -93,4 +93,11 @@ describe('tokenizeMessage', () => {
     expect(three).toEqual(' test ');
     expect(hastuc).toEqual('~hastuc-dibtux');
   });
+  it('should tokenize a url with a par', () => {
+    const example = 'test https://en.wikipedia.org/wiki/Turbo_(gastropod)';
+
+    const [{ text }, { url }] = tokenizeMessage(example);
+    expect(text).toBe('test ');
+    expect(url).toBe('https://en.wikipedia.org/wiki/Turbo_(gastropod)');
+  });
 });

--- a/pkg/interface/src/logic/lib/tokenizeMessage.test.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.test.js
@@ -100,4 +100,17 @@ describe('tokenizeMessage', () => {
     expect(text).toBe('test ');
     expect(url).toBe('https://en.wikipedia.org/wiki/Turbo_(gastropod)');
   });
+  it('should ignore ending commas', () => {
+    const example = 'https://tlon.io/test, foo';
+    const [{ url }, { text }] = tokenizeMessage(example);
+    expect(text).toBe(', foo');
+    expect(url).toBe('https://tlon.io/test');
+  });
+
+  it('should ignore ending dots', () => {
+    const example = 'https://tlon.io/test. foo';
+    const [{ url }, { text }] = tokenizeMessage(example);
+    expect(text).toBe('. foo');
+    expect(url).toBe('https://tlon.io/test');
+  });
 });

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -102,8 +102,10 @@ export function SidebarDmItem(props: {
 }) {
   const { ship, selected = false } = props;
   const contact = useContact(ship);
-  const title = contact?.nickname || (cite(ship) ?? ship);
-  const hideAvatars = false;
+  const { hideAvatars, hideNicknames }  = useSettingsState(s => s.calm);
+  const title = (!hideNicknames && contact?.nickname)
+    ? contact?.nickname
+    : (cite(ship) ?? ship);
   const { unreads } = useHarkDm(ship) || { unreads: 0 };
   const img =
     contact?.avatar && !hideAvatars ? (
@@ -131,7 +133,7 @@ export function SidebarDmItem(props: {
       hasUnread={(unreads as number) > 0}
       to={`/~landscape/messages/dm/${ship}`}
       title={title}
-      mono={!contact?.nickname}
+      mono={hideAvatars || !contact?.nickname}
       isSynced
     >
       {img}


### PR DESCRIPTION
- Also, respect calmengine settings in Messages sidebar (hideNicknames, hideAvatars)