### PR TITLE
hark-graph-hook: speed it up with static conversions

### DIFF
--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -30,12 +30,12 @@
   ?>  ?=(^ t.p)
   .^(mold i.p (scot %p our) i.t.p (scot %da now) t.t.p)
 ::
-++  scry-conversion
+++  scry-notif-conversion
   |=  [[our=@p now=@da] desk=term =mark]
-  ~+
+  ^-  $-(indexed-post:graph-store (unit notif-kind:hook))
   %^  scry  [our now]
-    tube:clay
-  /cc/[desk]/[mark]/notification-kind
+    $-(indexed-post:graph-store (unit notif-kind:hook))
+  /cf/[desk]/[mark]/notification-kind
 --
 ::
 =|  state-1
@@ -87,7 +87,7 @@
   |=  =mark
   ^-  card
   =/  =wire  /validator/[mark]
-  =/  =rave:clay  [%sing %c [%da now.bowl] /[mark]/notification-kind]
+  =/  =rave:clay  [%sing %f [%da now.bowl] /[mark]/notification-kind]
   [%pass wire %arvo %c %warp our.bowl [%home `rave]]
 ::
 ++  on-watch
@@ -214,19 +214,18 @@
       %-  ~(gas by *(set [resource index:graph-store]))
       (turn ~(tap in indices) (lead rid))
     :_  state(watching (~(dif in watching) to-remove))
-    =/  =tube:clay
-      (get-conversion:ha rid)
+    =/  convert  (get-conversion:ha rid)
     %+  roll
       ~(tap in indices)
     |=  [=index:graph-store out=(list card)]
     =|  =indexed-post:graph-store
     =.  index.p.indexed-post  index
-    =+  !<(u-notif-kind=(unit notif-kind:hook) (tube !>(indexed-post)))
-    ?~  u-notif-kind  out
-    =*  notif-kind  u.u-notif-kind
+    =/  notif-kind=(unit notif-kind:hook)
+      (convert indexed-post)
+    ?~  notif-kind  out
     =/  =stats-index:store
-      [%graph rid (scag parent.index-len.notif-kind index)]
-    ?.  ?=(%each mode.notif-kind)  out
+      [%graph rid (scag parent.index-len.u.notif-kind index)]
+    ?.  ?=(%each mode.u.notif-kind)  out
     :_  out 
     (poke-hark %read-each stats-index index)
   ::
@@ -285,7 +284,7 @@
       [%validator @ ~]
     :_  this
     =*  validator  i.t.wire
-    =/  =rave:clay  [%next %c [%da now.bowl] /[validator]/notification-kind]
+    =/  =rave:clay  [%next %f [%da now.bowl] /[validator]/notification-kind]
     [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
   ==
 ++  on-fail   on-fail:def
@@ -298,13 +297,13 @@
 ::
 ++  get-conversion
   |=  rid=resource
-  ^-  tube:clay
+  ^-  $-(indexed-post:graph-store (unit notif-kind:hook))
   =+  %^  scry  [our now]:bowl
          ,mark=(unit mark)
       /gx/graph-store/graph-mark/(scot %p entity.rid)/[name.rid]/noun
   ?~  mark
-    |=(v=vase !>(~))
-  (scry-conversion [our now]:bowl q.byk.bowl u.mark)
+    |=(=indexed-post:graph-store ~)
+  (scry-notif-conversion [our now]:bowl q.byk.bowl u.mark)
 ::
 ++  give
   |=  [paths=(list path) =update:hook]
@@ -355,8 +354,6 @@
     update-core(rid r, updates upds, mark m)
   ::
   ++  get-conversion
-    ::  LA:  this tube should be cached in %hark-graph-hook state
-    ::  instead of just trying to keep it warm, as the scry overhead is large
     ~+  (^get-conversion rid)
   ::
   ++  abet
@@ -410,9 +407,8 @@
     ?:  ?=(%| -.post.node)
       update-core
     =*  pos  p.post.node
-    =+  !<  notif-kind=(unit notif-kind:hook)
-        %-  get-conversion
-        !>(`indexed-post:graph-store`[0 pos])
+    =/  notif-kind=(unit notif-kind:hook)
+      (get-conversion [0 pos])
     ?~  notif-kind
       update-core
     =/  desc=@t


### PR DESCRIPTION
Given that we know the types of the conversions used in `%hark-graph-hook` at compile time, there's no need to use dynamic conversions. Replaces all tubes with static conversions.