### PR TITLE
btc: use blockfilter when requesting address info

### DIFF
--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -195,6 +195,9 @@
       ::
         %ping
       [%get-block-info ~]
+      ::
+        %block-info
+      [%get-block-info block.act]
     ==
   [~[(req-card act ract)] state]
 ::
@@ -284,6 +287,11 @@
     ?:  =(block.host-info block.r)
       ~[(send-status [%connected network.host-info block.r fee.r])]
     ~[(send-status [%new-block network.host-info block.r fee.r blockhash.r blockfilter.r])]
+    ::
+      %block-info
+    ?>  ?=([%get-block-info *] r)
+    :_  state
+    ~[(send-update [%.y %block-info network.host-info +.r])]
   ==
 ::
 ++  send-status

--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -85,8 +85,7 @@
   ::
   ?>  ?=([%clients *] pax)
   ?.  (is-whitelisted:hc src.bowl)
-    ~&  >>>  "btc-provider: blocked client {<src.bowl>}"
-    [~[[%give %kick ~ ~]] this]
+    ~|("btc-provider: blocked client {<src.bowl>}" !!)
   ~&  >  "btc-provider: accepted client {<src.bowl>}"
   :-  [do-ping:hc]~
   this(clients.host-info (~(put in clients.host-info) src.bowl))

--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -167,6 +167,11 @@
   |=  [=wire =sign:agent:gall]
   ^-  (quip card _this)
   ?+  -.sign  (on-agent:def wire sign)
+      %watch-ack
+    ?~  p.sign  `this
+    %-  (slog leaf+"connection rejected by provider ({<src.bowl>})" u.p.sign)
+    `this
+    ::
       %kick
     ?~  prov  `this
     ?:  ?&  ?=(%set-provider -.wire)
@@ -724,13 +729,9 @@
       (retry-scans network)
     ==
   =?  cards  ?&(?=(^ blockhash) ?=(^ blockfilter) (gth gap 0))
-    ;:  weld  cards
-      (retry-filtered-addrs network u.blockhash u.blockfilter)
-    ==
+    (weld cards (retry-filtered-addrs network u.blockhash u.blockfilter))
   =?  cards  (gth gap 50)
-    ;:  weld  cards
-      (retry-addrs network)
-    ==
+    (weld cards (retry-addrs network))
   :-  cards
   %_  state
     prov  `p(connected %.y)
@@ -755,7 +756,9 @@
   %-  zing
   %+  murn  ~(tap by scans)
   |=  [[=xpub:bc =chyg] =batch]
-  ?.  =(network network:(~(got by walts) xpub))  ~
+  =/  w  (~(get by walts) xpub)
+  ?~  w  ~
+  ?.  =(network network.u.w)     ~
   `-:(req-scan batch xpub chyg)
 ::  +retry-addrs: get info on addresses with unconfirmed UTXOs
 ::

--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -4,7 +4,7 @@
 ::  x/scanned: (list xpub) of all scanned wallets
 ::  x/balance/xpub: balance (in sats) of wallet
 /-  *btc-wallet, bp=btc-provider, file-server, launch-store
-/+  dbug, default-agent, bl=btc, bc=bitcoin, bip32, bip-b158
+/+  dbug, default-agent, bl=btc, bc=bitcoin, bip32
 |%
 ++  defaults
   |%
@@ -168,12 +168,14 @@
   ^-  (quip card _this)
   ?+  -.sign  (on-agent:def wire sign)
       %kick
-    ~&  >>>  "kicked from prov {<src.bowl>}"
     ?~  prov  `this
     ?:  ?&  ?=(%set-provider -.wire)
             =(host.u.prov src.bowl)
         ==
-      `this(prov ~)
+      :_  this(prov [~ src.bowl %.n])
+      :~  (watch-provider src.bowl)
+          (give-update %change-provider `[src.bowl %.n])
+      ==
     `this
     ::
       %fact
@@ -238,7 +240,6 @@
   ?>  (team:title our.bowl src.bowl)
   ?-  -.comm
       %set-provider
-    |^
     ?~  provider.comm
       ?~  prov  `state
       :_  state(prov ~)
@@ -252,20 +253,6 @@
         (watch-provider u.provider.comm)
         (give-update %change-provider `[u.provider.comm %.n])
     ==
-    ::
-    ++  watch-provider
-      |=  who=@p
-      ^-  card
-      :*  %pass  /set-provider/[(scot %p who)]  %agent  [who %btc-provider]
-          %watch  /clients
-      ==
-    ++  leave-provider
-      |=  who=@p
-      ^-  card
-      :*  %pass  /set-provider/[(scot %p who)]  %agent  [who %btc-provider]
-          %leave  ~
-      ==
-    --
   ::
       %check-provider
     =/  pax  /permitted/(scot %p provider.comm)
@@ -722,6 +709,7 @@
     (gulf +(block.btc-state) (dec block))
   =?  blocks  ?|(?=(~ blockhash) ?=(~ blockfilter))
     (snoc blocks block)
+  =?  blocks  (gth gap 50)  ~
   ::
   =/  cards=(list card)
     ;:  weld
@@ -738,6 +726,10 @@
   =?  cards  ?&(?=(^ blockhash) ?=(^ blockfilter) (gth gap 0))
     ;:  weld  cards
       (retry-filtered-addrs network u.blockhash u.blockfilter)
+    ==
+  =?  cards  (gth gap 50)
+    ;:  weld  cards
+      (retry-addrs network)
     ==
   :-  cards
   %_  state
@@ -792,7 +784,7 @@
   :-  ~
   %+  murn
     %~  tap  in
-    %:  all-match:bip-b158
+    %:  all-match:bip-b158:bc
         blockfilter
         blockhash
       ::
@@ -1125,6 +1117,19 @@
   |=  upd=update
   ^-  card
   [%give %fact ~[/all] %btc-wallet-update !>(upd)]
+::
+++  watch-provider
+  |=  who=@p
+  ^-  card
+  :*  %pass  /set-provider/[(scot %p who)]  %agent  [who %btc-provider]
+      %watch  /clients
+  ==
+++  leave-provider
+  |=  who=@p
+  ^-  card
+  :*  %pass  /set-provider/[(scot %p who)]  %agent  [who %btc-provider]
+      %leave  ~
+  ==
 ::
 ++  give-initial
   ^-  card

--- a/pkg/arvo/lib/bip/b158.hoon
+++ b/pkg/arvo/lib/bip/b158.hoon
@@ -211,19 +211,20 @@
   $(last-val (add delta last-val))
 ::  +all-match: returns all target byts that match
 ::   - filter: full block filter, with leading N
-::   - k: key for siphash (end of blockhash, reversed)
 ::   - targets: scriptpubkeys to match
 ::
 ++  all-match
-  |=  [filter=hexb:bc k=byts targets=(list byts)]
-  ^-  (set hexb:bc)
-  %-  ~(gas in *(set hexb:bc))
+  |=  [filter=hexb:bc blockhash=hexb:bc targets=(list [address:bc byts])]
+  ^-  (set [address:bc hexb:bc])
+  =/  k  (to-key (trip (to-cord:hxb:bcu blockhash)))
+  %-  ~(gas in *(set [address:bc hexb:bc]))
   =/  [p=@ m=@]  [p:params m:params]
   =/  [n=@ux gcs-set=bits:bc]  (parse-filter filter)
-  =/  target-map=(map @ hexb:bc)
-    %-  ~(gas by *(map @ hexb:bc))
+  =/  target-map=(map @ [address:bc hexb:bc])
+    %-  ~(gas by *(map @ [address:bc hexb:bc]))
     %+  turn  targets
-    |=(t=hexb:bc [(to-range:hsh t (mul n m) k) t])
+    |=  [a=address:bc t=hexb:bc]
+    [(to-range:hsh t (mul n m) k) a t]
   =+  target-hs=(sort ~(tap in ~(key by target-map)) lth)
   =+  last-val=0
   =|  matches=(list @)
@@ -244,4 +245,5 @@
   =^  delta  gcs-set
     (de:gol gcs-set p)
   $(last-val (add delta last-val))
+::
 --

--- a/pkg/arvo/lib/bitcoin.hoon
+++ b/pkg/arvo/lib/bitcoin.hoon
@@ -3,7 +3,7 @@
 ::  expose BIP libraries
 ::
 /-  sur=bitcoin
-/+  bech32=bip-b173, pbt=bip-b174, bcu=bitcoin-utils
+/+  bech32=bip-b173, pbt=bip-b174, bcu=bitcoin-utils, bip-b158
 =,  sur
 =,  bcu
 |%

--- a/pkg/arvo/lib/btc.hoon
+++ b/pkg/arvo/lib/btc.hoon
@@ -505,8 +505,10 @@
     (mk-url '/getblockcount' '')
     ::
       %get-block-info
+    =/  param=@t
+      ?~(block.ract '' (rsh [3 2] (scot %ui u.block.ract)))
     %-  get-request
-    (mk-url '/getblockinfo' '')
+    (mk-url '/getblockinfo/' param)
   ==
   ++  mk-url
     |=  [base=@t params=@t]

--- a/pkg/arvo/sur/btc-provider.hoon
+++ b/pkg/arvo/sur/btc-provider.hoon
@@ -31,6 +31,7 @@
       [%raw-tx txid=hexb]
       [%broadcast-tx rawtx=hexb]
       [%ping ~]
+      [%block-info block=(unit @ud)]
   ==
 ::
 +$  result
@@ -38,6 +39,7 @@
       [%tx-info =info:tx]
       [%raw-tx txid=hexb rawtx=hexb]
       [%broadcast-tx txid=hexb broadcast=? included=?]
+      [%block-info =network block=@ud fee=(unit sats) blockhash=hexb blockfilter=hexb]
   ==
 +$  error
   $%  [%not-connected status=@ud]
@@ -60,7 +62,7 @@
         [%get-raw-tx txid=hexb]
         [%broadcast-tx rawtx=hexb]
         [%get-block-count ~]
-        [%get-block-info ~]
+        [%get-block-info block=(unit @ud)]
     ==
   ::
   +$  result

--- a/pkg/arvo/tests/lib/bip/b158.hoon
+++ b/pkg/arvo/tests/lib/bip/b158.hoon
@@ -151,14 +151,11 @@
   ::
   ++  check-all-match
     |=  v=match-vector
+    =/  b=hexb  (from-cord:hxb (crip blockhash.v))
+    =/  inc=(list [address hexb])  (turn inc-spks.v |=(h=hexb [*address h]))
+    =/  exc=(list [address hexb])  (turn exc-spks.v |=(h=hexb [*address h]))
     %+  expect-eq
-      !>(`(set hexb)`(sy [*address inc-spks.v]))
-      !>  ^-  (set hexb)
-      %:  all-match
-          filter.v
-          blockhash.v
-          %+  turn  (weld inc-spks.v exc-spks.v)
-          |=(h=hexb [*address a])
-      ==
+      !>(`(set [address hexb])`(sy inc))
+      !>(`(set [address hexb])`(all-match filter.v b (weld inc exc)))
   --
 --

--- a/pkg/arvo/tests/lib/bip/b158.hoon
+++ b/pkg/arvo/tests/lib/bip/b158.hoon
@@ -151,9 +151,14 @@
   ::
   ++  check-all-match
     |=  v=match-vector
-    =+  k=(to-key blockhash.v)
     %+  expect-eq
-      !>(`(set hexb)`(sy inc-spks.v))
-      !>(`(set hexb)`(all-match filter.v k (weld inc-spks.v exc-spks.v)))
+      !>(`(set hexb)`(sy [*address inc-spks.v]))
+      !>  ^-  (set hexb)
+      %:  all-match
+          filter.v
+          blockhash.v
+          %+  turn  (weld inc-spks.v exc-spks.v)
+          |=(h=hexb [*address a])
+      ==
   --
 --


### PR DESCRIPTION
Now when we get updated about a new block, only request address info for addresses that match that block's blockfilter. If there's a gap of multiple blocks, we need to go request blockfilter information for those blocks specificially. 

This depends on this PR on the urbit-bitcoin-rpc repo, which allows you to make those requests for specific block information: https://github.com/timlucmiptev/urbit-bitcoin-rpc/pull/26