### PR TITLE
landscape: loosen owner check in popover

### DIFF
--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -56,8 +56,8 @@ export function parentPath(path: string) {
  * string -> enabled feed
  */
 export function getFeedPath(association: Association): string | null | undefined {
-  const { metadata } = association;
-  if(metadata.config && 'group' in metadata?.config && metadata.config?.group) {
+  const { metadata = { config: {} } } = association;
+  if (metadata.config && 'group' in metadata?.config && metadata.config?.group) {
     if ('resource' in metadata.config.group) {
       return metadata.config.group.resource;
     }

--- a/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
+++ b/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
@@ -31,7 +31,7 @@ export function PopoverRoutes(
 
   const groupSize = props.group.members.size;
 
-  const owner = resourceFromPath(props.association.group).ship.slice(1) === window.ship;
+  const owner = resourceFromPath(props.association?.group ?? '~zod/group').ship.slice(1) === window.ship;
 
   const admin = props.group?.tags?.role?.admin.has(window.ship) || false;
 


### PR DESCRIPTION
While this error only really happens if you have a severely malformed association, we shouldn't crash the FE in such cases. Possibly superseded by later work on data loading in Landscape, but for now, seems harmless to weave in here.

Fixes urbit/landscape#960