### PR TITLE
ted/glob: add exponential retry

### DIFF
--- a/pkg/arvo/ted/glob.hoon
+++ b/pkg/arvo/ted/glob.hoon
@@ -7,7 +7,12 @@
 ^-  form:m
 =+  !<([~ hash=@uv] arg)
 =/  url  "https://bootstrap.urbit.org/glob-{(scow %uv hash)}.glob"
-;<  =cord  bind:m  (fetch-cord:strandio url)
-~|  failed-glob+hash
-=+  ;;(=glob:glob (cue cord))
+;<  =glob:glob  bind:m
+  %+  (retry:strandio ,glob:glob)  `5
+  =/  n  (strand ,(unit glob:glob))
+  ;<  =cord  bind:n  (fetch-cord:strandio url)
+  %-  pure:n
+  %-  mole
+  |.
+  ;;(=glob:glob (cue cord))
 (pure:m !>(glob))


### PR DESCRIPTION
The GCP bucket will occasionally fail requests for no good reason. Adds exponential retry to the glob thread to prevent this from affecting UX. 

Fixes urbit/urbit#4958