### PR TITLE
observe-hook: add ability to warm static mark conversions

### DIFF
--- a/pkg/arvo/app/graph-push-hook.hoon
+++ b/pkg/arvo/app/graph-push-hook.hoon
@@ -26,18 +26,15 @@
       state-one
   ==
 ::
-+$  cached-transform
++$  post-transform
+  $-  indexed-post:store
   $-([index:store post:store atom ?] [index:store post:store])
 ::
-+$  cached-permission
++$  post-to-permission
   $-(indexed-post:store $-(vip-metadata:metadata permissions:store))
 ::
-::  TODO: come back to this and potentially use send a %t
-::  to be notified of validator changes
 +$  cache
   $:  graph-to-mark=(map resource:res (unit mark))
-      perm-marks=(map [mark @tas] cached-permission)
-      transform-marks=(map mark cached-transform)
   ==
 ::
 +$  inflated-state
@@ -47,8 +44,6 @@
 ::
 +$  cache-action
   $%  [%graph-to-mark (pair resource:res (unit mark))]
-      [%perm-marks (pair (pair mark @tas) cached-permission)]
-      [%transform-marks (pair mark cached-transform)]
   ==
 --
 ::
@@ -90,13 +85,9 @@
   =/  a=cache-action  !<(cache-action vase)
   =*  c                +.state
   =*  graph-to-mark    graph-to-mark.c
-  =*  perm-marks       perm-marks.c
-  =*  transform-marks  transform-marks.c
   =.  c
     ?-  -.a
       %graph-to-mark    c(graph-to-mark (~(put by graph-to-mark) p.a q.a))
-      %perm-marks       c(perm-marks (~(put by perm-marks) p.a q.a))
-      %transform-marks  c(transform-marks (~(put by transform-marks) p.a q.a))
     ==
   [~ this(+.state c)]
 ::
@@ -142,12 +133,9 @@
     |%
     ++  $
       ^-  (quip card (unit vase))
-      =/  transform=cached-transform
-        %+  fall
-          (~(get by transform-marks) u.mark)
-        =/  =tube:clay
-          .^(tube:clay (scry:hc %cc %home /[u.mark]/transform-add-nodes))
-        !<(cached-transform (tube !>(*indexed-post:store)))
+      =/  transform
+        %.  *indexed-post:store
+        .^(post-transform (scry:hc %cf %home /[u.mark]/transform-add-nodes))
       =/  [* result=(list [index:store node:store])]
         %+  roll
           (flatten-node-map ~(tap by nodes.q.update))
@@ -166,13 +154,6 @@
           %+  poke-self:pass:io  %graph-cache-hook
           !>  ^-  cache-action
           [%graph-to-mark rid mark]
-        ::
-          ?:  (~(has by transform-marks) u.mark)
-            ~
-          :_  ~
-          %+  poke-self:pass:io  %graph-cache-hook
-          !>  ^-  cache-action
-          [%transform-marks u.mark transform]
       ==
     ::
     ++  flatten-node-map
@@ -322,9 +303,7 @@
     [[%no %no %no] ~]
   =/  key  [u.mark (perm-mark-name perm)]
   =/  convert
-    %+  fall
-      (~(get by perm-marks.cache) key)
-    .^(cached-permission (scry %cf %home /[u.mark]/(perm-mark-name perm)))
+    .^(post-to-permission (scry %cf %home /[u.mark]/(perm-mark-name perm)))
   :-  ((convert indexed-post) vip)
   %-  zing
   :~  ?:  (~(has by graph-to-mark.cache) resource)
@@ -333,12 +312,6 @@
       %+  poke-self:pass:io  %graph-cache-hook
       !>  ^-  cache-action
       [%graph-to-mark resource mark]
-    ::
-      ?:  (~(has by perm-marks.cache) key)  ~
-      :_  ~
-      %+  poke-self:pass:io  %graph-cache-hook
-      !>  ^-  cache-action
-      [%perm-marks [u.mark (perm-mark-name perm)] convert]
   ==
   ::
   ++  perm-mark-name

--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -16,20 +16,9 @@
 +$  state-5  [%5 network:store]
 ++  orm      orm:store
 ++  orm-log  orm-log:store
-::
-+$  cache
-  $:  validators=(map mark $-(indexed-post:store indexed-post:store))
-  ==
-::
-::  TODO: come back to this and potentially use ford runes or otherwise
-::  send a %t to be notified of validator changes
-+$  inflated-state
-  $:  state-5
-      cache
-  ==
 --
 ::
-=|  inflated-state
+=|  state-5
 =*  state  -
 ::
 %-  agent:dbug
@@ -41,7 +30,7 @@
     def   ~(. (default-agent this %|) bowl)
 ::
 ++  on-init  [~ this]
-++  on-save  !>(-.state)
+++  on-save  !>(state)
 ++  on-load
   |=  =old=vase
   ^-  (quip card _this)
@@ -91,7 +80,7 @@
       (gas:orm-log ~ [now.bowl logged-update] ~)
     ==
   ::
-    %5  [cards this(-.state old, +.state *cache)]
+    %5  [cards this(state old)]
   ==
 ::
 ++  on-watch
@@ -593,8 +582,6 @@
     ?~  mark
       [%.y state]
     =/  validate=$-(indexed-post:store indexed-post:store)
-      %+  fall
-        (~(get by validators) u.mark)
       .^  $-(indexed-post:store indexed-post:store)
           %cf
           (scot %p our.bowl)
@@ -604,8 +591,6 @@
           %graph-indexed-post
           ~
       ==
-    =?  validators  !(~(has by validators) u.mark)
-      (~(put by validators) u.mark validate)
     :_  state
     |-  ^-  ?
     ?~  graph  %.y
@@ -624,7 +609,7 @@
   ++  poke-import
     |=  arc=*
     ^-  (quip card _state)
-    =^  cards  -.state
+    =^  cards  state
       (import:store arc our.bowl)
     [cards state]
   --

--- a/pkg/arvo/app/hark-graph-hook.hoon
+++ b/pkg/arvo/app/hark-graph-hook.hoon
@@ -74,21 +74,9 @@
     ==
   :_  this(state old)
   =.  cards  (flop cards)
-  %+  welp
-    ?:  (~(has by wex.bowl) [/graph our.bowl %graph-store])
-      cards
-    [watch-graph:ha cards]
-  %+  turn
-    ^-  (list mark)
-    :~  %graph-validator-chat
-        %graph-validator-link
-        %graph-validator-publish
-    ==
-  |=  =mark
-  ^-  card
-  =/  =wire  /validator/[mark]
-  =/  =rave:clay  [%sing %f [%da now.bowl] /[mark]/notification-kind]
-  [%pass wire %arvo %c %warp our.bowl [%home `rave]]
+  ?:  (~(has by wex.bowl) [/graph our.bowl %graph-store])
+    cards
+  [watch-graph:ha cards]
 ::
 ++  on-watch
   |=  =path
@@ -281,11 +269,8 @@
   ^-  (quip card _this)
   ?+  wire  (on-arvo:def wire sign-arvo)
     ::
-      [%validator @ ~]
-    :_  this
-    =*  validator  i.t.wire
-    =/  =rave:clay  [%next %f [%da now.bowl] /[validator]/notification-kind]
-    [%pass wire %arvo %c %warp our.bowl [%home `rave]]~
+    ::  no longer necessary
+    [%validator @ ~]  [~ this]
   ==
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -8,6 +8,12 @@
 ::
 |%
 +$  card  card:agent:gall
++$  state-0
+  $:  observers=(map serial observer:sur)
+      warm-cache=_|
+      static-conversions=(set [term term])
+  ==
+::
 +$  versioned-state
   $%  [%0 observers=(map serial observer:sur)]
       [%1 observers=(map serial observer:sur)]
@@ -15,6 +21,7 @@
       [%3 observers=(map serial observer:sur)]
       [%4 observers=(map serial observer:sur)]
       [%5 observers=(map serial observer:sur) warm-cache=_|]
+      [%6 state-0]
   ==
 ::
 +$  serial   @uv
@@ -28,7 +35,7 @@
 --
 ::
 %-  agent:dbug
-=|  [%5 observers=(map serial observer:sur) warm-cache=_|]
+=|  [%6 state-0]
 =*  state  -
 ::
 ^-  agent:gall
@@ -44,6 +51,36 @@
       (act [%watch %group-store /groups %group-on-remove-member])
       (act [%watch %metadata-store /updates %md-on-add-group-feed])
       (act [%warm-cache-all ~])
+    ::
+      (warm-static %graph-validator-chat %graph-indexed-post)
+      (warm-static %graph-validator-publish %graph-indexed-post)
+      (warm-static %graph-validator-link %graph-indexed-post)
+      (warm-static %graph-validator-post %graph-indexed-post)
+      (warm-static %graph-validator-dm %graph-indexed-post)
+    ::
+      (warm-static %graph-validator-chat %graph-permission-add)
+      (warm-static %graph-validator-publish %graph-permission-add)
+      (warm-static %graph-validator-link %graph-permission-add)
+      (warm-static %graph-validator-post %graph-permission-add)
+      (warm-static %graph-validator-dm %graph-permission-add)
+    ::
+      (warm-static %graph-validator-chat %graph-permission-remove)
+      (warm-static %graph-validator-publish %graph-permission-remove)
+      (warm-static %graph-validator-link %graph-permission-remove)
+      (warm-static %graph-validator-post %graph-permission-remove)
+      (warm-static %graph-validator-dm %graph-permission-remove)
+    ::
+      (warm-static %graph-validator-chat %notification-kind)
+      (warm-static %graph-validator-publish %notification-kind)
+      (warm-static %graph-validator-link %notification-kind)
+      (warm-static %graph-validator-post %notification-kind)
+      (warm-static %graph-validator-dm %notification-kind)
+    ::
+      (warm-static %graph-validator-chat %transform-add-nodes)
+      (warm-static %graph-validator-publish %transform-add-nodes)
+      (warm-static %graph-validator-link %transform-add-nodes)
+      (warm-static %graph-validator-post %transform-add-nodes)
+      (warm-static %graph-validator-dm %transform-add-nodes)
   ==
   ::
   ++  act
@@ -57,6 +94,19 @@
         %observe-action
         !>(action)
     ==
+  ::
+  ++  warm-static
+    |=  [from=term to=term]
+    ^-  card
+    :*  %pass
+        /poke
+        %agent
+        [our.bowl %observe-hook]
+        %poke
+        %observe-action
+        !>  ^-  action:sur
+        [%warm-static-conversion from to]
+    ==
   --
 ::
 ++  on-save   !>(state)
@@ -68,8 +118,44 @@
   =|  cards=(list card)
   |-
   ?-  -.old-state
-      %5
+      %6
     [cards this(state old-state)]
+  ::
+      %5
+    =.  cards
+      %+  weld  cards
+      :~  (warm-static %graph-validator-chat %graph-indexed-post)
+          (warm-static %graph-validator-publish %graph-indexed-post)
+          (warm-static %graph-validator-link %graph-indexed-post)
+          (warm-static %graph-validator-post %graph-indexed-post)
+          (warm-static %graph-validator-dm %graph-indexed-post)
+        ::
+          (warm-static %graph-validator-chat %graph-permission-add)
+          (warm-static %graph-validator-publish %graph-permission-add)
+          (warm-static %graph-validator-link %graph-permission-add)
+          (warm-static %graph-validator-post %graph-permission-add)
+          (warm-static %graph-validator-dm %graph-permission-add)
+        ::
+          (warm-static %graph-validator-chat %graph-permission-remove)
+          (warm-static %graph-validator-publish %graph-permission-remove)
+          (warm-static %graph-validator-link %graph-permission-remove)
+          (warm-static %graph-validator-post %graph-permission-remove)
+          (warm-static %graph-validator-dm %graph-permission-remove)
+        ::
+          (warm-static %graph-validator-chat %notification-kind)
+          (warm-static %graph-validator-publish %notification-kind)
+          (warm-static %graph-validator-link %notification-kind)
+          (warm-static %graph-validator-post %notification-kind)
+          (warm-static %graph-validator-dm %notification-kind)
+        ::
+          (warm-static %graph-validator-chat %transform-add-nodes)
+          (warm-static %graph-validator-publish %transform-add-nodes)
+          (warm-static %graph-validator-link %transform-add-nodes)
+          (warm-static %graph-validator-post %transform-add-nodes)
+          (warm-static %graph-validator-dm %transform-add-nodes)
+      ==
+    $(old-state [%6 observers.old-state %.n ~])
+  ::
       %4
     =.  cards
       :_  cards
@@ -109,6 +195,19 @@
         %observe-action
         !>(action)
     ==
+  ::
+  ++  warm-static
+    |=  [from=term to=term]
+    ^-  card
+    :*  %pass
+        /poke
+        %agent
+        [our.bowl %observe-hook]
+        %poke
+        %observe-action
+        !>  ^-  action:sur
+        [%warm-static-conversion from to]
+    ==
   --
 ::
 ++  on-poke
@@ -122,10 +221,12 @@
   =*  observer  observer.action
   =/  vals  (silt ~(val by observers))
   ?-  -.action
-    %watch           (watch observer vals)
-    %ignore          (ignore observer vals)
-    %warm-cache-all  warm-cache-all
-    %cool-cache-all  cool-cache-all
+    %watch                   (watch observer vals)
+    %ignore                  (ignore observer vals)
+    %warm-cache-all          warm-cache-all
+    %cool-cache-all          cool-cache-all
+    %warm-static-conversion  (warm-static-conversion from.action to.action)
+    %cool-static-conversion  (cool-static-conversion from.action to.action)
   ==
   ::
   ++  watch
@@ -170,6 +271,23 @@
     ?.  warm-cache
       ~|('cannot cool down cache that is already cool' !!)
     [~ this(warm-cache %.n)]
+  ::
+  ++  warm-static-conversion
+    |=  [from=term to=term]
+    ^-  (quip card _this)
+    ?:  (~(has in static-conversions) [from to])
+      ~|('cannot warm up a static conversion that is already warm' !!)
+    :_  this(static-conversions (~(put in static-conversions) [from to]))
+    =/  =wire  /static-convert/[from]/[to]
+    =/  =rave:clay  [%sing %f [%da now.bowl] /[from]/[to]]
+    [%pass wire %arvo %c %warp our.bowl %home `rave]~
+  ::
+  ++  cool-static-conversion
+    |=  [from=term to=term]
+    ^-  (quip card _this)
+    ?.  (~(has in static-conversions) [from to])
+      ~|('cannot cool a static conversion that is already cool' !!)
+    [~ this(static-conversions (~(del in static-conversions) [from to]))]
   --
 ::
 ++  on-agent
@@ -325,6 +443,18 @@
     ?~  riot
       ~
     =/  =rave:clay  [%next %b q.p.u.riot mark]
+    [%pass wire %arvo %c %warp our.bowl %home `rave]~
+  ::
+      [%static-convert @ @ ~]
+    =*  from  i.t.wire
+    =*  to    i.t.t.wire
+    ?.  (~(has in static-conversions) [from to])
+      ~
+    ?>  ?=([%clay %writ *] sign-arvo)
+    =*  riot  p.sign-arvo
+    ?~  riot
+      ~
+    =/  =rave:clay  [%next %f q.p.u.riot /[from]/[to]]
     [%pass wire %arvo %c %warp our.bowl %home `rave]~
   ==
 ::

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -58,17 +58,17 @@
       (warm-static %graph-validator-post %graph-indexed-post)
       (warm-static %graph-validator-dm %graph-indexed-post)
     ::
-      (warm-static %graph-validator-chat %graph-permission-add)
-      (warm-static %graph-validator-publish %graph-permission-add)
-      (warm-static %graph-validator-link %graph-permission-add)
-      (warm-static %graph-validator-post %graph-permission-add)
-      (warm-static %graph-validator-dm %graph-permission-add)
+      (warm-static %graph-validator-chat %graph-permissions-add)
+      (warm-static %graph-validator-publish %graph-permissions-add)
+      (warm-static %graph-validator-link %graph-permissions-add)
+      (warm-static %graph-validator-post %graph-permissions-add)
+      (warm-static %graph-validator-dm %graph-permissions-add)
     ::
-      (warm-static %graph-validator-chat %graph-permission-remove)
-      (warm-static %graph-validator-publish %graph-permission-remove)
-      (warm-static %graph-validator-link %graph-permission-remove)
-      (warm-static %graph-validator-post %graph-permission-remove)
-      (warm-static %graph-validator-dm %graph-permission-remove)
+      (warm-static %graph-validator-chat %graph-permissions-remove)
+      (warm-static %graph-validator-publish %graph-permissions-remove)
+      (warm-static %graph-validator-link %graph-permissions-remove)
+      (warm-static %graph-validator-post %graph-permissions-remove)
+      (warm-static %graph-validator-dm %graph-permissions-remove)
     ::
       (warm-static %graph-validator-chat %notification-kind)
       (warm-static %graph-validator-publish %notification-kind)
@@ -80,7 +80,6 @@
       (warm-static %graph-validator-publish %transform-add-nodes)
       (warm-static %graph-validator-link %transform-add-nodes)
       (warm-static %graph-validator-post %transform-add-nodes)
-      (warm-static %graph-validator-dm %transform-add-nodes)
   ==
   ::
   ++  act
@@ -130,17 +129,17 @@
           (warm-static %graph-validator-post %graph-indexed-post)
           (warm-static %graph-validator-dm %graph-indexed-post)
         ::
-          (warm-static %graph-validator-chat %graph-permission-add)
-          (warm-static %graph-validator-publish %graph-permission-add)
-          (warm-static %graph-validator-link %graph-permission-add)
-          (warm-static %graph-validator-post %graph-permission-add)
-          (warm-static %graph-validator-dm %graph-permission-add)
+          (warm-static %graph-validator-chat %graph-permissions-add)
+          (warm-static %graph-validator-publish %graph-permissions-add)
+          (warm-static %graph-validator-link %graph-permissions-add)
+          (warm-static %graph-validator-post %graph-permissions-add)
+          (warm-static %graph-validator-dm %graph-permissions-add)
         ::
-          (warm-static %graph-validator-chat %graph-permission-remove)
-          (warm-static %graph-validator-publish %graph-permission-remove)
-          (warm-static %graph-validator-link %graph-permission-remove)
-          (warm-static %graph-validator-post %graph-permission-remove)
-          (warm-static %graph-validator-dm %graph-permission-remove)
+          (warm-static %graph-validator-chat %graph-permissions-remove)
+          (warm-static %graph-validator-publish %graph-permissions-remove)
+          (warm-static %graph-validator-link %graph-permissions-remove)
+          (warm-static %graph-validator-post %graph-permissions-remove)
+          (warm-static %graph-validator-dm %graph-permissions-remove)
         ::
           (warm-static %graph-validator-chat %notification-kind)
           (warm-static %graph-validator-publish %notification-kind)
@@ -152,7 +151,6 @@
           (warm-static %graph-validator-publish %transform-add-nodes)
           (warm-static %graph-validator-link %transform-add-nodes)
           (warm-static %graph-validator-post %transform-add-nodes)
-          (warm-static %graph-validator-dm %transform-add-nodes)
       ==
     $(old-state [%6 observers.old-state %.n ~])
   ::

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -62,13 +62,11 @@
       (warm-static %graph-validator-publish %graph-permissions-add)
       (warm-static %graph-validator-link %graph-permissions-add)
       (warm-static %graph-validator-post %graph-permissions-add)
-      (warm-static %graph-validator-dm %graph-permissions-add)
     ::
       (warm-static %graph-validator-chat %graph-permissions-remove)
       (warm-static %graph-validator-publish %graph-permissions-remove)
       (warm-static %graph-validator-link %graph-permissions-remove)
       (warm-static %graph-validator-post %graph-permissions-remove)
-      (warm-static %graph-validator-dm %graph-permissions-remove)
     ::
       (warm-static %graph-validator-chat %notification-kind)
       (warm-static %graph-validator-publish %notification-kind)

--- a/pkg/arvo/app/observe-hook.hoon
+++ b/pkg/arvo/app/observe-hook.hoon
@@ -131,13 +131,11 @@
           (warm-static %graph-validator-publish %graph-permissions-add)
           (warm-static %graph-validator-link %graph-permissions-add)
           (warm-static %graph-validator-post %graph-permissions-add)
-          (warm-static %graph-validator-dm %graph-permissions-add)
         ::
           (warm-static %graph-validator-chat %graph-permissions-remove)
           (warm-static %graph-validator-publish %graph-permissions-remove)
           (warm-static %graph-validator-link %graph-permissions-remove)
           (warm-static %graph-validator-post %graph-permissions-remove)
-          (warm-static %graph-validator-dm %graph-permissions-remove)
         ::
           (warm-static %graph-validator-chat %notification-kind)
           (warm-static %graph-validator-publish %notification-kind)

--- a/pkg/arvo/mar/graph/cache/hook.hoon
+++ b/pkg/arvo/mar/graph/cache/hook.hoon
@@ -2,8 +2,6 @@
 |%
 +$  cache-action
   $%  [%graph-to-mark (pair resource:res (unit mark))]
-      [%perm-marks (pair (pair mark @tas) tube:clay)]
-      [%transform-marks (pair mark tube:clay)]
   ==
 --
 ::

--- a/pkg/arvo/mar/transform-add-nodes.hoon
+++ b/pkg/arvo/mar/transform-add-nodes.hoon
@@ -1,0 +1,12 @@
+/-  *post
+|_  i=indexed-post
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  i
+  --
+++  grab
+  |%
+  ++  noun  indexed-post
+  --
+--

--- a/pkg/arvo/sur/observe-hook.hoon
+++ b/pkg/arvo/sur/observe-hook.hoon
@@ -10,5 +10,7 @@
       ::
       [%warm-cache-all ~]
       [%cool-cache-all ~]
+      [%warm-static-conversion from=term to=term]
+      [%cool-static-conversion from=term to=term]
   ==
 --


### PR DESCRIPTION
Simplified our other apps' caching strategies and consolidated them into a general purpose utility in `%observe-hook`.  The previous caching strategy was fragile when marks were changed. Performance is approximately the same.