### PR TITLE
CalmEngine: Even calmer

### DIFF
--- a/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
@@ -3,14 +3,13 @@ import {
 
     Text
 } from '@tlon/indigo-react';
-import { Form, Formik, FormikHelpers } from 'formik';
+import { Form } from 'formik';
 import React, { useCallback } from 'react';
 import GlobalApi from '~/logic/api/global';
-import useSettingsState, { selectSettingsState, SettingsState } from '~/logic/state/settings';
-import { AsyncButton } from '~/views/components/AsyncButton';
+import useSettingsState, { SettingsState } from '~/logic/state/settings';
 import { BackButton } from './BackButton';
 import _ from 'lodash';
-import {FormikOnBlur} from '~/views/components/FormikOnBlur';
+import { FormikOnBlur } from '~/views/components/FormikOnBlur';
 
 interface FormSchema {
   hideAvatars: boolean;
@@ -36,23 +35,19 @@ const settingsSel = (s: SettingsState): FormSchema => ({
   audioShown: !s.remoteContentPolicy.audioShown
 });
 
-
 export function CalmPrefs(props: {
   api: GlobalApi;
 }) {
   const { api } = props;
   const initialValues = useSettingsState(settingsSel);
 
-  const onSubmit = useCallback(async (v: FormSchema, actions: FormikHelpers<FormSchema>) => {
-    let promises: Promise<any>[] = [];
+  const onSubmit = useCallback(async (v: FormSchema) => {
     _.forEach(v, (bool, key) => {
       const bucket = ['imageShown', 'videoShown', 'audioShown', 'oembedShown'].includes(key) ? 'remoteContentPolicy' : 'calm';
       if(initialValues[key] !== bool) {
-        promises.push(api.settings.putEntry(bucket, key, bool));
+        api.settings.putEntry(bucket, key, bool);
       }
-    })
-    await Promise.all(promises);
-    actions.setStatus({ success: null });
+    });
   }, [api]);
 
   return (

--- a/pkg/interface/src/views/components/FormikOnBlur.tsx
+++ b/pkg/interface/src/views/components/FormikOnBlur.tsx
@@ -11,14 +11,14 @@ export function FormikOnBlur<
   useEffect(() => {
     if (
       Object.keys(formikBag.errors || {}).length === 0 &&
-      formikBag.dirty && 
+      formikBag.dirty &&
       !formikBag.isSubmitting &&
       !submitting
     ) {
       setSubmitting(true);
       const { values } = formikBag;
       formikBag.submitForm().then(() => {
-        formikBag.resetForm({ values })
+        formikBag.resetForm({ values });
         setSubmitting(false);
       });
     }
@@ -28,6 +28,10 @@ export function FormikOnBlur<
     submitting,
     formikBag.isSubmitting
   ]);
+
+  useEffect(() => {
+    formikBag.resetForm({ values: props.initialValues });
+  }, [props.initialValues]);
 
   const { children, innerRef } = props;
 


### PR DESCRIPTION
- If the other toggle was clicked while we are waiting on a response for the other toggle, then would skip the submitting the second toggle click. Now no longer waits for a response
- If you refreshed right into the page, the settings would use the defaults and never be updated when the network response came in. Now updates the form whenever `initialValues` change

Fixes urbit/landscape#976