### PR TITLE
dm-hook: fix updating pendings

### DIFF
--- a/pkg/arvo/app/dm-hook.hoon
+++ b/pkg/arvo/app/dm-hook.hoon
@@ -191,7 +191,9 @@
     =.  ship-screen  (~(uni in ship-screen) (normalize-incoming nodes))
     =.  screened  (~(put by screened) src.bowl ship-screen)
     :_  state
-    (fact:io dm-hook-action+!>([%pendings ~(key by screened)]) ~[/updates])^~
+    =/  =action:hook
+      [%pendings ~(key by screened)]
+    (fact:io dm-hook-action+!>(action) ~[/updates])^~
   ::
   ++  dm-exists
     |=  =ship

--- a/pkg/arvo/app/dm-hook.hoon
+++ b/pkg/arvo/app/dm-hook.hoon
@@ -189,7 +189,9 @@
     ?>  =(1 ~(wyt by nodes))
     =/  ship-screen  (~(get ju screened) src.bowl)
     =.  ship-screen  (~(uni in ship-screen) (normalize-incoming nodes))
-    `state(screened (~(put by screened) src.bowl ship-screen))
+    =.  screened  (~(put by screened) src.bowl ship-screen)
+    :_  state
+    (fact:io dm-hook-action+!>([%pendings ~(key by screened)]) ~[/updates])^~
   ::
   ++  dm-exists
     |=  =ship


### PR DESCRIPTION
We weren't emitting facts when pendings got updated, so new pending messages would only show on refresh