### PR TITLE
DmResource: remove 'isAdmin' prop

### DIFF
--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -165,7 +165,7 @@ export function DmResource(props: DmResourceProps) {
         fetchMessages={fetchMessages}
         dismissUnread={dismissUnread}
         getPermalink={() => undefined}
-        isAdmin
+        isAdmin={false}
         onSubmit={onSubmit}
       />
     </Col>


### PR DESCRIPTION
Removes the 'delete message' action from direct messages by passing `isAdmin={false}`.

DmResource does not pass `onDelete` to its child ChatPane, but it does pass `isAdmin`, so the action is surfaced without any ability to delete, silently failing. I tried instantiating the same `removePosts` action, and it of course poked graph-push-hook, which failed during transform. dm-hook itself does not have any facility for deleting messages in its on-poke, so this seems unimplemented on back-end, and thus should not be surfaced on front-end.

As a feature it should be slated separately.

Fixes urbit/landscape#982.