### PR TITLE
npm: build ts -> js files before publishing

### DIFF
--- a/pkg/npm/api/package.json
+++ b/pkg/npm/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "repository": {
     "type": "git",
@@ -10,6 +10,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d",
   "scripts": {
+    "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "onchange './**/*.ts' -e './dist/**' -- npm run build",
     "build": "npm run clean && tsc -p tsconfig.json",

--- a/pkg/npm/api/tsconfig.json
+++ b/pkg/npm/api/tsconfig.json
@@ -5,7 +5,7 @@
 	  "outDir": "./dist",
     "module": "ES2020",
     "noImplicitAny": true,
-    "target": "ES2020",
+    "target": "ES2017",
     "pretty": true,
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": {
@@ -15,6 +15,7 @@
     "src"
   ],
   "scripts": {
+    "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "onchange './*.ts' -- npm run build",
     "build": "npm run clean && tsc -p tsconfig.json",


### PR DESCRIPTION
When publishing to npm, the `dist/*.js` files weren't being built, so the packages didn't work.

cc: @tylershuster