### PR TITLE
bip158: change swp to rev in +to-range

### DIFF
--- a/pkg/arvo/lib/bip/b158.hoon
+++ b/pkg/arvo/lib/bip/b158.hoon
@@ -157,7 +157,7 @@
   ++  to-range
     |=  [item=byts f=@ k=byts]
     ^-  @
-    (rsh [0 64] (mul f (swp 3 dat:(siphash k item))))
+    (rsh [0 64] (mul f +:(flim:sha (siphash k item))))
   ::  +set-construct: return sorted hashes of scriptpubkeys
   ::
   ++  set-construct

--- a/pkg/arvo/lib/bip/b158.hoon
+++ b/pkg/arvo/lib/bip/b158.hoon
@@ -157,7 +157,7 @@
   ++  to-range
     |=  [item=byts f=@ k=byts]
     ^-  @
-    (rsh [0 64] (mul f +:(flim:sha (siphash k item))))
+    (rsh [0 64] (mul f (rev 3 (siphash k item))))
   ::  +set-construct: return sorted hashes of scriptpubkeys
   ::
   ++  set-construct


### PR DESCRIPTION
change `swp` to `flim:sha` in +to-range of the bip158 lib to ensure leading 0's are preserved