### PR TITLE
meta: update janeway to v0.15.3.1

### DIFF
--- a/.github/actions/glob/Dockerfile
+++ b/.github/actions/glob/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaredtobin/janeway:v0.15.3
+FROM jaredtobin/janeway:v0.15.3.1
 COPY entrypoint.sh /entrypoint.sh
 EXPOSE 22/tcp
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
(The new image has npm's `unsafe-perm` set to true, which should fix some globbing issues).