### PR TITLE
interface: componentisation sweep

### DIFF
--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect } from 'react';
 import _ from 'lodash';
 import bigInt from 'big-integer';
 import { Box, Row, Col, Text } from '@tlon/indigo-react';
-import { Link } from 'react-router-dom';
 import { patp2dec } from 'urbit-ob';
 import { useContact } from '~/logic/state/contact';
 import useGraphState, { useDM } from '~/logic/state/graph';
@@ -12,6 +11,7 @@ import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { ChatPane } from './components/ChatPane';
 import airlock from '~/logic/api';
 import shallow from 'zustand/shallow';
+import { TextLink } from '~/views/components/Link';
 
 interface DmResourceProps {
   ship: string;
@@ -143,9 +143,9 @@ export function DmResource(props: DmResourceProps) {
             flexShrink={0}
             display={['block', 'none']}
           >
-            <Link to={'/~landscape/messages'}>
-              <Text>{'<- Back'}</Text>
-            </Link>
+            <TextLink to='/~landscape/messages'>
+              {'<- Back'}
+            </TextLink>
           </Box>
           {showNickname && (
             <Box mr="3">

--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -12,6 +12,7 @@ import { ChatPane } from './components/ChatPane';
 import airlock from '~/logic/api';
 import shallow from 'zustand/shallow';
 import { TextLink } from '~/views/components/Link';
+import { ShipName } from '~/views/components/ShipName';
 
 interface DmResourceProps {
   ship: string;
@@ -55,8 +56,7 @@ export function DmResource(props: DmResourceProps) {
   const unreadCount = (hark?.unreads as number) ?? 0;
   const contact = useContact(ship);
   const { hideNicknames } = useSettingsState(selectCalmState);
-  const showNickname = !hideNicknames && Boolean(contact);
-  const nickname = showNickname ? contact!.nickname : cite(ship) ?? ship;
+  const showNickname = !hideNicknames && contact?.nickname?.length > 0;
 
   const [
     getYoungerSiblings,
@@ -147,15 +147,11 @@ export function DmResource(props: DmResourceProps) {
               {'<- Back'}
             </TextLink>
           </Box>
-          {showNickname && (
-            <Box mr="3">
-              <Text fontWeight="medium" fontSize={2} mono={!showNickname}>
-                {nickname}
-              </Text>
-            </Box>
-          )}
-          <Box display={[showNickname ? 'none' : 'block', 'block']}>
-            <Text gray={showNickname} mono>
+          <Box mr="3">
+            <ShipName strong ship={ship} />
+          </Box>
+          <Box display={['none', showNickname ? 'block' : 'none']}>
+            <Text gray mono>
               {cite(ship)}
             </Text>
           </Box>

--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines-per-function */
-import { BaseImage, Box, Col, Icon, Row, Rule, Text } from '@tlon/indigo-react';
-import { Contact, MentionContent, Post } from '@urbit/api';
+import { Box, Col, Icon, Row, Rule, Text } from '@tlon/indigo-react';
+import { MentionContent, Post } from '@urbit/api';
 import bigInt from 'big-integer';
 import moment from 'moment';
 import React, {
@@ -10,16 +10,12 @@ import React, {
 } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import { useIdlingState } from '~/logic/lib/idling';
-import { Sigil } from '~/logic/lib/sigil';
 import { useCopy } from '~/logic/lib/useCopy';
-import {
-  cite, daToUnix, useHovering, useShowNickname, uxToHex
-} from '~/logic/lib/util';
-import { useContact } from '~/logic/state/contact';
-import { useDark } from '~/logic/state/join';
-import useSettingsState, { selectCalmState } from '~/logic/state/settings';
+import { daToUnix, useHovering } from '~/logic/lib/util';
 import { Dropdown } from '~/views/components/Dropdown';
 import ProfileOverlay from '~/views/components/ProfileOverlay';
+import { ShipImage } from '~/views/components/ShipImage';
+import { ShipName } from '~/views/components/ShipName';
 import { GraphContent } from '~/views/landscape/components/Graph/GraphContent';
 
 export const DATESTAMP_FORMAT = '[~]YYYY.M.D';
@@ -59,70 +55,14 @@ export const MessageAuthor = React.memo<any>(({
   showOurContact,
   ...props
 }) => {
-  const dark = useDark();
-  let contact: Contact | null = useContact(`~${msg.author}`);
-
   const date = daToUnix(bigInt(msg.index.split('/').reverse()[0]));
 
   const datestamp = moment
     .unix(date / 1000)
     .format(DATESTAMP_FORMAT);
-  contact =
-    ((msg.author === window.ship && showOurContact) ||
-      msg.author !== window.ship)
-      ? contact
-      : null;
 
-  const showNickname = useShowNickname(contact);
-  const { hideAvatars } = useSettingsState(selectCalmState);
-  const shipName = showNickname && contact?.nickname || cite(msg.author) || `~${msg.author}`;
-  const color = contact
-    ? `#${uxToHex(contact.color)}`
-    : dark
-    ? '#000000'
-    : '#FFFFFF';
-  const sigilClass = contact
-    ? ''
-    : dark
-    ? 'mix-blend-diff'
-    : 'mix-blend-darken';
-
-  const { copyDisplay, doCopy, didCopy } = useCopy(`~${msg.author}`, shipName);
   const { hovering, bind } = useHovering();
-  const nameMono = !(showNickname || didCopy);
 
-  const img =
-    contact?.avatar && !hideAvatars ? (
-      <BaseImage
-        display='inline-block'
-        referrerPolicy='no-referrer'
-        style={{ objectFit: 'cover' }}
-        src={contact.avatar}
-        height={24}
-        width={24}
-        borderRadius={1}
-      />
-    ) : (
-      <Box
-        width={24}
-        height={24}
-        display='flex'
-        justifyContent='center'
-        alignItems='center'
-        backgroundColor={color}
-        borderRadius={1}
-      >
-        <Sigil
-          ship={msg.author}
-          size={12}
-          display='block'
-          color={color}
-          classes={sigilClass}
-          icon
-          padding={0}
-        />
-      </Box>
-    );
   return (
     <Box pb="1" display='flex' alignItems='center'>
       <Box
@@ -134,7 +74,7 @@ export const MessageAuthor = React.memo<any>(({
         position='relative'
       >
         <ProfileOverlay cursor='auto' ship={msg.author}>
-          {img}
+          <ShipImage icon ship={`~${msg.author}`} size={24} sigilSize={12} />
         </ProfileOverlay>
       </Box>
       <Box flexGrow={1} display='block' className='clamp-message' {...bind}>
@@ -146,18 +86,7 @@ export const MessageAuthor = React.memo<any>(({
           display='flex'
           alignItems='baseline'
         >
-          <Text
-            fontSize={1}
-            mr={2}
-            flexShrink={1}
-            mono={nameMono}
-            fontWeight={nameMono ? '400' : '500'}
-            cursor='pointer'
-            onClick={doCopy}
-            title={showNickname ? `~${msg.author}` : contact?.nickname}
-          >
-            {copyDisplay}
-          </Text>
+          <ShipName strong copiable ship={`~${msg.author}`} mr={2} flexShrink={1} />
           <Text whiteSpace='nowrap' flexShrink={0} fontSize={0} gray>
             {timestamp}
           </Text>
@@ -514,110 +443,3 @@ export default React.memo(React.forwardRef((props: Omit<ChatMessageProps, 'inner
   <ChatMessage {...props} innerRef={ref} />
 )));
 
-export const MessagePlaceholder = ({
-  height,
-  index,
-  className = '',
-  style = {},
-  ...props
-}) => (
-  <Box
-    width='100%'
-    fontSize={2}
-    pl={3}
-    pt={4}
-    pr={3}
-    display='flex'
-    lineHeight='tall'
-    className={className}
-    style={{ height, ...style }}
-    {...props}
-  >
-    <Box
-      pr={3}
-      verticalAlign='top'
-      backgroundColor='white'
-      style={{ float: 'left' }}
-    >
-      <Text
-        display='block'
-        background='washedGray'
-        width='24px'
-        height='24px'
-        borderRadius='50%'
-        style={{
-          visibility: index % 5 == 0 ? 'initial' : 'hidden'
-        }}
-      ></Text>
-    </Box>
-    <Box
-      style={{ float: 'right', flexGrow: 1 }}
-      color='black'
-      className='clamp-message'
-    >
-      <Box
-        className='hide-child'
-        paddingTop={4}
-        style={{ visibility: index % 5 == 0 ? 'initial' : 'hidden' }}
-      >
-        <Text
-          display='inline-block'
-          verticalAlign='middle'
-          fontSize={0}
-          color='washedGray'
-          cursor='default'
-        >
-          <Text maxWidth='32rem' display='block'>
-            <Text
-              backgroundColor='washedGray'
-              borderRadius={2}
-              display='block'
-              width='100%'
-              height='100%'
-            ></Text>
-          </Text>
-        </Text>
-        <Text
-          display='inline-block'
-          mono
-          verticalAlign='middle'
-          fontSize={0}
-          color='washedGray'
-        >
-          <Text
-            background='washedGray'
-            borderRadius={2}
-            display='block'
-            height='1em'
-            style={{ width: `${((index % 3) + 1) * 3}em` }}
-          ></Text>
-        </Text>
-        <Text
-          mono
-          verticalAlign='middle'
-          fontSize={0}
-          ml={2}
-          color='washedGray'
-          borderRadius={2}
-          display={['none', 'inline-block']}
-          className='child'
-        >
-          <Text
-            backgroundColor='washedGray'
-            borderRadius={2}
-            display='block'
-            width='100%'
-            height='100%'
-          ></Text>
-        </Text>
-      </Box>
-      <Text
-        display='block'
-        backgroundColor='washedGray'
-        borderRadius={2}
-        height='1em'
-        style={{ width: `${(index % 5) * 20}%` }}
-      ></Text>
-    </Box>
-  </Box>
-);

--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -3,10 +3,11 @@ import { Group } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
 import bigInt from 'big-integer';
 import React, { useEffect } from 'react';
-import { Link, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import useGraphState from '~/logic/state/graph';
 import useMetadataState from '~/logic/state/metadata';
 import { Comments } from '~/views/components/Comments';
+import { TextLink } from '~/views/components/Link';
 import useGroupState from '../../../logic/state/group';
 import { LinkItem } from './components/LinkItem';
 import './css/custom.css';
@@ -101,7 +102,7 @@ export function LinkResource(props: LinkResourceProps) {
             return (
               <Col alignItems="center" overflowY="auto" width="100%">
               <Col width="100%" p={3} maxWidth="768px">
-                <Link to={resourceUrl}><Text px={3} bold>{'<- Back'}</Text></Link>
+                <TextLink to={resourceUrl} px={3} bold>{'<- Back'}</TextLink>
                 <LinkItem
                   key={node.post.index}
                   resource={resourcePath}

--- a/pkg/interface/src/views/apps/links/components/LinkItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkItem.tsx
@@ -1,7 +1,7 @@
 import { Action, Anchor, Box, Col, Icon, Row, Rule, Text } from '@tlon/indigo-react';
 import { Association, GraphNode, Group, markEachAsRead, removePosts, TextContent, UrlContent } from '@urbit/api';
 import React, { ReactElement, RefObject, useCallback, useEffect, useRef } from 'react';
-import { Link, Redirect } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import { roleForShip } from '~/logic/lib/group';
 import { getPermalinkForGraph, referenceToPermalink } from '~/logic/lib/permalinks';
 import { useCopy } from '~/logic/lib/useCopy';
@@ -11,6 +11,7 @@ import { Dropdown } from '~/views/components/Dropdown';
 import RemoteContent from '~/views/components/RemoteContent';
 import { PermalinkEmbed } from '../../permalinks/embed';
 import airlock from '~/logic/api';
+import { BoxLink } from '~/views/components/Link';
 
 interface LinkItemProps {
   node: GraphNode;
@@ -183,16 +184,15 @@ export const LinkItem = React.forwardRef((props: LinkItemProps, ref: RefObject<H
         lineHeight={1}
       />
       <Box ml="auto">
-        <Link
+        <BoxLink
+          display="flex"
           to={node.post.pending ? '#' : `${baseUrl}/index/${index}`}
           style={{ cursor: node.post.pending ? 'default' : 'pointer' }}
         >
-        <Box display='flex'>
           <Icon color={commColor} icon='Chat' />
           <Text color={commColor} ml={1}>{size}</Text>
-        </Box>
-      </Link>
-        </Box>
+        </BoxLink>
+      </Box>
 
       <Dropdown
         dropWidth="200px"

--- a/pkg/interface/src/views/apps/notifications/graph.tsx
+++ b/pkg/interface/src/views/apps/notifications/graph.tsx
@@ -3,8 +3,7 @@ import { Association, GraphNotificationContents, GraphNotifIndex, Post } from '@
 import { BigInteger } from 'big-integer';
 import { patp } from 'urbit-ob';
 import _ from 'lodash';
-import React, { useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import React from 'react';
 import styled from 'styled-components';
 import { pluralize } from '~/logic/lib/util';
 import useGroupState from '~/logic/state/group';
@@ -15,6 +14,7 @@ import {
 import Author from '~/views/components/Author';
 import { GraphContent } from '~/views/landscape/components/Graph/GraphContent';
 import { Header } from './header';
+import { ColLink } from '~/views/components/Link';
 
 const TruncBox = styled(Box)<{ truncate?: number }>`
   -webkit-line-clamp: ${p => p.truncate ?? 'unset'};
@@ -55,40 +55,39 @@ function describeNotification(
 
 function ContentSummary({ icon, name, author, to }) {
   return (
-    <Link to={to}>
-      <Col
-        gapY={1}
-        flexDirection={['column', 'row']}
-        alignItems={['flex-start', 'center']}
+    <ColLink
+      to={to}
+      gapY={1}
+      flexDirection={['column', 'row']}
+      alignItems={['flex-start', 'center']}
+    >
+      <Row
+        alignItems="center"
+        gapX={2}
+        p={1}
+        width="fit-content"
+        borderRadius={2}
+        border={1}
+        borderColor="lightGray"
       >
-        <Row
-          alignItems="center"
-          gapX={2}
-          p={1}
-          width="fit-content"
-          borderRadius={2}
-          border={1}
-          borderColor="lightGray"
-        >
-          <Icon display="block" icon={icon} />
-          <Text verticalAlign="baseline" fontWeight="medium">
-            {name}
-          </Text>
-        </Row>
-        <Row ml={[0, 1]} alignItems="center">
-          <Text lineHeight={1} fontWeight="medium" mr={1}>
-            by
-          </Text>
-          <Author
-            sigilPadding={6}
-            size={24}
-            dontShowTime
-            ship={author}
-            showImage
-          />
-        </Row>
-      </Col>
-    </Link>
+        <Icon display="block" icon={icon} />
+        <Text verticalAlign="baseline" fontWeight="medium">
+          {name}
+        </Text>
+      </Row>
+      <Row ml={[0, 1]} alignItems="center">
+        <Text lineHeight={1} fontWeight="medium" mr={1}>
+          by
+        </Text>
+        <Author
+          sigilPadding={6}
+          size={24}
+          dontShowTime
+          ship={author}
+          showImage
+        />
+      </Row>
+    </ColLink>
   );
 }
 
@@ -227,8 +226,7 @@ export function GraphNotification(props: {
   time: number;
   timebox: BigInteger;
 }) {
-  const { contents, index, read, time, timebox } = props;
-  const history = useHistory();
+  const { contents, index, time } = props;
 
   const authors = _.uniq(_.map(contents, 'author'));
   const singleAuthor = authors.length === 1;
@@ -244,22 +242,15 @@ export function GraphNotification(props: {
   const groupAssociation = useAssocForGroup(association?.group ?? '');
   const groups = useGroupState(state => state.groups);
 
-  const onClick = useCallback(() => {
-    if(dm) {
-      history.push(`/~landscape/messages/dm/~${authors[0]}`);
-      return;
-    }
-    const first = contents[0];
-    history.push(
-      getNodeUrl(
-        index.mark,
-        groups[association?.group]?.hidden,
-        association?.group,
-        association?.resource,
-        first.index
-      )
-    );
-  }, [timebox, index, read, history.push, authors, dm]);
+  const to =
+   dm ?  `/~landscape/messages/dm/~${authors[0]}`
+      : getNodeUrl(
+          index.mark,
+          groups[association?.group]?.hidden,
+          association?.group,
+          association?.resource,
+          contents[0].index
+        );
 
   const authorsInHeader =
     dm ||
@@ -282,7 +273,7 @@ export function GraphNotification(props: {
         groupTitle={groupTitle}
         content
       />
-      <Col onClick={onClick} gapY={2} flexGrow={1} width="100%" gridArea="main">
+      <ColLink to={to} gapY={2} flexGrow={1} width="100%" gridArea="main">
         <GraphNodes
           hideAuthors={hideAuthors}
           posts={contents.slice(0, 4)}
@@ -296,7 +287,7 @@ export function GraphNotification(props: {
             + {contents.length - 4} more
           </Text>
         )}
-      </Col>
+      </ColLink>
     </>
   );
 }

--- a/pkg/interface/src/views/apps/notifications/notifications.tsx
+++ b/pkg/interface/src/views/apps/notifications/notifications.tsx
@@ -1,7 +1,7 @@
-import { Box, Col, Icon, Row, Text } from '@tlon/indigo-react';
+import { Col, Icon, Row, Text } from '@tlon/indigo-react';
 import React, { ReactElement, useCallback, useRef } from 'react';
 import Helmet from 'react-helmet';
-import { Link, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import useGroupState from '~/logic/state/group';
 import useHarkState from '~/logic/state/hark';
 import { Body } from '~/views/components/Body';
@@ -10,6 +10,7 @@ import { useTutorialModal } from '~/views/components/useTutorialModal';
 import Inbox from './inbox';
 import airlock from '~/logic/api';
 import { readAll } from '@urbit/api';
+import { BoxLink } from '~/views/components/Link';
 
 const baseUrl = '/~notifications';
 
@@ -62,11 +63,9 @@ export default function NotificationsScreen(props: any): ReactElement {
                       >
                         Mark All Read
                       </StatelessAsyncAction>
-                      <Link to="/~settings#notifications">
-                        <Box>
-                          <Icon lineHeight={1} icon="Adjust" />
-                        </Box>
-                      </Link>
+                      <BoxLink to="/~settings#notifications">
+                        <Icon lineHeight={1} icon="Adjust" />
+                      </BoxLink>
                     </Row>
                   </Row>
                   {!view && <Inbox

--- a/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/EditProfile.tsx
@@ -24,6 +24,7 @@ import {
 } from './Profile';
 import airlock from '~/logic/api';
 import { editContact, setPublic } from '@urbit/api';
+import { TextLink } from '~/views/components/Link';
 
 const formSchema = Yup.object({
   nickname: Yup.string(),
@@ -151,17 +152,14 @@ export function EditProfile(props: any): ReactElement {
                   >
                     Save Edits
                   </Button>
-                  <Text
+                  <TextLink
                     py={2}
                     ml={3}
                     fontWeight='500'
-                    cursor='pointer'
-                    onClick={() => {
-                      history.push(`/~profile/${ship}`);
-                    }}
+                    to={`/~profile/${ship}`}
                   >
                     Cancel
-                  </Text>
+                  </TextLink>
                 </Row>
                 <ProfileStatus contact={contact} />
               </ProfileControls>

--- a/pkg/interface/src/views/apps/profile/components/Profile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/Profile.tsx
@@ -1,7 +1,6 @@
 import { BaseImage, Box, Center, Row, Text } from '@tlon/indigo-react';
 import { retrieve } from '@urbit/api';
 import React, { ReactElement, useEffect, useRef } from 'react';
-import { useHistory } from 'react-router-dom';
 import { Sigil } from '~/logic/lib/sigil';
 import { uxToHex } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
@@ -12,6 +11,7 @@ import { useTutorialModal } from '~/views/components/useTutorialModal';
 import { EditProfile } from './EditProfile';
 import { ViewProfile } from './ViewProfile';
 import airlock from '~/logic/api';
+import { TextLink } from '~/views/components/Link';
 
 export function ProfileHeader(props: any): ReactElement {
   return (
@@ -123,28 +123,23 @@ export function ProfileStatus(props: any): ReactElement {
 
 export function ProfileActions(props: any): ReactElement {
   const { ship, isPublic, contact } = props;
-  const history = useHistory();
   return (
     <Row>
       {ship === `~${window.ship}` ? (
         <>
-          <Text
+          <TextLink
             py={2}
-            cursor='pointer'
             fontWeight='500'
-            onClick={() => {
-              history.push(`/~profile/${ship}/edit`);
-            }}
+            to={`/~profile/${ship}/edit`}
           >
             Edit
             <Text
               fontWeight='500'
-              cursor='pointer'
               display={['none','inline']}
             >
                 {isPublic ? ' Public' : ' Private'} Profile
             </Text>
-          </Text>
+          </TextLink>
           <SetStatusBarModal
             isControl
             py={2}
@@ -155,14 +150,13 @@ export function ProfileActions(props: any): ReactElement {
         </>
       ) : (
         <>
-          <Text
+          <TextLink
             py={2}
-            cursor='pointer'
             fontWeight='500'
-            onClick={() => history.push(`/~landscape/messages/dm/${ship}`)}
+            to={`/~landscape/messages/dm/${ship}`}
           >
             Message
-          </Text>
+          </TextLink>
         </>
       )}
     </Row>

--- a/pkg/interface/src/views/apps/profile/components/Profile.tsx
+++ b/pkg/interface/src/views/apps/profile/components/Profile.tsx
@@ -1,10 +1,7 @@
 import { BaseImage, Box, Center, Row, Text } from '@tlon/indigo-react';
 import { retrieve } from '@urbit/api';
 import React, { ReactElement, useEffect, useRef } from 'react';
-import { Sigil } from '~/logic/lib/sigil';
-import { uxToHex } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
-import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import RichText from '~/views/components/RichText';
 import { SetStatusBarModal } from '~/views/components/SetStatusBarModal';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
@@ -12,6 +9,7 @@ import { EditProfile } from './EditProfile';
 import { ViewProfile } from './ViewProfile';
 import airlock from '~/logic/api';
 import { TextLink } from '~/views/components/Link';
+import { ShipImage } from '~/views/components/ShipImage';
 
 export function ProfileHeader(props: any): ReactElement {
   return (
@@ -28,9 +26,7 @@ export function ProfileHeader(props: any): ReactElement {
 }
 
 export function ProfileImages(props: any): ReactElement {
-  const { hideAvatars } = useSettingsState(selectCalmState);
   const { contact, hideCover, ship } = props;
-  const hexColor = contact?.color ? `#${uxToHex(contact.color)}` : '#000000';
 
   const anchorRef = useRef<HTMLDivElement>(null);
 
@@ -54,19 +50,6 @@ export function ProfileImages(props: any): ReactElement {
       />
     );
 
-  const image =
-    !hideAvatars && contact?.avatar ? (
-      <BaseImage
-        src={contact.avatar}
-        width='100%'
-        height='100%'
-        referrerPolicy="no-referrer"
-        style={{ objectFit: 'cover' }}
-      />
-    ) : (
-      <Sigil padding={24} ship={ship} size={128} color={hexColor} />
-    );
-
   return (
     <>
       <Row ref={anchorRef} width='100%' height='400px' position='relative'>
@@ -85,7 +68,7 @@ export function ProfileImages(props: any): ReactElement {
         marginTop='-64px'
         marginLeft='-64px'
       >
-        {image}
+        <ShipImage size={128} sigilSize={80} ship={ship} />
       </Box>
     </>
   );
@@ -130,6 +113,7 @@ export function ProfileActions(props: any): ReactElement {
           <TextLink
             py={2}
             fontWeight='500'
+            fontSize={1}
             to={`/~profile/${ship}/edit`}
           >
             Edit

--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -2,7 +2,7 @@ import { Action, Box, Col, Row, Text } from '@tlon/indigo-react';
 import { Association, Graph, GraphNode, Group, markEachAsRead, removePosts } from '@urbit/api';
 import bigInt from 'big-integer';
 import React, { useEffect, useState } from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { roleForShip } from '~/logic/lib/group';
 import { getPermalinkForGraph } from '~/logic/lib/permalinks';
 import { getComments, getLatestRevision } from '~/logic/lib/publish';
@@ -13,6 +13,7 @@ import { Spinner } from '~/views/components/Spinner';
 import { GraphContent } from '~/views/landscape/components/Graph/GraphContent';
 import { NoteNavigation } from './NoteNavigation';
 import airlock from '~/logic/api';
+import { ActionLink, TextLink } from '~/views/components/Link';
 
 interface NoteProps {
   ship: string;
@@ -66,9 +67,9 @@ export function Note(props: NoteProps & RouteComponentProps) {
   const ourRole = roleForShip(group, window.ship);
   if (window.ship === note?.post?.author) {
     adminLinks.push(
-      <Link to={`${baseUrl}/edit`}>
-        <Action backgroundColor="white">Update</Action>
-      </Link>
+      <ActionLink to={`${baseUrl}/edit`}>
+        Update
+      </ActionLink>
     );
   }
 
@@ -100,9 +101,9 @@ export function Note(props: NoteProps & RouteComponentProps) {
       gridRowGap={4}
       mx="auto"
     >
-      <Link to={rootUrl}>
-        <Text>{'<- Notebook Index'}</Text>
-      </Link>
+      <TextLink to={rootUrl}>
+        {'<- Notebook Index'}
+      </TextLink>
       <Col>
         <Text display="block" mb={2}>{title || ''}</Text>
         <Row alignItems="center">

--- a/pkg/interface/src/views/apps/publish/components/NoteNavigation.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NoteNavigation.tsx
@@ -3,8 +3,8 @@ import { Graph } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import moment from 'moment';
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
 import { getLatestRevision } from '~/logic/lib/publish';
+import { BoxLink } from '~/views/components/Link';
 import Timestamp from '~/views/components/Timestamp';
 
 function NavigationItem(props: {
@@ -14,14 +14,14 @@ function NavigationItem(props: {
   prev?: boolean;
 }): ReactElement {
   return (
-    <Box
+    <BoxLink
+      to={props.url}
       justifySelf={props.prev ? 'start' : 'end'}
       display="flex"
       flexDirection="column"
       justifyContent="flex-end"
       textAlign={props.prev ? 'left' : 'right'}
     >
-      <Link to={props.url}>
         <Text display='block' color="gray">
           {props.prev ? 'Previous' : 'Next'}
         </Text>
@@ -32,8 +32,7 @@ function NavigationItem(props: {
           fontSize={1}
           justifyContent={props.prev ? 'flex-start' : 'flex-end'}
         />
-      </Link>
-    </Box>
+    </BoxLink>
   );
 }
 

--- a/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotePreview.tsx
@@ -1,9 +1,8 @@
-import { Box, Col, Icon, Image, Row, Text } from '@tlon/indigo-react';
+import { Box, Icon, Image, Row, Text } from '@tlon/indigo-react';
 import { Group } from '@urbit/api';
 import { GraphNode } from '@urbit/api/graph';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import {
     getComments,
@@ -12,6 +11,7 @@ import {
 } from '~/logic/lib/publish';
 import useHarkState from '~/logic/state/hark';
 import Author from '~/views/components/Author';
+import { BoxLink, ColLink } from '~/views/components/Link';
 
 interface NotePreviewProps {
   host: string;
@@ -80,28 +80,25 @@ export function NotePreview(props: NotePreviewProps) {
 
   return (
     <Box width='100%' opacity={post.pending ? '0.5' : '1'}>
-      <Link
+      <ColLink
         to={post.pending ? '#' : url}
         style={ { cursor: cursorStyle } }
+        lineHeight='tall'
+        width='100%'
+        color={!isUnread ? 'lightGray' : 'blue'}
+        border={1}
+        borderRadius={2}
+        alignItems='flex-start'
+        overflow='hidden'
+        p={2}
       >
-        <Col
-          lineHeight='tall'
-          width='100%'
-          color={!isUnread ? 'lightGray' : 'blue'}
-          border={1}
-          borderRadius={2}
-          alignItems='flex-start'
-          overflow='hidden'
-          p={2}
-        >
-          <WrappedBox mb={2}><Text bold>{title}</Text></WrappedBox>
-          <WrappedBox>
-            <Text fontSize='14px' lineHeight='tall'>
-              <NotePreviewContent snippet={snippet} />
-            </Text>
-          </WrappedBox>
-        </Col>
-      </Link>
+        <WrappedBox mb={2}><Text bold>{title}</Text></WrappedBox>
+        <WrappedBox>
+          <Text fontSize='14px' lineHeight='tall'>
+            <NotePreviewContent snippet={snippet} />
+          </Text>
+        </WrappedBox>
+      </ColLink>
       <Row minWidth={0} flexShrink={0} width="100%" justifyContent="space-between" py={3} bg="white">
         <Author
           showImage
@@ -111,12 +108,10 @@ export function NotePreview(props: NotePreviewProps) {
           unread={isUnread}
         />
         <Box ml="auto" mr={1}>
-          <Link to={url}>
-            <Box display='flex'>
-              <Icon color={commColor} icon='Chat' />
-              <Text color={commColor} ml={1}>{numComments}</Text>
-            </Box>
-          </Link>
+          <BoxLink to={url} display='flex'>
+            <Icon color={commColor} icon='Chat' />
+            <Text color={commColor} ml={1}>{numComments}</Text>
+          </BoxLink>
         </Box>
       </Row>
     </Box>

--- a/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackButton.tsx
@@ -1,11 +1,10 @@
-import { Text } from '@tlon/indigo-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { TextLink } from '~/views/components/Link';
 
-export function BackButton(props: {}) {
+export function BackButton() {
   return (
-    <Link to='/~settings'>
-      <Text
+      <TextLink
+        to="/~settings"
         display={['block', 'none']}
         fontSize={2}
         fontWeight='medium'
@@ -13,7 +12,6 @@ export function BackButton(props: {}) {
         pb={0}
       >
         {'<- Back to System Preferences'}
-      </Text>
-    </Link>
+    </TextLink>
   );
 }

--- a/pkg/interface/src/views/components/Author.tsx
+++ b/pkg/interface/src/views/components/Author.tsx
@@ -1,14 +1,10 @@
-import { BaseImage, Box, Row, Text } from '@tlon/indigo-react';
+import { Box, Row } from '@tlon/indigo-react';
 import moment from 'moment';
 import React, { ReactElement, ReactNode } from 'react';
-import { Sigil } from '~/logic/lib/sigil';
-import { useCopy } from '~/logic/lib/useCopy';
-import { cite, useShowNickname, uxToHex } from '~/logic/lib/util';
-import { useContact } from '~/logic/state/contact';
-import { useDark } from '~/logic/state/join';
-import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { PropFunc } from '~/types';
 import ProfileOverlay from './ProfileOverlay';
+import { ShipImage } from './ShipImage';
+import { ShipName } from './ShipName';
 import Timestamp from './Timestamp';
 
 export interface AuthorProps {
@@ -41,34 +37,7 @@ function Author(props: AuthorProps & PropFunc<typeof Box>): ReactElement {
   const size = props.size || 16;
   const sigilPadding = props.sigilPadding || 2;
 
-  const dark = useDark();
-
-  const contact = useContact(ship);
-  const color = contact?.color ? `#${uxToHex(contact?.color)}` : dark ? '#000000' : '#FFFFFF';
-  const showNickname = useShowNickname(contact);
-  const { hideAvatars } = useSettingsState(selectCalmState);
-  const name = showNickname && contact ? contact.nickname : cite(ship);
   const stamp = moment(date);
-  const { copyDisplay, doCopy } = useCopy(`~${ship}`, name);
-
-  const sigil = fullNotIcon ? (
-    <Sigil ship={ship} size={size} color={color} padding={sigilPadding} />
-  ) : (
-    <Sigil ship={ship} size={size} color={color} icon padding={sigilPadding} />
-  );
-
-  const img =
-    contact?.avatar && !hideAvatars ? (
-      <BaseImage
-        referrerPolicy="no-referrer"
-        display='inline-block'
-        src={contact.avatar}
-        style={{ objectFit: 'cover' }}
-        height={size}
-        width={size}
-        borderRadius={1}
-      />
-    ) : sigil;
 
   return (
     <Row {...rest} alignItems='center' width='auto'>
@@ -80,26 +49,17 @@ function Author(props: AuthorProps & PropFunc<typeof Box>): ReactElement {
       >
         {showImage && (
           <ProfileOverlay ship={ship}>
-            {img}
+            <ShipImage
+              icon={!fullNotIcon}
+              ship={`~${ship}`}
+              size={size}
+              sigilSize={size - (2*sigilPadding)}
+            />
           </ProfileOverlay>
         )}
       </Box>
       <Box display='flex' alignItems='baseline'>
-        <Text
-          ml={showImage ? 2 : 0}
-          color='black'
-          fontSize='1'
-          cursor='pointer'
-          lineHeight={lineHeight}
-          fontFamily={showNickname ? 'sans' : 'mono'}
-          fontWeight={showNickname ? '500' : '400'}
-          mr={showNickname ? 0 : '2px'}
-          mt={showNickname ? 0 : '0px'}
-          title={showNickname ? cite(ship) : contact?.nickname}
-          onClick={doCopy}
-        >
-          {copyDisplay}
-        </Text>
+        <ShipName ship={`~${ship}`} ml={showImage ? 2 : 0} lineHeight={lineHeight} />
         { !dontShowTime && time && (
           <Timestamp
             height="fit-content"

--- a/pkg/interface/src/views/components/Body.tsx
+++ b/pkg/interface/src/views/components/Body.tsx
@@ -11,7 +11,7 @@ export function Body(
       <Container
         expand
         round
-        border={border ? border : [0, 1]}
+        borderWidth={border ? border : [0, 1]}
         {...boxProps}
       >
         {children}

--- a/pkg/interface/src/views/components/Body.tsx
+++ b/pkg/interface/src/views/components/Body.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@tlon/indigo-react';
 import React, { ReactNode } from 'react';
+import { Container } from './Container';
 
 export function Body(
   props: { children: ReactNode } & Parameters<typeof Box>[0]
@@ -7,17 +8,14 @@ export function Body(
   const { children, border, ...boxProps } = props;
   return (
     <Box fontSize={0} px={[0, 3]} pb={[0, 3]} height="100%" width="100%">
-      <Box
-        bg="white"
-        height="100%"
-        width="100%"
-        borderRadius={2}
+      <Container
+        expand
+        round
         border={border ? border : [0, 1]}
-        borderColor={['lightGray', 'lightGray']}
         {...boxProps}
       >
         {children}
-      </Box>
+      </Container>
     </Box>
   );
 }

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -3,7 +3,6 @@ import { Group, removePosts } from '@urbit/api';
 import { GraphNode } from '@urbit/api/graph';
 import bigInt from 'big-integer';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { roleForShip } from '~/logic/lib/group';
 import { getPermalinkForGraph } from '~/logic/lib/permalinks';
 import { getLatestCommentRevision } from '~/logic/lib/publish';
@@ -12,6 +11,7 @@ import useMetadataState from '~/logic/state/metadata';
 import Author from '~/views/components/Author';
 import { GraphContent } from '../landscape/components/Graph/GraphContent';
 import airlock from '~/logic/api';
+import { ActionLink } from './Link';
 
 interface CommentItemProps {
   pending?: boolean;
@@ -71,11 +71,9 @@ return false;
   const ourRole = roleForShip(group, window.ship);
   if (window.ship == post?.author && !disabled) {
     adminLinks.push(
-      <Link to={{ pathname: props.baseUrl, search: `?edit=${commentIndex}` }}>
-        <Action bg="white">
-          Update
-        </Action>
-      </Link>
+      <ActionLink to={{ pathname: props.baseUrl, search: `?edit=${commentIndex}` }}>
+        Update
+      </ActionLink>
     );
   }
 

--- a/pkg/interface/src/views/components/Container.tsx
+++ b/pkg/interface/src/views/components/Container.tsx
@@ -1,0 +1,18 @@
+import { allSystemStyle } from '@tlon/indigo-react';
+import { css, SystemStyleObject } from '@styled-system/css';
+import styled from 'styled-components';
+
+const style = ({ border, round = false, expand = false }) => {
+  const expandRules = expand ? { width: '100%', height: '100%' } : {};
+  return css({
+    ...expandRules,
+    borderRadius: round ? 2 : 1,
+    border: typeof border === 'undefined' ? 1 : border,
+    borderColor: 'lightGray',
+    backgroundColor: 'white',
+    display: 'flex',
+    flexDirection: 'column'
+  } as SystemStyleObject);
+};
+
+export const Container = styled.div(style, ...allSystemStyle);

--- a/pkg/interface/src/views/components/Container.tsx
+++ b/pkg/interface/src/views/components/Container.tsx
@@ -7,7 +7,7 @@ const style = ({ borderWidth, round = false, expand = false, gapY }) => {
   return css({
     ...expandRules,
     borderRadius: round ? 2 : 1,
-    borderColor: ['lightGray', 'lightGray', 'lightGray'],
+    borderColor: 'lightGray',
     borderWidth: typeof borderWidth === 'undefined' ? 1 : borderWidth,
     borderStyle: 'solid',
     backgroundColor: 'white',

--- a/pkg/interface/src/views/components/Container.tsx
+++ b/pkg/interface/src/views/components/Container.tsx
@@ -2,16 +2,19 @@ import { allSystemStyle } from '@tlon/indigo-react';
 import { css, SystemStyleObject } from '@styled-system/css';
 import styled from 'styled-components';
 
-const style = ({ border, round = false, expand = false }) => {
+const style = ({ borderWidth, round = false, expand = false, gapY }) => {
   const expandRules = expand ? { width: '100%', height: '100%' } : {};
   return css({
     ...expandRules,
     borderRadius: round ? 2 : 1,
-    border: typeof border === 'undefined' ? 1 : border,
-    borderColor: 'lightGray',
+    borderColor: ['lightGray', 'lightGray', 'lightGray'],
+    borderWidth: typeof borderWidth === 'undefined' ? 1 : borderWidth,
+    borderStyle: 'solid',
     backgroundColor: 'white',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    '& > *': typeof gapY === 'undefined' ? {} : { marginTop: gapY },
+    '& > :first-child': typeof gapY === 'undefined' ? {} : { marginTop: 0 }
   } as SystemStyleObject);
 };
 

--- a/pkg/interface/src/views/components/DropdownSearch.tsx
+++ b/pkg/interface/src/views/components/DropdownSearch.tsx
@@ -12,6 +12,7 @@ import React, {
 } from 'react';
 import { useDropdown } from '~/logic/lib/useDropdown';
 import { PropFunc } from '~/types/util';
+import { Container } from './Container';
 
 interface DropdownSearchExtraProps<C> {
   // check if entry is exact match
@@ -119,7 +120,7 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>): ReactElement {
       opts = options.includes(first) ? opts : [first, ...options];
     }
     return _.take(opts, 5).map((o, idx) =>
-      props.renderCandidate(
+      renderCandidate(
         o,
         !_.isUndefined(selected) && props.getKey(o) === props.getKey(selected),
         handleSelect
@@ -138,19 +139,16 @@ export function DropdownSearch<C>(props: DropdownSearchProps<C>): ReactElement {
         disabled={disabled}
         placeholder={placeholder}
         onBlur={onBlur}
+        onFocus={onFocus}
       />
       {dropdown.length !== 0 && query.length !== 0 && (
-        <Box
+        <Container
           mt={1}
-          border={1}
-          borderRadius={1}
-          borderColor="washedGray"
-          bg="white"
           width="100%"
           position="absolute"
         >
           {dropdown}
-        </Box>
+        </Container>
       )}
     </Box>
   );

--- a/pkg/interface/src/views/components/Link.tsx
+++ b/pkg/interface/src/views/components/Link.tsx
@@ -1,0 +1,67 @@
+import {
+  BoxProps,
+  ColProps,
+  allSystemStyle,
+  ActionProps,
+  asAction,
+  asButton,
+  ButtonProps,
+  TextProps,
+  RowProps
+} from '@tlon/indigo-react';
+import React from 'react';
+import styled from 'styled-components';
+import { css } from '@styled-system/css';
+import { Link, LinkProps } from 'react-router-dom';
+import { compose } from 'styled-system';
+
+export const BlockLink = styled(Link)`
+  display: block;
+`;
+
+export const ActionLink = asAction(BlockLink) as React.FC<
+  ActionProps & LinkProps
+>;
+
+export const ButtonLink = asButton(BlockLink) as React.FC<
+  ButtonProps & LinkProps
+>;
+
+export const BoxLink = styled(BlockLink)<
+  React.PropsWithChildren<LinkProps & BoxProps>
+>(compose(...allSystemStyle));
+
+export const colLinkStyle = ({ gapY }: ColProps) =>
+  css({
+    display: 'flex',
+    flexDirection: 'column',
+    '& > *': typeof gapY === 'undefined' ? {} : { marginTop: gapY },
+    '& > :first-child': typeof gapY === 'undefined' ? {} : { marginTop: 0 }
+  });
+
+export const ColLink = styled(Link)<
+  React.PropsWithChildren<LinkProps & ColProps>
+>(colLinkStyle, ...allSystemStyle);
+
+export const rowLinkStyle = ({ gapX }: RowProps) =>
+  css({
+    display: 'flex',
+    '& > *': typeof gapX === 'undefined' ? {} : { marginRight: gapX },
+    '& > :last-child': typeof gapX === 'undefined' ? {} : { marginRight: 0 }
+  });
+
+export const RowLink = styled(Link)<
+  React.PropsWithChildren<LinkProps & RowProps>
+>(rowLinkStyle, ...allSystemStyle);
+
+RowLink.defaultProps = {
+  alignItems: 'center'
+};
+
+export const TextLink = styled(Link)<
+  React.PropsWithChildren<LinkProps & TextProps>
+>(compose(...allSystemStyle));
+
+TextLink.defaultProps = {
+  color: 'black'
+};

--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -2,11 +2,11 @@ import { Text } from '@tlon/indigo-react';
 import { Contact, Content, Group } from '@urbit/api';
 import React from 'react';
 import { referenceToPermalink } from '~/logic/lib/permalinks';
-import { cite, deSig, useShowNickname } from '~/logic/lib/util';
-import { useContact } from '~/logic/state/contact';
+import { deSig } from '~/logic/lib/util';
 import { PropFunc } from '~/types';
 import ProfileOverlay from '~/views/components/ProfileOverlay';
 import RichText from '~/views/components/RichText';
+import { ShipName } from './ShipName';
 
 interface MentionTextProps {
   contact?: Contact;
@@ -41,24 +41,18 @@ export function Mention(props: {
   first?: boolean;
 } & PropFunc<typeof Text>) {
   const { ship, first = false, ...rest } = props;
-  const contact = useContact(`~${deSig(ship)}`);
-  const showNickname = useShowNickname(contact);
-  const name = showNickname ? contact?.nickname : cite(ship);
   return (
     <ProfileOverlay ship={ship} display="inline">
-      <Text
+      <ShipName
+        ship={`~${deSig(ship)}`}
         marginLeft={first? 0 : 1}
         marginRight={1}
         px={1}
         bg='washedBlue'
         color='blue'
-        fontSize={showNickname ? 1 : 0}
-        mono={!showNickname}
-        title={showNickname ? cite(ship) : contact?.nickname}
+        cursor="pointer"
         {...rest}
-      >
-        {name}
-      </Text>
+      />
     </ProfileOverlay>
   );
 }

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -25,9 +25,10 @@ import useSettingsState, { SettingsState } from '~/logic/state/settings';
 import { Portal } from './Portal';
 import { ProfileStatus } from './ProfileStatus';
 import RichText from './RichText';
+import { Container } from './Container';
 
 export const OVERLAY_HEIGHT = 250;
-const FixedOverlay = styled(Col)`
+const FixedOverlay = styled(Container)`
   position: fixed;
   -webkit-transition: all 0.1s ease-out;
   -moz-transition: all 0.1s ease-out;
@@ -138,11 +139,7 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
       <FixedOverlay
         ref={innerRef}
         {...coords}
-        backgroundColor='white'
-        color='washedGray'
-        border={1}
-        borderRadius={2}
-        borderColor='lightGray'
+        round
         boxShadow='0px 0px 0px 3px'
         zIndex={3}
         fontSize={0}

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -12,7 +12,6 @@ import { cite, uxToHex } from '@urbit/api';
 import shallow from 'zustand/shallow';
 import _ from 'lodash';
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
 import styled from 'styled-components';
 import { getRelativePosition } from '~/logic/lib/relativePosition';
@@ -26,6 +25,7 @@ import { Portal } from './Portal';
 import { ProfileStatus } from './ProfileStatus';
 import RichText from './RichText';
 import { Container } from './Container';
+import { BoxLink, RowLink } from './Link';
 
 export const OVERLAY_HEIGHT = 250;
 const FixedOverlay = styled(Container)`
@@ -54,7 +54,6 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
   const [open, _setOpen] = useState(false);
   const [coords, setCoords] = useState({});
   const [visible, setVisible] = useState(false);
-  const history = useHistory();
   const outerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const [hideAvatars, hideNicknames] = useSettingsState(selSettings, shallow);
@@ -148,26 +147,24 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
         padding={3}
         justifyContent='center'
       >
-        <Row color='black' padding={3} position='absolute' top={0} left={0}>
-           {!isOwn && (
-             <Icon
-               icon='Chat'
-               size={16}
-               cursor='pointer'
-               onClick={() => history.push(`/~landscape/messages/dm/~${ship}`)}
-             />
-           )}
-         </Row>
-        <Box
+        {!isOwn && (
+          <RowLink color='black' padding={3}
+position='absolute' top={0}
+left={0}
+             to={`/~landscape/messages/dm/~${ship}`}
+          >
+             <Icon icon='Chat' size={16} />
+         </RowLink>
+         )}
+        <BoxLink
           alignSelf='center'
           height='72px'
-          cursor='pointer'
-          onClick={() => history.push(`/~profile/~${ship}`)}
+          to={`/~profile/~${ship}`}
           overflow='hidden'
           borderRadius={2}
         >
           {img}
-        </Box>
+        </BoxLink>
         <Col
           position='absolute'
           overflow='hidden'

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -1,31 +1,23 @@
 import {
-  BaseImage, Box,
-
+  Box,
   BoxProps,
-  Center, Col,
-
-  Icon, Row,
-
-  Text
+  Col,
+  Icon, Row
 } from '@tlon/indigo-react';
-import { cite, uxToHex } from '@urbit/api';
-import shallow from 'zustand/shallow';
 import _ from 'lodash';
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import styled from 'styled-components';
 import { getRelativePosition } from '~/logic/lib/relativePosition';
-import { Sigil } from '~/logic/lib/sigil';
-import { useCopy } from '~/logic/lib/useCopy';
 import { useOutsideClick } from '~/logic/lib/useOutsideClick';
-import { useShowNickname } from '~/logic/lib/util';
 import { useContact } from '~/logic/state/contact';
-import useSettingsState, { SettingsState } from '~/logic/state/settings';
 import { Portal } from './Portal';
 import { ProfileStatus } from './ProfileStatus';
 import RichText from './RichText';
 import { Container } from './Container';
 import { BoxLink, RowLink } from './Link';
+import { ShipImage } from './ShipImage';
+import { ShipName } from './ShipName';
 
 export const OVERLAY_HEIGHT = 250;
 const FixedOverlay = styled(Container)`
@@ -42,8 +34,6 @@ type ProfileOverlayProps = BoxProps & {
   color?: string;
 };
 
-const selSettings = (s: SettingsState) => [s.calm.hideAvatars, s.calm.hideNicknames];
-
 const ProfileOverlay = (props: ProfileOverlayProps) => {
   const {
     ship,
@@ -56,13 +46,9 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
   const [visible, setVisible] = useState(false);
   const outerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
-  const [hideAvatars, hideNicknames] = useSettingsState(selSettings, shallow);
   const isOwn = useMemo(() => window.ship === ship, [ship]);
-  const { copyDisplay, doCopy, didCopy } = useCopy(`~${ship}`);
 
   const contact = useContact(`~${ship}`);
-  const color = `#${uxToHex(contact?.color ?? '0x0')}`;
-  const showNickname = useShowNickname(contact, hideNicknames);
 
   const setClosed = useCallback(() => {
     _setOpen(false);
@@ -109,25 +95,6 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
     };
   }, [open]);
 
-  const img =
-    contact?.avatar && !hideAvatars ? (
-      <BaseImage
-        referrerPolicy='no-referrer'
-        display='inline-block'
-        style={{ objectFit: 'cover' }}
-        src={contact.avatar}
-        height={60}
-        width={60}
-        borderRadius={2}
-      />
-    ) : (
-      <Box size={60} borderRadius={2} backgroundColor={color}>
-        <Center height={60}>
-          <Sigil ship={ship} size={32} color={color} />
-        </Center>
-      </Box>
-    );
-
   return (
     <Box ref={outerRef} {...rest} onClick={setOpen} cursor="pointer">
       <VisibilitySensor active={open} onChange={setVisible}>
@@ -139,7 +106,6 @@ const ProfileOverlay = (props: ProfileOverlayProps) => {
         ref={innerRef}
         {...coords}
         round
-        boxShadow='0px 0px 0px 3px'
         zIndex={3}
         fontSize={0}
         height='250px'
@@ -163,7 +129,7 @@ left={0}
           overflow='hidden'
           borderRadius={2}
         >
-          {img}
+          <ShipImage ship={`~${ship}`} size={72} />
         </BoxLink>
         <Col
           position='absolute'
@@ -175,25 +141,7 @@ left={0}
           left={0}
         >
           <Row width='100%'>
-            <Text
-              fontWeight='600'
-              mono={!showNickname}
-              textOverflow='ellipsis'
-              overflow='hidden'
-              whiteSpace='pre'
-              marginBottom={0}
-              cursor='pointer'
-              display={didCopy ? 'none' : 'block'}
-              onClick={doCopy}
-            >
-              {showNickname ? contact?.nickname : cite(ship)}
-            </Text>
-            <Text
-              fontWeight='600'
-              marginBottom={0}
-            >
-              {copyDisplay}
-            </Text>
+            <ShipName copiable strong mb={0} ship={`~${ship}`} />
           </Row>
           {isOwn ? (
             <ProfileStatus

--- a/pkg/interface/src/views/components/ShipImage.tsx
+++ b/pkg/interface/src/views/components/ShipImage.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { BaseImage, Box, Center } from '@tlon/indigo-react';
+import { Sigil } from '~/logic/lib/sigil';
+import { uxToHex } from '@urbit/api';
+import { useContact } from '~/logic/state/contact';
+import useSettingsState, { SettingsState } from '~/logic/state/settings';
+import { useDark } from '~/logic/state/join';
+
+interface ShipImageProps {
+  ship: string;
+  size: number;
+  icon?: boolean;
+  sigilSize?: number;
+  borderRadius?: number;
+}
+
+const selSettings = (s: SettingsState) => s.calm.hideAvatars;
+
+export function ShipImage(props: ShipImageProps) {
+  const { borderRadius = 1, ship, icon = false, size } = props;
+  const sigilSize = props.sigilSize ?? size / 2;
+  const contact = useContact(ship);
+  const hideAvatars = useSettingsState(selSettings);
+  const dark = useDark();
+  const color = contact?.color
+    ? `#${uxToHex(contact?.color)}`
+    : dark
+    ? '#000000'
+    : '#FFFFFF';
+
+  return contact?.avatar && !hideAvatars ? (
+    <BaseImage
+      referrerPolicy="no-referrer"
+      display="inline-block"
+      style={{ objectFit: 'cover' }}
+      src={contact.avatar}
+      height={size}
+      width={size}
+      borderRadius={borderRadius}
+    />
+  ) : (
+    <Box size={size} borderRadius={borderRadius} backgroundColor={color}>
+      <Center width={size} height={size}>
+        <Sigil icon={icon} ship={ship} size={sigilSize} color={color} />
+      </Center>
+    </Box>
+  );
+}

--- a/pkg/interface/src/views/components/ShipName.tsx
+++ b/pkg/interface/src/views/components/ShipName.tsx
@@ -1,0 +1,44 @@
+import { Text } from '@tlon/indigo-react';
+import React from 'react';
+import { useContact } from '~/logic/state/contact';
+import { useCopy } from '~/logic/lib/useCopy';
+import useSettingsState, { SettingsState } from '~/logic/state/settings';
+import { cite } from '@urbit/api/lib';
+import { PropFunc } from '~/types';
+
+const selSettings = (s: SettingsState) => s.calm.hideNicknames;
+type ShipNameProps = PropFunc<typeof Text> & {
+  ship: string;
+  strong?: boolean;
+  copiable?: boolean;
+};
+
+const noop = () => {};
+export function ShipName(props: ShipNameProps) {
+  const { ship, strong = false, copiable = false, ...rest } = props;
+  const contact = useContact(ship);
+  const hideNicknames = useSettingsState(selSettings);
+
+  const showNick = !hideNicknames && contact?.nickname?.length > 0;
+  const name = showNick ? contact?.nickname : cite(ship);
+  const { copyDisplay, doCopy } = useCopy(ship, name);
+  const fontWeight = (strong && showNick) ? '500' : '400';
+
+  return (
+    <Text
+      fontSize={1}
+      textOverflow='ellipsis'
+      overflow='hidden'
+      whiteSpace='pre'
+      mono={!showNick}
+      fontFamily={showNick ? 'sans' : 'mono'}
+      cursor={copiable ? 'pointer' : 'default'}
+      fontWeight={fontWeight}
+      onClick={copiable ? doCopy : noop}
+      title={showNick ? cite(ship) : contact?.nickname}
+      {...rest}
+    >
+      {copyDisplay}
+    </Text>
+  );
+}

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -2,7 +2,6 @@ import {
   BaseImage,
   Box,
   Button,
-  Col,
   Icon,
   Row,
   Text
@@ -22,6 +21,7 @@ import { ProfileStatus } from './ProfileStatus';
 import ReconnectButton from './ReconnectButton';
 import { StatusBarItem } from './StatusBarItem';
 import { useTutorialModal } from './useTutorialModal';
+import { Container } from './Container';
 
 const localSel = selectLocalState(['toggleOmnibox']);
 
@@ -140,13 +140,10 @@ const StatusBar = (props) => {
           flexShrink={0}
           offsetY={-48}
           options={
-            <Col
+            <Container
+              round
               py={2}
-              backgroundColor='white'
               color='washedGray'
-              border={1}
-              borderRadius={2}
-              borderColor='lightGray'
               boxShadow='0px 0px 0px 3px'
             >
               <Row
@@ -180,7 +177,7 @@ const StatusBar = (props) => {
                   ship={`~${ship}`}
                 />
               </Row>
-            </Col>
+            </Container>
           }
         >
           <StatusBarItem

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -1,13 +1,11 @@
 import {
   BaseImage,
   Box,
-  Button,
   Icon,
   Row,
   Text
 } from '@tlon/indigo-react';
 import React, { useRef } from 'react';
-import { useHistory } from 'react-router-dom';
 import { Sigil } from '~/logic/lib/sigil';
 import { uxToHex } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
@@ -22,12 +20,12 @@ import ReconnectButton from './ReconnectButton';
 import { StatusBarItem } from './StatusBarItem';
 import { useTutorialModal } from './useTutorialModal';
 import { Container } from './Container';
+import { ButtonLink, RowLink } from './Link';
 
 const localSel = selectLocalState(['toggleOmnibox']);
 
 const StatusBar = (props) => {
   const { ship } = props;
-  const history = useHistory();
   const runtimeLag = useLaunchState(state => state.runtimeLag);
   const ourContact = useContactState(state => state.contacts[`~${ship}`]);
   const notificationsCount = useHarkState(state => state.notificationsCount);
@@ -74,16 +72,16 @@ const StatusBar = (props) => {
       pb={3}
     >
       <Row>
-        <Button
+        <ButtonLink
           width='32px'
           borderColor='lightGray'
           mr={2}
           px={2}
-          onClick={() => history.push('/')}
+          to="/"
           {...props}
         >
           <Icon icon='Dashboard' color='black' />
-        </Button>
+        </ButtonLink>
         <StatusBarItem float={floatLeap} mr={2} onClick={() => toggleOmnibox()}>
           {!doNotDisturb && runtimeLag && (
             <Box display='block' right='-8px' top='-8px' position='absolute'>
@@ -146,28 +144,16 @@ const StatusBar = (props) => {
               color='washedGray'
               boxShadow='0px 0px 0px 3px'
             >
-              <Row
-                color='black'
-                cursor='pointer'
-                fontSize={1}
-                fontWeight='500'
-                px={3}
-                py={2}
-                onClick={() => history.push(`/~profile/~${ship}`)}
-              >
-                View Profile
-              </Row>
-              <Row
-                color='black'
-                cursor='pointer'
-                fontSize={1}
-                fontWeight='500'
-                px={3}
-                py={2}
-                onClick={() => history.push('/~settings')}
-              >
-                System Preferences
-              </Row>
+              <RowLink px={3} py={2} to={`/~profile/~${ship}`}>
+                <Text fontSize={1} fontWeight='500'>
+                  View Profile
+                </Text>
+              </RowLink>
+              <RowLink px={3} py={2} to={'/~settings'}>
+                <Text fontWeight='500' fontSize={1}>
+                  System Preferences
+                </Text>
+              </RowLink>
               <Row px={3} pt={2} pb={1} flexDirection='column'>
                 <Text color='gray' fontWeight='500' mb={1}>
                   Set Status:

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -1,19 +1,15 @@
 import {
-  BaseImage,
   Box,
   Icon,
   Row,
   Text
 } from '@tlon/indigo-react';
 import React, { useRef } from 'react';
-import { Sigil } from '~/logic/lib/sigil';
-import { uxToHex } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
 import useHarkState from '~/logic/state/hark';
 import useLaunchState from '~/logic/state/launch';
 import useInviteState from '~/logic/state/invite';
 import useLocalState, { selectLocalState } from '~/logic/state/local';
-import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { Dropdown } from './Dropdown';
 import { ProfileStatus } from './ProfileStatus';
 import ReconnectButton from './ReconnectButton';
@@ -21,6 +17,7 @@ import { StatusBarItem } from './StatusBarItem';
 import { useTutorialModal } from './useTutorialModal';
 import { Container } from './Container';
 import { ButtonLink, RowLink } from './Link';
+import { ShipImage } from './ShipImage';
 
 const localSel = selectLocalState(['toggleOmnibox']);
 
@@ -36,23 +33,6 @@ const StatusBar = (props) => {
   );
   const metaKey = window.navigator.platform.includes('Mac') ? '⌘' : 'Ctrl+';
   const { toggleOmnibox } = useLocalState(localSel);
-  const { hideAvatars } = useSettingsState(selectCalmState);
-
-  const color = ourContact ? `#${uxToHex(ourContact.color)}` : '#000';
-  const xPadding = !hideAvatars && ourContact?.avatar ? '0' : '2';
-  const bgColor = !hideAvatars && ourContact?.avatar ? '' : color;
-  const profileImage =
-    !hideAvatars && ourContact?.avatar ? (
-      <BaseImage
-        src={ourContact.avatar}
-        borderRadius={2}
-        width='32px'
-        height='32px'
-        style={{ objectFit: 'cover' }}
-      />
-    ) : (
-      <Sigil ship={ship} size={16} color={color} icon />
-    );
 
   const anchorRef = useRef(null);
 
@@ -166,15 +146,7 @@ const StatusBar = (props) => {
             </Container>
           }
         >
-          <StatusBarItem
-            px={xPadding}
-            width='32px'
-            flexShrink={0}
-            border={0}
-            backgroundColor={bgColor}
-          >
-            {profileImage}
-          </StatusBarItem>
+          <ShipImage icon ship={`~${ship}`} size={32} sigilSize={16} />
         </Dropdown>
       </Row>
     </Box>

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/index.tsx
@@ -9,7 +9,7 @@ import {
     metadataRemove
 } from '@urbit/api';
 import React, { useCallback, useRef } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { isChannelAdmin, isHost } from '~/logic/lib/group';
 import { useHashLink } from '~/logic/lib/useHashLink';
 import { FormGroup } from '~/views/components/FormGroup';
@@ -20,6 +20,7 @@ import { ChannelDetails } from './Details';
 import { ChannelNotifications } from './Notifications';
 import { ChannelPopoverRoutesSidebar } from './Sidebar';
 import airlock from '~/logic/api';
+import { TextLink } from '~/views/components/Link';
 
 interface ChannelPopoverRoutesProps {
   baseUrl: string;
@@ -75,9 +76,9 @@ export function ChannelPopoverRoutes(props: ChannelPopoverRoutesProps) {
         height="100%"
       >
         <Box pt={4} px={4} display={['block', 'none']}>
-          <Link to={props.baseUrl}>
-            <Text fontSize={1}>{'<- Back'}</Text>
-          </Link>
+          <TextLink fontSize={1} to={props.baseUrl}>
+            {'<- Back'}
+          </TextLink>
         </Box>
         <ChannelPopoverRoutesSidebar
           isAdmin={canAdmin}

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
@@ -1,9 +1,9 @@
-import { Box, Button, Col, Text } from '@tlon/indigo-react';
+import { Box, Col, Text } from '@tlon/indigo-react';
 import { Group } from '@urbit/api/groups';
 import { Association } from '@urbit/api/metadata';
-import React, { useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import React from 'react';
 import { resourceFromPath, roleForShip } from '~/logic/lib/group';
+import { ButtonLink } from '~/views/components/Link';
 import { GroupAdminSettings } from './Admin';
 import { GroupChannelSettings } from './Channels';
 import { GroupFeedSettings } from './GroupFeed';
@@ -19,13 +19,7 @@ interface GroupSettingsProps {
   baseUrl: string;
 }
 export function GroupSettings(props: GroupSettingsProps) {
-  const history = useHistory();
-
-  const linkRelative = useCallback(
-    (url: string) =>
-      useCallback(() => history.push(`${props.baseUrl}${url}`), [url]),
-    [history, props.baseUrl]
-  );
+  const linkRelative = (url: string) => `${props.baseUrl}${url}`;
 
   const isOwner =
     resourceFromPath(props.association.group).ship.slice(1) === window.ship;
@@ -43,7 +37,7 @@ export function GroupSettings(props: GroupSettingsProps) {
               Participants
             </Text>
             <Text gray>View list of all group participants and statuses</Text>
-            <Button primary mt={4} onClick={linkRelative('/participants')}>View List</Button>
+            <ButtonLink primary mt={4} to={linkRelative('/participants')}>View List</ButtonLink>
           </Col>
         </Section>
         { isAdmin && (

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -11,22 +11,23 @@ import { uxToHex } from '~/logic/lib/util';
 import { getTitleFromWorkspace } from '~/logic/lib/workspace';
 import useMetadataState from '~/logic/state/metadata';
 import { Workspace } from '~/types/workspace';
+import { Container } from '~/views/components/Container';
 import { Dropdown } from '~/views/components/Dropdown';
+import { BoxLink, RowLink } from '~/views/components/Link';
 import { MetadataIcon } from './MetadataIcon';
 
 const GroupSwitcherItem = ({ to, children, bottom = false, ...rest }) => (
-  <Link to={to}>
-    <Box
-      py={1}
-      {...rest}
-      borderBottom={bottom ? 0 : 1}
-      borderBottomColor="lightGray"
-    >
-      <Row p={2} alignItems="center">
-        {children}
-      </Row>
-    </Box>
-  </Link>
+  <BoxLink
+    to={to}
+    py={1}
+    {...rest}
+    borderBottom={bottom ? 0 : 1}
+    borderBottomColor="lightGray"
+  >
+    <Row p={2} alignItems="center">
+      {children}
+    </Row>
+  </BoxLink>
 );
 
 function RecentGroups(props: { recent: string[] }) {
@@ -47,8 +48,12 @@ function RecentGroups(props: { recent: string[] }) {
         const assoc = associations.groups[g];
         const color = uxToHex(assoc?.metadata?.color || '0x0');
         return (
-          <Link key={g} style={{ minWidth: 0 }} to={`/~landscape${g}`}>
-          <Row px={1} pb={2} alignItems="center">
+          <RowLink
+            key={g}
+            minWidth="0" to={`/~landscape${g}`}
+px={1} pb={2}
+alignItems="center"
+          >
             <Box
               borderRadius={1}
               border={1}
@@ -61,8 +66,7 @@ function RecentGroups(props: { recent: string[] }) {
               flexShrink={0}
             />
               <Text verticalAlign='top' maxWidth='100%' overflow='hidden' display='inline-block' style={{ textOverflow: 'ellipsis', whiteSpace: 'pre' }}>{assoc?.metadata?.title}</Text>
-            </Row>
-          </Link>
+          </RowLink>
         );
       })}
     </Col>
@@ -106,14 +110,7 @@ export function GroupSwitcher(props: {
             dropWidth="231px"
             alignY="top"
             options={
-              <Col
-                borderRadius={1}
-                border={1}
-                borderColor="lightGray"
-                bg="white"
-                width="100%"
-                alignItems="stretch"
-              >
+              <Container width="100%" alignItems="stretch">
                 {(props.baseUrl === '/~landscape/home') ?
                   <GroupSwitcherItem to="">
                   <Icon
@@ -173,7 +170,7 @@ export function GroupSwitcher(props: {
                     </GroupSwitcherItem>)}
                   </>
                 )}
-              </Col>
+              </Container>
             }
           >
             <Row flexGrow={1} alignItems="center" width='100%' minWidth={0} flexShrink={0}>

--- a/pkg/interface/src/views/landscape/components/Home/AddFeedBanner.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/AddFeedBanner.tsx
@@ -1,8 +1,9 @@
 import { Button, Icon, Row, Text } from '@tlon/indigo-react';
 import { disableGroupFeed } from '@urbit/api/graph';
 import React, { useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { resourceFromPath } from '~/logic/lib/group';
+import { ButtonLink } from '~/views/components/Link';
 import airlock from '~/logic/api';
 
 export const AddFeedBanner = (props) => {
@@ -76,11 +77,9 @@ export const AddFeedBanner = (props) => {
             <Button onClick={() => setDismissing(true)}>
               Dismiss
             </Button>
-            <Link replace to={`/~landscape${groupPath}/enable`}>
-              <Button primary cursor="pointer">
-                Enable Feed
-              </Button>
-            </Link>
+            <ButtonLink primary replace to={`/~landscape${groupPath}/enable`}>
+              Enable Feed
+            </ButtonLink>
           </>
         )}
 

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostFeed.tsx
@@ -43,7 +43,6 @@ class PostFeed extends React.Component<PostFeedProps, any> {
     const {
       graph,
       graphPath,
-      history,
       baseUrl,
       parentNode,
       grandparentNode,
@@ -82,7 +81,6 @@ class PostFeed extends React.Component<PostFeedProps, any> {
               association={association}
               index={nodeIndex}
               baseUrl={baseUrl}
-              history={history}
               isParent={true}
               isRelativeTime={false}
               vip={vip}
@@ -96,7 +94,6 @@ class PostFeed extends React.Component<PostFeedProps, any> {
             association={association}
             index={[...nodeIndex, index]}
             baseUrl={baseUrl}
-            history={history}
             isReply={true}
             parentPost={parentNode.post}
             isRelativeTime={true}
@@ -135,7 +132,6 @@ class PostFeed extends React.Component<PostFeedProps, any> {
             association={association}
             index={[...nodeIndex, index]}
             baseUrl={baseUrl}
-            history={history}
             parentPost={parentNode?.post}
             isReply={Boolean(parentNode)}
             isRelativeTime={true}
@@ -155,7 +151,6 @@ class PostFeed extends React.Component<PostFeedProps, any> {
           association={association}
           index={[...nodeIndex, index]}
           baseUrl={baseUrl}
-          history={history}
           parentPost={parentNode?.post}
           isReply={Boolean(parentNode)}
           isRelativeTime={true}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostFlatFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostFlatFeed.tsx
@@ -46,7 +46,6 @@ class PostFlatFeed extends React.Component<PostFeedProps, {}> {
     const {
       flatGraph,
       graphPath,
-      history,
       baseUrl,
       association,
       group,
@@ -84,7 +83,6 @@ class PostFlatFeed extends React.Component<PostFeedProps, {}> {
               association={association}
               index={index}
               baseUrl={baseUrl}
-              history={history}
               parentPost={parentNode?.post}
               isReply={index.length > 1}
               isRelativeTime={true}
@@ -125,7 +123,6 @@ class PostFlatFeed extends React.Component<PostFeedProps, {}> {
             association={association}
             index={index}
             baseUrl={baseUrl}
-            history={history}
             parentPost={parentNode?.post}
             isReply={index.length > 1}
             isRelativeTime={true}
@@ -144,7 +141,6 @@ class PostFlatFeed extends React.Component<PostFeedProps, {}> {
           association={association}
           index={index}
           baseUrl={baseUrl}
-          history={history}
           parentPost={parentNode?.post}
           isReply={index.length > 1}
           isRelativeTime={true}

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostItem/PostItem.tsx
@@ -1,12 +1,11 @@
 import { Box, Col, Row, Text } from '@tlon/indigo-react';
 import { Association, GraphNode, Group, Post } from '@urbit/api';
 import { BigInteger } from 'big-integer';
-import { History } from 'history';
 import React, { useCallback, useMemo, useState } from 'react';
-import { useHistory } from 'react-router';
 import { getPostRoute } from '~/logic/lib/graph';
 import { isWriter } from '~/logic/lib/group';
 import { useHovering } from '~/logic/lib/util';
+import { ColLink } from '~/views/components/Link';
 import { Mention } from '~/views/components/MentionText';
 import PostInput from '../PostInput';
 import PostContent from './PostContent';
@@ -19,7 +18,6 @@ export interface PostItemProps {
   bind?: unknown;
   graphPath: string;
   group: Group;
-  history: History;
   hovering?: boolean;
   index: BigInteger[];
   isParent?: boolean;
@@ -52,8 +50,6 @@ function PostItem(props: PostItemProps) {
   const [inReplyMode, setInReplyMode] = useState(false);
   const toggleReplyMode = useCallback(() => setInReplyMode(m => !m), []);
 
-  const history = useHistory();
-
   const canWrite = useMemo(() => {
     if (vip === '') {
       return true;
@@ -63,19 +59,6 @@ function PostItem(props: PostItemProps) {
     }
     return isWriter(group, association.resource);
   }, [group, association.resource, vip, index]);
-
-  const navigateToChildren = useCallback(() => {
-    history.push(
-      getPostRoute(association.resource, index, !isThread && !isHierarchical)
-    );
-  }, [
-    isHierarchical,
-    history.push,
-    index,
-    isParent,
-    isThread,
-    association.resource
-  ]);
 
   const postExists = Boolean(node.post) && typeof node.post !== 'string';
   const { hovering, bind } = useHovering();
@@ -88,7 +71,7 @@ function PostItem(props: PostItemProps) {
       width="100%"
       alignItems="center"
     >
-      <Col
+      <ColLink
         pt={2}
         border={1}
         borderColor={isParent ? 'gray' : 'lightGray'}
@@ -96,7 +79,7 @@ function PostItem(props: PostItemProps) {
         width="100%"
         maxWidth="600px"
         backgroundColor={hovering ? 'washedGray' : 'transparent'}
-        onClick={navigateToChildren}
+        to={getPostRoute(association.resource, index, !isThread && !isHierarchical)}
         cursor={isParent ? 'default' : 'pointer'}
         {...bind}
       >
@@ -137,7 +120,7 @@ function PostItem(props: PostItemProps) {
             <Text gray>This post has been deleted</Text>
           </Box>
         )}
-      </Col>
+      </ColLink>
       {inReplyMode ? (
         <Col width="100%" maxWidth="600px">
           <Box

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostReplies.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostReplies.tsx
@@ -9,7 +9,7 @@ import PostItem from './PostItem/PostItem';
 
 const graphSel = (s: GraphState) => s.getNode;
 import { useGroupForAssoc } from '~/logic/state/group';
-import { Switch, useParams, Route, useHistory } from 'react-router';
+import { Switch, useParams, Route } from 'react-router';
 import bigInt, { BigInteger } from 'big-integer';
 import { getNodeFromGraph } from '~/logic/lib/graph';
 
@@ -54,7 +54,6 @@ export default function PostReplies(props: PostRepliesProps) {
     pendingSize,
     index
   } = props;
-  const history = useHistory();
   const getNode = useGraphState(graphSel);
   const group = useGroupForAssoc(association);
   const graphPath = association.resource;
@@ -110,7 +109,6 @@ export default function PostReplies(props: PostRepliesProps) {
             isParent={true}
             parentPost={parentNode?.post}
             vip={vip}
-            history={history}
             group={group}
           />
         </Box>

--- a/pkg/interface/src/views/landscape/components/NewChannel.tsx
+++ b/pkg/interface/src/views/landscape/components/NewChannel.tsx
@@ -22,6 +22,7 @@ import { IconRadio } from '~/views/components/IconRadio';
 import { ShipSearch, shipSearchSchema, shipSearchSchemaInGroup } from '~/views/components/ShipSearch';
 import { ChannelWriteFieldSchema, ChannelWritePerms } from './ChannelWritePerms';
 import airlock from '~/logic/api';
+import { BoxLink } from '~/views/components/Link';
 
 type FormSchema = {
   name: string;
@@ -142,13 +143,13 @@ export function NewChannel(props: NewChannelProps): ReactElement {
       backgroundColor='white'
       {...rest}
     >
-      <Box
+      <BoxLink
         pb={3}
         display={workspace?.type === 'messages' ? 'none' : ['block', 'none']}
-        onClick={() => history.push(props?.baseUrl ?? '/')}
+        to={props?.baseUrl ?? '/'}
       >
         <Text>{'<- Back'}</Text>
-      </Box>
+      </BoxLink>
       <Box>
         <Text fontSize={2} bold>
           {workspace?.type === 'messages' && existingMembers ? 'New Group ' : null}

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -1,9 +1,7 @@
 import {
-    Action, Box, Col,
-
+    Box, Col,
     Icon,
     Image, Row,
-
     StatelessTextInput as Input, Text
 } from '@tlon/indigo-react';
 import { Contact, Contacts } from '@urbit/api/contacts';
@@ -15,7 +13,6 @@ import React, {
     ChangeEvent,
     ReactElement, useCallback, useMemo, useState
 } from 'react';
-import { Link } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
 import styled from 'styled-components';
 import { resourceFromPath, roleForShip } from '~/logic/lib/group';
@@ -26,6 +23,8 @@ import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { Dropdown } from '~/views/components/Dropdown';
 import { StatelessAsyncAction } from '~/views/components/StatelessAsyncAction';
 import airlock from '~/logic/api';
+import { ActionLink } from '~/views/components/Link';
+import { Container } from '~/views/components/Container';
 
 const TruncText = styled(Text)`
   white-space: nowrap;
@@ -338,29 +337,18 @@ function Participant(props: {
           alignX="right"
           alignY="top"
           options={
-            <Col
-              bg="white"
-              border={1}
-              borderRadius={1}
-              borderColor="lightGray"
-              gapY={2}
-              p={2}
-            >
-              <Action bg="transparent">
-                <Link to={`/~profile/~${contact.patp}`}>
-                  <Text color="black">View Profile</Text>
-                </Link>
-              </Action>
-              <Action bg="transparent">
-                <Link to={`/~landscape/dm/${contact.patp}`}>
-                  <Text color="green">Send Message</Text>
-                </Link>
-              </Action>
+            <Container gapY={2} p={2}>
+              <ActionLink color="black" bg="transparent" to={`/~profile/~${contact.patp}`}>
+                View Profile
+              </ActionLink>
+              <ActionLink color="green" bg="transparent" to={`/~landscape/dm/~${contact.patp}`}>
+                Send Message
+              </ActionLink>
               {props.role === 'admin' && (
                 <>
                   {(!isInvite && contact.patp !== window.ship) && (
-                    <StatelessAsyncAction onClick={onBan} bg="transparent">
-                      <Text color="red">Ban from {title}</Text>
+                    <StatelessAsyncAction destructive onClick={onBan} bg="transparent">
+                      Ban from {title}
                     </StatelessAsyncAction>
                   )}
                   {role === 'admin' ? (
@@ -369,8 +357,8 @@ function Participant(props: {
                     </StatelessAsyncAction>)
                   ) : (
                     <>
-                    {(contact.patp !== window.ship) && (<StatelessAsyncAction onClick={onKick} bg="transparent">
-                        <Text color="red">Kick from {title}</Text>
+                    {(contact.patp !== window.ship) && (<StatelessAsyncAction destructive onClick={onKick} bg="transparent">
+                        Kick from {title}
                       </StatelessAsyncAction>)}
                       {!contact.pending && <StatelessAsyncAction onClick={onPromote} bg="transparent">
                         Promote to Admin
@@ -379,7 +367,7 @@ function Participant(props: {
                   )}
                 </>
               )}
-            </Col>
+            </Container>
           }
         >
           <Icon display="block" icon="Ellipsis" />

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -1,7 +1,7 @@
 import {
     Box, Col,
     Icon,
-    Image, Row,
+    Row,
     StatelessTextInput as Input, Text
 } from '@tlon/indigo-react';
 import { Contact, Contacts } from '@urbit/api/contacts';
@@ -16,8 +16,7 @@ import React, {
 import VisibilitySensor from 'react-visibility-sensor';
 import styled from 'styled-components';
 import { resourceFromPath, roleForShip } from '~/logic/lib/group';
-import { Sigil } from '~/logic/lib/sigil';
-import { cite, uxToHex } from '~/logic/lib/util';
+import { cite } from '~/logic/lib/util';
 import useContactState from '~/logic/state/contact';
 import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { Dropdown } from '~/views/components/Dropdown';
@@ -25,6 +24,7 @@ import { StatelessAsyncAction } from '~/views/components/StatelessAsyncAction';
 import airlock from '~/logic/api';
 import { ActionLink } from '~/views/components/Link';
 import { Container } from '~/views/components/Container';
+import { ShipImage } from '~/views/components/ShipImage';
 
 const TruncText = styled(Text)`
   white-space: nowrap;
@@ -246,9 +246,8 @@ function Participant(props: {
 }) {
   const { contact, association, group } = props;
   const { title } = association.metadata;
-  const { hideAvatars, hideNicknames } = useSettingsState(selectCalmState);
+  const { hideNicknames } = useSettingsState(selectCalmState);
 
-  const color = uxToHex(contact.color);
   const isInvite = 'invite' in group.policy;
 
   const role = useMemo(
@@ -288,26 +287,13 @@ function Participant(props: {
     }
   }, [contact, association]);
 
-  const avatar =
-    contact?.avatar && !hideAvatars ? (
-      <Image
-        src={contact.avatar}
-        height={32}
-        width={32}
-        display='inline-block'
-        style={{ objectFit: 'cover' }}
-      />
-    ) : (
-      <Sigil ship={contact.patp} size={32} color={`#${color}`} />
-    );
-
   const hasNickname = contact.nickname && !hideNicknames;
 
   return (
     <>
       <Row flexDirection={['column', 'row']} gapX={2} alignItems={['flex-start', 'center']} width="100%" justifyContent="space-between" height={['96px', '60px']}>
         <Row gapX={4} alignItems="center" height="100%">
-      <Box>{avatar}</Box>
+          <Box><ShipImage sigilSize={30} ship={`~${contact.patp}`} size={32} /> </Box>
       <Col alignItems="self-start" justifyContent="center" gapY={1} height="100%" minWidth={0}>
         {hasNickname && (
           <Row minWidth={0} flexShrink={1}>

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -13,6 +13,7 @@ import useGroupState from '~/logic/state/group';
 import { Dropdown } from '~/views/components/Dropdown';
 import RichText from '~/views/components/RichText';
 import { MessageInvite } from '~/views/landscape/components/MessageInvite';
+import { BoxLink } from '~/views/components/Link';
 
 const TruncatedText = styled(RichText)`
   white-space: nowrap;
@@ -107,7 +108,7 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
   }
 
   const backLink = (
-    <Box
+    <BoxLink
       borderRight={1}
       borderRightColor='gray'
       pr={3}
@@ -116,11 +117,10 @@ export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
       my={1}
       flexShrink={0}
       display={['block','none']}
+      to={`/~landscape${workspace}`}
     >
-      <Link to={`/~landscape${workspace}`}>
-        <Text>{'<- Back'}</Text>
-      </Link>
-    </Box>
+      <Text>{'<- Back'}</Text>
+    </BoxLink>
   );
 
   const titleText = (

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import React, { useRef, ReactNode } from 'react';
 import urbitOb from 'urbit-ob';
-import { Icon, Row, Box, Text, BaseImage } from '@tlon/indigo-react';
+import { Icon, Row, Box, Text } from '@tlon/indigo-react';
 import { Association, cite } from '@urbit/api';
 import { HoverBoxLink } from '~/views/components/HoverBox';
-import { Sigil } from '~/logic/lib/sigil';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
 import { TUTORIAL_HOST, TUTORIAL_GROUP } from '~/logic/lib/tutorialModal';
 import { Workspace } from '~/types/workspace';
@@ -15,6 +14,7 @@ import Dot from '~/views/components/Dot';
 import useHarkState, { useHarkDm } from '~/logic/state/hark';
 import useSettingsState from '~/logic/state/settings';
 import useGraphState from '~/logic/state/graph';
+import { ShipImage } from '~/views/components/ShipImage';
 
 function useAssociationStatus(resource: string) {
   const [, , ship, name] = resource.split('/');
@@ -133,24 +133,6 @@ export const SidebarDmItem = React.memo((props: {
       ? contact?.nickname
       : cite(ship) ?? ship;
   const { unreads } = useHarkDm(ship) || { unreads: 0 };
-  const img =
-    contact?.avatar && !hideAvatars ? (
-      <BaseImage
-        referrerPolicy="no-referrer"
-        src={contact.avatar}
-        width="16px"
-        height="16px"
-        borderRadius={2}
-      />
-    ) : (
-      <Sigil
-        ship={ship}
-        color={`#${uxToHex(contact?.color || '0x0')}`}
-        icon
-        padding={2}
-        size={16}
-      />
-    );
 
   return (
     <SidebarItemBase
@@ -162,7 +144,7 @@ export const SidebarDmItem = React.memo((props: {
       mono={hideAvatars || !contact?.nickname}
       isSynced
     >
-      {img}
+      <ShipImage borderRadius={1} icon size={16} sigilSize={12} ship={ship} />
     </SidebarItemBase>
   );
 });

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -1,15 +1,12 @@
 import {
     Box,
-
     Col, Icon,
-
     ManagedCheckboxField as Checkbox, ManagedRadioButtonField as Radio, Row,
-
     Text
 } from '@tlon/indigo-react';
 import { FormikHelpers } from 'formik';
 import React, { ReactElement, useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { roleForShip } from '~/logic/lib/group';
 import { getGroupFromWorkspace } from '~/logic/lib/workspace';
 import useGroupState from '~/logic/state/group';
@@ -22,6 +19,7 @@ import { NewChannel } from '~/views/landscape/components/NewChannel';
 import { SidebarListConfig } from './types';
 import { getFeedPath } from '~/logic/lib/util';
 import { Container } from '~/views/components/Container';
+import { RowLink, TextLink } from '~/views/components/Link';
 
 export function SidebarListHeader(props: {
   initialValues: SidebarListConfig;
@@ -57,33 +55,23 @@ export function SidebarListHeader(props: {
   const unreadCount = useHarkState(
     s => s.unreads?.graph?.[feedPath ?? '']?.['/']?.unreads as number ?? 0
   );
+  const { pathname } = history.location;
+  const feedLink = `/~landscape${groupPath}/feed`;
 
   return (
     <Box>
     {( feedPath) ? (
-       <Row
+       <RowLink
          flexShrink={0}
-         alignItems="center"
          justifyContent="space-between"
          py={2}
          px={3}
          height='48px'
          borderBottom={1}
          borderColor="lightGray"
-         backgroundColor={['transparent',
-           history.location.pathname.includes(`/~landscape${groupPath}/feed`)
-           ? (
-            'washedGray'
-           ) : (
-            'transparent'
-           )]}
-           cursor={(
-             history.location.pathname === `/~landscape${groupPath}/feed`
-             ? 'default' : 'pointer'
-           )}
-         onClick={() => {
-           history.push(`/~landscape${groupPath}/feed`);
-         }}
+         backgroundColor={pathname.includes(feedLink) ?  'washedGray' : 'transparent'}
+         cursor={pathname === feedLink? 'default' : 'pointer' }
+         to={feedLink}
        >
          <Text>
            Group Feed
@@ -91,7 +79,7 @@ export function SidebarListHeader(props: {
          <Text mr={1} color="blue">
            { unreadCount > 0 && unreadCount}
          </Text>
-       </Row>
+       </RowLink>
      ) : null
     }
     <Row
@@ -134,14 +122,13 @@ export function SidebarListHeader(props: {
           </Dropdown>
         )
         : (
-       <Link style={{
-          display: isAdmin ? 'inline-block' : 'none' }}
-        to={groupPath
-          ? `/~landscape${groupPath}/new`
-          : `/~landscape/${props.workspace?.type}/new`}
+       <TextLink display={isAdmin ? 'inline-block' : 'none' }
+          to={groupPath
+            ? `/~landscape${groupPath}/new`
+            : `/~landscape/${props.workspace?.type}/new`}
        >
            <Icon icon="Plus" color="gray" pr='12px' />
-       </Link>
+       </TextLink>
           )
         }
       <Dropdown

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -21,6 +21,7 @@ import { FormikOnBlur } from '~/views/components/FormikOnBlur';
 import { NewChannel } from '~/views/landscape/components/NewChannel';
 import { SidebarListConfig } from './types';
 import { getFeedPath } from '~/logic/lib/util';
+import { Container } from '~/views/components/Container';
 
 export function SidebarListHeader(props: {
   initialValues: SidebarListConfig;
@@ -120,13 +121,13 @@ export function SidebarListHeader(props: {
             alignY="top"
             alignX={['right', 'left']}
             options={
-              <Col
+              <Container
                 background="white"
                 border={1}
                 borderColor="washedGray"
               >
               <NewChannel workspace={props.workspace} />
-              </Col>
+              </Container>
             }
           >
            <Icon icon="Plus" color="gray" pr='12px' />


### PR DESCRIPTION
interface: unify ship image and names rendering
Unifies the rendering of ship names and images everywhere in landscape. 

interface: refactor to use anchors instead of onclick

Introduces a variety of links components and uses them instead of
listening for a click event on a regular DOM node. This is both advantageous
for accessibility, as well as being more performant because we don't have to
create unnecessary link nodes. It's also less code

interface: add Container component
Just a component for big white boxes with borders, useful for `<Dropdown />` and main body content
