### PR TITLE
file-server: scry for identity

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -338,6 +338,9 @@
       [%x %clay %base %hash ~]
     =/  versions  (base-hash:version [our now]:bowl)
     ``hash+!>(?~(versions 0v0 (end [0 25] i.versions)))
+  ::
+      [%x %our ~]
+    ``json+!>(s+(scot %p our.bowl))
   ==
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def


### PR DESCRIPTION
Need the iphone app to get its own identity in a way that doesn't rely on the domain name.

I don't know if this is the best place to put this, but I don't know any better place. I figure since this is the place where`window.ship` is defined its somewhat related.