### PR TITLE
Gall: fix subscription synchronization

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -200,13 +200,14 @@
                 'ship'^(ship s)
                 'path'^(path p)
             ==
+          ::  TODO: display subscription nonce
           ::
           ++  outgoing
             |=  =boat:gall
             ^-  json
             :-  %a
             %+  turn  ~(tap by boat)
-            |=  [[w=wire s=^ship t=term] [a=? p=^path]]
+            |=  [[w=wire s=^ship t=term] [a=? p=^path nonce=@]]
             %-  pairs
             :~  'wire'^(path w)
                 'ship'^(ship s)

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -546,7 +546,7 @@
       ==
     :_  state
     %+  murn  ~(tap by wex.bowl)
-    |=  [[=wire =ship =term] [acked=? =path]]
+    |=  [[=wire =ship =term] [acked=? =path nonce=@]]
     ^-  (unit card)
     ?.  ?&  ?=([%thread @ *] wire)
             =(tid i.t.wire)

--- a/pkg/arvo/lib/dbug.hoon
+++ b/pkg/arvo/lib/dbug.hoon
@@ -84,7 +84,7 @@
         %+  sort  ~(tap by wex.bowl)
         |=  [[[a=wire *] *] [[b=wire *] *]]
         (aor a b)
-      |=  [[=wire =ship =term] [acked=? =path]]
+      |=  [[=wire =ship =term] [acked=? =path nonce=@]]
       ^-  (unit tank)
       =;  relevant=?
         ?.  relevant  ~

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1652,7 +1652,7 @@
   +$  bitt  (map duct (pair ship path))                 ::  incoming subs
   +$  boat                                              ::  outgoing subs
     %+  map  [=wire =ship =term]                        ::
-    [acked=? =path]                                     ::
+    [acked=? =path nonce=@]                             ::
   +$  bowl                                              ::  standard app state
           $:  $:  our=ship                              ::  host
                   src=ship                              ::  guest

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -45,6 +45,8 @@
 ::  $yoke: agent runner state
 ::
 ::    control-duct: TODO document
+::    run-nonce: unique for each rebuild
+::    sub-nonce: app-wide global %watch nonce
 ::    live: is this agent running? TODO document better
 ::    stats: TODO document
 ::    watches: incoming and outgoing subscription state
@@ -54,7 +56,8 @@
 ::
 +$  yoke
   $:  control-duct=duct
-      nonce=@t
+      run-nonce=@t
+      sub-nonce=@
       live=?
       =stats
       =watches
@@ -128,7 +131,7 @@
 ::
 +$  egg
   $:  control-duct=duct
-      nonce=@t
+      run-nonce=@t
       live=?
       =stats
       =watches
@@ -336,7 +339,7 @@
         control-duct  hen
         beak          bek
         agent         &+agent
-        nonce         (scot %uw (end 5 (shas %yoke-nonce eny)))
+        run-nonce         (scot %uw (end 5 (shas %yoke-nonce eny)))
       ==
     ::
     =/  old  mo-core
@@ -425,7 +428,7 @@
       [%a %plea ship %g path ames-request-all]
     ::
     =.  outstanding.state
-      =/  stand
+      =/  stan
         (~(gut by outstanding.state) [wire hen] *(qeu remote-request))
       (~(put by outstanding.state) [wire hen] (~(put to stand) -.deal))
     (mo-pass wire note-arvo)
@@ -711,7 +714,7 @@
     ?~  yoke
       %-  (slog leaf+"gall: {<dap>} dead, got {<+<.sign-arvo>}" ~)
       mo-core
-    ?.  =(nonce.u.yoke i.t.path)
+    ?.  =(run-nonce.u.yoke i.t.path)
       %-  (slog leaf+"gall: got old {<+<.sign-arvo>} for {<dap>}" ~)
       mo-core
     ?.  ?=([?(%gall %behn) %unto *] sign-arvo)
@@ -1130,23 +1133,27 @@
         ==
       ::
           %pass
-        =/  =duct  system-duct.state
-        =/  =wire  p.card
-        =/  =neet  q.card
+        =/  [=wire =neet]  [p q]:card
         =.  wire
+          :^  %use  agent-name  run-nonce.current-agent
           ?-  -.neet
             %agent  [%out (scot %p ship.neet) name.neet wire]
             %huck   [%out (scot %p ship.neet) name.neet wire]
             %arvo   [(scot %p attributing.agent-routes) wire]
           ==
-        =.  wire  [%use agent-name nonce.current-agent wire]
+        ::  increment nonce for new subscription
+        ::
+        =?    run-nonce.current-agent
+            &(?=(%agent -.neet) ?=(?(%watch %watch-as) -.deal.neet))
+          +(run-nonce.current-agent
+        ::
         =/  =note-arvo
           ?-  -.neet
             %arvo   note-arvo.neet
             %huck   note-arvo.neet
             %agent  [%g %deal [our ship.neet] [name deal]:neet]
           ==
-        [duct %pass wire note-arvo]~
+        [system-duct.state %pass wire note-arvo]~
       ==
     ::  +ap-breach: ship breached, so forget about them
     ::
@@ -1314,7 +1321,7 @@
               sup=inbound.watches.current-agent  ::  incoming
           ==                                          ::
           :*  act=change.stats.current-agent          ::  tick
-              eny=eny.stats.current-agent             ::  nonce
+              eny=eny.stats.current-agent             ::  entropy
               now=time.stats.current-agent            ::  time
               byk=beak.current-agent                  ::  source
       ==  ==
@@ -1648,25 +1655,28 @@
         $(moves t.moves, new-moves [move new-moves])
       =/  =wire  p.move.move
       ?>  ?=([%use @ @ %out @ @ *] wire)
-      =/  short-wire  t.t.t.t.t.t.wire
-      =/  =dock  [q.p q]:q.move.move
-      =/  =path
-        ?-  -.r.q.move.move
-          %watch     path.r.q.move.move
-          %watch-as  path.r.q.move.move
-        ==
-      ?:  (~(has by outbound.watches.current-agent) short-wire dock)
+      =/  [sys-wire=^wire sub-wire=^wire]  [(scag 6 wire) (slag 6 wire)]
+      =/  [=dock =deal]  [[q.p q] r]:q.move.move
+      ::
+      ?:  (~(has by outbound.watches.current-agent) sub-wire dock)
         =.  ap-core
           =/  =tang
-            ~[leaf+"subscribe wire not unique" >agent-name< >short-wire< >dock<]
+            ~[leaf+"subscribe wire not unique" >agent-name< >sub-wire< >dock<]
           =/  have
-            (~(got by outbound.watches.current-agent) short-wire dock)
+            (~(got by outbound.watches.current-agent) sub-wire dock)
           %-  (slog >out=have< tang)
           (ap-error %watch-not-unique tang)  ::  reentrant, maybe bad?
         $(moves t.moves)
-      =.  outbound.watches.current-agent
-        (~(put by outbound.watches.current-agent) [short-wire dock] [| path])
-      $(moves t.moves, new-moves [move new-moves])
+      ::
+      =.  p.move.move  :(weld sys-wire sub-nonce.current-agent use-wire)
+      %=    $
+          moves  t.moves
+          new-moves  [move new-moves]
+          sub-nonce.current-agent  +(sub-nonce.current-agent)
+          outbound.watches.current-agent
+        %+  ~(put by outbound.watches.current-agent)  [sub-wire dock]
+        [acked=| path=?-(-.deal %watch path.deal, %watch-as path.deal)]
+      ==
     --
   --
 ::  +call: request

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -12,9 +12,9 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
-::  $state-7: overall gall state, versioned
+::  $state-8: overall gall state, versioned
 ::
-+$  state-7  [%7 state]
++$  state-8  [%8 state]
 ::  $state: overall gall state
 ::
 ::    system-duct: TODO document
@@ -57,7 +57,7 @@
 +$  yoke
   $:  control-duct=duct
       run-nonce=@t
-      sub-nonce=@
+      sub-nonce=_1
       live=?
       =stats
       =watches
@@ -119,7 +119,7 @@
 ::  $spore: structures for update, produced by +stay
 ::
 +$  spore
-  $:  %7
+  $:  %8
       wipe-eyre-subs=_|  ::NOTE  band-aid for #3196, remove on next upgrade
       system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
@@ -132,6 +132,7 @@
 +$  egg
   $:  control-duct=duct
       run-nonce=@t
+      sub-nonce=@
       live=?
       =stats
       =watches
@@ -168,7 +169,7 @@
           [^duct %pass /whiz/gall %$ %whiz ~]~
       =/  adult  adult-core
       =.  state.adult
-        [%7 system-duct outstanding contacts yokes=~ blocked]:spore
+        [%8 system-duct outstanding contacts yokes=~ blocked]:spore
       =/  mo-core  (mo-abed:mo:adult duct)
       =.  mo-core
         =/  apps=(list [dap=term =egg])  ~(tap by eggs.spore)
@@ -233,7 +234,63 @@
       (molt duct `[duct %pass wire %b %huck sign])
     ::
     ++  load
-      |=  old=^spore
+      =>  |%
+          +$  spore-any
+            $%  spore-8
+                spore-7
+            ==
+          +$  spore-8  ^spore
+          +$  egg-8  egg
+          +$  watches-8  watches
+          +$  boat-8  boat
+          ::
+          ++  spore-7-to-8
+            |=  old=spore-7
+            ^-  spore-8
+            =-  old(- %8, eggs -)
+            %-  ~(run by eggs.old)
+            |=  =egg-7
+            ^-  egg-8
+            :*  control-duct.egg-7
+                run-nonce.egg-7
+                sub-nonce=0
+                live.egg-7
+                stats.egg-7
+                [inbound.watches.egg-7 (boat-7-to-8 outbound.watches.egg-7)]
+                [old-state beak marks]:egg-7
+            ==
+          ++  boat-7-to-8
+            |=  =boat-7
+            ^-  boat-8
+            %-  ~(run by boat-7)
+            |=  [acked=? =path]
+            [acked path nonce=0]
+          ::
+          +$  spore-7
+            $:  %7
+                wipe-eyre-subs=_|  ::NOTE  band-aid for #3196, remove on next upgrade
+                system-duct=duct
+                outstanding=(map [wire duct] (qeu remote-request))
+                contacts=(set ship)
+                eggs=(map term egg-7)
+                blocked=(map term (qeu blocked-move))
+            ==
+          +$  egg-7
+            $:  control-duct=duct
+                run-nonce=@t
+                live=?
+                =stats
+                watches=watches-7
+                old-state=(each vase vase)
+                =beak
+                marks=(map duct mark)
+            ==
+          +$  watches-7  [inbound=bitt outbound=boat-7]
+          +$  boat-7  (map [wire ship term] [acked=? =path])
+          --
+      |=  old=spore-any
+      =?  old  ?=(%7 -.old)  (spore-7-to-8 old)
+      ?>  ?=(%8 -.old)
       =.  spore  old
       ?.  =(~ eggs.spore)
         pupal-gate
@@ -244,7 +301,7 @@
     --
 ::  adult gall vane interface, for type compatibility with pupa
 ::
-=|  state=state-7
+=|  state=state-8
 |=  [now=@da eny=@uvJ rof=roof]
 =*  gall-payload  .
 =<  ~%  %gall-wrap  ..mo  ~
@@ -428,7 +485,7 @@
       [%a %plea ship %g path ames-request-all]
     ::
     =.  outstanding.state
-      =/  stan
+      =/  stand
         (~(gut by outstanding.state) [wire hen] *(qeu remote-request))
       (~(put by outstanding.state) [wire hen] (~(put to stand) -.deal))
     (mo-pass wire note-arvo)
@@ -744,8 +801,7 @@
         blocked.state  (~(put by blocked.state) dap blocked)
       ==
     =/  app  (ap-abed:ap dap routes)
-    =.  app
-      (ap-specific-take:app t.t.path sign)
+    =.  app  (ap-specific-take:app t.t.path sign)
     ap-abet:app
   ::  +mo-clear-queue: clear blocked tasks from the specified running agent.
   ::
@@ -1046,7 +1102,7 @@
         ap-core
       ::
           %slay
-        =/  out=(list [[=wire =ship =term] ? =path])
+        =/  out=(list [[=wire =ship =term] ? =path nonce=@])
           ~(tap by outbound.watches.current-agent)
         =/  inbound-paths=(set path)
           %-  silt
@@ -1059,7 +1115,7 @@
               ~
             [%give %kick ~(tap in inbound-paths) ~]~
           %+  turn  ~(tap by outbound.watches.current-agent)
-          |=  [[=wire =ship =term] ? =path]
+          |=  [[=wire =ship =term] ? =path nonce=@]
           [%pass wire %agent [ship term] %leave ~]
         =^  maybe-tang  ap-core  (ap-ingest ~ |.([will *agent]))
         ap-core
@@ -1141,11 +1197,6 @@
             %huck   [%out (scot %p ship.neet) name.neet wire]
             %arvo   [(scot %p attributing.agent-routes) wire]
           ==
-        ::  increment nonce for new subscription
-        ::
-        =?    run-nonce.current-agent
-            &(?=(%agent -.neet) ?=(?(%watch %watch-as) -.deal.neet))
-          +(run-nonce.current-agent
         ::
         =/  =note-arvo
           ?-  -.neet
@@ -1169,7 +1220,7 @@
           core(agent-duct agent-duct)
         $(in t.in)
       ::
-      =/  out=(list [[=wire =^ship =term] ? =path])
+      =/  out=(list [[=wire =^ship =term] ? =path nonce=@])
         ~(tap by outbound.watches.current-agent)
       |-  ^+  ap-core
       ?~  out
@@ -1177,7 +1228,8 @@
       =?  ap-core  =(ship ship.i.out)
         =/  core
           =.  agent-duct  system-duct.state
-          =/  way  [%out (scot %p ship) term.i.out wire.i.out]
+          =/  way
+            [%out (scot %p ship) term.i.out (scot %ud nonce.i.out) wire.i.out]
           (ap-specific-take way %kick ~)
         core(agent-duct agent-duct)
       $(out t.out)
@@ -1292,15 +1344,6 @@
       ?:  ?=(%& -.res)
         ``want^p.res
       ((slog leaf+"peek failed tube from {(trip have)} to {(trip want)}" ~) ~)
-    ::  +ap-update-subscription: update subscription.
-    ::
-    ++  ap-update-subscription
-      ~/  %ap-update-subscription
-      |=  [is-ok=? =other=ship other-agent=term =wire]
-      ^+  ap-core
-      ?:  is-ok
-        ap-core
-      (ap-kill-down wire [other-ship other-agent])
     ::  +ap-give: return result.
     ::
     ++  ap-give
@@ -1413,47 +1456,70 @@
       =/  other-agent  i.t.t.wire
       =/  =dock  [other-ship other-agent]
       =/  agent-wire  t.t.t.wire
-      ::  if subscription ack or close, handle before calling user code
+      |^  ^+  ap-core
+      ::  %poke-ack has no nonce
       ::
-      =?  outbound.watches.current-agent  ?=(%kick -.sign)
-        %-  ~(del by outbound.watches.current-agent)
-        [agent-wire dock]
-      ?:  ?&  ?=(%watch-ack -.sign)
-              !(~(has by outbound.watches.current-agent) [agent-wire dock])
-          ==
-        %-  %:  slog
-              leaf+"{<agent-name>}: got ack for nonexistent subscription"
-              leaf+"{<dock>}: {<agent-wire>}"
-              >wire=wire<
-              ~
-            ==
-        ap-core
+      ?:  ?=(%poke-ack -.sign)
+        ingest-and-check-error
+      ::  pop nonce off .agent-wire and match against stored subscription
       ::
-      =?  outbound.watches.current-agent  ?=(%watch-ack -.sign)
-        ?^  p.sign
-          %-  ~(del by outbound.watches.current-agent)
-          [agent-wire dock]
-        %+  ~(jab by outbound.watches.current-agent)  [agent-wire dock]
-        |=  [acked=? =path]
-        =.  .
-          ?.  acked
-            .
-          %-  =/  =tape
-                "{<agent-name>}: received 2nd watch-ack on {<wire dock path>}"
-              (slog leaf+tape ~)
-          .
-        [& path]
+      =^  nonce=@  agent-wire  [(slav %ud (head agent-wire)) (tail agent-wire)]
+      =/  sub-key  [agent-wire dock]
+      =/  wat  (~(get by outbound.watches.current-agent) sub-key)
+      ?~  wat
+        ::  we should be subscribed, but if not, no-op for integrity
+        ::
+        %.  ap-core
+        %-  slog  :~
+          leaf+"{<agent-name>}: got {<-.sign>} for nonexistent subscription"
+          leaf+"{<dock>}: {<agent-wire>}"
+          >wire=wire<
+        ==
+      ::  make sure wire nonce matches stored nonce
       ::
-      =^  maybe-tang  ap-core
-        %+  ap-ingest  ~  |.
-        (on-agent:ap-agent-core agent-wire sign)
-      ::  if failed %fact handling, kill subscription
+      ?.  =(nonce.u.wat nonce)
+        %.  ap-core
+        %-  slog  :~
+          =/  nonces  [expected=nonce.u.wat got=nonce]
+          =/  ok  |(?=(?(%fact %kick) -.sign) =(~ p.sign))
+          leaf+"{<agent-name>}: stale %watch-ack {<nonces>} ok={<ok>}"
+        ::
+          leaf+"{<dock>}: {<agent-wire>}"
+          >wire=wire<
+        ==
       ::
-      =?  ap-core  ?=(%fact -.sign)
-        (ap-update-subscription =(~ maybe-tang) p.dock q.dock agent-wire)
-      ?^  maybe-tang
-        (ap-error -.sign leaf/"closing subscription" u.maybe-tang)
-      ap-core
+      ?-    -.sign
+          %fact
+        =^  tan  ap-core  ingest
+        ?~  tan  ap-core
+        =.  ap-core  (ap-kill-down sub-key)
+        (ap-error -.sign leaf/"take %fact failed, closing subscription" u.tan)
+      ::
+          %kick
+        =.  outbound.watches.current-agent
+          (~(del by outbound.watches.current-agent) sub-key)
+        ::
+        ingest-and-check-error
+      ::
+          %watch-ack
+        =.  outbound.watches.current-agent
+          ?^  p.sign
+            (~(del by outbound.watches.current-agent) sub-key)
+          ::
+          %+  ~(jab by outbound.watches.current-agent)  sub-key
+          |=  val=[acked=? =path nonce=@]
+          =?  .  acked.val
+            %.(. (slog leaf+"{<agent-name>} 2nd watch-ack on {<val>}" ~))
+          val(acked &)
+        ::
+        ingest-and-check-error
+      ==
+      ++  ingest  (ap-ingest ~ |.((on-agent:ap-agent-core agent-wire sign)))
+      ++  ingest-and-check-error
+        ^+  ap-core
+        =^  tan  ap-core  ingest
+        ?~(tan ap-core (ap-error -.sign leaf/"take {<-.sign>} failed" u.tan))
+      --
     ::  +ap-install: install wrapper.
     ::
     ++  ap-install
@@ -1655,7 +1721,8 @@
         $(moves t.moves, new-moves [move new-moves])
       =/  =wire  p.move.move
       ?>  ?=([%use @ @ %out @ @ *] wire)
-      =/  [sys-wire=^wire sub-wire=^wire]  [(scag 6 wire) (slag 6 wire)]
+      =/  sys-wire=^wire  (scag 6 `^wire`wire)
+      =/  sub-wire=^wire  (slag 6 `^wire`wire)
       =/  [=dock =deal]  [[q.p q] r]:q.move.move
       ::
       ?:  (~(has by outbound.watches.current-agent) sub-wire dock)
@@ -1668,14 +1735,17 @@
           (ap-error %watch-not-unique tang)  ::  reentrant, maybe bad?
         $(moves t.moves)
       ::
-      =.  p.move.move  :(weld sys-wire sub-nonce.current-agent use-wire)
+      =.  p.move.move
+        (weld sys-wire [(scot %ud sub-nonce.current-agent) sub-wire])
       %=    $
           moves  t.moves
           new-moves  [move new-moves]
           sub-nonce.current-agent  +(sub-nonce.current-agent)
           outbound.watches.current-agent
         %+  ~(put by outbound.watches.current-agent)  [sub-wire dock]
-        [acked=| path=?-(-.deal %watch path.deal, %watch-as path.deal)]
+        :+  acked=|
+          path=?+(-.deal !! %watch path.deal, %watch-as path.deal)
+        sub-nonce.current-agent
       ==
     --
   --

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -396,7 +396,7 @@
         control-duct  hen
         beak          bek
         agent         &+agent
-        run-nonce         (scot %uw (end 5 (shas %yoke-nonce eny)))
+        run-nonce     (scot %uw (end 5 (shas %yoke-nonce eny)))
       ==
     ::
     =/  old  mo-core
@@ -1189,7 +1189,8 @@
         ==
       ::
           %pass
-        =/  [=wire =neet]  [p q]:card
+        =*  wire  p.card
+        =*  neet  q.card
         =.  wire
           :^  %use  agent-name  run-nonce.current-agent
           ?-  -.neet
@@ -1727,10 +1728,10 @@
       ?:  ?=([* %pass * %g %deal * * %leave *] move)
         =/  =wire  p.move.move
         ?>  ?=([%use @ @ %out @ @ *] wire)
-        =/  short-wire  t.t.t.t.t.t.wire
+        =/  sub-wire  t.t.t.t.t.t.wire
         =/  =dock  [q.p q]:q.move.move
         =.  outbound.watches.current-agent
-          (~(del by outbound.watches.current-agent) [short-wire dock])
+          (~(del by outbound.watches.current-agent) [sub-wire dock])
         $(moves t.moves, new-moves [move new-moves])
       ?.  ?=([* %pass * %g %deal * * ?(%watch %watch-as) *] move)
         $(moves t.moves, new-moves [move new-moves])
@@ -1752,7 +1753,7 @@
       ::
       =.  p.move.move
         (weld sys-wire [(scot %ud sub-nonce.current-agent) sub-wire])
-      %=    $
+      %_    $
           moves  t.moves
           new-moves  [move new-moves]
           sub-nonce.current-agent  +(sub-nonce.current-agent)


### PR DESCRIPTION
Adds a unique "nonce" (scare quotes to escape the ire of irascible cryptographers) to each subscription wire in Gall 
so that responses before a resubscribe can be distinguished from those after a resubscribe.  Responses on anything but the current nonce are printed and ignored -- this might get loud, but I thought it would be better to leave the printing in for now.  

Only `%watch` and `%watch-as` wires have nonces added to them.  Old pre-nonce wires are treated as nonce 0 for backward compatibility.  Each app begins with a nonce of 1, which is incremented on each new subscription the app makes.

Both fresh boot and upgrade have been successfully tested on a fakezod, but I haven't tested how this interacts with the %clog resubscribe machinery.  This probably shouldn't be merged until we also have automatic Ames flow closing, to prevent a linearly growing space leak.