### PR TITLE
btc-provider: ping _only_ once every 30 seconds

### DIFF
--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -72,8 +72,8 @@
     ^-  (quip card _state)
     ?-  -.comm
         %set-credentials
-      :_  state(host-info [api-url.comm %.n network.comm 0 *(set ship)])
-      ~[(start-ping-timer:hc ~s30)]
+      :-  ~[(start-ping-timer:hc ~s0)]
+      state(host-info [api-url.comm %.n network.comm 0 *(set ship)])
       ::
         %add-whitelist
       :-  ~

--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -81,7 +81,7 @@
       :_  state(timer `now.bowl)
       :*  (start-ping-timer ~s0)
           ?~  timer  ~
-          [[%pass /ping-time %arvo %b %rest u.timer] ~]
+          [[%pass /block-time %arvo %b %rest u.timer] ~]
       ==
     ==
   [cards this]
@@ -97,7 +97,7 @@
           ==
       :*  (start-ping-timer:hc ~s0)
           ?~  timer  ~
-          [[%pass /ping-time %arvo %b %rest u.timer] ~]
+          [[%pass /block-time %arvo %b %rest u.timer] ~]
       ==
       ::
         %add-whitelist

--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -75,9 +75,7 @@
     ?-  -.comm
         %set-credentials
       :_  state(host-info [api-url.comm %.n network.comm 0 *(set ship)])
-      :~  do-ping:hc
-          (start-ping-timer:hc ~s30)
-      ==
+      ~[(start-ping-timer:hc ~s30)]
       ::
         %add-whitelist
       :-  ~
@@ -182,8 +180,7 @@
   ?.  (is-whitelisted:hc src.bowl)
     ~|("btc-provider: blocked client {<src.bowl>}" !!)
   ~&  >  "btc-provider: accepted client {<src.bowl>}"
-  :-  [do-ping:hc]~
-  this(clients.host-info (~(put in clients.host-info) src.bowl))
+  `this(clients.host-info (~(put in clients.host-info) src.bowl))
 ::
 ++  on-arvo
   ~/  %on-arvo
@@ -194,7 +191,7 @@
   ::
   ?:  ?=([%ping-timer *] wir)
     :_  this
-    :~  do-ping:hc
+    :~  do-ping
         (start-ping-timer:hc ~s30)
     ==
   =^  cards  state
@@ -203,6 +200,14 @@
       (handle-rpc-response wir client-response.sign-arvo)
     ==
   [cards this]
+  ::
+  ++  do-ping
+    ^-  card
+    =/  act=action  [%ping ~]
+    :*  %pass  /ping/[(scot %da now.bowl)]  %agent
+        [our.bowl %btc-provider]  %poke
+        %btc-provider-action  !>(act)
+    ==
   ::
   ::  Handles HTTP responses from RPC servers. Parses for errors, 
   ::  then handles response. For actions that require collating multiple
@@ -346,12 +351,4 @@
   |=  interval=@dr
   ^-  card
   [%pass /ping-timer %arvo %b %wait (add now.bowl interval)]
-::
-++  do-ping
-  ^-  card
-  =/  act=action  [%ping ~]
-  :*  %pass  /ping/[(scot %da now.bowl)]  %agent
-      [our.bowl %btc-provider]  %poke
-      %btc-provider-action  !>(act)
-  ==
 --

--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -33,7 +33,6 @@
 ::
 ++  on-init
   ^-  (quip card _this)
-  ~&  >  '%btc-provider initialized successfully'
   =|  wl=^whitelist
   :-  ~
   %_  this
@@ -49,7 +48,6 @@
 ++  on-load
   |=  old-state=vase
   ^-  (quip card _this)
-  ~&  >  '%btc-provider recompiled successfully '
   `this(state !<(versioned-state old-state))
 ::
 ++  on-poke
@@ -132,7 +130,6 @@
     ^-  (quip card _state)
     :_  state
     ?.  ?|(connected.host-info ?=(%ping -.act))
-      ~&  >>>  "Not connected to RPC"
       ~[(send-update:hc [%| %not-connected 500])]
     :_  ~
     %+  req-card  act
@@ -303,7 +300,8 @@
 ~%  %btc-provider-helper  ..card  ~
 |_  =bowl:gall
 ++  send-status
-  |=  =status  ^-  card
+  |=  =status
+  ^-  card
   %-  ?:  ?=(%new-block -.status)
         ~&(>> "%new-block: {<block.status>}" same)
       same

--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -728,7 +728,7 @@
     =/  gap  (sub block block.btc-state)
     =?  blocks  (gth gap 1)
       (gulf +(block.btc-state) (dec block))
-    =?  blocks  ?|(?=(~ blockhash) ?=(~ blockfilter))
+    =?  blocks  ?&((gth gap 0) ?|(?=(~ blockhash) ?=(~ blockfilter)))
       (snoc blocks block)
     =?  blocks  (gth gap 50)  ~
     :_  %_  state


### PR DESCRIPTION
We currently ping once every 30 seconds *and* every time a peer connects. This can lead to the provider hanging, particularly in cases when someone reconnects repeatedly. The solution is to ping only on our schedule of once every 30 seconds.