### PR TITLE
file-server: restore who generator binding

### DIFF
--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -12,8 +12,8 @@
       [%glob =glob:glob]
   ==
 ::
-+$  state-3
-  $:  %3
++$  state-4
+  $:  %4
       =configuration:srv
       =serving
   ==
@@ -22,7 +22,7 @@
 %+  verb  |
 %-  agent:dbug
 ::
-=|  state-3
+=|  state-4
 =*  state  -
 ^-  agent:gall
 |_  =bowl:gall
@@ -42,6 +42,7 @@
       ==
   :~  (connect /)
       (connect /'~landscape')
+      [%pass /serve-who %arvo %e %serve [~ /who] %home /gen/who/hoon ~]
   ==
   ::
   ++  connect
@@ -56,6 +57,7 @@
   ^-  (quip card _this)
   |^
   =+  !<(old-state=versioned-state old-vase)
+  =|  cards=(list card)
   =?  old-state  ?=(%0 -.old-state)
     %=    old-state
         -  %1
@@ -79,16 +81,23 @@
       ^-  [^content ? ?]
       [content public %.y]
     ==
-  ?>  ?=(%3 -.old-state)
-  [~ this(state old-state)]
+  =?  cards  ?=(%3 -.old-state)
+    :_  cards
+    [%pass /serve-who %arvo %e %serve [~ /who] %home /gen/who/hoon ~]
+  =?  old-state  ?=(%3 -.old-state)
+    old-state(- %4)
+  ?>  ?=(%4 -.old-state)
+  [cards this(state old-state)]
   ::
   +$  serving-0  (map url-base=path [=clay=path public=?])
   +$  serving-1  (map url-base=path [=content public=?])
+  +$  serving-3  (map url-base=path [=content public=? single-page=?])
   +$  versioned-state
     $%  state-0
         [%1 state-1]
         [%2 state-1]
         state-3
+        state-4
     ==
   ::
   +$  state-0
@@ -99,6 +108,11 @@
   +$  state-1
     $:  =configuration:srv
         serving=serving-1
+    ==
+  +$  state-3
+    $:  %3
+        =configuration:srv
+        serving=serving-3
     ==
   --
 ::


### PR DESCRIPTION
Per the conversation in the landscape meeting, it makes more sense to do this https://github.com/urbit/urbit/pull/5056 in a way that doesn't require authentication. Now ships expose a `/who` path that returns their ship name.