### PR TITLE
btc-wallet: check if tile and file server are already initialized

### DIFF
--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -69,21 +69,31 @@
 ++  on-init
 ^-  (quip card _this)
   ~&  >  '%btc-wallet initialized'
-  =/  file
-    [%file-server-action !>([%serve-dir /'~btc' /app/btc-wallet %.n %.y])]
-  =/  tile
-    :-  %launch-action
-    !>  :+  %add
-      %btc-wallet
-    [[%custom `'/~btc' `'/~btc/img/tile.svg'] %.y]
+  ::
   =/  warning  [%settings-event !>([%put-entry %btc-wallet %warning %b %.y])]
   =/  currency
     [%settings-event !>([%put-entry %btc-wallet %currency %s 'USD'])]
-  :-  :~  [%pass /btc-wallet-server %agent [our.bowl %file-server] %poke file]
-          [%pass /btc-wallet-tile %agent [our.bowl %launch] %poke tile]
-          [%pass /warn %agent [our.bowl %settings-store] %poke warning]
-          [%pass /warn %agent [our.bowl %settings-store] %poke currency]
-      ==
+  =/  cards=(list card)
+    :~  [%pass /warn %agent [our.bowl %settings-store] %poke warning]
+        [%pass /warn %agent [our.bowl %settings-store] %poke currency]
+    ==
+  ::
+  =/  has-file=?  (gall-scry:hc ? %file-server /url/'~btc'/noun)
+  =/  has-tile=?
+    (~(has in (gall-scry:hc (set @tas) %launch /keys/noun)) %btc-wallet)
+  =?  cards  !has-file
+    =/  file
+      [%file-server-action !>([%serve-dir /'~btc' /app/btc-wallet %.n %.y])]
+    :_  cards
+    [%pass /btc-wallet-server %agent [our.bowl %file-server] %poke file]
+  =?  cards  !has-tile
+    =/  tile
+      :-  %launch-action
+      !>([%add %btc-wallet [%custom `'/~btc' `'/~btc/img/tile.svg'] %.y])
+    :_  cards
+    [%pass /btc-wallet-tile %agent [our.bowl %launch] %poke tile]
+  ::
+  :-  cards
   %_  this
       state
     :*  %1
@@ -1287,4 +1297,8 @@
   |=  [=xpub:bc w=walt]
   ^-  (unit xpub:bc)
   ?:(scanned.w `xpub ~)
+::
+++  gall-scry
+  |*  [=mold app=@tas =path]
+  .^(mold %gx (weld /(scot %p our.bowl)/[app]/(scot %da now.bowl) path))
 --

--- a/pkg/arvo/app/file-server.hoon
+++ b/pkg/arvo/app/file-server.hoon
@@ -352,6 +352,10 @@
       [%x %clay %base %hash ~]
     =/  versions  (base-hash:version [our now]:bowl)
     ``hash+!>(?~(versions 0v0 (end [0 25] i.versions)))
+  ::
+      [%x %url *]
+    =/  url  t.t.path
+    ``noun+!>((~(has by serving) url))
   ==
 ++  on-agent  on-agent:def
 ++  on-fail   on-fail:def


### PR DESCRIPTION
Addresses this issue: https://github.com/urbit/bitcoin-wallet/issues/25

This isn't really a sufficient solution though, fading the app should really just cause launch and file-server to remove the related stuff. Seems like if we're going to have fade, we also need an `on-fade` arm.