### PR TITLE
btc-provider: do not allow comets to connect unless we have explicitly whitelisted them

### DIFF
--- a/pkg/arvo/app/btc-provider.hoon
+++ b/pkg/arvo/app/btc-provider.hoon
@@ -348,12 +348,16 @@
   |=  user=ship
   ^-  ?
   |^
-  ?|  public.whitelist
-      =(our.bowl user)
-      ?&(kids.whitelist is-kid)
-      (~(has in users.whitelist) user)
-      in-group
-  ==
+  ?&  ?|  ?!(?=(%pawn (clan:title user)))
+          (~(has in users.whitelist) user)
+          =(our.bowl user)
+      ==
+      ?|  public.whitelist
+          ?&(kids.whitelist is-kid)
+          (~(has in users.whitelist) user)
+          =(our.bowl user)
+          in-group
+  ==  ==
   ::
   ++  is-kid
     =(our.bowl (sein:title our.bowl now.bowl user))


### PR DESCRIPTION
We had an errant comet that was slowing down `~tirrel` because it was still running the old `%btc-wallet` code that made repeated requests. I updated the conditions to ban all comets unless the one in particular is explicitly allowed. Let me know what you think.