### PR TITLE
scan-progress added

### DIFF
--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -979,7 +979,9 @@
           walts  (~(put by walts) xpub w(scanned %.y))
         ==
       %-  (slog ~[leaf+"Scanned xpub {<xpub>}"])
-      (set-curr-xpub:hc xpub)
+      =^  cards  state
+        (set-curr-xpub:hc xpub)
+      [[(give-update:hc [%scan-progress ~ ~]) cards] state]
     ::
     ::  +bump-batch
     ::  if the batch is done but the wallet isn't done scanning,

--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -210,7 +210,8 @@
           [(silt (gulf 0 endpoint)) endpoint %.n]
         =^  cards0  state  (req-scan:hc b xpub %0)
         =^  cards1  state  (req-scan:hc b xpub %1)
-        [(weld cards0 cards1) state]
+        :_  state
+        [(scan-progress:hc xpub) (weld cards0 cards1)]
       --
     ::
         %delete-wallet
@@ -602,7 +603,7 @@
             (turn inputs.ti |=(i=val:tx [i `payer]))
             %+  turn  outputs.ti
               |=  o=val:tx
-              ?:  =(pos.o vout) 
+              ?:  =(pos.o vout)
                 ::  check whether this is the output that went to payee
                 [o payee]
               [o `payer]
@@ -964,7 +965,8 @@
         (bump-batch xpub %0)
       =^  cards1=(list card)  state
         (bump-batch xpub %1)
-      [(weld cards0 cards1) state]
+      :_  state
+      [(scan-progress:hc xpub) (weld cards0 cards1)]
     ::
     ::  delete the xpub from scans and set wallet to scanned
     ::
@@ -1217,6 +1219,21 @@
   |=  upd=update
   ^-  card
   [%give %fact ~[/all] %btc-wallet-update !>(upd)]
+::
+++  scan-progress
+  |=  [=xpub:bc]
+  |^  ^-  card
+  %-  give-update
+  :+  %scan-progress
+  (to-idx (~(gut by scans.state) [xpub %0] *batch))
+  (to-idx (~(gut by scans.state) [xpub %1] *batch))
+  ++  to-idx
+    |=  b=batch
+    ^-  (unit idx:bc)
+    =/  s=(list idx:bc)
+      (sort ~(tap in todo.b) lth)
+    ?~  s  ~  `i.s
+  --
 ::
 ++  watch-provider
   |=  who=@p

--- a/pkg/arvo/lib/bitcoin-json.hoon
+++ b/pkg/arvo/lib/bitcoin-json.hoon
@@ -110,6 +110,7 @@
       %cancel-tx           (hexb txid.upd)
       %new-address         (address address.upd)
       %balance             (balance balance.upd)
+      %scan-progress       (scan-progress main.upd change.upd)
       %error               s+error.upd
       %broadcast-success   ~
     ==
@@ -160,6 +161,19 @@
     :~  confirmed+(numb p.u.b)
         unconfirmed+(numb q.u.b)
     ==
+  ::
+  ++  scan-progress
+    |=  [main=(unit idx:bitcoin) change=(unit idx:bitcoin)]
+    |^  ^-  json
+    %-  pairs
+    :~  main+(from-unit main)
+        change+(from-unit change)
+    ==
+    ++  from-unit
+      |=  i=(unit idx:bitcoin)
+      ?~  i  ~
+      (numb u.i)
+    --
   ::
   ++  btc-state
     |=  bs=btc-state:btc-wallet

--- a/pkg/arvo/sur/btc-wallet.hoon
+++ b/pkg/arvo/sur/btc-wallet.hoon
@@ -162,6 +162,10 @@
       [%new-address =address]
       [%balance balance=(unit [confirmed=sats unconfirmed=sats])]
       [%error =error]
+      ::  current index being scanned in each wallet part
+      ::   ~ if scan of that part is done
+      ::
+      [%scan-progress main=(unit idx) change=(unit idx)]
   ==
 ::
 --


### PR DESCRIPTION
@ixv added the `%scan-progress` update type. It is sent in `+init-batches` and `+check-scan`.

`main` and `change` are the 2 sub-wallets. `~` means fully scanned; an `idx` value is the lowest index of the current scanning batch.