### PR TITLE
fixed address bug for legacy addresses

### DIFF
--- a/pkg/arvo/lib/bitcoin.hoon
+++ b/pkg/arvo/lib/bitcoin.hoon
@@ -57,7 +57,9 @@
     ~/  %to-cord
     |=  a=address  ^-  cord
     ?:  ?=([%base58 *] a)
-      (scot %uc +.a)
+      %-  crip
+      %+  slag  2
+      (trip (scot %uc +.a))
     +.a
   ::
   ++  from-pubkey

--- a/pkg/arvo/lib/bitcoin.hoon
+++ b/pkg/arvo/lib/bitcoin.hoon
@@ -59,7 +59,7 @@
     ?:  ?=([%base58 *] a)
       %-  crip
       %+  slag  2
-      (trip (scot %uc +.a))
+      (scow %uc +.a)
     +.a
   ::
   ++  from-pubkey


### PR DESCRIPTION
Fixed `to-cord:adr` in `bitcoin.hoon`: it was printing old-style addresses with their Urbit `0c` prefix for the `@uc` aura.