### PR TITLE
interface: fixes blocking release

### DIFF
--- a/pkg/interface/src/logic/state/hark.ts
+++ b/pkg/interface/src/logic/state/hark.ts
@@ -1,5 +1,6 @@
 import {
   archive,
+  markCountAsRead,
   NotificationGraphConfig,
   NotifIndex,
   readNote,
@@ -32,6 +33,7 @@ export interface HarkState {
   unreads: Unreads;
   archive: (index: NotifIndex, time?: BigInteger) => Promise<void>;
   readNote: (index: NotifIndex) => Promise<void>;
+  readCount: (resource: string, index?: string) => Promise<void>;
 }
 
 const useHarkState = createState<HarkState>(
@@ -40,6 +42,10 @@ const useHarkState = createState<HarkState>(
     archivedNotifications: new BigIntOrderedMap<Timebox>(),
     doNotDisturb: false,
     unreadNotes: [],
+    readCount: async (resource: string, index?: string) => {
+      const poke = markCountAsRead(resource, index);
+      await pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
     archive: async (index: NotifIndex, time?: BigInteger) => {
       const poke = archive(index, time);
       await pokeOptimisticallyN(useHarkState, poke, [reduce]);

--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -26,7 +26,11 @@ export interface LocalState {
   setTutorialRef: (el: HTMLElement | null) => void;
   dark: boolean;
   mobile: boolean;
-  mdBreak: boolean;
+  breaks: {
+    sm: boolean;
+    md: boolean;
+    lg: boolean;
+  }
   background: BackgroundConfig;
   omniboxShown: boolean;
   suspendedFocus?: HTMLElement;
@@ -46,7 +50,11 @@ export const selectLocalState =
 const useLocalState = create<LocalStateZus>(persist((set, get) => ({
   dark: false,
   mobile: false,
-  mdBreak: false,
+  breaks: {
+    sm: false,
+    md: false,
+    lg: false
+  },
   background: undefined,
   theme: 'auto',
   hideAvatars: false,
@@ -126,7 +134,7 @@ const useLocalState = create<LocalStateZus>(persist((set, get) => ({
     blacklist: [
       'suspendedFocus', 'toggleOmnibox', 'omniboxShown', 'tutorialProgress',
       'prevTutStep', 'nextTutStep', 'tutorialRef', 'setTutorialRef', 'subscription',
-      'errorCount'
+      'errorCount', 'breaks'
     ],
   name: 'localReducer'
 }));

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -88,15 +88,21 @@ class App extends React.Component {
       // before the app has actually rendered, hence the timeout.
       this.themeWatcher = window.matchMedia('(prefers-color-scheme: dark)');
       this.mobileWatcher = window.matchMedia(`(max-width: ${theme.breakpoints[0]})`);
-      this.mediumWatcher = window.matchMedia(`(max-width: ${theme.breakpoints[1]})`);
+      this.smallWatcher = window.matchMedia(`(min-width: ${theme.breakpoints[0]})`);
+      this.mediumWatcher = window.matchMedia(`(min-width: ${theme.breakpoints[1]})`);
+      this.largeWatcher = window.matchMedia(`(min-width: ${theme.breakpoints[2]})`);
       // TODO: addListener is deprecated, but safari 13 requires it
       this.themeWatcher.addListener(this.updateTheme);
       this.mobileWatcher.addListener(this.updateMobile);
+      this.smallWatcher.addListener(this.updateSmall);
       this.mediumWatcher.addListener(this.updateMedium);
+      this.largeWatcher.addListener(this.updateLarge);
 
       this.updateMobile(this.mobileWatcher);
+      this.updateSmall(this.updateSmall);
       this.updateTheme(this.themeWatcher);
       this.updateMedium(this.mediumWatcher);
+      this.updateLarge(this.largeWatcher);
     }, 500);
     this.props.getBaseHash();
     this.props.getRuntimeLag();  // TODO  consider polling periodically
@@ -112,7 +118,9 @@ class App extends React.Component {
   componentWillUnmount() {
     this.themeWatcher.removeListener(this.updateTheme);
     this.mobileWatcher.removeListener(this.updateMobile);
+    this.smallWatcher.removeListener(this.updateSmall);
     this.mediumWatcher.removeListener(this.updateMedium);
+    this.largeWatcher.removeListener(this.updateLarge);
   }
 
   updateTheme(e) {
@@ -127,9 +135,21 @@ class App extends React.Component {
     });
   }
 
+  updateSmall = (e) => {
+    this.props.set((state) => {
+      state.breaks.sm = e.matches;
+    });
+  }
+
   updateMedium = (e) => {
     this.props.set((state) => {
-      state.mdBreak = e.matches;
+      state.breaks.md = e.matches;
+    });
+  }
+
+  updateLarge = (e) => {
+    this.props.set((state) => {
+      state.breaks.lg = e.matches;
     });
   }
 

--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -1,4 +1,4 @@
-import { Content, createPost, fetchIsAllowed, markCountAsRead, Post, removePosts } from '@urbit/api';
+import { Content, createPost, fetchIsAllowed, Post, removePosts } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
 import { BigInteger } from 'big-integer';
 import React, {
@@ -140,7 +140,7 @@ const ChatResource = (props: ChatResourceProps): ReactElement => {
   }, [resource]);
 
   const dismissUnread = useCallback(() => {
-    airlock.poke(markCountAsRead(association.resource));
+    useHarkState.getState().readCount(association.resource);
   }, [association.resource]);
 
   const getPermalink = useCallback(

--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -1,4 +1,4 @@
-import { cite, Content, markCountAsRead, Post } from '@urbit/api';
+import { cite, Content, Post } from '@urbit/api';
 import React, { useCallback, useEffect } from 'react';
 import _ from 'lodash';
 import bigInt from 'big-integer';
@@ -7,10 +7,9 @@ import { Link } from 'react-router-dom';
 import { patp2dec } from 'urbit-ob';
 import { useContact } from '~/logic/state/contact';
 import useGraphState, { useDM } from '~/logic/state/graph';
-import { useHarkDm } from '~/logic/state/hark';
+import useHarkState, { useHarkDm } from '~/logic/state/hark';
 import useSettingsState, { selectCalmState } from '~/logic/state/settings';
 import { ChatPane } from './components/ChatPane';
-import airlock from '~/logic/api';
 import shallow from 'zustand/shallow';
 
 interface DmResourceProps {
@@ -111,7 +110,8 @@ export function DmResource(props: DmResourceProps) {
   );
 
   const dismissUnread = useCallback(() => {
-    airlock.poke(markCountAsRead(`/ship/~${window.ship}/dm-inbox`, `/${patp2dec(ship)}`));
+    const resource = `/ship/~${window.ship}/dm-inbox`;
+    useHarkState.getState().readCount(resource, `/${patp2dec(ship)}`);
   }, [ship]);
 
   const onSubmit = useCallback(

--- a/pkg/interface/src/views/apps/links/components/LinkBlockInput.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkBlockInput.tsx
@@ -109,7 +109,7 @@ export function LinkBlockInput(props: LinkBlockInputProps) {
           onBlur={onBlur}
           promptUpload={promptUpload}
           onKeyPress={onKeyPress}
-          leftOffset="24px"
+          center
         />
       )}
       <Row

--- a/pkg/interface/src/views/apps/links/components/LinkBlocks.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkBlocks.tsx
@@ -25,23 +25,23 @@ const style = {
   alignItems: 'center'
 };
 const PADDING = 24;
-const MOBILE_PADDING = 16;
+const SMALL_PADDING = 16;
 
 export function LinkBlocks(props: LinkBlocksProps) {
   const { association } = props;
   const [linkSize, setLinkSize] = useState(250);
   const linkSizePx = `${linkSize}px`;
 
-  const isMobile = useLocalState(s => s.mobile || s.mdBreak);
-  const colCount = useMemo(() => (isMobile ? 2 : 4), [isMobile]);
+  const isSmall = useLocalState(s => !s.breaks.lg);
+  const colCount = useMemo(() => (isSmall ? 2 : 4), [isSmall]);
   const bind = useResize<HTMLDivElement>(
     useCallback(
       (entry) => {
         const { width } = entry.target.getBoundingClientRect();
-        const pad = isMobile ? MOBILE_PADDING : PADDING;
+        const pad = isSmall ? SMALL_PADDING : PADDING;
         setLinkSize((width - pad) / colCount - pad);
       },
-      [colCount, isMobile]
+      [colCount, isSmall]
     )
   );
 
@@ -68,7 +68,7 @@ export function LinkBlocks(props: LinkBlocksProps) {
   const renderItem = useCallback(
     React.forwardRef<any, any>(({ index }, ref) => {
       const chunk = orm.get(index) ?? [];
-      const space = [3, 3, 4];
+      const space = [3, 3, 3, 4];
 
       return (
         <Row

--- a/pkg/interface/src/views/components/StatelessUrlInput.tsx
+++ b/pkg/interface/src/views/components/StatelessUrlInput.tsx
@@ -11,8 +11,7 @@ type StatelessUrlInputProps = PropFunc<typeof BaseInput> & {
   onChange?: (value: string) => void;
   promptUpload: () => Promise<string>;
   canUpload: boolean;
-  placeholderOffset?: number | string | number[] | string[];
-  leftOffset?: number | string | number[] | string[];
+  center?: boolean;
 };
 
 export function StatelessUrlInput(props: StatelessUrlInputProps) {
@@ -23,41 +22,51 @@ export function StatelessUrlInput(props: StatelessUrlInputProps) {
     onChange = () => {},
     promptUpload,
     canUpload,
-    placeholderOffset = 0,
-    leftOffset = 0,
+    center = false,
     ...rest
   } = props;
 
   const placeholder = useMemo(
-    () => (
-      <Text
-        gray
-        position="absolute"
-        top={placeholderOffset}
-        left={leftOffset}
-        px={2}
-        pt={2}
-        style={{ pointerEvents: 'none' }}
-      >
-        {canUpload ? (
-          <>
-            Drop or{' '}
-            <Text
-              cursor="pointer"
-              color="blue"
-              style={{ pointerEvents: 'all' }}
-              onClick={() => promptUpload().then(onChange)}
-            >
-              upload
-            </Text>{' '}
-            a file, or paste a link here
-          </>
-        ) : (
-          'Paste a link here'
-        )}
-      </Text>
-    ),
-    [canUpload, promptUpload, onChange]
+    () => {
+      const centerProps = !center
+        ? {}
+        : {
+            width: '100%',
+            height: '100%',
+            alignItems: 'center',
+            justifyContent: 'center'
+          };
+
+      return (
+        <Box
+          px={2}
+          pt={2}
+          position="absolute"
+          {...centerProps}
+          style={{ pointerEvents: 'none' }}
+        >
+          <Text gray>
+            {canUpload ? (
+              <>
+                Drop or{' '}
+                <Text
+                  cursor="pointer"
+                  color="blue"
+                  style={{ pointerEvents: 'all' }}
+                  onClick={() => promptUpload().then(onChange)}
+                >
+                  upload
+                </Text>{' '}
+                a file, or paste a link here
+              </>
+            ) : (
+              'Paste a link here'
+            )}
+          </Text>
+        </Box>
+      );
+    },
+    [canUpload, promptUpload, onChange, center]
   );
 
   const handleChange = useCallback(

--- a/pkg/interface/src/views/components/VirtualScroller.tsx
+++ b/pkg/interface/src/views/components/VirtualScroller.tsx
@@ -217,11 +217,13 @@ export default class VirtualScroller<K,V> extends Component<VirtualScrollerProps
 
   onDown = (e: PointerEvent) => {
     this.scrollRef.setPointerCapture(e.pointerId);
+    document.documentElement.style.setProperty('--user-select', 'none');
     this.scrollDragging = true;
   }
 
   onUp = (e: PointerEvent) => {
     this.scrollRef.releasePointerCapture(e.pointerId);
+    document.documentElement.style.removeProperty('--user-select');
     this.scrollDragging = false;
   }
 
@@ -238,14 +240,14 @@ export default class VirtualScroller<K,V> extends Component<VirtualScrollerProps
   setScrollRef = (el: HTMLDivElement | null) => {
     if(!el) {
       this.scrollRef.removeEventListener('pointerdown', this.onDown);
-      this.scrollRef.removeEventListener('pointermove', this.onMove);
+      this.scrollRef.removeEventListener('mousemove', this.onMove);
       this.scrollRef.removeEventListener('pointerup', this.onUp);
       this.scrollRef = null;
       return;
     }
     this.scrollRef = el;
     this.scrollRef.addEventListener('pointerdown', this.onDown);
-    this.scrollRef.addEventListener('pointermove', this.onMove);
+    this.scrollRef.addEventListener('mousemove', this.onMove);
     this.scrollRef.addEventListener('pointerup', this.onUp);
   }
   // manipulate scrollbar manually, to dodge change detection

--- a/pkg/interface/src/views/landscape/css/custom.css
+++ b/pkg/interface/src/views/landscape/css/custom.css
@@ -31,3 +31,8 @@ ol, ul {
 span {
   box-sizing: border-box;
 }
+
+* {
+  user-select: var(--user-select, unset);
+  -webkit-user-select: var(--user-select, unset);
+}


### PR DESCRIPTION
interface: revive optimistic unread updating

Fixes urbit/landscape#1030

collections: style pass on smaller screen sizes

interface: add all breakpoints to state

VirtualScroller: fix scrollbar on safari

Moves to mousemove instead of pointermove events as a result of this
bug[1]. Adds a CSS rule to optionally globally disable selection of text,
to prevent this from occurring during scroll on safari, as
preventDefault() does nothing.

[1]: https://bugs.webkit.org/show_bug.cgi?id=220194
