### PR TITLE
btc-wallet: Show dollar sign instead of usd

### DIFF
--- a/pkg/btc-wallet/src/js/components/lib/walletModal.js
+++ b/pkg/btc-wallet/src/js/components/lib/walletModal.js
@@ -24,11 +24,7 @@ const WalletModal = () => {
   const [confirmingMasterTicket, setConfirmingMasterTicket] = useState(false);
   const [error, setError] = useState(false);
 
-  const checkTicket = ({
-    event: {
-      target: { value },
-    },
-  }) => {
+  const checkTicket = ({ target: { value } }) => {
     // TODO: port over bridge ticket validation logic
     if (confirmingMasterTicket) {
       setConfirmedMasterTicket(value);

--- a/pkg/btc-wallet/src/js/hooks/useSettings.js
+++ b/pkg/btc-wallet/src/js/hooks/useSettings.js
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import _ from 'lodash';
 import { api } from '../api';
-import { reduceHistory } from '../lib/util';
+import { mapDenominationToSymbol, reduceHistory } from '../lib/util';
 
 export const SettingsContext = createContext({
   network: 'bitcoin',
@@ -120,6 +120,7 @@ export const SettingsProvider = ({ channel, children }) => {
         const newCurrencyRates = currencyRates;
         for (let c in n) {
           newCurrencyRates[c] = n[c];
+          newCurrencyRates[c].symbol = mapDenominationToSymbol(c);
         }
         setCurrencyRates(newCurrencyRates);
         setTimeout(() => initializeCurrencyPoll(), 1000 * 60 * 15);

--- a/pkg/btc-wallet/src/js/lib/util.js
+++ b/pkg/btc-wallet/src/js/lib/util.js
@@ -118,3 +118,12 @@ export function reduceHistory(history) {
     return hest2.recvd - hest1.recvd;
   });
 }
+
+export function mapDenominationToSymbol(denomination) {
+  switch (denomination) {
+    case 'USD':
+      return '$';
+    default:
+      return denomination;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/urbit/bitcoin-wallet/issues/40.

Right now just mapping "USD" to "$" since the app can only toggle between USD and BTC, but we can add other currency symbols to the switch later.

Also fixed an issue I found with destructuring a param in checkTicket (event was always undefined).