### PR TITLE
btc-wallet: Fix copy from non-secure context issue

### DIFF
--- a/pkg/btc-wallet/src/js/components/lib/balance.js
+++ b/pkg/btc-wallet/src/js/components/lib/balance.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Row, Text, Button, Col } from '@tlon/indigo-react';
 import Send from './send.js';
 import CurrencyPicker from './currencyPicker.js';
-import { satsToCurrency } from '../../lib/util.js';
+import { copyToClipboard, satsToCurrency } from '../../lib/util.js';
 import { useSettings } from '../../hooks/useSettings.js';
 import { api } from '../../api';
 
@@ -21,8 +21,8 @@ const Balance = () => {
   const [copiedButton, setCopiedButton] = useState(false);
   const [copiedString, setCopiedString] = useState(false);
 
-  const copyAddress = (arg) => {
-    navigator.clipboard.writeText(address);
+  const copyAddress = async (arg) => {
+    await copyToClipboard(address);
     api.btcWalletCommand({ 'gen-new-address': null });
 
     if (arg === 'button') {

--- a/pkg/btc-wallet/src/js/lib/util.js
+++ b/pkg/btc-wallet/src/js/lib/util.js
@@ -127,3 +127,23 @@ export function mapDenominationToSymbol(denomination) {
       return denomination;
   }
 }
+
+export function copyToClipboard(textToCopy) {
+  // navigator clipboard api needs a secure context (https or localhost)
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(textToCopy);
+  } else {
+    let textArea = document.createElement('textarea');
+    textArea.value = textToCopy;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-999999px';
+    textArea.style.top = '-999999px';
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    return new Promise((res, rej) => {
+      document.execCommand('copy') ? res() : rej();
+      textArea.remove();
+    });
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/urbit/bitcoin-wallet/issues/36

We can't use `navigator.clipboard` from a non-secure context (i.e., must use localhost or https). Now using a function to determine if we're in a secure context and then using a workaround to make copying to the clipboard work if not.