### PR TITLE
landscape: allow setting shortcut for leap

### DIFF
--- a/pkg/interface/src/logic/state/settings.ts
+++ b/pkg/interface/src/logic/state/settings.ts
@@ -24,6 +24,7 @@ export interface ShortcutMapping {
   navBack: string;
   hideSidebar: string;
   readGroup: string;
+  leap: string;
 }
 
 export interface SettingsState {
@@ -95,7 +96,8 @@ const useSettingsState = createState<SettingsState>(
       navForward: 'ctrl+]',
       navBack: 'ctrl+[',
       hideSidebar: 'ctrl+\\',
-      readGroup: 'shift+Escape'
+      readGroup: 'shift+Escape',
+      leap: 'meta+/'
     },
     getAll: async () => {
       const { all } = await airlock.scry(getAll);

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -1,7 +1,6 @@
 import dark from '@tlon/indigo-dark';
 import light from '@tlon/indigo-light';
 import shallow from 'zustand/shallow';
-import 'mousetrap-global-bind';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import 'react-hot-loader';

--- a/pkg/interface/src/views/App.js
+++ b/pkg/interface/src/views/App.js
@@ -1,6 +1,5 @@
 import dark from '@tlon/indigo-dark';
 import light from '@tlon/indigo-light';
-import Mousetrap from 'mousetrap';
 import shallow from 'zustand/shallow';
 import 'mousetrap-global-bind';
 import * as React from 'react';
@@ -108,11 +107,6 @@ class App extends React.Component {
     this.props.getRuntimeLag();  // TODO  consider polling periodically
     this.props.getAll();
     gcpManager.start();
-    Mousetrap.bindGlobal(['command+/', 'ctrl+/'], (e) => {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.props.toggleOmnibox();
-    });
   }
 
   componentWillUnmount() {
@@ -195,6 +189,7 @@ class App extends React.Component {
                 ship={this.ship}
                 subscription={this.subscription}
                 connection={'aa'}
+                toggleOmnibox={this.props.toggleOmnibox}
               />
             </ErrorBoundary>
           </Router>

--- a/pkg/interface/src/views/apps/settings/components/lib/ShortcutSettings.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/ShortcutSettings.tsx
@@ -104,6 +104,7 @@ export default function ShortcutSettings() {
             />
             <ChordInput id="hideSidebar" label="Show/hide group sidebar" />
             <ChordInput id="readGroup" label="Read all in a group" />
+            <ChordInput id="leap" label="Leap" />
           </Box>
           <AsyncButton primary width="fit-content">Save Changes</AsyncButton>
         </Col>

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -7,7 +7,7 @@ import {
   Row,
   Text
 } from '@tlon/indigo-react';
-import React, { useRef } from 'react';
+import React, { useRef, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Sigil } from '~/logic/lib/sigil';
 import { uxToHex } from '~/logic/lib/util';
@@ -36,7 +36,9 @@ const StatusBar = (props) => {
   const invites = [].concat(
     ...Object.values(inviteState).map(obj => Object.values(obj))
   );
-  const metaKey = window.navigator.platform.includes('Mac') ? '⌘' : 'Ctrl+';
+  const leapKey: string = useSettingsState(
+    useCallback(s => s.keyboard['leap'], ['leap'])
+    )?.replace('meta+', '⌘') || '';
   const { toggleOmnibox } = useLocalState(localSel);
   const { hideAvatars } = useSettingsState(selectCalmState);
 
@@ -100,7 +102,7 @@ const StatusBar = (props) => {
             Leap
           </Text>
           <Text display={['none', 'inline']} ml={2} color='gray'>
-            {metaKey}/
+            {leapKey}
           </Text>
         </StatusBarItem>
         <ReconnectButton />

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -7,7 +7,7 @@ import {
   Row,
   Text
 } from '@tlon/indigo-react';
-import React, { useRef, useCallback } from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Sigil } from '~/logic/lib/sigil';
 import { uxToHex } from '~/logic/lib/util';
@@ -16,7 +16,7 @@ import useHarkState from '~/logic/state/hark';
 import useLaunchState from '~/logic/state/launch';
 import useInviteState from '~/logic/state/invite';
 import useLocalState, { selectLocalState } from '~/logic/state/local';
-import useSettingsState, { selectCalmState } from '~/logic/state/settings';
+import useSettingsState, { selectCalmState, SettingsState } from '~/logic/state/settings';
 import { Dropdown } from './Dropdown';
 import { ProfileStatus } from './ProfileStatus';
 import ReconnectButton from './ReconnectButton';
@@ -42,10 +42,9 @@ const StatusBar = (props) => {
   } else if (window.navigator.platform.includes('Win')) {
     metaKey = '⊞ Win+';
   }
+  const selKey = (s: SettingsState) => s.keyboard.leap.replace('meta+', metaKey);
 
-  const leapKey: string = useSettingsState(
-    useCallback(s => s.keyboard['leap'], ['leap'])
-    )?.replace('meta+', metaKey) || '';
+  const leapKey = useSettingsState(selKey);
   const { toggleOmnibox } = useLocalState(localSel);
   const { hideAvatars } = useSettingsState(selectCalmState);
 

--- a/pkg/interface/src/views/components/StatusBar.tsx
+++ b/pkg/interface/src/views/components/StatusBar.tsx
@@ -36,9 +36,17 @@ const StatusBar = (props) => {
   const invites = [].concat(
     ...Object.values(inviteState).map(obj => Object.values(obj))
   );
+
+  let metaKey = 'Super+';
+  if (window.navigator.platform.includes('Mac')) {
+    metaKey = '⌘';
+  } else if (window.navigator.platform.includes('Win')) {
+    metaKey = '⊞ Win+';
+  }
+
   const leapKey: string = useSettingsState(
     useCallback(s => s.keyboard['leap'], ['leap'])
-    )?.replace('meta+', '⌘') || '';
+    )?.replace('meta+', metaKey) || '';
   const { toggleOmnibox } = useLocalState(localSel);
   const { hideAvatars } = useSettingsState(selectCalmState);
 

--- a/pkg/interface/src/views/landscape/components/Content.tsx
+++ b/pkg/interface/src/views/landscape/components/Content.tsx
@@ -41,7 +41,7 @@ export const Content = (props) => {
     e.preventDefault();
     e.stopImmediatePropagation();
     props.toggleOmnibox();
-  }, []));
+  }, [props.toggleOmnibox]));
 
   const [hasProtocol, setHasProtocol] = useLocalStorageState(
     'registeredProtocol', false

--- a/pkg/interface/src/views/landscape/components/Content.tsx
+++ b/pkg/interface/src/views/landscape/components/Content.tsx
@@ -37,6 +37,12 @@ export const Content = (props) => {
     history.goBack();
   }, [history.goBack]));
 
+  useShortcut('leap', useCallback((e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    props.toggleOmnibox();
+  }, []));
+
   const [hasProtocol, setHasProtocol] = useLocalStorageState(
     'registeredProtocol', false
   );


### PR DESCRIPTION
- Adds fallback for Leap shortcut in initial state (`meta+/`)
- Moves Leap from the App.js component to the other shortcut contexts in Content
- Allows the Leap shortcut to be set in the settings menu
- Shows the current shortcut on the Leap button