### PR TITLE
vere: have king chdir to pier directory on boot

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -676,12 +676,19 @@ main(c3_i   argc,
     u3_Host.bot_f = _stop_on_boot_completed_cb;
   }
 
-#if 0
-  if ( 0 == getuid() ) {
-    chroot(u3_Host.dir_c);
-    u3_Host.dir_c = "/";
+  {
+    mkdir(u3_Host.dir_c, 0700);
+
+    //  Some day, it might be nice to chroot() here or something.
+    if ( 0 != chdir(u3_Host.dir_c) ) {
+      u3l_log("boot: chdir to %s failed: %s\r\n", u3_Host.dir_c,
+              strerror(errno));
+      exit(1);
+    }
+    c3_free(u3_Host.dir_c);
+    u3_Host.dir_c = strdup(".");
   }
-#endif
+
   u3_ve_sysopt();
 
   //  Block profiling signal, which should be delivered to exactly one thread.
@@ -727,7 +734,7 @@ main(c3_i   argc,
       mprint_i *= 2;
       abs_c = c3_malloc(mprint_i);
     }
-    printf("boot: home is %s/%s\n", abs_c, u3_Host.dir_c);
+    printf("boot: home is %s\n", abs_c);
     c3_free(abs_c);
   } else {
     printf("boot: home is %s\n", abs_c);


### PR DESCRIPTION
This was originally reviewed and applied in #5086, but that was based on release/next-sys, whereas it should have been based on release/next-vere. This PR has the correct merge base. See also #5106, which reverts the change on release/next-sys.

The original impetus for this was creating the %khan socket: Unix domain
socket paths are limited to 108 characters since they have to fit into a
struct sockaddr; we want the %khan socket to be relative to the pier;
hence it's most expedient if the socket is itself a relative path of
known length, and is created with cwd located at the pier directory.

There has also been talk about having the binary chroot itself to the
pier directory for ~security reasons. The code to do so existed, but was
ifdef'd out (and would require further work, e.g. patching in
/dev/urandom.)

This patch merely calls chdir in main and sets u3_Host.dir_c to ".". It
seems to work; however, u3_Host.dir_c (and u3_Local) is now largely
redundant, and is used in a lot of places to construct paths that look
like "./foo". Hence, references to it should be cleaned up in a future
change.