### PR TITLE
support third-party software distribution

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -14,8 +14,8 @@
       [%11 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
       [%12 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
       [%13 drum=state-2:drum helm=state:helm kiln=state-1:kiln]
-      [%14 drum=state-3:drum helm=state:helm kiln=state-1:kiln]
-      [%15 drum=state-3:drum helm=state:helm kiln=state-2:kiln]
+      [%14 drum=state-2:drum helm=state:helm kiln=state-1:kiln]
+      [%15 drum=state-2:drum helm=state:helm kiln=state-2:kiln]
       [%16 drum=state-4:drum helm=state:helm kiln=state-3:kiln]
       [%17 drum=state-4:drum helm=state:helm kiln=state-4:kiln]
   ==

--- a/pkg/grid/.eslintrc.js
+++ b/pkg/grid/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     'no-undef': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error'],
+    'no-unused-expressions': ['error', { allowShortCircuit: true }],
     'no-use-before-define': 'off',
     'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['draft'] }],
     '@typescript-eslint/no-use-before-define': 'off',

--- a/pkg/grid/src/components/AppLink.tsx
+++ b/pkg/grid/src/components/AppLink.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { Docket } from '../state/docket-types';
+
+export type AppLinkProps = Omit<LinkProps, 'to'> & {
+  app: Docket;
+  small?: boolean;
+  selected?: boolean;
+  to?: (app: Docket) => LinkProps['to'];
+};
+
+export const AppLink = ({
+  app,
+  to,
+  small = false,
+  selected = false,
+  className,
+  ...props
+}: AppLinkProps) => {
+  return (
+    <Link
+      to={(to && to(app)) || `/apps/${app.base}`}
+      className={classNames(
+        'flex items-center space-x-3 default-ring ring-offset-2 rounded-lg',
+        selected && 'ring-4',
+        className
+      )}
+      {...props}
+    >
+      <div
+        className={classNames(
+          'flex-none relative bg-gray-200 rounded-lg',
+          small ? 'w-8 h-8' : 'w-12 h-12'
+        )}
+        style={{ backgroundColor: app.color }}
+      >
+        {app.img && (
+          <img
+            className="absolute top-1/2 left-1/2 h-[40%] w-[40%] object-contain transform -translate-x-1/2 -translate-y-1/2"
+            src={app.img}
+            alt=""
+          />
+        )}
+      </div>
+      <div className="flex-1 text-black">
+        <p>{app.title}</p>
+        {app.info && !small && <p className="font-normal">{app.info}</p>}
+      </div>
+    </Link>
+  );
+};

--- a/pkg/grid/src/components/AppList.tsx
+++ b/pkg/grid/src/components/AppList.tsx
@@ -1,0 +1,44 @@
+import React, { MouseEvent, useCallback } from 'react';
+import { MatchItem } from '../nav/Nav';
+import { useRecentsStore } from '../nav/search/Home';
+import { Docket } from '../state/docket-types';
+import { AppLink, AppLinkProps } from './AppLink';
+
+type AppListProps = {
+  apps: Docket[];
+  labelledBy: string;
+  matchAgainst?: MatchItem;
+  onClick?: (e: MouseEvent<HTMLAnchorElement>, app: Docket) => void;
+} & Omit<AppLinkProps, 'app' | 'onClick'>;
+
+export function appMatches(target: Docket, match?: MatchItem): boolean {
+  if (!match) {
+    return false;
+  }
+
+  const matchValue = match.display || match.value;
+  return target.title === matchValue || target.base === matchValue;
+}
+
+export const AppList = ({ apps, labelledBy, matchAgainst, onClick, ...props }: AppListProps) => {
+  const addRecentApp = useRecentsStore((state) => state.addRecentApp);
+  const selected = useCallback((app: Docket) => appMatches(app, matchAgainst), [matchAgainst]);
+
+  return (
+    <ul className="space-y-8" aria-labelledby={labelledBy}>
+      {apps.map((app) => (
+        <li key={app.base} id={app.base} role="option" aria-selected={selected(app)}>
+          <AppLink
+            {...props}
+            app={app}
+            selected={selected(app)}
+            onClick={(e) => {
+              addRecentApp(app);
+              onClick && onClick(e, app);
+            }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/pkg/grid/src/components/DocketHeader.tsx
+++ b/pkg/grid/src/components/DocketHeader.tsx
@@ -8,8 +8,7 @@ interface DocketHeaderProps {
 
 export function DocketHeader(props: DocketHeaderProps) {
   const { docket, children } = props;
-  const color = `#${docket.color.slice(2).replace('.', '')}`.toUpperCase();
-  const { info, title, img } = docket;
+  const { info, title, img, color } = docket;
 
   return (
     <header className="grid grid-cols-[5rem,1fr] md:grid-cols-[8rem,1fr] auto-rows-min grid-flow-row-dense mb-5 sm:mb-8 gap-x-6 gap-y-4">

--- a/pkg/grid/src/components/ProviderLink.tsx
+++ b/pkg/grid/src/components/ProviderLink.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames';
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { Provider } from '../state/docket-types';
+import { ShipName } from './ShipName';
+
+export type ProviderLinkProps = Omit<LinkProps, 'to'> & {
+  provider: Provider;
+  small?: boolean;
+  selected?: boolean;
+  to?: (p: Provider) => LinkProps['to'];
+};
+
+export const ProviderLink = ({
+  provider,
+  to,
+  selected = false,
+  small = false,
+  className,
+  ...props
+}: ProviderLinkProps) => {
+  return (
+    <Link
+      to={(to && to(provider)) || `/leap/search/${provider.shipName}/apps`}
+      className={classNames(
+        'flex items-center space-x-3 default-ring ring-offset-2 rounded-lg',
+        selected && 'ring-4',
+        className
+      )}
+      {...props}
+    >
+      <div
+        className={classNames(
+          'flex-none relative bg-black rounded-lg',
+          small ? 'w-8 h-8' : 'w-12 h-12'
+        )}
+      >
+        {/* TODO: Handle sigils */}
+      </div>
+      <div className="flex-1 text-black">
+        <p className="font-mono">{provider.nickname || <ShipName name={provider.shipName} />}</p>
+        {provider.status && !small && <p className="font-normal">{provider.status}</p>}
+      </div>
+    </Link>
+  );
+};

--- a/pkg/grid/src/components/ProviderList.tsx
+++ b/pkg/grid/src/components/ProviderList.tsx
@@ -1,0 +1,55 @@
+import React, { MouseEvent, useCallback } from 'react';
+import { MatchItem } from '../nav/Nav';
+import { useRecentsStore } from '../nav/search/Home';
+import { Provider } from '../state/docket-types';
+import { ProviderLink, ProviderLinkProps } from './ProviderLink';
+
+export type ProviderListProps = {
+  providers: Provider[];
+  labelledBy: string;
+  matchAgainst?: MatchItem;
+  onClick?: (e: MouseEvent<HTMLAnchorElement>, p: Provider) => void;
+} & Omit<ProviderLinkProps, 'provider' | 'onClick'>;
+
+export function providerMatches(target: Provider, match?: MatchItem): boolean {
+  if (!match) {
+    return false;
+  }
+
+  const matchValue = match.display || match.value;
+  return target.nickname === matchValue || target.shipName === matchValue;
+}
+
+export const ProviderList = ({
+  providers,
+  labelledBy,
+  matchAgainst,
+  onClick,
+  ...props
+}: ProviderListProps) => {
+  const addRecentDev = useRecentsStore((state) => state.addRecentDev);
+  const selected = useCallback(
+    (provider: Provider) => providerMatches(provider, matchAgainst),
+    [matchAgainst]
+  );
+
+  return (
+    <ul className="space-y-8" aria-labelledby={labelledBy}>
+      {providers.map((p) => (
+        <li key={p.shipName} id={p.shipName} role="option" aria-selected={selected(p)}>
+          <ProviderLink
+            {...props}
+            provider={p}
+            selected={selected(p)}
+            onClick={(e) => {
+              addRecentDev(p);
+              if (onClick) {
+                onClick(e, p);
+              }
+            }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/pkg/grid/src/components/ShipName.tsx
+++ b/pkg/grid/src/components/ShipName.tsx
@@ -5,16 +5,20 @@ type ShipNameProps = {
 } & HTMLAttributes<HTMLSpanElement>;
 
 export const ShipName = ({ name, ...props }: ShipNameProps) => {
-  const parts = name.replace('~', '').split(/[_^-]/);
+  const parts = name.replace('~', '').split(/([_^-])/);
 
   return (
     <span {...props}>
       <span aria-hidden>~</span>
       {/* <span className="sr-only">sig</span> */}
       <span>{parts[0]}</span>
-      <span aria-hidden>-</span>
-      {/* <span className="sr-only">hep</span> */}
-      <span>{parts[1]}</span>
+      {parts.length > 1 && (
+        <>
+          <span aria-hidden>{parts[1]}</span>
+          {/* <span className="sr-only">hep</span> */}
+          <span>{parts[2]}</span>
+        </>
+      )}
     </span>
   );
 };

--- a/pkg/grid/src/nav/Leap.tsx
+++ b/pkg/grid/src/nav/Leap.tsx
@@ -136,7 +136,7 @@ export const Leap = React.forwardRef(({ menu, dropdown, showClose, className }: 
         return;
       }
 
-      const input = [slugify(getMatch(value)?.value || value)];
+      const input = [getMatch(value)?.value || slugify(value)];
       if (appsMatch) {
         input.unshift(match?.params.query || '');
       } else {

--- a/pkg/grid/src/nav/search/AppInfo.tsx
+++ b/pkg/grid/src/nav/search/AppInfo.tsx
@@ -6,9 +6,11 @@ import { Spinner } from '../../components/Spinner';
 import { TreatyMeta } from '../../components/TreatyMeta';
 import { useTreaty } from '../../logic/useTreaty';
 import { useLeapStore } from '../Nav';
+import { useRecentsStore } from './Home';
 import { useCharges } from '../../state/docket';
 
 export const AppInfo = () => {
+  const addRecentApp = useRecentsStore((state) => state.addRecentApp);
   const select = useLeapStore((state) => state.select);
   const { ship, desk, treaty, installStatus, copyApp, installApp } = useTreaty();
   const charges = useCharges();
@@ -36,7 +38,12 @@ export const AppInfo = () => {
       <DocketHeader docket={treaty}>
         <div className="col-span-2 md:col-span-1 flex items-center space-x-4">
           {installed && (
-            <PillButton as="a" href={`/apps/${treaty.base}`} target={treaty.title || '_blank'}>
+            <PillButton
+              as="a"
+              href={`/apps/${treaty.base}`}
+              target={treaty.title || '_blank'}
+              onClick={() => addRecentApp(treaty)}
+            >
               Open App
             </PillButton>
           )}

--- a/pkg/grid/src/nav/search/Apps.tsx
+++ b/pkg/grid/src/nav/search/Apps.tsx
@@ -1,14 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import fuzzy from 'fuzzy';
 import slugify from 'slugify';
-import classNames from 'classnames';
 import { ShipName } from '../../components/ShipName';
+import { Docket, Treaty } from '../../state/docket-types';
+import { MatchItem, useLeapStore } from '../Nav';
+import { AppList } from '../../components/AppList';
 import useDocketState from '../../state/docket';
-import { Treaty } from '../../state/docket-types';
-import { useLeapStore } from '../Nav';
 
 type AppsProps = RouteComponentProps<{ ship: string }>;
+
+export function appMatch(app: Docket): MatchItem {
+  return { value: app.base, display: app.title };
+}
 
 export const Apps = ({ match }: AppsProps) => {
   const { searchInput, selectedMatch, select } = useLeapStore((state) => ({
@@ -50,7 +54,7 @@ export const Apps = ({ match }: AppsProps) => {
   useEffect(() => {
     if (results) {
       useLeapStore.setState({
-        matches: results.map((treaty) => ({ value: treaty.desk, display: treaty.title }))
+        matches: results.map(appMatch)
       });
     }
   }, [results]);
@@ -65,18 +69,6 @@ export const Apps = ({ match }: AppsProps) => {
     }
   }, [provider]);
 
-  const isSelected = useCallback(
-    (target: Treaty) => {
-      if (!selectedMatch) {
-        return false;
-      }
-
-      const matchValue = selectedMatch.display || selectedMatch.value;
-      return target.title === matchValue || target.desk === matchValue;
-    },
-    [selectedMatch]
-  );
-
   return (
     <div className="dialog-inner-container md:px-6 md:py-8 h4 text-gray-400">
       <div id="developed-by">
@@ -88,41 +80,12 @@ export const Apps = ({ match }: AppsProps) => {
         </p>
       </div>
       {results && (
-        <ul className="space-y-8" aria-labelledby="developed-by">
-          {results.map((app) => (
-            <li
-              key={app.desk}
-              id={app.title || app.desk}
-              role="option"
-              aria-selected={isSelected(app)}
-            >
-              <Link
-                to={`${match?.path.replace(':ship', provider)}/${slugify(app.desk)}`}
-                className={classNames(
-                  'flex items-center space-x-3 default-ring ring-offset-2 rounded-lg',
-                  isSelected(app) && 'ring-4'
-                )}
-              >
-                <div
-                  className="flex-none relative w-12 h-12 bg-gray-200 rounded-lg"
-                  style={{ backgroundColor: app.color }}
-                >
-                  {app.img && (
-                    <img
-                      className="absolute top-1/2 left-1/2 h-[40%] w-[40%] object-contain transform -translate-x-1/2 -translate-y-1/2"
-                      src={app.img}
-                      alt=""
-                    />
-                  )}
-                </div>
-                <div className="flex-1 text-black">
-                  <p>{app.title}</p>
-                  {app.info && <p className="font-normal">{app.info}</p>}
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <AppList
+          apps={results}
+          labelledBy="developed-by"
+          matchAgainst={selectedMatch}
+          to={(app) => `${match?.path.replace(':ship', provider)}/${slugify(app.base)}`}
+        />
       )}
       <p>That&apos;s it!</p>
     </div>

--- a/pkg/grid/src/nav/search/Home.tsx
+++ b/pkg/grid/src/nav/search/Home.tsx
@@ -1,13 +1,115 @@
-import React from 'react';
+import produce from 'immer';
+import create from 'zustand';
+import React, { useEffect } from 'react';
+import { persist } from 'zustand/middleware';
+import { take } from 'lodash-es';
+import { Docket, Provider } from '../../state/docket-types';
+import { MatchItem, useLeapStore } from '../Nav';
+import { appMatch } from './Apps';
+import { providerMatch } from './Providers';
+import { AppList } from '../../components/AppList';
+import { ProviderList } from '../../components/ProviderList';
+import { AppLink } from '../../components/AppLink';
+import { ShipName } from '../../components/ShipName';
+import { ProviderLink } from '../../components/ProviderLink';
+import { useCharges } from '../../state/docket';
+
+interface RecentsStore {
+  recentApps: Docket[];
+  recentDevs: Provider[];
+  addRecentApp: (docket: Docket) => void;
+  addRecentDev: (dev: Provider) => void;
+}
+
+export const useRecentsStore = create<RecentsStore>(
+  persist(
+    (set) => ({
+      recentApps: [],
+      recentDevs: [],
+      addRecentApp: (docket) => {
+        set(
+          produce((draft: RecentsStore) => {
+            const hasApp = draft.recentApps.find((app) => app.base === docket.base);
+            if (!hasApp) {
+              draft.recentApps.unshift(docket);
+            }
+
+            draft.recentApps = take(draft.recentApps, 3);
+          })
+        );
+      },
+      addRecentDev: (dev) => {
+        set(
+          produce((draft: RecentsStore) => {
+            const hasDev = draft.recentDevs.find((p) => p.shipName === dev.shipName);
+            if (!hasDev) {
+              draft.recentDevs.unshift(dev);
+            }
+
+            draft.recentDevs = take(draft.recentDevs, 3);
+          })
+        );
+      }
+    }),
+    {
+      whitelist: ['recentApps', 'recentDevs'],
+      name: 'recents-store'
+    }
+  )
+);
 
 export const Home = () => {
+  const selectedMatch = useLeapStore((state) => state.selectedMatch);
+  const { recentApps, recentDevs, addRecentApp, addRecentDev } = useRecentsStore();
+  const charges = useCharges();
+  const groups = charges?.groups;
+  const zod = { shipName: '~zod' };
+
+  useEffect(() => {
+    const apps = recentApps.map(appMatch);
+    const devs = recentDevs.map(providerMatch);
+
+    useLeapStore.setState({
+      matches: ([] as MatchItem[]).concat(apps, devs)
+    });
+  }, [recentApps, recentDevs]);
+
   return (
-    <div className="h-full p-4 md:p-8 space-y-8 overflow-y-auto">
-      <h2 className="h4 text-gray-500">Recent Apps</h2>
-      <div className="min-h-[150px] rounded-xl bg-gray-100" />
+    <div className="h-full p-4 md:p-8 space-y-8 font-semibold leading-tight text-black overflow-y-auto">
+      <h2 id="recent-apps" className="h4 text-gray-500">
+        Recent Apps
+      </h2>
+      {recentApps.length === 0 && (
+        <div className="min-h-[150px] p-6 rounded-xl bg-gray-100">
+          <p className="mb-4">Apps you use will be listed here, in the order you used them.</p>
+          <p className="mb-6">You can click/tap/keyboard on a listed app to open it.</p>
+          {groups && <AppLink app={groups} small onClick={() => addRecentApp(groups)} />}
+        </div>
+      )}
+      {recentApps.length > 0 && (
+        <AppList apps={recentApps} labelledBy="recent-apps" matchAgainst={selectedMatch} small />
+      )}
       <hr className="-mx-4 md:-mx-8" />
-      <h2 className="h4 text-gray-500">Recent Developers</h2>
-      <div className="min-h-[150px] rounded-xl bg-gray-100" />
+      <h2 id="recent-devs" className="h4 text-gray-500">
+        Recent Developers
+      </h2>
+      {recentDevs.length === 0 && (
+        <div className="min-h-[150px] p-6 rounded-xl bg-gray-100">
+          <p className="mb-4">Urbit app developers you search for will be listed here.</p>
+          <p className="mb-6">
+            Try out app discovery by visiting <ShipName name="~zod" /> below.
+          </p>
+          <ProviderLink provider={zod} small onClick={() => addRecentDev(zod)} />
+        </div>
+      )}
+      {recentDevs.length > 0 && (
+        <ProviderList
+          providers={recentDevs}
+          labelledBy="recent-devs"
+          matchAgainst={selectedMatch}
+          small
+        />
+      )}
     </div>
   );
 };

--- a/pkg/grid/src/nav/search/Providers.tsx
+++ b/pkg/grid/src/nav/search/Providers.tsx
@@ -1,13 +1,16 @@
 import fuzzy from 'fuzzy';
-import classNames from 'classnames';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import { ShipName } from '../../components/ShipName';
+import React, { useEffect, useMemo, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import { Provider } from '../../state/docket-types';
+import { MatchItem, useLeapStore } from '../Nav';
+import { ProviderList } from '../../components/ProviderList';
 import useDocketState from '../../state/docket';
-import { useLeapStore } from '../Nav';
 
 type ProvidersProps = RouteComponentProps<{ ship: string }>;
+
+export function providerMatch(provider: Provider): MatchItem {
+  return { value: provider.shipName, display: provider.nickname };
+}
 
 export const Providers = ({ match }: ProvidersProps) => {
   const { selectedMatch, select } = useLeapStore((state) => ({
@@ -50,22 +53,10 @@ export const Providers = ({ match }: ProvidersProps) => {
   useEffect(() => {
     if (results) {
       useLeapStore.setState({
-        matches: results.map((p) => ({ value: p.shipName, display: p.nickname }))
+        matches: results.map(providerMatch)
       });
     }
   }, [results]);
-
-  const isSelected = useCallback(
-    (target: Provider) => {
-      if (!selectedMatch) {
-        return false;
-      }
-
-      const matchValue = selectedMatch.display || selectedMatch.value;
-      return target.nickname === matchValue || target.shipName === matchValue;
-    },
-    [selectedMatch]
-  );
 
   return (
     <div className="dialog-inner-container md:px-6 md:py-8 h4 text-gray-400" aria-live="polite">
@@ -76,32 +67,7 @@ export const Providers = ({ match }: ProvidersProps) => {
         </p>
       </div>
       {results && (
-        <ul className="space-y-8" aria-labelledby="providers">
-          {results.map((p) => (
-            <li
-              key={p.shipName}
-              id={p.nickname || p.shipName}
-              role="option"
-              aria-selected={isSelected(p)}
-            >
-              <Link
-                to={`${match?.path.replace(':ship', p.shipName)}/apps`}
-                className={classNames(
-                  'flex items-center space-x-3 default-ring ring-offset-2 rounded-lg',
-                  isSelected(p) && 'ring-4'
-                )}
-              >
-                <div className="flex-none relative w-12 h-12 bg-black rounded-lg">
-                  {/* TODO: Handle sigils */}
-                </div>
-                <div className="flex-1 text-black">
-                  <p className="font-mono">{p.nickname || <ShipName name={p.shipName} />}</p>
-                  {p.status && <p className="font-normal">{p.status}</p>}
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <ProviderList providers={results} labelledBy="providers" matchAgainst={selectedMatch} />
       )}
       <p>That&apos;s it!</p>
     </div>

--- a/pkg/grid/src/tiles/Tile.tsx
+++ b/pkg/grid/src/tiles/Tile.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 import { darken, hsla, lighten, parseToHsla, readableColorIsBlack } from 'color2k';
 import { TileMenu } from './TileMenu';
 import { Docket } from '../state/docket-types';
+import { useRecentsStore } from '../nav/search/Home';
 
 type TileProps = {
   docket: Docket;
@@ -22,6 +23,7 @@ function getMenuColor(color: string, lightText: boolean, active: boolean): strin
 }
 
 export const Tile: FunctionComponent<TileProps> = ({ docket, desk }) => {
+  const addRecentApp = useRecentsStore((state) => state.addRecentApp);
   const { title, base, color, img, status } = docket;
   const active = status === 'active';
   const lightText = !readableColorIsBlack(color);
@@ -37,6 +39,8 @@ export const Tile: FunctionComponent<TileProps> = ({ docket, desk }) => {
         !active && 'cursor-default'
       )}
       style={{ backgroundColor: active ? color || 'purple' : suspendColor }}
+      onClick={() => addRecentApp(docket)}
+      onAuxClick={() => addRecentApp(docket)}
     >
       <div>
         <TileMenu


### PR DESCRIPTION
Working PR, for transparency and ease of review.  Not ready for primetime yet, but the latest solid pill boots.

Some notes:
- I switched solid pills to just use clay `page`s, without converting to mime
- ford should share caches across desks
- gall should send %warp's to clay instead of scrying agent builds; rebuilding agents is way too slow
- I went ahead and tried the dojo yolo mode for shadow marks (I wrote it; actually haven't tried it yet)
- clay should get (at least two) verbosity levels; it's really nice to see all the files get built in ford, but not under all circumstances
- I cleaned up hood a bit; now it strips the sub-app's name off of every incoming wire, not just some of them
- I removed :goad, since the %goad move isn't part of gall's interface anymore -- if we need a goad, it could be rebuilt by writing something that sets an agent to %idle and then %jolt's it again
- I need to rewrite the |fade generator to have it ask kiln to suspend the agent and store that state in its $rein
- other than boot and some generators, this code hasn't been tested; next step is to make a landscape desk and test installing that, then test messing with kelvin versions in various desks and make sure the system code does the right thing