### PR TITLE
vere: use realpath() of urbit-worker binary

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -660,8 +660,16 @@ main(c3_i   argc,
 
   //  Set `u3_Host.wrk_c` to the worker executable path.
   c3_i worker_exe_len = 1 + strlen(argv[0]) + strlen("-worker");
-  u3_Host.wrk_c = c3_malloc(worker_exe_len);
-  snprintf(u3_Host.wrk_c, worker_exe_len, "%s-worker", argv[0]);
+  c3_c* wrk_c = c3_malloc(worker_exe_len);
+  snprintf(wrk_c, worker_exe_len, "%s-worker", argv[0]);
+  u3_Host.wrk_c = realpath(wrk_c, NULL);
+  c3_free(wrk_c);
+
+  if ( NULL == u3_Host.wrk_c ) {
+    fprintf(stderr, "failed to resolve urbit-worker: realpath: %s\n",
+            uv_strerror(errno));
+    u3_king_bail();
+  }
 
   if ( c3y == u3_Host.ops_u.dem ) {
     _fork_into_background_process();


### PR DESCRIPTION
This resolves an issue introduced in #5107: when the path to the urbit
binary is relative, chdir() prevented vere from finding the urbit-worker
executable (which is supposed to be in the same directory as the urbit
binary.)