### PR TITLE
interface: form handling, optimism sweep

### DIFF
--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -241,11 +241,13 @@ export function uxToHex(ux: string) {
 
 export const hexToUx = (hex) => {
   const ux = f.flow(
+    f.reverse,
     f.chunk(4),
     // eslint-disable-next-line prefer-arrow-callback
     f.map(x => _.dropWhile(x, function(y: unknown) {
-      return y === 0;
-    }).join('')),
+      return y === '0';
+    }).reverse().join('')),
+    f.reverse,
     f.join('.')
   )(hex.split(''));
   return `0x${ux}`;

--- a/pkg/interface/src/logic/state/graph.ts
+++ b/pkg/interface/src/logic/state/graph.ts
@@ -2,9 +2,9 @@ import BigIntOrderedMap from '@urbit/api/lib/BigIntOrderedMap';
 import { patp2dec } from 'urbit-ob';
 import shallow from 'zustand/shallow';
 
-import { Association, deSig, GraphNode, Graphs, FlatGraphs, resourceFromPath, ThreadGraphs, getGraph, getShallowChildren } from '@urbit/api';
+import { Association, deSig, GraphNode, Graphs, FlatGraphs, resourceFromPath, ThreadGraphs, getGraph, getShallowChildren, setScreen } from '@urbit/api';
 import { useCallback } from 'react';
-import { createState, createSubscription, reduceStateN } from './base';
+import { createState, createSubscription, reduceStateN, pokeOptimisticallyN } from './base';
 import airlock from '~/logic/api';
 import { addDmMessage, addPost, Content, getDeepOlderThan, getFirstborn, getNewest, getNode, getOlderSiblings, getYoungerSiblings, markPending, Post, addNode, GraphNodePoke } from '@urbit/api/graph';
 import { GraphReducer, reduceDm } from '../reducers/graph-update';
@@ -34,8 +34,8 @@ export interface GraphState {
   getGraph: (ship: string, name: string) => Promise<void>;
   addDmMessage: (ship: string, contents: Content[]) => Promise<void>;
   addPost: (ship: string, name: string, post: Post) => Promise<void>;
-
   addNode: (ship: string, name: string, post: GraphNodePoke) => Promise<void>;
+  setScreen: (screen: boolean) => void;
 }
 // @ts-ignore investigate zustand types
 const useGraphState = createState<GraphState>('Graph', (set, get) => ({
@@ -144,6 +144,10 @@ const useGraphState = createState<GraphState>('Graph', (set, get) => ({
     const data = await airlock.scry(getShallowChildren(ship, name, index));
     data['graph-update'].fetch = true;
     GraphReducer(data);
+  },
+  setScreen: (screen: boolean) => {
+    const poke = setScreen(screen);
+    pokeOptimisticallyN(useGraphState, poke, reduceDm);
   }
   // getKeys: async () => {
   //   const api = useApi();

--- a/pkg/interface/src/logic/state/hark.ts
+++ b/pkg/interface/src/logic/state/hark.ts
@@ -5,7 +5,14 @@ import {
   NotifIndex,
   readNote,
   Timebox,
-  Unreads
+  Unreads,
+  setMentions,
+  listenGroup,
+  ignoreGroup,
+  listenGraph,
+  ignoreGraph,
+  setWatchOnSelf,
+  setDoNotDisturb
 } from '@urbit/api';
 import { patp2dec } from 'urbit-ob';
 import _ from 'lodash';
@@ -34,6 +41,13 @@ export interface HarkState {
   archive: (index: NotifIndex, time?: BigInteger) => Promise<void>;
   readNote: (index: NotifIndex) => Promise<void>;
   readCount: (resource: string, index?: string) => Promise<void>;
+  setMentions: (mentions: boolean) => Promise<void>;
+  listenGraph: (graph: string, index: string) => Promise<void>;
+  ignoreGraph: (graph: string, index: string) => Promise<void>;
+  listenGroup: (group: string) => Promise<void>;
+  ignoreGroup: (group: string) => Promise<void>;
+  watchOnSelf: (watch: boolean) => Promise<void>;
+  setDoNotDisturb: (dnd: boolean) => Promise<void>;
 }
 
 const useHarkState = createState<HarkState>(
@@ -68,7 +82,34 @@ const useHarkState = createState<HarkState>(
       });
       reduceState(useHarkState, harkUpdate, [reduce]);
     },
-
+    setMentions: async (mentions) => {
+      const poke = setMentions(mentions);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    listenGroup: async (group) => {
+      const poke = listenGroup(group);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    ignoreGroup: async (group) => {
+      const poke = ignoreGroup(group);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    listenGraph: async (graph, index) => {
+      const poke = listenGraph(graph, index);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    ignoreGraph: async (graph, index) => {
+      const poke = ignoreGraph(graph, index);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    watchOnSelf: async (watch) => {
+      const poke = setWatchOnSelf(watch);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    setDoNotDisturb: async (dnd) => {
+      const poke = setDoNotDisturb(dnd);
+      pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
     notifications: new BigIntOrderedMap<Timebox>(),
     notificationsCount: 0,
     notificationsGraphConfig: {

--- a/pkg/interface/src/logic/state/settings.ts
+++ b/pkg/interface/src/logic/state/settings.ts
@@ -10,12 +10,14 @@ import {
   BaseState,
   createState,
   createSubscription,
-  reduceStateN
+  reduceStateN,
+  pokeOptimisticallyN
 } from '~/logic/state/base';
 import { useCallback } from 'react';
 import { reduceUpdate } from '../reducers/settings-update';
 import airlock from '~/logic/api';
-import { getAll } from '@urbit/api';
+import { getAll, Value } from '@urbit/api';
+import { putEntry } from '@urbit/api/settings';
 
 export interface ShortcutMapping {
   cycleForward: string;
@@ -43,6 +45,7 @@ export interface SettingsState {
   keyboard: ShortcutMapping;
   remoteContentPolicy: RemoteContentPolicy;
   getAll: () => Promise<void>;
+  putEntry: (bucket: string, key: string, value: Value) => void;
   leap: {
     categories: LeapCategories[];
   };
@@ -102,6 +105,10 @@ const useSettingsState = createState<SettingsState>(
       get().set((s) => {
         Object.assign(s, all);
       });
+    },
+    putEntry: (bucket: string, entry: string, value: Value) => {
+      const poke = putEntry(bucket, entry, value);
+      pokeOptimisticallyN(useSettingsState, poke, reduceUpdate);
     }
   }),
   [],

--- a/pkg/interface/src/stories/ColorInput.stories.tsx
+++ b/pkg/interface/src/stories/ColorInput.stories.tsx
@@ -6,7 +6,7 @@ import { Formik } from 'formik';
 import { ColorInput, ColorInputProps } from '~/views/components/ColorInput';
 
 const initialValues = {
-  color: '#33FF22'
+  color: '33FF22'
 };
 
 export default {

--- a/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/CalmPref.tsx
@@ -3,14 +3,12 @@ import {
 
     Text
 } from '@tlon/indigo-react';
-import { putEntry } from '@urbit/api/settings';
 import React, { useCallback } from 'react';
 import { Form } from 'formik';
 import useSettingsState, { SettingsState } from '~/logic/state/settings';
 import { BackButton } from './BackButton';
 import _ from 'lodash';
 import { FormikOnBlur } from '~/views/components/FormikOnBlur';
-import airlock from '~/logic/api';
 
 interface FormSchema {
   hideAvatars: boolean;
@@ -26,7 +24,7 @@ interface FormSchema {
 
 const settingsSel = (s: SettingsState): FormSchema => ({
     hideAvatars: s.calm.hideAvatars,
-    hideNicknames: s.calm.hideAvatars,
+    hideNicknames: s.calm.hideNicknames,
     hideUnreads: s.calm.hideUnreads,
     hideGroups: s.calm.hideGroups,
     hideUtilities: s.calm.hideUtilities,
@@ -40,10 +38,11 @@ export function CalmPrefs() {
   const initialValues = useSettingsState(settingsSel);
 
   const onSubmit = useCallback(async (v: FormSchema) => {
+    const { putEntry } = useSettingsState.getState();
     _.forEach(v, (bool, key) => {
       const bucket = ['imageShown', 'videoShown', 'audioShown', 'oembedShown'].includes(key) ? 'remoteContentPolicy' : 'calm';
       if(initialValues[key] !== bool) {
-        airlock.poke(putEntry(bucket, key, bool));
+        putEntry(bucket, key, bool);
       }
     });
   }, [initialValues]);

--- a/pkg/interface/src/views/apps/settings/components/lib/DmSettings.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/DmSettings.tsx
@@ -4,22 +4,25 @@ import {
   Box,
   ManagedToggleSwitchField
 } from '@tlon/indigo-react';
-import { Form, Formik } from 'formik';
+import { Form } from 'formik';
 import React, { useCallback } from 'react';
-import useGraphState from '~/logic/state/graph';
-import { AsyncButton } from '~/views/components/AsyncButton';
-import airlock from '~/logic/api';
-import { setScreen } from '@urbit/api/graph';
+import useGraphState, { GraphState } from '~/logic/state/graph';
+import { FormikOnBlur } from '~/views/components/FormikOnBlur';
+import shallow from 'zustand/shallow';
+
+const selInit = (s: GraphState) => ({
+  accept: !s.screening
+});
 
 export function DmSettings() {
-  const screening = useGraphState(s => s.screening);
-  const initialValues = { accept: !screening };
+  const initialValues = useGraphState(selInit, shallow);
   const onSubmit = useCallback(
     async (values, actions) => {
-      await airlock.poke(setScreen(!values.accept));
+      const { setScreen } = useGraphState.getState();
+      setScreen(!values.accept);
       actions.setStatus({ success: null });
     },
-    [screening]
+    []
   );
 
   return (
@@ -38,7 +41,7 @@ export function DmSettings() {
         <Box mb="4" fontWeight="medium" fontSize="1" color="gray">
           Direct Messages
         </Box>
-        <Formik initialValues={initialValues} onSubmit={onSubmit}>
+        <FormikOnBlur initialValues={initialValues} onSubmit={onSubmit}>
           <Form>
             <Col gapY="4">
               <ManagedToggleSwitchField
@@ -46,12 +49,9 @@ export function DmSettings() {
                 label="Auto-accept DM invites"
                 caption="Direct messages will be automatically joined, and you wil see any messages sent in notifications"
               />
-              <AsyncButton width="fit-content" primary>
-                Save Changes
-              </AsyncButton>
             </Col>
           </Form>
-        </Formik>
+        </FormikOnBlur>
       </Col>
     </Col>
   );

--- a/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
@@ -101,19 +101,18 @@ function Channel(props: { association: Association }) {
     return isWatching(config, association.resource);
   });
 
-  const [, , { setValue, setTouched }] = useField(
+  const [{ value }, , { setValue, setTouched }] = useField(
     `graph["${association.resource}"]`
   );
-  const [optValue, setOptValue] = useState(watching);
-
-  useEffect(() => {
-    setValue(optValue);
-    setTouched(true);
-  }, [watching]);
 
   const onClick = () => {
-    setOptValue(v => !v);
+    setValue(!value);
+    setTouched(true);
   };
+
+  useEffect(() => {
+    setValue(watching);
+  }, [watching]);
 
   const icon = getModuleIcon((metadata.config as GraphConfig)?.graph as GraphModule);
 
@@ -126,7 +125,7 @@ function Channel(props: { association: Association }) {
         <Text> {metadata.title}</Text>
       </Box>
       <Box gridColumn={4}>
-        <StatelessToggleSwitchField selected={optValue} onClick={onClick} />
+        <StatelessToggleSwitchField selected={value} onClick={onClick} />
       </Box>
     </>
   );

--- a/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
@@ -43,13 +43,13 @@ export function NotificationPreferences() {
         ignoreGraph,
         ignoreGroup,
         setDoNotDisturb,
-        setWatchOnSelf
+        watchOnSelf
       } = useHarkState.getState();
       if (values.mentions !== graphConfig.mentions) {
         setMentions(values.mentions);
       }
       if (values.watchOnSelf !== graphConfig.watchOnSelf) {
-        setWatchOnSelf(values.watchOnSelf);
+        watchOnSelf(values.watchOnSelf);
       }
       if (values.dnd !== dnd && !_.isUndefined(values.dnd)) {
         setDoNotDisturb(values.dnd);

--- a/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
@@ -11,6 +11,15 @@ import useHarkState from '~/logic/state/hark';
 import { FormikOnBlur } from '~/views/components/FormikOnBlur';
 import { BackButton } from './BackButton';
 import { GroupChannelPicker } from './GroupChannelPicker';
+import {
+  setMentions,
+  setWatchOnSelf,
+  setDoNotDisturb,
+  listenGraph,
+  listenGroup,
+  ignoreGraph,
+  ignoreGroup
+} from '@urbit/api';
 
 interface FormSchema {
   mentions: boolean;
@@ -36,32 +45,24 @@ export function NotificationPreferences() {
 
   const onSubmit = useCallback(async (values: FormSchema, actions: FormikHelpers<FormSchema>) => {
     try {
-      const {
-        setMentions,
-        listenGraph,
-        listenGroup,
-        ignoreGraph,
-        ignoreGroup,
-        setDoNotDisturb,
-        watchOnSelf
-      } = useHarkState.getState();
+      const { poke } = useHarkState.getState();
       if (values.mentions !== graphConfig.mentions) {
-        setMentions(values.mentions);
+        poke(setMentions(values.mentions));
       }
       if (values.watchOnSelf !== graphConfig.watchOnSelf) {
-        watchOnSelf(values.watchOnSelf);
+        poke(setWatchOnSelf(values.watchOnSelf));
       }
       if (values.dnd !== dnd && !_.isUndefined(values.dnd)) {
-        setDoNotDisturb(values.dnd);
+        poke(setDoNotDisturb(values.dnd));
       }
       _.forEach(values.graph, (listen: boolean, graph: string) => {
         if(listen !== isWatching(graphConfig, graph)) {
-          (listen ? listenGraph : ignoreGraph)(graph, '/');
+          poke((listen ? listenGraph : ignoreGraph)(graph, '/'));
         }
       });
       _.forEach(values.groups, (listen: boolean, group: string) => {
         if(listen !== groupConfig.includes(group)) {
-          (listen ? listenGroup : ignoreGroup)(group);
+          poke((listen ? listenGroup : ignoreGroup)(group));
         }
       });
       actions.setStatus({ success: null });

--- a/pkg/interface/src/views/components/ColorInput.tsx
+++ b/pkg/interface/src/views/components/ColorInput.tsx
@@ -7,8 +7,9 @@ import {
     StatelessTextInput as Input
 } from '@tlon/indigo-react';
 import { useField } from 'formik';
-import React, { FormEvent } from 'react';
+import React, { FormEvent, useState, useEffect } from 'react';
 import { hexToUx } from '~/logic/lib/util';
+import { uxToHex } from '@urbit/api/dist';
 
 export type ColorInputProps = Parameters<typeof Col>[0] & {
   id: string;
@@ -17,24 +18,40 @@ export type ColorInputProps = Parameters<typeof Col>[0] & {
   disabled?: boolean;
 };
 
+const COLOR_REGEX = /^(\d|[a-f]|[A-F]){6}$/;
+
+function padHex(hex: string) {
+  if(hex.length === 0) {
+    return '000000';
+  }
+  const repeat = 6 / hex.length;
+  if(Math.floor(repeat) === repeat) {
+    return hex.repeat(repeat);
+  }
+  if(hex.length < 6) {
+    return hex.slice(0,3).repeat(2);
+  }
+  return hex.slice(0,6);
+}
+
 export function ColorInput(props: ColorInputProps) {
   const { id, placeholder, label, caption, disabled, ...rest } = props;
-  const [{ value, onBlur }, meta, { setValue }] = useField(id);
+  const [{ value, onBlur }, meta, { setValue, setTouched }] = useField(id);
+  const [field, setField] = useState('');
+ // const [error, setError] = useState<string | undefined>();
 
-  const hex = value.replace('#', '').replace('0x', '').replace('.', '');
-  const padded = hex.padStart(6, '0');
+  useEffect(() => {
+    const newValue = hexToUx(padHex(field));
+    setValue(newValue);
+    setTouched(true);
+  }, [field]);
 
   const onChange = (e: FormEvent<HTMLInputElement>) => {
-    let { value: newValue } = e.target as HTMLInputElement;
-    newValue = newValue.replace('#', '');
-    const valid = newValue.match(/^(\d|[a-f]|[A-F]){0,6}$/);
-
-    if (!valid) {
-      return;
-    }
-    const result = hexToUx(newValue);
-    setValue(result);
+    const { value: newValue } = e.target as HTMLInputElement;
+    setField(newValue);
   };
+  const isValid = value.match(COLOR_REGEX);
+  const hex = uxToHex(value);
 
   return (
     <Box display='flex' flexDirection='column' {...rest}>
@@ -51,7 +68,7 @@ export function ColorInput(props: ColorInputProps) {
           borderBottomRightRadius={0}
           onBlur={onBlur}
           onChange={onChange}
-          value={hex}
+          value={field}
           disabled={disabled || false}
           borderRight={0}
           placeholder={placeholder}
@@ -64,14 +81,12 @@ export function ColorInput(props: ColorInputProps) {
           borderColor='lightGray'
           width='32px'
           alignSelf='stretch'
-          bg={`#${padded}`}
+          bg={isValid ? `#${hex}` : 'transparent'}
         >
           <Input
             width='100%'
             height='100%'
             alignSelf='stretch'
-            onChange={onChange}
-            value={padded}
             disabled={disabled || false}
             type='color'
             opacity={0}

--- a/pkg/interface/src/views/components/ColorInput.tsx
+++ b/pkg/interface/src/views/components/ColorInput.tsx
@@ -37,8 +37,7 @@ function padHex(hex: string) {
 export function ColorInput(props: ColorInputProps) {
   const { id, placeholder, label, caption, disabled, ...rest } = props;
   const [{ value, onBlur }, meta, { setValue, setTouched }] = useField(id);
-  const [field, setField] = useState('');
- // const [error, setError] = useState<string | undefined>();
+  const [field, setField] = useState(uxToHex(value));
 
   useEffect(() => {
     const newValue = hexToUx(padHex(field));

--- a/pkg/interface/src/views/components/ColorInput.tsx
+++ b/pkg/interface/src/views/components/ColorInput.tsx
@@ -47,10 +47,10 @@ export function ColorInput(props: ColorInputProps) {
 
   const onChange = (e: FormEvent<HTMLInputElement>) => {
     const { value: newValue } = e.target as HTMLInputElement;
-    setField(newValue);
+    setField(newValue.slice(1));
   };
-  const isValid = value.match(COLOR_REGEX);
   const hex = uxToHex(value);
+  const isValid = COLOR_REGEX.test(hex);
 
   return (
     <Box display='flex' flexDirection='column' {...rest}>
@@ -90,6 +90,7 @@ export function ColorInput(props: ColorInputProps) {
             type='color'
             opacity={0}
             overflow='hidden'
+            onChange={onChange}
           />
         </Box>
       </Row>

--- a/pkg/interface/src/views/components/FormikOnBlur.tsx
+++ b/pkg/interface/src/views/components/FormikOnBlur.tsx
@@ -1,35 +1,27 @@
 import { FormikConfig, FormikProvider, FormikValues, useFormik } from 'formik';
-import React, { useEffect, useImperativeHandle, useState } from 'react';
+import React, { useEffect, useImperativeHandle, useCallback } from 'react';
 
 export function FormikOnBlur<
   Values extends FormikValues = FormikValues,
   ExtraProps = {}
 >(props: FormikConfig<Values> & ExtraProps) {
   const formikBag = useFormik<Values>({ ...props, validateOnBlur: true });
-  const [submitting, setSubmitting] = useState(false);
 
-  useEffect(() => {
+  const trySubmit = useCallback(_.debounce((formikBag) => {
     if (
       Object.keys(formikBag.errors || {}).length === 0 &&
       formikBag.dirty &&
-      !formikBag.isSubmitting &&
-      !submitting
+      !formikBag.isSubmitting
     ) {
-      setSubmitting(true);
-      const { values } = formikBag;
-      formikBag.validateForm(values)
-        .then(valid => valid ?
-          formikBag.submitForm().then(() => {
-            formikBag.resetForm({ values });
-            setSubmitting(false);
-          }) : null
-        );
+      formikBag.submitForm();
     }
+  }, 100), []);
+
+  useEffect(() => {
+    trySubmit(formikBag);
   }, [
-    formikBag.errors,
-    formikBag.dirty,
-    submitting,
-    formikBag.isSubmitting
+    formikBag.values,
+    formikBag.errors
   ]);
 
   useEffect(() => {

--- a/pkg/interface/src/views/components/FormikOnBlur.tsx
+++ b/pkg/interface/src/views/components/FormikOnBlur.tsx
@@ -1,5 +1,6 @@
 import { FormikConfig, FormikProvider, FormikValues, useFormik } from 'formik';
 import React, { useEffect, useImperativeHandle, useCallback } from 'react';
+import _ from 'lodash';
 
 export function FormikOnBlur<
   Values extends FormikValues = FormikValues,

--- a/pkg/interface/src/views/components/ImageInput.tsx
+++ b/pkg/interface/src/views/components/ImageInput.tsx
@@ -1,8 +1,13 @@
 import {
-  BaseInput, Box,
+  BaseInput,
+  Box,
   Button,
-  Icon, Label, Row, StatelessTextInput as Input,
-  Text
+  Icon,
+  Label,
+  Row,
+  StatelessTextInput as Input,
+  Text,
+  ErrorLabel
 } from '@tlon/indigo-react';
 import { useField } from 'formik';
 import React, { ReactElement, useCallback, useRef, useState } from 'react';
@@ -20,23 +25,19 @@ const prompt = (
   uploading,
   meta,
   clickUploadButton,
-  canUpload
+  canUpload,
+  error
 ) => {
-  if (
-    !focus &&
-    !field.value &&
-    !uploading &&
-    meta.error === undefined
-  ) {
+  if (!focus && !field.value && !uploading && error === undefined) {
     return (
       <Text
-        color='black'
-        fontWeight='500'
-        position='absolute'
+        color="black"
+        fontWeight="500"
+        position="absolute"
         left={2}
-        display='flex'
-        height='100%'
-        alignItems='center'
+        display="flex"
+        height="100%"
+        alignItems="center"
         lineHeight={1}
         style={{ pointerEvents: 'none' }}
         onSelect={e => e.preventDefault}
@@ -50,7 +51,7 @@ const prompt = (
               cursor="pointer"
               color="blue"
               style={{ pointerEvents: 'all' }}
-              mx='0.5ch'
+              mx="0.5ch"
               onClick={clickUploadButton}
             >
               upload
@@ -70,9 +71,9 @@ const uploadingStatus = (uploading, meta) => {
       <Text
         position="absolute"
         left={2}
-        display='flex'
-        height='100%'
-        alignItems='center'
+        display="flex"
+        height="100%"
+        alignItems="center"
         lineHeight={1}
         gray
         onSelect={e => e.preventDefault}
@@ -84,27 +85,27 @@ const uploadingStatus = (uploading, meta) => {
   return null;
 };
 
-const errorRetry = (meta, focus, uploading, clickUploadButton) => {
-  if (!focus && meta.error !== undefined) {
+const errorRetry = (meta, error, focus, uploading, clickUploadButton) => {
+  if (!focus && error !== undefined && meta.touched) {
     return (
       <Text
         position="absolute"
         left={2}
-        display='flex'
-        height='100%'
-        alignItems='center'
+        display="flex"
+        height="100%"
+        alignItems="center"
         lineHeight={1}
-        color='red'
+        color="red"
         style={{ pointerEvents: 'none' }}
         onSelect={e => e.preventDefault}
       >
-        {meta.error}
+        {error}
         {', '}please{' '}
         <Text
-          fontWeight='500'
-          cursor='pointer'
-          color='blue'
-          mx='0.5ch'
+          fontWeight="500"
+          cursor="pointer"
+          color="blue"
+          mx="0.5ch"
           style={{ pointerEvents: 'all' }}
           onClick={clickUploadButton}
         >
@@ -143,7 +144,8 @@ export const clearButton = (field, uploading, clearEvt) => {
 export function ImageInput(props: ImageInputProps): ReactElement {
   const { id, label, caption } = props;
   const { uploadDefault, canUpload, uploading } = useStorage();
-  const [field, meta, { setValue, setError }] = useField(id);
+  const [field, meta, { setValue, setTouched }] = useField(id);
+  const [uploadError, setUploadError] = useState();
   const [focus, setFocus] = useState(false);
   const ref = useRef<HTMLInputElement | null>(null);
 
@@ -170,9 +172,10 @@ export function ImageInput(props: ImageInputProps): ReactElement {
       const url = await uploadDefault(file);
       setFocus(false);
       setValue(url);
+      setTouched(true);
     } catch (e) {
       setFocus(false);
-      setError(e.message);
+      setUploadError(e);
     }
   }, [ref.current, uploadDefault, canUpload, setValue]);
 
@@ -184,19 +187,19 @@ export function ImageInput(props: ImageInputProps): ReactElement {
           {caption}
         </Label>
       ) : null}
-      <Row mt={2} alignItems="flex-end" position='relative' width='100%'>
-        {prompt(field, focus, uploading, meta, clickUploadButton, canUpload)}
+      <Row mt={2} alignItems="flex-end" position="relative" width="100%">
+        {prompt(field, focus, uploading, meta, clickUploadButton, canUpload, uploadError)}
         {clearButton(field, uploading, clearEvt)}
         {uploadingStatus(uploading, meta)}
-        {errorRetry(meta, focus, uploading, clickUploadButton)}
-        <Box background='white' borderRadius={2} width='100%'>
+        {errorRetry(meta, uploadError, focus, uploading, clickUploadButton)}
+        <Box background="white" borderRadius={2} width="100%">
           <Input
             {...field}
-            width='100%'
+            width="100%"
             type={'text'}
             onFocus={() => setFocus(true)}
             onBlur={e => handleBlur(e)}
-            hasError={meta.touched && meta.error !== undefined}
+            hasError={Boolean(uploadError)}
           />
         </Box>
         {canUpload && (
@@ -213,6 +216,9 @@ export function ImageInput(props: ImageInputProps): ReactElement {
           </>
         )}
       </Row>
+      <ErrorLabel mt="2" hasError={Boolean(meta.touched && meta.error)}>
+        {meta.error}
+      </ErrorLabel>
     </Box>
   );
 }


### PR DESCRIPTION
- Fixes ColorInput text entry case
- Makes DM settings optimistic, removes submission button
- Changes ImageInput to not set the form error on upload failure, instead setting its own error variable
- Fixes CalmEngine pulling incorrect prop from form
- Unifies optimistic state handling for forms

The one true way ™ to do optimistic form inputs now is to do the following
- Ensure that you're hooking into optimistic state updates inside the onSubmit, and select the initialValues directly from state (i.e. the selector that you pass the hook should return initialValues directly
- use formikOnBlur
- done!