### PR TITLE
interface: prevent crash in reducers on new group DMs

### DIFF
--- a/pkg/interface/src/logic/reducers/group-update.ts
+++ b/pkg/interface/src/logic/reducers/group-update.ts
@@ -103,6 +103,9 @@ const addMembers = (json: GroupUpdate, state: GroupState): GroupState => {
   if ('addMembers' in json) {
     const { resource, ships } = json.addMembers;
     const resourcePath = resourceAsPath(resource);
+    if(!(resourcePath in state.groups)) {
+      return;
+    }
     for (const member of ships) {
       state.groups[resourcePath].members.add(member);
       if (


### PR DESCRIPTION
Fixes urbit/landscape#1044 by preventing a crash in the reducer that would kill the subscription. FWIW, i strongly dislike that we receive the cards backwards on the channel (which is the cause of this bug), i'd be interested in ways to make this more usable. Wondering whether we should catch exceptions from callbacks in @urbit/http-api ?