### PR TITLE
|mount: support simple @tas arg

### DIFF
--- a/pkg/arvo/gen/hood/mount.hoon
+++ b/pkg/arvo/gen/hood/mount.hoon
@@ -7,11 +7,21 @@
 ::::
   ::
 :-  %say
+=>  |%
+    +$  bath
+      $@  desk
+      (lest knot)
+    --
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [[pax=path pot=$@(~ [v=@tas ~])] ~]
+        [=bath pot=$@(~ [v=@tas ~])]
+        ~
     ==
-?~  pot
-  =+  bem=(need (de-beam pax))
-  $(pot ~[?^(s.bem (rear s.bem) q.bem)])
-:-  %kiln-mount
-[pax v.pot]
+=/  bem=beam
+  ?@  bath  [bec(q bath) /]
+  (need (de-beam `path`bath))
+::
+=/  =desk
+  ?^  pot  v.pot
+  ?^(s.bem (rear s.bem) q.bem)
+::
+[%kiln-mount (en-beam bem) desk]

--- a/pkg/arvo/gen/hood/mount.hoon
+++ b/pkg/arvo/gen/hood/mount.hoon
@@ -17,7 +17,7 @@
         ~
     ==
 =/  bem=beam
-  ?@  bath  [bec(q bath) /]
+  ?@  bath  [bec(q bath, r da+now) /]
   (need (de-beam `path`bath))
 ::
 =/  =desk


### PR DESCRIPTION
I got sick of running `|mount /=landscape=`, or forgetting that the syntax is different from `|commit %landscape`.  This preserves all existing behavior, but now you can also just type `|mount %landscape`, which will expand out to `/=landscape=`.