### PR TITLE
lens: remove contact importing

### DIFF
--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -25,8 +25,6 @@
     ^-  (list @tas)
     :~  %group-store
         %metadata-store
-        %contact-store
-        %contact-hook
         %invite-store
         %graph-store
     ==


### PR DESCRIPTION
Necessary to revive ropsten testnet for now. It's not critical that we import contacts, as none of it has changed. The contact import logic needs a total rewrite anyway, given that it dates back to pre-contact unification.