### PR TITLE
graph-store: patch importing

### DIFF
--- a/pkg/arvo/lib/graph-store.hoon
+++ b/pkg/arvo/lib/graph-store.hoon
@@ -1,4 +1,4 @@
-/-  sur=graph-store, pos=post
+/-  sur=graph-store, pos=post, pull-hook
 /+  res=resource, migrate
 =<  [sur .]
 =<  [pos .]
@@ -872,6 +872,10 @@
     ^-  card:agent:gall
     =/  res-path  (en-path:res rid)
     =/  wire  [%try-rejoin (scot %ud nack-count) res-path]
-    [%pass wire %agent [entity.rid %graph-push-hook] %watch resource+res-path]
+    =/  =cage  
+      :-  %pull-hook-action 
+      !>  ^-  action:pull-hook
+      [%add [entity .]:rid]
+    [%pass wire %agent [our %graph-pull-hook] %poke cage]
   --
 --


### PR DESCRIPTION
Patches importing so that the ropsten testnet will work successfully. Does not restore the previous behaviour, which was to check that the graph existed and we had permissions, backing off exponentially and on success would begin to sync the graph. Such behaviour is not really useful for the ropsten usecase, and was designed for network-wide breaches. As we can coordinate ships coming off and online on the testnet, these timing problems are a nonissue. 