### PR TITLE
interface: actually resume channels

### DIFF
--- a/pkg/interface/src/logic/api/bootstrap.ts
+++ b/pkg/interface/src/logic/api/bootstrap.ts
@@ -29,8 +29,10 @@ export async function bootstrapApi() {
 
   airlock.onOpen = () => {
     useLocalState.setState({ subscription: 'connected' });
-    [useGraphState].map(s => s.getState()?.clear?.());
   };
+
+  [useGraphState].map(s => s.getState()?.clear?.());
+  useGraphState.getState().getShallowChildren(`~${window.ship}`, 'dm-inbox');
 
   const promises = [
     useHarkState,

--- a/pkg/interface/src/logic/api/bootstrap.ts
+++ b/pkg/interface/src/logic/api/bootstrap.ts
@@ -29,6 +29,7 @@ export async function bootstrapApi() {
 
   airlock.onOpen = () => {
     useLocalState.setState({ subscription: 'connected' });
+    [useGraphState].map(s => s.getState()?.clear?.());
   };
 
   const promises = [

--- a/pkg/interface/src/logic/state/base.ts
+++ b/pkg/interface/src/logic/state/base.ts
@@ -1,7 +1,7 @@
 import { applyPatches, Patch, produceWithPatches, setAutoFreeze, enablePatches } from 'immer';
 import { compose } from 'lodash/fp';
 import _ from 'lodash';
-import create, { GetState, SetState, UseStore } from 'zustand';
+import create, { GetState, SetState, UseStore, PartialState } from 'zustand';
 import { persist } from 'zustand/middleware';
 import Urbit, { SubscriptionRequestInterface, FatalError } from '@urbit/http-api';
 import { Poke } from '@urbit/api';
@@ -94,6 +94,7 @@ export interface BaseState<StateType extends {}> {
   removePatch: (id: string) => void;
   optSet: (fn: (state: StateType & BaseState<StateType>) => void) => string;
   initialize: (api: Urbit) => Promise<void>;
+  clear: () => void;
 }
 
 export function createSubscription(app: string, path: string, e: (data: any) => void): SubscriptionRequestInterface {
@@ -114,8 +115,12 @@ export const createState = <T extends {}>(
   name: string,
   properties: T | ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => T),
   blacklist: (keyof BaseState<T> | keyof T)[] = [],
-  subscriptions: ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => SubscriptionRequestInterface)[] = []
+  subscriptions: ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => SubscriptionRequestInterface)[] = [],
+  clear?: PartialState<T & BaseState<T>>
 ): UseStore<T & BaseState<T>> => create<T & BaseState<T>>(persist<T & BaseState<T>>((set, get) => ({
+  clear: () => {
+    set(clear);
+  },
   initialize: async (api: Urbit) => {
     await Promise.all(subscriptions.map(sub => api.subscribe(sub(set, get))));
   },

--- a/pkg/interface/src/logic/state/base.ts
+++ b/pkg/interface/src/logic/state/base.ts
@@ -1,7 +1,7 @@
 import { applyPatches, Patch, produceWithPatches, setAutoFreeze, enablePatches } from 'immer';
 import { compose } from 'lodash/fp';
 import _ from 'lodash';
-import create, { GetState, SetState, UseStore, PartialState } from 'zustand';
+import create, { GetState, SetState, UseStore } from 'zustand';
 import { persist } from 'zustand/middleware';
 import Urbit, { SubscriptionRequestInterface, FatalError } from '@urbit/http-api';
 import { Poke } from '@urbit/api';
@@ -116,10 +116,10 @@ export const createState = <T extends {}>(
   properties: T | ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => T),
   blacklist: (keyof BaseState<T> | keyof T)[] = [],
   subscriptions: ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => SubscriptionRequestInterface)[] = [],
-  clear?: PartialState<T & BaseState<T>>
+  clear?: Partial<T>
 ): UseStore<T & BaseState<T>> => create<T & BaseState<T>>(persist<T & BaseState<T>>((set, get) => ({
   clear: () => {
-    set(clear);
+    set(clear as T & BaseState<T>);
   },
   initialize: async (api: Urbit) => {
     await Promise.all(subscriptions.map(sub => api.subscribe(sub(set, get))));

--- a/pkg/interface/src/logic/state/base.ts
+++ b/pkg/interface/src/logic/state/base.ts
@@ -3,7 +3,7 @@ import { compose } from 'lodash/fp';
 import _ from 'lodash';
 import create, { GetState, SetState, UseStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-import Urbit, { SubscriptionRequestInterface } from '@urbit/http-api';
+import Urbit, { SubscriptionRequestInterface, FatalError } from '@urbit/http-api';
 import { Poke } from '@urbit/api';
 import airlock from '~/logic/api';
 
@@ -102,7 +102,9 @@ export function createSubscription(app: string, path: string, e: (data: any) => 
     path,
     event: e,
     err: () => {},
-    quit: () => {}
+    quit: () => {
+      throw new FatalError('subscription clogged');
+    }
   };
   // TODO: err, quit handling (resubscribe?)
   return request;

--- a/pkg/interface/src/logic/state/graph.ts
+++ b/pkg/interface/src/logic/state/graph.ts
@@ -25,6 +25,7 @@ export interface GraphState {
   pendingDms: Set<string>;
   screening: boolean;
   graphTimesentMap: Record<number, string>;
+  getShallowChildren: (ship: string, name: string, index?: string) => Promise<void>;
   getDeepOlderThan: (ship: string, name: string, count: number, start?: string) => Promise<void>;
   getNewest: (ship: string, resource: string, count: number, index?: string) => Promise<void>;
   getOlderSiblings: (ship: string, resource: string, count: number, index?: string) => Promise<void>;

--- a/pkg/interface/src/logic/state/graph.ts
+++ b/pkg/interface/src/logic/state/graph.ts
@@ -252,9 +252,17 @@ const useGraphState = createState<GraphState>('Graph', (set, get) => ({
     if(j) {
       reduceStateN(get(), j, reduceDm);
     }
-  })
+  })],
+  {
+    graphs: {},
+    looseNodes: {},
+    graphTimesentMap: {},
+    flatGraphs: {},
+    threadGraphs: {},
+    pendingDms: new Set<string>()
+  }
 
-]);
+);
 
 export function useGraph(ship: string, name: string) {
   return useGraphState(

--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -250,7 +250,8 @@ export class Urbit {
           }
         },
         onerror: (error) => {
-          if(!(error instanceof FatalError) && this.errorCount++ < 5) {
+          console.warn(error);
+          if(!(error instanceof FatalError) && this.errorCount++ < 4) {
             this.onRetry && this.onRetry();
             return Math.pow(2, this.errorCount - 1) * 750;
           }

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -194,3 +194,7 @@ export interface Message extends Record<string, any> {
   action: Action;
   id?: number;
 }
+
+export class ResumableError extends Error {}
+
+export class FatalError extends Error {}


### PR DESCRIPTION
- Reenables subscription resume after the fix blocking it was releasd.
- If kicked, restart channel
- If we are restarting a channel totally, then wipe graph-store state to avoid data inconsistency

Running this on my phone produces a roughly 100ms reconnect time from launch. Merging this should probably be held until the dated release, as changing the channel interface is notoriously prone to breakage.