### PR TITLE
eyre: restart subscriptions faster

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01d10efc143cba7d3b8f9951883521f6dabf711ac002c27d396b8f15abd14bfa
-size 12608565
+oid sha256:5f956dfe955674be0f60bea120147611dc93dc24cb0cf629f545fa8062920b0d
+size 12851422

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6afbe5409c3b416c095bead50b35814646d7037a94eaf4b6bef3ab1a46f184bf
-size 13100602
+oid sha256:ce031908f428f9a2a887ea8bdfee527f047cdbdc7392e2575e6351cb890278ac
+size 13239513

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1289,7 +1289,7 @@
     $%  $>(%poke-ack sign:agent:gall)
         $>(%watch-ack sign:agent:gall)
         $>(%kick sign:agent:gall)
-        [%fact =mark =noun]
+        [%fact =json]
     ==
   ::  channel: connection to the browser
   ::

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -67,10 +67,6 @@
 ::  more structures
 ::
 |%
-+$  ver-axle
-  $%  axle
-      axle-2020-10-18
-  ==
 ::
 +$  axle
   $:  ::  date: date at which http-server's state was updated to this data structure
@@ -81,48 +77,6 @@
       =server-state
   ==
 ::
-++  axle-2020-10-18
-  =<  axle
-  |%
-  +$  axle  [date=%~2020.10.18 =server-state]
-  +$  server-state
-    $:  bindings=(list [=binding =duct =action])
-        =cors-registry
-        connections=(map duct outstanding-connection)
-        =authentication-state
-        =channel-state
-        domains=(set turf)
-        =http-config
-        ports=[insecure=@ud secure=(unit @ud)]
-        outgoing-duct=duct
-    ==
-  ::
-  +$  channel-event
-    $%  $>(%poke-ack sign:agent:gall)
-        $>(%watch-ack sign:agent:gall)
-        $>(%kick sign:agent:gall)
-        [%fact =mark noun=*]
-    ==
-  ::
-  +$  channel
-    $:  state=(each timer duct)
-        next-id=@ud
-        last-ack=@da
-        events=(qeu [id=@ud request-id=@ud =channel-event])
-        unacked=(map @ud @ud)
-        subscriptions=(map @ud [ship=@p app=term =path duc=duct])
-        heartbeat=(unit timer)
-    ==
-  ::
-  +$  channel-state
-    $:  ::  session: mapping between an arbitrary key to a channel
-        ::
-        session=(map @t channel)
-        ::  by-duct: mapping from ducts to session key
-        ::
-        duct-to-key=(map duct @t)
-    ==
-  --
 ::  +server-state: state relating to open inbound HTTP connections
 ::
 +$  server-state
@@ -1444,7 +1398,7 @@
           :^  duct  %pass
             (subscription-wire channel-id request-id ship app)
           :*  %g  %deal  [our ship]  app
-              `task:agent:gall`[%watch path]
+              `task:agent:gall`[%watch-as %json path]
           ==
         ::
         =.  session.channel-state.state
@@ -1662,29 +1616,9 @@
       |=  =sign:agent:gall
       ^-  (unit (quip move channel-event))
       ?.  ?=(%fact -.sign)  ``sign
-      =/  [from=(unit mark) jsyn=(unit json)]
-        ?:  ?=(%json p.cage.sign)  [~ `!<(json q.cage.sign)]
-        ::  find and use tube from fact mark to json
-        ::
-        =*  have=mark  p.cage.sign
-        =*  desc=tape  "from {(trip have)} to json"
-        =/  convert=(unit vase)
-          =/  cag=(unit (unit cage))
-            (rof ~ %cf [our %home da+now] /[have]/json)
-          ?.  ?=([~ ~ *] cag)  ~
-          `q.u.u.cag
-        ?~  convert
-          ((slog leaf+"eyre: no convert {desc}" ~) [~ ~])
-        ~|  "conversion failed {desc}"
-        [`have `!<(json (slym u.convert q.q.cage.sign))]
-      ?~  jsyn  ~
-      %-  some
-      :-  ?~  from  ~
-          :_  ~
-          :^  duct  %pass  /conversion-cache/[u.from]
-          [%c %warp our %home `[%sing %f da+now /[u.from]/json]]
-      [%fact u.jsyn]
-    ::  +channel-event-to-json: render chanel event from request-id as json
+      ?.  ?=(%json p.cage.sign)  ~
+      ``[%fact !<(json q.cage.sign)]
+    ::  +channel-event-to-json: render channel event from request-id as json
     ::
     ++  channel-event-to-json
       ~%  %channel-event-to-json  ..part  ~
@@ -2525,7 +2459,53 @@
 ::  +load: migrate old state to new state (called on vane reload)
 ::
 ++  load
-  |=  old=ver-axle
+  =>  |%
+      +$  axle-any
+        $%  axle
+            axle-2020-10-18
+        ==
+      ::
+      ++  axle-2020-10-18
+        =<  axle
+        |%
+        +$  axle  [date=%~2020.10.18 =server-state]
+        +$  server-state
+          $:  bindings=(list [=binding =duct =action])
+              =cors-registry
+              connections=(map duct outstanding-connection)
+              =authentication-state
+              =channel-state
+              domains=(set turf)
+              =http-config
+              ports=[insecure=@ud secure=(unit @ud)]
+              outgoing-duct=duct
+          ==
+        ::
+        +$  channel-event
+          $%  $>(%poke-ack sign:agent:gall)
+              $>(%watch-ack sign:agent:gall)
+              $>(%kick sign:agent:gall)
+              [%fact =mark *]
+          ==
+        ::
+        +$  channel
+          $:  state=(each timer duct)
+              next-id=@ud
+              last-ack=@da
+              events=(qeu [id=@ud request-id=@ud =channel-event])
+              unacked=(map @ud @ud)
+              subscriptions=(map @ud [ship=@p app=term =path duc=duct])
+              heartbeat=(unit timer)
+          ==
+        ::
+        +$  channel-state
+          $:  session=(map @t channel)
+              duct-to-key=(map duct @t)
+          ==
+        --
+
+      --
+  |=  old=axle-any
   ^+  ..^$
   =?  old  ?=(%~2020.10.18 -.old)
     =*  sta  server-state.old
@@ -2543,7 +2523,7 @@
   ..^$(ax old)
 ::  +stay: produce current state
 ::
-++  stay  `ver-axle`ax
+++  stay  ax
 ::  +scry: request a path in the urbit namespace
 ::
 ++  scry

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1512,11 +1512,6 @@
               !(~(has by subscriptions.u.channel) request-id)
           ==
         [~ state]
-      ::  attempt to convert the sign to json.
-      ::  if conversion succeeds, we *can* send it. if the client is actually
-      ::  connected, we *will* send it immediately.
-      ::
-      ::  if we can send it, store the event as unacked
       ::
       =/  chan  (sign-to-channel-event sign)
       =/  next-id  next-id.u.channel
@@ -1624,8 +1619,6 @@
       ~%  %channel-event-to-json  ..part  ~
       |=  [request-id=@ud =channel-event]
       ^-  json
-      ::  for facts, we try to convert the result to json
-      ::
       =,  enjs:format
       %-  pairs
       ^-  (list [@t json])


### PR DESCRIPTION
Stores the precomputed JSON in the channel event fact, instead of
converting it twice. This removes clamming and conversion from the
hot path of reestablishing a channel. Roughly a 100x speedup in 
re-opening channels, down to 4 ms