### PR TITLE
jets: updates +rip and +rep stub jets to defer to nock

### DIFF
--- a/pkg/urbit/jets/c/rep.c
+++ b/pkg/urbit/jets/c/rep.c
@@ -170,7 +170,7 @@ u3qc_rep(u3_atom a,
   }
 
   u3l_log("rep: stub\r\n");
-  return u3m_bail(c3__fail);
+  return u3_none;
 }
 
 u3_noun

--- a/pkg/urbit/jets/c/rip.c
+++ b/pkg/urbit/jets/c/rip.c
@@ -160,7 +160,7 @@ u3qc_rip(u3_atom a,
   }
 
   u3l_log("rip: stub\r\n");
-  return u3m_bail(c3__fail);
+  return u3_none;
 }
 
 u3_noun


### PR DESCRIPTION
The jets for `+rip` and `+rep` are embarrassingly partial; see #4049 and #1210 for context. This PR updates them to defer to nock, rather than bail non-deterministically in unimplemented cases. Finishing their implementations remains a priority.

/cc @ohAitch 