### PR TITLE
azimuth: update for latest ecliptic address

### DIFF
--- a/pkg/arvo/lib/azimuth.hoon
+++ b/pkg/arvo/lib/azimuth.hoon
@@ -87,7 +87,7 @@
         0x223c.067f.8cf2.8ae1.73ee.5caf.ea60.ca44.c335.fecb
       ::
       ++  ecliptic
-        0x6ac0.7b7c.4601.b5ce.11de.8dfe.6335.b871.c7c4.dd4d
+        0x9ef2.7de6.1615.4ff8.b388.93c5.9522.b69c.7ba8.a81c
       ::
       ++  linear-star-release
         0x86cd.9cd0.992f.0423.1751.e376.1de4.5cec.ea5d.1801


### PR DESCRIPTION
The static Ecliptic address in /lib/azimuth hadn't been updated to reflect the recent upgrade yet.