### PR TITLE
graph-store: Handle missing update-logs gracefully in scries

### DIFF
--- a/pkg/arvo/app/graph-store.hoon
+++ b/pkg/arvo/app/graph-store.hoon
@@ -647,11 +647,12 @@
     =/  =term   i.t.t.t.path
     =/  update-log
       (~(get by update-logs) [ship term])
-    ?~  update-log  [~ ~]
     :-  ~  :-  ~  :-  %noun
     !>
     ?+    t.t.t.t.path  (on-peek:def path)
-      ~  `update-log:store`u.update-log
+        ~
+      ^-  update-log:store
+      ?~(update-log *update-log:store u.update-log)
     ::
         [%latest ~]
       ^-  (unit time)
@@ -663,6 +664,7 @@
       ^-  update-log:store
       =*  start  i.t.t.t.t.t.path
       =*  end    i.t.t.t.t.t.t.path
+      ?~  update-log  *update-log:store
       %^  lot:orm-log
           u.update-log
         (slaw %da start)


### PR DESCRIPTION
If a subscription was kicked before receiving any graph-updates on it,
then the attempt to construct a valid resubscribe path would fail, as
the scry crashes. Fixes this by handling the missing update-log case
correctly.