### PR TITLE
khan: control plane

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,7 +36,7 @@ let
         };
       };
     })
-
+    (import ./overlays/haskell.nix)
     # General unguarded (native) overrides for nixpkgs.
     (import ./overlays/native.nix)
 

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -1,0 +1,111 @@
+final: prev:
+let
+  compiler-nix-name = "ghc884";
+  project = prev.haskell-nix.stackProject {
+    compiler-nix-name = "ghc884";
+    index-state = "2020-09-24T00:00:00Z";
+
+    # This is incredibly difficult to get right, almost everything goes wrong.
+    # See: https://github.com/input-output-hk/haskell.nix/issues/496
+    src = prev.haskell-nix.haskellLib.cleanSourceWith {
+      # Otherwise this depends on the name in the parent directory, which
+      # reduces caching, and is particularly bad on Hercules.
+      # See: https://github.com/hercules-ci/support/issues/40
+      name = "urbit-hs";
+      src = ../../pkg/hs;
+    };
+
+    modules = [{
+      # This corresponds to the set of packages (boot libs) that ship with GHC.
+      # We declare them yere to ensure any dependency gets them from GHC itself
+      # rather than trying to re-install them into the package database.
+      nonReinstallablePkgs = [
+        "Cabal"
+        "Win32"
+        "array"
+        "base"
+        "binary"
+        "bytestring"
+        "containers"
+        "deepseq"
+        "directory"
+        "filepath"
+        "ghc"
+        "ghc-boot"
+        "ghc-boot-th"
+        "ghc-compact"
+        "ghc-heap"
+        "ghc-prim"
+        "ghci"
+        "ghcjs-prim"
+        "ghcjs-th"
+        "haskeline"
+        "hpc"
+        "integer-gmp"
+        "integer-simple"
+        "mtl"
+        "parsec"
+        "pretty"
+        "process"
+        "rts"
+        "stm"
+        "template-haskell"
+        "terminfo"
+        "text"
+        "time"
+        "transformers"
+        "unix"
+        "xhtml"
+      ];
+
+      # Override various project-local flags and build configuration.
+      packages = {
+        urbit-king.components.exes.urbit-king = {
+          enableStatic = prev.enableStatic;
+          enableShared = !prev.enableStatic;
+
+          configureFlags = prev.lib.optionals prev.enableStatic [
+            "--ghc-option=-optl=-L${prev.lmdb}/lib"
+            "--ghc-option=-optl=-L${prev.gmp}/lib"
+            "--ghc-option=-optl=-L${prev.libffi}/lib"
+            "--ghc-option=-optl=-L${prev.zlib}/lib"
+          ] ++ prev.lib.optionals (prev.enableStatic && prev.stdenv.isDarwin)
+            [ "--ghc-option=-optl=-L${prev.darwin.libiconv}/lib" ];
+
+          postInstall = prev.lib.optionalString (prev.enableStatic && prev.stdenv.isDarwin) ''
+          find "$out/bin" -type f -exec \
+            install_name_tool -change \
+              ${prev.stdenv.cc.libc}/lib/libSystem.B.dylib \
+              /usr/lib/libSystem.B.dylib {} \;
+        '';
+        };
+
+        urbit-king.components.tests.urbit-king-tests.testFlags =
+          [ "--brass-pill=${prev.brass.lfs}" ];
+
+        lmdb.components.library.libs = prev.lib.mkForce [ prev.lmdb ];
+      };
+    }];
+  };
+  hls = import prev.sources.nix-haskell-hls {
+    config = {
+      ghcVersion = compiler-nix-name;
+
+      hls.unstable = true;
+
+      haskell-nix.checkMaterialization = false;
+      haskell-nix.nixpkgs-pin = "nixpkgs-2009";
+      haskell-nix.hackage.index = {
+        state = project.index-state;
+        sha256 =
+          "f8ef4679f4c3f0c7a075dfef715f1db1b51e3934dc28cef9b3f83b2e1f1e2f77";
+      };
+    };
+  };
+in {
+  tools = [
+      hls.hls-renamed
+      hls.hls-wrapper-nix
+      hls.implicit-hie
+  ];
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -95,6 +95,18 @@
         "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nix-haskell-hls": {
+        "branch": "master",
+        "description": "Nix builds of Haskell Language Server",
+        "homepage": null,
+        "owner": "shajra",
+        "repo": "nix-haskell-hls",
+        "rev": "3ab2de08ff62461ae60c5c0dfedde0d8ee873ed4",
+        "sha256": "1b7bhkjw3s8d5lvzfdb98h0cmx8yi9ddp8v20386glm7xj0lr1fy",
+        "type": "tarball",
+        "url": "https://github.com/shajra/nix-haskell-hls/archive/3ab2de08ff62461ae60c5c0dfedde0d8ee873ed4.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "master",
         "description": "Nix Packages collection",

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1353,7 +1353,6 @@
       =.  way  (grow way)
       %+  push  [way duct bars.gem]
       ~|  bar-stack=`(list ^duct)`[duct bars.gem]
-      ~&  >  wayvv+way
       %.  task
       call:(spin:(plow way) duct eny dud)
     ::  +take: retreat along call-stack

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1353,6 +1353,7 @@
       =.  way  (grow way)
       %+  push  [way duct bars.gem]
       ~|  bar-stack=`(list ^duct)`[duct bars.gem]
+      ~&  >  wayvv+way
       %.  task
       call:(spin:(plow way) duct eny dud)
     ::  +take: retreat along call-stack
@@ -1677,6 +1678,7 @@
     %g  %gall
     %i  %iris
     %j  %jael
+    %k  %khan
   ==
 --  =>
 ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2084,6 +2084,22 @@
     +$  oath  @                                         ::  signature
     --  ::  pki
   --  ::  jael
+::                                                      ::::
+::::                    ++khan                            ::  (1k) control plane
+  ::                                                    ::::
+++  khan  ^?
+  |%
+  +$  gift                                              ::  out result <-$
+    $%  [%avow syn=sign-arvo]                           ::  response to %fyrd
+    ==
+  +$  task                                              ::  in request ->$
+    $~  [%vega ~]                                       ::
+    $%  $>(%born vane-task)                             ::  new unix process
+        [%fyrd syn=sign-arvo]                           ::  jammed request
+        $>(%trim vane-task)                             ::  trim state
+        $>(%vega vane-task)                             ::  report upgrade
+    ==
+  --  ::khan
 ::
 +$  gift-arvo                                           ::  out result <-$
   $~  [%doze ~]
@@ -2095,6 +2111,7 @@
       gift:gall
       gift:iris
       gift:jael
+      gift:khan
   ==
 +$  task-arvo                                           ::  in request ->$
   $%  task:ames
@@ -2105,6 +2122,7 @@
       task:gall
       task:iris
       task:jael
+      task:khan
   ==
 +$  note-arvo                                           ::  out request $->
   $~  [%b %wake ~]
@@ -2117,6 +2135,7 @@
       [%i task:iris]
       [%j task:jael]
       [%$ %whiz ~]
+      [%k task:khan]
       [@tas %meta vase]
   ==
 ::  full vane names are required in vanes
@@ -2137,6 +2156,7 @@
       [%gall gift:gall]
       [%iris gift:iris]
       [%jael gift:jael]
+      [%khan gift:khan]
   ==
 ::  $unix-task: input from unix
 ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2089,9 +2089,10 @@
   ::                                                    ::::
 ++  khan  ^?
   |%
-  +$  socket-config
+  +$  socket-config                                     :: activates and sets up vane
     $:
-        file=path
+        active=?
+        clients=(list term)
     ==
   +$  socket-event
     $:
@@ -2127,7 +2128,7 @@
       gift:gall
       gift:iris
       gift:jael
-      gift:khan                                         ::khan gift
+      gift:khan
   ==
 +$  task-arvo                                           ::  in request ->$
   $%  task:ames

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2089,15 +2089,21 @@
   ::                                                    ::::
 ++  khan  ^?
   |%
+  +$  socket-config
+    $:
+        file=path
+    ==
   +$  gift                                              ::  out result <-$
     $%  [%avow syn=sign-arvo]                           ::  response to %fyrd
-    ==
+        [%set-config =socket-config]
+==
   +$  task                                              ::  in request ->$
     $~  [%vega ~]
     $%
         [%fyrd p=fyrd]                                  ::  jammed requests
         $>(%vega vane-task)                             :: vega
         $>(%trim vane-task)
+        $>(%born vane-task)
     ==
   +$  fyrd                                              ::  input
     $%  [%mas ~]                                        ::  |mass ocmmand

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2093,10 +2093,15 @@
     $:
         file=path
     ==
+  +$  socket-event
+    $:
+        %socket-done  data=*                            :: done
+    ==
   +$  gift                                              ::  out result <-$
     $%  [%avow syn=sign-arvo]                           ::  response to %fyrd
         [%set-config =socket-config]
-==
+        [%response =socket-event]
+    ==
   +$  task                                              ::  in request ->$
     $~  [%vega ~]
     $%
@@ -2106,8 +2111,8 @@
         $>(%born vane-task)
     ==
   +$  fyrd                                              ::  input
-    $%  [%mas ~]                                        ::  |mass ocmmand
-        [%cod ~]                                        ::  code reset
+    $%  [%mas ~]                                        ::  |mass
+        [%cod ?]                                        ::  code reset
     ==                                                  ::
 
   --  ::khan
@@ -2122,7 +2127,7 @@
       gift:gall
       gift:iris
       gift:jael
-      gift:khan
+      gift:khan                                         ::khan gift
   ==
 +$  task-arvo                                           ::  in request ->$
   $%  task:ames
@@ -2167,7 +2172,7 @@
       [%gall gift:gall]
       [%iris gift:iris]
       [%jael gift:jael]
-      ::  [%khan gift:khan]
+      [%khan gift:khan]                                 ::khan gifts
   ==
 ::  $unix-task: input from unix
 ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2093,12 +2093,17 @@
     $%  [%avow syn=sign-arvo]                           ::  response to %fyrd
     ==
   +$  task                                              ::  in request ->$
-    $~  [%vega ~]                                       ::
-    $%  $>(%born vane-task)                             ::  new unix process
-        [%fyrd syn=sign-arvo]                           ::  jammed request
-        $>(%trim vane-task)                             ::  trim state
-        $>(%vega vane-task)                             ::  report upgrade
+    $~  [%vega ~]
+    $%
+        [%fyrd p=fyrd]                                  ::  jammed requests
+        $>(%vega vane-task)                             :: vega
+        $>(%trim vane-task)
     ==
+  +$  fyrd                                              ::  input
+    $%  [%mas ~]                                        ::  |mass ocmmand
+        [%cod ~]                                        ::  code reset
+    ==                                                  ::
+
   --  ::khan
 ::
 +$  gift-arvo                                           ::  out result <-$
@@ -2134,8 +2139,8 @@
       [%g task:gall]
       [%i task:iris]
       [%j task:jael]
-      [%$ %whiz ~]
       [%k task:khan]
+      [%$ %whiz ~]
       [@tas %meta vase]
   ==
 ::  full vane names are required in vanes
@@ -2143,7 +2148,7 @@
 +$  sign-arvo                                           ::  in result $<-
   $%  [%ames gift:ames]
       $:  %behn
-          $%  gift:behn
+          $%  gift:behn                                 ::
               $>(%wris gift:clay)
               $>(%writ gift:clay)
               $>(%mere gift:clay)
@@ -2156,7 +2161,7 @@
       [%gall gift:gall]
       [%iris gift:iris]
       [%jael gift:jael]
-      [%khan gift:khan]
+      ::  [%khan gift:khan]
   ==
 ::  $unix-task: input from unix
 ::
@@ -2175,6 +2180,7 @@
       ::
       $>(%born vane-task)
       ::  %eyre: cancel request
+      ::
       ::
       [%cancel-request ~]
       ::  %dill: reset terminal configuration

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -1,0 +1,153 @@
+::  %behn, just a timer
+!:
+!?  164
+::
+=,  khan
+|=  our=ship
+=>  |%
+    +$  move  [p=duct q=(wite note gift)]
+    +$  note                                            ::  out request $->
+      $%  $:  %k                                        ::   to self
+                $>  $?  %crud                           ::
+                        %avow                           ::
+                        %fyrd                           ::
+                ==                                      ::
+             task                                       ::
+          ==                                            ::
+          $:  %d                                        ::    to %dill
+              $>(%flog task:dill)                       ::  log output
+      ==  ==                                            ::
+    +$  sign
+      $%  [%khan $>(%command gift)]
+      ==
+    ::
+    +$  khan-state
+      $:  %0
+          unix-duct=duct
+      ==
+    ::
+    --
+::
+=>
+~%  %khan  ..part  ~
+|%
+++  per-event
+  =|  moves=(list move)
+  |=  [[now=@da =duct] state=khan-state]
+  ::
+  |%
+  ::  %entry-points
+  ::
+  ::  +born: urbit restarted; refresh?
+  ::
+  ++  born  !!
+  ::  +crud: handle failure of previous arvo event
+  ::
+  ++  crud
+    |=  [tag=@tas error=tang]
+    ^+  [moves state]
+    !!
+  ::  +avow: give back
+  ::
+  ++  avow
+    |=  syn=sign-arvo
+    =<  [moves state]
+    event-core(moves [duct %give %avow syn]~)
+  ::  +fyrd: commands
+  ::
+  ++  fyrd  %command
+  ::  +trim: in response to memory pressue
+  ::
+  ++  trim  [moves state]
+  ::  +vega: learn of a kernel upgrade
+  ::
+  ++  vega  [moves state]
+  ::  %utilities
+  ::
+  ::+|
+  ::
+  ++  event-core  .
+--
+::
+=|  khan-state
+=*  state  -
+|=  [now=@da eny=@uvJ rof=roof]
+=*  khan-gate  .
+^?
+|%
+::  +call: handle a +task:khan request
+::
+++  call
+  ~%  %khan-call  ..part  ~
+  |=  $:  hen=duct
+          dud=(unit goof)
+          wrapped-task=(hobo task)
+      ==
+  ^-  [(list move) _khan-gate]
+  ::
+  =/  =task  ((harden task) wrapped-task)
+  =/  event-core  (per-event [now hen] state)
+  ::
+  =^  moves  state
+    ::
+    ::  handle error notifications
+    ::
+    ?^  dud
+      (crud:event-core -.task tang.u.dud)
+    ::
+    ?-  -.task
+      %born  born:event-core
+      %trim  trim:event-core
+      %vega  vega:event-core
+      %fyrd  fyrd:event-core
+    ==
+  [moves khan-gate]
+::  +load: migrate an old state to a new khan version
+::
+++  load
+  |=  old=khan-state
+  ^+  khan-gate
+  khan-gate(state old)
+::  +scry: view state
+::
+++  scry
+  ^-  roon
+  |=  [lyc=gang car=term bem=beam]
+  ^-  (unit (unit cage))
+  =*  ren  car
+  =*  why=shop  &/p.bem
+  =*  syd  q.bem
+  =*  lot=coin  $/r.bem
+  =*  tyl  s.bem
+
+  ?:  &(=(ren %$) =(tyl /whey))
+    =/  maz=(list mass)
+      :~  timers+&+state
+      ==
+    ``mass+!>(maz)
+  ::  only respond for the local identity, %$ desk, current timestamp
+  ::
+  ?.  ?&  =(&+our why)
+          =([%$ %da now] lot)
+          =(%$ syd)
+      ==
+    ~
+  ?.  ?=(%x ren)  ~
+  ?+  tyl  [~ ~]
+      [%debug %state ~]
+    [~ ~]
+  ==
+::
+++  stay  state
+++  take
+  |=  [tea=wire hen=duct dud=(unit goof) hin=sign]
+  ^-  [(list move) _khan-gate]
+  ?^  dud
+    ~|(%khan-take-dud (mean tang.u.dud))
+  ::
+  ?>  ?=([%drip @ ~] tea)
+  =/  event-core  (per-event [now hen] state)
+  =^  moves  state
+    (take-drip:event-core (slav %ud i.t.tea) error.hin)
+  [moves khan-gate]
+--

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -22,7 +22,7 @@
       ==  ==
       ::
     +$  sign
-      $%  [%khan $>(%avow gift)]                        :: avow
+      $%  [%khan $>(%response gift)]
       ==
     ::
     +$  khan-state
@@ -37,7 +37,7 @@
 |%
 ++  per-event
   =|  moves=(list move)
-  |=  [[now=@da =duct] state=khan-state]
+  |=  [[now=@da =duct rof=roof] state=khan-state]
   ::
   |%
   ::  %entry-points
@@ -54,7 +54,7 @@
     event-core(moves [duct %give %set-config "khan.soc"]~)
 
 
-  ::  +avow: give back
+  ::  +avow: give back gifts
   ::
   ++  avow
     |=  syn=sign-arvo
@@ -64,14 +64,24 @@
   ::
   ++  fyrd
     |=  com=^fyrd
-    ^+  [moves state]
     =<  [moves state]
+    ^+  event-core
     ~&  >  fyrd+com
-    ~!  -.com
     ?-  -.com
       %mas  ~&  todo+com  event-core                    :: |mass
       %cod
         =/  cov
+          ?.    +.com
+            =/  sey=(unit (unit cage))
+              ~&  sey+"here"
+              (rof ~ %j [our %code da+now] /(scot %p our))
+            =/  res=(unit @p)
+              ?~  sey  ~
+              ?~  u.sey  ~
+              `!<(@p q.u.u.sey)
+            ~&  res+res
+            [duct %give [%response %socket-done res]]~ :: give code
+
           [duct %pass / %j %step ~]~
         event-core(moves cov)
     ==
@@ -106,7 +116,8 @@
   ^-  [(list move) _khan-gate]
   ::
   =/  =task  ((harden task) wrapped-task)
-  =/  event-core  (per-event [now hen] state)
+  ~&  task+task
+  =/  event-core  (per-event [now hen rof] state)
   ::
   =^  moves  state
     ::
@@ -144,7 +155,6 @@
       :~  state+&+state
       ==
     ``mass+!>(maz)
-  ::  only respond for the local identity, %$ desk, current timestamp
   ::
   ?.  ?&  =(&+our why)
           =([%$ %da now] lot)
@@ -161,6 +171,7 @@
 ++  take
   |=  [tea=wire hen=duct dud=(unit goof) hin=sign]
   ^-  [(list move) _khan-gate]
+  ~&  hin+hin
   ?^  dud
     ~|(%khan-take-dud (mean tang.u.dud))
   ::

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -48,6 +48,12 @@
     |=  [tag=@tas error=tang]
     ^+  [moves state]
     [[duct %slip %d %flog %crud tag error]~ state]
+  ++  born
+    ^+  [moves state]
+    =<  [moves state]
+    event-core(moves [duct %give %set-config "khan.soc"]~)
+
+
   ::  +avow: give back
   ::
   ++  avow
@@ -111,6 +117,7 @@
     ?-  -.task
       %trim  trim:event-core
       %vega  vega:event-core                            :: vega
+      %born  born:event-core
       %fyrd  (fyrd:event-core p.task)                   :: fyrd
     ==
   [moves khan-gate]

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -1,4 +1,4 @@
-::  %behn, just a timer
+::  %khan
 !:
 !?  164
 ::
@@ -6,19 +6,23 @@
 |=  our=ship
 =>  |%
     +$  move  [p=duct q=(wite note gift)]
-    +$  note                                            ::  out request $->
-      $%  $:  %k                                        ::   to self
-                $>  $?  %crud                           ::
-                        %avow                           ::
-                        %fyrd                           ::
+    +$  note                                          ::  out request $->
+      $%
+        $:  %j                                        :: to %jael
+              $>(%step task:jael)
+          ==
+        $:  %k                                        ::   to self
+                $>  $?
+                        %fyrd
                 ==                                      ::
              task                                       ::
           ==                                            ::
           $:  %d                                        ::    to %dill
               $>(%flog task:dill)                       ::  log output
-      ==  ==                                            ::
+      ==  ==
+      ::
     +$  sign
-      $%  [%khan $>(%command gift)]
+      $%  [%khan $>(%avow gift)]                        :: avow
       ==
     ::
     +$  khan-state
@@ -38,15 +42,12 @@
   |%
   ::  %entry-points
   ::
-  ::  +born: urbit restarted; refresh?
-  ::
-  ++  born  !!
   ::  +crud: handle failure of previous arvo event
   ::
   ++  crud
     |=  [tag=@tas error=tang]
     ^+  [moves state]
-    !!
+    [[duct %slip %d %flog %crud tag error]~ state]
   ::  +avow: give back
   ::
   ++  avow
@@ -55,7 +56,19 @@
     event-core(moves [duct %give %avow syn]~)
   ::  +fyrd: commands
   ::
-  ++  fyrd  %command
+  ++  fyrd
+    |=  com=^fyrd
+    ^+  [moves state]
+    =<  [moves state]
+    ~&  >  fyrd+com
+    ~!  -.com
+    ?-  -.com
+      %mas  ~&  todo+com  event-core                    :: |mass
+      %cod
+        =/  cov
+          [duct %pass / %j %step ~]~
+        event-core(moves cov)
+    ==
   ::  +trim: in response to memory pressue
   ::
   ++  trim  [moves state]
@@ -67,6 +80,7 @@
   ::+|
   ::
   ++  event-core  .
+  --
 --
 ::
 =|  khan-state
@@ -94,12 +108,10 @@
     ::
     ?^  dud
       (crud:event-core -.task tang.u.dud)
-    ::
     ?-  -.task
-      %born  born:event-core
       %trim  trim:event-core
-      %vega  vega:event-core
-      %fyrd  fyrd:event-core
+      %vega  vega:event-core                            :: vega
+      %fyrd  (fyrd:event-core p.task)                   :: fyrd
     ==
   [moves khan-gate]
 ::  +load: migrate an old state to a new khan version
@@ -122,7 +134,7 @@
 
   ?:  &(=(ren %$) =(tyl /whey))
     =/  maz=(list mass)
-      :~  timers+&+state
+      :~  state+&+state
       ==
     ``mass+!>(maz)
   ::  only respond for the local identity, %$ desk, current timestamp
@@ -135,7 +147,7 @@
   ?.  ?=(%x ren)  ~
   ?+  tyl  [~ ~]
       [%debug %state ~]
-    [~ ~]
+    ``state+!>([~ state])
   ==
 ::
 ++  stay  state
@@ -145,9 +157,5 @@
   ?^  dud
     ~|(%khan-take-dud (mean tang.u.dud))
   ::
-  ?>  ?=([%drip @ ~] tea)
-  =/  event-core  (per-event [now hen] state)
-  =^  moves  state
-    (take-drip:event-core (slav %ud i.t.tea) error.hin)
-  [moves khan-gate]
+  [~ khan-gate]
 --

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -48,12 +48,12 @@
     |=  [tag=@tas error=tang]
     ^+  [moves state]
     [[duct %slip %d %flog %crud tag error]~ state]
+  ::
+  ::  +born: alive, set up config
   ++  born
     ^+  [moves state]
     =<  [moves state]
-    event-core(moves [duct %give %set-config "khan.soc"]~)
-
-
+    event-core(moves [duct %give %set-config & ~]~)   :: live event?
   ::  +avow: give back gifts
   ::
   ++  avow

--- a/pkg/hs/stack.yaml
+++ b/pkg/hs/stack.yaml
@@ -23,6 +23,7 @@ extra-deps:
 # This allows building on NixOS.
 nix:
   packages:
+    - lmdb
     - pkgconfig
     - zlib
 

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
@@ -11,7 +11,7 @@
     Types used in both Events and Effects.
 -}
 module Urbit.Arvo.Common
-  ( KingId(..), ServId(..)
+  ( KingId(..), ServId(..), SocketId(..), SocketType(..), SReqApi(..)
   , Vere(..), Wynn(..)
   , Json, JsonNode(..)
   , Desk(..), Mime(..)
@@ -19,8 +19,7 @@ module Urbit.Arvo.Common
   , HttpServerConf(..), PEM(..), Key, Cert
   , HttpEvent(..), Method, Header(..), ResponseHeader(..)
   , ReOrg(..), reorgThroughNoun
-  , AmesDest, Ipv4(..), Ipv6(..), Patp(..), Galaxy, AmesAddress(..)
-  ) where
+  , AmesDest, Ipv4(..), Ipv6(..), Patp(..), Galaxy, AmesAddress(..), SocketConf(..), SocketEvent(..)) where
 
 import Urbit.Prelude
 
@@ -46,6 +45,9 @@ newtype KingId = KingId { unKingId :: UV }
   deriving newtype (Eq, Ord, Show, Num, Real, Enum, Integral, FromNoun, ToNoun)
 
 newtype ServId = ServId { unServId :: UV }
+  deriving newtype (Eq, Ord, Show, Num, Enum, Integral, Real, FromNoun, ToNoun)
+
+newtype SocketId = SocketId { unSocketId :: UV }
   deriving newtype (Eq, Ord, Show, Num, Enum, Integral, Real, FromNoun, ToNoun)
 
 -- Arvo Version Negotiation ----------------------------------------------------
@@ -130,6 +132,30 @@ data HttpServerConf = HttpServerConf
 
 deriveNoun ''HttpServerConf
 
+-- Socket Configuration -------------------------------------------------------
+data SocketConf = SocketConf
+    { scFilePath :: FilePath
+    , scType :: SocketType
+    }
+  deriving (Show)
+data SocketType = STGeneric
+    | STReq SReqApi
+data SReqApi = SReqApi
+  { sReq :: Ship -> Word64 -> STM ()
+  -- , sKil :: Ship -> Word64 -> STM ()
+  }
+instance Show SocketType where
+  show = \case
+    STReq _      -> "STReq"
+    STGeneric -> "STGeneric"
+
+data SocketEvent
+    = SocketStart Noun
+    | SocketContinue Noun
+    | SocketCancel ()
+  deriving (Eq, Ord, Show)
+
+deriveNoun ''SocketEvent
 
 -- Desk and Mime ---------------------------------------------------------------
 

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
@@ -11,7 +11,7 @@
     Types used in both Events and Effects.
 -}
 module Urbit.Arvo.Common
-  ( KingId(..), ServId(..), SocketId(..), SocketType(..), SReqApi(..)
+  ( KingId(..), ServId(..), SocketId(..)
   , Vere(..), Wynn(..)
   , Json, JsonNode(..)
   , Desk(..), Mime(..)
@@ -133,21 +133,6 @@ data HttpServerConf = HttpServerConf
 deriveNoun ''HttpServerConf
 
 -- Socket Configuration -------------------------------------------------------
-data SocketConf = SocketConf
-    { scFilePath :: FilePath
-    , scType :: SocketType
-    }
-  deriving (Show)
-data SocketType = STGeneric
-    | STReq SReqApi
-data SReqApi = SReqApi
-  { sReq :: Ship -> Word64 -> STM ()
-  -- , sKil :: Ship -> Word64 -> STM ()
-  }
-instance Show SocketType where
-  show = \case
-    STReq _      -> "STReq"
-    STGeneric -> "STGeneric"
 
 data SocketEvent
     = SocketStart Noun
@@ -156,6 +141,13 @@ data SocketEvent
   deriving (Eq, Ord, Show)
 
 deriveNoun ''SocketEvent
+
+data SocketConf = SocketConf
+    { scFilePath :: FilePath
+    }
+  deriving (Eq, Ord, Show)
+
+deriveNoun ''SocketConf
 
 -- Desk and Mime ---------------------------------------------------------------
 

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
@@ -144,7 +144,8 @@ data SocketEvent
 deriveNoun ''SocketEvent
 
 data SocketConf = SocketConf
-    { scFilePath :: FilePath
+    { scActive :: Bool
+    , scClients :: [Term]
     }
   deriving (Eq, Ord, Show)
 

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Common.hs
@@ -137,6 +137,7 @@ deriveNoun ''HttpServerConf
 data SocketEvent
     = SocketStart Noun
     | SocketContinue Noun
+    | SocketDone Noun
     | SocketCancel ()
   deriving (Eq, Ord, Show)
 

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Effect.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Effect.hs
@@ -14,8 +14,8 @@ import Urbit.Prelude
 
 import Control.Monad.Fail (fail)
 import Numeric.Natural    (Natural)
-import Urbit.Arvo.Common (KingId(..), ServId(..))
-import Urbit.Arvo.Common (Header, HttpEvent, HttpServerConf, Method, Mime)
+import Urbit.Arvo.Common (SocketConf, KingId(..), ServId(..), SocketId(..))
+import Urbit.Arvo.Common (Header, HttpEvent, HttpServerConf, Method, Mime, SocketEvent)
 import Urbit.Arvo.Common (AmesDest, Turf)
 import Urbit.Arvo.Common (ReOrg(..), reorgThroughNoun)
 import Urbit.Arvo.Common (Desk, Wynn)
@@ -240,7 +240,18 @@ deriveNoun ''TermEf
 data KhanEf
   = KhanEfAvow Path Noun
   | KhanEfFyrd Path Noun
+  deriving (Eq, Ord, Show)
 
+deriveNoun ''KhanEf
+
+data SocketEf
+  = SEError (KingId, ()) ()
+  | SESetConfig (SocketId, ()) SocketConf
+  | SEResponse  (SocketId, UD, UD, ()) SocketEvent
+
+  deriving (Eq, Ord, Show)
+
+deriveNoun ''SocketEf
 -- IO-Driver Routing -----------------------------------------------------------
 
 data VaneEf

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Effect.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Effect.hs
@@ -236,6 +236,10 @@ deriveNoun ''Stub
 deriveNoun ''Blit
 deriveNoun ''TermEf
 
+-- Khan Effects ----------------------------------------------------------------
+data KhanEf
+  = KhanEfAvow Path Noun
+  | KhanEfFyrd Path Noun
 
 -- IO-Driver Routing -----------------------------------------------------------
 
@@ -243,8 +247,10 @@ data VaneEf
     = VENewt       NewtEf
     | VEHttpClient HttpClientEf
     | VEHttpServer HttpServerEf
+    | VESocket     SocketEf
     | VEBehn       BehnEf
     | VETerm       TermEf
+    | VEKhan       KhanEf
     | VEClay       SyncEf
     | VESync       SyncEf
     | VEBoat       SyncEf

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
@@ -207,12 +207,12 @@ deriveNoun ''AmesEv
 -- Socket Events ---------------------------------------------------------------
 data SocketReq = SocketReq
   {
-    sFile :: FilePath
-  , sRequest :: Noun
+    sRequest :: Noun
+  -- , sId :: Noun
   } deriving (Eq , Ord, Show)
 
 data SocketEv
-    = SocketEvRequest       (SocketId, UD, UD, ()) SocketReq
+    = SocketEvFyrd       (SocketId, UD, UD, ()) SocketReq
     | SocketEvCancelRequest (SocketId, UD, UD, ()) ()
     | SocketEvRequestLocal  (SocketId, UD, UD, ()) SocketReq
     | SocketEvLive          (SocketId, ())         FilePath

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
@@ -215,7 +215,7 @@ data SocketEv
     = SocketEvFyrd       (SocketId, UD, UD, ()) SocketReq
     | SocketEvCancelRequest (SocketId, UD, UD, ()) ()
     | SocketEvRequestLocal  (SocketId, UD, UD, ()) SocketReq
-    | SocketEvLive          (SocketId, ())         FilePath
+    | SocketEvLive          (SocketId, ())         Bool [Term]
     | SocketEvBorn          (KingId, ())         ()
     | SocketEvCrud          Path                 Noun
   deriving (Eq, Ord, Show)

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
@@ -215,7 +215,7 @@ data SocketEv
     = SocketEvRequest       (SocketId, UD, UD, ()) SocketReq
     | SocketEvCancelRequest (SocketId, UD, UD, ()) ()
     | SocketEvRequestLocal  (SocketId, UD, UD, ()) SocketReq
-    | SocketEvLive          (SocketId, ())         Port (Maybe Port)
+    | SocketEvLive          (SocketId, ())         FilePath
     | SocketEvBorn          (KingId, ())         ()
     | SocketEvCrud          Path                 Noun
   deriving (Eq, Ord, Show)

--- a/pkg/hs/urbit-king/lib/Urbit/King/Config.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Config.hs
@@ -16,12 +16,16 @@ data PierConfig = PierConfig
   , _pcDryRun    :: Bool
   , _pcSerfExe   :: Maybe Text
   , _pcSerfFlags :: [Serf.Flag]
+  , _pcSocketPath :: FilePath
   } deriving (Show)
 
 makeLenses ''PierConfig
 
 class HasPierPath a where
   pierPathL :: Lens' a FilePath
+
+class HasSocketPath a where
+  socketPathL :: Lens' a FilePath
 
 class HasDryRun a where
   dryRunL :: Lens' a Bool
@@ -34,6 +38,9 @@ instance HasPierPath PierConfig where
 
 instance HasDryRun PierConfig where
   dryRunL = pcDryRun
+
+instance HasSocketPath PierConfig where
+  socketPathL = pcSocketPath
 
 
 -------------------------------------------------------------------------------

--- a/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/King/Main.hs
@@ -146,6 +146,7 @@ toPierConfig pierPath serfExe o@(CLI.Opts{..}) = PierConfig { .. }
   _pcDryRun    = oDryRun || isJust oDryFrom
   _pcSerfExe   = serfExe
   _pcSerfFlags = toSerfFlags o
+  _pcSocketPath = (pierPath <> "/khan.soc")
 
 toNetworkConfig :: CLI.Opts -> NetworkConfig
 toNetworkConfig CLI.Opts {..} = NetworkConfig { .. }

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Khan.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Khan.hs
@@ -1,0 +1,119 @@
+{-|
+  Khan: Http Server Driver
+-}
+
+module Urbit.Vere.Khan
+  ( khan
+  , khan'
+  )
+where
+
+import Urbit.Prelude hiding (Builder)
+
+import Urbit.Arvo                hiding (ServerId, reqUrl)
+import Urbit.King.App            ( killKingActionL
+                                 , HasKingId(..)
+                                 , HasMultiKhanApi(..)
+                                 , HasPierEnv(..)
+                                 )
+import Urbit.King.Config
+
+import Data.List.NonEmpty          (NonEmpty((:|)))
+import Data.PEM                    (pemParseBS, pemWriteBS)
+import RIO.Prelude                 (decodeUtf8Lenient)
+import System.Random               (randomIO)
+
+
+-- Types -----------------------------------------------------------------------
+
+type HasShipEnv e = (HasLogFunc e, HasNetworkConfig e, HasPierConfig e)
+
+type ReqId = UD
+
+newtype Drv = Drv (MVar (Maybe Sock))
+
+data Sock = Sock
+  {
+    sLiveReqs  :: TVar LiveReqs
+  }
+
+-- Khan Driver -----------------------------------------------------------------
+
+khan'
+  :: (HasPierEnv e, HasMultiKhanApi e)
+  => Ship
+  -> Bool
+  -> (Text -> RIO e ())
+  -> KingSubsite
+  -> RIO e ([Ev], RAcquire e (DriverApi SocketEf))
+
+khan' who isFake stderr sub = do
+  ventQ :: TQueue EvErr <- newTQueueIO
+  env <- ask
+
+  let (bornEvs, startDriver) =
+        khan env who (writeTQueue ventQ) isFake stderr
+
+  let runDriver = do
+        diOnEffect <- startDriver
+        let diEventSource = fmap RRWork <$> tryReadTQueue ventQ
+        pure (DriverApi {..})
+
+  pure (bornEvs, runDriver)
+
+{-|
+  Khan -- IO Driver
+-}
+khan
+  :: forall e
+   . (HasPierEnv e)
+  => e
+  -> Ship
+  -> (EvErr -> STM ())
+  -> Bool
+  -> (Text -> RIO e ())
+  -> ([Ev], RAcquire e (SocketEf -> IO ()))
+khan env who plan isFake stderr = (initialEvents, runSocket)
+ where
+  king = fromIntegral (env ^. kingIdL)
+  initialEvents :: [Ev]
+  initialEvents = [bornEv king]
+
+  runSocket :: RAcquire e (SocketEf -> IO ())
+  runSocket = handleEf <$> mkRAcquire
+    (Drv <$> newMVar Nothing)
+    (\(Drv v) -> stopService v kill >>= fromEither)
+
+  kill :: HasLogFunc e => Sock -> RIO e ()
+  kill Sock{..} = do
+    atomically (leaveMultiKhan multi who)
+    io (saKil sLop)
+    io (saKil sIns)
+    io $ for_ sSec (\sec -> (saKil sec))
+    io (removeSocketFile sSocketsFile)
+
+  restart :: Drv -> SocketConf -> RIO e Sock
+  restart (Drv var) conf = do
+    logInfo "Reconnecting socket"
+    let onFatal = runRIO env $ do
+          stderr "A socket problem has occurred. Please restart your ship."
+          view killKingActionL >>= atomically
+    let startAct = connectSocket who isFake conf plan stderr onFatal
+    res <- fromEither =<< restartService var startAct kill
+    logInfo "Done reconnecting socket"
+    pure res
+
+  liveFailed _ = pure ()
+
+  handleEf :: Drv -> SocketEf -> IO ()
+  handleEf drv = runRIO env . \case
+    HSESetConfig (i, ()) conf -> do
+      logInfo (displayShow ("KHAN", "%set-config"))
+      Sock {..} <- restart drv conf
+      logInfo (displayShow ("KHAN", "%set-config", "Sending %live"))
+      atomically $ plan (EvErr (liveEv sServId sSocket) liveFailed)
+      logInfo "Write ports file"
+      io (write sSocketFile sSocket)
+    HSEResponse (i, req, _seq, ()) ev -> do
+      logDebug (displayShow ("KHAN", "%response"))
+      execRespActs drv who (fromIntegral req) ev

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/Socket.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/Socket.hs
@@ -1,0 +1,167 @@
+
+module Urbit.Vere.Khan.Socket
+  ( SockApi(..)
+  , serv
+  , SockType(..)
+  , SReqApi(..)
+  , SockConf(..)
+  )
+where
+
+import Urbit.Prelude hiding (Builder)
+
+import Network.Socket as Net
+import qualified Control.Exception as E
+import qualified Network.Socket.ByteString as NBS
+
+
+-- Internal Types --------------------------------------------------------------
+
+data SockApi = SockApi
+  { saKil :: IO ()
+  , saFile :: STM FilePath
+  }
+
+data SockConf = SockConf { scFilePath :: FilePath, scType :: SockType }
+  deriving (Show)
+
+data SockType = STGeneric
+    | STReq SReqApi
+
+data SReqApi = SReqApi
+  { sReq :: Ship -> Word64 -> STM ()
+  -- , sKil :: Ship -> Word64 -> STM ()
+  }
+instance Show SockType where
+  show = \case
+    STReq _      -> "STReq"
+    STGeneric -> "STGeneric"
+
+bindListen :: Net.Socket -> FilePath -> IO SockAddr
+bindListen sok file = do
+  Net.bind sok . SockAddrUnix $ file
+  Net.listen sok 1
+  pure $ SockAddrUnix $ file
+
+unixSocket :: IO (Either IOError Net.Socket)
+unixSocket =
+  tryIOError (Net.socket Net.AF_UNIX Net.Stream Net.defaultProtocol)
+
+tryOpen :: FilePath -> IO (Either IOError (SockAddr, Net.Socket))
+tryOpen socketFile =
+  unixSocket >>= \case
+    Left  exn -> pure (Left exn)
+    Right sok -> tryIOError (bindListen sok socketFile) >>= \case
+      Left  exn -> Net.close sok $> Left exn
+      Right adr  -> pure (Right (adr, sok))
+
+retry :: HasLogFunc e => RIO e (Either IOError a) -> RIO e a
+retry act = act >>= \case
+  Right res -> pure res
+  Left  exn -> do
+    logDbg ctx ("Failed to open socket. Waiting 5s, then trying again.", exn)
+    threadDelay 5_000_000
+    retry act
+ where
+  ctx = ["KHAN", "SERV", "retry"]
+logDbg :: (HasLogFunc e, Show a) => [Text] -> a -> RIO e ()
+logDbg ctx msg = logInfo (prefix <> suffix)
+ where
+  prefix = display (concat $ fmap (<> ": ") ctx)
+  suffix = displayShow msg
+forceOpenSocket
+  :: forall e
+   . HasLogFunc e
+  => FilePath
+  -> RAcquire e (SockAddr, Net.Socket)
+forceOpenSocket socketFile = mkRAcquire opn kil
+ where
+  kil = io . Net.close . snd
+
+  opn = do
+    (a, s) <- retry $ io $ tryOpen socketFile
+    pure (a, s)
+recvOnSocket
+  :: forall e
+   . HasLogFunc e
+  => Socket
+  -> RAcquire e (ByteString, Net.Socket)
+recvOnSocket s = mkRAcquire rcv kil
+ where
+  kil = io . Net.close . snd
+
+  rcv = do
+    res <- io $ NBS.recv s 400000
+    pure (res, s)
+
+startServer
+  :: HasLogFunc e
+  => Net.Socket
+  -> IO ()
+  -> RIO e ()
+startServer sok onFatal = do
+  envir <- ask
+
+  -- let handler r e = do
+  --       when (isFatal e) $ do
+  --         runRIO envir $ logError $ display $ msg r e
+  --         onFatal
+  --     isFatal e
+  --       | Just (IOError {ioe_type = ResourceExhausted}) <- fromException e
+  --       = True
+  --       | otherwise = False
+
+  --     msg r e = case r of
+  --       Just r  -> "khan: failed request from " <> (tshow $ W.remoteHost r)
+  --               <> " for " <> (tshow $ r) <> ": " <> tshow e
+  --       Nothing -> "khan: server exception: " <> tshow e
+
+  runUnixSocket sok
+  pure ()
+
+
+--------------------------------------------------------------------------------
+
+realServ :: HasLogFunc e
+         => IO () -> SockConf -> RIO e SockApi
+realServ onFatal conf@SockConf {..} = do
+  logInfo (displayShow ("KHAN", "SERV", "Running Real Server"))
+  fil <- newEmptyTMVarIO
+  tid <- async (runServ fil)
+  pure $ SockApi { saKil = cancel tid,
+                   saFile = readTMVar fil
+                 }
+ where
+  runServ vFile = do
+    logInfo (displayShow ("KHAN", "SERV", "runServ"))
+    rwith (forceOpenSocket scFilePath) $ \(sok) -> do
+      atomically (putTMVar vFile scFilePath)
+      startServer (snd sok) onFatal
+
+serv :: HasLogFunc e =>  IO () -> SockConf -> RIO e SockApi
+serv onFatal conf = realServ onFatal conf
+
+runUnixSocket :: (HasLogFunc e) => Net.Socket -> RIO e ByteString
+runUnixSocket sok = do
+  env <- ask
+  io $ forever $ E.bracketOnError (accept sok) (close . fst) $
+    \(conn, SockAddrUnix fil) -> runRIO env $ do
+      logInfo (displayShow ("KHAN", "SOCKET", "message on socket"))
+      rwith (recvOnSocket sok) $ \(dat, s_) -> do
+        runRIO env $ logInfo (displayShow ("KHAN", "SOCKET", "msg: " <> tshow dat))
+        io $ (NBS.sendAll conn dat)
+      -- byt <- io $ toStrict <$> (NBS.recv sok 4000000)
+      -- dat <- cueBSExn byt >>= fromNounExn
+
+      -- forkFinally  (atomically $ socketFinally conn)
+      -- where
+      --   socketFinally conn = \case
+      --     Right rr -> pure rr
+      --     Left err -> withRIOThread $ do
+      --       logError (displayShow ("KHAN", "SOCKET", "error on socket: " <> tshow err))
+      --       gracefulClose conn 5000
+
+-- withRIOThread :: (HasLogFunc e) => RIO e a -> RIO e (Async a)
+-- withRIOThread act = do
+--     env <- ask
+--     io $ async $ runRIO env $ act

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/SocketFile.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/SocketFile.hs
@@ -3,36 +3,13 @@
 -}
 
 module Urbit.Vere.Khan.SocketFile
-  ( KhanSocket(..)
-  , writeSocketFile
-  , removeSocketFile
+  ( removeSocketFile
   )
 where
 
 import Urbit.Prelude
 
 import System.Directory (doesFileExist, removeFile)
-import Urbit.Arvo       (Port(unPort))
-
-
--- Types -----------------------------------------------------------------------
-
-data KhanSocket = KhanSocket
-  { pHttps :: Maybe Port
-  , pHttp  :: Port
-  , pLoop  :: Port
-  }
- deriving (Eq, Ord, Show)
-
-
--- Creating and Deleting `.http.ports` files. ----------------------------------
-
-socketFileText :: KhanSocket -> Text
-socketFileText KhanSocket {..} = unlines $ catMaybes
-  [ pHttps <&> \p -> (tshow p <> " secure public")
-  , Just (tshow (unPort pHttp) <> " insecure public")
-  , Just (tshow (unPort pLoop) <> " insecure loopback")
-  ]
 
 removeSocketFile :: FilePath -> IO ()
 removeSocketFile pax = do
@@ -40,5 +17,3 @@ removeSocketFile pax = do
     True  -> removeFile pax
     False -> pure ()
 
-writeSocketFile :: FilePath -> KhanSocket -> IO ()
-writeSocketFile f = writeFile f . encodeUtf8 . socketFileText

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/SocketFile.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Khan/SocketFile.hs
@@ -1,0 +1,44 @@
+{-|
+  Khan: Socket File
+-}
+
+module Urbit.Vere.Khan.SocketFile
+  ( KhanSocket(..)
+  , writeSocketFile
+  , removeSocketFile
+  )
+where
+
+import Urbit.Prelude
+
+import System.Directory (doesFileExist, removeFile)
+import Urbit.Arvo       (Port(unPort))
+
+
+-- Types -----------------------------------------------------------------------
+
+data KhanSocket = KhanSocket
+  { pHttps :: Maybe Port
+  , pHttp  :: Port
+  , pLoop  :: Port
+  }
+ deriving (Eq, Ord, Show)
+
+
+-- Creating and Deleting `.http.ports` files. ----------------------------------
+
+socketFileText :: KhanSocket -> Text
+socketFileText KhanSocket {..} = unlines $ catMaybes
+  [ pHttps <&> \p -> (tshow p <> " secure public")
+  , Just (tshow (unPort pHttp) <> " insecure public")
+  , Just (tshow (unPort pLoop) <> " insecure loopback")
+  ]
+
+removeSocketFile :: FilePath -> IO ()
+removeSocketFile pax = do
+  doesFileExist pax >>= \case
+    True  -> removeFile pax
+    False -> pure ()
+
+writeSocketFile :: FilePath -> KhanSocket -> IO ()
+writeSocketFile f = writeFile f . encodeUtf8 . socketFileText

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Pier.hs
@@ -524,7 +524,7 @@ drivers env who isFake plan scry termSys stderr serfSIGINT stat sub = do
 
   putStrLn ("ship is " <> tshow who)
 
-  let initialEvents = mconcat [behnBorn,clayBorn,amesBorn,httpBorn,irisBorn,termBorn]
+  let initialEvents = mconcat [behnBorn,clayBorn,amesBorn,httpBorn,irisBorn,khanBorn,termBorn]
 
   let runDrivers = do
         behn <- runBehn
@@ -538,7 +538,7 @@ drivers env who isFake plan scry termSys stderr serfSIGINT stat sub = do
         -- have no events to offer.
         acquireWorker "Event Prioritization" $ forever $ atomically $ do
           let x = diEventSource
-          let eventSources = [x term, x clay, x behn, x iris, x eyre, x ames]
+          let eventSources = [x term, x khan, x clay, x behn, x iris, x eyre, x ames]
           pullEvent eventSources >>= \case
             Nothing -> retry
             Just rr -> plan rr

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Term.hs
@@ -566,7 +566,8 @@ localClient doneSignal = fst <$> mkRAcquire start stop
                 loop rd
               else if w <= 26 then do
                 case pack [BS.w2c (w + 97 - 1)] of
-                    "d" -> atomically doneSignal
+                    -- TODO: send doneSignal only on empty dojo
+                    -- "d" -> atomically doneSignal
                     c   -> do sendBelt $ Ctl $ Cord c
                               loop rd
               else if w == 27 then do

--- a/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
+++ b/pkg/hs/urbit-noun/lib/Urbit/Noun/Conversions.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-deprecations -Wno-orphans #-}
 {-|
     Large Library of conversion between various types and Nouns.
 -}
@@ -372,7 +373,7 @@ instance FromNoun a => FromNoun (Lenient a) where
         fromNounErr n & \case
           Right x  -> pure (GoodParse x)
           Left err -> do
-            -- traceM ("LENIENT.FromNoun: " <> show err)
+            traceM ("LENIENT.FromNoun: " <> show err)
             -- traceM (ppShow n)
             pure (FailParse n)
 

--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,7 @@ in pkgsLocal.hs.shellFor {
     pkgs.nixfmt
     pkgs.shfmt
     pkgs.stack
+    pkgs.haskell-language-server
     (import pkgs.sources.niv { }).niv
   ] ++ mergeFrom "buildInputs";
 

--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,7 @@ in pkgsLocal.hs.shellFor {
 
   # Haskell tools to make available on the shell's PATH.
   tools = {
+    cabal = "3.2.0.0";
     shellcheck = "0.7.1";
     ormolu = "0.1.3.0";
   };


### PR DESCRIPTION
Send tasks as jammed nouns to arvo through a unix socket. For now, these tasks are specific, pre-defined ones (i.e to request a code request and to retrieve a code). Could be more generic in theory. 

To try this out, jam and save a task (can define your own in lull.hoon and khan.hoon) in the dojo , and then send it through the socket with `nc`. 

![](https://archiv.nyc3.digitaloceanspaces.com/littel-wolfur/2021.8.12..02.42.33-khan.gif)

Some initial WIP documentation, with TODOs (in addition to a couple scattered around the code):

- Spec
	- Vere/Khan
		- TODO Refactor to remove socket references in type names where they are not helpful
		- a `SockAPI` created in `startServ`
			- [[SockApi]]
			- Created with `watch` , which takes an `IO` and a `SockConf`
				- [[SockConf]]
					- `FilePath` and `SockType`
					- [[SockType]]
						- [[STGeneric]]
							- No effect handler, just return on the socket.
						- [[STReq]]
							- [[SReqApi]]
								-
								  ``` javascript
								  data SReqApi = SReqApi
								    { sReq :: Ship -> Word64 -> STM ()
								    -- , sKil :: Ship -> Word64 -> STM ()
								    }
								  								  
								  ```
								- Holds a function `sReq` used to handle effects. This is used to send a [[khan-task]] to arvo.
								- TODO Figure out `sKil`
				- Delegates to [[watchSocket]]
					- The main loop handling incoming messages on a [[Socket]] . This is done through the [[Net.Socket/accept]] function, which returns a new socket on which to send data back.
					- Takes a [[Net.Socket]] and the [[SockType]]
		- The [[SockApi]] is then used to create a `Sock` holding the socket id, the api and the conf corresponding to the socket.
			- DONE Do [[Sock]] , [[SockConf]] , and [[SockApi]] need to the same FilePath reference?
				- Probably only needs to be set in one place.
				- The one in [[Sock]] is used to remove the file, and the one in [[SockConf]] is used to open the socket.
					- Changed to only use the one in [[SockConf]]
		- Driver
			- Invoked in the Pier module.
			- `khan'` : Creates a `DriverApi` with a `SocketEf` along with a set of events.
				- [[DriverApi]]
					- `DriverApi` consists of an [[STM]] of a [[RunReq]] and a function that runs when an event is received. If the [[SockType]] is [[STReq]] then this will be in [[SReqApi]] .
						- The first argument is the Event Source and is created by applying the `RRWork` [[RunReq]] to the read queue.
			- `khan` : Creates the initial events and the function that runs on every event.
				- Takes a `plan` and a `stderr`
					- `plan` : [[STM]]
						- `writeTQueue` - writes to a FIFO queue.
					- `stderr` : Text to [[RIO]]
				- Returns a function that wrapped in [[RAcquire]] that responds to a [[SocketEf]] .
					- The [[Net.Socket]] isn't opened until a [[SESetConfig]] effect is seen.
					- A response to a [[SocketEvFyrd]] is expected to come in as a [[SocketResponse]] .
						- TODO Better naming
	- Effects
		- [[SocketEf]]
		- [[router]] loop manages incoming effects.