### PR TITLE
build: Fix MacOS 11.x build

### DIFF
--- a/nix/overlays/native.nix
+++ b/nix/overlays/native.nix
@@ -18,14 +18,6 @@ in {
     ];
   });
 
-  curlMinimal = prev.curl.override {
-    http2Support = false;
-    scpSupport = false;
-    gssSupport = false;
-    ldapSupport = false;
-    brotliSupport = false;
-  };
-
   lmdb = prev.lmdb.overrideAttrs (attrs: {
     patches =
       optionalList attrs.patches ++ prev.lib.optional prev.stdenv.isDarwin [

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, coreutils, pkgconfig, argon2u, cacert, ca-bundle, curlMinimal
+{ lib, stdenv, coreutils, pkgconfig, argon2u, cacert, ca-bundle, curl
 , ed25519, ent, ge-additions, gmp, h2o, herb, ivory, libaes_siv, libscrypt
 , libsigsegv, libuv, lmdb, murmur3, openssl, secp256k1, softfloat3, zlib
 , enableStatic ? stdenv.hostPlatform.isStatic, enableDebug ? false
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     argon2u
     cacert
     ca-bundle
-    curlMinimal
+    curl
     ed25519
     ent
     ge-additions

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": null,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "166ab9d237409c4b74b1f8ca31476ead35e8fe53",
-        "sha256": "13i43kvbkdl3dh8b986j6mxbn355mqjhcxrd8cni8zfx1z0wrscr",
+        "rev": "40a495973af84a5726efb0da68513d053280459d",
+        "sha256": "1c8qrrsxz12rv299rfp7hfd1nci4j4d6mng96hv6n7q6hdqkvyrs",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/166ab9d237409c4b74b1f8ca31476ead35e8fe53.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/40a495973af84a5726efb0da68513d053280459d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "softfloat3": {


### PR DESCRIPTION
# Context

Ran into the same problem others were reporting in #4214 when trying to `make build` on MacOS 11.5.1. [This comment](https://github.com/NixOS/nixpkgs/issues/91748#issuecomment-836960758) from the official `nixpkgs` repo pointed me in the right direction, and provides more detail about why it was failing (in short, `ld` was out of date).

One open question for someone who is more familiar with the Urbit build process: is it okay that this PR replaces the `curlMinimal` dependency with `curl`? After updating `nixpkgs`, that was also causing the build to fail, so I removed it :)

Closes #4214

# Changes

- updated `nixpkgs` using `niv`
- use `curl` instead of `curlMinimal` in `urbit` build inputs

# Before

![image](https://user-images.githubusercontent.com/16504501/129811484-0ebb8aa3-0c54-4225-89d8-223a09408108.png)

# After

![image](https://user-images.githubusercontent.com/16504501/129811521-d18262e6-ce4d-42e2-9a8c-751f17e22e74.png)
