### PR TITLE
u3: refactors address layout macros, combines darwin/aarch64

### DIFF
--- a/pkg/urbit/include/c/portable.h
+++ b/pkg/urbit/include/c/portable.h
@@ -104,6 +104,8 @@
 #   endif
 
   /** Address space layout.
+  ***
+  ***   NB: 2^29 words == 2GB
   **/
 #   if defined(U3_OS_linux)
 #     ifdef __LP64__
@@ -115,17 +117,24 @@
 #     else
 #       define U3_OS_LoomBase 0x36000000
 #     endif
-#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
-#   elif defined(U3_OS_osx) && defined(U3_CPU_aarch64) || defined(U3_OS_mingw)
+#       define U3_OS_LoomBits 29
+#   elif defined(U3_OS_mingw)
 #       define U3_OS_LoomBase 0x28000000000
-#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
-#   elif defined(U3_OS_osx) || defined(U3_OS_bsd)
+#       define U3_OS_LoomBits 29
+#   elif defined(U3_OS_osx)
+#     ifdef __LP64__
+#       define U3_OS_LoomBase 0x28000000000
+#     else
+#       define U3_OS_LoomBase 0x4000000
+#     endif
+#       define U3_OS_LoomBits 29
+#   elif defined(U3_OS_bsd)
 #     ifdef __LP64__
 #       define U3_OS_LoomBase 0x200000000
 #     else
 #       define U3_OS_LoomBase 0x4000000
 #     endif
-#       define U3_OS_LoomBits 29            //  ie, 2^29 words == 2GB
+#       define U3_OS_LoomBits 29
 #   else
 #     error "port: LoomBase"
 #   endif


### PR DESCRIPTION
Building on the apple silicon `m1brew` build changes in #4675 and related discussion in https://github.com/urbit/urbit/issues/4257#issuecomment-891802105, this PR changes the loombase for all darwin builds, making our darwin static binaries run correctly under rosetta.

/cc @locpyl-tidnyd 

Closes #4257 