### PR TITLE
landscape: altered RemoteContent regexes for images, video, and audio to include period literal.

### DIFF
--- a/pkg/interface/src/views/components/RemoteContent/index.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/index.tsx
@@ -38,10 +38,10 @@ export interface RemoteContentProps {
 }
 
 export const IMAGE_REGEX = new RegExp(
-  /(jpg|img|png|gif|tiff|jpeg|webp|webm|svg)$/i
+  /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.webm|\.svg)$/i
 );
-export const AUDIO_REGEX = new RegExp(/(mp3|wav|ogg|m4a)$/i);
-export const VIDEO_REGEX = new RegExp(/(mov|mp4|ogv)$/i);
+export const AUDIO_REGEX = new RegExp(/(\.mp3|\.wav|\.ogg|\.m4a)$/i);
+export const VIDEO_REGEX = new RegExp(/(\.mov|\.mp4|\.ogv)$/i);
 
 const emptyRef = () => {};
 export function RemoteContent(props: RemoteContentProps) {


### PR DESCRIPTION
This prevents URLs ending in 'mov', 'ogg', etc. from rendering as empty video/audio, allowing people to learn about Isaac Asimov and William Rees-Mogg. Tested locally, seems to work.

Guessing @urcades is a reasonable maintainer to tag?