### PR TITLE
metadata-store: Handle removes on kick correctly

### DIFF
--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -247,8 +247,8 @@
         =/  assocs=(list [=md-resource:store grp=resource =metadatum:store])
           ~(tap by associations)
         =/  old-resources=(set md-resource:store)  (~(get ju group-indices) group)
-        =/  cur-resources=(set md-resource:store)  ~(key by assocs)
-        =.  state   (remove-gone group (~(dif in old-resource) cur-resource))
+        =/  cur-resources=(set md-resource:store)  ~(key by associations)
+        =.  state   (remove-gone group (~(dif in old-resources) cur-resources))
         |-
         ?~  assocs
           :_  state
@@ -260,17 +260,17 @@
         $(assocs t)
       ::
       ++  remove-gone
-        |=  [group=resource gone=(set md-resource:store)
+        |=  [group=resource gone=(set md-resource:store)]
         ^+  state
         %+  roll  ~(tap in gone)
         |=  [=md-resource:store out=_state]
         %_  out
           associations      (~(del by associations.out) md-resource)
           group-indices     (~(del ju group-indices.out) group md-resource)
-          resource-indices  (~(del ju resource-indices.out) md-resource group)
+          resource-indices  (~(del by resource-indices.out) md-resource)
           ::
             app-indices
-          (~(del ju app-indices.out) app.md-resource group resource.md-resource)
+          (~(del ju app-indices.out) app-name.md-resource group resource.md-resource)
         ==
       --
     ::

--- a/pkg/arvo/app/metadata-store.hoon
+++ b/pkg/arvo/app/metadata-store.hoon
@@ -246,15 +246,32 @@
         |=  [group=resource =associations:store]
         =/  assocs=(list [=md-resource:store grp=resource =metadatum:store])
           ~(tap by associations)
-        :-  (send-diff:mc %initial-group group associations)
+        =/  old-resources=(set md-resource:store)  (~(get ju group-indices) group)
+        =/  cur-resources=(set md-resource:store)  ~(key by assocs)
+        =.  state   (remove-gone group (~(dif in old-resource) cur-resource))
         |-
         ?~  assocs
-          state
+          :_  state
+          (send-diff:mc %initial-group group associations)
         =,  assocs
         ?>  =(group grp.i)
         =^  cards  state
           (handle-add group [md-resource metadatum]:i)
         $(assocs t)
+      ::
+      ++  remove-gone
+        |=  [group=resource gone=(set md-resource:store)
+        ^+  state
+        %+  roll  ~(tap in gone)
+        |=  [=md-resource:store out=_state]
+        %_  out
+          associations      (~(del by associations.out) md-resource)
+          group-indices     (~(del ju group-indices.out) group md-resource)
+          resource-indices  (~(del ju resource-indices.out) md-resource group)
+          ::
+            app-indices
+          (~(del ju app-indices.out) app.md-resource group resource.md-resource)
+        ==
       --
     ::
     ++  poke-import

--- a/pkg/interface/src/logic/state/metadata.ts
+++ b/pkg/interface/src/logic/state/metadata.ts
@@ -1,4 +1,4 @@
-import { Association, Associations, MetadataUpdatePreview } from '@urbit/api';
+import { Association, Associations, MetadataUpdatePreview } from '@urbit/api/metadata';
 import _ from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 import {

--- a/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupifyForm.tsx
@@ -36,7 +36,7 @@ export function GroupifyForm(props: GroupifyFormProps) {
         name,
         values.group?.toString() || undefined
       ));
-      let mod = association['app-name'];
+      let mod: string = association['app-name'];
       if (association?.metadata?.config && 'graph' in association.metadata.config) {
         mod = association.metadata.config.graph as AppName;
       }

--- a/pkg/interface/src/views/landscape/components/Resource.tsx
+++ b/pkg/interface/src/views/landscape/components/Resource.tsx
@@ -26,7 +26,7 @@ export function Resource(props: ResourceProps): ReactElement {
   const notificationsCount = useHarkState(state => state.notificationsCount);
   const associations = useMetadataState(state => state.associations);
   const contacts = useContactState(state => state.contacts);
-  let app = association['app-name'];
+  let app: string = association['app-name'];
   if (association?.metadata?.config && 'graph' in association.metadata.config) {
     app = association.metadata.config.graph as AppName;
   }

--- a/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/ResourceSkeleton.tsx
@@ -65,7 +65,7 @@ type ResourceSkeletonProps = {
 
 export function ResourceSkeleton(props: ResourceSkeletonProps): ReactElement {
   const { association, baseUrl, children } = props;
-  let app = association['app-name'];
+  let app: string = association['app-name'];
   if (association?.metadata?.config && 'graph' in association.metadata.config) {
     app = association.metadata.config.graph as AppName;
   }

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { useRef, ReactNode } from 'react';
 import urbitOb from 'urbit-ob';
 import { Icon, Row, Box, Text, BaseImage } from '@tlon/indigo-react';
-import { Association, cite, AppName } from '@urbit/api';
+import { Association, cite } from '@urbit/api';
 import { HoverBoxLink } from '~/views/components/HoverBox';
 import { Sigil } from '~/logic/lib/sigil';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
@@ -176,9 +176,9 @@ export const SidebarAssociationItem = React.memo((props: {
   const { association, selected } = props;
   const title = getItemTitle(association) || '';
   const appName = association?.['app-name'];
-  let mod = appName;
+  let mod: string = appName;
   if (association?.metadata?.config && 'graph' in association.metadata.config) {
-    mod = association.metadata.config.graph as AppName;
+    mod = association.metadata.config.graph ;
   }
   const rid = association?.resource;
   const groupPath = association?.group;

--- a/pkg/npm/api/metadata/lib.ts
+++ b/pkg/npm/api/metadata/lib.ts
@@ -1,5 +1,5 @@
-import { AppName, Path, Poke, uxToHex, PatpNoSig } from '../lib';
-import { Association, Metadata, MetadataUpdate, MetadataUpdateAdd, MetadataUpdateRemove, MetadataEditField, MetadataUpdateEdit } from './types';
+import { Path, Poke, uxToHex, PatpNoSig } from '../lib';
+import { MdAppName, Association, Metadata, MetadataUpdate, MetadataUpdateAdd, MetadataUpdateRemove, MetadataEditField, MetadataUpdateEdit } from './types';
 
 export const METADATA_UPDATE_VERSION = 2;
 
@@ -11,7 +11,7 @@ export const metadataAction = <T extends MetadataUpdate>(data: T, version: numbe
 
 export const add = (
   ship: PatpNoSig,
-  appName: AppName,
+  appName: MdAppName,
   resource: Path,
   group: Path,
   title: string,
@@ -44,10 +44,10 @@ export const add = (
 export { add as metadataAdd };
 
 export const remove = (
-  appName: AppName,
+  appName: MdAppName,
   resource: string,
   group: string
-): Poke<MetadataUpdateRemove> => metadataAction({
+): Poke<MetadataUpdateRemove> => metadataAction<MetadataUpdateRemove>({
   remove: {
     group,
     resource: {
@@ -62,7 +62,7 @@ export { remove as metadataRemove };
 export const edit = (
   association: Association,
   edit: MetadataEditField
-): Poke<MetadataUpdateEdit> => metadataAction({
+): Poke<MetadataUpdateEdit> => metadataAction<MetadataUpdateEdit>({
   edit: {
     group: association.group,
     resource: {
@@ -84,7 +84,7 @@ export const update = (
 ): Poke<MetadataUpdateAdd> => {
   const metadata = { ...association.metadata, ...newMetadata };
     metadata.color = uxToHex(metadata.color);
-    return metadataAction({
+    return metadataAction<MetadataUpdateAdd>({
       add: {
         group: association.group,
         resource: {

--- a/pkg/npm/api/metadata/types.ts
+++ b/pkg/npm/api/metadata/types.ts
@@ -1,4 +1,4 @@
-import { AppName, Path, Patp } from '../lib';
+import { Path, Patp } from '../lib';
 
 export type MetadataUpdate =
   MetadataUpdateInitial
@@ -41,7 +41,7 @@ export type MetadataUpdateRemove = {
 
 export interface MdResource {
   resource: string;
-  'app-name': AppName;
+  'app-name': 'groups' | 'graph';
 }
 
 export interface MetadataUpdatePreview {

--- a/pkg/npm/api/metadata/types.ts
+++ b/pkg/npm/api/metadata/types.ts
@@ -1,5 +1,7 @@
 import { Path, Patp } from '../lib';
 
+export type MdAppName = 'groups' | 'graph';
+
 export type MetadataUpdate =
   MetadataUpdateInitial
 | MetadataUpdateAdd
@@ -26,6 +28,7 @@ export type MetadataUpdateUpdate = {
 export interface MetadataUpdateEdit {
   edit: {
     resource: MdResource;
+    group: string;
     edit: MetadataEditField;
   }
 }
@@ -41,7 +44,7 @@ export type MetadataUpdateRemove = {
 
 export interface MdResource {
   resource: string;
-  'app-name': 'groups' | 'graph';
+  'app-name': MdAppName;
 }
 
 export interface MetadataUpdatePreview {


### PR DESCRIPTION
Previously, if an %initial-group fact had less associations than the agent did, we ignored those missing facts. This causes channels to not remove their metadata correctly. Addresses this issue both in %metadata-store and also in the associated reducer