### PR TITLE
docket: add web interface for glob uploading

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -413,15 +413,20 @@
     :-  desk
     ::  all submitted files must be complete
     ::
-    ::TODO  do we want to ignore .DS_Store and other such files?
     ?.  =('glob' name)  [glob (cat 3 'weird part: ' name) err]
     ?~  file            [glob 'file without filename' err]
     ?~  type            [glob (cat 3 'file without type: ' u.file) err]
     ?^  code            [glob (cat 3 'strange encoding: ' u.code) err]
     =/  filp            (rush u.file fip)
     ?~  filp            [glob (cat 3 'strange filename: ' u.file) err]
-    :_  err
+    ::  ignore metadata files and other "junk"
+    ::TODO  consider expanding coverage
+    ::
+    ?:  =('.DS_Store' (rear `path`u.filp))
+      [glob err]
     ::  make sure to exclude the top-level dir from the path
+    ::
+    :_  err
     %+  ~(put by glob)  (slag 1 `path`u.filp)
     [u.type (as-octs:mimes:html body)]
   ::

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -48,13 +48,14 @@
 ++  on-load
   |=  =vase
   ^-  (quip card _this)
+  ~&  %ayy
   =+  !<(old=state-0 vase)
   =*  cha  ~(. ch q.byk.bowl)
-  |^  
+  |^
   =.  -.state  old
   =.  +.state  inflate-cache
   `this
-  ::  
+  ::
   ++  inflate-cache
     ^-  cache
     %-  ~(gas by *(map term desk))
@@ -68,7 +69,7 @@
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card _this)
-  |^  
+  |^
   =^  cards  state
     ?+  mark  (on-poke:def:cc mark vase)
       %docket-install    (install !<([ship desk] vase))
@@ -80,9 +81,7 @@
     ::
         %handle-http-request
       =+  !<([id=@ta req=inbound-request:eyre] vase)
-      :_  state
-      %+  give-simple-payload:app  id
-      (handle-http-request:cc req)
+      (handle-http-request:cc id req)
     ==
   [cards this]
   ::
@@ -90,7 +89,7 @@
     |=  [=ship =desk]
     ^-  (quip card _state)
     =+  .^(=treaty:treaty %gx (scry:io %treaty /treaty/(scot %p ship)/[desk]/noun))
-    ?<  ~|(%bad-install-desk (~(has by charges) desk)) 
+    ?<  ~|(%bad-install-desk (~(has by charges) desk))
     =.  charges
       (~(put by charges) desk docket.treaty %install ~)
     =*  cha   ~(. ch desk)
@@ -115,7 +114,7 @@
   ^-  (quip card _this)
   =^  cards  state
     ?+  path  (on-watch:def path)
-        [%http-response *]  
+        [%http-response *]
       ?>  (team:title [our src]:bowl)
       `state
     ::
@@ -203,12 +202,12 @@
     ::
         [%install ~]
       ?>  ?=(%poke-ack -.sign)
-      ?~  p.sign  
+      ?~  p.sign
         :_(state ~[warp-next:cha]) :: request warp
       =.  charges   (new-chad:cha hung+'Failed install')
       ((slog leaf+"Failed installing %{(trip desk)}" u.p.sign) `state)
     ::
-        [%uninstall ~] 
+        [%uninstall ~]
       ?>  ?=(%poke-ack -.sign)
       ?~  p.sign  `state
       ((slog leaf+"Failed to uninstall %{(trip desk)}" u.p.sign) `state)
@@ -249,7 +248,7 @@
   |^  ^-  (quip card _this)
   =^  cards  state
     ?+  wire  (on-arvo:def wire sign)
-        [%init ~]  
+        [%init ~]
       =*  cha  ~(. ch q.byk.bowl)
       =.  charges  (~(put by charges) q.byk.bowl [docket:cha %install ~])
       [fetch-glob:cha state]
@@ -258,7 +257,7 @@
     ::
         [%eyre ~]
       ?>  ?=([%eyre %bound *] sign)
-      ?:  accepted.sign   `state 
+      ?:  accepted.sign   `state
       ~&  [dap.bowl %failed-to-bind path.binding.sign]
       `state
     ==
@@ -269,7 +268,7 @@
     =*  cha  ~(. ch desk)
     ?+  wire  ~|(%lc-arvo-bad-wire !!)
     ::
-        [%warp ~]  
+        [%warp ~]
       ?>  ?=([?(%clay %behn) %writ *] sign)
       ?.  (~(has by charges) desk)  `state
       ?~  p.sign  ::
@@ -295,50 +294,84 @@
 ++  pass  pass:io
 ++  def  ~(. (default-agent state %|) bowl)
 ::
-++  inline-js-response
-  |=  js=cord
-  ^-  simple-payload:http
-  %.  (as-octs:mimes:html js)
-  %*  .  js-response:gen
-    cache  %.n
-  ==
-::
 ++  handle-http-request
-  |=  =inbound-request:eyre
-  ^-  simple-payload:http
-  %+  require-authorization-simple:app  inbound-request
-  =*  req       request.inbound-request
-  =*  headers   header-list.req
-  =/  req-line  (parse-request-line url.req)
-  ?.  =(method.req %'GET')  not-found:gen
-  ?:  &(=(ext.req-line `%js) ?=([%session ~] site.req-line))
-    %-  inline-js-response 
-    (rap 3 'window.ship = "' (rsh 3 (scot %p our.bowl)) '";' ~)
-  ?.  ?=([%apps @ *] site.req-line)
-    (redirect:gen '/apps/grid/')
-  =/  des=(unit desk)
-    (~(get by by-base) i.t.site.req-line)
-  ?~  des  not-found:gen
-  =/  cha=(unit charge) 
-    (~(get by charges) u.des)
-  ?~  cha  not-found:gen
-  ?.  ?=(%glob -.chad.u.cha)  not-found:gen
-  =*  glob  glob.chad.u.cha
-  =/  suffix=^path
-    (weld (slag 2 `^path`site.req-line) (drop ext.req-line))
-  ?:  =(suffix /desk/js) 
-    %-  inline-js-response
-    (rap 3 'window.desk = "' u.des '";' ~)
-
-  =/  data=mime
-    (~(gut by glob) suffix (~(got by glob) /index/html))
-  =/  mime-type=@t  (rsh 3 (crip <p.data>))
-  =/  headers
-    :~  content-type+mime-type 
-        max-1-wk:gen 
+  |=  [eyre-id=@ta inbound-request:eyre]
+  ^-  (quip card _state)
+  ::
+  ::TODO  caz needed? facts, maybe?
+  =;  [payload=simple-payload:http caz=(list card) =_state]
+    :_  state
+    %+  weld  caz
+    (give-simple-payload:app eyre-id payload)
+  ::
+  ::NOTE  we don't use +require-authorization-simple here because we want
+  ::      to short-circuit all the below logic for the unauthenticated case.
+  ?.  authenticated
+    :_  [~ state]
+    =-  [[307 ['location' -]~] ~]
+    (cat 3 '/~/login?redirect=' url.request)
+  ::
+  |^  ?+  method.request  [[405^~ ~] ~ state]
+        %'GET'   [handle-get-request ~ state]
+        %'POST'  handle-post-request
+      ==
+  ::
+  ++  handle-get-request
+    ^-  simple-payload:http
+    =*  headers   header-list.request
+    =/  req-line  (parse-request-line url.request)
+    ?+  [site ext]:req-line  (redirect:gen '/apps/grid/')
+        [[%session ~] [~ %js]]
+      %-  inline-js-response
+      (rap 3 'window.ship = "' (rsh 3 (scot %p our.bowl)) '";' ~)
+    ::
+        [[%upload ~] ?(~ [~ %html])]
+      !!  ::TODO
+    ::
+        [[%apps @ *] *]
+      %+  payload-from-glob
+        (snag 1 site.req-line)
+      req-line(site (slag 2 site.req-line))
+    ==
+  ::
+  ++  handle-post-request
+    ^-  [simple-payload:http (list card) _state]
+    !!  ::TODO
+  ::
+  ++  inline-js-response
+    |=  js=cord
+    ^-  simple-payload:http
+    %.  (as-octs:mimes:html js)
+    %*  .  js-response:gen
+      cache  %.n
+    ==
+  ::
+  ++  payload-from-glob
+    |=  [from=@ta what=request-line]
+    ^-  simple-payload:http
+    =/  des=(unit desk)
+      (~(get by by-base) from)
+    ?~  des  not-found:gen
+    =/  cha=(unit charge)
+      (~(get by charges) u.des)
+    ?~  cha  not-found:gen
+    ?.  ?=(%glob -.chad.u.cha)  not-found:gen
+    =*  glob  glob.chad.u.cha
+    =/  suffix=^path
+      (weld site.what (drop ext.what))
+    ?:  =(suffix /desk/js)
+      %-  inline-js-response
+      (rap 3 'window.desk = "' u.des '";' ~)
+    =/  data=mime
+      (~(gut by glob) suffix (~(got by glob) /index/html))
+    =/  mime-type=@t  (rsh 3 (crip <p.data>))
+    =;  headers
+      [[200 headers] `q.data]
+    :~  content-type+mime-type
+        max-1-wk:gen
         'service-worker-allowed'^'/'
     ==
-  [[200 headers] `q.data]
+  --
 ::
 ++  get-light-charge
   |=  =charge

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -48,7 +48,6 @@
 ++  on-load
   |=  =vase
   ^-  (quip card _this)
-  ~&  %ayy
   =+  !<(old=state-0 vase)
   =*  cha  ~(. ch q.byk.bowl)
   |^
@@ -89,7 +88,9 @@
     |=  [=ship =desk]
     ^-  (quip card _state)
     =+  .^(=treaty:treaty %gx (scry:io %treaty /treaty/(scot %p ship)/[desk]/noun))
-    ?<  ~|(%bad-install-desk (~(has by charges) desk))
+    ?:  (~(has by charges) desk)
+      ~|  %bad-install-desk
+      !!
     =.  charges
       (~(put by charges) desk docket.treaty %install ~)
     =*  cha   ~(. ch desk)
@@ -377,7 +378,6 @@
       =*  cha      ~(. ch desk)
       =/  =charge  (~(got by charges) desk)
       ::
-      ::REVIEW  these are important, right?
       =?  err  =(~ glob)
         ['no files for glob' err]
       =?  err  ?=(%glob -.href.docket.charge)

--- a/pkg/garden/lib/multipart.hoon
+++ b/pkg/garden/lib/multipart.hoon
@@ -1,0 +1,49 @@
+::  multipart: multipart/form-data request decoding
+::
+|%
++$  part
+  $:  file=(unit @t)                   ::  filename
+      type=(unit mite)                 ::  content-type
+      code=(unit @t)                   ::  content-transfer-encoding
+      body=@t                          ::  content
+  ==
+::
+++  de-request
+  |=  [=header-list:http body=(unit octs)]
+  ^-  (unit (list [@t part]))
+  ?~  body  ~
+  ?~  cot=(get-header:http 'content-type' header-list)      ~
+  ?.  =('multipart/form-data; boundary=' (end 3^30 u.cot))  ~
+  %+  rush  q.u.body
+  (dep (rsh 3^30 u.cot))
+::
+++  dep
+  |=  del=@t
+  |^
+  %+  knee    *(list [@t part])        |.  ~+
+  ;~  pose  (cold ~ (full tip))        ::  end, or
+  ;~  pfix  dim  nip                   ::  section start
+  ;~  plug  ;~  plug                   ::  containing:
+          (ifix [cof doq] nom)         ::  name
+    (punt (ifix [cup doq] nod))        ::  filename
+    (punt ;~(pfix nip cut nab))        ::  content-type
+    (punt ;~(pfix nip cue nom))        ::  con-tra-encoding
+          (ifix [sip nip] nag)         ::  content
+  ==  ^$  ==  ==  ==
+  ::
+  ++  cof   (jest 'Content-Disposition: form-data; name="')
+  ++  cue   (jest 'Content-Transfer-Encoding: ')
+  ++  cup   (jest '; filename="')
+  ++  cut   (jest 'Content-Type: ')
+  ++  dim   (jest (cat 3 '--' del))
+  ++  nip   (jest '\0d\0a')
+  ++  nab   (more fas urs:ab)
+  ++  nag   (dine ;~(less ;~(plug nip dim) next))
+  ++  nod   (dine ;~(less doq next))
+  ++  nom   (dine alp)
+  ++  sip   ;~(plug nip nip)
+  ++  tip   ;~(plug dim hep hep nip)
+  ::
+  ++  dine  |*(r=rule (cook (cury rep 3) (star r)))
+  --
+--

--- a/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Arvo/Event.hs
@@ -85,7 +85,7 @@ instance FromNoun Pass where
 -- seed. These aren't actually private keys, but public/private keypairs which
 -- can be derived from these seeds.
 data Ring = Ring { ringSign :: BS.ByteString, ringCrypt :: BS.ByteString }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance ToNoun Ring where
   toNoun Ring{..} =
@@ -117,6 +117,36 @@ data Seed = Seed
     }
   deriving (Eq, Show)
 
+data Germs = Germs
+    { gShip :: Ship
+    , gFeed :: [Germ]
+    }
+  deriving (Eq, Show)
+
+data Germ = Germ
+    { gLife :: Life
+    , gRing :: Ring
+    }
+  deriving (Eq, Ord, Show)
+
+data Feed
+  = Feed0 Seed
+  | Feed1 Germs
+  deriving (Eq, Show)
+
+--NOTE  reify type environment
+$(pure [])
+
+instance ToNoun Feed where
+  toNoun = \case
+    Feed0 s -> $(deriveToNounFunc ''Seed) s
+    Feed1 s -> C (C (A 1) (A 0)) $ $(deriveToNounFunc ''Germs) s
+
+instance FromNoun Feed where
+  parseNoun = \case
+    (C (C (A 1) (A 0)) s) -> Feed1 <$> $(deriveFromNounFunc ''Germs) s
+    n                     -> Feed0 <$> $(deriveFromNounFunc ''Seed) n
+
 type Public = (Life, HoonMap Life Pass)
 
 data Dnses = Dnses { dPri::Cord, dSec::Cord, dTer::Cord }
@@ -145,6 +175,7 @@ data Dawn = MkDawn
 deriveNoun ''Dnses
 deriveNoun ''EthPoint
 deriveNoun ''Seed
+deriveNoun ''Germ
 deriveNoun ''Dawn
 
 
@@ -239,6 +270,16 @@ data BoatEv
 deriveNoun ''BoatEv
 
 
+-- Boat Events -----------------------------------------------------------------
+
+data JaelEv
+    = JaelEvRekey () (Life, Ring)
+    | JaelEvCrud Path Noun
+  deriving (Eq, Show)
+
+deriveNoun ''JaelEv
+
+
 -- Timer Events ----------------------------------------------------------------
 
 data BehnEv
@@ -313,6 +354,7 @@ data BlipEv
     | BlipEvBoat       BoatEv
     | BlipEvHttpClient HttpClientEv
     | BlipEvHttpServer HttpServerEv
+    | BlipEvJael       JaelEv
     | BlipEvNewt       NewtEv
     | BlipEvSync       SyncEv
     | BlipEvTerm       TermEv
@@ -335,6 +377,7 @@ instance ToNoun Ev where
     EvBlip v@BlipEvBoat{}       -> reorgThroughNoun ("clay", v)
     EvBlip v@BlipEvHttpClient{} -> reorgThroughNoun ("iris", v)
     EvBlip v@BlipEvHttpServer{} -> reorgThroughNoun ("eyre", v)
+    EvBlip v@BlipEvJael{}       -> reorgThroughNoun ("jael", v)
     EvBlip v@BlipEvNewt{}       -> reorgThroughNoun ("ames", v)
     EvBlip v@BlipEvSync{}       -> reorgThroughNoun ("clay", v)
     EvBlip v@BlipEvTerm{}       -> reorgThroughNoun ("dill", v)
@@ -362,6 +405,7 @@ getSpinnerNameForEvent = \case
         BlipEvBoat _           -> Just "boat"
         BlipEvHttpClient _     -> Just "iris"
         BlipEvHttpServer _     -> Just "eyre"
+        BlipEvJael _           -> Just "jael"
         BlipEvNewt _           -> Just "newt"
         BlipEvSync _           -> Just "clay"
         BlipEvTerm t | isRet t -> Nothing

--- a/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
+++ b/pkg/hs/urbit-king/lib/Urbit/Vere/Dawn.hs
@@ -335,45 +335,72 @@ retrievePoint endpoint block ship =
       [x] -> pure x
       _   -> error "JSON server returned multiple return values."
 
-validateShipAndGetSponsor :: String -> TextBlockNum -> Seed -> RIO e Ship
-validateShipAndGetSponsor endpoint block (Seed ship life ring oaf) =
-  case clanFromShip ship of
-    Ob.Comet -> validateComet
-    Ob.Moon  -> validateMoon
-    _        -> validateRest
+validateFeedAndGetSponsor :: String
+                          -> TextBlockNum
+                          -> Feed
+                          -> RIO e (Seed, Ship)
+validateFeedAndGetSponsor endpoint block = \case
+    Feed0 s -> do
+      r <- validateSeed s
+      case r of
+        Left e  -> error e
+        Right r -> pure (s, r)
+    Feed1 s -> validateGerms s
+
   where
-    validateComet = do
-      -- A comet address is the fingerprint of the keypair
-      let shipFromPass = cometFingerprint $ ringToPass ring
-      when (ship /= shipFromPass) $
-        error ("comet name doesn't match fingerprint " <> show ship <> " vs " <>
-              show shipFromPass)
-      when (life /= 1) $
-        error ("comet can never be re-keyed")
-      pure (shipSein ship)
+    validateGerms Germs{..} =
+      case gFeed of
+        []    -> error "no usable keys in keyfile"
+        (Germ{..}:f) -> do
+                  let seed = Seed gShip gLife gRing Nothing
+                  r :: Either String Ship
+                    <- validateSeed seed
+                  case r of
+                    Left _  -> validateGerms $ Germs gShip f
+                    Right r -> pure (seed, r)
 
-    validateMoon = do
-      -- TODO: The current code in zuse does nothing, but we should be able to
-      -- try to validate the oath against the current as exists planet on
-      -- chain.
-      pure $ shipSein ship
+    validateSeed (Seed ship life ring oaf) =
+      case clanFromShip ship of
+        Ob.Comet -> validateComet
+        Ob.Moon  -> validateMoon
+        _        -> validateRest
+      where
+        validateComet = do
+          -- A comet address is the fingerprint of the keypair
+          let shipFromPass = cometFingerprint $ ringToPass ring
+          if (ship /= shipFromPass) then
+            pure $ Left ("comet name doesn't match fingerprint " <>
+                         show ship <> " vs " <>
+                         show shipFromPass)
+          else if (life /= 1) then
+            pure $ Left "comet can never be re-keyed"
+          else
+            pure $ Right (shipSein ship)
 
-    validateRest = do
-      putStrLn ("boot: retrieving " <> renderShip ship <> "'s public keys")
+        validateMoon = do
+          -- TODO: The current code in zuse does nothing, but we should be able
+          -- to try to validate the oath against the current as exists planet
+          -- on chain.
+          pure $ Right $ shipSein ship
 
-      whoP <- retrievePoint endpoint block ship
-      case epNet whoP of
-        Nothing -> error "ship not keyed"
-        Just (netLife, pass, contNum, (hasSponsor, who), _) -> do
-          when (netLife /= life) $
-              error ("keyfile life mismatch; keyfile claims life " <>
-                    show life <> ", but Azimuth claims life " <>
-                    show netLife)
-          when ((ringToPass ring) /= pass) $
-              error "keyfile does not match blockchain"
-          -- TODO: The hoon code does a breach check, but the C code never
-          -- supplies the data necessary for it to function.
-          pure who
+        validateRest = do
+          putStrLn ("boot: retrieving " <> renderShip ship <> "'s public keys")
+
+          --TODO  could cache this lookup
+          whoP <- retrievePoint endpoint block ship
+          case epNet whoP of
+            Nothing -> pure $ Left "ship not keyed"
+            Just (netLife, pass, contNum, (hasSponsor, who), _) -> do
+              if (netLife /= life) then
+                pure $ Left ("keyfile life mismatch; keyfile claims life " <>
+                             show life <> ", but Azimuth claims life " <>
+                             show netLife)
+              else if ((ringToPass ring) /= pass) then
+                pure $ Left "keyfile does not match blockchain"
+              -- TODO: The hoon code does a breach check, but the C code never
+              -- supplies the data necessary for it to function.
+              else
+                pure $ Right who
 
 
 -- Walk through the sponsorship chain retrieving the actual sponsorship chain
@@ -402,8 +429,8 @@ getSponsorshipChain endpoint block = loop
             pure $ chain <> [(ship, ethPoint)]
 
 -- Produces either an error or a validated boot event structure.
-dawnVent :: HasLogFunc e => String -> Seed -> RIO e (Either Text Dawn)
-dawnVent provider dSeed@(Seed ship life ring oaf) =
+dawnVent :: HasLogFunc e => String -> Feed -> RIO e (Either Text Dawn)
+dawnVent provider feed =
   -- The type checker can't figure this out on its own.
   (onLeft tshow :: Either SomeException Dawn -> Either Text Dawn) <$> try do
     putStrLn ("boot: requesting ethereum information from " <> pack provider)
@@ -417,7 +444,8 @@ dawnVent provider dSeed@(Seed ship life ring oaf) =
     let dBloq = hexStrToAtom hexStrBlock
     putStrLn ("boot: ethereum block #" <> tshow dBloq)
 
-    immediateSponsor <- validateShipAndGetSponsor provider hexStrBlock dSeed
+    (dSeed, immediateSponsor)
+      <- validateFeedAndGetSponsor provider hexStrBlock feed
     dSponsor <- getSponsorshipChain provider hexStrBlock immediateSponsor
 
     putStrLn "boot: retrieving galaxy table"
@@ -431,7 +459,7 @@ dawnVent provider dSeed@(Seed ship life ring oaf) =
 
     let dNode = Nothing
 
-    pure $ MkDawn{..}
+    pure MkDawn{..}
 
 
 -- Comet List ------------------------------------------------------------------

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1289,7 +1289,8 @@
                      u3_noun who,                   //  identity
                      u3_noun ven,                   //  boot event
                      u3_noun pil,                   //  type-of/path-to pill
-                     u3_noun pax);                  //  path to pier
+                     u3_noun pax,                   //  path to pier
+                     u3_weak fed);                  //  extra private keys
 
       /* u3_pier_stay(): restart the new pier system.
       */
@@ -1334,7 +1335,7 @@
       /* u3_dawn_vent(): validated boot event
       */
         u3_noun
-        u3_dawn_vent(u3_noun seed);
+        u3_dawn_vent(u3_noun ship, u3_noun seed);
 
       /* u3_king_commence(): start the daemon
       */

--- a/pkg/urbit/vere/dawn.c
+++ b/pkg/urbit/vere/dawn.c
@@ -209,7 +209,10 @@ _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
   u3l_log("boot: invalid keys for %s '%s'\r\n", rac_c, how_c);
 
   // XX deconstruct sas, print helpful error messages
-  u3m_p("pre-boot error", u3t(sas));
+  while ( u3_nul != sas ) {
+    u3m_p("pre-boot error", u3h(sas));
+    sas = u3t(sas);
+  }
 
   u3z(how);
   c3_free(how_c);
@@ -310,7 +313,7 @@ _dawn_sponsor(u3_noun who, u3_noun rac, u3_noun pot)
   u3_noun uni = u3dc("sponsor:dawn", u3k(who), u3k(pot));
 
   if ( c3n == u3h(uni) ) {
-    _dawn_fail(who, rac, uni);
+    _dawn_fail(who, rac, u3nc(u3t(uni), u3_nul));
     return u3_none;
   }
 
@@ -324,11 +327,10 @@ _dawn_sponsor(u3_noun who, u3_noun rac, u3_noun pot)
 /* u3_dawn_vent(): validated boot event
 */
 u3_noun
-u3_dawn_vent(u3_noun seed)
+u3_dawn_vent(u3_noun ship, u3_noun feed)
 {
-  u3_noun url, bok, pos, pon, zar, tuf;
+  u3_noun url, bok, sed, pos, pon, zar, tuf;
 
-  u3_noun ship = u3k(u3h(seed));
   u3_noun rank = u3do("clan:title", u3k(ship));
 
   url = _dawn_purl(rank);
@@ -366,22 +368,17 @@ u3_dawn_vent(u3_noun seed)
       pot = u3v_wish("*point:azimuth");
     }
     else {
-      u3_noun who;
-
-      who = u3k(ship);
       u3l_log("boot: retrieving %s's public keys\r\n",
               u3_Host.ops_u.who_c);
 
       {
-        u3_noun oct = u3dc("point:give:dawn", u3k(bok), u3k(who));
+        u3_noun oct = u3dc("point:give:dawn", u3k(bok), u3k(ship));
         u3_noun luh = _dawn_eth_rpc(url_c, u3k(oct));
 
         pot = _dawn_need_unit(u3dc("point:take:dawn", u3k(ship), u3k(luh)),
                               "boot: failed to retrieve public keys");
         u3z(oct); u3z(luh);
       }
-
-      u3z(who);
     }
 
     //  +live:dawn: network state
@@ -392,13 +389,13 @@ u3_dawn_vent(u3_noun seed)
 
     u3l_log("boot: verifying keys\r\n");
 
-    //  (each sponsor=ship error=@tas)
+    //  (each seed (lest error=@tas))
     //
-    u3_noun sas = u3dt("veri:dawn", u3k(seed), u3k(pot), u3k(liv));
+    sed = u3dq("veri:dawn", u3k(ship), u3k(feed), u3k(pot), u3k(liv));
 
-    if ( u3_nul != sas ) {
+    if ( c3n == u3h(sed) ) {
       // bails, won't return
-      _dawn_fail(ship, rank, sas);
+      _dawn_fail(ship, rank, u3t(sed));
       return u3_none;
     }
 
@@ -458,7 +455,6 @@ u3_dawn_vent(u3_noun seed)
 
       son = _dawn_need_unit(u3dc("point:take:dawn", u3k(pos), u3k(luh)),
                             "boot: failed to retrieve sponsor keys");
-
       // append to sponsor chain list
       //
       pon = u3nc(u3nc(u3k(pos), u3k(son)), pon);
@@ -475,11 +471,14 @@ u3_dawn_vent(u3_noun seed)
     u3z(son);
   }
 
-  u3z(rank); u3z(pos); u3z(ship);
-
   //  [%dawn seed sponsors galaxies domains block eth-url snap]
   //
-  return u3nc(c3__dawn, u3nq(seed, pon, zar, u3nt(tuf, bok, url)));
+  u3_noun ven = u3nc(c3__dawn,
+                     u3nq(u3k(u3t(sed)), pon, zar, u3nt(tuf, bok, url)));
+
+  u3z(sed); u3z(rank); u3z(pos); u3z(ship); u3z(feed);
+
+  return ven;
 }
 
 /* _dawn_come(): mine a comet under a list of stars

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -159,7 +159,7 @@ _king_fake(u3_noun ship, u3_noun pill, u3_noun path)
   //  XX link properly
   //
   u3_noun vent = u3nc(c3__fake, u3k(ship));
-  u3K.pir_u    = u3_pier_boot(sag_w, ship, vent, pill, path);
+  u3K.pir_u    = u3_pier_boot(sag_w, ship, vent, pill, path, u3_none);
 }
 
 /* _king_come(): mine a comet under star (unit)
@@ -182,7 +182,7 @@ _king_slog(u3_noun hod)
 /* _king_dawn(): boot from keys, validating
 */
 void
-_king_dawn(u3_noun seed, u3_noun pill, u3_noun path)
+_king_dawn(u3_noun feed, u3_noun pill, u3_noun path)
 {
   // enable ivory slog printfs
   //
@@ -190,8 +190,10 @@ _king_dawn(u3_noun seed, u3_noun pill, u3_noun path)
 
   //  XX link properly
   //
-  u3_noun vent = u3_dawn_vent(seed);
-  u3K.pir_u = u3_pier_boot(sag_w, u3k(u3h(seed)), vent, pill, path);
+  //NOTE  +slav is safe because _boothack_key already verified it
+  u3_noun ship = u3dc("slav", 'p', u3i_string(u3_Host.ops_u.who_c));
+  u3_noun vent = u3_dawn_vent(u3k(ship), u3k(feed));
+  u3K.pir_u    = u3_pier_boot(sag_w, ship, vent, pill, path, feed);
 
   // disable ivory slog printfs
   //
@@ -378,7 +380,8 @@ _boothack_pill(void)
 static u3_noun
 _boothack_key(u3_noun kef)
 {
-  u3_noun seed, ship;
+  u3_noun seed;
+  u3_weak ship = u3_none;
 
   {
     u3_noun des = u3dc("slaw", c3__uw, u3k(kef));
@@ -390,19 +393,24 @@ _boothack_key(u3_noun kef)
       exit(1);
     }
 
-    //  +seed:able:jael: private key file
+    //  +feed:able:jael: keyfile
     //
     u3_noun pro = u3m_soft(0, u3ke_cue, u3k(u3t(des)));
     if ( u3_blip != u3h(pro) ) {
-      u3l_log("dawn: unable to cue private key\r\n");
+      u3l_log("dawn: unable to cue keyfile\r\n");
       exit(1);
     }
     seed = u3k(u3t(pro));
     u3z(pro);
 
-    //  local reference, not counted
+    //  if it's a single seed, we can trivially sanity-check early
     //
-    ship = u3h(seed);
+    if ( c3y == u3ud(u3h(seed)) ) {
+      //  local reference, not counted
+      //
+      ship = u3h(seed);
+    }
+
     u3z(des);
     u3z(kef);
   }
@@ -417,7 +425,9 @@ _boothack_key(u3_noun kef)
       exit(1);
     }
 
-    if ( c3n == u3r_sing(ship, u3t(whu)) ) {
+    if ( (u3_none != ship) &&
+         (c3n == u3r_sing(ship, u3t(whu))) )
+    {
       u3_noun how = u3dc("scot", 'p', u3k(ship));
       c3_c* how_c = u3r_string(u3k(how));
       u3l_log("dawn: mismatch between -w %s and -K %s\r\n",

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -1733,7 +1733,11 @@ _pier_pill_parse(u3_noun pil)
 /* _pier_boot_make(): construct boot sequence
 */
 static u3_boot
-_pier_boot_make(u3_noun who, u3_noun wyr, u3_noun ven, u3_noun pil)
+_pier_boot_make(u3_noun who,
+                u3_noun wyr,
+                u3_noun ven,
+                u3_noun pil,
+                u3_weak fed)
 {
   u3_boot bot_u = _pier_pill_parse(pil); // transfer
 
@@ -1757,6 +1761,20 @@ _pier_boot_make(u3_noun who, u3_noun wyr, u3_noun ven, u3_noun pil)
     bot_u.mod = u3nc(u3nc(wir, wyr), bot_u.mod);  // transfer [wir] and [wyr]
   }
 
+  //  include additional key configuration events if we have multiple keys
+  //
+  if ( (u3_none != fed) && (c3y == u3du(u3h(fed))) ) {
+    u3_noun wir = u3nt(c3__j, c3__seed, u3_nul);
+    u3_noun tag = u3i_string("rekey");
+    u3_noun kyz = u3t(u3t(fed));
+    while ( u3_nul != kyz ) {
+      u3_noun cad = u3nc(u3k(tag), u3k(u3h(kyz)));
+      bot_u.use = u3nc(u3nc(u3k(wir), cad), bot_u.use);
+      kyz = u3t(kyz);
+    }
+    u3z(tag); u3z(wir);
+  }
+
   //  prepend legacy boot event to the userspace sequence
   //
   {
@@ -1771,13 +1789,18 @@ _pier_boot_make(u3_noun who, u3_noun wyr, u3_noun ven, u3_noun pil)
     bot_u.use = u3nc(u3nc(wir, cad), bot_u.use);
   }
 
+  u3z(fed);
   return bot_u;
 }
 
 /* _pier_boot_plan(): construct and commit boot sequence
 */
 static c3_o
-_pier_boot_plan(u3_pier* pir_u, u3_noun who, u3_noun ven, u3_noun pil)
+_pier_boot_plan(u3_pier* pir_u,
+                u3_noun who,
+                u3_noun ven,
+                u3_noun pil,
+                u3_weak fed)
 {
   u3_boot bot_u;
   {
@@ -1785,7 +1808,7 @@ _pier_boot_plan(u3_pier* pir_u, u3_noun who, u3_noun ven, u3_noun pil)
     pir_u->fak_o = ( c3__fake == u3h(ven) ) ? c3y : c3n;
     u3r_chubs(0, 2, pir_u->who_d, who);
 
-    bot_u = _pier_boot_make(who, _pier_wyrd_card(pir_u), ven, pil);
+    bot_u = _pier_boot_make(who, _pier_wyrd_card(pir_u), ven, pil, fed);
     pir_u->lif_w = u3qb_lent(bot_u.bot);
   }
 
@@ -1860,7 +1883,8 @@ u3_pier_boot(c3_w  wag_w,                   //  config flags
              u3_noun who,                   //  identity
              u3_noun ven,                   //  boot event
              u3_noun pil,                   //  type-of/path-to pill
-             u3_noun pax)                   //  path to pier
+             u3_noun pax,                   //  path to pier
+             u3_weak fed)                   //  extra private keys
 {
   u3_pier* pir_u;
 
@@ -1872,7 +1896,7 @@ u3_pier_boot(c3_w  wag_w,                   //  config flags
 
   //  XX must be called from on_lord_live
   //
-  if ( c3n == _pier_boot_plan(pir_u, who, ven, pil) ) {
+  if ( c3n == _pier_boot_plan(pir_u, who, ven, pil, fed) ) {
     fprintf(stderr, "pier: boot plan fail\r\n");
     //  XX dispose
     //


### PR DESCRIPTION
As discussed with @belisarius222 and @ryjm yesterday, we want to make it easy to add glob data into ships without going through clay.

Other options include shipping an external script for sending the files into the ship (either eyre or kahn), and/or reviving `.urb/get`. The web interface here seems like the cheapest, least issue-prone, short-term option.  

@liam-fitzgerald please take a look at the docket behavior this triggers,

https://github.com/urbit/urbit/blob/72955838f214d00bb7b85a62bf14fdec619e0710/pkg/garden/app/docket.hoon#L391-L396

as well as the error cases that it tries to catch.

https://github.com/urbit/urbit/blob/72955838f214d00bb7b85a62bf14fdec619e0710/pkg/garden/app/docket.hoon#L380-L384

I have tested this in the sense that uploading works and error cases are caught, but I haven't tried using or sharing the resulting glob yet.

Would also love to get feedback on the terminology here ("globulator" is obviously temporary), as well as what instructions/direction (if any) should be displayed on the upload page.

(Note that the `/lib/multipart` here is copied straight from a personal project. It's been tested in the wild already, and seems to handle the multi-file upload case here without issue, even when including images and other binary files.)

If we think the upload page's logic is too big, we can probably factor it out into a separate file.