### PR TITLE
|ames-prod reset congestion control

### DIFF
--- a/pkg/arvo/gen/hood/ames-prod.hoon
+++ b/pkg/arvo/gen/hood/ames-prod.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  [^ ships=(list ship) ~]
+:-  %helm-ames-prod
+ships

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -142,6 +142,10 @@
     !!
   abet:(flog %text "< {<src.bowl>}: {(trip mes)}")
 ::
+++  poke-ames-prod
+  |=  ships=(list ship)
+  abet:(emit %pass /helm/prod %arvo %a %prod ships)
+::
 ++  poke-atom
   |=  ato=@
   =+  len=(scow %ud (met 3 ato))
@@ -195,6 +199,7 @@
 ++  poke
   |=  [=mark =vase]
   ?+  mark  ~|([%poke-helm-bad-mark mark] !!)
+    %helm-ames-prod        =;(f (f !<(_+<.f vase)) poke-ames-prod)
     %helm-ames-sift        =;(f (f !<(_+<.f vase)) poke-ames-sift)
     %helm-ames-verb        =;(f (f !<(_+<.f vase)) poke-ames-verb)
     %helm-ames-wake        =;(f (f !<(_+<.f vase)) poke-ames-wake)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -357,6 +357,7 @@
   ::
   ::    %born: process restart notification
   ::    %init: vane boot
+  ::    %prod: re-send a packet per flow, to all peers if .ships is ~
   ::    %sift: limit verbosity to .ships
   ::    %spew: set verbosity toggles
   ::    %trim: release memory
@@ -370,6 +371,7 @@
     ::
         $>(%born vane-task)
         $>(%init vane-task)
+        [%prod ships=(list ship)]
         [%sift ships=(list ship)]
         [%spew veb=(list verb)]
         [%stir arg=@t]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2615,7 +2615,7 @@
     |-  ^+  packet-pump
     ?:  =(0 sot)  packet-pump
     ?:  =(~ liv)  packet-pump
-    =^  hed  liv  (pop:packet-queue live.state)
+    =^  hed  liv  (pop:packet-queue liv)
     =.  packet-pump  (give %send (to-static-fragment hed))
     $(sot (dec sot))
   ::  +on-wake: handle packet timeout


### PR DESCRIPTION
Sometimes Ames waits for a couple minutes before re-sending a packet.  This is annoying, especially when debugging, so I added an `|ames-prod` generator that resets congestion control for all flows on the specified list of ships, or all ships if no argument.  This causes at least one packet to be re-sent on each open flow to each peer, and resets congestion control to initial values.

We should also fix Ames so it no longer has this problem, but sometimes you just want to tell the computer to send the packet already.

cc @philipcmonk, you might want to take quick lookover here too.