### PR TITLE
docket: download globs over ames

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+
 /* Examples
 
    Shared urbit and urbit-worker binaries:

--- a/pkg/base-dev/lib/docket.hoon
+++ b/pkg/base-dev/lib/docket.hoon
@@ -7,7 +7,8 @@
     $:  title=(unit @t)
         info=(unit @t)
         color=(unit @ux)
-        glob=(unit url)
+        glob-http=(unit url)
+        glob-ames=(unit =ship)
         base=(unit term)
         site=(unit path)
         image=(unit url)
@@ -28,8 +29,11 @@
     =/  href=(unit href)
       ?^  site.draft  `[%site u.site.draft]
       ?~  base.draft  ~
-      ?~  glob.draft  ~
-      `[%glob [u.base.draft [%http u.glob]:draft]]
+      ?^  glob-http.draft
+        `[%glob [u.base %http u.glob-http]:draft]
+      ?~  glob-ames.draft
+        ~
+      `[%glob [u.base %ship u.glob-ames]:draft]
     ?~  href  ~
     =,  draft
     :-  ~
@@ -56,7 +60,8 @@
         %title  draft(title `title.clause)
         %info   draft(info `info.clause)
         %color  draft(color `color.clause)
-        %glob   draft(glob `url.clause)
+        %glob-http   draft(glob-http `url.clause)
+        %glob-ames   draft(glob-ames `ship:clause)
         %base   draft(base `base.clause)
         %site   draft(site `path.clause)
         %image  draft(image `url.clause)
@@ -79,10 +84,12 @@
         ==
         ?~  image.d  ~  ~[image+u.image.d]
         ?:  ?=(%site -.href.d)  ~[site+path.href.d]
+        =/  loc=glob-location  glob-location.href.d
         :~  base+base.href.d
-            glob+url.glob-location.href.d
-        ==
-    ==
+            ?-  -.loc
+              %http  [%glob-http url.loc]
+              %ship  [%glob-ames ship.loc]
+    ==  ==  ==
   ::
   ++  spit-clause
     |=  =clause
@@ -91,6 +98,7 @@
     ?+  -.clause  "'{(trip +.clause)}'"
       %color  (scow %ux color.clause)
       %site   (spud path.clause)
+      %glob-ames  ~&  ship+ship.clause  "{(scow %p ship.clause)}"
       ::
         %version
       =,  version.clause
@@ -154,13 +162,27 @@
   ++  href
     |=  h=^href
     %+  frond  -.h
-    ?-  -.h
-      %glob  (pairs base+s+base.h ~)
-      %site  s+(spat path.h)
+    ?-    -.h
+        %site  s+(spat path.h)
+        %glob
+      %-  pairs
+      :~  base+s+base.h
+          glob-location+(glob-location glob-location.h)
+      ==
+    ==
+  ::
+  ++  glob-location
+    |=  loc=^glob-location
+    ^-  json
+    %+  frond  -.loc
+    ?-  -.loc
+      %http  (pairs url+s+url.loc ~)
+      %ship  (ship ship.loc)
     ==
   ::
   ++  charge
     |=  c=^charge
+    ~!  charge+charge
     %+  merge  (docket docket.c)
     %-  pairs
     :~  chad+(chad chad.c)

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -260,6 +260,15 @@
   ;<  ~  bind:m  (send-raw-card card)
   (take-watch-ack wire)
 ::
+++  watch-one
+  |=  [=wire =dock =path]
+  =/  m  (strand ,cage)
+  ^-  form:m
+  ;<  ~  bind:m  (watch wire dock path)
+  ;<  =cage  bind:m  (take-fact wire)
+  ;<  ~  bind:m  (take-kick wire)
+  (pure:m cage)
+::
 ++  watch-our
   |=  [=wire =term =path]
   =/  m  (strand ,~)

--- a/pkg/base-dev/sur/docket.hoon
+++ b/pkg/base-dev/sur/docket.hoon
@@ -10,6 +10,7 @@
 ::
 +$  glob-location
   $%  [%http =url]
+      [%ship =ship]
   ==
 ::  $href: Where a tile links to
 ::
@@ -45,7 +46,8 @@
   $%  [%title title=@t]
       [%info info=@t]
       [%color color=@ux]
-      [%glob url=cord]
+      [%glob-http url=cord]
+      [%glob-ames =ship]
       [%image =url]
       [%site =path]
       [%base base=term]

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -123,6 +123,17 @@
         [%charges ~]
       ?>  (team:title [our src]:bowl)
       `state
+    ::
+        [%glob @ ~]
+      ~&  path+path
+      =/  desk  (~(got by by-base) i.t.path)
+      =/  =charge  (~(got by charges) desk)
+      ~&  charge+charge
+      ?>  ?=(%glob -.chad.charge)
+      :_  state
+      :~  [%give %fact ~[path] %glob !>(`glob`glob.chad.charge)] ::
+          [%give %kick ~[path] ~]
+      ==
     ==
   [cards this]
 ::
@@ -348,11 +359,12 @@
   ++  new-chad  |=(c=chad (~(jab by charges) desk |=(charge +<(chad c))))
   ++  fetch-glob
     =/  =charge  (~(got by charges) desk)
+    ~&  charge+charge
     =/  tid=@t  (cat 3 'docket-' (scot %uv (sham (mix eny.bowl desk))))
     ?>  ?=(%glob -.href.docket.charge)
-    ?>  ?=(%http -.glob-location.href.docket.charge)
-    =*  url  url.glob-location.href.docket.charge
-    =/  =cage  spider-start+!>([~ `tid byk.bowl(r da+now.bowl) %glob !>(`url)])
+    =*  loc  glob-location.href.docket.charge
+    ~&  loc+loc
+    =/  =cage  spider-start+!>([~ `tid byk.bowl(r da+now.bowl) %glob !>(`[loc desk])])
     :~  (watch-our:(pass %glob) %spider /thread-result/[tid])
         (poke-our:(pass %glob) %spider cage)
     ==

--- a/pkg/garden/desk.docket
+++ b/pkg/garden/desk.docket
@@ -1,7 +1,8 @@
-:~  title+'Grid'
-    info+'An app launcher for urbit.'
+:~  title+'Garden'
+    info+'Test desc'
     color+0xee.5432
-    glob+'https://bootstrap.urbit.org/glob-0v2.j0idj.t8248.c4bfl.hvf09.ud4ns.glob'
+    ::glob-http+'https://bootstrap.urbit.org/glob-0v2.j0idj.t8248.c4bfl.hvf09.ud4ns.glob'
+    glob-ames+~zod
     base+'grid'
     version+[0 0 1]
     website+'https://tlon.io'

--- a/pkg/garden/ted/glob.hoon
+++ b/pkg/garden/ted/glob.hoon
@@ -5,13 +5,33 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<([~ url=cord] arg)
-;<  =glob:docket  bind:m
-  %+  (retry:strandio ,glob:docket)  `5
-  =/  n  (strand ,(unit glob:docket))
-  ;<  =cord  bind:n  (fetch-cord:strandio (trip url))
-  %-  pure:n
-  %-  mole
-  |.
-  ;;(=glob:docket (cue cord))
-(pure:m !>(glob))
+=+  !<([~ loc=glob-location:docket base=term] arg)
+|^
+?-  -.loc
+  %http  (fetch-http url.loc)
+  %ship  (fetch-ames ship.loc base)
+==
+::
+++  fetch-http
+  |=  url=cord
+  ^-  form:m
+  ;<  =glob:docket  bind:m
+    %+  (retry:strandio ,glob:docket)  `5
+    =/  n  (strand ,(unit glob:docket))
+    ;<  =cord  bind:n  (fetch-cord:strandio (trip url))
+    %-  pure:n
+    %-  mole
+    |.
+    ;;(=glob:docket (cue cord))
+  (pure:m !>(glob))
+::
+::  download from ship's docket state
+++  fetch-ames
+  |=  [=ship base=term]
+  ^-  form:m
+  ;<  =bowl:spider  bind:m  get-bowl:strandio
+  ;<  =cage  bind:m
+    (watch-one:strandio /glob/(scot %da now:bowl) [ship %docket] /glob/[base])
+  ?>  ?=(%glob p.cage)
+  (pure:m q.cage)
+--


### PR DESCRIPTION
Kind of a pain to test, need a better way to insert a `charge` directly.
Either that or rework `chad`, since it will cause the currently stored glob to be deleted when the desk.docket file is updated.

Open to some suggestions here.