### PR TITLE
http-api: add method to try to initialize from existing cookie

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -138,7 +138,7 @@ export class Urbit {
    * Try to use an existing session, for browser use only.
    *
    * This method will check that `window.ship` is set, and try to connect to the airlock
-   * at window.location.origin as window.ship.
+   * as window.ship.
    * (Generally one should include `<script src="/~landscape/js/session.js"></script>`
    * in e.g. the index.html file of a React app, in order to set window.ship).
    * If so, it will attempt to poke and initialize the event source in the same manner as 'authenticate'.
@@ -148,13 +148,10 @@ export class Urbit {
     if(!isBrowser) {
       throw('tryExistingSession is for browser use only');
     }
-    if(typeof window.location.origin === 'undefined') {
-      throw 'Cannot try existing session, window.location.origin is undefined';
-    }
     if(typeof (window as any).ship === 'undefined') {
       throw 'Cannot try existing session, window.ship is undefined';
     }
-    const airlock = new Urbit(window.location.origin);
+    const airlock = new Urbit(''); // Use a top-level relative URL for the channel
     airlock.verbose = verbose;
     airlock.ship = (window as any).ship;
     await airlock.eventSource();

--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -78,7 +78,7 @@ export class Urbit {
 
   onOpen?: () => void = null;
 
-  /** This is basic interpolation to get the cpokehannel URL of an instantiated Urbit connection. */
+  /** This is basic interpolation to get the channel URL of an instantiated Urbit connection. */
   private get channelUrl(): string {
     return `${this.url}/~/channel/${this.uid}`;
   }

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -137,6 +137,11 @@ export interface AuthenticationInterface {
   verbose?: boolean;
 }
 
+export interface ExistingSessionInterface {
+  verbose: boolean;
+  setGlobal: boolean;
+}
+
 /**
  * Subscription event handlers
  * 


### PR DESCRIPTION
(and session.js context)

(draft because not yet tested, would appreciate style/architecture comments)

Implements #5198

Provides a static method to initialize an `Urbit` airlock object based on the existing session cookies in a browser, and the `window.ship` property set by the dynamically generated `session.js`, thus allowing applications using the HTTP api to avoid
requiring a separate login step when loaded from a ship in an existing browser session.

It is intended that browser applications using react will add a static script tag

```html
<script src="/~landscape/js/session.js"></script>
```

This mechanism is currently used by the bitcoin wallet and Landscape to dynamically determine the ship name. 
An application which includes this script tag will then be able to invoke `await Urbit.tryExistingSession()` to receive an airlock object, which will connect to the `window.location.origin` as the base URL for the airlock. If either of the necessary properties (`window.location.origin` and `window.ship`) are undefined, or the context is not a browser, or if the initialization of the event source throws an exception, then `Urbit.tryExistingSession()` will throw an exception.