### PR TITLE
group-view: do not crash on rejoin

### DIFF
--- a/pkg/arvo/app/group-view.hoon
+++ b/pkg/arvo/app/group-view.hoon
@@ -193,7 +193,8 @@
   ++  jn-start
     |=  [rid=resource =^ship]
     ^+  jn-core
-    ?<  (~(has by joining) rid)
+    ?>  ?=  $@(~ [~ %done])
+            (bind (~(get by joining) rid) |=(request:view progress))
     =.  joining
       (~(put by joining) rid [%.n now.bowl ship %start])
     =.  jn-core


### PR DESCRIPTION
`%done` join requests no longer prevent a rejoin

Fixes urbit/landscape#1113