### PR TITLE
dist: fix update ordering in kiln, wire to UI

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -2,8 +2,8 @@
 /+  drum=hood-drum, helm=hood-helm, kiln=hood-kiln
 |%
 +$  state
-  $~  [%18 *state:drum *state:helm *state:kiln]
-  $>(%18 any-state)
+  $~  [%19 *state:drum *state:helm *state:kiln]
+  $>(%19 any-state)
 ::
 +$  any-state
   $%  [ver=?(%1 %2 %3 %4 %5 %6) lac=(map @tas fin-any-state)]
@@ -19,6 +19,7 @@
       [%16 drum=state-4:drum helm=state:helm kiln=state-3:kiln]
       [%17 drum=state-4:drum helm=state:helm kiln=state-4:kiln]
       [%18 drum=state-4:drum helm=state:helm kiln=state-5:kiln]
+      [%19 drum=state-4:drum helm=state:helm kiln=state-6:kiln]
   ==
 +$  any-state-tuple
   $:  drum=any-state:drum

--- a/pkg/arvo/mar/kiln/bump.hoon
+++ b/pkg/arvo/mar/kiln/bump.hoon
@@ -1,0 +1,23 @@
+|%
++$  bump  [%kiln-bump except=(set desk) force=_|]
+--
+|_  b=bump
+++  grab
+  |%
+  ++  noun  bump
+  ++  json
+    ^-  $-(^json bump)
+    =,  dejs:format
+    %+  pe  %kiln-bump
+    %-  ot
+    :~  except+(as so)
+        force+bo
+    ==
+  --
+++  grow
+  |%
+  ++  noun  b
+  --
+--
+        
+

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -202,11 +202,11 @@
         kelvin+(numb num.w)
     ==
   ::
-  ++  woof
-    |=  =rung
+  ++  rung
+    |=  r=^rung
     %-  pairs
-    :~  aeon+(numb aeon.rung)
-        weft+(weft weft.rung)
+    :~  aeon+(numb aeon.r)
+        weft+(weft weft.r)
     ==
   ::
   ++  rein
@@ -222,7 +222,7 @@
     :~  ship+s+(scot %p ship.rail.a)
         desk+s+desk.rail.a
         aeon+(numb aeon.rail.a)
-        next+a+(turn next.a woof)
+        next+a+(turn next.a rung)
         rein+(rein rein.a)
     ==
   --

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -1,6 +1,6 @@
 import { pick } from 'lodash-es';
 import React, { useCallback } from 'react';
-import { kilnSuspend } from '@urbit/api/hood';
+import { kilnBump } from '@urbit/api/hood';
 import { AppList } from '../../components/AppList';
 import { Button } from '../../components/Button';
 import { Dialog, DialogClose, DialogContent, DialogTrigger } from '../../components/Dialog';
@@ -49,9 +49,8 @@ export const BaseBlockedNotification = ({ notification }: BaseBlockedNotificatio
   const handlePauseOTAs = useCallback(() => {}, []);
 
   const handleArchiveApps = useCallback(async () => {
-    await Promise.all(desks.map((d) => api.poke(kilnSuspend(d))));
-    // TODO: retrigger OTA?
-  }, [desks]);
+    api.poke(kilnBump(true));
+  }, []);
 
   return (
     <section

--- a/pkg/npm/api/hood/lib.ts
+++ b/pkg/npm/api/hood/lib.ts
@@ -59,11 +59,16 @@ export function kilnRevive(
   };
 }
 
-export const kilnBump: Poke<any> = {
-  app: 'hood',
-  mark: 'kiln-bump',
-  json: null
-};
+export function kilnBump(force = false, except = [] as string[]) {
+  return {
+    app: 'hood',
+    mark: 'kiln-bump',
+    json: {
+      force,
+      except
+    }
+  };
+}
 
 export const scryLag: Scry = ({ app: 'hood', path: '/kiln/lag' });
 


### PR DESCRIPTION
When we receive the %mere gift from clay, the kernel has not yet been
reloaded. This means any attempts to bump desks will fail, as they will
be bumped against the old kernel. Rectifies this by continuing the %base
desk update flow in +on-load, instead of +take-merge-main. Also adds a
wef=(unit weft) to the state in order to discriminate whether or not the
kernel has just been reloaded

Also allows bumps to be triggered from the UI