### PR TITLE
btc-wallet: Fix decrement underflow in del-all-piym

### DIFF
--- a/pkg/arvo/app/btc-wallet.hoon
+++ b/pkg/arvo/app/btc-wallet.hoon
@@ -601,7 +601,7 @@
           %=  state
               pend.piym     (~(del by pend.piym) txid)
               ps.piym       (~(del by ps.piym) payer)
-              num-fam.piym  (~(put by num-fam.piym) payer (dec nf))
+              num-fam.piym  (~(put by num-fam.piym) payer (?:((gth nf 0) (dec nf) 0)))
           ==
         --
       ::


### PR DESCRIPTION
We were seeing the following error in dojo on btc-wallet:

```
poke failed from %btc-wallet on wire /~2021.9.11..15.13.04..989c
decrement-underflow
/app/btc-wallet/hoon:<[604 59].[604 67]>
/app/btc-wallet/hoon:<[604 29].[604 68]>
/app/btc-wallet/hoon:<[601 11].[605 13]>
/app/btc-wallet/hoon:<[600 11].[605 13]>
/app/btc-wallet/hoon:<[599 11].[605 13]>
/app/btc-wallet/hoon:<[576 20].[576 54]>
/app/btc-wallet/hoon:<[576 9].[580 11]>
/app/btc-wallet/hoon:<[574 9].[580 11]>
/app/btc-wallet/hoon:<[572 9].[580 11]>
/app/btc-wallet/hoon:<[571 9].[580 11]>
/app/btc-wallet/hoon:<[567 9].[580 11]>
/app/btc-wallet/hoon:<[566 9].[580 11]>
/app/btc-wallet/hoon:<[565 13].[580 11]>
/app/btc-wallet/hoon:<[565 9].[606 11]>
/app/btc-wallet/hoon:<[506 11].[506 36]>
/app/btc-wallet/hoon:<[505 9].[509 15]>
/app/btc-wallet/hoon:<[503 9].[509 15]>
/app/btc-wallet/hoon:<[502 7].[513 26]>
/app/btc-wallet/hoon:<[501 7].[630 9]>
/app/btc-wallet/hoon:<[500 7].[630 9]>
/app/btc-wallet/hoon:<[469 5].[654 7]>
/app/btc-wallet/hoon:<[468 5].[654 7]>
/app/btc-wallet/hoon:<[164 7].[164 42]>
/app/btc-wallet/hoon:<[163 7].[164 42]>
/app/btc-wallet/hoon:<[153 5].[165 7]>
/app/btc-wallet/hoon:<[152 3].[166 15]>
/app/btc-wallet/hoon:<[151 3].[655 5]>
/app/btc-wallet/hoon:<[150 3].[655 5]>
/sys/vane/gall/hoon:<[1.372 9].[1.372 37]>
```

Trying to decrement a number below 0 is no bueno. This is my first hoon PR, so feel free to tell me this is dumb.

cc @timlucmiptev @jalehman 
