### PR TITLE
kiln, gall: Fix removing agents from desk

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8972fd91602b0d2cca76ade229d11aaaca0bc3c89da53c42f4f12895190b4b2
-size 13762742
+oid sha256:f24c64caed01a0cd6cfc7c82cc540ad1da0c2fd8f4e5e858bae59407e2a90c75
+size 13881546

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -624,6 +624,12 @@
     ~>  %slog.0^leaf/"kiln: finished downloading update for {here}"
     =/  old-weft  `weft`[%zuse zuse]
     =/  new-weft  (read-kelvin-foreign [ship desk aeon]:rail.rak)
+    =?  vats  liv.rein.rak
+      =/  bill      (read-bill-foreign [ship desk aeon]:rail.rak)
+      =/  wan       (sy (get-apps-want bill rein.rak))
+      =/  hav       (sy (get-apps-live our loc now))
+      =/  ded       ~(tap in (~(dif in hav) wan))
+      (stop-dudes ded)
     =.  aeon.rail.rak  +(aeon.rail.rak)
     |^  ^+  vats
     ?:  =(%base loc)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -580,7 +580,10 @@
     =/  yok=(unit yoke)  (~(get by yokes.state) dap)
     ?~  yok
       ~>  %slog.[0 leaf+"gall: no agent to reload: {<dap>}"]
-      mo-core
+      cor
+    ?:  ?=(%| -.agent)
+      ~>  %slog.[0 leaf+"gall: dead agent reload: {<dap>}"]
+      cor
     =/  bek=beak  [our q.beak.u.yok p.sign-arvo]
     =/  rag  (mo-scry-agent-cage dap q.bek p.sign-arvo)
     ?:  ?=(%| -.rag)

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -112,6 +112,26 @@
   ?~  =<(fil .^(arch cy/pax))
     ~
   [~ .^(weft cx/pax)]
+::  +read-bill-foreign: read /desk/bill from a foreign desk
+::
+++  read-bill-foreign
+  |=  [=ship =desk =aeon]
+  ^-  bill
+  =/  her  (scot %p ship)
+  =/  syd  (scot %tas desk)
+  =/  yon  (scot %ud aeon)
+  ::
+  =/  dom  .^(dome cv/~[her syd yon])
+  =/  tak  (scot %uv (~(got by hit.dom) let.dom))
+  =/  yak  .^(yaki cs/~[her syd yon %yaki tak])
+  =/  lob  (scot %uv (~(got by q.yak) /desk/bill))
+  =/  bob  .^(blob cs/~[her syd yon %blob lob])
+  ::
+  ;;  bill
+  ?-  -.bob
+    %direct  q.q.bob
+    %delta   q.r.bob
+  ==
 ::  +read-bill: read contents of /desk/bill manifest
 ::
 ++  read-bill


### PR DESCRIPTION
A two-parter, designed to cleanup the flow of removing an agent from a desk

notes:
- |commiting straight into an installed desk still breaks.
- L583 returned `mo-cor` instead of `cor`. My understanding is that this will throw away all the previously executed iterations of the `roll`, but continue the iteration regardless. I believe this constitutes a bug and so changed it to return `cor`


kiln: kill agents before merge

If a remote commit is downloaded that simultaneously removes an agent from
desk.bill but also removes the associated source files, then the commit
will fail as gall will not have received the card to kill the agent yet.
Instead, we read our foreign copy of the bill in +take-download, and
kill any necessary agents there, preventing a reload of the deleted
agent from occurring.

gall: ignore reload for dead agents

Fixes a bug where even if an agent was dead, if its source was modified,
then gall would still attempt a scry for its cage.