### PR TITLE
dist: docket: improve upload page

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -337,31 +337,66 @@
     %-  as-octt:mimes:html
     %-  en-xml:html
     ^-  manx
+    ::  desks: with local globs, eligible for upload
+    ::
+    =/  desks=(list desk)
+      %+  murn  ~(tap by charges)
+      |=  [d=desk [docket *]]
+      ^-  (unit desk)
+      =-  ?:(- `d ~)
+      ?&  ?=(%glob -.href)
+          =([%ames our.bowl] glob-location.href)
+      ==
+    ::
     ;html
       ;head
         ;title:"%docket globulator"
         ;meta(charset "utf-8");
-        ;style:'* { font-family: monospace; margin-top: 1em; }'
+        ;style:'''
+               * { font-family: monospace; margin-top: 1em; }
+               li { margin-top: 0.5em; }
+               '''
       ==
       ;body
         ;h2:"%docket globulator"
         ;+  ?.  =(~ msg)
               :-  [%p ~]
               (join `manx`;br; (turn msg |=(m=@t `manx`:/"{(trip m)}")))
-            ;p:"ur on ur own kid, glhf"  ::TODO  instructions
-        ;form(method "post", enctype "multipart/form-data")
-          ::TODO  could be dropdown
-          ;input(type "text", name "desk", placeholder "desk");
-          ;br;
-          ;input
-            =type             "file"
-            =name             "glob"
-            =directory        ""
-            =webkitdirectory  ""
-            =mozdirectory     "";
-          ;br;
-          ;button(type "submit"):"Glob!"
-        ==
+            ;ol(start "0")
+              ;li:"""
+                  if necessary, create a desk whose desk.docket specifies
+                  a glob hosted on the local ship.
+                  """
+              ;li:"select the desk you want to upload the glob for."
+              ;li:"""
+                  select a directory containing the glob contents.
+                  usually contains at least an /index.html.
+                  """
+              ;li:"glob!"
+            ==
+        ;+  ?:  =(~ desks)
+              ;p:"no desks eligible for glob upload"
+            ;form(method "post", enctype "multipart/form-data")
+              ;label
+                ;+  :/"desk: "
+                ;select(name "desk")
+                  ;*  %+  turn  desks
+                      |=(d=desk =+((trip d) ;option(value -):"{-}"))
+                ==
+              ==
+              ;br;
+              ;label
+                ;+  :/"data: "
+                ;input
+                  =type             "file"
+                  =name             "glob"
+                  =directory        ""
+                  =webkitdirectory  ""
+                  =mozdirectory     "";
+              ==
+              ;br;
+              ;button(type "submit"):"glob!"
+            ==
       ==
     ==
   ::
@@ -375,9 +410,13 @@
       =/  =charge  (~(got by charges) desk)
       ::
       =?  err  =(~ glob)
-        ['no files for glob' err]
-      =?  err  ?=(%glob -.href.docket.charge)
+        ['no files in glob' err]
+      =?  err  !?=(%glob -.href.docket.charge)
         ['desk does not use glob' err]
+      =?  err  ?&  ?=(%glob -.href.docket.charge)
+                   !=([%ames our.bowl] glob-location.href.docket.charge)
+               ==
+        ['desk\'s glob not hosted here' err]
       ::
       ?.  =(~ err)
         :_  [~ state]


### PR DESCRIPTION
Most notably, we further restrict the desks eligible for glob upload
to just the ones whose glob is said to be hosted on the local ship.
I'm assuming this is correct and sane, because I'm having trouble imagining the flow/use of uploading a glob in the "uploaded glob for desk that says it gets glob from a remote location" cases.

On the upload page, we replace the desk input field with a dropdown
from which eligible desks can be selected.
Additionally we now display some instructions, instead of leaving
developers entirely on their own.

Looks like so:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/3829764/133278830-a7a58f61-de7b-4384-826f-de2e1259b234.png">

Or like so if there's no local-glob desks:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/3829764/133278870-7ae4590e-f067-483f-baae-3ba1f1d8d321.png">
