### PR TITLE
vere: windows fixes, refactoring for new terminal

### DIFF
--- a/pkg/urbit/compat/mingw/ptty.c
+++ b/pkg/urbit/compat/mingw/ptty.c
@@ -126,10 +126,10 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
       uty_u->wsz_f = _ttyf_get_winsize;
     }
   } else {
-    if ( 0 == (e = uv_pipe_init(lup_u, &uty_u->pin_u.pop_u, 0)) &&
-         0 == (e = uv_pipe_init(lup_u, &uty_u->pop_u.pop_u, 0)) &&
-         0 == (e = uv_pipe_open(&uty_u->pin_u.pop_u, 0)) &&
-         0 == (e = uv_pipe_open(&uty_u->pop_u.pop_u, 1)) )
+    if ( 0 == (e = uv_pipe_init(lup_u, &uty_u->pin_u.pip_u, 0)) &&
+         0 == (e = uv_pipe_init(lup_u, &uty_u->pop_u.pip_u, 0)) &&
+         0 == (e = uv_pipe_open(&uty_u->pin_u.pip_u, 0)) &&
+         0 == (e = uv_pipe_open(&uty_u->pop_u.pip_u, 1)) )
     {
       fprintf(stderr, "vere: running interactive in a terminal emulator is experimental\r\n"
                       "      use -t to disable interactivity or use native Windows console\r\n") ;

--- a/pkg/urbit/compat/mingw/uv.patch
+++ b/pkg/urbit/compat/mingw/uv.patch
@@ -15,6 +15,14 @@ index 0f2bb869b..f81245ec6 100644
      if (err == ERROR_ACCESS_DENIED) {
        /*
         * SetNamedPipeHandleState can fail if the handle doesn't have either
+@@ -1054,7 +1054,6 @@ static DWORD WINAPI uv_pipe_writefile_thread_proc(void* parameter) {
+   assert(req != NULL);
+   assert(req->type == UV_WRITE);
+   assert(handle->type == UV_NAMED_PIPE);
+-  assert(req->write_buffer.base);
+
+   result = WriteFile(handle->handle,
+                      req->write_buffer.base,
 diff --git a/src/win/tty.c b/src/win/tty.c
 index c359d5601..1b9d4f853 100644
 --- a/src/win/tty.c

--- a/pkg/urbit/compat/poor-mans-nix-shell.sh
+++ b/pkg/urbit/compat/poor-mans-nix-shell.sh
@@ -61,7 +61,7 @@ buildnixdep () {
         narinfo="$cache/${hash}.narinfo"
         if curl -fLI "$narinfo"
         then
-          url="$cache/$(curl -fL -H "Accept: application/json" "$narinfo"|jq -r '.url')"
+          url="$cache/$(curl -fL "$narinfo"|while IFS=: read k v; do if [ "$k" == "URL" ]; then echo $v; fi; done)"
           echo Found $url
           strip=0
           hash=

--- a/pkg/urbit/compat/posix/ptty.c
+++ b/pkg/urbit/compat/posix/ptty.c
@@ -147,10 +147,10 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
     return NULL;
   }
 
-  uv_pipe_init(lup_u, &uty_u->pin_u.pop_u, 0);
-  uv_pipe_init(lup_u, &uty_u->pop_u.pop_u, 0);
-  uv_pipe_open(&uty_u->pin_u.pop_u, 0);
-  uv_pipe_open(&uty_u->pop_u.pop_u, 1);
+  uv_pipe_init(lup_u, &uty_u->pin_u.pip_u, 0);
+  uv_pipe_init(lup_u, &uty_u->pop_u.pip_u, 0);
+  uv_pipe_open(&uty_u->pin_u.pip_u, 0);
+  uv_pipe_open(&uty_u->pop_u.pip_u, 1);
 
   //  Load old terminal state to restore.
   //

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -222,9 +222,8 @@
     /* u3_ustm: uv stream.
     */
       typedef union _u3_ustm {
-        uv_pipe_t  pop_u;
-        uv_tcp_t   wax_u;
-        uv_tty_t   tty_u;
+        uv_pipe_t pip_u;
+        uv_tty_t  tty_u;
       } u3_ustm;
 
     /* u3_ttyf: simple unix tty function.

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -342,25 +342,24 @@ _term_it_send_csi(u3_utty *uty_u, c3_c cmd_c, c3_w num_w, ...)
   //  argument digits (5 per arg) and separators (1 per arg, minus 1).
   //  freed via _term_it_write.
   //
-  c3_c* pas_c = malloc( sizeof(*pas_c) * (2 + num_w * 6) );
-  c3_c  was_c = 0;
+  c3_c* pas_c = c3_malloc( 2 + num_w * 6 );
+  c3_y  len_y = 0;
 
-  pas_c[was_c++] = '\033';
-  pas_c[was_c++] = '[';
+  pas_c[len_y++] = '\033';
+  pas_c[len_y++] = '[';
 
-  while ( num_w > 0 ) {
+  while ( num_w-- ) {
     c3_w par_w = va_arg(ap, c3_w);
-    was_c += sprintf(pas_c+was_c, "%d", par_w);
+    len_y += sprintf(pas_c+len_y, "%d", par_w);
 
-    if ( --num_w > 0 ) {
-      pas_c[was_c++] = ';';
+    if ( num_w ) {
+      pas_c[len_y++] = ';';
     }
   }
 
-  pas_c[was_c++] = cmd_c;
+  pas_c[len_y++] = cmd_c;
 
-  uv_buf_t pas_u = uv_buf_init(pas_c, was_c);
-  _term_it_write(uty_u, &pas_u, pas_c);
+  _term_it_send(uty_u, len_y, (c3_y*)pas_c);
 
   va_end(ap);
 }

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -298,7 +298,9 @@ static void
 _term_it_dump_buf(u3_utty*  uty_u,
                   uv_buf_t* buf_u)
 {
-  _term_it_write(uty_u, buf_u, 0);
+  if ( buf_u->len ) {
+    _term_it_write(uty_u, buf_u, 0);
+  }
 }
 
 /* _term_it_dump(): write static vector.
@@ -315,12 +317,17 @@ _term_it_dump(u3_utty*    uty_u,
 /* _term_it_send(): write dynamic vector, freeing pointer.
 */
 static void
-_term_it_send(u3_utty*    uty_u,
-              c3_w        len_w,
-              const c3_y* hun_y)
+_term_it_send(u3_utty* uty_u,
+              c3_w     len_w,
+              c3_y*    hun_y)
 {
-  uv_buf_t buf_u = uv_buf_init((c3_c*)hun_y, len_w);
-  _term_it_write(uty_u, &buf_u, (void*)hun_y);
+  if ( len_w ) {
+    uv_buf_t buf_u = uv_buf_init((c3_c*)hun_y, len_w);
+    _term_it_write(uty_u, &buf_u, (void*)hun_y);
+  }
+  else {
+    c3_free(hun_y);
+  }
 }
 
 /* _term_it_send_csi(): send csi escape sequence

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -97,9 +97,9 @@ u3_term_log_init(void)
     uty_u = c3_calloc(sizeof(u3_utty));
     uty_u->fid_i = 1;
 
-    uv_pipe_init(u3L, &(uty_u->pin_u.pop_u), 0);
-    uv_pipe_init(u3L, &(uty_u->pop_u.pop_u), 0);
-    uv_pipe_open(&(uty_u->pop_u.pop_u), uty_u->fid_i);
+    uv_pipe_init(u3L, &(uty_u->pin_u.pip_u), 0);
+    uv_pipe_init(u3L, &(uty_u->pop_u.pip_u), 0);
+    uv_pipe_open(&(uty_u->pop_u.pip_u), uty_u->fid_i);
   }
   else {
     //  Initialize event processing.  Rawdog it.


### PR DESCRIPTION
This PR fixes a crash on windows (under `-t`) by applying libuv/libuv#3302 (allowing null writes to `uv_pipe_t`). Additionally, it suppresses (most) null writes in `term.c`, and includes a little refactoring.

/cc @locpyl-tidnyd 