### PR TITLE
u3: replaces spurious bloq-size bail:exit's in +rap and +rep jets

### DIFF
--- a/pkg/urbit/jets/c/rap.c
+++ b/pkg/urbit/jets/c/rap.c
@@ -11,7 +11,7 @@
            u3_noun b)
   {
     if ( !_(u3a_is_cat(a)) || (a >= 32) ) {
-      return u3m_bail(c3__exit);
+      return u3m_bail(c3__fail);
     }
     else {
       c3_g       a_g = a;

--- a/pkg/urbit/jets/c/rep.c
+++ b/pkg/urbit/jets/c/rep.c
@@ -98,7 +98,7 @@ _block_rep(u3_atom a,
            u3_noun b)
 {
   if ( !_(u3a_is_cat(a)) || (a >= 32) ) {
-    return u3m_bail(c3__exit);
+    return u3m_bail(c3__fail);
   }
   else {
     c3_g       a_g = a;


### PR DESCRIPTION
This PR fixes a couple jet mismatches in bloq-size invariant handling.