### PR TITLE
hoon: correctly parse empty path

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5962,7 +5962,14 @@
 ++  spat  |=(pax=path (crip (spud pax)))                ::  render path to cord
 ++  spud  |=(pax=path ~(ram re (smyt pax)))             ::  render path to tape
 ++  stab  |=(zep=@t `path`(rash zep stap))              ::  parse cord to path
-++  stap  ;~(pfix fas (more fas urs:ab))                ::  path parser
+++  stap                                                ::  path parser
+  %+  sear
+    |=  p=path
+    ^-  (unit path)
+    ?:  ?=([~ ~] p)  `~
+    ?.  =(~ (rear p))  `p
+    ~
+  ;~(pfix fas (most fas urs:ab))
 ::
 ::::  4n: virtualization
   ::


### PR DESCRIPTION
And reject non-empty paths ending in empty segments.

The following cases were being parsed incorrectly:
- `/` represents the empty path, `~`. This was being parsed into `[~. ~]`
- `/x/` is not valid. This was being parsed into `[~.x ~. ~]`

This happens because `urs:ab` has no problem parsing the empty string.
For some supported cases, like `//x` (`[~. ~.x ~]`), this is actually desired
behavior, but it results in trailing empty segments for paths ending in `/`.

Here we apply a `+sear` on top of the existing parser, that transform the `/`
case to produce `~`, and ensures the absence of a trailing empty segment in
all other cases.

Note that we change `(more fas urs:ab)` to `(most fas urs:ab)`. Since `urs:ab`
parses the empty string, this doesn't actually make a difference, but it does
make it more obvious that the `+rear` call will never crash.

Alternative approaches I attempted all resulted in much more complicated
parser, so the dumb `+sear` seems preferable.
We do eat the performance cost of an additional list traversal (in `+rear`)
with this change, but that is probably not the end of the world.

If anyone can golf a cute smol parser that solves for this, I'd be happy to use that instead.

All tests seem to pass, but note that `/x/` was previously a valid path, and will no longer parse after this change. Luckily, `+stap` is used (directly & indirectly) in only a few places:
- parsing for some ford runes,
- `+pa:dejs:format` (currently only used in hark chat-hook parsing),
- eyre's `%subscribe` command parsing (which should arguably use `+pa:dejs` instead).
- scry & export path parsing in pier.c (for `-X`)

I believe none of these cases expect/care about trailing empty segments, and will continue to work fine with the new behavior.

Fixes #1501.