### PR TITLE
serf: fix incorrect conditional (integer precision) in event tracing

### DIFF
--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -572,7 +572,7 @@ _serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
 u3_noun
 u3_serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
 {
-  c3_t  tac_t = ( u3C.wag_w & u3o_trace );
+  c3_t  tac_t = !!( u3C.wag_w & u3o_trace );
   c3_c  lab_c[2056];
   u3_noun pro;
 


### PR DESCRIPTION
I had broken event labels in `-j` trace output in a previous refactoring.