### PR TITLE
azimuth: update for latest ecliptic address

### DIFF
--- a/pkg/arvo/lib/azimuth.hoon
+++ b/pkg/arvo/lib/azimuth.hoon
@@ -87,7 +87,7 @@
         0x223c.067f.8cf2.8ae1.73ee.5caf.ea60.ca44.c335.fecb
       ::
       ++  ecliptic
-        0x9ef2.7de6.1615.4ff8.b388.93c5.9522.b69c.7ba8.a81c
+        0xa5b6.109a.d2d3.5191.b3bc.32c0.0e45.26be.56fe.321f
       ::
       ++  linear-star-release
         0x86cd.9cd0.992f.0423.1751.e376.1de4.5cec.ea5d.1801


### PR DESCRIPTION
The upgrade hasn't triggered yet, but opening this so we don't forget.

Notably, the previous address change hasn't even made it to master yet. (^: