### PR TITLE
treaty: default to hardcoded ship instead of sponsor

### DIFF
--- a/pkg/arvo/mar/kiln/vats-diff.hoon
+++ b/pkg/arvo/mar/kiln/vats-diff.hoon
@@ -11,7 +11,7 @@
     ?-  -.diff
       %block  (block +.diff)
       ?(%merge-sunk %merge-fail)  (desk-arak-err +.diff)
-      ?(%reset %merge %suspend %revive)  (desk-arak +.diff)
+      ?(%reset %commit %suspend %revive)  (desk-arak +.diff)
     ==
     ::
     ++  block

--- a/pkg/base-dev/mar/ship.hoon
+++ b/pkg/base-dev/mar/ship.hoon
@@ -1,0 +1,13 @@
+|_  s=ship
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  s
+  ++  json  s+(scot %p s)
+  --
+++  grab
+  |%
+  ++  noun  ship
+  ++  json  (su:dejs:format ;~(pfix sig fed:ag))
+  --
+--

--- a/pkg/garden/app/treaty.hoon
+++ b/pkg/garden/app/treaty.hoon
@@ -1,6 +1,9 @@
 /-  docket, *treaty
 /+  default-agent, agentio, verb, dbug
 |%
+::  TODO: update before livenet deploy
+++  default-ally  ~zod
+::
 +$  card  card:agent:gall
 +$  state-0
   $:  treaties=(map [=ship =desk] treaty)
@@ -23,9 +26,8 @@
     pass  pass:io
     cc    ~(. +> bowl)
 ++  on-init  
-  =/  sponsor=ship  (sein:title [our now our]:bowl)
-  ?:  =(our.bowl sponsor)  `this
-  (on-poke %ally-update-0 !>([%add sponsor]))
+  ?:  =(our.bowl default-ally)  `this
+  (on-poke %ally-update-0 !>([%add default-ally]))
 ++  on-save  !>(state)
 ++  on-load
   |=  =vase
@@ -120,8 +122,9 @@
   |=  =path
   ^-  (unit (unit cage))
   ?+  path  (on-peek:def path)
-    [%x %alliance ~]  ``(alliance-update:cg:ca %ini entente)
-    [%x %allies ~]    ``(ally-update:cg:ca %ini allies)
+    [%x %alliance ~]      ``(alliance-update:cg:ca %ini entente)
+    [%x %default-ally ~]  ``ship+!>(default-ally)
+    [%x %allies ~]        ``(ally-update:cg:ca %ini allies)
   ::
      [%x %treaties @ ~]
     =/  =ship  (slav %p i.t.t.path)

--- a/pkg/garden/mar/ship.hoon
+++ b/pkg/garden/mar/ship.hoon
@@ -1,0 +1,1 @@
+../../base-dev/mar/ship.hoon

--- a/pkg/grid/src/app.tsx
+++ b/pkg/grid/src/app.tsx
@@ -49,7 +49,8 @@ const AppRoutes = () => {
   useEffect(() => {
     window.name = 'grid';
 
-    const { fetchAllies, fetchCharges } = useDocketState.getState();
+    const { fetchDefaultAlly, fetchAllies, fetchCharges } = useDocketState.getState();
+    fetchDefaultAlly();
     fetchCharges();
     fetchAllies();
     const { fetchVats, fetchLag } = useKilnState.getState();

--- a/pkg/grid/src/nav/search/Home.tsx
+++ b/pkg/grid/src/nav/search/Home.tsx
@@ -10,7 +10,7 @@ import { ProviderList } from '../../components/ProviderList';
 import { AppLink } from '../../components/AppLink';
 import { ShipName } from '../../components/ShipName';
 import { ProviderLink } from '../../components/ProviderLink';
-import { DocketWithDesk, useCharges } from '../../state/docket';
+import useDocketState, { DocketWithDesk, useCharges } from '../../state/docket';
 import { getAppHref } from '../../state/util';
 import useContactState from '../../state/contact';
 
@@ -75,7 +75,9 @@ export const Home = () => {
   const charges = useCharges();
   const groups = charges?.groups;
   const contacts = useContactState((s) => s.contacts);
-  const zod = { shipName: '~zod', ...contacts['~zod'] };
+  const defaultAlly = useDocketState((s) =>
+    s.defaultAlly ? { shipName: s.defaultAlly, ...contacts[s.defaultAlly] } : null
+  );
   const providerList = recentDevs.map((d) => ({ shipName: d, ...contacts[d] }));
 
   useEffect(() => {
@@ -125,15 +127,15 @@ export const Home = () => {
       {recentDevs.length === 0 && (
         <div className="min-h-[150px] p-6 rounded-xl bg-gray-50">
           <p className="mb-4">Urbit app developers you search for will be listed here.</p>
-          {zod && (
+          {defaultAlly && (
             <>
               <p className="mb-6">
-                Try out app discovery by visiting <ShipName name="~zod" /> below.
+                Try out app discovery by visiting <ShipName name={defaultAlly.shipName} /> below.
               </p>
               <ProviderLink
-                provider={zod}
+                provider={defaultAlly}
                 size="small"
-                onClick={() => addRecentDev(zod.shipName)}
+                onClick={() => addRecentDev(defaultAlly.shipName)}
               />
             </>
           )}

--- a/pkg/grid/src/state/docket.ts
+++ b/pkg/grid/src/state/docket.ts
@@ -9,6 +9,7 @@ import {
   scryAllies,
   scryAllyTreaties,
   scryCharges,
+  scryDefaultAlly,
   Treaty,
   Docket,
   Treaties,
@@ -40,7 +41,9 @@ interface DocketState {
   charges: ChargesWithDesks;
   treaties: Treaties;
   allies: Allies;
+  defaultAlly: string | null;
   fetchCharges: () => Promise<void>;
+  fetchDefaultAlly: () => Promise<void>;
   requestTreaty: (ship: string, desk: string) => Promise<Treaty>;
   fetchAllies: () => Promise<Allies>;
   fetchAllyTreaties: (ally: string) => Promise<Treaties>;
@@ -50,6 +53,11 @@ interface DocketState {
 }
 
 const useDocketState = create<DocketState>((set, get) => ({
+  defaultAlly: useMockData ? '~zod' : null,
+  fetchDefaultAlly: async () => {
+    const defaultAlly = await api.scry<string>(scryDefaultAlly);
+    set({ defaultAlly });
+  },
   fetchCharges: async () => {
     const charg = useMockData
       ? await fakeRequest(mockCharges)

--- a/pkg/npm/api/docket/lib.ts
+++ b/pkg/npm/api/docket/lib.ts
@@ -20,6 +20,11 @@ export const scryTreaties: Scry = {
   path: '/treaties'
 };
 
+export const scryDefaultAlly: Scry = {
+  app: 'treaty',
+  path: '/default-ally'
+};
+
 export const scryAllies: Scry = {
   app: 'treaty',
   path: '/allies'


### PR DESCRIPTION
- Our handling of 'allies' (treaty's term for a provider that allows app discovery), was inconsistent and incomplete. We previously used the ship sponsor, however this presents usability issues if the user's sponsor is offline, or doesn't maintain a useful list of apps. Additionally, we previously prompted to view ~zod's desks in the UI, if we didn't have any other allies to look at, which was inconsistent, because it should prompt for the sponsor, as they're the only ship that's guaranteed to be allied.
- No longer defaults to the sponsor, instead using a hardcoded ship name.
- Adjusts frontend to respect this hardcoded ship name

cc: @urcades 