### PR TITLE
urcrypt: argon2 only optimize for x86_64 on x86_64

### DIFF
--- a/pkg/urcrypt/Makefile.am
+++ b/pkg/urcrypt/Makefile.am
@@ -89,8 +89,18 @@ libargon2_la_SOURCES = argon2/src/core.h \
 		       argon2/src/core.c \
 		       argon2/src/blake2/blake2b.c \
 		       argon2/src/thread.c \
-		       argon2/src/encoding.c \
-		       argon2/src/opt.c
+		       argon2/src/encoding.c
+
+# argon2 different sources for different CPU architectures
+# opt.c requires SSE instructions and won't work on AArch64 et al.
+if ARCH_X86_64
+libargon2_la_SOURCES += \
+	argon2/src/opt.c
+endif
+if ARCH_GENERIC
+libargon2_la_SOURCES += \
+	argon2/src/ref.c
+endif
 
 # scrypt
 libscrypt_la_CPPFLAGS = -D_FORTIFY_SOURCE=2

--- a/pkg/urcrypt/configure.ac
+++ b/pkg/urcrypt/configure.ac
@@ -101,6 +101,17 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_CHECK_FUNCS([memset])
 
+# Checks for CPU architecture, uses SSE instructions if on X86_64
+AS_CASE([$host_cpu],
+    [x86_64], [ARCH=x86_64
+    AC_MSG_WARN("Architecture x86_64: Building libargon2 with optimizations")],
+    [ARCH=generic
+    AC_MSG_WARN("Architecture $host_cpu is not x86_64: Building libargon2 without optimizations")]
+)
+AC_SUBST([ARCH])
+AM_CONDITIONAL([ARCH_X86_64],  [test "$ARCH" = 'x86_64'])
+AM_CONDITIONAL([ARCH_GENERIC], [test "$ARCH" = 'generic'])
+
 # Finish and output
 AC_CONFIG_FILES([Makefile liburcrypt-$URCRYPT_API_VERSION.pc:liburcrypt.pc.in])
 AC_OUTPUT


### PR DESCRIPTION
fixes urcrypt's automake/autoconf files so that libargon2 will compile on architectures without SSE instructions, but x86_64 will still use the optimizations 