### PR TITLE
clay: fix failure to load apps

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -3404,6 +3404,19 @@
           [new-cach.rov fod.dom]
         (read-unknown mool.rov(case [%ud u.aeon.rov]) new-cach.rov)
       =.  new-cach.rov  n
+      ?:  ?&  !(complete old-cach.rov)
+              (complete new-cach.rov)
+          ==
+        :_  fod.dom  :-  %&
+        %-  malt
+        %+  murn  ~(tap in paths.mool.rov)
+        |=  [=care =path]
+        ^-  (unit [mood (unit (each cage lobe))])
+        =/  cached  (~(get by new-cach.rov) [care path])
+        ?.  ?=([~ ~ *] cached)
+          %-  (slog 'clay: strange new-cache' >[care path cached]< ~)
+          ~
+        `u=[[care [%ud let.dom] path] u.u.cached]
       ::  if they're still not both complete, wait again.
       ::
       ?.  ?&  (complete old-cach.rov)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -526,8 +526,7 @@
     ::
     ?>  ?=([%cor @ @ @ @ ~] path)
     =/  [dap=term her=@ta desk=@ta dat=@ta ~]  t.path
-    =/  tim  (slav da+dat)
-    =/  =beak  [(slav %p her) desk da+tim]
+    =/  =beak  [(slav %p her) desk da+now]
     ?>  ?=([?(%behn %clay) %writ *] sign-arvo)
     |^  ^+  mo-core
     ?~  p.sign-arvo
@@ -539,13 +538,13 @@
     ?:  ?=(%| -.res)
       (fail leaf+["gall: bad agent {<dap>}"] p.res)
     =.  mo-core  (mo-receive-core dap beak p.res)
-    (mo-subscribe-to-agent-builds tim)
+    (mo-subscribe-to-agent-builds now)
     ::
     ++  fail
       |=  =tang
       ^+  mo-core
       =.  mo-core  (mo-give %onto |+tang)
-      =/  =case  [%da tim]
+      =/  =case  [%da now]
       =/  =wire  /sys/cor/[dap]/[her]/[desk]/(scot case)
       (mo-pass wire %c %warp p.beak desk ~ %next %a case /app/[dap]/hoon)
     --


### PR DESCRIPTION
When you loaded an app with an error, then fixed the error, it would
create the main gall %mult subscription at a time in the past.  Then,
clay would never fill the subscription since it couldn't get the old %a
entries for the apps.

This fixes the issue in two ways:  first, don't subscribe in the past.
Second, if clay can't get the old versions, just fire the subscription
anyway.

@belisarius222 please merge or cherry-pick this into dist upon approval, so everything gets tested there.