### PR TITLE
kiln, docket: fix local installation

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -496,6 +496,10 @@
     ~>  %slog.0^leaf/"kiln: local install {here}"
     =.  vats  (update-running-apps (get-apps-diff our loc now rein.rak))
     =.  vats  (emit listen:pass)
+    ::NOTE  for foreign desks, the download triggers a "real" commit, because
+    ::      we actually download the data. for local desks we do not download
+    ::      any data, it's already there, so we emit a commit "manually".
+    =.  vats  (emit (diff:give %commit lac rak))
     vats
   ::  +reset: resync after failure
   ::

--- a/pkg/garden-dev/sur/docket.hoon
+++ b/pkg/garden-dev/sur/docket.hoon
@@ -24,6 +24,7 @@
 ::  $chad: State of a docket
 ::
 +$  chad
+  $~  [%install ~]
   $%  :: Done
       [%glob =glob]
       [%site ~]

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -602,7 +602,10 @@
     (poke-our:(pass %install) %hood kiln-install+!>([desk ship remote]))
   ++  uninstall
     (poke-our:(pass %uninstall) %hood kiln-uninstall+!>(desk))
-  ++  new-docket  |=(d=^docket (~(jab by charges) desk |=(charge +<(docket d))))
+  ++  new-docket
+    |=  d=^docket
+    %+  ~(put by charges)  desk
+    [d chad:(~(gut by charges) desk *charge)]
   ++  new-chad  |=(c=chad (~(jab by charges) desk |=(charge +<(chad c))))
   ++  fetch-glob
     ^-  (list card)


### PR DESCRIPTION
I noticed docket wasn't getting notified when I ran `|install our %something`. Turns out kiln just wasn't sending the `%commit` diffs that docket relied on in the local case.

Patched kiln to send a `%commit` during local install. Not entirely sure if this is the semantically correct change, please lmk.

Once kiln was sending the notifications, docket was crashing when trying to add the new docket to state, so patched that as well.