### PR TITLE
clay: print stacktrace on build failure

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4172,7 +4172,7 @@
       !:
       =-  ?:  ?=(%& -<)  p.-
           %.  [[~ ~] fod]
-          (slog leaf+"clay: read-at-aeon fail {<[desk=syd mun]>}" ~)
+          (slog leaf+"clay: read-at-aeon fail {<[desk=syd mun]>}" p.-)
       %-  mule  |.
       ?-  care.mun
           %d


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/1207