### PR TITLE
blockquote: Remove unnecessary log of quote contents

### DIFF
--- a/pkg/interface/src/views/landscape/components/Graph/blockquote.js
+++ b/pkg/interface/src/views/landscape/components/Graph/blockquote.js
@@ -1,6 +1,6 @@
 /*  eslint-disable */
 /** pulled from remark-parse
- * 
+ *
  *  critical change is that blockquotes require a newline to be continued, see
  *  the `if(!prefixed) conditional
  */
@@ -120,7 +120,6 @@ function blockquote(eat, value, silent) {
 
   exit = self.enterBlock()
   contents = self.tokenizeBlock(contents.join(lineFeed), now)
-  console.log(values);
   exit()
 
   const added = add({type: 'blockquote', children: contents})


### PR DESCRIPTION
`blockquote.js` included a call to log the contents of the blockquote to the console. If viewing a channel with many blockquotes it slightly spams your console.