### PR TITLE
graph-pull-hook: restore network connectivity

### DIFF
--- a/pkg/arvo/gen/kick.hoon
+++ b/pkg/arvo/gen/kick.hoon
@@ -2,6 +2,7 @@
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
         ~
-        ~
+        nice=?
+
     ==
-[%kick %kick]
+[%kick nice]

--- a/pkg/landscape/app/graph-pull-hook.hoon
+++ b/pkg/landscape/app/graph-pull-hook.hoon
@@ -1,5 +1,6 @@
 /-  *resource
 /+  store=graph-store, graph, default-agent, verb, dbug, pull-hook
+/+  agentio
 ~%  %graph-pull-hook-top  ..part  ~
 |%
 +$  card  card:agent:gall
@@ -40,7 +41,7 @@
   |=  =vase
   ?:  =(q.vase ~)
     :_  this
-    (poke-self:pass kick+!>(%kick))^~
+    (poke-self:pass kick+!>(%.y))^~
   `this
 ::
 ++  on-poke   on-poke:def

--- a/pkg/landscape/app/graph-pull-hook.hoon
+++ b/pkg/landscape/app/graph-pull-hook.hoon
@@ -12,6 +12,11 @@
       3  3
       %.n
   ==
++$  state-nul  ~
++$  state-0    [%0 ~]
++$  versioned-state
+  $%  state-0
+  ==
 --
 ::
 %-  agent:dbug
@@ -19,15 +24,25 @@
 ^-  agent:gall
 %-  (agent:pull-hook config)
 ^-  (pull-hook:pull-hook config)
+=|  state-0
+=*  state  -
 |_  =bowl:gall
 +*  this  .
     def   ~(. (default-agent this %|) bowl)
     dep   ~(. (default:pull-hook this config) bowl)
     gra   ~(. graph bowl)
+    io    ~(. agentio bowl)
+    pass  pass:io
 ::
 ++  on-init   on-init:def
-++  on-save   !>(~)
-++  on-load   on-load:def
+++  on-save   !>(state)
+++  on-load
+  |=  =vase
+  ?:  =(q.vase ~)
+    :_  this
+    (poke-self:pass kick+!>(%kick))^~
+  `this
+::
 ++  on-poke   on-poke:def
 ++  on-peek   on-peek:def
 ++  on-arvo   on-arvo:def

--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -648,11 +648,12 @@
     =/  =term   i.t.t.t.path
     =/  update-log
       (~(get by update-logs) [ship term])
-    ?~  update-log  [~ ~]
     :-  ~  :-  ~  :-  %noun
     !>
     ?+    t.t.t.t.path  (on-peek:def path)
-      ~  `update-log:store`u.update-log
+        ~  
+      ^-  update-log:store
+      ?~(update-log *update-log:store u.update-log)
     ::
         [%latest ~]
       ^-  (unit time)
@@ -662,6 +663,7 @@
     ::
         [%subset @ @ ~]
       ^-  update-log:store
+      ?~  update-log  *update-log:store
       =*  start  i.t.t.t.t.t.path
       =*  end    i.t.t.t.t.t.t.path
       %^  lot:orm-log

--- a/pkg/landscape/lib/pull-hook.hoon
+++ b/pkg/landscape/lib/pull-hook.hoon
@@ -250,7 +250,7 @@
                   diplomatic
               ==
             ~
-          (poke-self:pass kick+!>(%kick))^~
+          (poke-self:pass kick+!>(%.n))^~
         :_  this
         :(weld cards og-cards kick)
        ::
@@ -295,8 +295,9 @@
         ::
           %kick
         ?>  (team:title [our src]:bowl)
+        =+  !<(nice=? vase)
         =^  [cards=(list card:agent:gall) hook=_pull-hook]  state
-          restart-subs:hc
+          (restart-subs:hc nice)
         =.  pull-hook  hook
         [cards this]
       ::
@@ -386,6 +387,7 @@
       ver  ~(. versioning [bowl [update-mark version min-version]:config])
   ::
   ++  restart-subs
+    |=  nice=?
     =|  acc-cards=(list card)
     =/  subs=(list resource)
       ~(tap in ~(key by tracking))
@@ -394,7 +396,7 @@
       [[acc-cards pull-hook] state]
     =*  rid  i.subs
     =^  [crds=(list card) hook=_pull-hook]  state
-      tr-abet:tr-on-load:(tr-abed:track-engine rid)
+      tr-abet:(tr-on-load:(tr-abed:track-engine rid) nice)
     =.  pull-hook  hook
     $(subs t.subs, acc-cards (weld acc-cards crds))
 
@@ -431,6 +433,12 @@
       =^  caz  pull-hook
         (ap)
       (tr-emis caz)
+    ::
+    ++  tr-sane
+      ^-  ?
+      ?+  -.status  %.y
+        %active  (~(has by wex.bowl) [tr-sub-wire tr-sub-dock])
+      ==
     ::  +|  %sign: sign handling
     ::
     ::
@@ -539,10 +547,11 @@
       tr-core(status [%sub-ver ver])
     ::
     ++  tr-on-load
+      |=  nice=?
       ?+  -.status  tr-core
         %failed-kick  tr-restart
-        %active       tr-rewatch
-        ::
+        %active       ?:(&(tr-sane nice) tr-core tr-rewatch)
+      ::
           %sub-ver
         ?.  (supported:ver (append-version:ver ver.status))
           tr-core
@@ -576,11 +585,6 @@
     ++  tr-sub-dock
       ^-  dock
       [ship push-hook-name.config]
-    ::
-    ++  tr-check-sub
-      ?:  (~(has by wex.bowl) [tr-sub-wire tr-sub-dock])
-        tr-core
-      tr-kick
     ::
     ++  tr-watch-unver
       |=  pax=path
@@ -645,6 +649,11 @@
   ::
   ++  version-wir 
     (make-wire /version)
+  ::
+  ++  version-dock
+    |=  =ship
+    ^-  dock
+    [ship push-hook-name.config]
   ::
   ++  watch-version
     |=  =ship


### PR DESCRIPTION
- The pull hook renegotiation poke may have crashed during the software distribution OTA. This PR fixes this by rerunning the poke.
- Additionally adds a flag to the kick poke to specify the aggressiveness of renegotiations. 