### PR TITLE
jael: add %ruin task for pretend-breaching others

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1906,6 +1906,7 @@
         [%private-keys ~]                             ::  sub to privates
         [%public-keys ships=(set ship)]               ::  sub to publics
         [%rekey =life =ring]                          ::  update private keys
+        [%ruin ships=(set ship)]                      ::  pretend breach
         $>(%trim vane-task)                           ::  trim state
         [%turf ~]                                     ::  view domains
         $>(%vega vane-task)                           ::  report upgrade

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -489,6 +489,7 @@
     ::    [%trim p=@ud]
     ::
         %trim
+      ::TODO  consider %ruin-ing long-offline comets
       +>.$
     ::
     ::  watch private keys
@@ -521,6 +522,20 @@
         =.  moz  [[hen %give %done ~] moz]
         $(tac message)
       ==
+    ::
+    ::  pretend ships breached
+    ::    [%ruin ships=(set ship)]
+    ::
+        %ruin
+      ::NOTE  we blast this out to _all_ known ducts, because the common
+      ::      use case for this is comets, about who nobody cares.
+      =/  dus  ~(key by yen.zim.pki)
+      =/  sus  ~(. su hen now pki etn)
+      =/  sis  ~(tap in ships.tac)
+      |-
+      ?~  sis  (curd abet:sus)
+      =.  sus  (exec:sus dus %give %public-keys %breach i.sis)
+      $(sis t.sis)
     ==
   ::
   ++  take


### PR DESCRIPTION
The initial use case here is clearing state relating to long-gone
comets, but this could prove to be a useful general-purpose rescue tool.

@philipcmonk you used this successfully during rescue, right? Should we ship it as-is, or provide some integration/generator/whatever?