### PR TITLE
hood: report %kids desk hash in +report-vats

### DIFF
--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -65,8 +65,7 @@
   =+  .^  raz=(list vat)
           %gx  /(scot %p our)/hood/(scot %da now)/kiln/vats/noun
       ==
-  %+  weld
-    [(report-kids our now) ~]
+  :-  (report-kids our now)
   (turn raz |=(v=vat (report-vat our now v)))
 ::  +report-vat: report on a single desk installation
 ::

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -65,6 +65,8 @@
   =+  .^  raz=(list vat)
           %gx  /(scot %p our)/hood/(scot %da now)/kiln/vats/noun
       ==
+  %+  weld
+    [(report-kids our now) ~]
   (turn raz |=(v=vat (report-vat our now v)))
 ::  +report-vat: report on a single desk installation
 ::
@@ -103,6 +105,18 @@
       leaf/"source aeon:      {?~(rail.arak <~> <aeon.u.rail.arak>)}"
       leaf/"pending updates:  {pen}"
   ==
+::  +report-kids: non-vat cz hash report for kids desk
+::
+++  report-kids
+  |=  [our=ship now=@da]
+  ^-  tank
+  =/  dek  %kids
+  =/  ego  (scot %p our)
+  =/  wen  (scot %da now)
+  ?.  (~(has in .^((set desk) %cd /[ego]/base/[wen])) dek)
+    leaf/"no %kids desk"
+  =+  .^(hash=@uv %cz /[ego]/[dek]/[wen])
+  leaf/"%kids %cz hash:     {<hash>}"
 ::  +read-kelvin-foreign: read /sys/kelvin from a foreign desk
 ::
 ++  read-kelvin-foreign

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -112,7 +112,7 @@
   =/  dek  %kids
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
-  ?.  (~(has in .^((set desk) %cd /[ego]/base/[wen])) dek)
+  ?.  (~(has in .^((set desk) %cd /[ego]//[wen])) dek)
     leaf/"no %kids desk"
   =+  .^(hash=@uv %cz /[ego]/[dek]/[wen])
   leaf/"%kids %cz hash:     {<hash>}"


### PR DESCRIPTION
`+vats` / `+trouble` are generators that simply print the output of the `+report-vats` arm of sur/hood/hoon.

@philipcmonk asked for the kids hash to be printed as well.