### PR TITLE
docket: better glob upload handling

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -510,6 +510,12 @@
       [[404^~ ~] [~ state]]
     ::
     =;  [desk=@ta =glob err=(list @t)]
+      =*  error-result
+        :_  [~ state]
+        [[400 ~] `(upload-page err)]
+      ::
+      ?.  =(~ err)  error-result
+      ::
       =*  cha      ~(. ch desk)
       =/  =charge  (~(got by charges) desk)
       ::
@@ -518,9 +524,7 @@
       =?  err  !?=(%glob -.href.docket.charge)
         ['desk does not use glob' err]
       ::
-      ?.  =(~ err)
-        :_  [~ state]
-        [[400 ~] `(upload-page err)]
+      ?.  =(~ err)  error-result
       :-  [[200 ~] `(upload-page 'successfully globbed' ~)]
       ?>  ?=(%glob -.href.docket.charge)
       ::

--- a/pkg/garden/lib/multipart.hoon
+++ b/pkg/garden/lib/multipart.hoon
@@ -37,7 +37,7 @@
   ++  cut   (jest 'Content-Type: ')
   ++  dim   (jest (cat 3 '--' del))
   ++  nip   (jest '\0d\0a')
-  ++  nab   (more fas urs:ab)
+  ++  nab   (more fas (cook (cury rap 3) (plus qit)))
   ++  nag   (dine ;~(less ;~(plug nip dim) next))
   ++  nod   (dine ;~(less doq next))
   ++  nom   (dine alp)


### PR DESCRIPTION
Herein we improve docket's glob upload behavior by making it more receptive to non-standard content-types, and having it show error messages early instead of continuing on with potentially bad data.

See commit messages for additional details. Fixes #5282.