### PR TITLE
u3: fix big noun equality

### DIFF
--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -333,7 +333,7 @@ _cr_sing_cape_test(u3p(u3h_root) har_p, u3_noun a, u3_noun b)
   u3t_on(euq_o);
 
   u3z(key);
-  return ( u3_none == val ) ? c3y : c3n;
+  return ( u3_none != val ) ? c3y : c3n;
 }
 
 /* _cr_sing_cape_keep(): store [a] and [b] to short-circuit subsequent tests.


### PR DESCRIPTION
Large nearly-identical nouns were reported as equal due to a bug
introduced in e389220d1889e80a20c5cb2e8f9bd5cf279629c9.  This fixes that.

The bug was noticed when small changes were made to files and they
didn't register as changes to clay's %a subscribers.

Fixes #5285