### PR TITLE
kiln: refresh dudes on local reinstall

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -551,8 +551,8 @@
     =.  vats  (abed lac)
     ?^  rail.rak
       go
-    ~>  %slog.(fmt "{<lac>} already installed locally, ignoring")
-    vats
+    ~>  %slog.(fmt "{<lac>} already installed locally, refreshing")
+    update-running-dudes
     ::
     ++  go
       =.  loc  lac


### PR DESCRIPTION
This should fix a bug where after uninstalling and reinstalling a desk locally, the agents would not be jolted back to life.