### PR TITLE
interface: safer de-sigging

### DIFF
--- a/pkg/interface/src/logic/lib/group.ts
+++ b/pkg/interface/src/logic/lib/group.ts
@@ -1,4 +1,4 @@
-import { Path, PatpNoSig } from '@urbit/api';
+import { deSig, Path, PatpNoSig } from '@urbit/api';
 import { Group, Resource, roleTags, RoleTags } from '@urbit/api/groups';
 import _ from 'lodash';
 
@@ -36,7 +36,7 @@ export function isWriter(group: Group, resource: string) {
 }
 
 export function isChannelAdmin(group: Group, resource: string, ship = `~${window.ship}`) {
-  const role = roleForShip(group, ship.slice(1));
+  const role = roleForShip(group, deSig(ship));
 
   return (
     isHost(resource, ship) ||

--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -501,7 +501,7 @@ const DM_REGEX = /ship\/~([a-z]|-)*\/dm--/;
 export function getItemTitle(association: Association): string {
   if (DM_REGEX.test(association.resource)) {
     const [, , ship, name] = association.resource.split('/');
-    if (ship.slice(1) === window.ship) {
+    if (deSig(ship) === window.ship) {
       return cite(`~${name.slice(4)}`);
     }
     return cite(ship);

--- a/pkg/interface/src/logic/state/graph.ts
+++ b/pkg/interface/src/logic/state/graph.ts
@@ -54,7 +54,7 @@ const useGraphState = createState<GraphState>('Graph', (set, get) => ({
     const promise = airlock.poke(poke);
     const pending = clone(poke);
     markPending(pending.json['add-nodes'].nodes);
-    pending.json['add-nodes'].resource.ship = pending.json['add-nodes'].resource.ship.slice(1);
+    pending.json['add-nodes'].resource.ship = deSig(pending.json['add-nodes'].resource.ship);
     GraphReducer({
       'graph-update': pending.json
     });
@@ -65,7 +65,7 @@ const useGraphState = createState<GraphState>('Graph', (set, get) => ({
     const promise = airlock.thread(thread);
     const { body } = clone(thread);
     markPending(body['add-nodes'].nodes);
-    body['add-nodes'].resource.ship = body['add-nodes'].resource.ship.slice(1);
+    body['add-nodes'].resource.ship = deSig(body['add-nodes'].resource.ship);
     GraphReducer({
       'graph-update': body,
       'graph-update-flat': body,
@@ -78,7 +78,7 @@ const useGraphState = createState<GraphState>('Graph', (set, get) => ({
     const promise = airlock.thread(thread);
     const { body } = clone(thread);
     markPending(body['add-nodes'].nodes);
-    body['add-nodes'].resource.ship = body['add-nodes'].resource.ship.slice(1);
+    body['add-nodes'].resource.ship = deSig(body['add-nodes'].resource.ship);
     GraphReducer({
       'graph-update': body,
       'graph-update-flat': body,

--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -1,4 +1,4 @@
-import { Content, createPost, fetchIsAllowed, Post, removePosts } from '@urbit/api';
+import { Content, createPost, fetchIsAllowed, Post, removePosts, deSig } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
 import { BigInteger } from 'big-integer';
 import React, {
@@ -115,14 +115,14 @@ const fetchMessages = useCallback(async (newer: boolean) => {
         pageSize,
         `/${index.toString()}`
       );
-      return expectedSize !== getCurrGraphSize(ship.slice(1), name);
+      return expectedSize !== getCurrGraphSize(deSig(ship), name);
     } else {
       const index = graph.peekSmallest()?.[0];
       if (!index) {
         return false;
       }
       await getOlderSiblings(ship, name, pageSize, `/${index.toString()}`);
-      const currSize = getCurrGraphSize(ship.slice(1), name);
+      const currSize = getCurrGraphSize(deSig(ship), name);
       console.log(currSize);
       const done = expectedSize !== currSize;
       return done;

--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -1,4 +1,4 @@
-import { acceptDm, cite, Content, declineDm, Post, removeDmMessage } from '@urbit/api';
+import { acceptDm, cite, Content, declineDm, deSig, Post, removeDmMessage } from '@urbit/api';
 import React, { useCallback, useEffect } from 'react';
 import _ from 'lodash';
 import bigInt from 'big-integer';
@@ -59,7 +59,7 @@ export function DmResource(props: DmResourceProps) {
   const { hideNicknames } = useSettingsState(selectCalmState);
   const showNickname = !hideNicknames && Boolean(contact);
   const nickname = showNickname ? contact!.nickname : cite(ship) ?? ship;
-  const pending = useGraphState(s => s.pendingDms.has(ship.slice(1)));
+  const pending = useGraphState(s => s.pendingDms.has(deSig(ship)));
 
   const [
     getYoungerSiblings,

--- a/pkg/interface/src/views/apps/links/LinkResource.tsx
+++ b/pkg/interface/src/views/apps/links/LinkResource.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, Col, LoadingSpinner, Text } from '@tlon/indigo-react';
-import { Group } from '@urbit/api';
+import { deSig, Group } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
 import bigInt from 'big-integer';
 import React, { useEffect } from 'react';
@@ -31,7 +31,7 @@ export function LinkResource(props: LinkResourceProps) {
   const associations = useMetadataState(state => state.associations);
 
   const [, , ship, name] = rid.split('/');
-  const resourcePath = `${ship.slice(1)}/${name}`;
+  const resourcePath = `${deSig(ship)}/${name}`;
   const resource: any = associations.graph[rid]
     ? associations.graph[rid]
     : { metadata: {} };

--- a/pkg/interface/src/views/apps/links/LinkWindow.tsx
+++ b/pkg/interface/src/views/apps/links/LinkWindow.tsx
@@ -1,5 +1,5 @@
 import { Box, Col, Text } from '@tlon/indigo-react';
-import { Association, Graph, Group } from '@urbit/api';
+import { Association, deSig, Graph, Group } from '@urbit/api';
 import bigInt, { BigInteger } from 'big-integer';
 import React, {
   Component, ReactNode
@@ -73,7 +73,7 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
           >
             <LinkSubmit
               name={name}
-              ship={ship.slice(1)}
+              ship={deSig(ship)}
             />
           </Col>
           { typeof post !== 'string' && <LinkItem {...linkProps} /> }
@@ -109,7 +109,7 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
           {this.canWrite() ? (
             <LinkSubmit
               name={name}
-              ship={ship.slice(1)}
+              ship={deSig(ship)}
             />
           ) : (
             <Text>

--- a/pkg/interface/src/views/apps/permalinks/app.tsx
+++ b/pkg/interface/src/views/apps/permalinks/app.tsx
@@ -1,4 +1,4 @@
-import { Association, GraphConfig } from '@urbit/api';
+import { Association, deSig, GraphConfig } from '@urbit/api';
 import React, { useCallback } from 'react';
 import {
   Redirect, Route, Switch
@@ -76,7 +76,7 @@ function GroupRoutes(props: { group: string; url: string }) {
           if(!association) {
             return null;
           }
-          if(!graphKeys.has(`${ship.slice(1)}/${name}`)) {
+          if(!graphKeys.has(`${deSig(ship)}/${name}`)) {
             if(graphKeys.size > 1) { // TODO: Better loading logic see https://github.com/urbit/landscape/issues/1063
               return <Redirect
                 to={toQuery(

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -1,5 +1,5 @@
 import { BaseAnchor, Box, BoxProps, Button, Center, Col, H3, Icon, Image, Row, Text } from '@tlon/indigo-react';
-import { Association, GraphNode, resourceFromPath, GraphConfig, Treaty } from '@urbit/api';
+import { Association, GraphNode, resourceFromPath, GraphConfig, Treaty, deSig } from '@urbit/api';
 import React, { useCallback, useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Link, useLocation } from 'react-router-dom';
@@ -83,7 +83,7 @@ function GraphPermalink(
   const location = useLocation();
   const { ship, name } = resourceFromPath(graph);
   const node = useGraphState(
-    useCallback(s => s.looseNodes?.[`${ship.slice(1)}/${name}`]?.[index] as GraphNode, [
+    useCallback(s => s.looseNodes?.[`${deSig(ship)}/${name}`]?.[index] as GraphNode, [
       graph,
       index
     ])

--- a/pkg/interface/src/views/apps/publish/components/NotebookRoutes.tsx
+++ b/pkg/interface/src/views/apps/publish/components/NotebookRoutes.tsx
@@ -1,6 +1,6 @@
 import { Center, LoadingSpinner } from '@tlon/indigo-react';
 import {
-  Association
+  Association, deSig
 } from '@urbit/api';
 import bigInt from 'big-integer';
 import React, { useEffect } from 'react';
@@ -31,7 +31,7 @@ export function NotebookRoutes(
 
   const graphs = useGraphState(state => state.graphs);
 
-  const graph = graphs[`${ship.slice(1)}/${book}`];
+  const graph = graphs[`${deSig(ship)}/${book}`];
 
   const groups = useGroupState(state => state.groups);
 

--- a/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/GroupChannelPicker.tsx
@@ -4,7 +4,7 @@ import {
   Text,
   StatelessToggleSwitchField
 } from '@tlon/indigo-react';
-import { Association, GraphConfig, resourceFromPath } from '@urbit/api';
+import { Association, deSig, GraphConfig, resourceFromPath } from '@urbit/api';
 import { useField } from 'formik';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
@@ -53,7 +53,7 @@ function GroupWithChannels(props: { association: Association }) {
   const joinedGraphs = useGraphState(s => s.graphKeys);
   const joinedGroupGraphs = _.pickBy(graphs, (_, graph: string) => {
     const { ship, name } = resourceFromPath(graph);
-    return joinedGraphs.has(`${ship.slice(1)}/${name}`);
+    return joinedGraphs.has(`${deSig(ship)}/${name}`);
   });
 
   const [open, setOpen] = useState(false);

--- a/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
+++ b/pkg/interface/src/views/landscape/components/ChannelPopoverRoutes/ChannelPermissions.tsx
@@ -5,7 +5,7 @@ import {
 
     Text
 } from '@tlon/indigo-react';
-import { addTag, Association, Group, PermVariation, removeTag, metadataEdit } from '@urbit/api';
+import { addTag, Association, Group, PermVariation, removeTag, metadataEdit, deSig } from '@urbit/api';
 import { Form, Formik } from 'formik';
 import _ from 'lodash';
 import React from 'react';
@@ -79,7 +79,7 @@ export function GraphPermissions(props: GraphPermissionsProps) {
   );
 
   let [, , hostShip] = association.resource.split('/');
-  hostShip = hostShip.slice(1);
+  hostShip = deSig(hostShip);
 
   const writePerms =
     writers.size === 0

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Admin.tsx
@@ -5,7 +5,7 @@ import {
     Text
 } from '@tlon/indigo-react';
 import _ from 'lodash';
-import { changePolicy, Enc } from '@urbit/api';
+import { changePolicy, deSig, Enc } from '@urbit/api';
 import { Group, GroupPolicy } from '@urbit/api/groups';
 import { Association, metadataEdit, MetadataEditField } from '@urbit/api/metadata';
 import { Form, Formik, FormikHelpers } from 'formik';
@@ -96,7 +96,7 @@ export function GroupAdminSettings(props: GroupAdminSettingsProps) {
   };
 
   const disabled =
-    resourceFromPath(association.group).ship.slice(1) !== window.ship &&
+    deSig(resourceFromPath(association.group).ship) !== window.ship &&
     roleForShip(group, window.ship) !== 'admin';
   if(disabled)
 return null;

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Channels.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Channels.tsx
@@ -1,5 +1,5 @@
 import { Col, Icon, Row, Text } from '@tlon/indigo-react';
-import { Association, Group, metadataRemove, metadataEdit } from '@urbit/api';
+import { Association, Group, metadataRemove, metadataEdit, deSig } from '@urbit/api';
 import React, { useCallback } from 'react';
 import { resourceFromPath, roleForShip } from '~/logic/lib/group';
 import { getModuleIcon, GraphModule } from '~/logic/lib/util';
@@ -36,7 +36,7 @@ export function GroupChannelSettings(props: GroupChannelSettingsProps) {
   );
 
   const disabled =
-    resourceFromPath(association.group).ship.slice(1) !== window.ship &&
+    deSig(resourceFromPath(association.group).ship) !== window.ship &&
     roleForShip(group, window.ship) !== 'admin';
   return (
     <Col maxWidth="384px" width="100%">

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupSettings.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Col, Text } from '@tlon/indigo-react';
+import { deSig } from '@urbit/api';
 import { Group } from '@urbit/api/groups';
 import { Association } from '@urbit/api/metadata';
 import React, { useCallback } from 'react';
@@ -28,7 +29,7 @@ export function GroupSettings(props: GroupSettingsProps) {
   );
 
   const isOwner =
-    resourceFromPath(props.association.group).ship.slice(1) === window.ship;
+    deSig(resourceFromPath(props.association.group).ship) === window.ship;
 
   const isAdmin =
     isOwner || roleForShip(props.group, window.ship) === 'admin';

--- a/pkg/interface/src/views/landscape/components/Home/GroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/GroupFeed.tsx
@@ -1,5 +1,5 @@
 import { Col } from '@tlon/indigo-react';
-import { markCountAsRead } from '@urbit/api';
+import { deSig, markCountAsRead } from '@urbit/api';
 import React, {
   useEffect
 } from 'react';
@@ -35,7 +35,7 @@ function GroupFeed(props) {
   const graphTimesentMap = useGraphState(state => state.graphTimesentMap);
 
   const pendingSize = Object.keys(
-    graphTimesentMap[`${graphResource.ship.slice(1)}/${graphResource.name}`] ||
+    graphTimesentMap[`${deSig(graphResource.ship)}/${graphResource.name}`] ||
     {}
   ).length;
 
@@ -44,7 +44,7 @@ function GroupFeed(props) {
 
   const history = useHistory();
 
-  const graphId = `${graphResource.ship.slice(1)}/${graphResource.name}`;
+  const graphId = `${deSig(graphResource.ship)}/${graphResource.name}`;
   const graph = graphs[graphId];
 
   useEffect(() => {

--- a/pkg/interface/src/views/landscape/components/Home/Post/PostThread.tsx
+++ b/pkg/interface/src/views/landscape/components/Home/Post/PostThread.tsx
@@ -10,7 +10,7 @@ import { arrToString } from '@urbit/api/lib/BigIntArrayOrderedMap';
 import useGraphState from '~/logic/state/graph';
 import PostFlatFeed from './PostFlatFeed';
 import PostInput from './PostInput';
-import { Association, PermVariation } from '@urbit/api';
+import { Association, deSig, PermVariation } from '@urbit/api';
 import { useParams, Switch, Route } from 'react-router';
 import { useGroupForAssoc } from '~/logic/state/group';
 
@@ -68,7 +68,7 @@ export default function PostThread(props: PostThreadProps) {
     getFirstborn(ship, name, `/${index.map(i => i.toString()).join('/')}`);
   }, [association.resource, index]);
 
-  const graphId = `${ship.slice(1)}/${name}`;
+  const graphId = `${deSig(ship)}/${name}`;
   const threadGraph = useGraphState(useCallback(s => s.threadGraphs[graphId] || {}, [graphId]));
 
   const shouldRenderFeed = arrToString(index) in threadGraph;

--- a/pkg/interface/src/views/landscape/components/Participants.tsx
+++ b/pkg/interface/src/views/landscape/components/Participants.tsx
@@ -9,6 +9,7 @@ import {
 import { Contact, Contacts } from '@urbit/api/contacts';
 import { addTag, removeMembers, changePolicy, Group, removeTag, RoleTags } from '@urbit/api/groups';
 import { Association } from '@urbit/api/metadata';
+import { deSig } from '@urbit/api';
 import _ from 'lodash';
 import f from 'lodash/fp';
 import React, {
@@ -62,11 +63,11 @@ const emptyContact = (patp: string, pending: boolean): Participant => ({
 
 function getParticipants(cs: Contacts, group: Group) {
   const contacts: Participant[] = _.flow(
-    f.omitBy<Contacts>((_c, patp) => !group.members.has(patp.slice(1))),
+    f.omitBy<Contacts>((_c, patp) => !group.members.has(deSig(patp))),
     f.toPairs,
     f.map(([patp, c]: [string, Contact]) => ({
       ...c,
-      patp: patp.slice(1),
+      patp: deSig(patp),
       pending: false
     }))
   )(cs);

--- a/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
+++ b/pkg/interface/src/views/landscape/components/PopoverRoutes.tsx
@@ -1,5 +1,6 @@
 import { Box, Col, Text } from '@tlon/indigo-react';
 import { Group } from '@urbit/api/groups';
+import { deSig } from '@urbit/api';
 import { Association } from '@urbit/api/metadata';
 import React, { ReactElement, useCallback, useRef } from 'react';
 import { Link, Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -28,8 +29,8 @@ export function PopoverRoutes(
   useHashLink();
 
   const groupSize = props.group.members.size;
-
-  const owner = resourceFromPath(props.association?.group ?? '~zod/group').ship.slice(1) === window.ship;
+  const ship = resourceFromPath(props.association?.group ?? '//~zod/group').ship;
+  const owner = deSig(ship) === window.ship;
 
   const admin = props.group?.tags?.role?.admin.has(window.ship) || false;
 

--- a/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/Apps.tsx
@@ -1,4 +1,4 @@
-import { Graphs, UnreadStats } from '@urbit/api';
+import { deSig, Graphs, UnreadStats } from '@urbit/api';
 import { useCallback } from 'react';
 import { SidebarAppConfig } from './types';
 
@@ -10,7 +10,7 @@ export function useGraphModule(
   const getStatus = useCallback(
     (s: string) => {
       const [, , host, name] = s.split('/');
-      const graphKey = `${host.slice(1)}/${name}`;
+      const graphKey = `${deSig(host)}/${name}`;
       if (!graphKeys.has(graphKey)) {
         return 'unsubscribed';
       }

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarItem.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { useRef, ReactNode } from 'react';
 import urbitOb from 'urbit-ob';
 import { Icon, Row, Box, Text, BaseImage } from '@tlon/indigo-react';
-import { Association, cite } from '@urbit/api';
+import { Association, cite, deSig } from '@urbit/api';
 import { HoverBoxLink } from '~/views/components/HoverBox';
 import { Sigil } from '~/logic/lib/sigil';
 import { useTutorialModal } from '~/views/components/useTutorialModal';
@@ -18,7 +18,7 @@ import useGraphState from '~/logic/state/graph';
 
 function useAssociationStatus(resource: string) {
   const [, , ship, name] = resource.split('/');
-  const graphKey = `${ship.slice(1)}/${name}`;
+  const graphKey = `${deSig(ship)}/${name}`;
   const isSubscribed = useGraphState(s => s.graphKeys.has(graphKey));
   const stats = useHarkStat(`/graph/~${graphKey}`);
   const { count, each } = stats;


### PR DESCRIPTION
This tries to switch all cases where we are de-sigging a ship to use the safer `deSig` from the @urbit/api pkg. 
This should hopefully address: 
- urbit/landscape#1230
- urbit/landscape#1231
- urbit/landscape#1232
- urbit/landscape#1247
- urbit/landscape#1257