### PR TITLE
%base: add %mounts thread to list current mounts

### DIFF
--- a/pkg/arvo/ted/mounts.hoon
+++ b/pkg/arvo/ted/mounts.hoon
@@ -1,0 +1,16 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+?.  ?=(~ q.arg)
+  (strand-fail:strand %has-arg ~)
+;<  ~  bind:m  (send-raw-card:strandio %pass /mounts %arvo %c %boat ~)
+;<  res=[=wire sign=sign-arvo]  bind:m  take-sign-arvo:strandio
+?.  ?=([%mounts ~] wire.res)
+  (strand-fail:strand %bad-wire ~)
+?.  ?=([%clay %hill *] sign.res)
+  (strand-fail:strand %bad-sign ~)
+(pure:m !>(`(set @tas)`(silt p.sign.res)))


### PR DESCRIPTION
currently there's no way to get a list of mount points from the dojo. You can look in your pier but occassionally there's some weirdness and you're not sure if something is mounted or not. Also if you mount something other than a whole desk named as itself it's sometimes mildly confusing as to what is its correct `%name` to unmount it.

This thread is run like `-mounts` with no args and spits out a `(set @tas)` of the mount points.