### PR TITLE
gen: make |ota useful again

### DIFF
--- a/pkg/arvo/gen/hood/ota.hoon
+++ b/pkg/arvo/gen/hood/ota.hoon
@@ -8,11 +8,11 @@
   ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=?(~ [%disable ~] [her=@p sud=@tas ~]) ~]
+        arg=?([%disable ~] [her=@p sud=?(~ [@tas ~])])
+        ~
     ==
-?~  arg
-  :-  %kiln-ota-info  ~
-:-  %kiln-ota
+:-  %kiln-install
 ?:  ?=([%disable ~] arg)
-  ~
-`[her sud]:arg
+  [%base p.bec %base]
+:+  %base  her.arg
+?@(sud.arg %kids -.sud.arg)


### PR DESCRIPTION
As an alias for installing into the base desk. Defaults to the remote
ship's %kids desk if no desk is specified.

(Note that the use of `%disabled` here, along with the optionality of the desk field, requires that the desk be explicitly specified when sourcing your otas from `~dozwet-timdec-sigted-dibtep`. I assume that this is not, in practice, a problem.)