### PR TITLE
system-prefs: fixing non-null assertion errors on null rail

### DIFF
--- a/pkg/grid/src/nav/preferences/SystemUpdatePrefs.tsx
+++ b/pkg/grid/src/nav/preferences/SystemUpdatePrefs.tsx
@@ -13,7 +13,7 @@ export const SystemUpdatePrefs = () => {
   );
   const base = useVat('base');
   const otasEnabled = base && !(base.arak?.rail?.paused ?? true);
-  const otaSource = base && base.arak.rail!.ship!;
+  const otaSource = base && base.arak.rail?.ship;
 
   const toggleBase = useCallback((on: boolean) => toggleOTAs('base', on), [toggleOTAs]);
 


### PR DESCRIPTION
I think non-null assertion is not working like we think you can see an example in the TS playground in this [link to repro](https://www.typescriptlang.org/play?#code/C4TwDgpgBASghgSwDZQLxQN4Cgq6gZwAsEwAuA4AJwQDsBzKAHyhoFckkBuLAXyy1CQoAQUpwA1mkw48Y5OXjImLdl179B0AEJx80dNjxQ4Y8eVETufLAGMA9jXzAoAI10RyOvVMN4TE8l8jXDkkcjYOGVw+a3tHZ3w7VkobfVd3KAAyTPS9ADp-cTzQgEI8ohIS-jjEpAg8pDs6AApE5NSASk4gA)

Seems like it doesn't actually do runtime checks to guard against nulls.

This addresses urbit/landscape#1265, urbit/landscape#1275, urbit/landscape#1278