### PR TITLE
Revert "btc-wallet: import pre-dist settings as needed"

### DIFF
--- a/pkg/bitcoin/app/btc-wallet.hoon
+++ b/pkg/bitcoin/app/btc-wallet.hoon
@@ -24,7 +24,6 @@
     $%  state-0
         state-1
         state-2
-        state-3
     ==
 ::
 +$  state-0
@@ -58,9 +57,8 @@
 ::
 +$  state-1  [%1 base-state]
 +$  state-2  [%2 base-state]
-+$  state-3  [%3 base-state]
 --
-=|  state-3
+=|  state-2
 =*  state  -
 %-  agent:dbug
 ^-  agent:gall
@@ -85,7 +83,7 @@
   :-  cards
   %_  this
       state
-    :*  %3
+    :*  %2
         ~
         *(map xpub:bc walt)
         *^btc-state
@@ -112,37 +110,8 @@
   =|  cards=(list card)
   |-
   ?-  -.ver
-      %3
-    [cards this(state ver)]
-  ::
       %2
-    =-  $(-.ver %3, cards (weld cards -))
-    ^-  (list card)
-    =/  bas=path  /(scot %p our.bowl)/settings-store/(scot %da now.bowl)
-    ?.  .^(? %gu bas)
-      ~&  [dap.bowl %settings-store-mia]
-      ~
-    ?.  .^(? %gx (weld bas /has-bucket/landscape/btc-wallet/noun))
-      ~
-    =/  dat
-      .^(data:settings %gx (weld bas /bucket/landscape/btc-wallet/noun))
-    ?>  ?=(%bucket -.dat)
-    |^  :-  =/  del=event:settings  [%del-bucket %landscape %btc-wallet]
-            (poke-our:hc %settings-store %settings-event !>(del))
-        %-  zing
-        %+  turn  ~(tap by bucket.dat)
-        (cork copy-if-missing drop)
-    ::
-    ++  copy-if-missing
-      |=  [=key:settings =val:settings]
-      ^-  (unit card)
-      =/  hav=?
-        .^(? %gx (weld bas /has-entry/[q.byk.bowl]/btc-wallet/[key]/noun))
-      ?:  hav  ~
-      ~&  [dap.bowl %importing-previous-setting key]
-      =/  put=event:settings  [%put-entry q.byk.bowl %btc-wallet key val]
-      `(poke-our:hc %settings-store %settings-event !>(put))
-    --
+    [cards this(state ver)]
   ::
       %1
     =?  cards  ?=(^ prov.ver)
@@ -895,7 +864,7 @@
     ::
         %tx-info
       ::  TODO: why do we get a nest-fail when using =^ ?
-      =/  [cards=(list card) sty=state-3]
+      =/  [cards=(list card) sty=state-2]
         (handle-tx-info:hc info.p.upd)
       :_  sty
       :_  cards


### PR DESCRIPTION
Reverts #5311 until we get around to doing https://github.com/urbit/urbit/pull/5311#issuecomment-944316198. Non-stepwise OTAs strike again.