### PR TITLE
landscape: fix failing scry causing messages to be improperly validated

### DIFF
--- a/pkg/landscape/lib/signatures.hoon
+++ b/pkg/landscape/lib/signatures.hoon
@@ -33,6 +33,8 @@
         ,deed=[a=life b=pass c=(unit @ux)]
         our  %deed  now  /(scot %p q.signature)/(scot %ud r.signature)
       ==
+  ::  if signature is from a past life, skip validation
+  ::  XX: should be visualised on frontend, not great.
   ?.  =(a.deed r.signature)  %.y
   ::  verify signature from ship at life
   ::


### PR DESCRIPTION
If we received a graph-node with that was signed by a past or future
life of a ship, then we would potentially crash scrying for the public
keys. Now, if there is a mismatch between lives, we simply no-op and
treat the signature as valid.