### PR TITLE
gall: add +on-rift arm to agents

### DIFF
--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -383,6 +383,7 @@
       ==
     [cards this]
   ::
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -119,6 +119,7 @@
         (handle-wake:ac wen)
       [cards this]
     ==
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -165,5 +165,6 @@
   ==
 ::
 ++  on-arvo   on-arvo:def
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -83,6 +83,7 @@
   ++  on-watch  on-watch:def
   ++  on-leave  on-leave:def
   ++  on-arvo   on-arvo:def
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -75,6 +75,7 @@
   ++  on-peek   on-peek:def
   ++  on-leave  on-leave:def
   ++  on-agent  on-agent:def
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/dns-collector.hoon
+++ b/pkg/arvo/app/dns-collector.hoon
@@ -150,5 +150,6 @@
 ::
 ++  on-agent  on-agent:def
 ++  on-arvo   on-arvo:def
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1669,6 +1669,8 @@
         %http-response  (he-http-response:he-full t.wire +>.sign-arvo)
     ==
   [moves ..on-init]
+::
+++  on-rift  |=(ship `..on-init)
 ::  if dojo fails unexpectedly, kill whatever each session is working on
 ::
 ++  on-fail

--- a/pkg/arvo/app/eth-sender.hoon
+++ b/pkg/arvo/app/eth-sender.hoon
@@ -114,6 +114,7 @@
   ++  on-watch  on-watch:def
   ++  on-leave  on-leave:def
   ++  on-arvo   on-arvo:def
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -474,5 +474,6 @@
     this(dogs.state (~(put by dogs.state) path dog))
   ==
 ::
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -171,6 +171,7 @@
   ++  on-peek   on-peek:def
   ++  on-watch  on-watch:def
   ++  on-leave  on-leave:def
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/herm.hoon
+++ b/pkg/arvo/app/herm.hoon
@@ -72,5 +72,6 @@
 ++  on-leave  on-leave:def
 ++  on-peek   on-peek:def
 ++  on-agent  on-agent:def
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -45,7 +45,6 @@
     helm-core  (helm bowl helm.state)
     kiln-core  (kiln bowl kiln.state)
 ::
-++  on-fail   on-fail:def
 ++  on-init
   ^-  step:agent:gall
   =^  d  drum.state  on-init:drum-core
@@ -123,4 +122,7 @@
     [%helm *]  =^(c helm.state (take-arvo:helm-core t.wire syn) [c this])
     [%kiln *]  =^(c kiln.state (take-arvo:kiln-core t.wire syn) [c this])
   ==
+::
+++  on-rift   on-rift:def
+++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/language-server.hoon
+++ b/pkg/arvo/app/language-server.hoon
@@ -106,6 +106,7 @@
       ==
     [cards this]
   ::
+  ++  on-rift   on-rift:def
   ++  on-fail   on-fail:def
   --
 ::

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -275,5 +275,6 @@
     (on-arvo:def wire sign-arvo)
   [~ this]
 ::
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -225,5 +225,6 @@
     on-init
   ==
 ::
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/shoe.hoon
+++ b/pkg/arvo/app/shoe.hoon
@@ -40,6 +40,7 @@
 ++  on-peek   on-peek:def
 ++  on-agent  on-agent:def
 ++  on-arvo   on-arvo:def
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 ::
 ++  command-parser

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -307,6 +307,8 @@
         [%bind ~]      `state
       ==
     [cards this]
+  ::
+  ++  on-rift   on-rift:def
   ::  On unexpected failure, kill all outstanding strands
   ::
   ++  on-fail

--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -150,5 +150,7 @@
       ?:(gen-ok.state %all-generators-built %some-generators-failed)
     [~ this]
   ==
+::
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/app/time.hoon
+++ b/pkg/arvo/app/time.hoon
@@ -33,5 +33,7 @@
     ~&  [%took `@dr`(sub now.bowl (slav %da i.wire))]
     [~ this]
   ==
+::
+++  on-rift   on-rift:def
 ++  on-fail   on-fail:def
 --

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1757,6 +1757,10 @@
         |~  [wire sign-arvo]
         *(quip card _^|(..on-init))
       ::
+      ++  on-rift
+        |~  ship
+        *(quip card _^|(..on-init))
+      ::
       ++  on-fail
         |~  [term tang]
         *(quip card _^|(..on-init))

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -161,7 +161,11 @@
       =-  :_  ->
           %+  welp
             (skip -< |=(move ?=([* %give %onto *] +<)))
-          [^duct %pass /whiz/gall %$ %whiz ~]~
+          :~  [^duct %pass /whiz/gall %$ %whiz ~]
+            ::
+              ::NOTE  also done in +init, but idempotent
+              [system-duct.state %pass /sys/era %j %public-keys ~]
+          ==
       =/  adult  adult-core
       =.  state.adult
         [%8 system-duct outstanding contacts yokes=~ blocked]:spore
@@ -459,7 +463,7 @@
         (~(gut by outstanding.state) [wire hen] *(qeu remote-request))
       (~(put by outstanding.state) [wire hen] (~(put to stand) -.deal))
     (mo-pass wire note-arvo)
-  ::  +mo-track-ship: subscribe to ames and jael for notices about .ship
+  ::  +mo-track-ship: subscribe to ames for notices about .ship
   ::
   ++  mo-track-ship
     |=  =ship
@@ -474,11 +478,6 @@
     ::  ask ames to track .ship's connectivity
     ::
     =.  moves  [[system-duct.state %pass /sys/lag %a %heed ship] moves]
-    ::  ask jael to track .ship's breaches
-    ::
-    =/  =note-arvo  [%j %public-keys (silt ship ~)]
-    =.  moves
-      [[system-duct.state %pass /sys/era note-arvo] moves]
     mo-core
   ::  +mo-untrack-ship: cancel subscriptions to ames and jael for .ship
   ::
@@ -494,10 +493,6 @@
     =.  contacts.state  (~(del in contacts.state) ship)
     ::
     =.  moves  [[system-duct.state %pass /sys/lag %a %jilt ship] moves]
-    ::
-    =/  =note-arvo  [%j %nuke (silt ship ~)]
-    =.  moves
-      [[system-duct.state %pass /sys/era note-arvo] moves]
     mo-core
   ::  +mo-breach: ship breached, so forget about them
   ::
@@ -1152,6 +1147,12 @@
     ++  ap-breach
       |=  =ship
       ^+  ap-core
+      =.  ap-core
+        =^  maybe-tang  ap-core
+          %+  ap-ingest  ~  |.
+          (on-rift:ap-agent-core ship)
+        ?~  maybe-tang  ap-core
+        (ap-error %on-breach u.maybe-tang)
       =/  in=(list [=duct =^ship =path])
         ~(tap by inbound.watches.yoke)
       |-  ^+  ap-core
@@ -1391,7 +1392,7 @@
         %+  ap-ingest  ~  |.
         (on-arvo:ap-agent-core wire sign-arvo)
       ?^  maybe-tang
-        (ap-error %arvo-response u.maybe-tang)
+        (ap-error %on-arvo u.maybe-tang)
       ap-core
     ::  +ap-specific-take: specific take.
     ::
@@ -1707,7 +1708,12 @@
       mo-abet:(mo-send-foreign-request:mo-core q.sock term deal)
     mo-abet:(mo-handle-local:mo-core p.sock term deal)
   ::
-      %init  [~ gall-payload(system-duct.state duct)]
+      %init
+    ::  ask jael to track .ship's breaches
+    ::
+    :_  gall-payload(system-duct.state duct)
+    [duct %pass /sys/era %j %public-keys ~]~
+  ::
       %plea
     =/  =ship  ship.task
     =/  =path  path.plea.task

--- a/pkg/base-dev/lib/dbug.hoon
+++ b/pkg/base-dev/lib/dbug.hoon
@@ -146,6 +146,12 @@
     =^  cards  agent  (on-arvo:ag wire sign-arvo)
     [cards this]
   ::
+  ++  on-rift
+    |=  =ship
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  agent  (on-rift:ag ship)
+    [cards this]
+  ::
   ++  on-fail
     |=  [=term =tang]
     ^-  (quip card:agent:gall agent:gall)

--- a/pkg/base-dev/lib/default-agent.hoon
+++ b/pkg/base-dev/lib/default-agent.hoon
@@ -62,6 +62,10 @@
   ~|  "unexpected system response {<-.sign-arvo>} to {<dap.bowl>} on wire {<wire>}"
   !!
 ::
+++  on-rift
+  |=  =ship
+  `agent
+::
 ++  on-fail
   |=  [=term =tang]
   %-  (slog leaf+"error in {<dap.bowl>}" >term< tang)

--- a/pkg/base-dev/lib/shoe.hoon
+++ b/pkg/base-dev/lib/shoe.hoon
@@ -109,6 +109,10 @@
     |~  [wire sign-arvo]
     *(quip card _^|(..on-init))
   ::
+  ++  on-rift
+    |~  ship
+    *(quip card _^|(..on-init))
+  ::
   ++  on-fail
     |~  [term tang]
     *(quip card _^|(..on-init))
@@ -363,6 +367,12 @@
     ^-  (quip card:agent:gall agent:gall)
     =^  cards  shoe  (on-arvo:og wire sign-arvo)
     [(deal cards) this]
+  ::
+  ++  on-rift
+    |=  =ship
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-rift:og ship)
+    [cards this]
   ::
   ++  on-fail
     |=  [=term =tang]

--- a/pkg/base-dev/lib/skeleton.hoon
+++ b/pkg/base-dev/lib/skeleton.hoon
@@ -44,6 +44,11 @@
   ^-  (quip card:agent:gall agent:gall)
   !!
 ::
+++  on-rift
+  |~  ship
+  ^-  (quip card:agent:gall agent:gall)
+  !!
+::
 ++  on-fail
   |~  [term tang]
   ^-  (quip card:agent:gall agent:gall)

--- a/pkg/base-dev/lib/verb.hoon
+++ b/pkg/base-dev/lib/verb.hoon
@@ -80,6 +80,12 @@
   =^  cards  agent  (on-arvo:ag wire sign-arvo)
   [[(emit-event %on-arvo wire [- +<]:sign-arvo) cards] this]
 ::
+++  on-rift
+  |=  =ship
+  %-  (print bowl |.("{<dap.bowl>}: on-rift for {<ship>}"))
+  =^  cards  agent  (on-rift:ag ship)
+  [[(emit-event %on-rift ship) cards] this]
+::
 ++  on-fail
   |=  [=term =tang]
   ^-  (quip card:agent:gall agent:gall)

--- a/pkg/base-dev/sur/verb.hoon
+++ b/pkg/base-dev/sur/verb.hoon
@@ -7,6 +7,7 @@
       [%on-leave =path]
       [%on-agent =wire sign=term]
       [%on-arvo =wire vane=term sign=term]
+      [%on-rift =ship]
       [%on-fail =term]
   ==
 --


### PR DESCRIPTION
Instead of subscribing only to breach notifications for ships that its
agents have interacted with, gall now listens to all breach
notifications across the network.

These notifications now get passed into all running agents through
+on-rift, taking the involved ship as an argument.

Notably, +on-rift is called _before_ an agent's subscriptions get
cleaned up. This ensures agents have full information for deciding how
to handle the breach. But because +on-leave and +on-agent (%kick) may
still be called afterwards, the agent is advised to not clean up
subscription state during +on-rift handling.

Developed together with @philipcmonk after getting bitten by an "app didn't know about breach" situation. This has been a long time coming!

We should hold off on merging & releasing this for a month or two, and do outreach to developers to let them know this is coming so they can prepare. We should also upgrade the apps in the other desks as part of this PR before it gets merged.

@joemfb tagging you for kelvin bump ops.