### PR TITLE
btc-wallet: cleanup provider modal text

### DIFF
--- a/pkg/btc-wallet/src/components/ProviderModal.tsx
+++ b/pkg/btc-wallet/src/components/ProviderModal.tsx
@@ -99,9 +99,9 @@ const ProviderModal = () => {
       </Row>
       <Box mt={3}>
         <Text fontSize="14px" fontWeight="regular" color="gray">
-          In order to perform Bitcoin transaction in Landscape, you&apos;ll need
-          to set a provider node. A provider node is an urbit which maintains a
-          synced Bitcoin ledger.
+          In order to use the Bitcoin wallet on your ship you&apos;ll need to
+          set a provider node. A provider node is an urbit ship which maintains
+          a synced Bitcoin ledger.
           <a
             style={{ fontSize: '14px' }}
             target="_blank"


### PR DESCRIPTION
remove reference to landsacpe, also refer to the provider as an "urbit ship" and not just an "urbit".

related to https://github.com/urbit/bitcoin-wallet/issues/45.

cc @timlucmiptev @arthyn @liam-fitzgerald 