### PR TITLE
btc-wallet: fix link to settings

### DIFF
--- a/pkg/btc-wallet/src/components/Header.tsx
+++ b/pkg/btc-wallet/src/components/Header.tsx
@@ -45,7 +45,7 @@ const Header = () => {
       </Row>
       <Row alignItems="center">
         {connection}
-        <Link to="/~btc/settings">
+        <Link to="/settings">
           <Box
             backgroundColor="white"
             borderRadius={4}


### PR DESCRIPTION
Link to settings in the header pointed to the pre-app distribution path for the wallet.

cc: @timlucmiptev @arthyn @liam-fitzgerald 