### PR TITLE
grid: match docket image to tile image

### DIFF
--- a/pkg/grid/src/components/DocketImage.tsx
+++ b/pkg/grid/src/components/DocketImage.tsx
@@ -25,7 +25,7 @@ export function DocketImage({ color, image, className = '', size = 'full' }: Doc
       style={{ backgroundColor: tileColor }}
     >
       {image && (
-        <img className="absolute top-0 left-0 h-full w-full object-contain" src={image} alt="" />
+        <img className="absolute top-0 left-0 h-full w-full object-cover" src={image} alt="" />
       )}
     </div>
   );


### PR DESCRIPTION
As in #5322 305cd0b, but for the app icon that shows in leap.