### PR TITLE
docket: add scry endpoint for app versions

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -168,6 +168,11 @@
     %+  turn  ~(tap by charges)
     |=  [=desk =charge]
     [desk (get-light-charge charge)]
+    ::
+      [%x %charges @ %version ~]
+    ?~  charge=(~(get by charges) i.t.t.path)
+      [~ ~]
+    ``noun+!>(version.docket.u.charge)
   ==
 ::
 ++  on-agent


### PR DESCRIPTION
Applications might want to do rudimentary version checks prior to scrying and other such operations.