### PR TITLE
npm: fix builds for npm packages

### DIFF
--- a/pkg/npm/api/tsconfig.json
+++ b/pkg/npm/api/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-	  "outDir": "./dist",
-    "module": "ES2020",
+    "outDir": "./dist",
+    "module": "CommonJS",
     "noImplicitAny": true,
-    "target": "ES2017",
+    "target": "ES5",
+    "downlevelIteration": true,
     "pretty": true,
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/pkg/npm/http-api/tsconfig.json
+++ b/pkg/npm/http-api/tsconfig.json
@@ -2,10 +2,11 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "@types"],
   "compilerOptions": {
-	  "outDir": "./dist",
-    "module": "ESNext",
+    "outDir": "./dist",
+    "module": "CommonJS",
     "noImplicitAny": true,
-    "target": "ESNext",
+    "target": "ES5",
+    "downlevelIteration": true,
     "pretty": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -17,7 +18,7 @@
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "*" : ["./node_modules/@types/*", "*"]
+      "*": ["./node_modules/@types/*", "*"]
     }
   }
 }


### PR DESCRIPTION
The npm packages were previously targeting ESNext and ES2020 on build, and they were also using esmodules rather than commonjs.

See this issue: https://github.com/urbit/urbit/issues/5329

Because of that setup you actually couldn't even run `npm start` in the `pkg/interface` directory to run landscape locally.

probably best for @arthyn to review this one.