### PR TITLE
hark-graph-hook: fix dm notifications

### DIFF
--- a/pkg/landscape/app/hark-graph-hook.hoon
+++ b/pkg/landscape/app/hark-graph-hook.hoon
@@ -464,7 +464,7 @@
     ++  should-notify
       ?|  is-mention
           (~(has in watching) [rid parent-idx])
-          =(mark `%graph-validator-dm)
+          =(mark %graph-validator-dm)
       ==
     ::
     ++  add-note


### PR DESCRIPTION
The mark in the sample of the `+handle-update` door used to be a (unit mark) pre-refactor, but the comparison was never updated to work. Fixed.