### PR TITLE
hark-store: cap size of half-open timeboxes

### DIFF
--- a/pkg/garden/app/hark-store.hoon
+++ b/pkg/garden/app/hark-store.hoon
@@ -403,11 +403,12 @@
       (~(put by half-open) bin now.bowl)
     =/  existing  (get-lid archive/time bin) 
     =/  new  (merge-notification existing note)
+    =?  half-open  (lth 30 (lent body.new))
+      (~(del by half-open) bin)
     =.  poke-core
       (put-lid archive/time bin new)
     =.  poke-core  (del-lid lid bin)
-    =.  poke-core  (give %archived now.bowl unseen+~ (~(got re archive) time bin))
-    =.  poke-core  (give %archived now.bowl seen+~ (~(got re archive) time bin))
+    =.  poke-core  (give %archived time lid (~(got re archive) time bin))
     $(bins t.bins)
   ::
   ++  read-count

--- a/pkg/garden/tests/app/hark-store.hoon
+++ b/pkg/garden/tests/app/hark-store.hoon
@@ -30,7 +30,7 @@
   [%read-count place]
 ::
 +$  state
-  $:  %8
+  $:  %9
       places=(map place:hark stats:hark)
       seen=timebox:hark
       unseen=timebox:hark
@@ -87,4 +87,17 @@
   =/  actual-archive=notification:hark
     (~(got re archive.state) (add *time ~s1) bin)
   (expect-eq !>(expected-archive) !>(actual-archive))
+::
+++  test-half-open-capped
+  =|  run=@ud 
+  |-
+  ?:  =(run 31)
+    =+  !<(=state on-save:agent)
+    (expect-eq !>(~) !>(half-open.state))
+  =^  movs  agent  
+     (~(on-poke agent (bowl run)) %hark-action !>((add-note run)))
+  =^  mavs  agent  
+     (~(on-poke agent (bowl run)) %hark-action !>(read-count))
+  $(run +(run))
+::
 --


### PR DESCRIPTION
Prevents unnecessarily large timeboxes from accumulating, which can
negatively impact performance.