### PR TITLE
docket: note browser compatibility on upload page

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -478,6 +478,8 @@
                   """
               ;li:"glob!"
             ==
+            (safari and internet explorer do not support uploading directory
+            trees properly. please glob from other browsers.)
         ;+  ?:  =(~ desks)
               ;p:"no desks eligible for glob upload"
             ;form(method "post", enctype "multipart/form-data")


### PR DESCRIPTION
I was originally gonna do something about urbit/landscape#1279, but it turns out directory tree uploading just straight-up doesn't work properly in Safari.

Instead, we add this little note, so that at least the user/developer knows why their glob isn't being uploaded/served correctly.