### PR TITLE
vere: add stack cleanup for computation-skipping dynamic hints

### DIFF
--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1026,13 +1026,19 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
       case u3_none: {
         u3_noun fen = u3_nul;
         c3_w  nef_w = _n_comp(&fen, nef, los_o, tel_o);
+        // add appropriate hind opcode
+        ++nef_w; _n_emit(&fen, ( c3y == los_o ) ? HILL : HILK);
+        // skip over the cleanup opcode
+        ++nef_w; _n_emit(&fen, u3nc(SBIP, 1));
 
+        //  call hilt_fore
         //  HILB overflows to HILS
-        //
         ++tot_w; _n_emit(ops, u3nc(HILB, u3nc(u3k(hif), u3k(nef))));
-        ++tot_w; _n_emit(ops, u3nc(SBIN, nef_w + 1));
+        // if fore return c3n, skip fen
+        ++tot_w; _n_emit(ops, u3nc(SBIN, nef_w));
         tot_w += nef_w; _n_apen(ops, fen);
-        ++tot_w; _n_emit(ops, ( c3y == los_o ) ? HILL : HILK);
+        // post-skip cleanup opcode
+        ++tot_w; _n_emit(ops, ( c3y == los_o ) ? TOSS : SWAP);
       } break;
     }
   }
@@ -1057,14 +1063,21 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
           case u3_none: {
             u3_noun fen = u3_nul;
             c3_w  nef_w = _n_comp(&fen, nef, los_o, tel_o);
+            // add appropriate hind opcode
+            ++nef_w; _n_emit(&fen, ( c3y == los_o ) ? HINL : HINK);
+            // skip over the cleanup opcode
+            ++nef_w; _n_emit(&fen, u3nc(SBIP, 1));
 
+            // push clue
             tot_w += _n_comp(ops, hod, c3n, c3n);
+            //  call hint_fore
             //  HINB overflows to HINS
-            //
             ++tot_w; _n_emit(ops, u3nc(HINB, u3nc(u3k(zep), u3k(nef))));
-            ++tot_w; _n_emit(ops, u3nc(SBIN, nef_w + 1));
+            // if fore return c3n, skip fen
+            ++tot_w; _n_emit(ops, u3nc(SBIN, nef_w));
             tot_w += nef_w; _n_apen(ops, fen);
-            ++tot_w; _n_emit(ops, ( c3y == los_o ) ? HINL : HINK);
+            // post-skip cleanup opcode
+            ++tot_w; _n_emit(ops, ( c3y == los_o ) ? TOSS : SWAP);
           } break;
         }
       } break;


### PR DESCRIPTION
This PR fixes a bug in the bytecode interpreters dynamic hint protocol (added in #3979). The stack was not being properly cleaned up if the hint short-circuited the nock evaluation (as a memoization hint would). This feature has never been used by any deployed code, so the bug has not had any impact.

Fix (and bug discovery) courtesy of @frodwith.