### PR TITLE
hark-system-hook: use correct mark for cage from kiln

### DIFF
--- a/pkg/garden/app/hark-system-hook.hoon
+++ b/pkg/garden/app/hark-system-hook.hoon
@@ -44,7 +44,7 @@
       %kick                    :_(this (drop safe-watch:kiln:cc))
     ::
         %fact
-      ?.  ?=(%kiln-vats-diff p.cage.sign)  `this
+      ?.  ?=(%kiln-vats-diff-0 p.cage.sign)  `this
       =+  !<(=diff:hood q.cage.sign)
       ?+  -.diff  `this
       ::


### PR DESCRIPTION
Fixes lack of update notifications