### PR TITLE
hark-graph-hook: correctly get rear of index

### DIFF
--- a/pkg/interface/src/views/apps/publish/components/Note.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Note.tsx
@@ -61,6 +61,9 @@ export function Note(props: NoteProps & RouteComponentProps) {
   const noteId = bigInt(index[1]);
   useEffect(() => {
     airlock.poke(markEachAsRead(toHarkPlace(association.resource), `/${index[1]}`));
+    // Unread may be malformed, dismiss anyway
+    // TODO: remove when %read-graph is implemented
+    airlock.poke(markEachAsRead(toHarkPlace(association.resource), `/1`));
   }, [association, props.note]);
 
   const adminLinks: JSX.Element[] = [];

--- a/pkg/landscape/app/hark-graph-hook.hoon
+++ b/pkg/landscape/app/hark-graph-hook.hoon
@@ -486,7 +486,7 @@
           update-core
         ?-  mode.kind 
           %count  (hark %unread-count place %.y 1)
-          %each   (hark %unread-each place /(rsh 4 (scot %ui (rear index.post))))
+          %each   (hark %unread-each place /(rsh 4 (scot %ui (rear self-idx))))
           %none   update-core
         ==
       ==
@@ -497,7 +497,7 @@
           update-core
         ?-  mode.kind 
           %count  (hark %unread-count place %.n 1)
-          %each   (hark %read-each place /(rsh 4 (scot %ui (rear index.post))))
+          %each   (hark %read-each place /(rsh 4 (scot %ui (rear self-idx))))
           %none   update-core
         ==
       ==


### PR DESCRIPTION
- Correctly get ID from index, was incorrectly fetching version numbers from notes instead of the note ID
- Works around malformed unreads by dismissing them