### PR TITLE
copyedits: apptile menu, remove/suspend interfaces

### DIFF
--- a/pkg/grid/src/tiles/RemoveApp.tsx
+++ b/pkg/grid/src/tiles/RemoveApp.tsx
@@ -22,16 +22,19 @@ export const RemoveApp = () => {
   return (
     <Dialog open onOpenChange={(open) => !open && history.push('/')}>
       <DialogContent showClose={false} className="space-y-6" containerClass="w-full max-w-md">
-        <h1 className="h4">Remove &ldquo;{getAppName(docket)}&rdquo;?</h1>
+        <h1 className="h4">Uninstall &ldquo;{getAppName(docket)}&rdquo;?</h1>
         <p className="text-base tracking-tight pr-6">
-          This will remove the software&apos;s tile from your home screen.
+          The app tile will be removed from Landscape, all processes will be stopped and their data archived, and the app will stop receiving updates.
+        </p>
+        <p className="text-base tracking-tight pr-6">
+          If the app is reinstalled, the archived data will be restored and you'll be able to pick up where you left off.
         </p>
         <div className="flex space-x-6">
           <DialogClose as={Button} variant="secondary">
             Cancel
           </DialogClose>
           <DialogClose as={Button} onClick={handleRemoveApp}>
-            Remove &ldquo;{getAppName(docket)}&rdquo;
+            Uninstall
           </DialogClose>
         </div>
       </DialogContent>

--- a/pkg/grid/src/tiles/SuspendApp.tsx
+++ b/pkg/grid/src/tiles/SuspendApp.tsx
@@ -27,15 +27,17 @@ export const SuspendApp = () => {
       <DialogContent showClose={false} className="space-y-6" containerClass="w-full max-w-md">
         <h1 className="h4">Suspend &ldquo;{getAppName(charge)}&rdquo;</h1>
         <p className="text-base tracking-tight pr-6">
-          Suspending an app will turn off automatic updates. You cannot use an app when it is
-          suspended, but you can resume it at any time.
+          All processes will be stopped and data archived. The app will continue to receive updates from its publisher. 
+        </p>
+        <p className="text-base tracking-tight pr-6">
+          When unsuspended, archived data will be loaded and all processes will resume running, so you can pick up where you left off.
         </p>
         <div className="flex space-x-6">
           <DialogClose as={Button} variant="secondary">
             Cancel
           </DialogClose>
           <DialogClose as={Button} onClick={handleSuspendApp}>
-            Suspend &ldquo;{getAppName(charge)}&rdquo;
+            Suspend
           </DialogClose>
         </div>
       </DialogContent>

--- a/pkg/grid/src/tiles/TileMenu.tsx
+++ b/pkg/grid/src/tiles/TileMenu.tsx
@@ -85,7 +85,7 @@ export const TileMenu = ({ desk, chad, menuColor, lightText, className }: TileMe
           )}
           {suspended && <Item onSelect={() => toggleDocket(desk)}>Resume App</Item>}
           <Item as={Link} to={`/app/${desk}/remove`} onSelect={linkOnSelect}>
-            Remove App
+            Uninstall App
           </Item>
         </DropdownMenu.Group>
         <DropdownMenu.Arrow className="w-4 h-[10px] fill-current" style={{ color: menuColor }} />


### PR DESCRIPTION
Changes up some copy in the app tile menus and the resulting pop ups for app removal and app suspension.

Addresses isssues https://github.com/urbit/landscape/issues/1237 and https://github.com/urbit/landscape/issues/1235