### PR TITLE
grid: add readme and contributor docs

### DIFF
--- a/pkg/grid/CONTRIBUTING.md
+++ b/pkg/grid/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Landscape
+
+Thank you for your interest in contributing to the Urbit ecosystem.
+
+Landscape is entirely open to contributions from the community. We mainly organize through our [project board], [issues], and [weekly call].
+
+For now our code is stored in the main [urbit repo]. If you would like to contribute feel free to open up a PR there.
+
+## Git Conventions
+
+For Landscape we follow the same conventions as the main repo which can be found in it's [contributing doc]. This can be summarized as the following:
+
+Commits should try to be atomic and focused on one feature at a time. Work-in-progress commits should be rebased and combined into one so that the commit history stays clean.
+
+Commits should follow this format:
+
+> component: short description
+>
+> long description
+
+Where `component` is the closest most relevant area of the code base written as concisely as possible. The short description that accompanies should be a super concise summary of the changes. The total length of the commit message should strive to be 50 characters or less. The long description is optional, but should be used if further explanation is necessary.
+
+### Pull Requests
+
+A pull request (PR) should have a title similar in structure to our commit messages where it has a short identifier component followed by a very concise summary of the PR's intent. All PRs should have a description further laying out what it accomplishes. If the PR addresses certain Github issues, those should be referenced in the body of the description so they get linked. If there are visual or design changes screenshots should also be included.
+
+PRs to this repo should currently ask for review from the following contributors:
+
+- [Liam - @liam-fitzgerald](https://github.com/liam-fitzgerald)
+- [Hunter - @arthyn](https://github.com/arthyn)
+- [James - @nerveharp](https://github.com/nerveharp)
+
+If visual or designs are changed please also request review from:
+
+- [Éd - @urcades](https://github.com/urcades)
+- [Gavin - @g-a-v-i-n](https://github.com/g-a-v-i-n)
+
+## Further Information
+
+If you haven't yet, check out the main [contributing doc] at the base of the repo for information on how to get started developing on Urbit. Also you can find a host of resources on [developers.urbit.org], including ways to earn address space by contributing.
+
+[project board]: https://github.com/orgs/urbit/projects/17
+[issues]: https://github.com/urbit/landscape/issues
+[weekly call]: https://github.com/urbit/landscape/issues/792
+[urbit repo]: https://github.com/urbit/urbit
+[contributing doc]: ../../CONTRIBUTING.md
+[developers.urbit.org]: https://developers.urbit.org/

--- a/pkg/grid/README.md
+++ b/pkg/grid/README.md
@@ -1,0 +1,43 @@
+# Landscape
+
+Landscape provides the primary launching interface for Tlon's suite of userspace applications. This directory contains the front-end web application to power said interface.
+
+Landscape is built primarily using [React], [Typescript], and [Tailwind CSS]. [Vite] ensures that all code and assets are loaded appropriately, bundles the application for distribution and provides a functional dev environment.
+
+## Getting Started
+
+To get started using Landscape first you need to run, `npm run bootstrap` at the top level of the greater urbit repo. This will install your npm dependencies and correctly link the current implementation of the packages at `pkg/npm/*` to your dependencies.
+
+If you intend to edit those packages will developing on Landscape, you should also have `npm run watch-libs` running to build and re-link them after every change.
+
+Once that's done, you can then run `npm run mock` if you'd like to get started immediately. This will use hard-coded mock data to power the interface so you can work on the interface without being connected to a ship.
+
+To develop against a working ship, you first need to add a `.env.local` file to the root of this directory. This file will not be committed. Adding `VITE_SHIP_URL={URL}` where **{URL}** is the URL of the ship you would like to point to, will allow you to run `npm run dev`. This will proxy all requests to the ship except for those powering the interface, allowing you to see live data.
+
+Regardless of what you run to develop, Vite will hot-reload code changes as you work so you don't have to constantly refresh.
+
+## Deploying
+
+To deploy, run `npm run build` which will bundle all the code and assets into the `dist/` folder. This can then be made into a glob by doing the following:
+
+1. Create or launch an urbit using the -F flag
+2. On that urbit, if you don't already have a desk to run from, run `|merge %work our %base` to create a new desk and mount it with `|mount %work`.
+3. Now the `%work` desk is accessible through the host OS's filesystem as a directory of that urbit's pier ie `~/zod/work`.
+4. From the directory of grid you can run `rsync -avL --delete dist/ ~/zod/work/grid` where `~/zod` is your fake urbit's pier.
+5. Once completed you can then run `|commit %work` on your urbit and you should see your files logged back out from the dojo.
+6. Now run `=dir /=garden` to switch to the garden desk directory
+7. You can now run `-make-glob %work /grid` which will take the grid folder where you just added files and create a glob which can be thought of as a sort of bundle. It will be output to `~/zod/.urb/put`.
+8. If you navigate to `~/zod/.urb/put` you should see a file that looks like this `glob-0v5.fdf99.nph65.qecq3.ncpjn.q13mb.glob`. The characters between `glob-` and `.glob` are a hash of the glob's contents.
+9. If you're working at Tlon, you can upload this to our Google storage using `gsutil cp glob-*.* gs://bootstrap.urbit.org`. Otherwise any publicly available HTTP endpoint that can serve files should be sufficient for distributing the glob.
+10. Once you've uploaded the glob, you should then update the corresponding entry in the docket file that represents Landscape which currently resides at `pkg/garden/desk.docket-0`. Both the full URL and the hash should be updated to match the glob we just created, on the line that looks like this:
+
+```hoon
+    glob-http+['https://bootstrap.urbit.org/glob-0v5.fdf99.nph65.qecq3.ncpjn.q13mb.glob' 0v5.fdf99.nph65.qecq3.ncpjn.q13mb]
+```
+
+11. This can now be safely committed and deployed.
+
+[react]: https://reactjs.org/
+[typescript]: https://www.typescriptlang.org/
+[tailwind css]: https://tailwindcss.com/
+[vite]: https://vitejs.dev/


### PR DESCRIPTION
This PR adds both a README.md and CONTRIBUTING.md so that people can more easily get onboarded to working with grid. We should consider making something of a template out of these for the rest of our apps.