### PR TITLE
useResize: fix destructor

### DIFF
--- a/pkg/interface/src/logic/lib/useResize.ts
+++ b/pkg/interface/src/logic/lib/useResize.ts
@@ -15,11 +15,12 @@ export function useResize<T extends HTMLElement>(
         callback(entry, observer);
       }
     }
+    let el = ref.current;
     const resizeObs = new ResizeObserver(observer);
-    resizeObs.observe(ref.current, { box: 'border-box' });
+    resizeObs.observe(el, { box: 'border-box' });
 
     return () => {
-      resizeObs.unobserve(ref.current);
+      resizeObs.unobserve(el);
     };
   }, [callback]);
 


### PR DESCRIPTION
Interior mutability bites again. This was causing a memory leak, as the reference to the element was never let go