### PR TITLE
interface: fix read-graph, readGroup actions

### DIFF
--- a/pkg/interface/src/logic/state/hark.ts
+++ b/pkg/interface/src/logic/state/hark.ts
@@ -9,7 +9,8 @@ import {
   harkBinToId,
   decToUd,
   unixToDa,
-  opened
+  opened,
+  markEachAsRead
 } from '@urbit/api';
 import { Poke } from '@urbit/http-api';
 import { patp2dec } from 'urbit-ob';
@@ -25,6 +26,7 @@ import {
   reduceStateN
 } from './base';
 import { reduce, reduceGraph, reduceGroup } from '../reducers/hark-update';
+import useMetadataState from './metadata';
 
 export const HARK_FETCH_MORE_COUNT = 3;
 
@@ -43,6 +45,8 @@ export interface HarkState {
   unreads: Unreads;
   archiveNote: (bin: HarkBin, lid: HarkLid) => Promise<void>;
   readCount: (path: string) => Promise<void>;
+  readGraph: (graph: string) => Promise<void>;
+  readGroup: (group: string) => Promise<void>;
 }
 
 const useHarkState = createState<HarkState>(
@@ -53,6 +57,38 @@ const useHarkState = createState<HarkState>(
     unreadNotes: [],
     poke: async (poke: Poke<any>) => {
       await pokeOptimisticallyN(useHarkState, poke, [reduce]);
+    },
+    readGraph: async (graph: string) => {
+      const prefix = `/graph/${graph.slice(6)}`;
+      let counts = [] as string[];
+      let eaches = [] as [string, string][];
+      Object.entries(get().unreads).forEach(([path, unreads]) => {
+        if (path.startsWith(prefix)) {
+          if(unreads.count > 0) {
+            counts.push(path);
+          }
+          unreads.each.forEach(unread => {
+            eaches.push([path, unread]);
+          });
+        }
+      });
+      get().set(draft => {
+        counts.forEach(path => {
+          draft.unreads[path].count = 0;
+        });
+        eaches.forEach(([path, each]) => {
+          draft.unreads[path].each = [];
+        });
+      });
+      await Promise.all([
+        ...counts.map(path => markCountAsRead({ desk: window.desk, path })),
+        ...eaches.map(([path, each]) => markEachAsRead({ desk: window.desk, path }, each))
+      ].map(pok => api.poke(pok)));
+    },
+    readGroup: async (group: string) => {
+      const graphs = 
+        _.pickBy(useMetadataState.getState().associations.graph, a => a.group === group);
+      await Promise.all(Object.keys(graphs).map(get().readGraph));
     },
     readCount: async (path) => {
       const poke = markCountAsRead({ desk: (window as any).desk, path });

--- a/pkg/interface/src/views/apps/publish/components/Notebook.tsx
+++ b/pkg/interface/src/views/apps/publish/components/Notebook.tsx
@@ -7,6 +7,7 @@ import useContactState from '~/logic/state/contact';
 import useGroupState from '~/logic/state/group';
 import airlock from '~/logic/api';
 import { NotebookPosts } from './NotebookPosts';
+import useHarkState from '~/logic/state/hark';
 
 interface NotebookProps {
   ship: string;
@@ -35,7 +36,7 @@ export function Notebook(props: NotebookProps & RouteComponentProps): ReactEleme
   const showNickname = useShowNickname(contact);
 
   const readBook = useCallback(() => {
-    airlock.poke(readGraph(association.resource));
+    useHarkState.getState().readGraph(association.resource, 'graph-validator-publish');
   }, [association.resource]);
 
   if (!group) {

--- a/pkg/interface/src/views/landscape/components/GroupsPane.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupsPane.tsx
@@ -43,7 +43,7 @@ export function GroupsPane(props: GroupsPaneProps) {
 
   useShortcut('readGroup', useCallback(() => {
     if(groupPath) {
-      airlock.poke(readGroup(groupPath));
+      useHarkState.getState().readGroup(groupPath);
     }
   }, [groupPath]));
 


### PR DESCRIPTION
Fixes the missing %read-graph and %read-group actions by reimplementing them in the interface. 