### PR TITLE
jael, azimuth: reconfigure for L2

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -59,7 +59,10 @@
     ^-  (quip card _this)
     =.  net.state  %local
     :_  this
-    [%pass /eth-watcher %agent [our.bowl %eth-watcher] %watch /logs/[dap.bowl]]~
+    :~  [%pass /eth-watcher %agent [our.bowl %eth-watcher] %watch /logs/[dap.bowl]]
+        [%pass /old-tracker %agent [our.bowl %azimuth-tracker] %poke %kiln-nuke !>([%azimuth-tracker %base])]
+        [%pass /lo %arvo %j %listen ~ [%| dap.bowl]]
+    ==
   ::
   ++  on-save   !>(state)
   ++  on-load

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -60,7 +60,7 @@
     =.  net.state  %local
     :_  this
     :~  [%pass /eth-watcher %agent [our.bowl %eth-watcher] %watch /logs/[dap.bowl]]
-        [%pass /old-tracker %agent [our.bowl %azimuth-tracker] %poke %kiln-nuke !>([%azimuth-tracker %base])]
+        [%pass /old-tracker %agent [our.bowl %hood] %poke %kiln-nuke !>([%azimuth-tracker %base])]
         [%pass /lo %arvo %j %listen ~ [%| dap.bowl]]
     ==
   ::

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -314,7 +314,7 @@
       ::
       =.  +>.$  (poke-watch hen %azimuth nod.own.pki)
       =.  +>.$
-        ::  get everything from azimuth-tracker because jael subscriptions
+        ::  get everything from /app/azimuth because jael subscriptions
         ::  seem to be flaky for now
         ::
         ?:  &
@@ -548,7 +548,7 @@
         [%behn %wake *]
       ?^  error.hin
         %-  %+  slog
-              leaf+"jael unable to resubscribe, run :azimuth-tracker|listen"
+              leaf+"jael unable to resubscribe, run :azimuth|listen"
             u.error.hin
           +>.$
       ?>  ?=([%breach @ ~] tea)
@@ -565,7 +565,14 @@
         [%gall %unto *]
       ?-    +>-.hin
           %raw-fact  !!
-          %kick      ~|([%jael-unexpected-quit tea hin] !!)
+      ::
+          %kick
+        ?>  ?=([@ *] tea)
+        =*  app  i.tea
+        ::NOTE  we expect azimuth-tracker to be kill
+        ?:  =(%azimuth-tracker app)  +>.$
+        ~|([%jael-unexpected-quit tea hin] !!)
+      ::
           %poke-ack
         ?~  p.p.+>.hin
           +>.$


### PR DESCRIPTION
Jael needs to be reconfigured to listen to the new aagent for azimuth
events, and the old app needs to be shut down. We do this in
/app/azimuth's +on-init.

Additionally, we make sure that jael doesn't crash when it (as expected)
loses its subscription to the old agent.

Only tested on a fakenet ship so far, which might not hit the full/relevant case here.