### PR TITLE
dojo: improve safety of mark conversion

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -910,8 +910,12 @@
         =/  has-mark  .?((get-fit:clay he-beak %mar p.bil))
         ?.  has-mark  ::  yolo
           (dy-hand p.bil q.cag)
-        =+  .^(=tube:clay cc+(en-beam he-beak /[p.cag]/[p.bil]))
-        (dy-hand p.bil (tube q.cag))
+        =/  res
+          =+  .^(=tube:clay cc+(en-beam he-beak /[p.cag]/[p.bil]))
+          (mule |.((tube q.cag)))
+        ?:  ?=(%| -.res)
+          (he-diff(poy ~) %tan leaf+"dojo: %as %{(trip p.bil)} failed" p.res)
+        (dy-hand p.bil p.res)
       ::
           %do
         =/  gat  (dy-eval p.bil)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -902,6 +902,9 @@
           %dv  (dy-sing hand+q.bil %a p.bil (snoc q.bil %hoon))
           %ge  (dy-run-generator (dy-cage p.p.p.bil) q.p.bil)
           %sa
+        =/  has-mark  .?((get-fit:clay he-beak %mar p.bil))
+        ?.  has-mark
+          (he-diff(poy ~) %tan leaf+"dojo: %{(trip p.bil)} missing" ~)
         =+  .^(=dais:clay cb+(en-beam he-beak /[p.bil]))
         (dy-hand p.bil *vale:dais)
       ::


### PR DESCRIPTION
Since ford fusion, `:dojo` crashes on failed mark conversion or bunting a non-existent mark. Such crashes unlink dojo from drum, which discards the session and its history. This PR appropriately protects and virtualizes those operations.

Also, has dojo's mark conversion always been a mold invocation? That seems unnecessarily expensive -- it'd be nice to just cast if the value already nests.