### PR TITLE
vere: update event injection for four letter vanes

### DIFF
--- a/pkg/urbit/vere/io/fore.c
+++ b/pkg/urbit/vere/io/fore.c
@@ -48,7 +48,7 @@ _fore_inject(u3_auto* car_u, c3_c* pax_c)
     u3l_log("pier: invalid wire in -I ovum\n");
   }
   else if (  (c3n == u3a_is_atom(tar))
-          || (1 < u3r_met(3, tar)) )
+          || (4 < u3r_met(3, tar)) )
   {
     u3l_log("pier: invalid target in -I wire\n");
   }


### PR DESCRIPTION
Event injection validation was never updated to support routing on a
full vane name. Upgrades the check, so that wires with a first element
longer than 4 characters fail validation, instead of the previous limit
of 1 character