### PR TITLE
clay: support labels

### DIFF
--- a/pkg/arvo/gen/hood/label.hoon
+++ b/pkg/arvo/gen/hood/label.hoon
@@ -8,7 +8,13 @@
   ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=[syd=desk lab=@tas ~] ~]
+        [arg=[syd=desk lab=@tas ~] aeon=aeon:clay ~]
     ==
+:: handle optional aeon
+::
+=/  aey=(unit aeon:clay)
+  ?:  =(0 aeon)
+    ~
+  `aeon
 :-  %kiln-label
-[syd lab]:arg
+[syd.arg lab.arg aey]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1211,9 +1211,9 @@
   abet:abet:(install:vats +<)
 ::
 ++  poke-label
-  |=  [syd=desk lab=@tas]
+  |=  [syd=desk lab=@tas aey=(unit aeon)]
   =+  pax=/(scot %p our)/[syd]/[lab]
-  (poke-info "labeled {(spud pax)}" `[syd %| lab])
+  (poke-info "labeled {(spud pax)}" `[syd %| lab aey])
 ::
 ++  poke-merge
   |=  kiln-merge

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -850,7 +850,7 @@
   +$  mool  [=case paths=(set (pair care path))]        ::  requests in desk
   +$  nori                                              ::  repository action
     $%  [%& p=soba]                                     ::  delta
-        [%| p=@tas]                                     ::  label
+        [%| p=@tas q=(unit aeon)]                       ::  label
     ==                                                  ::
   +$  nuri                                              ::  repository action
     $%  [%& p=suba]                                     ::  delta

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1468,7 +1468,7 @@
     :: rewriting would violate referential transparency
     ::
     ~|  %tried-to-rewrite-existing-label
-    ~&  "requested aeon: {<yon>}, existing aeon: {<u.yen>}"
+    ~|  "requested aeon: {<yon>}, existing aeon: {<u.yen>}"
     !!
   ::
   ::  Porcelain commit

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1450,9 +1450,26 @@
   ++  label
     |=  [bel=@tas aey=(unit aeon)]
     ^+  ..park
-    =/  yon      ?~(aey let.dom u.aey)
-    =.  lab.dom  (~(put by lab.dom) bel yon)
-    ..park
+    =/  yon  ?~(aey let.dom u.aey)
+    =/  yen  (~(get by lab.dom) bel)  :: existing aeon?
+    ::  no existing aeon is bound to this label
+    ::
+    ?~  yen
+      =.  lab.dom  (~(put by lab.dom) bel yon)
+      ..park
+    :: an aeon is bound to this label, 
+    :: but it is the same as the existing one, so we no-op
+    ::
+    ?:  =(u.yen yon)
+      ~&  "clay: tried to rebind existing label {<bel>} to equivalent aeon {<yon>}"
+      ..park
+    :: an existing aeon bound to the label
+    :: that is distinct from the requested one.
+    :: rewriting would violate referential transparency
+    ::
+    ~|  %tried-to-rewrite-existing-label
+    ~&  "requested aeon: {<yon>}, existing aeon: {<u.yen>}"
+    !!
   ::
   ::  Porcelain commit
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4400,13 +4400,11 @@
   ::
       %info
     ?:  ?=(%| -.dit.req)
-      :: initial pass. doing it directly inline rather than putting any logic into ++de
       =/  bel=@tas         p.dit.req
       =/  aey=(unit aeon)  q.dit.req
       =^  mos  ruf
         =/  den  ((de now rof hen ruf) our des.req)
         abet:(label:den bel aey)
-        :: ~&  "labeling current aeon {<let.dom>} on {<des.req>}"
       [mos ..^$]
     =/  [deletes=(set path) changes=(map path cage)]
       =/  =soba  p.dit.req

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1445,6 +1445,15 @@
       ==
     ==
   ::
+  :: Attach label to aeon
+  ::
+  ++  label
+    |=  [bel=@tas aey=(unit aeon)]
+    ^+  ..park
+    =/  yon      ?~(aey let.dom u.aey)
+    =.  lab.dom  (~(put by lab.dom) bel yon)
+    ..park
+  ::
   ::  Porcelain commit
   ::
   ++  info
@@ -4374,8 +4383,14 @@
   ::
       %info
     ?:  ?=(%| -.dit.req)
-      ~|  %labelling-not-implemented
-      !!
+      :: initial pass. doing it directly inline rather than putting any logic into ++de
+      =/  bel=@tas         p.dit.req
+      =/  aey=(unit aeon)  q.dit.req
+      =^  mos  ruf
+        =/  den  ((de now rof hen ruf) our des.req)
+        abet:(label:den bel aey)
+        :: ~&  "labeling current aeon {<let.dom>} on {<des.req>}"
+      [mos ..^$]
     =/  [deletes=(set path) changes=(map path cage)]
       =/  =soba  p.dit.req
       =|  deletes=(set path)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1445,7 +1445,7 @@
       ==
     ==
   ::
-  :: Attach label to aeon
+  ::  Attach label to aeon
   ::
   ++  label
     |=  [bel=@tas aey=(unit aeon)]
@@ -1457,15 +1457,15 @@
     ?~  yen
       =.  lab.dom  (~(put by lab.dom) bel yon)
       ..park
-    :: an aeon is bound to this label, 
-    :: but it is the same as the existing one, so we no-op
+    ::  an aeon is bound to this label, 
+    ::  but it is the same as the existing one, so we no-op
     ::
     ?:  =(u.yen yon)
       ~&  "clay: tried to rebind existing label {<bel>} to equivalent aeon {<yon>}"
       ..park
-    :: an existing aeon bound to the label
-    :: that is distinct from the requested one.
-    :: rewriting would violate referential transparency
+    ::  an existing aeon bound to the label
+    ::  that is distinct from the requested one.
+    ::  rewriting would violate referential transparency
     ::
     ~|  %tried-to-rewrite-existing-label
     ~|  "requested aeon: {<yon>}, existing aeon: {<u.yen>}"


### PR DESCRIPTION
This PR finishes off the implementation for using labels in the clay filesystem. Labels are `@tas` which you can use in place of dates or revision numbers.

<details>
<summary>Examples to try</summary>
Make a change to `<ship>/base/gen/hood/label.hoon` after mounting, then run the following

```hoon
|label %base %v2
|label %base %origin, =aeon 1

.^(@t %cx /=base/v2/gen/hood/label/hoon)
.^(@t %cx /=base/origin/gen/hood/label/hoon)
```

</details>

Many thanks to @philipcmonk who worked through this with me.