### PR TITLE
meta: enforce LF line endings for hoon files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,8 @@ pkg/arvo/tmp/landscape.jam filter=lfs diff=lfs merge=lfs -text
 pkg/arvo/tmp/base.jam filter=lfs diff=lfs merge=lfs -text
 pkg/arvo/tmp/bitcoin.jam filter=lfs diff=lfs merge=lfs -text
 pkg/arvo/tmp/webterm.jam filter=lfs diff=lfs merge=lfs -text
-
+*.hoon text eol=lf
+*.kelvin text eol=lf
+*.bill text eol=lf
+*.docket-0 text eol=lf
+*.ship text eol=lf


### PR DESCRIPTION
This is a simple change which forces all hoon files to be checked in and checked out using LF newlines, regardless of the user's `core.autocrlf` setting. Without this, developers on Windows can inadvertently try to create a fakezod with illegal line endings, all while receiving unrelated error messages.