### PR TITLE
azimuth: make +run-logs tail-recursive

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -277,8 +277,16 @@
   |=  [logs=(list event-log:rpc:ethereum)]
   ^-  (quip tagged-diff _state)
   =+  net=(get-network net.state)
+  =|  effects=(list tagged-diff)
+  !.  ::  saves 700MB replaying snapshot
+  =-  =/  res  (mule -)
+      ?-  -.res
+        %&  p.res
+        %|  (mean 'naive: fail!' p.res)
+      ==
+  |.
   ?~  logs
-    `state
+    [(flop effects) state]
   ?~  mined.i.logs
     $(logs t.logs)
   =/  [raw-effects=effects:naive new-nas=_nas.state]
@@ -292,13 +300,7 @@
       ?~  input.u.mined.i.logs
         [%bat *@]
       [%bat u.input.u.mined.i.logs]
-    =/  res
-      %-  mule
-      |.((%*(. naive lac |) verifier chain-id.net nas.state input))
-    ?-  -.res
-      %&  p.res
-      %|  ((slog 'naive-fail' p.res) `nas.state)
-    ==
+    (%*(. naive lac |) verifier chain-id.net nas.state input)
   ::  TODO: move to /lib/dice ?
   ::
   =/  [new-own=_own.state new-spo=_spo.state]
@@ -325,8 +327,8 @@
   =/  effects-1
     =/  =id:block  [block-hash block-number]:u.mined.i.logs
     (turn raw-effects |=(=diff:naive [id diff]))
-  =^  effects-2  state  $(logs t.logs)
-  [(welp effects-1 effects-2) state]
+  =.  effects  (welp (flop effects-1) effects)
+  $(logs t.logs)
 ::
 ++  to-udiffs
   |=  effects=(list tagged-diff)


### PR DESCRIPTION
Also kick the call to +mule out of the loop.  By uncommenting the
diagnostics in u3m_fall, I measured that running through the 290k events
the azimuth snapshot required this much memory:

Head recursive, +mule in:  1.1GB
Head recursive, +mule out: 780MB
Tail recursive, +mule in:  700MB
Tail recursive, +mule out: 70MB

So this commit chooses the last one.  The most delicate part is making
sure the effects are the right order; this uses the usual idiom.

Kicking +mule out of the loop is okay because lib/naive should never
fail, and if it does then azimuth shouldn't advance until an out-of-band
solution is decided.

Addresses #5431