### PR TITLE
claz: better linear lockup ops support

### DIFF
--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -200,6 +200,9 @@
   =/  contracts  (get-contracts network)
   ?+  -.call  ecliptic:contracts
     %send-point  delegated-sending:contracts
+  ::
+      ?(%approve-batch-transfer %transfer-batch %withdraw)
+    linear-star-release:contracts
   ==
 ::
 ++  deed

--- a/pkg/arvo/app/claz.hoon
+++ b/pkg/arvo/app/claz.hoon
@@ -382,7 +382,7 @@
           ?>  =(%king (clan:title s))
           (~(put in ss) (^sein:title s))
         |-
-        ?~  parents  txs
+        ?~  parents  !! ::txs
         =.  txs
           %+  do-here  ecliptic:mainnet-contracts
           (set-spawn-proxy:dat i.parents lockup-contract)
@@ -397,15 +397,18 @@
         =.  txs
           %+  do-here  ecliptic:mainnet-contracts
           (set-transfer-proxy:dat i.what lockup-contract)
+        =.  txs
+          %+  do-here  lockup-contract
+          (deposit:dat to i.what)
         $(what t.what)
       ==
     ::  depositing
     ::
     |-
     ?~  what  txs
-    =.  txs
-      %+  do-here  lockup-contract
-      (deposit:dat to i.what)
+    :: =.  txs
+    ::   %+  do-here  lockup-contract
+    ::   (deposit:dat to i.what)
     $(what t.what)
   ++  do-here
     |=  [contract=address dat=tape]

--- a/pkg/arvo/lib/claz.hoon
+++ b/pkg/arvo/lib/claz.hoon
@@ -44,6 +44,10 @@
     %cast-document-vote    (cast-document-vote:dat +.call)
   ::
     %send-point  (send-point:dat +.call)
+  ::
+    %approve-batch-transfer  (approve-batch-transfer:dat +.call)
+    %transfer-batch          (transfer-batch:dat +.call)
+    %withdraw                (withdraw:dat +.call)
   ==
 ::
 +$  call-data  call-data:rpc
@@ -73,6 +77,10 @@
   ++  deposit                 (enc deposit:cal)
   ::
   ++  send-point              (enc send-point:cal)
+  ::
+  ++  approve-batch-transfer  (enc approve-batch-transfer:cal)
+  ++  transfer-batch          (enc transfer-batch:cal)
+  ++  withdraw                (enc withdraw:cal)
   --
 ::
 ::TODO  lib
@@ -250,6 +258,27 @@
     :~  [%uint `@`as]
         [%uint `@`point]
         [%address to]
+    ==
+  ::
+  ++  approve-batch-transfer
+    |=  to=address
+    ^-  call-data
+    :-  'approveBatchTransfer(address)'
+    :~  [%address to]
+    ==
+  ::
+  ++  transfer-batch
+    |=  from=address
+    ^-  call-data
+    :-  'transferBatch(address)'
+    :~  [%address from]
+    ==
+  ::
+  ++  withdraw
+    |=  to=address
+    ^-  call-data
+    :-  'withdraw(address)'
+    :~  [%address to]
     ==
   ::
   ::  read calls

--- a/pkg/arvo/lib/claz.hoon
+++ b/pkg/arvo/lib/claz.hoon
@@ -42,6 +42,8 @@
     %adopt                 (adopt:dat +.call)
     %start-document-poll   (start-document-poll:dat +.call)
     %cast-document-vote    (cast-document-vote:dat +.call)
+    %start-upgrade-poll    (start-upgrade-poll:dat +.call)
+    %cast-upgrade-vote     (cast-upgrade-vote:dat +.call)
   ::
     %send-point  (send-point:dat +.call)
   ::
@@ -71,6 +73,8 @@
   ++  adopt                   (enc adopt:cal)
   ++  start-document-poll     (enc start-document-poll:cal)
   ++  cast-document-vote      (enc cast-document-vote:cal)
+  ++  start-upgrade-poll      (enc start-upgrade-poll:cal)
+  ++  cast-upgrade-vote       (enc cast-upgrade-vote:cal)
   ::
   ++  register-linear         (enc register-linear:cal)
   ++  register-conditional    (enc register-conditional:cal)
@@ -175,6 +179,25 @@
     :-  'castDocumentVote(uint8,bytes32,bool)'
     :~  [%uint `@`gal]
         [%bytes-n 32^hash]
+        [%bool support]
+    ==
+  ::
+  ++  start-upgrade-poll
+    |=  [gal=ship =address]
+    ^-  call-data
+    ?>  =(%czar (clan:title gal))
+    :-  'startUpgradePoll(uint8,address)'
+    :~  [%uint `@`gal]
+        [%address address]
+    ==
+  ::
+  ++  cast-upgrade-vote
+    |=  [gal=ship =address support=?]
+    ^-  call-data
+    ?>  =(%czar (clan:title gal))
+    :-  'castUpgradeVote(uint8,address,bool)'
+    :~  [%uint `@`gal]
+        [%address address]
         [%bool support]
     ==
   ::

--- a/pkg/arvo/sur/claz.hoon
+++ b/pkg/arvo/sur/claz.hoon
@@ -68,6 +68,10 @@
       [%cast-document-vote gal=ship hash=@ vote=?]
     ::
       [%send-point as=ship point=ship to=address]
+    ::
+      [%approve-batch-transfer to=address]
+      [%transfer-batch from=address]
+      [%withdraw to=address]
   ==
 ::
 ++  prep-result

--- a/pkg/arvo/sur/claz.hoon
+++ b/pkg/arvo/sur/claz.hoon
@@ -66,6 +66,8 @@
       [%adopt who=ship]
       [%start-document-poll gal=ship hash=@]
       [%cast-document-vote gal=ship hash=@ vote=?]
+      [%start-upgrade-poll gal=ship =address]
+      [%cast-upgrade-vote gal=ship =address vote=?]
     ::
       [%send-point as=ship point=ship to=address]
     ::


### PR DESCRIPTION
I keep making these changes locally, so probably good to just commit them instead. 0a5bcf7 is pretty ugly, but gets the job done. We're not doing spawn-based lockups anymore anyway.

Arguably this should go into its own `pkg/` folder too, but the easier access is nice for now.