### PR TITLE
nix: bump secp256k1 to latest version

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -140,7 +140,7 @@
         "pmnsh": {
             "include": "include",
             "lib": ".libs",
-            "prepare": "./autogen.sh && ./configure --disable-shared --enable-module-recovery CFLAGS=-DSECP256K1_API=",
+            "prepare": "./autogen.sh && ./configure --disable-shared --enable-module-recovery --enable-module-schnorrsig CFLAGS=-DSECP256K1_API=",
             "make": "libsecp256k1.la"
         },
         "owner": "bitcoin-core",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -145,10 +145,10 @@
         },
         "owner": "bitcoin-core",
         "repo": "secp256k1",
-        "rev": "26de4dfeb1f1436dae1fcf17f57bdaa43540f940",
-        "sha256": "03i3nv8d3ci7q9y98q11rrp3rvwdqc0hc0ss0pr6xckybvizsmbb",
+        "rev": "793ad9016a09c3bf5a5f280c812c46526250d839",
+        "sha256": "1ckz4qgi639100l1g26hwm744hxqmzahlhmw059yj7fr273w4rc6",
         "type": "tarball",
-        "url": "https://github.com/bitcoin-core/secp256k1/archive/26de4dfeb1f1436dae1fcf17f57bdaa43540f940.tar.gz",
+        "url": "https://github.com/bitcoin-core/secp256k1/archive/793ad9016a09c3bf5a5f280c812c46526250d839.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "stackage.nix": {


### PR DESCRIPTION
Needed for Schnorr signatures.