### PR TITLE
hoon: wip, make parsers operate on cords

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -989,7 +989,7 @@
     ^-  (each (unit (each dojo-command tape)) hair)     ::  prefix+result
     =+  len=+((lent txt))                               ::  line length
     =.  txt  (weld buf `tape`(weld txt "\0a"))          ::
-    =+  vex=((full parse-command-line:he-parser) [1 1] txt)
+    =+  vex=((full parse-command-line:he-parser) [1 1] (crip txt))
     ?:  =(q.p.vex len)                                  ::  matched to line end
       [%& ~]                                            ::
     ?:  =(p.p.vex +((lent (skim txt |=(a=@ =(10 a)))))) ::  parsed all lines
@@ -1289,7 +1289,7 @@
         (insert-magic:auto (add (lent buf) pos) :(weld buf (tufa buf.say)))
     =/  id-len  (sub fore-pos back-pos)
     =/  fore-pos-diff  (sub fore-pos pos)
-    =+  vex=((full parse-command-line:he-parser) [1 1] txt)
+    =+  vex=((full parse-command-line:he-parser) [1 1] (crip txt))
     ?.  ?=([* ~ [* @ %ex *] *] vex)
       (he-tab-not-hoon pos :(weld buf (tufa buf.say) "\0a"))
     =/  typ  p:(slop q:he-hoon-head !>(..zuse))

--- a/pkg/arvo/mar/snip.hoon
+++ b/pkg/arvo/mar/snip.hoon
@@ -25,12 +25,12 @@
     ?~  lim  [0 ~]
     =/  [lam=@u hed=manx]
       ?:  ?=(_;/(**) i.mal)
-        [lim ;/(tay)]:(deword lim v.i.a.g.i.mal)
+        [lim ;/((trip tay))]:(deword lim (crip v.i.a.g.i.mal))
       [rem ele(c res)]:[ele=i.mal $(mal c.i.mal)]
     [rem - res]:[hed $(lim lam, mal t.mal)]
   ::
   ++  deword
-    |=  [lim=@u tay=tape]  ^-  [lim=@u tay=tape]
+    |=  [lim=@u tay=cord]  ^-  [lim=@u tay=cord]
     ?~  tay  [lim tay]
     ?~  lim  [0 ~]
     =+  wer=(dot 1^1 tay)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4031,8 +4031,8 @@
           ^=  q                                         ::
           ?@  +.b  ~                                    ::
           :-  ~                                         ::
-          u=[p=(a +>-.b) q=[p=(hair -.b) q=(tape +.b)]] ::
-+$  nail  [p=hair q=tape]                               ::  parsing input
+          u=[p=(a +>-.b) q=[p=(hair -.b) q=(cord +.b)]] ::
++$  nail  [p=hair q=cord]                               ::  parsing input
 +$  pint  [p=[p=@ q=@] q=[p=@ q=@]]                     ::  line+column range
 +$  rule  _|:($:nail $:edge)                            ::  parsing rule
 +$  spot  [p=path q=pint]                               ::  range in file
@@ -4914,22 +4914,24 @@
 ::
 ++  inde  |*  sef=rule                                  :: indentation block
   |=  nail  ^+  (sef)
-  =+  [har tap]=[p q]:+<
+  =+  [har cor]=[p q]:+<
   =+  lev=(fil 3 (dec q.har) ' ')
   =+  eol=(just `@t`10)
-  =+  =-  roq=((star ;~(pose prn ;~(sfix eol (jest lev)) -)) har tap)
+  =+  =-  roq=((star ;~(pose prn ;~(sfix eol (jest lev)) -)) har cor)
       ;~(simu ;~(plug eol eol) eol)
   ?~  q.roq  roq
-  =+  vex=(sef har(q 1) p.u.q.roq)
+  =+  vex=(sef har(q 1) (crip p.u.q.roq))
   =+  fur=p.vex(q (add (dec q.har) q.p.vex))
   ?~  q.vex  vex(p fur)
   =-  vex(p fur, u.q -)
-  :+  &3.vex
-    &4.vex(q.p (add (dec q.har) q.p.&4.vex))
-  =+  res=|4.vex
-  |-  ?~  res  |4.roq
-  ?.  =(10 -.res)  [-.res $(res +.res)]
-  (welp [`@t`10 (trip lev)] $(res +.res))
+  :+  &3.vex  ::  p.u.q.vex, out value
+    &4.vex(q.p (add (dec q.har) q.p.&4.vex))  ::  p.q.u.q.vex, hair
+  =+  res=|4.vex  ::  q.q.u.q.vex, cord
+  |-  ?:  =('' res)  |4.roq  ::  cord
+  =+  nep=(end 3 res)
+  =+  nex=(rsh 3 res)
+  ?.  =(10 nep)  (cat 3 nep $(res nex))
+  (cat 3 (cat 3 10 lev) $(res nex))
 ::
 ++  ifix
   |*  [fel=[rule rule] hof=rule]
@@ -4945,9 +4947,9 @@
   |-  ^-  (like @t)
   ?:  =(`@`0 daf)
     [p=p.tub q=[~ u=[p=fad q=tub]]]
-  ?:  |(?=(~ q.tub) !=((end 3 daf) i.q.tub))
+  ?:  !=((end 3 daf) (end 3 q.tub))
     (fail tub)
-  $(p.tub (lust i.q.tub p.tub), q.tub t.q.tub, daf (rsh 3 daf))
+  $(p.tub (lust (end 3 q.tub) p.tub), q.tub (rsh 3 q.tub), daf (rsh 3 daf))
 ::
 ++  just                                                ::  XX redundant, jest
   ~/  %just                                             ::  match a char
@@ -4955,9 +4957,9 @@
   ~/  %fun
   |=  tub=nail
   ^-  (like char)
-  ?~  q.tub
+  ?:  =('' q.tub)
     (fail tub)
-  ?.  =(daf i.q.tub)
+  ?.  =(daf (end 3 q.tub))
     (fail tub)
   (next tub)
 ::
@@ -4975,9 +4977,10 @@
   ~/  %fun
   |=  tub=nail
   ^-  (like char)
-  ?~  q.tub
+  ?:  =('' q.tub)
     (fail tub)
-  ?.  (lien bud |=(a=char =(i.q.tub a)))
+  =+  nep=(end 3 q.tub)
+  ?.  (lien bud |=(a=char =(nep a)))
     (fail tub)
   (next tub)
 ::
@@ -4992,10 +4995,11 @@
 ++  next                                                ::  consume a char
   |=  tub=nail
   ^-  (like char)
-  ?~  q.tub
+  ?:  =('' q.tub)
     (fail tub)
-  =+  zac=(lust i.q.tub p.tub)
-  [zac [~ i.q.tub [zac t.q.tub]]]
+  =+  nep=(end 3 q.tub)
+  =+  zac=(lust nep p.tub)
+  [zac [~ nep [zac (rsh 3 q.tub)]]]
 ::
 ++  perk                                                ::  parse cube fork
   |*  a=(pole @tas)
@@ -5030,9 +5034,10 @@
   ~/  %fun
   |=  tub=nail
   ^-  (like char)
-  ?~  q.tub
+  ?:  =('' q.tub)
     (fail tub)
-  ?.  ?&((gte i.q.tub les) (lte i.q.tub mos))
+  =+  nep=(end 3 q.tub)
+  ?.  ?&((gte nep les) (lte nep mos))
     (fail tub)
   (next tub)
 ::
@@ -5083,17 +5088,18 @@
       [n.nuc [n.yal l.yal l.nuc] r.nuc]
   ~%  %fun  ..^$  ~
   |=  tub=nail
-  ?~  q.tub
+  ?:  =('' q.tub)
     (fail tub)
   |-
   ?~  hel
     (fail tub)
+  =+  nep=(end 3 q.tub)
   ?:  ?@  p.n.hel
-        =(p.n.hel i.q.tub)
-      ?&((gte i.q.tub -.p.n.hel) (lte i.q.tub +.p.n.hel))
-    ::  (q.n.hel [(lust i.q.tub p.tub) t.q.tub])
+        =(p.n.hel nep)
+      ?&((gte nep -.p.n.hel) (lte nep +.p.n.hel))
+    ::  (q.n.hel [(lust nep p.tub) (rsh 3 q.tub)])
     (q.n.hel tub)
-  ?:  (wor i.q.tub p.n.hel)
+  ?:  (wor nep p.n.hel)
     $(hel l.hel)
   $(hel r.hel)
 ::
@@ -5156,19 +5162,19 @@
 ::
 ::::  4g: parsing (outside caller)
   ::
-++  rash  |*([naf=@ sab=rule] (scan (trip naf) sab))
+++  scan  |*([naf=tape sab=rule] (rash (crip naf) sab))
 ++  rose  |*  [los=tape sab=rule]
-          =+  vex=(sab [[1 1] los])
+          =+  vex=(sab [[1 1] (crip los)])
           =+  len=(lent los)
           ?.  =(+(len) q.p.vex)  [%| p=(dec q.p.vex)]
           ?~  q.vex
             [%& p=~]
           [%& p=[~ u=p.u.q.vex]]
-++  rush  |*([naf=@ sab=rule] (rust (trip naf) sab))
-++  rust  |*  [los=tape sab=rule]
+++  rust  |*([naf=tape sab=rule] (rush (crip naf) sab))
+++  rush  |*  [los=cord sab=rule]
           =+  vex=((full sab) [[1 1] los])
           ?~(q.vex ~ [~ u=p.u.q.vex])
-++  scan  |*  [los=tape sab=rule]
+++  rash  |*  [los=cord sab=rule]
           =+  vex=((full sab) [[1 1] los])
           ?~  q.vex
             ~_  (show [%m '{%d %d}'] p.p.vex q.p.vex ~)
@@ -5245,25 +5251,7 @@
            (cook |=(a=char (sub a 87)) (shim 'a' 'f'))
            (cook |=(a=char (sub a 55)) (shim 'A' 'F'))
          ==
-++  iny                                                 :: indentation block
-  |*  sef=rule
-  |=  nail  ^+  (sef)
-  =+  [har tap]=[p q]:+<
-  =+  lev=(fil 3 (dec q.har) ' ')
-  =+  eol=(just `@t`10)
-  =+  =-  roq=((star ;~(pose prn ;~(sfix eol (jest lev)) -)) har tap)
-      ;~(simu ;~(plug eol eol) eol)
-  ?~  q.roq  roq
-  =+  vex=(sef har(q 1) p.u.q.roq)
-  =+  fur=p.vex(q (add (dec q.har) q.p.vex))
-  ?~  q.vex  vex(p fur)
-  =-  vex(p fur, u.q -)
-  :+  &3.vex
-    &4.vex(q.p (add (dec q.har) q.p.&4.vex))
-  =+  res=|4.vex
-  |-  ?~  res  |4.roq
-  ?.  =(10 -.res)  [-.res $(res +.res)]
-  (welp [`@t`10 (trip lev)] $(res +.res))
+++  iny  inde                                           :: indentation block
 ::
 ++  low  (shim 'a' 'z')                                 ::  lowercase
 ++  mes  %+  cook                                       ::  hexbyte
@@ -5948,8 +5936,8 @@
   |=  txt=@ta  ^-  (unit coin)
   =+  ^=  vex
       ?:  (gth 0x7fff.ffff txt)                         ::  XX  petty cache
-        ~+  ((full nuck:so) [[1 1] (trip txt)])
-      ((full nuck:so) [[1 1] (trip txt)])
+        ~+  ((full nuck:so) [[1 1] txt])
+      ((full nuck:so) [[1 1] txt])
   ?~  q.vex
     ~
   [~ p.u.q.vex]
@@ -12065,7 +12053,7 @@
       =|  hac=(list item)
       =/  cur=item  [%down ~]
       =|  par=(unit (pair hair wall))
-      |_  [loc=hair txt=tape]
+      |_  [loc=hair txt=cord]
       ::
       ++  $                                           ::  resolve
         ^-  (like tarp)
@@ -12139,18 +12127,20 @@
         |-  ^+  [[lin *(unit _err)] +<.^$]  :: parsed tape and halt/error
         ::
         ::  no unterminated lines
-        ?~  txt
+        ?:  =('' txt)
           ~?  verbose  %unterminated-line
           [[~ ``loc] +<.^$]
-        ?.  =(`@`10 i.txt)
+        =+  nep=(end 3 txt)
+        =+  nex=(rsh 3 txt)
+        ?.  =(`@`10 nep)
           ?:  (gth inr.ind q.loc)
-            ?.  =(' ' i.txt)
+            ?.  =(' ' nep)
               ~?  verbose  expected-indent+[inr.ind loc txt]
               [[~ ``loc] +<.^$]
-            $(txt t.txt, q.loc +(q.loc))
+            $(txt nex, q.loc +(q.loc))
           ::
           ::  save byte and repeat
-          $(txt t.txt, q.loc +(q.loc), lin [i.txt lin])
+          $(txt nex, q.loc +(q.loc), lin [nep lin])
         =.  lin
         ::
         ::  trim trailing spaces
@@ -12159,7 +12149,7 @@
             $(lin t.lin)
           (flop lin)
           ::
-        =/  eat-newline=nail  [[+(p.loc) 1] t.txt]
+        =/  eat-newline=nail  [[+(p.loc) 1] nex]
         =/  saw  look(+<.$ eat-newline)
         ::
         ?:  ?=([~ @ %end ?(%stet %dent)] saw)           ::  stop on == or dedent
@@ -12199,11 +12189,11 @@
           ;/("{+<}\0a")
         ::
         ::  yex: block recomposed, with newlines
-        =/  yex=tape
-          %-  zing
+        =/  yex=cord
+          %+  rap  3
           %+  turn  (flop q.u.par)
           |=  a=tape
-          (runt [(dec inr.ind) ' '] "{a}\0a")
+          (rap 3 (fil 3 (dec inr.ind) ' ') (crip a) '\0a' ~)
         ::
         ::  vex: parse of paragraph
         =/  vex=(like tarp)
@@ -12359,7 +12349,7 @@
           =.  inr.ind  (add 2 inr.ind)
           ::
           ::  "parse" marker
-          =.  txt  (slag (sub inr.ind q.loc) txt)
+          =.  txt  (rsh 3^(sub inr.ind q.loc) txt)
           =.  q.loc  inr.ind
           ::
           (push typ)
@@ -12423,7 +12413,7 @@
                 fex=rule
                 sab=rule
             ==
-        |=  [loc=hair txt=tape]
+        |=  [loc=hair txt=cord]
         ^+  *sab
         ::
         ::  vex: fenced span
@@ -12431,7 +12421,7 @@
         ?~  q.vex  vex
         ::
         ::  hav: reparse full fenced text
-        =/  hav  ((full sab) [loc p.u.q.vex])
+        =/  hav  ((full sab) [loc (crip p.u.q.vex)])
         ::
         ::  reparsed error position is always at start
         ?~  q.hav  [loc ~]
@@ -12449,7 +12439,7 @@
       ::
       ++  echo                                          ::  hoon literal
         |*  sab=rule
-        |=  [loc=hair txt=tape]
+        |=  [loc=hair txt=cord]
         ^-  (like tape)
         ::
         ::  vex: result of parsing wide hoon
@@ -12463,7 +12453,7 @@
         |-  ^-  tape
         ?:  =(q.q.u.q.vex txt)  ~
         ?~  txt  ~
-        [i.txt $(txt +.txt)]
+        [(end 3 txt) $(txt (rsh 3 txt))]
       ::
       ++  non-empty
         |*  a=rule

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -794,7 +794,7 @@
       ^-  vase
       =^  cag=cage  nub  (read-file path)
       ?>  =(%hoon p.cag)
-      =/  tex=tape  (trip !<(@t q.cag))
+      =/  tex=cord  !<(@t q.cag)
       =/  =pile  (parse-pile path tex)
       =.  hoon.pile  !,(*hoon .)
       =^  res=vase  nub  (run-pile pile)
@@ -819,7 +819,7 @@
       :: ~>  %slog.0^leaf/"ford: make file {(spud path)}"
       =^  cag=cage  nub  (read-file path)
       ?>  =(%hoon p.cag)
-      =/  tex=tape  (trip !<(@t q.cag))
+      =/  tex=cord  !<(@t q.cag)
       =/  =pile  (parse-pile path tex)
       =^  res=vase  nub  (run-pile pile)
       =^  top  stack.nub  pop-stack
@@ -870,15 +870,16 @@
       [res nub]
     ::
     ++  parse-pile
-      |=  [pax=path tex=tape]
+      |=  [pax=path tex=cord]
       ^-  pile
-      =/  [=hair res=(unit [=pile =nail])]  ((pile-rule pax) [1 1] tex)
+      =/  [=hair res=(unit [=pile =nail])]
+        ((pile-rule pax) [1 1] tex)
       ?^  res  pile.u.res
       %-  mean  %-  flop
       =/  lyn  p.hair
       =/  col  q.hair
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
-          leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
+          leaf+(trip (snag (dec lyn) (to-wain:format tex)))
           leaf+(runt [(dec col) '-'] "^")
       ==
     ::
@@ -1457,7 +1458,7 @@
     ?~  yen
       =.  lab.dom  (~(put by lab.dom) bel yon)
       ..park
-    ::  an aeon is bound to this label, 
+    ::  an aeon is bound to this label,
     ::  but it is the same as the existing one, so we no-op
     ::
     ?:  =(u.yen yon)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4584,12 +4584,12 @@
               (cook |=(a=tape (rap 3 ^-((list @) a))) (star aln))
               dot
             ==
-        [1^1 (flop (trip i.rax))]
+        [1^1 (swp 3 i.rax)]
       ?~  q.raf
         [~ [i.rax ~]]
-      =+  `[ext=term [@ @] fyl=tape]`u.q.raf
+      =+  `[ext=term [@ @] fyl=cord]`u.q.raf
       :-  `ext
-      ?:(=(~ fyl) ~ [(crip (flop fyl)) ~])
+      ?:(=(~ fyl) ~ [(swp 3 fyl) ~])
     ::                                                  ::  ++apat:de-purl:html
     ++  apat                                            ::  2396 abs_path
       %+  cook  deft

--- a/pkg/base-dev/lib/der.hoon
+++ b/pkg/base-dev/lib/der.hoon
@@ -177,11 +177,12 @@
   ++  till
     |=  tub=nail
     ^-  (like (list @D))
-    ?~  q.tub
+    ?:  =('' q.tub)
       (fail tub)
     ::  fuz: first byte - length, or length of the length
     ::
-    =*  fuz  i.q.tub
+    =/  fuz  (end 3 q.tub)
+    =/  fur  (rsh 3 q.tub)
     ::  nex: offset of value bytes from fuz
     ::  len: length of value bytes
     ::
@@ -191,20 +192,20 @@
       =/  faz  (end [0 7] fuz)
       ?:  =(0 (cut 0 [7 1] fuz))
         [0 faz]
-      [faz (rep 3 (flop (scag faz t.q.tub)))]
+      [faz (swp 3 (end 3^faz fur))]
     ?:  ?&  !=(0 nex)
             !=(nex (met 3 len))
         ==
       (fail tub)
     ::  zuf: value bytes
     ::
-    =/  zuf  (swag [nex len] t.q.tub)
-    ?.  =(len (lent zuf))
+    =/  zuf  (cut 3 [nex len] fur)
+    ?.  =(len (met 3 zuf))
       (fail tub)
     ::  zaf:  product nail
     ::
     =/  zaf  [p.p.tub (add +(nex) q.p.tub)]
-    [zaf `[zuf zaf (slag (add nex len) t.q.tub)]]
+    [zaf `[(trip zuf) zaf (rsh 3^(add nex len) fur)]]
   --
 --
 

--- a/pkg/base-dev/lib/language-server/complete.hoon
+++ b/pkg/base-dev/lib/language-server/complete.hoon
@@ -10,7 +10,7 @@
 ::
 ++  lily
   |*  [los=tape sab=rule]
-  =+  vex=(sab [[1 1] los])
+  =+  vex=(sab [[1 1] (crip los)])
   ?~  q.vex
     [%| p=p.vex(q (dec q.p.vex))]
   ?.  =(~ q.q.u.q.vex)

--- a/pkg/urbit/jets/e/parse.c
+++ b/pkg/urbit/jets/e/parse.c
@@ -71,8 +71,8 @@
       return _fail(tub);
     }
     else {
-      u3_noun iq_tub = u3h(q_tub);
-      u3_noun tq_tub = u3t(q_tub);
+      u3_noun iq_tub = u3qc_end(3, 1, q_tub);
+      u3_noun tq_tub = u3qc_rsh(3, 1, q_tub);
 
       zac = _slip(iq_tub, p_tub);
 
@@ -483,7 +483,7 @@
       return _fail(tub);
     }
     else {
-      u3_noun iq_tub = u3h(q_tub);
+      u3_noun iq_tub = u3qc_end(3, 1, q_tub);
 
       if ( c3y == u3r_sing(daf, iq_tub) ) {
         return _next(tub);
@@ -519,7 +519,7 @@
       return _fail(tub);
     }
     else {
-      u3_noun iq_tub = u3h(q_tub);
+      u3_noun iq_tub = u3qc_end(3, 1, q_tub);
 
       while ( c3y == u3du(bud) ) {
         if ( c3y == u3r_sing(u3h(bud), iq_tub) ) {
@@ -744,7 +744,7 @@
     }
     else {
       u3_noun p_zep, q_zep;
-      u3_noun iq_tub = u3h(q_tub);
+      u3_noun iq_tub = u3qc_end(3, 1, q_tub);
 
       u3x_cell(zep, &p_zep, &q_zep);
       if ( _(u3a_is_cat(p_zep)) &&
@@ -860,7 +860,7 @@
       return _fail(tub);
     }
     else {
-      u3_noun iq_tub = u3h(q_tub);
+      u3_noun iq_tub = u3qc_end(3, 1, q_tub);
 
       if ( !_(u3a_is_cat(iq_tub)) ) {
         return u3m_bail(c3__fail);

--- a/pkg/urbit/jets/e/parse.c
+++ b/pkg/urbit/jets/e/parse.c
@@ -67,7 +67,7 @@
     u3_noun zac;
 
     u3x_cell(tub, &p_tub, &q_tub);
-    if ( c3n == u3du(q_tub) ) {
+    if ( u3_nul == q_tub ) {
       return _fail(tub);
     }
     else {
@@ -479,7 +479,7 @@
 
     u3x_cell(tub, &p_tub, &q_tub);
 
-    if ( c3n == u3du(q_tub) ) {
+    if ( u3_nul == q_tub ) {
       return _fail(tub);
     }
     else {
@@ -515,7 +515,7 @@
 
     u3x_cell(tub, &p_tub, &q_tub);
 
-    if ( c3n == u3du(q_tub) ) {
+    if ( u3_nul == q_tub ) {
       return _fail(tub);
     }
     else {
@@ -739,7 +739,7 @@
 
     u3x_cell(tub, &p_tub, &q_tub);
 
-    if ( c3n == u3du(q_tub) ) {
+    if ( u3_nul == q_tub ) {
       return _fail(tub);
     }
     else {
@@ -856,7 +856,7 @@
     u3_noun p_tub, q_tub;
 
     u3x_cell(tub, &p_tub, &q_tub);
-    if ( c3n == u3du(q_tub) ) {
+    if ( u3_nul == q_tub ) {
       return _fail(tub);
     }
     else {


### PR DESCRIPTION
This has been mentioned in passing in the past, so figured I'd take a stab at it for laughs. Initial results are... not very promising.

Taking out the jets and testing this using the `/tests/sys/zuse/html` de-xml and de-json tests, the old version is ~20% faster. Testing against `(ream .^(@t %cx %/sys/zuse/hoon)` though, the old version is _~24 times faster_ than the parsers in this pr. That feels like way too big a difference, I have to wonder if I just did something very wrong here.

Having trouble comparing the jetted version, because when I try to start up vere with these changes I hit an atom assertion, something is trying to parse `"$:type"` using the jet (even with jet hints still commented out in hoon.hoon), but I'm not sure where that's being parsed (during the `lite: arvo formula` phase).

Could be interesting to compare the memory characteristics here as well, wish we had `%duel` as a memory-oriented corollary to `%bout`.

Opening this draft pr as an rfc. Pile on!