### PR TITLE
improve de-xml parser

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4422,7 +4422,7 @@
     ::                                                  ::  ++chrd:de-xml:html
     ++  chrd                                            ::  character data
       %+  cook  |=(a=tape ^-(mars ;/(a)))
-      (plus ;~(less doq ;~(pose (just `@`10) escp)))
+      (plus ;~(pose (just `@`10) escp))
     ::                                                  ::  ++comt:de-xml:html
     ++  comt                                            ::  comments
       =-  (ifix [(jest '<!--') (jest '-->')] (star -))


### PR DESCRIPTION
de-xml parser fails when xml content node contains doublequotes (`doq` rule), this PR proposes to remove this restriction as high-level javascript APIs that operate on DOM don't entitize/encode doublequotes by default.