### PR TITLE
roller: update roller and roller-rpc with quota related methods

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -130,6 +130,7 @@
         ~&  [%rerunning (lent logs.state)]
         =.  points.nas.state  ~
         =.  own.state  ~
+        =.  spo.state  ~
         =^  *  state  (run-logs:do logs.state)
         `this
       ::
@@ -329,7 +330,7 @@
     ?:  =(naive.net address.i.logs)
       (tx-effects:dice chain-id.net raw-effects cache indices)
     =<  indices
-    (point-effects:dice raw-effects cache nas.state indices)
+    (point-effects:dice raw-effects points.cache points.nas.state indices)
   =:  own.state  own.indices
       spo.state  spo.indices
     ==

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -309,7 +309,8 @@
     [(flop effects) state]
   ?~  mined.i.logs
     $(logs t.logs)
-  =/  [raw-effects=effects:naive new-nas=_nas.state]
+  =+  cache=nas.state
+  =^  raw-effects  nas.state
     =/  =^input:naive
       :-  block-number.u.mined.i.logs
       ?:  =(azimuth.net address.i.logs)
@@ -321,28 +322,14 @@
         [%bat *@]
       [%bat u.input.u.mined.i.logs]
     (%*(. naive lac |) verifier chain-id.net nas.state input)
-  ::  TODO: move to /lib/dice ?
-  ::
-  =/  [new-own=_own.state new-spo=_spo.state]
-    =<  [own spo]
+  =/  =indices  [own spo]:state
+  =.  indices
     ?.  =(azimuth.net address.i.logs)
-      %:  apply-effects:dice
-        chain-id.net
-        raw-effects
-        nas.state
-        own.state
-        spo.state
-      ==
-    %:  update-indices:dice
-      raw-effects
-      nas.state
-      new-nas
-      own.state
-      spo.state
-    ==
-  =:  nas.state  new-nas
-      own.state  new-own
-      spo.state  new-spo
+      (apply-effects:dice chain-id.net raw-effects cache indices)
+    =<  indices
+    (update-indices:dice raw-effects cache nas.state indices)
+  =:  own.state  own.indices
+      spo.state  spo.indices
     ==
   =/  effects-1
     =/  =id:block  [block-hash block-number]:u.mined.i.logs

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -322,12 +322,14 @@
         [%bat *@]
       [%bat u.input.u.mined.i.logs]
     (%*(. naive lac |) verifier chain-id.net nas.state input)
+  ::  TODO: make index update optional?
+  ::
   =/  =indices  [own spo]:state
   =.  indices
-    ?.  =(azimuth.net address.i.logs)
-      (apply-effects:dice chain-id.net raw-effects cache indices)
+    ?:  =(naive.net address.i.logs)
+      (tx-effects:dice chain-id.net raw-effects cache indices)
     =<  indices
-    (update-indices:dice raw-effects cache nas.state indices)
+    (point-effects:dice raw-effects cache nas.state indices)
   =:  own.state  own.indices
       spo.state  spo.indices
     ==

--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -151,12 +151,14 @@
     ?:  ?=(l2-tx method)
       (process-rpc id +.params method over-quota:scry)
     ?+  method  [~ ~(method error:json-rpc id)]
+      %cancel-transaction      (cancel-tx id +.params)
+      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
+      %get-remaining-quota     `(quota-remaining id +.params ship-quota:scry)
       %get-point               `(get-point id +.params point:scry)
       %get-ships               `(get-ships id +.params ships:scry)
-      %cancel-transaction      (cancel-tx id +.params)
       %get-spawned             `(get-spawned id +.params spawned:scry)
       %get-unspawned           `(get-spawned id +.params unspawned:scry)
-      %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
       %get-sponsored-points    `(sponsored-points id +.params sponsored:scry)
       %get-owned-points        `(get-ships id +.params owned:scry)
       %get-transferring-for    `(get-ships id +.params transfers:scry)
@@ -168,18 +170,13 @@
       %get-pending-by-address  `(addr:pending id +.params addr:pending:scry)
       %get-pending-tx          `(hash:pending id +.params hash:pending:scry)
       %get-transaction-status  `(status id +.params tx-status:scry)
-      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %get-predicted-state     `(get-naive id +.params predicted:scry)
       %get-nonce               `(nonce id +.params nonce:scry)
       %get-history             `(history id +.params addr:history:scry)
       %get-roller-config       `(get-config id +.params config:scry)
-      %prepare-for-signing     `(hash-transaction id +.params chain:scry | &)
       %get-unsigned-tx         `(hash-transaction id +.params chain:scry & |)
-      %get-predicted-state     `(get-naive id +.params predicted:scry)
+      %prepare-for-signing     `(hash-transaction id +.params chain:scry | &)
       %hash-raw-transaction    `(hash-raw-transaction id +.params)
-      :: TODO: deprecated, remove (used together with personal_sign)
-      ::
-      %hash-transaction        ::`(hash-transaction id +.params chain:scry | &)
-                               `(hash-transaction id +.params chain:scry & |)
     ==
   --
 ::
@@ -354,6 +351,13 @@
     .^  ?
         %gx
         (~(scry agentio bowl) %roller /over-quota/(scot %p ship)/atom)
+    ==
+  ::
+  ++  ship-quota
+    |=  =ship
+    .^  @ud
+        %gx
+        (~(scry agentio bowl) %roller /ship-quota/(scot %p ship)/atom)
     ==
   ::
   ++  ready

--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -152,9 +152,11 @@
       (process-rpc id +.params method over-quota:scry)
     ?+  method  [~ ~(method error:json-rpc id)]
       %cancel-transaction      (cancel-tx id +.params)
-      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %when-next-batch         `(next-timer id +.params next-batch:scry)
+      %when-next-slice         `(next-timer id +.params next-slice:scry)
       %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
       %get-remaining-quota     `(quota-remaining id +.params ship-quota:scry)
+      %get-allowance           `(ship-allowance id +.params allowance:scry)
       %get-point               `(get-point id +.params point:scry)
       %get-ships               `(get-ships id +.params ships:scry)
       %get-spawned             `(get-spawned id +.params spawned:scry)
@@ -304,7 +306,13 @@
   ++  next-batch
     .^  time
         %gx
-        (~(scry agentio bowl) %roller /next-batch/noun)
+        (~(scry agentio bowl) %roller /next-batch/atom)
+    ==
+  ::
+  ++  next-slice
+    .^  time
+        %gx
+        (~(scry agentio bowl) %roller /next-slice/atom)
     ==
   ::
   ++  nonce
@@ -358,6 +366,13 @@
     .^  @ud
         %gx
         (~(scry agentio bowl) %roller /ship-quota/(scot %p ship)/atom)
+    ==
+  ::
+  ++  allowance
+    |=  =ship
+    .^  (unit @ud)
+        %gx
+        (~(scry agentio bowl) %roller /allowance/(scot %p ship)/noun)
     ==
   ::
   ++  ready

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -232,7 +232,7 @@
   ++  on-init
     ^-  (quip card _this)
     =:  frequency    ~h1
-        quota        7
+        quota        25
         slice        ~d7
         resend-time  ~m5
         update-rate  ~m5
@@ -592,8 +592,6 @@
         ::
             %naive-state
           ~&  >  %received-azimuth-state
-          ::  cache naive and ownership state
-          ::
           =+  !<([nas=^state:naive =indices] q.cage.sign)
           =^  effects  state
             (predicted-state:do nas indices)
@@ -968,7 +966,7 @@
       ::  TODO: set up a timer to retry this in ~mX ?
       ::
       ~?  lverb  [dap.bowl %nonce-out-sync]  [~ state]
-    =/  nonce=@ud   u.next-nonce
+    =/  nonce=@ud  u.next-nonce
     =^  updates-2  history  (update-history:dice history pending %sending)
     =/  =address:ethereum   (get-address pk)
     =:  pending     ~

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -950,10 +950,13 @@
 ++  try-apply
   |=  [nas=^state:naive force=? =raw-tx:naive]
   ^-  [[? ups=(list update)] _state]
-  =/  [success=? ups=(list update) predicted=_nas owners=_own sponsors=_spo]
+  =/  [success=? ups=(list update) predicted=_nas =indices]
     (apply-raw-tx:dice force chain-id raw-tx nas own spo)
-  :-  [success ups]
-  state(pre predicted, own owners, spo sponsors)
+  =:  pre  predicted
+      own  own.indices
+      spo  spo.indices
+    ==
+  [[success ups] state]
 ::
 ++  get-l1-address
   |=  [=tx:naive nas=^state:naive]

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -279,6 +279,7 @@
       [%x %quota ~]           ``atom+!>(quota)
       [%x %slice ~]           ``atom+!>(slice)
       [%x %over-quota @ ~]    (over-quota i.t.t.path)
+      [%x %ship-quota @ ~]    (ship-quota i.t.t.path)
       [%x %ready ~]           ``atom+!>(?=(^ points.pre))
     ==
     ::
@@ -450,6 +451,16 @@
       ?~  who=(slaw %p wat)  [~ ~]
       =/  [exceeded=? *]  (quota-exceeded u.who)
       ``atom+!>(exceeded)
+    ::
+    ++  ship-quota
+      |=  wat=@t
+      ?~  who=(slaw %p wat)  [~ ~]
+      =/  [exceeded=? next-quota=@ud]  (quota-exceeded u.who)
+      :+  ~  ~
+      :-  %atom
+      !>  ^-  @ud
+      ?:  exceeded  0
+      (sub quota.state (dec next-quota))
     ::
     --
   ::

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -864,6 +864,8 @@
     ==
   ::
       %setkey
+    =?  pk.config  =((end [3 2] pk.config) '0x')
+      (rsh [3 2] pk.config)
     ?~  pk=(de:base16:mimes:html pk.config)
       `state
     [(get-nonce q.u.pk /nonce) state(pk q.u.pk)]

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -1137,6 +1137,12 @@
   ::  print error if there was one
   ::
   ~?  ?=(%| -.result)  [dap.bowl %send-error +.p.result]
+  ::  if this nonce was removed from the queue by a
+  ::  previous resend-with-higher-gas thread, it's done
+  ::
+  ?.  (has:ors:dice sending [address nonce])
+    ~?  lverb  [dap.bowl %done-sending [address nonce]]
+    `state
   =/  =send-tx  (got:ors:dice sending [address nonce])
   =?  sending  ?=(%& -.result)
     %^  put:ors:dice  sending

--- a/pkg/arvo/gen/roller/assign.hoon
+++ b/pkg/arvo/gen/roller/assign.hoon
@@ -1,0 +1,6 @@
+::  Assigns a specific quota to the given ship
+::  Not providing a quota allows the ship to submit any number of transactions
+::
+:-  %say
+|=  [* [=ship quota=(unit @ud) ~] ~]
+[%roller-action %assign ship quota]

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -680,4 +680,13 @@
   ?.  =((lent ~(tap by params)) 0)
     ~(params error:json-rpc id)
   [%result id (azimuth-config:to-json azimuth-config)]
+::
+++  quota-remaining
+  |=  [id=@t params=(map @t json) quota-left=$-(@p @ud)]
+  ^-  response:rpc
+  ?.  =((lent ~(tap by params)) 1)
+    ~(params error:json-rpc id)
+  ?~  ship=(ship:from-json params)
+    ~(params error:json-rpc id)
+  [%result id (numb:enjs:format (quota-left u.ship))]
 --

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -599,7 +599,7 @@
     ~(parse error:json-rpc id)
   [%result id (tx-status:to-json (scry u.hash))]
 ::
-++  next-batch
+++  next-timer
   |=  [id=@t params=(map @t json) when=time]
   ^-  response:rpc
   ?.  =((lent ~(tap by params)) 0)
@@ -689,4 +689,16 @@
   ?~  ship=(ship:from-json params)
     ~(params error:json-rpc id)
   [%result id (numb:enjs:format (quota-left u.ship))]
+::
+++  ship-allowance
+  |=  [id=@t params=(map @t json) allowance=$-(@p (unit @ud))]
+  ^-  response:rpc
+  ?.  =((lent ~(tap by params)) 1)
+    ~(params error:json-rpc id)
+  ?~  ship=(ship:from-json params)
+    ~(params error:json-rpc id)
+  :+  %result  id
+  ?^  allow=(allowance u.ship)
+    (numb:enjs:format u.allow)
+  s+(crip "No quota restrictions for {(scow %p u.ship)}")
 --

--- a/pkg/arvo/lib/dice.hoon
+++ b/pkg/arvo/lib/dice.hoon
@@ -4,6 +4,16 @@
 /+  naive, *naive-transactions
 ::
 |%
+::  orp: ordered points in naive state by parent ship
+::
+++  orp  ((on ship point:naive) por:naive)
+::  ors: ordered sending map by (increasing) L1 nonce
+::
+++  ors  ((on l1-tx-pointer send-tx) nonce-order)
+::  orh: ordered tx history by (decreasing) timestamp
+::
+++  orh  ((on time roll-tx) gth)
+::
 ++  nonce-order
   |=  [a=[* =nonce:naive] b=[* =nonce:naive]]
   (lte nonce.a nonce.b)
@@ -26,171 +36,270 @@
   ?.  (verify-sig-and-nonce:naive verifier chain-t nas raw-tx)
     ~&  >>>  [%verify-sig-and-nonce %failed tx.raw-tx]
     [force ~ nas indices]
-  =^  *  points.nas
+  =^  effects-1  points.nas
     (increment-nonce:naive nas from.tx.raw-tx)
   ?~  nex=(receive-tx:naive nas tx.raw-tx)
     ~&  >>>  [%receive-tx %failed]
     [force ~ ?:(force nas cache) indices]
   =*  new-nas   +.u.nex
-  =*  effects   -.u.nex
+  =/  effects   (welp effects-1 -.u.nex)
   =^  updates   indices
-    (point-effects effects cache new-nas [own spo]:indices)
+    (point-effects effects points.cache points.new-nas [own spo]:indices)
   [& updates new-nas indices]
 ::
 ++  point-effects
-  |=  [=effects:naive cache=^state:naive nas=^state:naive =indices]
+  |=  [=effects:naive cache=points:naive =points:naive =indices]
   ^-  [(list update) indices=_indices]
-  =;  [updates=(list update) indices=_indices]
-    [(flop updates) indices]
-  %+  roll  effects
-  |=  [=diff:naive updates=(list update) indices=_indices]
-  =,  orm:naive
-  ?.  ?=([%point *] diff)  [updates indices]
-  =*  ship      ship.diff
-  =*  sponsors  spo.indices
-  =*  owners    own.indices
-  =/  old=(unit point:naive)
-    (get points.cache ship)
-  =/  new=point:naive
-    (need (get points.nas ship))
+  =^  updates=(list update)  indices
+    %+  roll  effects
+    |=  [=diff:naive updates=(list update) indices=_indices]
+    ?.  |(?=([%point *] diff) ?=([%nonce *] diff))
+      [updates indices]
+    ?:  ?=([%nonce *] diff)
+      :_  indices
+      (welp (nonce-updates diff cache points) updates)
+    ?>  ?=([%point *] diff)
+    =*  ship      ship.diff
+    =*  sponsors  spo.indices
+    =*  owners    own.indices
+    =/  old=(unit point:naive)  (get:orp cache ship)
+    =/  new=point:naive         (need (get:orp points ship))
+    =^  update-1  sponsors
+      (sponsorship diff ship new old sponsors)
+    =^  update-2  owners
+      (ownership diff ship new old owners)
+    =/  update-3=_updates
+      (point-data-updates diff ship new old)
+    :_  indices
+    :(welp update-3 update-2 update-1 updates)
+  [(flop updates) indices]
+::
+++  sponsorship
+  |=  [=diff:naive =ship new=point:naive old=(unit point:naive) =sponsors]
+  ::^+  sponsors
+  ^-  (quip update _sponsors)
+  ?.  ?=([%point *] diff)  `sponsors
   =*  event  +>.diff
-  |^
-  =.  sponsors  sponsorship
-  =^  update    owners  ownership
-  [(welp update updates) indices]
-  ::
-  ++  sponsorship
-    ^+  sponsors
-    ?+    -.event  sponsors
-        %owner
-      ?^  old
-        ::  ownership change
-        ::
-        sponsors
-      ::  owner event with ?=(~ old) is a spawn
+  ?+    -.event  `sponsors
+      %owner
+    ?^  old
+      ::  ownership change
       ::
-      =*  parent  who.sponsor.net.new
-      ?:  =(parent ship)  sponsors
-      %+  ~(put by sponsors)  parent
-      ?~  sponsor=(~(get by sponsors) parent)
-        :_  *(set @p)
-        (~(put in *(set @p)) ship)
-      :_  requests.u.sponsor
-      (~(put in residents.u.sponsor) ship)
+      `sponsors
+    ::  owner event with ?=(~ old) is a spawn
     ::
-        %escape
-      ?~  old     sponsors
-      =*  from    who.sponsor.net.u.old
-      =*  to      to.event
-      =*  escape  escape.net.u.old
-      ?~  to
-        :: cancel/reject escape
-        ::
-        ?~  escape  sponsors
-        ?~  receiver=(~(get by sponsors) u.escape)
-          sponsors
-        %+  ~(put by sponsors)  u.escape
-        :-  residents.u.receiver
-        (~(del in requests.u.receiver) ship)
-      ::  normal escape
+    =*  parent  who.sponsor.net.new
+    ?:  =(parent ship)  `sponsors
+    ::  updates for proxy %own are taken care of
+    ::  in +sponsorship  to avoid duplicates
+    ::
+    :-  ~
+    %+  ~(put by sponsors)  parent
+    ?~  sponsor=(~(get by sponsors) parent)
+      :_  *(set @p)
+      (~(put in *(set @p)) ship)
+    :_  requests.u.sponsor
+    (~(put in residents.u.sponsor) ship)
+  ::
+      %escape
+    ?~  old     `sponsors
+    =*  from    who.sponsor.net.u.old
+    =*  to      to.event
+    =*  escape  escape.net.u.old
+    ?~  to
+      :: cancel/reject escape
       ::
-      %+  ~(put by sponsors)  u.to
-      ?~  receiver=(~(get by sponsors) u.to)
-        :-  *(set @p)
-        (~(put in *(set @p)) ship)
+      ?~  escape  `sponsors
+      ?~  receiver=(~(get by sponsors) u.escape)
+        `sponsors
+      ::
+      :-  (proxy-updates diff ship new old)
+      ::
+      %+  ~(put by sponsors)  u.escape
       :-  residents.u.receiver
-      (~(put in requests.u.receiver) ship)
+      (~(del in requests.u.receiver) ship)
+    ::  normal escape
     ::
-        %sponsor
-      ?~  old   sponsors
-      =*  from  who.sponsor.net.u.old
-      =*  to    sponsor.event
-      =/  previous  (~(get by sponsors) from)
-      ?~  to
-        :: detach
-        ::
-        ?~  previous  sponsors
-        %+  ~(put by sponsors)  from
-        :_  requests.u.previous
-        (~(del in residents.u.previous) ship)
-      ::  accepted
-      ::
-      =/  receiver  (~(get by sponsors) u.to)
-      =?  sponsors  ?=(^ receiver)
-        %+  ~(put by sponsors)  u.to
-        :-  (~(put in residents.u.receiver) ship)
-        (~(del in requests.u.receiver) ship)
-      =?  sponsors  ?=(^ previous)
-        %+  ~(put by sponsors)  from
-        :_  requests.u.previous
-        (~(del in residents.u.previous) ship)
-      sponsors
-    ==
+    :-  (proxy-updates diff ship new old)
+    ::
+    %+  ~(put by sponsors)  u.to
+    ?~  receiver=(~(get by sponsors) u.to)
+      :-  *(set @p)
+      (~(put in *(set @p)) ship)
+    :-  residents.u.receiver
+    (~(put in requests.u.receiver) ship)
   ::
-  ++  ownership
-    ^-  (quip update _owners)
-    =;  [to=(unit owner) from=(unit owner)]
-      =?  owners  &(?=(^ from) !=(address.u.from 0x0))
-        (~(del ju owners) u.from ship)
-      ?:  ?|  =(~ to)
-              &(?=(^ to) =(address.u.to 0x0))
-          ==
-        [~ owners]
-      ?~  to  [~ owners]
-      :-  [%point ship new u.to from]~
-      (~(put ju owners) u.to ship)
-    ?+    -.event  [~ ~]
-        %owner
-      :-  `[%own +.event]
-      ?~  old  ~
-      `[%own address.owner.own.u.old]
+      %sponsor
+    ?~  old   `sponsors
+    =*  from  who.sponsor.net.u.old
+    =*  to    sponsor.event
+    =/  previous  (~(get by sponsors) from)
+    ?~  to
+      :: detach
+      ::
+      ?~  previous  `sponsors
+      ::
+      :-  (proxy-updates diff ship new old)
+      ::
+      %+  ~(put by sponsors)  from
+      :_  requests.u.previous
+      (~(del in residents.u.previous) ship)
+    ::  accepted
     ::
-        %management-proxy
-      :-  `[%manage +.event]
-      ?~  old  ~
-      `[%manage address.management-proxy.own.u.old]
-    ::
-        %spawn-proxy
-      :-  `[%spawn +.event]
-      ?~  old  ~
-      `[%spawn address.spawn-proxy.own.u.old]
-    ::
-        %voting-proxy
-      :-  `[%vote +.event]
-      ?~  old  ~
-      `[%vote address.voting-proxy.own.u.old]
-    ::
-        %transfer-proxy
-      :-  `[%transfer +.event]
-      ?~  old  ~
-      `[%transfer address.transfer-proxy.own.u.old]
-    ==
-  --
+    =/  receiver  (~(get by sponsors) u.to)
+    =?  sponsors  ?=(^ receiver)
+      %+  ~(put by sponsors)  u.to
+      :-  (~(put in residents.u.receiver) ship)
+      (~(del in requests.u.receiver) ship)
+    =?  sponsors  ?=(^ previous)
+      %+  ~(put by sponsors)  from
+      :_  requests.u.previous
+      (~(del in residents.u.previous) ship)
+    :_  sponsors
+    (proxy-updates diff ship new old)
+  ==
+::
+++  ownership
+  |=  [=diff:naive =ship new=point:naive old=(unit point:naive) =owners]
+  ^-  (quip update _owners)
+  ?.  ?=([%point *] diff)  `owners
+  =*  event  +>.diff
+  =;  [to=(unit owner) from=(unit owner)]
+    =?  owners  &(?=(^ from) !=(address.u.from 0x0))
+      (~(del ju owners) u.from ship)
+    ?:  ?|  =(~ to)
+            &(?=(^ to) =(address.u.to 0x0))
+        ==
+      [~ owners]
+    ?~  to  [~ owners]
+    :_  (~(put ju owners) u.to ship)
+    [%point diff ship new old u.to from]~
+  ?+    -.event  [~ ~]
+      %owner
+    :-  `[%own +.event]
+    ?~  old  ~
+    `[%own address.owner.own.u.old]
+  ::
+      %management-proxy
+    :-  `[%manage +.event]
+    ?~  old  ~
+    `[%manage address.management-proxy.own.u.old]
+  ::
+      %spawn-proxy
+    :-  `[%spawn +.event]
+    ?~  old  ~
+    `[%spawn address.spawn-proxy.own.u.old]
+  ::
+      %voting-proxy
+    :-  `[%vote +.event]
+    ?~  old  ~
+    `[%vote address.voting-proxy.own.u.old]
+  ::
+      %transfer-proxy
+    :-  `[%transfer +.event]
+    ?~  old  ~
+    `[%transfer address.transfer-proxy.own.u.old]
+  ==
+::
+++  proxy-updates
+  |=  [=diff:naive =ship =point:naive old=(unit point:naive)]
+  ^-  (list update)
+  =/  proxies=(list proxy:naive)
+    ~[%own %spawn %manage %vote %transfer]
+  ?~  old  ~
+  %-  flop
+  %+  roll  proxies
+  |=  [=proxy:naive updates=(list update)]
+  ?~  owner=(get-owner u.old proxy)  updates
+  :_  updates
+  [%point diff ship point old u.owner ~]
+::
+++  nonce-updates
+  |=  [=diff:naive cache=points:naive =points:naive]
+  ^-  (list update)
+  ?.  ?=([%nonce *] diff)  ~
+  =/  old=(unit point:naive)  (get:orp cache ship.diff)
+  =/  new=point:naive         (need (get:orp points ship.diff))
+  (point-data-updates diff ship.diff new old)
+::
+++  point-data-updates
+  |=  [=diff:naive =ship =point:naive old=(unit point:naive)]
+  ^-  (list update)
+  ?.  ?=([%point *] diff)  ~
+  =*  event  +>.diff
+  ?+    -.event  ~
+    %rift      (proxy-updates +<)
+    %keys      (proxy-updates +<)
+    %dominion  (proxy-updates +<)
+  ==
 ::
 ++  get-owner
   |=  [=point:naive =proxy:naive]
-  ^-  [=nonce:naive _point]
-  =*  own  own.point
+  ^-  (unit owner)
+  =,  own.point
   ?-    proxy
       %own
-    :-  nonce.owner.own
-    point(nonce.owner.own +(nonce.owner.own))
+    ?:(=(address.owner 0x0) ~ `own+address.owner)
   ::
       %spawn
-    :-  nonce.spawn-proxy.own
-    point(nonce.spawn-proxy.own +(nonce.spawn-proxy.own))
+    ?:(=(address.spawn-proxy 0x0) ~ `spawn+address.spawn-proxy)
   ::
       %manage
-    :-  nonce.management-proxy.own
-    point(nonce.management-proxy.own +(nonce.management-proxy.own))
+    ?:(=(address.management-proxy 0x0) ~ `manage+address.management-proxy)
   ::
       %vote
-    :-  nonce.voting-proxy.own
-    point(nonce.voting-proxy.own +(nonce.voting-proxy.own))
+    ?:(=(address.voting-proxy 0x0) ~ `vote+address.voting-proxy)
   ::
       %transfer
-    :-  nonce.transfer-proxy.own
-    point(nonce.transfer-proxy.own +(nonce.transfer-proxy.own))
+    ?:(=(address.transfer-proxy 0x0) ~ `transfer+address.transfer-proxy)
   ==
 ::
+++  get-nonce
+  |=  [=point:naive =proxy:naive]
+  ^-  nonce:naive
+  =,  own.point
+  ?-  proxy
+    %own       nonce.owner
+    %spawn     nonce.spawn-proxy
+    %manage    nonce.management-proxy
+    %vote      nonce.voting-proxy
+    %transfer  nonce.transfer-proxy
+  ==
+::
+++  controlled-ships
+  |=  [=address:ethereum =owners]
+  ^-  (list [=proxy:naive =ship])
+  =/  proxies=(list proxy:naive)
+    ~[%own %spawn %manage %vote %transfer]
+  %+  roll  proxies
+  |=  [=proxy:naive ships=(list [=proxy:naive ship])]
+  %+  welp
+    %+  turn
+      ~(tap in (~(get ju owners) [proxy address]))
+    (lead proxy)
+  ships
+::  +update-history: updates status for all given list of transaction
+::
+++  update-history
+  |=  [=history txs=(list pend-tx) =status]
+  ^-  (quip update _history)
+  =^  updates=(list update)  history
+    %+  roll  txs
+    |=  [=pend-tx ups=(list update) history=_history]
+    =,  pend-tx
+    =/  =roll-tx
+      =,  pend-tx
+      :*  ship.from.tx.raw-tx
+          status
+          (hash-raw-tx raw-tx)
+          (l2-tx +<.tx.raw-tx)
+      ==
+    =/  txs=(tree hist-tx)
+      ?~  txs=(~(get by history) address)  ~
+      u.txs
+    =?  txs  ?=(^ txs)  +:(del:orh txs time)
+    :-  [tx+[pend-tx status] ups]
+    %+  ~(put by history)  address
+    (put:orh txs [time roll-tx])
+  [(flop updates) history]
 --

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -19,8 +19,7 @@
   ==
 ::
 +$  indices
-  $:  nas=^state:naive
-      own=owners
+  $:  own=owners
       spo=sponsors
   ==
 ::

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -6,6 +6,7 @@
 +$  owner     [=proxy:naive =address:naive]
 +$  owners    (jug owner ship)
 +$  sponsors  (map ship [residents=(set ship) requests=(set ship)])
++$  history   (map address:ethereum (tree hist-tx))
 +$  net       ?(%mainnet %ropsten %local %default)
 ::
 +$  config
@@ -68,9 +69,16 @@
   ==
 ::
 +$  update
-  $%  [%point =ship =point:naive new=owner old=(unit owner)]
-      [%tx =address:ethereum =roll-tx]
-  ==
+  $%  [%tx =pend-tx =status]
+    ::
+      $:  %point
+          =diff:naive
+          =ship
+          new=point:naive
+          old=(unit point:naive)
+          to=owner
+          from=(unit owner)
+  ==  ==
 ::
 +$  hist-tx  [p=time q=roll-tx]
 +$  roll-tx  [=ship =status hash=keccak type=l2-tx]
@@ -92,4 +100,8 @@
       next-gas-price=@ud
       txs=(list raw-tx:naive)
   ==
+::
++$  roller-data
+  [chain-id=@ =points:naive history=(tree hist-tx) =owners =sponsors]
+::
 --

--- a/pkg/arvo/ted/roller/send.hoon
+++ b/pkg/arvo/ted/roller/send.hoon
@@ -101,7 +101,7 @@
   ;<  rep=(unit client-response:iris)  bind:m
     take-maybe-response:strandio
   =*  fallback
-    ~&  %fallback-gas-price
+    ~&  >>  %fallback-gas-price
     (pure:m 10.000.000.000)
   ?.  ?&  ?=([~ %finished *] rep)
           ?=(^ full-file.u.rep)


### PR DESCRIPTION
Adds suport for [roller-api](https://github.com/urbit/urbit/tree/roller/typescript-client/pkg/npm/roller-api) client [0.1.14](https://github.com/urbit/urbit/commit/347593316f8868e24a4286adabdd59421da96f81) and [0.1.13](https://github.com/urbit/urbit/commit/816afe3fa44d353148fe8e477ecd0c6d65127a5e):

- `%spawns-remaining`
- `%get-remaining-quota`
- `%when-next-slice`
- `%get-allowance`

Also refactoring and cleanup of `/lib/dice.hoon` and `/app/roller.hoon` to support a future, WIP [`/app/roller-cli.hoon`](https://github.com/urbit/urbit/pull/5459)