### PR TITLE
roller-cli: add cli to interact with azimuth rollers

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -130,6 +130,7 @@
         ~&  [%rerunning (lent logs.state)]
         =.  points.nas.state  ~
         =.  own.state  ~
+        =.  spo.state  ~
         =^  *  state  (run-logs:do logs.state)
         `this
       ::
@@ -329,7 +330,7 @@
     ?:  =(naive.net address.i.logs)
       (tx-effects:dice chain-id.net raw-effects cache indices)
     =<  indices
-    (point-effects:dice raw-effects cache nas.state indices)
+    (point-effects:dice raw-effects points.cache points.nas.state indices)
   =:  own.state  own.indices
       spo.state  spo.indices
     ==

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -309,7 +309,8 @@
     [(flop effects) state]
   ?~  mined.i.logs
     $(logs t.logs)
-  =/  [raw-effects=effects:naive new-nas=_nas.state]
+  =+  cache=nas.state
+  =^  raw-effects  nas.state
     =/  =^input:naive
       :-  block-number.u.mined.i.logs
       ?:  =(azimuth.net address.i.logs)
@@ -321,28 +322,14 @@
         [%bat *@]
       [%bat u.input.u.mined.i.logs]
     (%*(. naive lac |) verifier chain-id.net nas.state input)
-  ::  TODO: move to /lib/dice ?
-  ::
-  =/  [new-own=_own.state new-spo=_spo.state]
-    =<  [own spo]
+  =/  =indices  [own spo]:state
+  =.  indices
     ?.  =(azimuth.net address.i.logs)
-      %:  apply-effects:dice
-        chain-id.net
-        raw-effects
-        nas.state
-        own.state
-        spo.state
-      ==
-    %:  update-indices:dice
-      raw-effects
-      nas.state
-      new-nas
-      own.state
-      spo.state
-    ==
-  =:  nas.state  new-nas
-      own.state  new-own
-      spo.state  new-spo
+      (apply-effects:dice chain-id.net raw-effects cache indices)
+    =<  indices
+    (update-indices:dice raw-effects cache nas.state indices)
+  =:  own.state  own.indices
+      spo.state  spo.indices
     ==
   =/  effects-1
     =/  =id:block  [block-hash block-number]:u.mined.i.logs

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -322,12 +322,14 @@
         [%bat *@]
       [%bat u.input.u.mined.i.logs]
     (%*(. naive lac |) verifier chain-id.net nas.state input)
+  ::  TODO: make index update optional?
+  ::
   =/  =indices  [own spo]:state
   =.  indices
-    ?.  =(azimuth.net address.i.logs)
-      (apply-effects:dice chain-id.net raw-effects cache indices)
+    ?:  =(naive.net address.i.logs)
+      (tx-effects:dice chain-id.net raw-effects cache indices)
     =<  indices
-    (update-indices:dice raw-effects cache nas.state indices)
+    (point-effects:dice raw-effects cache nas.state indices)
   =:  own.state  own.indices
       spo.state  spo.indices
     ==

--- a/pkg/arvo/app/roller-cli.hoon
+++ b/pkg/arvo/app/roller-cli.hoon
@@ -398,9 +398,6 @@
   ++  submit
     |=  [=address:ethereum =tx:naive]
     ^-  (quip card _state)
-    ::  TODO: to state
-    ::
-    =/  chain-id=@  1.337
     ?~  roller=(~(get by addresses) address)
       ~&  >>>  'can\'t find address'
       `state
@@ -413,10 +410,7 @@
       `state
     =/  =nonce:naive
       (get-nonce:dice (got:orp:dice points ship.from.tx) proxy.from.tx)
-    =/  =keccak
-      %-  hash-tx:lib
-      (unsigned-tx:lib chain-id nonce (gen-tx-octs:lib tx))
-    =/  sig=octs  (sign-tx chain-id pk nonce tx)
+    =/  sig=octs  (sign-tx chain-id.state pk nonce tx)
     :_  state
     [(submit-tx roller address q.sig tx)]~
   --

--- a/pkg/arvo/app/roller-cli.hoon
+++ b/pkg/arvo/app/roller-cli.hoon
@@ -1,0 +1,480 @@
+::  roller-cli: CLI for L2 Azimuth Rollers
+::
+::  The CLI subscribes, upon the user's request, to a roller (local or remote)
+::  sending an address that the CLI user controls, and receving the naive state
+::  associated to the points controlled by that address; the history of the
+::  L2 txs for it, if any; an index of the points (per proxy) controlled by the
+::  address; and sponsor/owner indices, if the address controls any points.
+::
+::  Upon sending a command, the roller will register the L2 tx, add it to its
+::  pending queue if valid, and notifies us of any change in its state, but also
+::  of any of the cnanges that our tx has in the naive state, so we can update
+::  the information for the points we control.
+::
+::  These updates come in the form on point:update and tx:update. The first is
+::  used to update the naive state an the ownership and sponsorhips indices, and
+::  the second for the state of the transactions we submit.
+::
+/-  *dice
+/+  dice,
+    naive,
+    lib=naive-transactions,
+    *fake-roller,
+    shoe,
+    verb,
+    dbug,
+    default-agent,
+    ethereum
+|%
++$  app-state
+  $:  %0
+      ::TODO
+      ::chain-id=@
+      addresses=(map @ux [roller=ship pk=@])
+      :: TODO: keep track of sessions
+      ::
+      :: sessions=(map sole-id session)
+      =points:naive
+      =owners
+      =sponsors
+      =history
+  ==
+::
++$  card         card:shoe
+--
+::  Helpers
+::
+=>  |%
+    ++  todo  ~
+    --
+::  Cards
+::
+=>  |%
+    ++  to-shoe
+      |=  [to=(list @ta) =shoe-effect:shoe]
+      shoe+to^shoe-effect
+    ::
+    ++  track-address
+      |=  [roller=ship =address:ethereum]
+      ^-  card
+      =/  =wire  /connect/[(scot %ux address)]
+      [%pass wire %agent [roller %roller] %watch wire]
+    ::
+    ++  track-transactions
+      |=  [roller=ship =address:ethereum]
+      ^-  card
+      =/  =wire  /txs/[(scot %ux address)]
+      [%pass wire %agent [roller %roller] %watch wire]
+    ::
+    ++  track-points
+      |=  [roller=ship =address:ethereum]
+      ^-  card
+      =/  =wire  /points/[(scot %ux address)]
+      [%pass wire %agent [roller %roller] %watch wire]
+    --
+::
+=|  app-state
+=*  state  -
+::
+%+  verb  |
+%-  agent:dbug
+^-  agent:gall
+%-  (agent:shoe command-cli)
+^-  (shoe:shoe command-cli)
+::  Main
+::
+=<
+  |_  =bowl:gall
+  +*  this  .
+      def   ~(. (default-agent this %|) bowl)
+      des   ~(. (default:shoe this command-cli) bowl)
+      do    ~(. +> bowl)
+  ::
+  ++  on-init   on-init:def
+  ++  on-save   !>(state)
+  ++  on-load
+    |=  old=vase
+    ^-  (quip card _this)
+    `this(state !<(app-state old))
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    ?+    mark  (on-poke:def mark vase)
+        %cli-command
+      =+  !<(poke=command-cli vase)
+      (on-command *@ta poke)
+    ==
+  ::
+  ++  on-watch  on-watch:def
+  ++  on-leave  on-leave:def
+  ::  +on-peek: scry paths
+  ::
+  ::    /x/ships/[0x1234.abcd]  ->  %noun  (list ship)
+  ::
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    |^
+    ?+  path  ~
+      [%x %ships @ ~]  (ships i.t.t.path)
+    ==
+    ::
+    ++  ships
+      |=  wat=@t
+      :+  ~  ~
+      :-  %noun
+      !>  ^-  (list ship)
+      ?~  address=(slaw %ux wat)  ~
+      =/  proxies=(list proxy:naive)
+        ~[%own %spawn %manage %vote %transfer]
+      %+  roll  proxies
+      |=  [=proxy:naive ships=(list ship)]
+      %+  welp
+        ~(tap in (~(get ju owners) [proxy u.address]))
+      ships
+    --
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    |^
+    ?+  wire  (on-agent:def wire sign)
+      [%connect @ ~]  (init-data i.t.wire sign)
+      [%txs @ ~]      (transactions i.t.wire sign)
+      [%points @ ~]   (points i.t.wire sign)
+    ==
+    ::
+    ++  init-data
+      |=  [wat=@t =sign:agent:gall]
+      ^-  (quip card _this)
+      ?+  -.sign  (on-agent:def wire sign)
+          %fact
+        ~&  p.cage.sign
+        ?+  p.cage.sign  (on-agent:def wire sign)
+            %roller-data
+          ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
+          =+  !<(=roller-data q.cage.sign)
+          =,  roller-data
+          =:  ::chain-id.state  chain-id
+              points.state    points
+              owners.state    owners
+              sponsors.state  sponsors
+              history.state   (~(put by history.state) u.addr history)
+            ==
+          [~ this]
+        ==
+      ==
+    ::
+    ++  transactions
+      |=  [wat=@t =sign:agent:gall]
+      ^-  (quip card _this)
+      ?+  -.sign  (on-agent:def wire sign)
+          %fact
+        ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
+        ?+  p.cage.sign  (on-agent:def wire sign)
+            %tx
+          ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
+          =+  !<(=update q.cage.sign)
+          ?>  ?=(%tx -.update)
+          =/  hash=tape
+            =/  keccak=tape
+              %+  scow  %ux
+              (hash-tx:lib raw.raw-tx.pend-tx.update)
+            =+  len=(lent keccak)
+            ;:  weld
+              (swag [0 6] keccak)
+              "..."
+              (swag [(sub len 4) len] keccak)
+            ==
+          =^  *  history.state
+           (update-history:dice history.state [[pend-tx]~ status]:update)
+          =/  console=tape
+            "Tx hash: {hash} -> {(trip status.update)}"
+          :_  this
+          :_  ~
+          :-  %shoe
+          :-  ~
+          :-  %sole
+          ?.  =(src our):bowl
+            [%txt console]
+          [%klr [[`%br ~ `%g] [(crip console)]~]~]
+        ==
+      ==
+    ::
+    ++  points
+      |=  [wat=@t =sign:agent:gall]
+      ^-  (quip card _this)
+      ?+  -.sign  (on-agent:def wire sign)
+          %fact
+        ?+  p.cage.sign  (on-agent:def wire sign)
+            %point
+          ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
+          =+  !<(=update q.cage.sign)
+          ?>  ?=(%point -.update)
+          =,  update
+          =^  *  sponsors.state
+            (sponsorship:dice diff ship new old sponsors.state)
+          =^  *  owners.state
+            (ownership:dice diff ship new old owners.state)
+          =.  points.state  (put:orp:dice points.state ship new)
+          =/  console=tape
+            %+  weld
+              "Point update: {(scow %p ship)} -> "
+            "{(trip proxy.to)} - {(scow %ux address.to)}"
+          :_  this
+          :_  ~
+          :-  %shoe
+          :-  ~
+          :-  %sole
+          ?.  =(src our):bowl
+            [%txt console]
+          [%klr [[`%br ~ `%g] [(crip console)]~]~]
+        ==
+      ==
+    --
+  ::
+  ++  on-arvo         on-arvo:def
+  ++  on-fail         on-fail:def
+  ++  command-parser  build-parser:do
+  ::
+  ++  tab-list
+    |=  sole-id=@ta
+    ^-  (list [@t tank])
+    :~  ['txs' leaf+"list available L2 transaction"]
+        ['submit' leaf+"sends| a L2 transaction to the Roller"]
+        ['cancel' leaf+"cancels a (pending) L2 transaction"]
+        ['history' leaf+"shows all current submitted transactions"]
+        ['track' leaf+"loads an ethereum address and tracks points and L2 txs"]
+    ==
+  ::
+  ++  on-command
+    |=  [sole-id=@ta command=command-cli]
+    ^-  (quip card _this)
+    ~&  ~(wyt by points.state)
+    =^  cards  state
+      ?+  -.command  !!
+          %connect  (~(connect commands:do sole-id) +.command)
+          %submit   (~(submit commands:do sole-id) +.command)
+          %history  (~(history commands:do sole-id) +.command)
+          %point    (~(point commands:do sole-id) +.command)
+          %ships    (~(ships commands:do sole-id) +.command)
+      ==
+    [cards this]
+  ::
+  ++  can-connect
+    |=  sole-id=@ta
+    ^-  ?
+    ?|  =(~zod src.bowl)
+        (team:title [our src]:bowl)
+    ==
+  ::
+  ++  on-connect      on-connect:des
+  ++  on-disconnect   on-disconnect:des
+  --
+::
+|_  =bowl:gall
+++  commands
+  |_  sole-id=@ta
+  ::
+  ++  connect
+    |=  [roller=ship =address:ethereum pk=@]
+    ^-  (quip card _state)
+    =/  [to=(list _sole-id) fec=shoe-effect:shoe]
+      :-  [sole-id]~
+      :-  %sole
+      =/  =tape
+        "Listening to updates for {(scow %ux address)} from {(scow %p roller)}"
+      ?.  =(src our):bowl
+        [%txt tape]
+      [%klr [[`%br ~ `%g] [(crip tape)]~]~]
+    =.  addresses  (~(put by addresses) address [roller pk])
+    :_  state
+    =;  cards=(list card)
+      ?:  =(*@ta sole-id)  cards
+      [(to-shoe to fec) cards]
+    :~  (track-address roller address)
+        (track-points roller address)
+        (track-transactions roller address)
+    ==
+  ::
+  ++  ships
+    |=  =address:ethereum
+    ^-  (quip card _state)
+    ::  TODO: console formatting
+    ::
+    ~&  (controlled-ships:dice address owners.state)
+    [~ state]
+  ::
+  ++  point
+    |=  =ship
+    ^-  (quip card _state)
+    ~&  ~(wyt by points.state)
+    ::  TODO: console formatting
+    ::
+    ~&  (get:orp:dice points.state ship)
+    [~ state]
+  ::
+  ++  history
+    |=  =address:ethereum
+    ^-  (quip card _state)
+    :_  state
+    =;  [to=(list _sole-id) fec=shoe-effect:shoe]
+      [%shoe to fec]~
+    :-  [sole-id]~
+    :^  %table
+        ~[t+'signing ship' t+'type' t+'status' t+'hash' t+'time']
+      ~[14 20 9 13 26]
+    ?~  history=(~(get by history.state) address)
+      ~&  "nope"^history.state
+      ~
+    %+  turn  (tap:orh:dice u.history)
+    |=  [=time roll-tx]
+    |^  ~[p+ship t+type t+status t+pack-hash t+pack-time]
+    ::
+    ++  pack-time
+      %-  crip
+      (scag 21 (scow %da time))
+    ::
+    ++  pack-address
+      =+  addr=(scow %ux address)
+      =+  len=(lent addr)
+      :-  %t
+      %-  crip
+      ;:  weld
+        (swag [0 6] addr)
+        "..."
+        (swag [(sub len 4) len] addr)
+      ==
+    ::
+    ++  pack-hash
+      =+  hash=(scow %ux hash)
+      =+  len=(lent hash)
+      %-  crip
+      ;:  weld
+        (swag [0 6] hash)
+        "..."
+      (swag [(sub len 4) len] hash)
+      ==
+    --
+  ::
+  ++  submit
+    |=  [=address:ethereum =tx:naive]
+    ^-  (quip card _state)
+    ::  TODO: to state
+    ::
+    =/  chain-id=@  1.337
+    =/  roller=@p  roller:(~(got by addresses) address)
+    ?~  owned=(~(get ju owners) [proxy.from.tx address])
+      ~&  >>>  'address doesn\'t control any points'
+      `state
+    ?:  (~(has in ^-((set @p) owned)) ship.from.tx)
+      ~&  >>>  'can\'t find point'
+      `state
+    =/  =nonce:naive
+      (get-nonce:dice (got:orp:dice points ship.from.tx) proxy.from.tx)
+    =/  =keccak
+      %-  hash-tx:lib
+      (unsigned-tx:lib chain-id nonce (gen-tx-octs:lib tx))
+    =/  sig=octs  (fake-sig tx address nonce)
+    :_  state
+    ::  TODO: to cards
+    ::
+    :_  ~
+    :*  %pass
+        /submit
+        %agent
+        [roller %roller]
+        %poke
+        roller-action+!>([%submit | address q.sig %don tx])
+    ==
+  --
+::
+++  build-parser
+  |=  sole-id=@ta
+  ^+  |~(nail *(like [? command-cli]))
+  ::  wait for 'enter' to run the command
+  ::
+  |^
+  %+  stag  |
+  ;~  pose
+    ;~((glue ace) (tag %connect) connect)
+    ;~(plug (tag %point) ;~(pfix sig fed:ag))
+    ;~(plug (tag %history) ;~(pfix (jest ' 0x') hex))
+    ;~((glue ace) (tag %submit) submit)
+    ;~((glue ace) (tag %ships) address)
+  ==
+  ::
+  ++  tag      |*(a=@tas (cold a (jest a)))  :: TODO (from /app/chat-cli) into stdlib
+  ++  roller   ;~(pfix sig fed:ag)
+  ++  address  ;~(pfix (jest '0x') hex)
+  ++  connect
+    (cook ,[ship address:ethereum @] ;~((glue ace) roller address dem))
+  ::
+  ++  sponsorship
+    %-  perk
+    :~  %escape
+        %cancel-escape
+        %adopt
+        %reject
+        %detach
+    ==
+  ::
+  ++  ownership
+    %-  perk
+    :~  %set-management-proxy
+        %set-spawn-proxy
+        %set-transfer-proxy
+    ==
+  ::
+  ++  proxies
+    (perk %own %spawn %manage %vote %transfer ~)
+  ::
+  ++  submit
+    %+  cook  ,[address:naive tx:naive]
+    ;~  (glue ace)
+      address
+      ::  from=[ship proxy:naive]
+      ::
+      %+  cook  ,[ship proxy:naive]
+      %+  ifix  [sel ser]
+      ;~((glue ace) ;~(pfix sig fed:ag) proxies)
+      ::  skim-tx:naive
+      ::
+      %+  cook  ,skim-tx:naive
+      ;~  pose
+        ::  [%transfer-point =address reset=?]
+        ::
+        ;~  (glue ace)
+          (perk %transfer-point ~)
+          address
+          ;~(pose (cold & (just 'y')) (cold | (just 'n')))
+        ==
+        ::  [%spawn ship address:naive]
+        ::
+        ;~  (glue ace)
+          (perk %spawn ~)
+          ;~(pfix sig fed:ag)
+          address
+        ==
+        :: [%configure-keys encrypt=@ auth=@ crypto-suite=@ breach=?]
+        ::
+        ;~  (glue ace)
+          (perk %configure-keys ~)
+          address
+          address
+          dem
+          ;~(pose (cold & (just 'y')) (cold | (just 'n')))
+        ==
+        :: [?([%escape %cancel-escape %adopt %reject %detach]) ship]
+        ::
+        ;~((glue ace) sponsorship ;~(pfix sig fed:ag))
+        :: $:  ?([%set-management-proxy %set-spawn-proxy %set-transfer-proxy])
+        ::     address
+        :: ==
+        ::
+        ;~((glue ace) ownership address)
+      ==
+    ==
+  --
+--

--- a/pkg/arvo/app/roller-cli.hoon
+++ b/pkg/arvo/app/roller-cli.hoon
@@ -273,11 +273,14 @@
   ++  tab-list
     |=  sole-id=@ta
     ^-  (list [@t tank])
-    :~  ['txs' leaf+"list available L2 transaction"]
-        ['submit' leaf+"sends| a L2 transaction to the Roller"]
-        ['cancel' leaf+"cancels a (pending) L2 transaction"]
+    :~  ['submit' leaf+"sends| a L2 transaction to the Roller"]
         ['history' leaf+"shows all current submitted transactions"]
-        ['track' leaf+"loads an ethereum address and tracks points and L2 txs"]
+        ['point' leaf+"shows point information for the given ship"]
+        ['ships' leaf+"shows controlled ships by the given address"]
+        ['connect' leaf+"loads an ethereum address to listen for updates"]
+        ::  TODO
+        :: ['txs' leaf+"list available L2 transaction"]
+        ::['cancel' leaf+"cancels a (pending) L2 transaction"]
     ==
   ::
   ++  on-command

--- a/pkg/arvo/app/roller-cli.hoon
+++ b/pkg/arvo/app/roller-cli.hoon
@@ -26,13 +26,12 @@
     ethereum
 |%
 +$  app-state
-  $:  %0
-      ::TODO
-      ::chain-id=@
-      addresses=(map @ux [roller=ship pk=@])
+  $:  %1
+      chain-id=@
       :: TODO: keep track of sessions?
       ::
       :: sessions=(map sole-id session)
+      addresses=(map @ux [roller=ship pk=@])
       =points:naive
       =owners
       =sponsors
@@ -113,7 +112,23 @@
   ++  on-load
     |=  old=vase
     ^-  (quip card _this)
-    `this(state !<(app-state old))
+    |^
+    =+  !<(old-state=app-states old)
+    =?  old-state  ?=(%0 -.old-state)
+      [%1 1.337 +.old-state]
+    ?>  ?=(%1 -.old-state)
+    `this(state old-state)
+    ::
+    ++  app-states  $%(state-0 app-state)
+    ++  state-0
+      $:  %0
+          (map @ux [roller=ship pk=@])
+          points:naive
+          owners:dice
+          sponsors:dice
+          history:dice
+      ==
+    --
   ::
   ++  on-poke
     |=  [=mark =vase]
@@ -173,7 +188,7 @@
           ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
           =+  !<(=roller-data q.cage.sign)
           =,  roller-data
-          =:  ::chain-id.state  chain-id
+          =:  chain-id.state  chain-id
               points.state    points
               owners.state    owners
               sponsors.state  sponsors

--- a/pkg/arvo/app/roller-cli.hoon
+++ b/pkg/arvo/app/roller-cli.hoon
@@ -31,7 +31,7 @@
       ::TODO
       ::chain-id=@
       addresses=(map @ux [roller=ship pk=@])
-      :: TODO: keep track of sessions
+      :: TODO: keep track of sessions?
       ::
       :: sessions=(map sole-id session)
       =points:naive
@@ -42,11 +42,6 @@
 ::
 +$  card         card:shoe
 --
-::  Helpers
-::
-=>  |%
-    ++  todo  ~
-    --
 ::  Cards
 ::
 =>  |%
@@ -150,7 +145,6 @@
       ^-  (quip card _this)
       ?+  -.sign  (on-agent:def wire sign)
           %fact
-        ~&  p.cage.sign
         ?+  p.cage.sign  (on-agent:def wire sign)
             %roller-data
           ?~  addr=(slaw %ux wat)  (on-agent:def wire sign)
@@ -251,7 +245,6 @@
   ++  on-command
     |=  [sole-id=@ta command=command-cli]
     ^-  (quip card _this)
-    ~&  ~(wyt by points.state)
     =^  cards  state
       ?+  -.command  !!
           %connect  (~(connect commands:do sole-id) +.command)
@@ -309,7 +302,6 @@
   ++  point
     |=  =ship
     ^-  (quip card _state)
-    ~&  ~(wyt by points.state)
     ::  TODO: console formatting
     ::
     ~&  (get:orp:dice points.state ship)
@@ -326,7 +318,6 @@
         ~[t+'signing ship' t+'type' t+'status' t+'hash' t+'time']
       ~[14 20 9 13 26]
     ?~  history=(~(get by history.state) address)
-      ~&  "nope"^history.state
       ~
     %+  turn  (tap:orh:dice u.history)
     |=  [=time roll-tx]

--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -151,12 +151,14 @@
     ?:  ?=(l2-tx method)
       (process-rpc id +.params method over-quota:scry)
     ?+  method  [~ ~(method error:json-rpc id)]
+      %cancel-transaction      (cancel-tx id +.params)
+      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
+      %get-remaining-quota     `(quota-remaining id +.params ship-quota:scry)
       %get-point               `(get-point id +.params point:scry)
       %get-ships               `(get-ships id +.params ships:scry)
-      %cancel-transaction      (cancel-tx id +.params)
       %get-spawned             `(get-spawned id +.params spawned:scry)
       %get-unspawned           `(get-spawned id +.params unspawned:scry)
-      %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
       %get-sponsored-points    `(sponsored-points id +.params sponsored:scry)
       %get-owned-points        `(get-ships id +.params owned:scry)
       %get-transferring-for    `(get-ships id +.params transfers:scry)
@@ -168,18 +170,13 @@
       %get-pending-by-address  `(addr:pending id +.params addr:pending:scry)
       %get-pending-tx          `(hash:pending id +.params hash:pending:scry)
       %get-transaction-status  `(status id +.params tx-status:scry)
-      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %get-predicted-state     `(get-naive id +.params predicted:scry)
       %get-nonce               `(nonce id +.params nonce:scry)
       %get-history             `(history id +.params addr:history:scry)
       %get-roller-config       `(get-config id +.params config:scry)
-      %prepare-for-signing     `(hash-transaction id +.params chain:scry | &)
       %get-unsigned-tx         `(hash-transaction id +.params chain:scry & |)
-      %get-predicted-state     `(get-naive id +.params predicted:scry)
+      %prepare-for-signing     `(hash-transaction id +.params chain:scry | &)
       %hash-raw-transaction    `(hash-raw-transaction id +.params)
-      :: TODO: deprecated, remove (used together with personal_sign)
-      ::
-      %hash-transaction        ::`(hash-transaction id +.params chain:scry | &)
-                               `(hash-transaction id +.params chain:scry & |)
     ==
   --
 ::
@@ -354,6 +351,13 @@
     .^  ?
         %gx
         (~(scry agentio bowl) %roller /over-quota/(scot %p ship)/atom)
+    ==
+  ::
+  ++  ship-quota
+    |=  =ship
+    .^  @ud
+        %gx
+        (~(scry agentio bowl) %roller /ship-quota/(scot %p ship)/atom)
     ==
   ::
   ++  ready

--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -152,9 +152,11 @@
       (process-rpc id +.params method over-quota:scry)
     ?+  method  [~ ~(method error:json-rpc id)]
       %cancel-transaction      (cancel-tx id +.params)
-      %when-next-batch         `(next-batch id +.params next-batch:scry)
+      %when-next-batch         `(next-timer id +.params next-batch:scry)
+      %when-next-slice         `(next-timer id +.params next-slice:scry)
       %spawns-remaining        `(spawns-remaining id +.params unspawned:scry)
       %get-remaining-quota     `(quota-remaining id +.params ship-quota:scry)
+      %get-allowance           `(ship-allowance id +.params allowance:scry)
       %get-point               `(get-point id +.params point:scry)
       %get-ships               `(get-ships id +.params ships:scry)
       %get-spawned             `(get-spawned id +.params spawned:scry)
@@ -304,7 +306,13 @@
   ++  next-batch
     .^  time
         %gx
-        (~(scry agentio bowl) %roller /next-batch/noun)
+        (~(scry agentio bowl) %roller /next-batch/atom)
+    ==
+  ::
+  ++  next-slice
+    .^  time
+        %gx
+        (~(scry agentio bowl) %roller /next-slice/atom)
     ==
   ::
   ++  nonce
@@ -358,6 +366,13 @@
     .^  @ud
         %gx
         (~(scry agentio bowl) %roller /ship-quota/(scot %p ship)/atom)
+    ==
+  ::
+  ++  allowance
+    |=  =ship
+    .^  (unit @ud)
+        %gx
+        (~(scry agentio bowl) %roller /allowance/(scot %p ship)/noun)
     ==
   ::
   ++  ready

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -950,10 +950,13 @@
 ++  try-apply
   |=  [nas=^state:naive force=? =raw-tx:naive]
   ^-  [[? ups=(list update)] _state]
-  =/  [success=? ups=(list update) predicted=_nas owners=_own sponsors=_spo]
+  =/  [success=? ups=(list update) predicted=_nas =indices]
     (apply-raw-tx:dice force chain-id raw-tx nas own spo)
-  :-  [success ups]
-  state(pre predicted, own owners, spo sponsors)
+  =:  pre  predicted
+      own  own.indices
+      spo  spo.indices
+    ==
+  [[success ups] state]
 ::
 ++  get-l1-address
   |=  [=tx:naive nas=^state:naive]

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -279,6 +279,7 @@
       [%x %quota ~]           ``atom+!>(quota)
       [%x %slice ~]           ``atom+!>(slice)
       [%x %over-quota @ ~]    (over-quota i.t.t.path)
+      [%x %ship-quota @ ~]    (ship-quota i.t.t.path)
       [%x %ready ~]           ``atom+!>(?=(^ points.pre))
     ==
     ::
@@ -450,6 +451,16 @@
       ?~  who=(slaw %p wat)  [~ ~]
       =/  [exceeded=? *]  (quota-exceeded u.who)
       ``atom+!>(exceeded)
+    ::
+    ++  ship-quota
+      |=  wat=@t
+      ?~  who=(slaw %p wat)  [~ ~]
+      =/  [exceeded=? next-quota=@ud]  (quota-exceeded u.who)
+      :+  ~  ~
+      :-  %atom
+      !>  ^-  @ud
+      ?:  exceeded  0
+      (sub quota.state (dec next-quota))
     ::
     --
   ::

--- a/pkg/arvo/gen/roller-cli/command.hoon
+++ b/pkg/arvo/gen/roller-cli/command.hoon
@@ -1,0 +1,5 @@
+/+  *dice
+::
+:-  %say
+|=  [* [=command-cli ~] ~]
+[%cli-command command-cli]

--- a/pkg/arvo/gen/roller/assign.hoon
+++ b/pkg/arvo/gen/roller/assign.hoon
@@ -1,0 +1,6 @@
+::  Assigns a specific quota to the given ship
+::  Not providing a quota allows the ship to submit any number of transactions
+::
+:-  %say
+|=  [* [=ship quota=(unit @ud) ~] ~]
+[%roller-action %assign ship quota]

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -680,4 +680,13 @@
   ?.  =((lent ~(tap by params)) 0)
     ~(params error:json-rpc id)
   [%result id (azimuth-config:to-json azimuth-config)]
+::
+++  quota-remaining
+  |=  [id=@t params=(map @t json) quota-left=$-(@p @ud)]
+  ^-  response:rpc
+  ?.  =((lent ~(tap by params)) 1)
+    ~(params error:json-rpc id)
+  ?~  ship=(ship:from-json params)
+    ~(params error:json-rpc id)
+  [%result id (numb:enjs:format (quota-left u.ship))]
 --

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -599,7 +599,7 @@
     ~(parse error:json-rpc id)
   [%result id (tx-status:to-json (scry u.hash))]
 ::
-++  next-batch
+++  next-timer
   |=  [id=@t params=(map @t json) when=time]
   ^-  response:rpc
   ?.  =((lent ~(tap by params)) 0)
@@ -689,4 +689,16 @@
   ?~  ship=(ship:from-json params)
     ~(params error:json-rpc id)
   [%result id (numb:enjs:format (quota-left u.ship))]
+::
+++  ship-allowance
+  |=  [id=@t params=(map @t json) allowance=$-(@p (unit @ud))]
+  ^-  response:rpc
+  ?.  =((lent ~(tap by params)) 1)
+    ~(params error:json-rpc id)
+  ?~  ship=(ship:from-json params)
+    ~(params error:json-rpc id)
+  :+  %result  id
+  ?^  allow=(allowance u.ship)
+    (numb:enjs:format u.allow)
+  s+(crip "No quota restrictions for {(scow %p u.ship)}")
 --

--- a/pkg/arvo/lib/dice.hoon
+++ b/pkg/arvo/lib/dice.hoon
@@ -4,6 +4,16 @@
 /+  naive, *naive-transactions
 ::
 |%
+::  orp: ordered points in naive state by parent ship
+::
+++  orp  ((on ship point:naive) por:naive)
+::  ors: ordered sending map by (increasing) L1 nonce
+::
+++  ors  ((on l1-tx-pointer send-tx) nonce-order)
+::  orh: ordered tx history by (decreasing) timestamp
+::
+++  orh  ((on time roll-tx) gth)
+::
 ++  nonce-order
   |=  [a=[* =nonce:naive] b=[* =nonce:naive]]
   (lte nonce.a nonce.b)
@@ -26,171 +36,270 @@
   ?.  (verify-sig-and-nonce:naive verifier chain-t nas raw-tx)
     ~&  >>>  [%verify-sig-and-nonce %failed tx.raw-tx]
     [force ~ nas indices]
-  =^  *  points.nas
+  =^  effects-1  points.nas
     (increment-nonce:naive nas from.tx.raw-tx)
   ?~  nex=(receive-tx:naive nas tx.raw-tx)
     ~&  >>>  [%receive-tx %failed]
     [force ~ ?:(force nas cache) indices]
   =*  new-nas   +.u.nex
-  =*  effects   -.u.nex
+  =/  effects   (welp effects-1 -.u.nex)
   =^  updates   indices
-    (point-effects effects cache new-nas [own spo]:indices)
+    (point-effects effects points.cache points.new-nas [own spo]:indices)
   [& updates new-nas indices]
 ::
 ++  point-effects
-  |=  [=effects:naive cache=^state:naive nas=^state:naive =indices]
+  |=  [=effects:naive cache=points:naive =points:naive =indices]
   ^-  [(list update) indices=_indices]
-  =;  [updates=(list update) indices=_indices]
-    [(flop updates) indices]
-  %+  roll  effects
-  |=  [=diff:naive updates=(list update) indices=_indices]
-  =,  orm:naive
-  ?.  ?=([%point *] diff)  [updates indices]
-  =*  ship      ship.diff
-  =*  sponsors  spo.indices
-  =*  owners    own.indices
-  =/  old=(unit point:naive)
-    (get points.cache ship)
-  =/  new=point:naive
-    (need (get points.nas ship))
+  =^  updates=(list update)  indices
+    %+  roll  effects
+    |=  [=diff:naive updates=(list update) indices=_indices]
+    ?.  |(?=([%point *] diff) ?=([%nonce *] diff))
+      [updates indices]
+    ?:  ?=([%nonce *] diff)
+      :_  indices
+      (welp (nonce-updates diff cache points) updates)
+    ?>  ?=([%point *] diff)
+    =*  ship      ship.diff
+    =*  sponsors  spo.indices
+    =*  owners    own.indices
+    =/  old=(unit point:naive)  (get:orp cache ship)
+    =/  new=point:naive         (need (get:orp points ship))
+    =^  update-1  sponsors
+      (sponsorship diff ship new old sponsors)
+    =^  update-2  owners
+      (ownership diff ship new old owners)
+    =/  update-3=_updates
+      (point-data-updates diff ship new old)
+    :_  indices
+    :(welp update-3 update-2 update-1 updates)
+  [(flop updates) indices]
+::
+++  sponsorship
+  |=  [=diff:naive =ship new=point:naive old=(unit point:naive) =sponsors]
+  ::^+  sponsors
+  ^-  (quip update _sponsors)
+  ?.  ?=([%point *] diff)  `sponsors
   =*  event  +>.diff
-  |^
-  =.  sponsors  sponsorship
-  =^  update    owners  ownership
-  [(welp update updates) indices]
-  ::
-  ++  sponsorship
-    ^+  sponsors
-    ?+    -.event  sponsors
-        %owner
-      ?^  old
-        ::  ownership change
-        ::
-        sponsors
-      ::  owner event with ?=(~ old) is a spawn
+  ?+    -.event  `sponsors
+      %owner
+    ?^  old
+      ::  ownership change
       ::
-      =*  parent  who.sponsor.net.new
-      ?:  =(parent ship)  sponsors
-      %+  ~(put by sponsors)  parent
-      ?~  sponsor=(~(get by sponsors) parent)
-        :_  *(set @p)
-        (~(put in *(set @p)) ship)
-      :_  requests.u.sponsor
-      (~(put in residents.u.sponsor) ship)
+      `sponsors
+    ::  owner event with ?=(~ old) is a spawn
     ::
-        %escape
-      ?~  old     sponsors
-      =*  from    who.sponsor.net.u.old
-      =*  to      to.event
-      =*  escape  escape.net.u.old
-      ?~  to
-        :: cancel/reject escape
-        ::
-        ?~  escape  sponsors
-        ?~  receiver=(~(get by sponsors) u.escape)
-          sponsors
-        %+  ~(put by sponsors)  u.escape
-        :-  residents.u.receiver
-        (~(del in requests.u.receiver) ship)
-      ::  normal escape
+    =*  parent  who.sponsor.net.new
+    ?:  =(parent ship)  `sponsors
+    ::  updates for proxy %own are taken care of
+    ::  in +sponsorship  to avoid duplicates
+    ::
+    :-  ~
+    %+  ~(put by sponsors)  parent
+    ?~  sponsor=(~(get by sponsors) parent)
+      :_  *(set @p)
+      (~(put in *(set @p)) ship)
+    :_  requests.u.sponsor
+    (~(put in residents.u.sponsor) ship)
+  ::
+      %escape
+    ?~  old     `sponsors
+    =*  from    who.sponsor.net.u.old
+    =*  to      to.event
+    =*  escape  escape.net.u.old
+    ?~  to
+      :: cancel/reject escape
       ::
-      %+  ~(put by sponsors)  u.to
-      ?~  receiver=(~(get by sponsors) u.to)
-        :-  *(set @p)
-        (~(put in *(set @p)) ship)
+      ?~  escape  `sponsors
+      ?~  receiver=(~(get by sponsors) u.escape)
+        `sponsors
+      ::
+      :-  (proxy-updates diff ship new old)
+      ::
+      %+  ~(put by sponsors)  u.escape
       :-  residents.u.receiver
-      (~(put in requests.u.receiver) ship)
+      (~(del in requests.u.receiver) ship)
+    ::  normal escape
     ::
-        %sponsor
-      ?~  old   sponsors
-      =*  from  who.sponsor.net.u.old
-      =*  to    sponsor.event
-      =/  previous  (~(get by sponsors) from)
-      ?~  to
-        :: detach
-        ::
-        ?~  previous  sponsors
-        %+  ~(put by sponsors)  from
-        :_  requests.u.previous
-        (~(del in residents.u.previous) ship)
-      ::  accepted
-      ::
-      =/  receiver  (~(get by sponsors) u.to)
-      =?  sponsors  ?=(^ receiver)
-        %+  ~(put by sponsors)  u.to
-        :-  (~(put in residents.u.receiver) ship)
-        (~(del in requests.u.receiver) ship)
-      =?  sponsors  ?=(^ previous)
-        %+  ~(put by sponsors)  from
-        :_  requests.u.previous
-        (~(del in residents.u.previous) ship)
-      sponsors
-    ==
+    :-  (proxy-updates diff ship new old)
+    ::
+    %+  ~(put by sponsors)  u.to
+    ?~  receiver=(~(get by sponsors) u.to)
+      :-  *(set @p)
+      (~(put in *(set @p)) ship)
+    :-  residents.u.receiver
+    (~(put in requests.u.receiver) ship)
   ::
-  ++  ownership
-    ^-  (quip update _owners)
-    =;  [to=(unit owner) from=(unit owner)]
-      =?  owners  &(?=(^ from) !=(address.u.from 0x0))
-        (~(del ju owners) u.from ship)
-      ?:  ?|  =(~ to)
-              &(?=(^ to) =(address.u.to 0x0))
-          ==
-        [~ owners]
-      ?~  to  [~ owners]
-      :-  [%point ship new u.to from]~
-      (~(put ju owners) u.to ship)
-    ?+    -.event  [~ ~]
-        %owner
-      :-  `[%own +.event]
-      ?~  old  ~
-      `[%own address.owner.own.u.old]
+      %sponsor
+    ?~  old   `sponsors
+    =*  from  who.sponsor.net.u.old
+    =*  to    sponsor.event
+    =/  previous  (~(get by sponsors) from)
+    ?~  to
+      :: detach
+      ::
+      ?~  previous  `sponsors
+      ::
+      :-  (proxy-updates diff ship new old)
+      ::
+      %+  ~(put by sponsors)  from
+      :_  requests.u.previous
+      (~(del in residents.u.previous) ship)
+    ::  accepted
     ::
-        %management-proxy
-      :-  `[%manage +.event]
-      ?~  old  ~
-      `[%manage address.management-proxy.own.u.old]
-    ::
-        %spawn-proxy
-      :-  `[%spawn +.event]
-      ?~  old  ~
-      `[%spawn address.spawn-proxy.own.u.old]
-    ::
-        %voting-proxy
-      :-  `[%vote +.event]
-      ?~  old  ~
-      `[%vote address.voting-proxy.own.u.old]
-    ::
-        %transfer-proxy
-      :-  `[%transfer +.event]
-      ?~  old  ~
-      `[%transfer address.transfer-proxy.own.u.old]
-    ==
-  --
+    =/  receiver  (~(get by sponsors) u.to)
+    =?  sponsors  ?=(^ receiver)
+      %+  ~(put by sponsors)  u.to
+      :-  (~(put in residents.u.receiver) ship)
+      (~(del in requests.u.receiver) ship)
+    =?  sponsors  ?=(^ previous)
+      %+  ~(put by sponsors)  from
+      :_  requests.u.previous
+      (~(del in residents.u.previous) ship)
+    :_  sponsors
+    (proxy-updates diff ship new old)
+  ==
+::
+++  ownership
+  |=  [=diff:naive =ship new=point:naive old=(unit point:naive) =owners]
+  ^-  (quip update _owners)
+  ?.  ?=([%point *] diff)  `owners
+  =*  event  +>.diff
+  =;  [to=(unit owner) from=(unit owner)]
+    =?  owners  &(?=(^ from) !=(address.u.from 0x0))
+      (~(del ju owners) u.from ship)
+    ?:  ?|  =(~ to)
+            &(?=(^ to) =(address.u.to 0x0))
+        ==
+      [~ owners]
+    ?~  to  [~ owners]
+    :_  (~(put ju owners) u.to ship)
+    [%point diff ship new old u.to from]~
+  ?+    -.event  [~ ~]
+      %owner
+    :-  `[%own +.event]
+    ?~  old  ~
+    `[%own address.owner.own.u.old]
+  ::
+      %management-proxy
+    :-  `[%manage +.event]
+    ?~  old  ~
+    `[%manage address.management-proxy.own.u.old]
+  ::
+      %spawn-proxy
+    :-  `[%spawn +.event]
+    ?~  old  ~
+    `[%spawn address.spawn-proxy.own.u.old]
+  ::
+      %voting-proxy
+    :-  `[%vote +.event]
+    ?~  old  ~
+    `[%vote address.voting-proxy.own.u.old]
+  ::
+      %transfer-proxy
+    :-  `[%transfer +.event]
+    ?~  old  ~
+    `[%transfer address.transfer-proxy.own.u.old]
+  ==
+::
+++  proxy-updates
+  |=  [=diff:naive =ship =point:naive old=(unit point:naive)]
+  ^-  (list update)
+  =/  proxies=(list proxy:naive)
+    ~[%own %spawn %manage %vote %transfer]
+  ?~  old  ~
+  %-  flop
+  %+  roll  proxies
+  |=  [=proxy:naive updates=(list update)]
+  ?~  owner=(get-owner u.old proxy)  updates
+  :_  updates
+  [%point diff ship point old u.owner ~]
+::
+++  nonce-updates
+  |=  [=diff:naive cache=points:naive =points:naive]
+  ^-  (list update)
+  ?.  ?=([%nonce *] diff)  ~
+  =/  old=(unit point:naive)  (get:orp cache ship.diff)
+  =/  new=point:naive         (need (get:orp points ship.diff))
+  (point-data-updates diff ship.diff new old)
+::
+++  point-data-updates
+  |=  [=diff:naive =ship =point:naive old=(unit point:naive)]
+  ^-  (list update)
+  ?.  ?=([%point *] diff)  ~
+  =*  event  +>.diff
+  ?+    -.event  ~
+    %rift      (proxy-updates +<)
+    %keys      (proxy-updates +<)
+    %dominion  (proxy-updates +<)
+  ==
 ::
 ++  get-owner
   |=  [=point:naive =proxy:naive]
-  ^-  [=nonce:naive _point]
-  =*  own  own.point
+  ^-  (unit owner)
+  =,  own.point
   ?-    proxy
       %own
-    :-  nonce.owner.own
-    point(nonce.owner.own +(nonce.owner.own))
+    ?:(=(address.owner 0x0) ~ `own+address.owner)
   ::
       %spawn
-    :-  nonce.spawn-proxy.own
-    point(nonce.spawn-proxy.own +(nonce.spawn-proxy.own))
+    ?:(=(address.spawn-proxy 0x0) ~ `spawn+address.spawn-proxy)
   ::
       %manage
-    :-  nonce.management-proxy.own
-    point(nonce.management-proxy.own +(nonce.management-proxy.own))
+    ?:(=(address.management-proxy 0x0) ~ `manage+address.management-proxy)
   ::
       %vote
-    :-  nonce.voting-proxy.own
-    point(nonce.voting-proxy.own +(nonce.voting-proxy.own))
+    ?:(=(address.voting-proxy 0x0) ~ `vote+address.voting-proxy)
   ::
       %transfer
-    :-  nonce.transfer-proxy.own
-    point(nonce.transfer-proxy.own +(nonce.transfer-proxy.own))
+    ?:(=(address.transfer-proxy 0x0) ~ `transfer+address.transfer-proxy)
   ==
 ::
+++  get-nonce
+  |=  [=point:naive =proxy:naive]
+  ^-  nonce:naive
+  =,  own.point
+  ?-  proxy
+    %own       nonce.owner
+    %spawn     nonce.spawn-proxy
+    %manage    nonce.management-proxy
+    %vote      nonce.voting-proxy
+    %transfer  nonce.transfer-proxy
+  ==
+::
+++  controlled-ships
+  |=  [=address:ethereum =owners]
+  ^-  (list [=proxy:naive =ship])
+  =/  proxies=(list proxy:naive)
+    ~[%own %spawn %manage %vote %transfer]
+  %+  roll  proxies
+  |=  [=proxy:naive ships=(list [=proxy:naive ship])]
+  %+  welp
+    %+  turn
+      ~(tap in (~(get ju owners) [proxy address]))
+    (lead proxy)
+  ships
+::  +update-history: updates status for all given list of transaction
+::
+++  update-history
+  |=  [=history txs=(list pend-tx) =status]
+  ^-  (quip update _history)
+  =^  updates=(list update)  history
+    %+  roll  txs
+    |=  [=pend-tx ups=(list update) history=_history]
+    =,  pend-tx
+    =/  =roll-tx
+      =,  pend-tx
+      :*  ship.from.tx.raw-tx
+          status
+          (hash-raw-tx raw-tx)
+          (l2-tx +<.tx.raw-tx)
+      ==
+    =/  txs=(tree hist-tx)
+      ?~  txs=(~(get by history) address)  ~
+      u.txs
+    =?  txs  ?=(^ txs)  +:(del:orh txs time)
+    :-  [tx+[pend-tx status] ups]
+    %+  ~(put by history)  address
+    (put:orh txs [time roll-tx])
+  [(flop updates) history]
 --

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -104,4 +104,34 @@
 +$  roller-data
   [chain-id=@ =points:naive history=(tree hist-tx) =owners =sponsors]
 ::
++$  command-cli
+  $%  ::  List all possible L2 tx types
+      ::
+      [%l2-tx ~]  :: ?
+      ::  Loads a new address (login?)
+      ::    — should require signing?
+      ::    - it subscribes to the Roller, for updates to it
+      ::    - innitially receives a list of points (if any) it controls
+      :: TODO: add tag
+      ::
+      [%connect =ship =address:naive pk=@]
+      ::  Table of all submitted txs, by address
+      ::
+      [%history address:ethereum]
+      ::  Table of all unsigned txs, by address
+      ::
+      [%show-unsigned ~]
+      ::  Signs and Submit an unsigned txs (signed)
+      ::
+      [%submit address:naive tx:naive]
+      ::  Cancels a submitted (but pending) txs
+      ::
+      [%cancel ~]
+      ::  Ships owned by an address
+      ::
+      [%ships address:naive]
+      ::  Point data for a given ship
+      ::
+      [%point ship]
+  ==
 --

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -19,8 +19,7 @@
   ==
 ::
 +$  indices
-  $:  nas=^state:naive
-      own=owners
+  $:  own=owners
       spo=sponsors
   ==
 ::

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -6,6 +6,7 @@
 +$  owner     [=proxy:naive =address:naive]
 +$  owners    (jug owner ship)
 +$  sponsors  (map ship [residents=(set ship) requests=(set ship)])
++$  history   (map address:ethereum (tree hist-tx))
 +$  net       ?(%mainnet %ropsten %local %default)
 ::
 +$  config
@@ -68,9 +69,16 @@
   ==
 ::
 +$  update
-  $%  [%point =ship =point:naive new=owner old=(unit owner)]
-      [%tx =address:ethereum =roll-tx]
-  ==
+  $%  [%tx =pend-tx =status]
+    ::
+      $:  %point
+          =diff:naive
+          =ship
+          new=point:naive
+          old=(unit point:naive)
+          to=owner
+          from=(unit owner)
+  ==  ==
 ::
 +$  hist-tx  [p=time q=roll-tx]
 +$  roll-tx  [=ship =status hash=keccak type=l2-tx]
@@ -92,4 +100,8 @@
       next-gas-price=@ud
       txs=(list raw-tx:naive)
   ==
+::
++$  roller-data
+  [chain-id=@ =points:naive history=(tree hist-tx) =owners =sponsors]
+::
 --

--- a/pkg/arvo/ted/roller/send.hoon
+++ b/pkg/arvo/ted/roller/send.hoon
@@ -101,7 +101,7 @@
   ;<  rep=(unit client-response:iris)  bind:m
     take-maybe-response:strandio
   =*  fallback
-    ~&  %fallback-gas-price
+    ~&  >>  %fallback-gas-price
     (pure:m 10.000.000.000)
   ?.  ?&  ?=([~ %finished *] rep)
           ?=(^ full-file.u.rep)


### PR DESCRIPTION
Marked as draft for now, functionality is pretty much the same as this [demo](https://www.youtube.com/watch?v=iEUxoBuTvqY) but the CLI gets, in addition to transaction status, point updates (for example if the nonce is incremented, we receive an update with the new one, so it can be retrieved locally for signing transactions).

I'd be interested to hear if this is something we could add together with the roller, or can be extracted out at a later time into a separate indexer/roller desk.

It also lacks a nice way of choosing the type of L2 transaction that you want to do. I can imagine a sort of dialog that retrieved users' data and uses it based on the entered actions (e.g. "Do you want to escape?" "Enter your new parent...")