### PR TITLE
eyre: include mark of fact in channel json

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c29577dc949ac0689ba3c97ad13b812ea6c3c6cc9d255b770d2da95fd9af84b9
-size 23121802
+oid sha256:ba617d22ef0e2feae06dedc642ebaab94b39311b1597ee7f7f80f011f76a7271
+size 23229296

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1705,12 +1705,16 @@
         ==
       ::
           %fact
-        :~  ['response' [%s 'diff']]
+        :+  ['response' [%s 'diff']]
           ::
-            :-  'json'
-            ~|  [%unexpected-fact-mark p.cage.sign]
-            ?>  =(%json p.cage.sign)
-            !<(json q.cage.sign)
+          :-  'json'
+          ~|  [%unexpected-fact-mark p.cage.sign]
+          ?>  =(%json p.cage.sign)
+          !<(json q.cage.sign)
+        ::
+        ?~  from  ~
+        :~  ['mark' [%s mark.u.from]]
+            ['desk' [%s desk.u.from]]
         ==
       ::
           %kick

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1706,16 +1706,13 @@
       ::
           %fact
         :+  ['response' [%s 'diff']]
-          ::
           :-  'json'
           ~|  [%unexpected-fact-mark p.cage.sign]
           ?>  =(%json p.cage.sign)
           !<(json q.cage.sign)
         ::
         ?~  from  ~
-        :~  ['mark' [%s mark.u.from]]
-            ['desk' [%s desk.u.from]]
-        ==
+        ['mark' [%s mark.u.from]]~
       ::
           %kick
         ['response' [%s 'quit']]~


### PR DESCRIPTION
This change greatly improves the ergonomics of working with channel JSON
in statically typed languages, as the polymorphism is moved out of the
actual diff and into the event framing.