### PR TITLE
interface: fix publish url preprocessing

### DIFF
--- a/pkg/interface/src/logic/lib/tokenizeMessage.js
+++ b/pkg/interface/src/logic/lib/tokenizeMessage.js
@@ -19,7 +19,7 @@ export const isUrl = (str) => {
 
 const raceRegexes = (str) => {
   let link = str.match(URL_REGEX);
-  while(link?.[1]?.endsWith('(')) {
+  while(link?.[1]?.endsWith('(') || link?.[1].endsWith('[')) {
     const resumePos = link[1].length + link[2].length;
     const resume = str.slice(resumePos);
     link = resume.match(URL_REGEX);


### PR DESCRIPTION
There's a bug in the publish url preprocessing where if the link text is a url (like this `[http://example.com](http://example.com)`)
it will treat it like the graph `%url` content type instead of letting markdown handle it. The fix is just to detect that case in the same fashion that we detect urls in parens

Let me know if master is the wrong branch to target here, I'm out of the loop on the release process.