### PR TITLE
interface: minor group join fixes

### DIFF
--- a/pkg/interface/src/logic/lib/notificationRedirects.ts
+++ b/pkg/interface/src/logic/lib/notificationRedirects.ts
@@ -1,5 +1,7 @@
 import useMetadataState from '../state/metadata';
 import ob from 'urbit-ob';
+import useInviteState from '../state/invite';
+import {resourceAsPath} from '../../../../npm/api/dist';
 
 function getGroupResourceRedirect(key: string) {
   const association = useMetadataState.getState().associations.graph[`/ship/${key}`];
@@ -67,7 +69,9 @@ function getGraphRedirect(link: string) {
 
 function getInviteRedirect(link: string) {
   const [,,app,uid] = link.split('/');
-  return `/invites/${app}/${uid}`;
+  const invite = useInviteState.getState().invites[app][uid];
+  if(!invite) { return ''; }
+  return { search: `?join-kind=${app}&join-path=${encodeURIComponent(resourceAsPath(invite.resource))}` };
 }
 
 function getDmRedirect(link: string) {

--- a/pkg/interface/src/logic/reducers/invite-update.ts
+++ b/pkg/interface/src/logic/reducers/invite-update.ts
@@ -8,6 +8,7 @@ type InviteState = State & BaseState<State>;
 const initial = (json: InviteUpdate, state: InviteState): InviteState => {
   const data = _.get(json, 'initial', false);
   if (data) {
+    state.loaded = true;
     state.invites = data;
   }
   return state;

--- a/pkg/interface/src/logic/state/invite.ts
+++ b/pkg/interface/src/logic/state/invite.ts
@@ -32,6 +32,10 @@ const useInviteState = createState<InviteState>(
 
 export default useInviteState;
 
+interface InviteWithUid extends Invite {
+  uid: string;
+}
+
 export function useInviteForResource(app: string, ship: string, name: string) {
   const { invites } = useInviteState();
   const matches = Object.entries(invites?.[app] || {})
@@ -39,6 +43,6 @@ export function useInviteForResource(app: string, ship: string, name: string) {
       const isMatch = (invite.resource.ship === deSig(ship)
         && invite.resource.name === name)
       return isMatch ? [{ uid, ...invite}, ...acc] : acc;
-    }, [] as Invite[])
+    }, [] as InviteWithUid[])
   return matches?.[0];
 }

--- a/pkg/interface/src/logic/state/invite.ts
+++ b/pkg/interface/src/logic/state/invite.ts
@@ -9,14 +9,16 @@ import {
 
 export interface InviteState {
   invites: Invites;
+  loaded: boolean;
 }
 
 const useInviteState = createState<InviteState>(
   'Invite',
   {
-    invites: {}
+    invites: {},
+    loaded: false
   },
-  ['invites'],
+  ['invites', 'loaded'],
   [
     (set, get) =>
       createSubscription('invite-store', '/all', (e) => {

--- a/pkg/interface/src/logic/state/invite.ts
+++ b/pkg/interface/src/logic/state/invite.ts
@@ -36,7 +36,7 @@ export function useInviteForResource(app: string, ship: string, name: string) {
     .reduce((acc, [uid, invite]) => {
       const isMatch = (invite.resource.ship === deSig(ship)
         && invite.resource.name === name)
-      return isMatch ? [invite, ...acc] : acc;
+      return isMatch ? [{ uid, ...invite}, ...acc] : acc;
     }, [] as Invite[])
   return matches?.[0];
 }

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -115,7 +115,12 @@ function GraphPermalink(
     })();
   }, [pending, graph, index]);
   const showTransclusion = Boolean(association && node && transcluded < 1);
-  const permalink = getPermalinkForGraph(group, graph, index);
+  const permalink = (() => {
+    const link = `/perma${getPermalinkForGraph(group, graph, index).slice(16)}`;
+    return (!association && !loading)
+      ? { search: `?join-kind=group&join-path=${encodeURIComponent(group)}&redir=${encodeURIComponent(link)}`  }
+        :  link
+  })();
 
   const [nodeGroupHost, nodeGroupName] = association?.group.split('/').slice(-2) ?? ['Unknown', 'Unknown'];
   const [nodeChannelHost, nodeChannelName] = association?.resource
@@ -140,7 +145,7 @@ function GraphPermalink(
   return (
     <Col
       as={Link}
-      to={`/perma${permalink.slice(16)}`}
+      to={permalink}
       width="100%"
       bg="white"
       maxWidth={full ? null : '500px'}

--- a/pkg/interface/src/views/landscape/components/Content.tsx
+++ b/pkg/interface/src/views/landscape/components/Content.tsx
@@ -16,6 +16,7 @@ import Landscape from '~/views/landscape/index';
 import GraphApp from '../../apps/graph/App';
 import { getNotificationRedirect } from '~/logic/lib/notificationRedirects';
 import {JoinRoute} from './Join/Join';
+import useInviteState from '~/logic/state/invite';
 
 export const Container = styled(Box)`
    flex-grow: 1;
@@ -28,16 +29,20 @@ export const Content = (props) => {
   const history = useHistory();
   const location = useLocation();
   const mdLoaded = useMetadataState(s => s.loaded);
+  const inviteLoaded = useInviteState(s => s.loaded);
 
   useEffect(() => {
     const query = new URLSearchParams(location.search);
-    if(mdLoaded && query.has('grid-note')) {
+    if(!(mdLoaded && inviteLoaded)) {
+      return;
+    }
+    if(query.has('grid-note')) {
       history.push(getNotificationRedirect(query.get('grid-note')!));
-    } else if(mdLoaded && query.has('grid-link')) {
+    } else if(query.has('grid-link')) {
       const link = decodeURIComponent(query.get('grid-link')!);
       history.push(`/perma${link}`);
     }
-  }, [location.search, mdLoaded]);
+  }, [location.search, mdLoaded, inviteLoaded]);
 
   useShortcut('navForward', useCallback((e) => {
     e.preventDefault();

--- a/pkg/interface/src/views/landscape/components/GroupSummary.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSummary.tsx
@@ -33,7 +33,7 @@ export function GroupSummary(
   );
 
   return (
-    <Col {...rest} gapY={4} maxWidth={["100%", "288px"]}>
+    <Col gapY={4} maxWidth={["100%", "288px"]} {...rest}>
       <Row gapX={2} width="100%">
         <MetadataIcon
           width="40px"

--- a/pkg/interface/src/views/landscape/components/Join/Join.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Join.tsx
@@ -160,16 +160,19 @@ function JoinError(props: {
 
 export interface JoinProps {
   desc: JoinDesc;
+  redir?: string;
   modal?: boolean;
   dismiss?: () => void;
 }
 
 export function Join(props: JoinProps) {
-  const { desc, modal, dismiss } = props;
+  const { desc, modal, dismiss, redir } = props;
   const { group, kind } = desc;
   const [, , ship, name] = group.split("/");
   const graph = kind === "graph";
-  const finishedPath = graph
+  const finishedPath = !!redir
+    ? redir
+    : graph
     ? `/~landscape/messages/resource/chat/${ship}/${name}`
     : `/~landscape/ship/${ship}/${name}`;
 
@@ -319,6 +322,7 @@ export function JoinRoute(props: { graph?: boolean; modal?: boolean }) {
   const { pathname } = useLocation();
   const kind = query.get("join-kind");
   const path = query.get("join-path");
+  const redir = query.get('redir');
   if (!kind) {
     return null;
   }
@@ -334,7 +338,7 @@ export function JoinRoute(props: { graph?: boolean; modal?: boolean }) {
   };
 
   return desc ? (
-    <Join desc={desc} modal dismiss={dismiss} />
+    <Join desc={desc} modal dismiss={dismiss} redir={redir} />
   ) : (
     <JoinPrompt kind={kind} dismiss={dismiss} />
   );

--- a/pkg/interface/src/views/landscape/components/Join/Join.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Join.tsx
@@ -184,7 +184,7 @@ export function Join(props: JoinProps) {
     joinRequest && joinLoad.includes(joinRequest.progress as any);
 
   useEffect(() => {
-    if(isDone && desc.kind ===  'graph') {
+    if(isDone) {
       history.push(finishedPath);
     }
   }, [isDone, desc]);

--- a/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
@@ -18,7 +18,7 @@ import { resourceFromPath } from "~/logic/lib/group";
 import useMetadataState, { usePreview } from "~/logic/state/metadata";
 import useInviteState, { useInviteForResource } from "~/logic/state/invite";
 
-const SUMMARY_HEIGHT = "72px";
+const SUMMARY_HEIGHT = "96px";
 const SUMMARY_WIDTH = ["90vw", "512px"];
 
 export type JoinKind = "graph" | "groups";
@@ -42,7 +42,7 @@ export function JoinSkeleton(props: JoinSkeletonProps) {
 
   const inner = (
     <Col
-      maxWidth={modal ? "384px" : undefined}
+      width={modal ? ["90vw", "384px"] : undefined}
       borderRadius="2"
       backgroundColor="white"
     >
@@ -78,28 +78,19 @@ export function JoinBody(props: { desc: JoinDesc }) {
   const { ship, name } = resourceFromPath(group);
 
   const invite = useInviteForResource(kind, ship, name);
-  const [override, setOverride] = useState(false);
-
-  useEffect(() => {
-    let interval = setInterval(() => {
-      setOverride((s) => !s);
-    }, 5000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
 
   return (
     <>
       {!desc ? "Prompt invite link" : null}
-      {preview && override ? (
+      {preview ? (
         <GroupSummary
           memberCount={preview.members}
           channelCount={preview["channel-count"]}
           metadata={preview.metadata}
           height={SUMMARY_HEIGHT}
-          width={SUMMARY_WIDTH}
+          width="100%"
+          maxWidth="100%"
+          overflow="hidden"
         />
       ) : (
         <FallbackSummary path={group} />
@@ -130,12 +121,15 @@ function FallbackSummary(props: { path: string }) {
   return (
     <Row
       height={SUMMARY_HEIGHT}
-      width={SUMMARY_WIDTH}
+      width="100%"
+      overflow="hidden"
       alignItems="center"
       gapX="0"
     >
       <Author gray fullNotIcon size={40} showImage ship={ship} dontShowTime />
-      <Text mono>/{name}</Text>
+      <Text mono whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+        /{name}
+      </Text>
     </Row>
   );
 }

--- a/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
@@ -19,7 +19,6 @@ import useMetadataState, { usePreview } from "~/logic/state/metadata";
 import useInviteState, { useInviteForResource } from "~/logic/state/invite";
 
 const SUMMARY_HEIGHT = "96px";
-const SUMMARY_WIDTH = ["90vw", "512px"];
 
 export type JoinKind = "graph" | "groups";
 

--- a/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
@@ -18,6 +18,9 @@ import { resourceFromPath } from "~/logic/lib/group";
 import useMetadataState, { usePreview } from "~/logic/state/metadata";
 import useInviteState, { useInviteForResource } from "~/logic/state/invite";
 
+const SUMMARY_HEIGHT = "72px";
+const SUMMARY_WIDTH = ["90vw", "512px"];
+
 export type JoinKind = "graph" | "groups";
 
 export interface JoinDesc {
@@ -79,25 +82,24 @@ export function JoinBody(props: { desc: JoinDesc }) {
 
   useEffect(() => {
     let interval = setInterval(() => {
-      setOverride(s => !s);
+      setOverride((s) => !s);
     }, 5000);
 
     return () => {
       clearInterval(interval);
-    }
+    };
   }, []);
-
 
   return (
     <>
       {!desc ? "Prompt invite link" : null}
-      {(preview && override) ? (
+      {preview && override ? (
         <GroupSummary
           memberCount={preview.members}
           channelCount={preview["channel-count"]}
           metadata={preview.metadata}
-          height="72px"
-          width="256px"
+          height={SUMMARY_HEIGHT}
+          width={SUMMARY_WIDTH}
         />
       ) : (
         <FallbackSummary path={group} />
@@ -126,7 +128,12 @@ function FallbackSummary(props: { path: string }) {
   const [, , ship, name] = path.split("/");
 
   return (
-    <Row height="72px" width="256px" alignItems="center" gapX="0">
+    <Row
+      height={SUMMARY_HEIGHT}
+      width={SUMMARY_WIDTH}
+      alignItems="center"
+      gapX="0"
+    >
       <Author gray fullNotIcon size={40} showImage ship={ship} dontShowTime />
       <Text mono>/{name}</Text>
     </Row>

--- a/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Skeleton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   Col,
   Row,
@@ -75,15 +75,29 @@ export function JoinBody(props: { desc: JoinDesc }) {
   const { ship, name } = resourceFromPath(group);
 
   const invite = useInviteForResource(kind, ship, name);
+  const [override, setOverride] = useState(false);
+
+  useEffect(() => {
+    let interval = setInterval(() => {
+      setOverride(s => !s);
+    }, 5000);
+
+    return () => {
+      clearInterval(interval);
+    }
+  }, []);
+
 
   return (
     <>
       {!desc ? "Prompt invite link" : null}
-      {preview ? (
+      {(preview && override) ? (
         <GroupSummary
           memberCount={preview.members}
           channelCount={preview["channel-count"]}
           metadata={preview.metadata}
+          height="72px"
+          width="256px"
         />
       ) : (
         <FallbackSummary path={group} />
@@ -112,7 +126,7 @@ function FallbackSummary(props: { path: string }) {
   const [, , ship, name] = path.split("/");
 
   return (
-    <Row alignItems="center" gapX="0">
+    <Row height="72px" width="256px" alignItems="center" gapX="0">
       <Author gray fullNotIcon size={40} showImage ship={ship} dontShowTime />
       <Text mono>/{name}</Text>
     </Row>


### PR DESCRIPTION
- Fixes graph redirects of unjoined groups
- Stops the group summary from reflowing the modal when loaded
- Adds invite declination
- Fixes clicking on an invite notification
- Fixes group navigation