### PR TITLE
pkg: include atom mark in base-dev

### DIFF
--- a/pkg/arvo/mar/atom.hoon
+++ b/pkg/arvo/mar/atom.hoon
@@ -1,18 +1,1 @@
-::
-::::  /hoon/atom/mar
-  ::
-/?    310
-::
-::::  A minimal atom mark
-  ::
-=,  mimes:html
-|_  ato=@
-++  grab  |%
-          ++  noun  @
-          ++  mime  |=([* p=octs] q.p)
-          --
-++  grow  |%
-          ++  mime  [/application/x-urb-unknown (as-octs ato)]
-          --
-++  grad  %mime
---
+../../base-dev/mar/atom.hoon

--- a/pkg/base-dev/mar/atom.hoon
+++ b/pkg/base-dev/mar/atom.hoon
@@ -1,0 +1,18 @@
+::
+::::  /hoon/atom/mar
+  ::
+/?    310
+::
+::::  A minimal atom mark
+  ::
+=,  mimes:html
+|_  ato=@
+++  grab  |%
+          ++  noun  @
+          ++  mime  |=([* p=octs] q.p)
+          --
+++  grow  |%
+          ++  mime  [/application/x-urb-unknown (as-octs ato)]
+          --
+++  grad  %mime
+--


### PR DESCRIPTION
Found out the hard way that the `%atom` mark was actually not included in base-dev. Proposing here that it should be in there, considering it's not too uncommon to produce data with that mark.