### PR TITLE
fmt: auto format whitespace in C code using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,131 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+Language: Cpp
+AlignAfterOpenBracket: Align
+#AlignArrayOfStructures: Left # >= 13.0
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: true
+#AttributeMacros:
+  #- __capability
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: None
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterControlStatement: MultiLine
+  AfterEnum: false
+  AfterFunction: true
+  AfterStruct: false
+  AfterUnion: false
+  BeforeElse: true
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+ColumnLimit: 80
+#CommentPragmas:  '^ IWYU pragma:'
+ContinuationIndentWidth: 2
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat: false
+#ForEachMacros:
+  #- foreach
+  #- Q_FOREACH
+  #- BOOST_FOREACH
+#IfMacros: 
+  #- IF
+#StatementAttributeLikeMacros:
+  #- Q_EMIT
+IncludeBlocks: Regroup
+#IncludeCategories:
+  #- Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    #Priority:        2
+    #SortPriority:    0
+    #CaseSensitive:   false
+  #- Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    #Priority:        3
+    #SortPriority:    0
+    #CaseSensitive:   false
+  #- Regex:           '.*'
+    #Priority:        1
+    #SortPriority:    0
+    #CaseSensitive:   false
+#IncludeIsMainRegex: '(Test)?$'
+#IncludeIsMainSourceRegex: ''
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+#MacroBlockBegin: ''
+#MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+#PPIndentWidth: -1 # >= 13.0
+#PenaltyBreakAssignment: 2
+#PenaltyBreakBeforeFirstCallParameter: 19
+#PenaltyBreakComment: 300
+#PenaltyBreakFirstLessLess: 120
+#PenaltyBreakString: 1000
+#PenaltyBreakTemplateDeclaration: 10
+#PenaltyExcessCharacter: 1000000
+#PenaltyReturnTypeOnItsOwnLine: 60
+#PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+ReflowComments: true # CaseInsensitive >= 13.0
+SortIncludes: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: true
+#SpacesInLineCommentPrefix: # >= 13.0
+  #Maximum: 1
+  #Minimum: 1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#StatementAttributeLikeMacros:
+#StatementMacros:
+  #- Q_UNUSED
+  #- QT_REQUIRE_VERSION
+TabWidth: 2
+TypenameMacros:
+  - u3p
+UseCRLF: false
+UseTab: Never
+#WhitespaceSensitiveMacros:
+  #- STRINGIZE
+  #- PP_STRINGIZE
+  #- BOOST_PP_STRINGIZE
+  #- NS_SWIFT_NAME
+  #- CF_SWIFT_NAME
+---
+Language: JavaScript
+InsertTrailingCommas: Wrapped

--- a/sh/fmt-c
+++ b/sh/fmt-c
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Usage: fmt-c
+
+set -euo pipefail
+
+cd "${0%/*}/.."
+
+echo "Formatting C"
+
+find pkg -type f -name '*.[ch]' \
+  -exec clang-format -i --Werror {} \+

--- a/shell.nix
+++ b/shell.nix
@@ -53,6 +53,7 @@ in pkgsLocal.hs.shellFor {
   # Nixpkgs tools to make available on the shell's PATH.
   buildInputs = [
     pkgs.cacert
+    pkgs.clang-tools
     pkgs.nixfmt
     pkgs.shfmt
     pkgs.stack


### PR DESCRIPTION
Use `clang-format` to format whitespace in C source and header files. The current configuration conforms as closely to the existing style of C code as possible, including:
- Align pointers to the left.
```c
void* ptr_v;
```
- Put the return type of a function on its own line.
```c
c3_w
fun(void)
{

}
```
- Include the open curly brace on same line as control statements, struct declarations, and enum declarations.
```c
if ( c3n == var_o ) {

}

for ( var_w = 0; var_w < 137; var_w ++ ) {

}

while ( 137 > var_w ) {

}

enum bar {

};


struct foo {

};

```
- Add the open curly brace to a new line for function declarations and before else statements.
```c
if ( c3n == var_o ) {

}
else {

}

c3_w
fun(void)
{

}
```
- Add leading and trailing space inside of parentheses.
```c
if ( c3n == var_o && c3y == rav_o ) {

}
```
- Align consecutive variable declarations and assignments.
- Align macro definitions.
- Align inline comments.

Note that the above is a non-exhaustive list of the formatting options selected. For a comprehensive view, take a look at `.clang-format` and the [clang-format options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).