### PR TITLE
groups: fix permission handling

### DIFF
--- a/pkg/landscape/app/metadata-pull-hook.hoon
+++ b/pkg/landscape/app/metadata-pull-hook.hoon
@@ -326,7 +326,7 @@
   :_  this
   %+  turn  ~(tap by associations)
   |=  [=md-resource:metadata =association:metadata]
-  %+  poke-our:pass:io  %metadata-store
+  %+  poke-our:pass:io:hc  %metadata-store
   :-  %metadata-update-2
   !>  ^-   update:metadata
   [%remove resource md-resource]

--- a/pkg/landscape/app/metadata-push-hook.hoon
+++ b/pkg/landscape/app/metadata-push-hook.hoon
@@ -1,6 +1,6 @@
 ::  metadata-push-hook [landscape]:
 ::
-/-  *group, *invite-store, store=metadata-store
+/-  *group, *invite-store, store=metadata-store, group-store
 /+  default-agent, verb, dbug, grpl=group, push-hook,
     resource, mdl=metadata, gral=graph, agentio
 ~%  %group-hook-top  ..part  ~
@@ -21,13 +21,23 @@
 ::
 +$  state-null  ~
 +$  state-zero  [%0 ~]
++$  state-one   [%1 ~]
 ::
 +$  versioned-state
   $%  state-null
       state-zero
+      state-one
   ==
 --
 ::
+::
+=+
+  ^=  hook-core
+  |_  =bowl:gall
+  +*  io    ~(. agentio bowl)
+      pass   pass:io
+  ++  watch-groups  (~(watch-our pass /groups) %group-store /groups)
+  --
 ::
 =|  state-zero
 =*  state  -
@@ -43,11 +53,20 @@
     met       ~(. mdl bowl)
     gra       ~(. gral bowl)
     io        ~(. agentio bowl)
+    hc        ~(. hook-core bowl) 
     pass      pass:io
 ::
-++  on-init  on-init:def
-++  on-save  !>(~)
-++  on-load  on-load:def
+++  on-init
+  :_  this
+  ~[watch-groups:hc]
+::
+++  on-save  !>(state)
+++  on-load
+  |=  =vase
+  =+  !<(old=versioned-state vase)
+  ?:  ?=([%0 ~] old)  `this
+  :_  this
+  ~[watch-groups:hc]
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -82,7 +101,44 @@
     ==
   --
 ::
-++  on-agent  on-agent:def
+++  on-agent
+  |=  [=wire =sign:agent:gall]
+  ?.  ?=([%groups ~] wire)
+    (on-agent:def wire sign)
+  ?+  -.sign  (on-agent:def wire sign)
+    %kick  :_(this ~[watch-groups:hc])
+  ::
+      %fact
+    ?.  =(p.cage.sign %group-update-0)  `this
+    =+  !<(=update:group-store q.cage.sign)
+    ?.  ?=(%remove-members -.update)  `this
+    |^
+    =/  graphs=(set resource)
+      (hosting-graphs resource.update)
+    :_  this
+    %+  weld
+       (turn ~(tap in graphs) (cury revoke %graph-push-hook))
+    ?.  =(entity.resource.update our.bowl)  ~
+    (revoke %metadata-push-hook resource.update)^~
+    ::
+    ++  revoke
+      |=  [=dude:gall rid=resource]
+      =/  =action:push-hook  [%revoke ships.update rid]
+      =/  =cage              push-hook-action+!>(action)
+      (poke-our:pass dude cage)
+    ::
+    ++  hosting-graphs
+      |=  rid=resource
+      ^-  (set resource)
+      =/  graphs=associations:store
+        (app-metadata-for-group:met resource.update %graph)
+      %-  ~(gas in *(set resource))
+      %+  murn  ~(tap in ~(key by graphs))
+      |=  [app=term graph=resource]
+      ?.  =(our.bowl entity.graph)  ~
+      `graph
+    --
+  ==
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
 ++  on-peek   on-peek:def

--- a/pkg/landscape/app/metadata-push-hook.hoon
+++ b/pkg/landscape/app/metadata-push-hook.hoon
@@ -21,12 +21,10 @@
 ::
 +$  state-null  ~
 +$  state-zero  [%0 ~]
-+$  state-one   [%1 ~]
 ::
 +$  versioned-state
   $%  state-null
       state-zero
-      state-one
   ==
 --
 ::

--- a/pkg/landscape/lib/pull-hook.hoon
+++ b/pkg/landscape/lib/pull-hook.hoon
@@ -432,7 +432,7 @@
     ::
     ++  tr-emis
       |=  caz=(list card)
-      tr-core(cards (welp (flop cards) cards))
+      tr-core(cards (welp (flop caz) cards))
     ::
     ++  tr-ap-og
       |=  ap=_^?(|.(*(quip card _pull-hook)))

--- a/pkg/landscape/lib/push-hook.hoon
+++ b/pkg/landscape/lib/push-hook.hoon
@@ -423,11 +423,14 @@
     ::
     ++  revoke
       |=  [ships=(set ship) rid=resource]
-      =/  pax=path
+      =/  ver-pax=path
+        [%resource %ver (en-path:resource rid)]
+      =/  unver-pax=path
         [%resource (en-path:resource rid)]
       :_  state
       %+  murn
-        (incoming-subscriptions pax)
+        %+  welp  (incoming-subscriptions unver-pax)
+        (incoming-subscriptions ver-pax)
       |=  [her=ship =path]
       ^-  (unit card)
       ?.  (~(has in ships) her)

--- a/pkg/landscape/ted/group/leave.hoon
+++ b/pkg/landscape/ted/group/leave.hoon
@@ -22,8 +22,20 @@
   :-  %pull-hook-action
   !>  ^-  action:pull-hook
   [%remove rid]
-;<  ~  bind:m  (raw-poke-our %contact-pull-hook pull-hook-act)
-;<  ~  bind:m  (raw-poke-our %metadata-pull-hook pull-hook-act)
-;<  ~  bind:m  (raw-poke-our %group-pull-hook pull-hook-act)
-;<  ~  bind:m  (raw-poke-our %group-store %group-update-0 !>([%remove-group rid ~]))
+=/  leave=cage
+  :-  %group-update-0
+  !>  ^-  update:store
+  [%remove-members rid (silt our.bowl ~)]
+=/  remove=cage
+  :-  %group-update-0
+  !>  ^-  update:store
+  [%remove-group rid ~]
+;<  ~  bind:m
+  (raw-poke-our %group-push-hook leave)
+;<  ~  bind:m
+  (raw-poke-our %group-pull-hook pull-hook-act)
+;<  ~  bind:m
+  (raw-poke-our %contact-pull-hook pull-hook-act)
+;<  ~  bind:m
+  (raw-poke-our %group-store remove)
 (pure:m !>(~))

--- a/pkg/landscape/ted/group/leave.hoon
+++ b/pkg/landscape/ted/group/leave.hoon
@@ -26,5 +26,4 @@
 ;<  ~  bind:m  (raw-poke-our %metadata-pull-hook pull-hook-act)
 ;<  ~  bind:m  (raw-poke-our %group-pull-hook pull-hook-act)
 ;<  ~  bind:m  (raw-poke-our %group-store %group-update-0 !>([%remove-group rid ~]))
-;<  ~  bind:m  (cleanup-md:view rid)
 (pure:m !>(~))


### PR DESCRIPTION
Aggressively refactors the permissioning flow for groups, so as to make more reliable

On leaving a group:
- Leaving a group is triggered through the `-group-leave` thread
- This pokes group-push-hook, to remove ourselves from the groups, group-store to remove our copy of the group, and group-pull-hook, to cancel syncing of group
- When hosts hear of a %remove-members fact in the metadata-push-hook, it revokes the ships included in that fact. This should trigger the usual nacking and cleanup flow, which has been thoroughly tested.

