### PR TITLE
Adding tag == c3_doze check to _behn_io_kick in Behn io driver

### DIFF
--- a/pkg/urbit/vere/io/behn.c
+++ b/pkg/urbit/vere/io/behn.c
@@ -189,7 +189,8 @@ _behn_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
 
   if (  (c3n == u3r_cell(wir, &i_wir, 0))
      || (c3n == u3r_cell(cad, &tag, &dat))
-     || (c3__behn != i_wir) )
+     || (c3__behn != i_wir) 
+     || (c3__doze != tag) )
   {
     ret_o = c3n;
   }


### PR DESCRIPTION
@joemfb and I (really just Joe) noticed this bug in the Behn io driver when he was walking me through how IO drivers work. it wasn't checking that the tag on the kick was c3__doze, and now it does.

Yay! first PR!