### PR TITLE
u3: fix compilation of dynamic hints in tail position

### DIFF
--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1023,7 +1023,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
 
       case c3__bout: {
         u3_noun fen = u3_nul;
-        c3_w  nef_w = _n_comp(&fen, nef, los_o, tel_o);
+        c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
         // add appropriate hind opcode
         ++nef_w; _n_emit(&fen, ( c3y == los_o ) ? HILL : HILK);
         // skip over the cleanup opcode
@@ -1058,7 +1058,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
 
           case c3__bout: {
             u3_noun fen = u3_nul;
-            c3_w  nef_w = _n_comp(&fen, nef, los_o, tel_o);
+            c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
             // add appropriate hind opcode
             ++nef_w; _n_emit(&fen, ( c3y == los_o ) ? HINL : HINK);
             // skip over the cleanup opcode


### PR DESCRIPTION
This PR fixes a miscompilation of dynamic hints in the bytecode interpreter. Calls (nock 9) in hinted formulas in tail position were being compiled into tail calls, but hinted formulas (in the dynamic hint protocol) are never in tail position, as there is a post-evaluation callback.

This bug caused a crash, which was first observed in #5477. Dynamic hints were added in #3979, and first used in #5261.

/cc @frodwith 