### PR TITLE
helm: bind /who.json

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -2,27 +2,28 @@
 /+  drum=hood-drum, helm=hood-helm, kiln=hood-kiln
 |%
 +$  state
-  $~  [%22 *state:drum *state:helm *state:kiln]
-  $>(%22 any-state)
+  $~  [%23 *state:drum *state:helm *state:kiln]
+  $>(%23 any-state)
 ::
 +$  any-state
   $%  [ver=?(%1 %2 %3 %4 %5 %6) lac=(map @tas fin-any-state)]
-      [%7 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%8 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%9 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%10 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%11 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%12 drum=state-2:drum helm=state:helm kiln=state-0:kiln]
-      [%13 drum=state-2:drum helm=state:helm kiln=state-1:kiln]
-      [%14 drum=state-2:drum helm=state:helm kiln=state-1:kiln]
-      [%15 drum=state-2:drum helm=state:helm kiln=state-2:kiln]
-      [%16 drum=state-4:drum helm=state:helm kiln=state-3:kiln]
-      [%17 drum=state-4:drum helm=state:helm kiln=state-4:kiln]
-      [%18 drum=state-4:drum helm=state:helm kiln=state-5:kiln]
-      [%19 drum=state-4:drum helm=state:helm kiln=state-6:kiln]
-      [%20 drum=state-4:drum helm=state:helm kiln=state-7:kiln]
-      [%21 drum=state-4:drum helm=state:helm kiln=state-8:kiln]
-      [%22 drum=state-4:drum helm=state:helm kiln=state-9:kiln]
+      [%7 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%8 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%9 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%10 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%11 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%12 drum=state-2:drum helm=state-1:helm kiln=state-0:kiln]
+      [%13 drum=state-2:drum helm=state-1:helm kiln=state-1:kiln]
+      [%14 drum=state-2:drum helm=state-1:helm kiln=state-1:kiln]
+      [%15 drum=state-2:drum helm=state-1:helm kiln=state-2:kiln]
+      [%16 drum=state-4:drum helm=state-1:helm kiln=state-3:kiln]
+      [%17 drum=state-4:drum helm=state-1:helm kiln=state-4:kiln]
+      [%18 drum=state-4:drum helm=state-1:helm kiln=state-5:kiln]
+      [%19 drum=state-4:drum helm=state-1:helm kiln=state-6:kiln]
+      [%20 drum=state-4:drum helm=state-1:helm kiln=state-7:kiln]
+      [%21 drum=state-4:drum helm=state-1:helm kiln=state-8:kiln]
+      [%22 drum=state-4:drum helm=state-1:helm kiln=state-9:kiln]
+      [%23 drum=state-4:drum helm=state-2:helm kiln=state-9:kiln]
   ==
 +$  any-state-tuple
   $:  drum=any-state:drum
@@ -48,6 +49,7 @@
 ++  on-fail   on-fail:def
 ++  on-init
   ^-  step:agent:gall
+  =^  h  helm.state  on-init:helm-core
   =^  d  drum.state  on-init:drum-core
   =^  k  kiln.state  on-init:kiln-core
   [:(welp d k) this]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -1,27 +1,33 @@
 /+  pill
 =*  card  card:agent:gall
 |%
-+$  state  state-1
++$  state  state-2
 +$  any-state
  $~  *state
- $%  state-1
+ $%  state-2
+     state-1
      state-0
  ==
-+$  state-1
-  $:  %1
-      mass-timer=[way=wire nex=@da tim=@dr]
-  ==
++$  state-2  [%2 =mass-timer]
++$  state-1  [%1 =mass-timer]
 +$  state-0  [%0 hoc=(map bone session-0)]
 +$  session-0
   $:  say=*
       mud=*
-      mass-timer=[way=wire nex=@da tim=@dr]
+      =mass-timer
   ==
+::
++$  mass-timer  [way=wire nex=@da tim=@dr]
 ::
 ++  state-0-to-1
   |=  s=state-0
-  ^-  state
+  ^-  state-1
   [%1 mass-timer:(~(got by hoc.s) 0)]
+::
+++  state-1-to-2
+  |=  s=state-1
+  ^-  state-2
+  [%2 +.s]
 --
 |=  [=bowl:gall sat=state]
 =|  moz=(list card)
@@ -39,11 +45,17 @@
   ^+  this
   ?~(caz this $(caz t.caz, this (emit i.caz)))
 ::
+++  on-init
+  (poke-serve [~ /who] %base /gen/who/hoon ~)
+::
 ++  on-load
   |=  [hood-version=@ud old=any-state]
   =<  abet
-  =?  old  ?=(%0 -.old)  (state-0-to-1 old)
-  ?>  ?=(%1 -.old)
+  =?  old   ?=(%0 -.old)  (state-0-to-1 old)
+  =?  this  ?=(%1 -.old)
+    (emil -:(poke-serve [~ /who] %base /gen/who/hoon ~))
+  =?  old   ?=(%1 -.old)  (state-1-to-2 old)
+  ?>  ?=(%2 -.old)
   this(sat old)
 ::
 ++  poke-rekey                                        ::  rotate private keys

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -45,6 +45,7 @@
       (~(connect pass /eyre) [~ /] %docket)
       (~(wait pass /init) (add 1 now.bowl))
       (~(connect pass /eyre) [~ /apps] %docket)
+      (~(arvo pass /eyre) %e %serve [~ /who] %base /gen/who/hoon ~)
   ==
 ::
 ++  on-load
@@ -55,7 +56,8 @@
   |^
   =.  -.state  old
   =.  +.state  inflate-cache
-  `this
+  :_  this
+  [(~(arvo pass /eyre) %e %serve [~ /who] %base /gen/who/hoon ~)]~
   ::
   ++  inflate-cache
     ^-  cache

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -45,7 +45,6 @@
       (~(connect pass /eyre) [~ /] %docket)
       (~(wait pass /init) (add 1 now.bowl))
       (~(connect pass /eyre) [~ /apps] %docket)
-      (~(arvo pass /eyre) %e %serve [~ /who] %base /gen/who/hoon ~)
   ==
 ::
 ++  on-load
@@ -56,8 +55,7 @@
   |^
   =.  -.state  old
   =.  +.state  inflate-cache
-  :_  this
-  [(~(arvo pass /eyre) %e %serve [~ /who] %base /gen/who/hoon ~)]~
+  `this
   ::
   ++  inflate-cache
     ^-  cache


### PR DESCRIPTION
Before the software distribution era, file-server used to bind this. Ships that existed pre-dist still have that bound, pointing to the generator in `%home`. Ships that booted directly into the softdist world though, never got this endpoint bound.

Apparently some things still (want to) depend on this. This PR simply restores the endpoint and makes sure it's pointing to the generator on base. Some slightly odd coupling here, with the generator on base, and docket (who now sets up the binding) living in garden, but unless we want to have kiln set this up I'm not sure there's a better place to do this right now.