### PR TITLE
zuse: Allow 32-bit unicode escape sequences

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5351,6 +5351,7 @@
   ++  qex  (bass 16 ;~(plug sex (stun [0 3] hit)))
   ++  qib  (bass 2 (stun [4 4] sib))
   ++  qix  (bass 16 (stun [4 4] six))
+  ++  qux  (bass 16 (stun [4 8] hit))
   ++  seb  (cold 1 (just '1'))
   ++  sed  (cook |=(a=@ (sub a '0')) (shim '1' '9'))
   ++  sev  ;~(pose sed sov)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4244,7 +4244,7 @@
             [b+8 t+9 n+10 f+12 r+13 ~]
           =*  wow  `(map @t @)`(malt lip)
           (sear ~(get by wow) low)
-        =*  tuf  ;~(pfix (just 'u') (cook tuft qix:ab))
+        =*  tuf  ;~(pfix (just 'u') (cook tuft qux:ab))
         ;~(pose doq fas soq bas loo tuf)
       ==
     ::                                                  ::  ++expo:de-json:html


### PR DESCRIPTION
Allows 32-bit escape sequences in `de-json:html`