### PR TITLE
helm: update |rekey to work with multikey files

### DIFF
--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -68,12 +68,10 @@
   =|  caz=(list card)
   %-  emil
   |-
-  ?~  kyz.fed
-    caz
-  =/  sed=seed:jael  [who [lyf key ~]:i.kyz]:fed
+  ?~  kyz.fed  (flop caz)
   %=  $
-      kyz.fed  t.kyz.fed
-      caz      (snoc caz [%pass / %arvo %j %rekey lyf.sed key.sed])
+    kyz.fed  t.kyz.fed
+    caz      [[%pass / %arvo %j %rekey i.kyz.fed] caz]
   ==
 ::
 ++  ames-secret

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -48,18 +48,33 @@
 ::
 ++  poke-rekey                                        ::  rotate private keys
   |=  des=@t
-  =/  sed=(unit seed:jael)
+  =/  fud=(unit feed:jael)
     %+  biff
       (bind (slaw %uw des) cue)
-    (soft seed:jael)
+    (soft feed:jael)
   =<  abet
-  ?~  sed
+  ?~  fud
     ~&  %invalid-private-key
     this
-  ?.  =(our.bowl who.u.sed)
-    ~&  [%wrong-private-key-ship who.u.sed]
+  =/  fed  (need fud)
+  ?@  -.fed
+    ?.  =(our.bowl who.fed)
+      ~&  [%wrong-private-key-ship who.fed]
+      this
+    (emit %pass / %arvo %j %rekey lyf.fed key.fed)
+  ?.  =(our.bowl who.fed)
+    ~&  [%wrong-private-key-ship who.fed]
     this
-  (emit %pass / %arvo %j %rekey lyf.u.sed key.u.sed)
+  =|  caz=(list card)
+  %-  emil
+  |-
+  ?~  kyz.fed
+    caz
+  =/  sed=seed:jael  [who [lyf key ~]:i.kyz]:fed
+  %=  $
+      kyz.fed  t.kyz.fed
+      caz      (snoc caz [%pass / %arvo %j %rekey lyf.sed key.sed])
+  ==
 ::
 ++  ames-secret
   ^-  @t


### PR DESCRIPTION
Addresses #5516

The old |rekey expected a `seed:jael`, this rewrites |rekey to work with
`feed:jael` which has `seed:jael` as a case so it is backwards
compatible with old keyfiles.

I suspect there is room for improvement here:

https://github.com/urbit/urbit/pull/5522/commits/3651f6a7c653f6e72767a2a0f14a0759b6e6d931#diff-dcb56b92e2927b7d8184f5dd10c0bab7b18e7340bbdec1ffb5c4800d11075936R60-R66

 namely the use of identical `?.` statements twice in a row. We can't look at `who.fed` until after the `?@` so that the compiler knows what its looking at, so it seems like we need this but I could be overlooking something about `$^` molds (which `feed:jael` is) that makes it so this can be a bit cleaner. The only idea I've had so far is to factor the `?.` statements into its own arm under a `|^`, but I think this loses a tiny bit of clarity.