### PR TITLE
u3: consolidate functions in events.c

### DIFF
--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -15,17 +15,6 @@ struct {
   c3_w mug_w[u3a_pages];
 } u3K;
 
-/* _ce_check_page(): checksum page.
-*/
-static c3_w
-_ce_check_page(c3_w pag_w)
-{
-  c3_w* mem_w = u3_Loom + (pag_w << u3a_page);
-  c3_w  mug_w = u3r_mug_words(mem_w, (1 << u3a_page));
-
-  return mug_w;
-}
-
 /* _ce_maplloc(): crude off-loom allocator.
 */
 static void*

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -126,19 +126,6 @@ _ce_image_open(u3e_image* img_u)
   }
 }
 
-/* _ce_patch_write_control(): write control block file.
-*/
-static void
-_ce_patch_write_control(u3_ce_patch* pat_u)
-{
-  c3_w len_w = sizeof(u3e_control) +
-               (pat_u->con_u->pgs_w * sizeof(u3e_line));
-
-  if ( len_w != write(pat_u->ctl_i, pat_u->con_u, len_w) ) {
-    c3_assert(0);
-  }
-}
-
 /* _ce_patch_read_control(): read control block file.
 */
 static c3_o
@@ -441,7 +428,11 @@ _ce_patch_compose(void)
     pat_u->con_u->sou_w = sou_w;
     pat_u->con_u->pgs_w = pgc_w;
 
-    _ce_patch_write_control(pat_u);
+    // Write u3e_control struct to patch's control file.
+    {
+      c3_w len_w = sizeof(u3e_control) + (pat_u->con_u->pgs_w * sizeof(u3e_line));
+      c3_assert(len_w == write(pat_u->ctl_i, pat_u->con_u, len_w));
+    }
     return pat_u;
   }
 }

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -240,13 +240,7 @@ _ce_patch_open(void)
          len_w != sizeof(u3e_control) +
                   (pat_u->con_u->pgs_w * sizeof(u3e_line)) )
     {
-      c3_free(pat_u->con_u);
-      pat_u->con_u = 0;
-
-      close(pat_u->ctl_i);
-      close(pat_u->mem_i);
-      c3_free(pat_u);
-
+      _ce_patch_free(pat_u);
       _ce_patch_delete();
 
       return 0;

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -14,20 +14,6 @@ struct {
   c3_w sou_w;
   c3_w mug_w[u3a_pages];
 } u3K;
-
-/* _ce_mapfree(): crude off-loom allocator.
-*/
-static void
-_ce_mapfree(void* map_v)
-{
-  c3_w* map_w = map_v;
-  c3_i res_i;
-
-  map_w -= 1;
-  res_i = munmap(map_w, map_w[0]);
-
-  c3_assert(0 == res_i);
-}
 #endif
 
 /* u3e_fault(): handle a memory event with libsigsegv protocol.

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -74,8 +74,16 @@ u3e_fault(void* adr_v, c3_i ser_i)
   return 1;
 }
 
-/* _ce_image_open(): open or create image.
-*/
+/* Open the image file at <path to pier>/.urb/chk/<segment name>.bin. If the
+ * file does not already exist, then create it.
+ *
+ * @param img_u  memory segment struct containing the segment name. File
+ *               descriptor and page length fields are filled in by this
+ *               function.
+ *
+ * @return c3y   image file was successfully opened (or created).
+ * @return c3n   image file could not be opened (or created).
+ */
 static c3_o
 _ce_image_open(u3e_image* img_u)
 {

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -126,32 +126,6 @@ _ce_image_open(u3e_image* img_u)
   }
 }
 
-/* _ce_patch_create(): create patch files.
-*/
-static void
-_ce_patch_create(u3_ce_patch* pat_u)
-{
-  c3_c ful_c[8193];
-
-  snprintf(ful_c, 8192, "%s", u3P.dir_c);
-  mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb", u3P.dir_c);
-  mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
-  if ( -1 == (pat_u->ctl_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    fprintf(stderr, "loom: patch open control.bin: %s\r\n", strerror(errno));
-    c3_assert(0);
-  }
-
-  snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
-  if ( -1 == (pat_u->mem_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
-    fprintf(stderr, "loom: patch open memory.bin: %s\r\n", strerror(errno));
-    c3_assert(0);
-  }
-}
-
 /* _ce_patch_delete(): delete a patch.
 */
 static void
@@ -398,7 +372,31 @@ _ce_patch_compose(void)
     u3_ce_patch* pat_u = c3_malloc(sizeof(u3_ce_patch));
     c3_w i_w, pgc_w;
 
-    _ce_patch_create(pat_u);
+    // Create and open the patch's control and memory files.
+    {
+      c3_c ful_c[8193];
+
+      snprintf(ful_c, sizeof(ful_c)-1, "%s", u3P.dir_c);
+      mkdir(ful_c, 0700);
+
+      snprintf(ful_c, sizeof(ful_c)-1, "%s/.urb", u3P.dir_c);
+      mkdir(ful_c, 0700);
+
+      snprintf(ful_c, sizeof(ful_c)-1, "%s/.urb/chk/control.bin", u3P.dir_c);
+      pat_u->ctl_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600);
+      if ( -1 == pat_u->ctl_i ) {
+        fprintf(stderr, "loom: patch open control.bin: %s\r\n", strerror(errno));
+        c3_assert(0);
+      }
+
+      snprintf(ful_c, sizeof(ful_c)-1, "%s/.urb/chk/memory.bin", u3P.dir_c);
+      pat_u->mem_i = open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600);
+      if ( -1 == pat_u->mem_i ) {
+        fprintf(stderr, "loom: patch open memory.bin: %s\r\n", strerror(errno));
+        c3_assert(0);
+      }
+    }
+
     pat_u->con_u = c3_malloc(sizeof(u3e_control) + (pgs_w * sizeof(u3e_line)));
     pat_u->con_u->ver_y = u3e_version;
     pgc_w = 0;

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -15,31 +15,6 @@ struct {
   c3_w mug_w[u3a_pages];
 } u3K;
 
-/* _ce_maplloc(): crude off-loom allocator.
-*/
-static void*
-_ce_maplloc(c3_w len_w)
-{
-  void* map_v;
-
-  map_v = mmap(0,
-               len_w,
-               (PROT_READ | PROT_WRITE),
-               (MAP_ANON | MAP_PRIVATE),
-               -1, 0);
-
-  if ( -1 == (c3_ps)map_v ) {
-    c3_assert(0);
-  }
-  else {
-    c3_w* map_w = map_v;
-
-    map_w[0] = len_w;
-
-    return map_w + 1;
-  }
-}
-
 /* _ce_mapfree(): crude off-loom allocator.
 */
 static void

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -126,11 +126,21 @@ _ce_image_open(u3e_image* img_u)
   }
 }
 
-/* _ce_patch_delete(): delete a patch.
-*/
+/* _ce_patch_delete(): clean up the patch's resources and delete its control and
+ * memory files from the filesystem.
+ *
+ * @param pat_u  pointer to a patch struct. Can be NULL.
+ */
 static void
-_ce_patch_delete(void)
+_ce_patch_delete(u3_ce_patch* pat_u)
 {
+  if ( 0 != pat_u ) {
+    c3_free(pat_u->con_u);
+    close(pat_u->ctl_i);
+    close(pat_u->mem_i);
+    c3_free(pat_u);
+  }
+
   c3_c ful_c[8193];
 
   snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
@@ -185,23 +195,12 @@ _ce_patch_verify(u3_ce_patch* pat_u)
   return c3y;
 }
 
-/* _ce_patch_free(): free a patch.
-*/
-static void
-_ce_patch_free(u3_ce_patch* pat_u)
-{
-  c3_free(pat_u->con_u);
-  close(pat_u->ctl_i);
-  close(pat_u->mem_i);
-  c3_free(pat_u);
-}
-
 /* _ce_patch_open(): open patch, if any.
 */
 static u3_ce_patch*
 _ce_patch_open(void)
 {
-  u3_ce_patch* pat_u;
+  u3_ce_patch* pat_u = 0;
   c3_c ful_c[8193];
   c3_i ctl_i, mem_i;
 
@@ -220,7 +219,7 @@ _ce_patch_open(void)
   if ( -1 == (mem_i = open(ful_c, O_RDWR)) ) {
     close(ctl_i);
 
-    _ce_patch_delete();
+    _ce_patch_delete(pat_u);
     return 0;
   }
   pat_u = c3_malloc(sizeof(u3_ce_patch));
@@ -240,15 +239,12 @@ _ce_patch_open(void)
          len_w != sizeof(u3e_control) +
                   (pat_u->con_u->pgs_w * sizeof(u3e_line)) )
     {
-      _ce_patch_free(pat_u);
-      _ce_patch_delete();
-
+      _ce_patch_delete(pat_u);
       return 0;
     }
   }
   if ( c3n == _ce_patch_verify(pat_u) ) {
-    _ce_patch_free(pat_u);
-    _ce_patch_delete();
+    _ce_patch_delete(pat_u);
     return 0;
   }
   return pat_u;
@@ -735,8 +731,7 @@ u3e_save(void)
 
   _ce_image_sync(&u3P.nor_u);
   _ce_image_sync(&u3P.sou_u);
-  _ce_patch_free(pat_u);
-  _ce_patch_delete();
+  _ce_patch_delete(pat_u);
 
   _ce_backup();
 }
@@ -775,8 +770,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         _ce_patch_apply(pat_u);
         _ce_image_sync(&u3P.nor_u);
         _ce_image_sync(&u3P.sou_u);
-        _ce_patch_free(pat_u);
-        _ce_patch_delete();
+        _ce_patch_delete(pat_u);
       }
 
       /* Write image files to memory; reinstate protection.

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -260,23 +260,6 @@ _ce_patch_open(void)
   return pat_u;
 }
 
-/* _ce_patch_write_page(): write a page of patch memory.
-*/
-static void
-_ce_patch_write_page(u3_ce_patch* pat_u,
-                     c3_w         pgc_w,
-                     c3_w*        mem_w)
-{
-  if ( -1 == lseek(pat_u->mem_i, (pgc_w << (u3a_page + 2)), SEEK_SET) ) {
-    c3_assert(0);
-  }
-  if ( (1 << (u3a_page + 2)) !=
-       write(pat_u->mem_i, mem_w, (1 << (u3a_page + 2))) )
-  {
-    c3_assert(0);
-  }
-}
-
 /* _ce_patch_count_page(): count a page, producing new counter.
 */
 static c3_w
@@ -312,7 +295,12 @@ _ce_patch_save_page(u3_ce_patch* pat_u,
 #if 0
     u3l_log("protect a: page %d\r\n", pag_w);
 #endif
-    _ce_patch_write_page(pat_u, pgc_w, mem_w);
+    // Write page to patch's memory file.
+    {
+      c3_assert(-1 != lseek(pat_u->mem_i, pgc_w << (u3a_page + 2), SEEK_SET));
+      c3_w len_w = 1 << (u3a_page + 2);
+      c3_assert(len_w == write(pat_u->mem_i, mem_w, len_w));
+    }
 
     if ( -1 == mprotect(u3_Loom + (pag_w << u3a_page),
                         (1 << (u3a_page + 2)),

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -26,47 +26,6 @@ _ce_check_page(c3_w pag_w)
   return mug_w;
 }
 
-/* u3e_check(): compute a checksum on all memory within the watermarks.
-*/
-void
-u3e_check(c3_c* cap_c)
-{
-  c3_w nor_w = 0;
-  c3_w sou_w = 0;
-
-  {
-    c3_w nwr_w, swu_w;
-
-    u3m_water(&nwr_w, &swu_w);
-
-    nor_w = (nwr_w + ((1 << u3a_page) - 1)) >> u3a_page;
-    sou_w = (swu_w + ((1 << u3a_page) - 1)) >> u3a_page;
-  }
-
-  /* Count dirty pages.
-  */
-  {
-    c3_w i_w, sum_w, mug_w;
-
-    sum_w = 0;
-    for ( i_w = 0; i_w < nor_w; i_w++ ) {
-      mug_w = _ce_check_page(i_w);
-      if ( strcmp(cap_c, "boot") ) {
-        c3_assert(mug_w == u3K.mug_w[i_w]);
-      }
-      sum_w += mug_w;
-    }
-    for ( i_w = 0; i_w < sou_w; i_w++ ) {
-      mug_w = _ce_check_page((u3a_pages - (i_w + 1)));
-      if ( strcmp(cap_c, "boot") ) {
-        c3_assert(mug_w == u3K.mug_w[(u3a_pages - (i_w + 1))]);
-      }
-      sum_w += mug_w;
-    }
-    u3l_log("%s: sum %x (%x, %x)\r\n", cap_c, sum_w, nor_w, sou_w);
-  }
-}
-
 /* _ce_maplloc(): crude off-loom allocator.
 */
 static void*


### PR DESCRIPTION
In preparation for iterating over the north and south segments of the snapshot in the same direction as mentioned [here](https://github.com/urbit/urbit/pull/5477#discussion_r779236258) in #5477, clean up the functions in [`events.c`](https://github.com/urbit/urbit/tree/peter/consolidate-event-functions/pkg/urbit/noun/events.c) by;
- deleting functions that are not called from anywhere in the system (`u3e_check()`, `_ce_check_page()`, `_ce_maplloc()`, `_ce_mapfree()`);
- deleting short static functions in [`events.c`](https://github.com/urbit/urbit/tree/peter/consolidate-event-functions/pkg/urbit/noun/events.c) with only a single call site (`_ce_patch_write_page()`, `_ce_patch_create()`, `_ce_patch_read_control()`, `_ce_patch_write_control()`) and instead inling the functionality at the call site;
- and folding the functionality of `_ce_patch_free()` into `_ce_patch_delete()`.