### PR TITLE
webterm: improve selection look & feel

### DIFF
--- a/pkg/interface/webterm/app.tsx
+++ b/pkg/interface/webterm/app.tsx
@@ -45,7 +45,8 @@ const makeTheme = (dark: boolean): ITheme => {
     foreground: fg,
     background: bg,
     brightBlack: '#7f7f7f',  // NOTE  slogs
-    cursor: fg
+    cursor: fg,
+    selection: fg
   };
 };
 
@@ -66,7 +67,9 @@ const termConfig: ITerminalOptions = {
   bellSound: bel,
   //
   //  allows text selection by holding modifier (option, or shift)
-  macOptionClickForcesSelection: true
+  macOptionClickForcesSelection: true,
+  //  prevent insertion of simulated arrow keys on-altclick
+  altClickMovesCursor: false
 };
 
 const csi = (cmd: string, ...args: number[]) => {


### PR DESCRIPTION
Specifies a selection highlight color to make sure it's legible within the active theme. Fixes the visual aspect of urbit/landscape#1270 and #5507, but the selection functionality itself is still hard to discover.

Also disables some xterm.js behavior that would cause alt-clicking to insert arrow keys, with the intent to move the cursor to that location. We (will fully) support clicks natively, so there's no need for this.

Selection highlight color is just whatever the current foreground color is, but notably still gets rendered at the usual 50(?)% opacity.

<img width="343" alt="image" src="https://user-images.githubusercontent.com/3829764/148548335-fec2a7c6-17ad-4c16-b69d-41fb8598f783.png">

<img width="342" alt="image" src="https://user-images.githubusercontent.com/3829764/148548339-28f569e5-f11d-41fa-b5e1-a47e237cfd2d.png">
