### PR TITLE
group-chat: fix joins

### DIFF
--- a/pkg/garden/desk.docket-0
+++ b/pkg/garden/desk.docket-0
@@ -1,10 +1,10 @@
 :~  title+'System'
     info+'An app launcher for Urbit.'
     color+0xee.5432
-    glob-http+['https://bootstrap.urbit.org/glob-0v4.64ana.19ug9.ik7l6.og080.68ce4.glob' 0v4.64ana.19ug9.ik7l6.og080.68ce4]
+    glob-http+['https://bootstrap.urbit.org/glob-0v5.1o2c9.g1btf.nandl.703oh.40up1.glob' 0v5.1o2c9.g1btf.nandl.703oh.40up1]
     ::glob-ames+~zod^0v0
     base+'grid'
-    version+[1 0 2]
+    version+[1 0 3]
     website+'https://tlon.io'
     license+'MIT'
 ==

--- a/pkg/interface/src/logic/lib/notificationRedirects.ts
+++ b/pkg/interface/src/logic/lib/notificationRedirects.ts
@@ -1,17 +1,17 @@
 import useMetadataState from '../state/metadata';
 import ob from 'urbit-ob';
 import useInviteState from '../state/invite';
-import { resourceAsPath } from '@urbit/api';
+import { deSig, resourceAsPath } from '@urbit/api';
 
 function getGroupResourceRedirect(key: string) {
-  const association = useMetadataState.getState().associations.graph[`/ship/${key}`];
-  const { metadata } = association;
-  if(!association || !('graph' in metadata.config)) {
+  const graphs = useMetadataState.getState().associations.graph;
+  const association = graphs[`/ship/${key}`];
+  if(!association || !('graph' in association.metadata.config)) {
     return '';
   }
 
   const section = association.group === association.resource ? '/messages' : association.group;
-  return `/~landscape${section}/resource/${metadata.config.graph}${association.resource}`;
+  return `/~landscape${section}/resource/${association.metadata.config.graph}${association.resource}`;
 }
 
 function getPostRedirect(key: string, segs: string[]) {
@@ -70,7 +70,17 @@ function getGraphRedirect(link: string) {
 function getInviteRedirect(link: string) {
   const [,,app,uid] = link.split('/');
   const invite = useInviteState.getState().invites[app][uid];
-  if(!invite) { return ''; }
+  if(!invite) {
+    return '';
+  }
+
+  const { ship, name } = invite.resource;
+  const alreadyJoined = getGroupResourceRedirect(`~${deSig(ship)}/${name}`);
+
+  if (alreadyJoined) {
+    return alreadyJoined;
+  }
+
   return { search: `?join-kind=${app}&join-path=${encodeURIComponent(resourceAsPath(invite.resource))}` };
 }
 

--- a/pkg/interface/src/logic/reducers/hark-update.ts
+++ b/pkg/interface/src/logic/reducers/hark-update.ts
@@ -242,7 +242,7 @@ function timebox(json: any, state: HarkState): HarkState {
         const time = makePatDa(lid.archive);
         const old = state.archive.get(time) || {};
         notifications.forEach((note: any) => {
-          if(note.bin.desk !== window.desk) {
+          if(note.bin.place.desk !== window.desk) {
             return;
           }
           const binId = harkBinToId(note.bin);
@@ -252,7 +252,7 @@ function timebox(json: any, state: HarkState): HarkState {
     } else {
         const seen = 'seen' in lid ? 'seen' : 'unseen';
         notifications.forEach((note: any) => {
-          if(note.bin.desk !== window.desk) {
+          if(note.bin.place.desk !== window.desk) {
             return;
           }
           const binId = harkBinToId(note.bin);

--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -89,7 +89,7 @@ const ChatResource = (props: ChatResourceProps): ReactElement => {
   );
 
   const isAdmin = useMemo(
-    () => (group ? group.tags.role.admin.has(`~${window.ship}`) : false),
+    () => group ? group.tags.role.admin.has(deSig(window.ship)) : false,
     [group]
   );
 

--- a/pkg/interface/src/views/apps/chat/DmResource.tsx
+++ b/pkg/interface/src/views/apps/chat/DmResource.tsx
@@ -77,7 +77,7 @@ export function DmResource(props: DmResourceProps) {
   );
 
   useEffect(() => {
-    if(dm.size === 0) {
+    if(dm.size === 0 && !pending) {
       getNewest(`~${window.ship}`, 'dm-inbox', 100, `/${patp2dec(ship)}`);
     }
   }, [ship, dm]);
@@ -134,6 +134,7 @@ export function DmResource(props: DmResourceProps) {
     history.push('/~landscape/messages');
     await airlock.poke(declineDm(ship));
   };
+
   return (
     <Col width="100%" height="100%" overflow="hidden">
       <Row

--- a/pkg/interface/src/views/apps/launch/App.tsx
+++ b/pkg/interface/src/views/apps/launch/App.tsx
@@ -40,7 +40,7 @@ export const LaunchApp = (props: LaunchAppProps): ReactElement | null => {
         </title>
       </Helmet>
       <Route path="/join/:ship/:name">
-        <JoinRoute modal />
+        <JoinRoute />
       </Route>
       <ScrollbarLessBox
         height="100%"

--- a/pkg/interface/src/views/landscape/components/Join/Join.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Join.tsx
@@ -7,19 +7,19 @@ import {
   ManagedTextInputField,
   ManagedCheckboxField,
   ContinuousProgressBar,
-} from "@tlon/indigo-react";
-import { Formik, Form } from "formik";
-import React, { useEffect } from "react";
-import { useHistory, useLocation, useParams } from "react-router-dom";
-import useGroupState from "~/logic/state/group";
-import useInviteState, { useInviteForResource } from "~/logic/state/invite";
-import useMetadataState, { usePreview } from "~/logic/state/metadata";
-import { decline, Invite } from "@urbit/api";
-import { join, JoinRequest } from "@urbit/api/groups";
-import airlock from "~/logic/api";
-import { joinError, joinResult, joinLoad, JoinProgress } from "@urbit/api";
-import { useQuery } from "~/logic/lib/useQuery";
-import { JoinKind, JoinDesc, JoinSkeleton } from "./Skeleton";
+} from '@tlon/indigo-react';
+import { Formik, Form } from 'formik';
+import React, { useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import useGroupState from '~/logic/state/group';
+import { useInviteForResource } from '~/logic/state/invite';
+import { usePreview } from '~/logic/state/metadata';
+import { decline, Invite } from '@urbit/api';
+import { join, JoinRequest } from '@urbit/api/groups';
+import airlock from '~/logic/api';
+import { joinError, joinLoad, JoinProgress } from '@urbit/api';
+import { useQuery } from '~/logic/lib/useQuery';
+import { JoinKind, JoinDesc, JoinSkeleton } from './Skeleton';
 
 interface InviteWithUid extends Invite {
   uid: string;
@@ -42,7 +42,7 @@ function JoinForm(props: {
 }) {
   const { desc, dismiss, invite } = props;
   const onSubmit = (values: FormSchema) => {
-    const [, , ship, name] = desc.group.split("/");
+    const [, , ship, name] = desc.group.split('/');
     airlock.poke(
       join(ship, name, desc.kind, values.autojoin, values.shareContact)
     );
@@ -52,26 +52,26 @@ function JoinForm(props: {
     airlock.poke(decline(desc.kind, invite.uid));
     dismiss();
   };
-  const isGroups = desc.kind === "groups";
+  const isGroups = desc.kind === 'groups';
 
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
       <Form>
-        <Col p="4" gapY="4">
+        <Col p='4' gapY='4'>
           {isGroups ? (
-            <ManagedCheckboxField id="autojoin" label="Join all channels" />
+            <ManagedCheckboxField id='autojoin' label='Join all channels' />
           ) : null}
-          <ManagedCheckboxField id="shareContact" label="Share identity" />
-          <Row justifyContent="space-between" width="100%">
+          <ManagedCheckboxField id='shareContact' label='Share identity' />
+          <Row justifyContent='space-between' width='100%'>
             <Button onClick={dismiss}>Dismiss</Button>
-            <Row gapX="2">
+            <Row gapX='2'>
               {!invite ? null : (
-                <Button onClick={onDecline} destructive type="button">
+                <Button onClick={onDecline} destructive type='button'>
                   Decline
                 </Button>
               )}
-              <Button primary type="submit">
-                {!invite ? "Join Group" : "Accept"}
+              <Button primary type='submit'>
+                {!invite ? 'Join Group' : 'Accept'}
               </Button>
             </Row>
           </Row>
@@ -80,10 +80,6 @@ function JoinForm(props: {
     </Formik>
   );
 }
-const REQUEST: JoinDesc = {
-  group: "/ship/~bitbet-bolbel/urbit-community",
-  kind: "groups",
-};
 
 export function JoinInitial(props: {
   invite?: InviteWithUid;
@@ -93,7 +89,7 @@ export function JoinInitial(props: {
 }) {
   const { desc, dismiss, modal, invite } = props;
   const title = (() => {
-    const name = desc.kind === "graph" ? "Group Chat" : "Group";
+    const name = desc.kind === 'graph' ? 'Group Chat' : 'Group';
     if (invite) {
       return `You've been invited to a ${name}`;
     } else {
@@ -117,11 +113,11 @@ function JoinLoading(props: {
   const { desc, request, dismiss, modal, finished } = props;
   const history = useHistory();
   useEffect(() => {
-    if (desc.kind === "graph" && request.progress === "done") {
+    if (desc.kind === 'graph' && request.progress === 'done') {
       history.push(finished);
     }
   }, [request]);
-  const name = desc.kind === "graph" ? "Group Chat" : "Group";
+  const name = desc.kind === 'graph' ? 'Group Chat' : 'Group';
   const title = `Joining ${name}, please wait`;
   const onCancel = () => {
     useGroupState.getState().abortJoin(desc.group);
@@ -129,7 +125,7 @@ function JoinLoading(props: {
   };
   return (
     <JoinSkeleton modal={modal} desc={desc} title={title}>
-      <Col maxWidth="512px" p="4" gapY="4">
+      <Col maxWidth='512px' p='4' gapY='4'>
         {joinLoad.indexOf(request.progress as any) !== -1 ? (
           <JoinProgressIndicator progress={request.progress} />
         ) : null}
@@ -139,7 +135,7 @@ function JoinLoading(props: {
             offline, or the connection between you both may be unstable.
           </Text>
         </Box>
-        <Row gapX="2">
+        <Row gapX='2'>
           <Button onClick={dismiss}>Dismiss</Button>
           <Button destructive onClick={onCancel}>
             Cancel Join
@@ -160,14 +156,14 @@ function JoinError(props: {
   const group = preview?.metadata?.title ?? desc.group;
   const title = `Joining ${group} failed`;
   const explanation =
-    request.progress === "no-perms"
-      ? "You do not have the correct permissions"
-      : "An unexpected error occurred";
+    request.progress === 'no-perms'
+      ? 'You do not have the correct permissions'
+      : 'An unexpected error occurred';
 
   return (
     <JoinSkeleton modal={modal} title={title} desc={desc}>
-      <Col p="4" gapY="4">
-        <Text fontWeight="medium">{explanation}</Text>
+      <Col p='4' gapY='4'>
+        <Text fontWeight='medium'>{explanation}</Text>
         <Row>
           <Button>Dismiss</Button>
         </Row>
@@ -186,26 +182,26 @@ export interface JoinProps {
 export function Join(props: JoinProps) {
   const { desc, modal, dismiss, redir } = props;
   const { group, kind } = desc;
-  const [, , ship, name] = group.split("/");
-  const graph = kind === "graph";
-  const finishedPath = !!redir
+  const [, , ship, name] = group.split('/');
+  const graph = kind === 'graph';
+  const finishedPath = redir
     ? redir
     : graph
     ? `/~landscape/messages/resource/chat/${ship}/${name}`
     : `/~landscape/ship/${ship}/${name}`;
 
   const history = useHistory();
-  const joinRequest = useGroupState((s) => s.pendingJoin[group]);
+  const joinRequest = useGroupState(s => s.pendingJoin[group]);
   const invite = useInviteForResource(kind, ship, name);
 
-  const isDone = joinRequest && joinRequest.progress === "done";
+  const isDone = joinRequest && joinRequest.progress === 'done';
   const isErrored =
     joinRequest && joinError.includes(joinRequest.progress as any);
   const isLoading =
     joinRequest && joinLoad.includes(joinRequest.progress as any);
 
   useEffect(() => {
-    if (isDone && desc.kind == "graph") {
+    if (isDone && desc.kind == 'graph') {
       history.push(finishedPath);
     }
   }, [isDone, desc]);
@@ -232,10 +228,6 @@ export function Join(props: JoinProps) {
   );
 }
 
-interface PromptFormProps {
-  kind: string;
-}
-
 interface PromptFormSchema {
   link: string;
 }
@@ -245,37 +237,37 @@ export interface JoinPromptProps {
 }
 
 export function JoinPrompt(props: JoinPromptProps) {
-  const { kind, dismiss } = props;
-  const { query, appendQuery } = useQuery();
+  const { dismiss } = props;
+  const { appendQuery } = useQuery();
   const history = useHistory();
   const initialValues = {
-    link: "",
+    link: ''
   };
 
   const onSubmit = async ({ link }: PromptFormSchema) => {
     const path = `/ship/${link}`;
     history.push({
-      search: appendQuery({ "join-path": path }),
+      search: appendQuery({ 'join-path': path })
     });
   };
 
   return (
-    <JoinSkeleton modal body={<Text>a</Text>} title="Join a Group">
+    <JoinSkeleton modal body={<Text>a</Text>} title='Join a Group'>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <Col p="4" gapY="4">
+          <Col p='4' gapY='4'>
             <ManagedTextInputField
-              label="Invite Link"
-              id="link"
-              caption="Enter either a web+urbitgraph:// link or an identifier in the form ~sampel-palnet/group"
+              label='Invite Link'
+              id='link'
+              caption='Enter either a web+urbitgraph:// link or an identifier in the form ~sampel-palnet/group'
             />
-            <Row gapX="2">
-              {!!dismiss ? (
-                <Button type="button" onClick={dismiss}>
+            <Row gapX='2'>
+              {dismiss ? (
+                <Button type='button' onClick={dismiss}>
                   Dismiss
                 </Button>
               ) : null}
-              <Button type="submit" primary>
+              <Button type='submit' primary>
                 Join
               </Button>
             </Row>
@@ -289,26 +281,26 @@ export function JoinPrompt(props: JoinPromptProps) {
 function JoinProgressIndicator(props: { progress: JoinProgress }) {
   const { progress } = props;
   const percentage =
-    progress === "done" ? 100 : (joinLoad.indexOf(progress as any) + 1) * 25;
+    progress === 'done' ? 100 : (joinLoad.indexOf(progress as any) + 1) * 25;
 
   const description = (() => {
     switch (progress) {
-      case "start":
-        return "Connecting to host";
-      case "added":
-        return "Retrieving members";
-      case "metadata":
-        return "Retrieving channels";
-      case "done":
-        return "Finished";
+      case 'start':
+        return 'Connecting to host';
+      case 'added':
+        return 'Retrieving members';
+      case 'metadata':
+        return 'Retrieving channels';
+      case 'done':
+        return 'Finished';
       default:
-        return "";
+        return '';
     }
   })();
 
   return (
-    <Col gapY="2">
-      <Text color="lightGray">{description}</Text>
+    <Col gapY='2'>
+      <Text color='lightGray'>{description}</Text>
       <ContinuousProgressBar percentage={percentage} />
     </Col>
   );
@@ -323,8 +315,7 @@ export interface JoinDoneProps {
 
 export function JoinDone(props: JoinDoneProps) {
   const { desc, modal, finished, dismiss } = props;
-  const { preview, error } = usePreview(desc.group);
-  const name = desc.kind === "groups" ? "Group" : "Group Chat";
+  const name = desc.kind === 'groups' ? 'Group' : 'Group Chat';
   const title = `Joined ${name} successfully`;
   const history = useHistory();
 
@@ -334,9 +325,9 @@ export function JoinDone(props: JoinDoneProps) {
 
   return (
     <JoinSkeleton title={title} modal={modal} desc={desc}>
-      <Col p="4" gapY="4">
-        <JoinProgressIndicator progress="done" />
-        <Row gapX="2">
+      <Col p='4' gapY='4'>
+        <JoinProgressIndicator progress='done' />
+        <Row gapX='2'>
           <Button onClick={dismiss}>Dismiss</Button>
           <Button onClick={onView} primary>
             View Group
@@ -347,21 +338,20 @@ export function JoinDone(props: JoinDoneProps) {
   );
 }
 
-export function JoinRoute(props: { graph?: boolean; modal?: boolean }) {
-  const { modal = false, graph = false } = props;
+export function JoinRoute() {
   const { query } = useQuery();
   const history = useHistory();
   const { pathname } = useLocation();
-  const kind = query.get("join-kind");
-  const path = query.get("join-path");
-  const redir = query.get("redir");
+  const kind = query.get('join-kind');
+  const path = query.get('join-path');
+  const redir = query.get('redir');
   if (!kind) {
     return null;
   }
   const desc: JoinDesc = path
     ? {
         group: path,
-        kind: graph ? "graph" : "groups",
+        kind: kind as JoinKind
       }
     : undefined;
 

--- a/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
+++ b/pkg/interface/src/views/landscape/components/Sidebar/SidebarListHeader.tsx
@@ -45,7 +45,7 @@ export function SidebarListHeader(props: {
 
   const metadata = associations?.groups?.[groupPath]?.metadata;
   const memberMetadata =
-    groupPath ? metadata.vip === 'member-metadata' : false;
+    groupPath && metadata ? metadata.vip === 'member-metadata' : false;
 
   const isAdmin = memberMetadata || (role === 'admin') || (props.workspace?.type === 'home') || (props.workspace?.type === 'messages');
 

--- a/pkg/landscape/desk.docket-0
+++ b/pkg/landscape/desk.docket-0
@@ -1,10 +1,10 @@
 :~  title+'Groups'
     info+'A suite of applications to communicate on Urbit'
     color+0xee.5432
-    glob-http+['https://bootstrap.urbit.org/glob-0v3.m2nd4.9tg9d.vs9ls.9rj6u.7lqhg.glob' 0v3.m2nd4.9tg9d.vs9ls.9rj6u.7lqhg]
+    glob-http+['https://bootstrap.urbit.org/glob-0v7.i3htk.kflos.l8nic.q5u2o.v8oir.glob' 0v7.i3htk.kflos.l8nic.q5u2o.v8oir]
 
     base+'landscape'
-    version+[1 0 4]
+    version+[1 0 5]
     website+'https://tlon.io'
     license+'MIT'
 ==


### PR DESCRIPTION
This fixes a few issues with the way `JoinRoute` was processing `kind` so we were never getting correct differentiation between groups and group chats which caused issues when clicking 'View Group'. 

- ensures that we retain join request state if the modal is open, and ensure that group is in state before allowing them to navigate to it
- notification link handling to redirect to the already joined chat, if already joined.
- fixes an issue causing notifications to not show at all because the check for desk was slightly off.
- stops DMs from trying to load if we haven't accepted it yet
- fixes potential undefined ref in `SidebarListHeader` urbit/landscape#1268

The original "joins" refactor addressed urbit/landscape#1308, urbit/landscape#1342, but this fixes the final part of the flow and a few other miscellaneous bugs.

Fixes urbit/landscape#1342