### PR TITLE
ames: ignore missing peer-state on-publ-sponsor

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1593,10 +1593,12 @@
       ?~  sponsor
         ~|  %ames-lost-sponsor^our^ship  !!
       ::
-      =/  =peer-state         (got-peer-state ship)
-      =.  sponsor.peer-state  u.sponsor
-      ::
-      =.  peers.ames-state  (~(put by peers.ames-state) ship %known peer-state)
+      =/  state=(unit peer-state)  (get-peer-state ship)
+      ?~  state
+        %-  (slog leaf+"ames: missing peer-state, ignoring" ~)
+        event-core
+      =.  sponsor.u.state   u.sponsor
+      =.  peers.ames-state  (~(put by peers.ames-state) ship %known u.state)
       event-core
     ::  +on-publ-full: handle new pki data for peer(s)
     ::


### PR DESCRIPTION
This adds a fix that crashed the [latest OTA](https://github.com/urbit/urbit/releases/tag/urbit-os-v2.119) due to a [`%freaky-alien`](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/vane/ames.hoon#L1835) error. The solution is to use `+get-peer-state` instead, and ignore the event.