### PR TITLE
eth-watcher: fix zoom-margin to account for reorgs

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -21,7 +21,7 @@
 =,  jael
 |%
 +$  app-state
-  $:  %4
+  $:  %5
       url=@ta
       =net
       whos=(set ship)
@@ -128,13 +128,20 @@
       :_  old-state(- %4)
       ~&  >  '%azimuth: updating to state 4'
       [%pass /resend-pk %arvo %j %resend ~]^cards-2
-    ?>  ?=(%4 -.old-state)
-    [cards-3 this(state old-state)]
+    =^  cards-4  old-state
+      ?.  ?=(%4 -.old-state)  [cards-3 old-state]
+      =^  cards  this
+        %-  %*(. on-poke +.state.this +.old-state)
+        [%azimuth-poke !>([%watch [url net]:old-state])]
+      ~&  >  '%azimuth: updating to state 5'
+      [cards state.this(- %5)]
+    ?>  ?=(%5 -.old-state)
+    [cards-4 this(state old-state)]
     ::
-    ++  app-states  $%(state-0 state-1-2-3 app-state)
+    ++  app-states  $%(state-0 state-1-2-3-4 app-state)
     ::
-    +$  state-1-2-3
-      $:  ?(%1 %2 %3)
+    +$  state-1-2-3-4
+      $:  ?(%1 %2 %3 %4)
           url=@ta
           =net
           whos=(set ship)
@@ -190,9 +197,6 @@
       [[%pass /lo %arvo %j %listen (silt whos.poke) source.poke]~ this]
     ::
         %watch
-      :: TODO: only wipe out state when switching networks?
-      :: ?:  =(net.state net.poke)
-      ::   [~ this]
       =:  nas.state   ?:(?=(%default net.poke) nas.snap *^state:naive)
           own.state   ?:(?=(%default net.poke) owners.snap ~)
           spo.state   ?:(?=(%default net.poke) sponsors.snap ~)

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -462,9 +462,9 @@
   ++  release-logs
     |=  [=path dog=watchdog]
     ^-  (quip card watchdog)
-    ?:  (lth number.dog 0)  :: TODO: 30!
+    ?:  (lth number.dog 30)
       `dog
-    =/  rel-number  (sub number.dog 0)  :: TODO: 30!
+    =/  rel-number  (sub number.dog 30)
     =/  numbers=(list number:block)  ~(tap in ~(key by pending-logs.dog))
     =.  numbers  (sort numbers lth)
     =^  logs=(list event-log:rpc:ethereum)  dog

--- a/pkg/arvo/ted/eth-watcher.hoon
+++ b/pkg/arvo/ted/eth-watcher.hoon
@@ -82,8 +82,8 @@
   |=  [pup=watchpup =latest=number:block]
   =/  m  (strand:strandio ,watchpup)
   ^-  form:m
-  =/  zoom-margin=number:block  0  :: TODO: 30!
-  =/  zoom-step=number:block  100.000
+  =/  zoom-margin=number:block  30
+  =/  zoom-step=number:block    100.000
   ?:  (lth latest-number (add number.pup zoom-margin))
     (pure:m pup)
   =/  up-to-number=number:block


### PR DESCRIPTION
The previous value—used for testing—didn't consider block reorgs, which meant that if we zoom to the latest block that has no transactions, but that gets later replaced by a 1-block reorg that does have a transaction, we'll miss it, making our Azimuth state incomplete.

To fix it, we rewind the Azimuth state to the contents of the snapshot, and then start retrieving logs from the latest one we have.