### PR TITLE
lib/ethereum: +address-to-checksum gate to ethereum lib as per EIP-55

### DIFF
--- a/pkg/base-dev/lib/ethereum.hoon
+++ b/pkg/base-dev/lib/ethereum.hoon
@@ -948,6 +948,21 @@
   %-  prefix-hex
   (render-hex-bytes 20 `@`a)
 ::
+++  address-to-checksum
+  |=  =address
+  ^-  tape
+  =/  hexed  (render-hex-bytes 20 `@`a)
+  =/  hash  (keccak-256:keccak:crypto (as-octs:mimes:html (crip hexed)))
+  =|  ret=tape
+  =/  pos  63
+  |-
+  ?~  hexed  (prefix-hex (flop ret))
+  =/  char  i.hexed
+  ?:  (lth char 58)  $(pos (dec pos), ret [char ret], hexed t.hexed)
+  =/  nib  (cut 2 [pos 1] hash)
+  ?:  (lth 7 nib)  $(pos (dec pos), ret [(sub char 32) ret], hexed t.hexed)
+  $(pos (dec pos), ret [char ret], hexed t.hexed)
+::
 ++  transaction-to-hex
   |=  h=@
   ^-  tape


### PR DESCRIPTION
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md

I needed it because some api's i'm hitting fail if the address isn't checksummed.

Could maybe be written better, haven't done much byte munging in hoon. Feel free to improve.