### PR TITLE
hoon: fix comment indent in abs:si

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2205,7 +2205,7 @@
 ++  si                                                  ::  signed integer
   ^?
   |%
-  ++  abs  |=(a=@s (add (end 0 a) (rsh 0 a)))         ::  absolute value
+  ++  abs  |=(a=@s (add (end 0 a) (rsh 0 a)))           ::  absolute value
   ++  dif  |=  [a=@s b=@s]                              ::  subtraction
            (sum a (new !(syn b) (abs b)))
   ++  dul  |=  [a=@s b=@]                               ::  modulus


### PR DESCRIPTION
comment gap had 2 spaces less than the others. Made it uniform.