### PR TITLE
helm: fix |rekey to work with multikey files

### DIFF
--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -68,12 +68,10 @@
   =|  caz=(list card)
   %-  emil
   |-
-  ?~  kyz.fed
-    caz
-  =/  sed=seed:jael  [who [lyf key ~]:i.kyz]:fed
+  ?~  kyz.fed  (flop caz)
   %=  $
-      kyz.fed  t.kyz.fed
-      caz      (snoc caz [%pass / %arvo %j %rekey lyf.sed key.sed])
+    kyz.fed  t.kyz.fed
+    caz      [[%pass / %arvo %j %rekey i.kyz.fed] caz]
   ==
 ::
 ++  ames-secret

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -48,18 +48,33 @@
 ::
 ++  poke-rekey                                        ::  rotate private keys
   |=  des=@t
-  =/  sed=(unit seed:jael)
+  =/  fud=(unit feed:jael)
     %+  biff
       (bind (slaw %uw des) cue)
-    (soft seed:jael)
+    (soft feed:jael)
   =<  abet
-  ?~  sed
+  ?~  fud
     ~&  %invalid-private-key
     this
-  ?.  =(our.bowl who.u.sed)
-    ~&  [%wrong-private-key-ship who.u.sed]
+  =/  fed  (need fud)
+  ?@  -.fed
+    ?.  =(our.bowl who.fed)
+      ~&  [%wrong-private-key-ship who.fed]
+      this
+    (emit %pass / %arvo %j %rekey lyf.fed key.fed)
+  ?.  =(our.bowl who.fed)
+    ~&  [%wrong-private-key-ship who.fed]
     this
-  (emit %pass / %arvo %j %rekey lyf.u.sed key.u.sed)
+  =|  caz=(list card)
+  %-  emil
+  |-
+  ?~  kyz.fed
+    caz
+  =/  sed=seed:jael  [who [lyf key ~]:i.kyz]:fed
+  %=  $
+      kyz.fed  t.kyz.fed
+      caz      (snoc caz [%pass / %arvo %j %rekey lyf.sed key.sed])
+  ==
 ::
 ++  ames-secret
   ^-  @t


### PR DESCRIPTION
This is identical to #5522, I was just asked to merge it into `next/arvo` instead of `release/next-userspace`