### PR TITLE
aqua: rerevive

### DIFF
--- a/pkg/arvo/gen/brass.hoon
+++ b/pkg/arvo/gen/brass.hoon
@@ -26,7 +26,7 @@
       ::
         ~
     ==
-:-  %boot-pill
+:-  %pill
 ^-  pill:pill
 ::  sys: root path to boot system, `/~me/[desk]/now/sys`
 ::  bas: root path to boot system' desk

--- a/pkg/arvo/gen/solid.hoon
+++ b/pkg/arvo/gen/solid.hoon
@@ -29,7 +29,7 @@
       ::
         dub=_|
     ==
-:-  %boot-pill
+:-  %pill
 ^-  pill:pill
 ::  sys: root path to boot system, `/~me/[desk]/now/sys`
 ::  bas: root path to boot system' desk

--- a/pkg/arvo/mar/aqua/effect.hoon
+++ b/pkg/arvo/mar/aqua/effect.hoon
@@ -1,0 +1,18 @@
+::
+::::  /hoon/aqua/effect/mar
+  ::
+/?    310
+::
+/-  *aquarium
+|_  f=aqua-effect
+++  grow
+  |%
+  ++  mime  [/application/octet-stream 0 *@] :: (as-octs:mimes:html (jam f))]
+  ++  noun  f
+  --
+++  grab
+  |%                                                    ::  convert from
+  ++  noun  aqua-effect                                 ::  clam from %noun
+  --
+++  grad  %noun
+--


### PR DESCRIPTION
Building on #5029 (which seems to have been automatically merged?), here's a couple of changes to get `:aqua` closer to working. The `%pill`/`%boot-pill` mark changes had never been fully reverted. And the `%aqua-effect` conversion to `%mime` is stubbed out, as I don't see how it should be necessary (but its absence was causing crashes).

It seems like `%ames` packets are not being delivered. And some timers may also be being dropped -- the basic ph tests hang after booting.

/cc @lukechampine 