### PR TITLE
vere: tidy up disk module

### DIFF
--- a/pkg/urbit/Doxyfile
+++ b/pkg/urbit/Doxyfile
@@ -1085,7 +1085,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/pkg/urbit/c/queue.c
+++ b/pkg/urbit/c/queue.c
@@ -121,6 +121,21 @@ c3_queue_peek_front(const c3_queue* que_u)
 }
 
 void*
+c3_queue_peek(const c3_queue* que_u, const size_t idx_i)
+{
+  if ( NULL == que_u || c3_queue_length(que_u) <= idx_i ) {
+    return NULL;
+  }
+
+  c3_node* nod_u = que_u->fir_u;
+  for ( size_t cnt_i = 0; cnt_i < idx_i; cnt_i++ ) {
+    nod_u = nod_u->nex_u;
+  }
+
+  return nod_u->dat_v;
+}
+
+void*
 c3_queue_pop_back(c3_queue* que_u)
 {
   if ( NULL == que_u ) {

--- a/pkg/urbit/c/queue.c
+++ b/pkg/urbit/c/queue.c
@@ -3,8 +3,13 @@
 #include "c/queue.h"
 
 #include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "c/types.h"
+#include "c/defs.h"
 
 //! Single element of a doubly-linked list.
 typedef struct _c3_node {
@@ -23,9 +28,9 @@ struct _c3_queue {
 static c3_node*
 _create_node(void* dat_v, size_t siz_i)
 {
-  c3_node* nod_u = malloc(sizeof(c3_node));
+  c3_node* nod_u = c3_malloc(sizeof(c3_node));
   assert(nod_u);
-  nod_u->dat_v = malloc(siz_i);
+  nod_u->dat_v = c3_malloc(siz_i);
   memcpy(nod_u->dat_v, dat_v, siz_i);
   nod_u->nex_u = NULL;
   nod_u->pre_u = NULL;
@@ -35,10 +40,14 @@ _create_node(void* dat_v, size_t siz_i)
 c3_queue*
 c3_queue_init(void)
 {
-  c3_queue* que_u = calloc(1, sizeof(c3_queue));
+  c3_queue* que_u = c3_malloc(sizeof(c3_queue));
   if ( NULL == que_u ) {
     return NULL;
   }
+
+  que_u->fir_u = NULL;
+  que_u->las_u = NULL;
+  que_u->len_i = 0;
 
   return que_u;
 }
@@ -135,7 +144,7 @@ c3_queue_pop_back(c3_queue* que_u)
   que_u->len_i--;
 
   void* dat_v = nod_u->dat_v;
-  free(nod_u);
+  c3_free(nod_u);
 
   return dat_v;
 }
@@ -164,7 +173,7 @@ c3_queue_pop_front(c3_queue* que_u)
   que_u->len_i--;
 
   void* dat_v = nod_u->dat_v;
-  free(nod_u);
+  c3_free(nod_u);
 
   return dat_v;
 }
@@ -178,9 +187,9 @@ c3_queue_free(c3_queue* que_u)
 
   c3_node* nod_u;
   while ( NULL != (nod_u = c3_queue_pop_front(que_u)) ) {
-    free(nod_u->dat_v);
-    free(nod_u);
+    c3_free(nod_u->dat_v);
+    c3_free(nod_u);
   }
 
-  free(que_u);
+  c3_free(que_u);
 }

--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -43,6 +43,10 @@
     */
 #     define c3_stub       c3_assert(!"stub")
 
+    /* Element count of an array.
+    */
+#    define c3_arr_len(arr) (sizeof(arr) / sizeof(arr[0]))
+
     /* Size in words.
     */
 #     define c3_wiseof(x)  (((sizeof (x)) + 3) >> 2)

--- a/pkg/urbit/include/c/queue.h
+++ b/pkg/urbit/include/c/queue.h
@@ -32,6 +32,7 @@ c3_queue_length(const c3_queue* que_u);
 //!
 //! @return NULL  [que_u] was NULL.
 //! @return       Heap-allocated pointer to the newly added node's payload.
+//!               Must not be freed by caller.
 void*
 c3_queue_push_back(c3_queue* que_u, void* dat_v, size_t siz_i);
 
@@ -43,6 +44,7 @@ c3_queue_push_back(c3_queue* que_u, void* dat_v, size_t siz_i);
 //!
 //! @return NULL  [que_u] was NULL.
 //! @return       Heap-allocated pointer to the newly added node's payload.
+//!               Must not be freed by caller.
 void*
 c3_queue_push_front(c3_queue* que_u, void* dat_v, size_t siz_i);
 
@@ -51,7 +53,8 @@ c3_queue_push_front(c3_queue* que_u, void* dat_v, size_t siz_i);
 //! @param[in] que_u  Queue to get the last node's data from.
 //!
 //! @return NULL  [que_u] was NULL.
-//! @return       Heap-allocated pointer to the last node's payload.
+//! @return       Heap-allocated pointer to the last node's payload. Must not
+//!               be freed by caller.
 void*
 c3_queue_peek_back(const c3_queue* que_u);
 
@@ -60,9 +63,22 @@ c3_queue_peek_back(const c3_queue* que_u);
 //! @param[in] que_u  Queue to get the first node's data from.
 //!
 //! @return NULL  [que_u] was NULL.
-//! @return       Heap-allocated pointer to the first node's payload.
+//! @return       Heap-allocated pointer to the first node's payload. Must not
+//!               be freed by caller.
 void*
 c3_queue_peek_front(const c3_queue* que_u);
+
+//! Get the data of the node at the given index in the queue.
+//!
+//! @param[in] que_u  Queue to get the node's data from.
+//! @param[in] idx_i  Zero-based index of the node of interest.
+//!
+//! @return NULL  [que_u] was NULL.
+//! @return NULL  [idx_i] was an invalid index.
+//! @return       Heap-allocated pointer to the first node's payload. Must not
+//!               be freed by caller.
+void*
+c3_queue_peek(const c3_queue* que_u, const size_t idx_i);
 
 //! Remove the last node from the back of the queue.
 //!
@@ -70,7 +86,7 @@ c3_queue_peek_front(const c3_queue* que_u);
 //!
 //! @return NULL  [que_u] was NULL.
 //! @return       Heap-allocated pointer to node's payload popped from the back
-//!               of [que_u].
+//!               of [que_u]. Must be freed by caller.
 void*
 c3_queue_pop_back(c3_queue* que_u);
 
@@ -80,7 +96,7 @@ c3_queue_pop_back(c3_queue* que_u);
 //!
 //! @return NULL  [que_u] was NULL.
 //! @return       Heap-allocated pointer to node's payload popped from the front
-//!               of [que_u].
+//!               of [que_u]. Must be freed by caller.
 void*
 c3_queue_pop_front(c3_queue* que_u);
 

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -17,13 +17,6 @@ typedef struct _u3_fact {
   u3_noun            job;               //  (pair date ovum)
 } u3_fact;
 
-//! Serialized fact
-typedef struct _u3_feat {
-  c3_d             eve_d;
-  size_t           len_i;
-  c3_y*            hun_y;
-} u3_feat;
-
 //! Disk sync callbak.
 typedef void (*u3_disk_news)(void*, c3_d, c3_o);
 

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -29,31 +29,31 @@ typedef void (*u3_disk_news)(void*, c3_d, c3_o);
 
 //! Manage event persistence.
 typedef struct _u3_disk {
-  u3_dire*         dir_u;               //  main pier directory
-  u3_dire*         urb_u;               //  urbit system data
-  u3_dire*         com_u;               //  log directory
-  c3_o             liv_o;               //  live
-  void*            mdb_u;               //  lmdb environment.
-  c3_d             sen_d;               //  commit requested
-  c3_d             dun_d;               //  committed
-  c3_w             hit_w[100];          //  batch histogram
-  struct {                              //  new write queue
-    u3_feat*       ent_u;               //  queue entry (highest)
-    u3_feat*       ext_u;               //  queue exit (lowest)
+  u3_dire*         dir_u;       //!< main pier directory
+  u3_dire*         urb_u;       //!< urbit system data
+  u3_dire*         com_u;       //!< log directory
+  c3_o             liv_o;       //!< live
+  void*            mdb_u;       //!< lmdb environment.
+  c3_d             sen_d;       //!< commit requested
+  c3_d             dun_d;       //!< committed
+  c3_w             hit_w[100];  //!< batch histogram
+  struct {                      //!< new write queue
+    u3_feat*       ent_u;       //!< queue entry (highest)
+    u3_feat*       ext_u;       //!< queue exit (lowest)
   } put_u;
-  struct {                              //  write control
-    union {                             //  thread/request
-      uv_work_t    ted_u;               //
-      uv_req_t     req_u;               //
+  struct {                      //!< write control
+    union {                     //!< thread/request
+      uv_work_t    ted_u;
+      uv_req_t     req_u;
     };
-    void*          ptr_v;               //  async context
-    u3_disk_news   don_f;               //  async write cb
-    c3_o           ted_o;               //  c3y == active
-    c3_o           ret_o;               //  result
-    c3_d           eve_d;               //  first event
-    c3_d           len_w;               //  number of events
-    c3_y*          byt_y[100];          //  array of bytes
-    size_t         siz_i[100];          //  array of lengths
+    void*          ptr_v;       //!< async context
+    u3_disk_news   don_f;       //!< async write cb
+    c3_o           ted_o;       //!< c3y == active
+    c3_o           ret_o;       //!< result
+    c3_d           eve_d;       //!< first event
+    c3_d           len_w;       //!< number of events
+    c3_y*          byt_y[100];  //!< array of bytes
+    size_t         siz_i[100];  //!< array of lengths
   } sav_u;
 } u3_disk;
 

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -112,6 +112,10 @@ u3_disk_async(u3_disk*     log_u,
               void*        ptr_v,
               u3_disk_news don_f);
 
+//! Commit all available events, if idle.
+void
+u3_disk_commit(u3_disk* log_u);
+
 //! Enqueue completed event for persistence.
 void
 u3_disk_plan(u3_disk* log_u, u3_fact* tac_u);

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -87,6 +87,8 @@ u3_disk_sift(u3_disk* log_u,
              u3_noun*   job);
 
 //! Print status info.
+//!
+//! @param[in] log_u  Disk object to report status info for.
 void
 u3_disk_info(u3_disk* log_u);
 

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -116,7 +116,7 @@ u3_disk_async(u3_disk*     log_u,
 void
 u3_disk_commit(u3_disk* log_u);
 
-//! Enqueue completed event for persistence.
+//! Enqueue completed event (aka fact) for persistence.
 void
 u3_disk_plan(u3_disk* log_u, u3_fact* tac_u);
 

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -4,6 +4,7 @@
 #define U3_VERE_DISK_H
 
 #include "c/portable.h"
+#include "c/queue.h"
 #include "c/types.h"
 #include "noun/aliases.h"
 #include "vere/foil.h"
@@ -21,7 +22,6 @@ typedef struct _u3_feat {
   c3_d             eve_d;
   size_t           len_i;
   c3_y*            hun_y;
-  struct _u3_feat* nex_u;
 } u3_feat;
 
 //! Disk sync callbak.
@@ -37,10 +37,7 @@ typedef struct _u3_disk {
   c3_d             sen_d;       //!< commit requested
   c3_d             dun_d;       //!< committed
   c3_w             hit_w[100];  //!< batch histogram
-  struct {                      //!< new write queue
-    u3_feat*       ent_u;       //!< queue entry (highest)
-    u3_feat*       ext_u;       //!< queue exit (lowest)
-  } put_u;
+  c3_queue*        put_u;       //!< new write queue
   struct {                      //!< write control
     union {                     //!< thread/request
       uv_work_t    ted_u;

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -61,13 +61,6 @@ typedef struct _u3_disk_walk u3_disk_walk;
 u3_disk*
 u3_disk_init(c3_c* pax_c);
 
-//! Serialize an event for persistence.
-c3_w
-u3_disk_etch(u3_disk* log_u,
-             u3_noun    eve,
-             c3_l     mug_l,
-             c3_y**   out_y);
-
 //! Print status info.
 //!
 //! @param[in] log_u  Disk object to report status info for.

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -15,7 +15,6 @@ typedef struct _u3_fact {
   c3_d             eve_d;               //  event number
   c3_l             mug_l;               //  kernel mug after
   u3_noun            job;               //  (pair date ovum)
-  struct _u3_fact* nex_u;               //  next in queue
 } u3_fact;
 
 //! Serialized fact

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -3,11 +3,12 @@
 #ifndef U3_VERE_DISK_H
 #define U3_VERE_DISK_H
 
+#include <uv.h>
+
 #include "c/portable.h"
 #include "c/queue.h"
 #include "c/types.h"
 #include "noun/aliases.h"
-#include "vere/foil.h"
 
 //! Completed event
 typedef struct _u3_fact {
@@ -29,9 +30,9 @@ typedef void (*u3_disk_news)(void*, c3_d, c3_o);
 
 //! Manage event persistence.
 typedef struct _u3_disk {
-  u3_dire*         dir_u;       //!< main pier directory
-  u3_dire*         urb_u;       //!< urbit system data
-  u3_dire*         com_u;       //!< log directory
+  c3_c*            dir_c;       //!< main pier directory
+  c3_c*            urb_c;       //!< urbit system data
+  c3_c*            log_c;       //!< log directory
   c3_o             liv_o;       //!< live
   void*            mdb_u;       //!< lmdb environment.
   c3_d             sen_d;       //!< commit requested

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -11,17 +11,17 @@
 #include "noun/aliases.h"
 
 //! Completed event
-typedef struct _u3_fact {
-  c3_d             eve_d;               //  event number
-  c3_l             mug_l;               //  kernel mug after
-  u3_noun            job;               //  (pair date ovum)
+typedef struct {
+  c3_d             eve_d;  //!< event number
+  c3_l             mug_l;  //!< kernel mug after
+  u3_noun            job;  //!< (pair date ovum)
 } u3_fact;
 
 //! Disk sync callbak.
 typedef void (*u3_disk_news)(void*, c3_d, c3_o);
 
 //! Manage event persistence.
-typedef struct _u3_disk {
+typedef struct {
   c3_c*            dir_c;       //!< main pier directory
   c3_c*            urb_c;       //!< urbit system data
   c3_c*            log_c;       //!< log directory
@@ -49,9 +49,9 @@ typedef struct _u3_disk {
 
 //! Pier metadata.
 typedef struct _u3_meta {
-  c3_d who_d[2];                    //  identity
-  c3_o fak_o;                       //  fake bit
-  c3_w lif_w;                       //  lifecycle length
+  c3_d who_d[2];  //!< identity
+  c3_o fak_o;     //!<  fake bit
+  c3_w lif_w;     //!<  lifecycle length
 } u3_meta;
 
 //! Opaque event log iterator.

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -68,14 +68,6 @@ u3_disk_etch(u3_disk* log_u,
              c3_l     mug_l,
              c3_y**   out_y);
 
-//! Parse a persisted event buffer.
-c3_o
-u3_disk_sift(u3_disk* log_u,
-             size_t   len_i,
-             c3_y*    dat_y,
-             c3_l*    mug_l,
-             u3_noun*   job);
-
 //! Print status info.
 //!
 //! @param[in] log_u  Disk object to report status info for.

--- a/pkg/urbit/include/vere/disk.h
+++ b/pkg/urbit/include/vere/disk.h
@@ -98,10 +98,6 @@ u3_disk_save_meta(u3_disk* log_u, const u3_meta* met_u);
 u3_weak
 u3_disk_read_list(u3_disk* log_u, c3_d eve_d, c3_d len_d, c3_l* mug_l);
 
-//! Enqueue completed event list, without autocommit.
-void
-u3_disk_plan_list(u3_disk* log_u, u3_noun lit);
-
 //! Commit planned events.
 c3_o
 u3_disk_sync(u3_disk* log_u);

--- a/pkg/urbit/vere/db/lmdb.c
+++ b/pkg/urbit/vere/db/lmdb.c
@@ -521,7 +521,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
   //
   if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
     mdb_logerror(stderr, ret_w, "lmdb: meta read: txn_begin fail");
-    return read_f(ptr_v, 0, 0);
+    return;
   }
 
   //  open the database in the transaction
@@ -529,7 +529,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
   if ( (ret_w =  mdb_dbi_open(txn_u, "META", 0, &mdb_u)) ) {
     mdb_logerror(stderr, ret_w, "lmdb: meta read: dbi_open fail");
     mdb_txn_abort(txn_u);
-    return read_f(ptr_v, 0, 0);
+    return;
   }
 
   //  read by string key, invoking callback with result
@@ -540,7 +540,7 @@ u3_lmdb_read_meta(MDB_env*    env_u,
     if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, &val_u)) ) {
       mdb_logerror(stderr, ret_w, "lmdb: read failed");
       mdb_txn_abort(txn_u);
-      return read_f(ptr_v, 0, 0);
+      return;
     }
     else {
       read_f(ptr_v, val_u.mv_size, val_u.mv_data);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -531,14 +531,15 @@ u3_disk_read_meta(u3_disk* log_u, u3_meta* met_u)
   return c3y;
 }
 
+//! @n (1) Cancel write thread.
+//!        XX can deadlock when called from signal handler.
+//!        XX revise SIGTSTP handling.
+//! @n (2) Close database.
+//! @n (3) Dispose of planned writes.
 void
 u3_disk_exit(u3_disk* log_u)
 {
-  //  cancel write thread
-  //
-  //    XX can deadlock when called from signal handler
-  //    XX revise SIGTSTP handling
-  //
+  // (1)
   if ( c3y == log_u->sav_u.ted_o ) {
     c3_i sas_i;
 
@@ -548,13 +549,10 @@ u3_disk_exit(u3_disk* log_u)
     while ( UV_EBUSY == sas_i );
   }
 
-  //  close database
-  //
+  // (2)
   u3_lmdb_exit(log_u->mdb_u);
 
-  //  dispose planned writes
-  //
-
+  // (3)
   {
     u3_feat* fet_u = log_u->put_u.ext_u;
 

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -226,24 +226,16 @@ u3_disk_commit(u3_disk* log_u)
 }
 
 //! Enqueue fact for persistence.
-static void
-_disk_plan(u3_disk* log_u, u3_fact* tac_u)
-{
-  u3_feat* fet_u = c3_malloc(sizeof(*fet_u));
-  fet_u->eve_d = ++log_u->sen_d;
-  fet_u->len_i = (size_t)u3_disk_etch(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
-
-  c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
-}
-
 void
 u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
   c3_assert( (1ULL + log_u->sen_d) == tac_u->eve_d );
 
-  _disk_plan(log_u, tac_u);
+  u3_feat* fet_u = c3_malloc(sizeof(*fet_u));
+  fet_u->eve_d = ++log_u->sen_d;
+  fet_u->len_i = (size_t)u3_disk_etch(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
 
-  u3_disk_commit(log_u);
+  c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
 }
 
 void
@@ -258,7 +250,7 @@ u3_disk_plan_list(u3_disk* log_u, u3_noun lit)
     //
     tac_u.mug_l = 0;
     tac_u.job = i;
-    _disk_plan(log_u, &tac_u);
+    u3_disk_plan(log_u, &tac_u);
   }
 
   u3z(lit);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -1,5 +1,5 @@
-/* vere/disk.c
-*/
+//! @file disk.c
+
 #include "vere/disk.h"
 
 #include "all.h"
@@ -16,8 +16,7 @@ struct _u3_disk_walk {
   c3_o          liv_o;
 };
 
-/* _disk_commit_done(): commit complete.
- */
+//! Commit complete.
 static void
 _disk_commit_done(u3_disk* log_u)
 {
@@ -67,8 +66,7 @@ _disk_commit_done(u3_disk* log_u)
 static void
 _disk_commit(u3_disk* log_u);
 
-/* _disk_commit_after_cb(): on the main thread, finish write
-*/
+//! On the main thread, finish write
 static void
 _disk_commit_after_cb(uv_work_t* ted_u, c3_i sas_i)
 {
@@ -82,8 +80,7 @@ _disk_commit_after_cb(uv_work_t* ted_u, c3_i sas_i)
   }
 }
 
-/* _disk_commit_cb(): off the main thread, write event-batch.
-*/
+//! Off the main thread, write event-batch.
 static void
 _disk_commit_cb(uv_work_t* ted_u)
 {
@@ -96,8 +93,7 @@ _disk_commit_cb(uv_work_t* ted_u)
                                     log_u->sav_u.siz_i);
 }
 
-/* _disk_commit_start(): queue async event-batch write.
-*/
+//! Queue async event-batch write.
 static void
 _disk_commit_start(u3_disk* log_u)
 {
@@ -110,8 +106,6 @@ _disk_commit_start(u3_disk* log_u)
                                           _disk_commit_after_cb);
 }
 
-/* u3_disk_etch(): serialize an event for persistence.
-*/
 c3_w
 u3_disk_etch(u3_disk* log_u,
              u3_noun    eve,
@@ -148,8 +142,7 @@ u3_disk_etch(u3_disk* log_u,
   }
 }
 
-/* _disk_batch(): create a write batch
-*/
+//! Create a write batch
 static c3_o
 _disk_batch(u3_disk* log_u)
 {
@@ -187,8 +180,7 @@ _disk_batch(u3_disk* log_u)
   }
 }
 
-/* _disk_commit(): commit all available events, if idle.
-*/
+//! Commit all available events, if idle.
 static void
 _disk_commit(u3_disk* log_u)
 {
@@ -209,8 +201,7 @@ _disk_commit(u3_disk* log_u)
   }
 }
 
-/* _disk_plan(): enqueue serialized fact (feat) for persistence.
-*/
+//! Enqueue serialized fact (feat) for persistence.
 static void
 _disk_plan(u3_disk* log_u,
            c3_l     mug_l,
@@ -231,8 +222,6 @@ _disk_plan(u3_disk* log_u,
   }
 }
 
-/* u3_disk_plan(): enqueue completed event for persistence.
-*/
 void
 u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
@@ -243,8 +232,6 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
   _disk_commit(log_u);
 }
 
-/* u3_disk_plan_list(): enqueue completed event list, without autocommit.
-*/
 void
 u3_disk_plan_list(u3_disk* log_u, u3_noun lit)
 {
@@ -260,8 +247,6 @@ u3_disk_plan_list(u3_disk* log_u, u3_noun lit)
   u3z(lit);
 }
 
-/* u3_disk_sync(): commit planned events.
-*/
 c3_o
 u3_disk_sync(u3_disk* log_u)
 {
@@ -286,8 +271,6 @@ u3_disk_sync(u3_disk* log_u)
   return ret_o;
 }
 
-/* u3_disk_async(): active autosync with callbacks.
-*/
 void
 u3_disk_async(u3_disk*     log_u,
               void*        ptr_v,
@@ -299,8 +282,6 @@ u3_disk_async(u3_disk*     log_u,
   log_u->sav_u.don_f = don_f;
 }
 
-/* u3_disk_sift(): parse a persisted event buffer.
-*/
 c3_o
 u3_disk_sift(u3_disk* log_u,
              size_t   len_i,
@@ -342,8 +323,7 @@ struct _cd_list {
   c3_l     mug_l;
 };
 
-/* _disk_read_list_cb(): lmdb read callback, invoked for each event in order
-*/
+//! Lmdb read callback, invoked for each event in order
 static c3_o
 _disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
 {
@@ -365,8 +345,6 @@ _disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
   return c3y;
 }
 
-/* u3_disk_read_list(): synchronously read a cons list of events.
-*/
 u3_weak
 u3_disk_read_list(u3_disk* log_u, c3_d eve_d, c3_d len_d, c3_l* mug_l)
 {
@@ -386,8 +364,6 @@ u3_disk_read_list(u3_disk* log_u, c3_d eve_d, c3_d len_d, c3_l* mug_l)
   }
 }
 
-/* u3_disk_walk_init(): init iterator.
-*/
 u3_disk_walk*
 u3_disk_walk_init(u3_disk* log_u,
                   c3_d     eve_d,
@@ -405,8 +381,6 @@ u3_disk_walk_init(u3_disk* log_u,
   return wok_u;
 }
 
-/* u3_disk_walk_live(): check if live.
-*/
 c3_o
 u3_disk_walk_live(u3_disk_walk* wok_u)
 {
@@ -417,8 +391,6 @@ u3_disk_walk_live(u3_disk_walk* wok_u)
   return wok_u->liv_o;
 }
 
-/* u3_disk_walk_step(): get next fact.
-*/
 c3_o
 u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
 {
@@ -445,8 +417,6 @@ u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
   return c3y;
 }
 
-/* u3_disk_walk_done(): close iterator.
-*/
 void
 u3_disk_walk_done(u3_disk_walk* wok_u)
 {
@@ -454,8 +424,7 @@ u3_disk_walk_done(u3_disk_walk* wok_u)
   c3_free(wok_u);
 }
 
-/* _disk_save_meta(): serialize atom, save as metadata at [key_c].
-*/
+//! Serialize atom, save as metadata at [key_c].
 static c3_o
 _disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
 {
@@ -470,8 +439,6 @@ _disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
   }
 }
 
-/* u3_disk_save_meta(): save metadata.
-*/
 c3_o
 u3_disk_save_meta(u3_disk* log_u, const u3_meta* met_u)
 {
@@ -492,8 +459,7 @@ u3_disk_save_meta(u3_disk* log_u, const u3_meta* met_u)
   return c3y;
 }
 
-/* _disk_meta_read_cb(): copy [val_p] to atom [ptr_v] if present.
-*/
+//! Copy [val_p] to atom [ptr_v] if present.
 static void
 _disk_meta_read_cb(void* ptr_v, size_t val_i, void* val_p)
 {
@@ -504,8 +470,7 @@ _disk_meta_read_cb(void* ptr_v, size_t val_i, void* val_p)
   }
 }
 
-/* _disk_read_meta(): read metadata at [key_c], deserialize.
-*/
+//! Read metadata at [key_c], deserialize.
 static u3_weak
 _disk_read_meta(u3_disk* log_u, const c3_c* key_c)
 {
@@ -514,8 +479,6 @@ _disk_read_meta(u3_disk* log_u, const c3_c* key_c)
   return dat;
 }
 
-/* u3_disk_read_meta(): read metadata.
-*/
 c3_o
 u3_disk_read_meta(u3_disk* log_u, u3_meta* met_u)
 {
@@ -568,8 +531,6 @@ u3_disk_read_meta(u3_disk* log_u, u3_meta* met_u)
   return c3y;
 }
 
-/* u3_disk_exit(): close the log.
-*/
 void
 u3_disk_exit(u3_disk* log_u)
 {
@@ -616,8 +577,6 @@ u3_disk_exit(u3_disk* log_u)
 #endif
 }
 
-/* u3_disk_info(): print status info.
-*/
 void
 u3_disk_info(u3_disk* log_u)
 {

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -10,6 +10,13 @@
 #undef DISK_TRACE_JAM
 #undef DISK_TRACE_CUE
 
+//! Serialized fact
+typedef struct {
+  c3_d             eve_d;
+  size_t           len_i;
+  c3_y*            hun_y;
+} u3_feat;
+
 struct _u3_disk_walk {
   u3_lmdb_walk  itr_u;
   u3_disk*      log_u;

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -725,10 +725,11 @@ u3_disk_init(c3_c* pax_c)
     //  "[..] on 64-bit there is no penalty for making this huge (say 1TB)."
     //
     {
+      const size_t siz_i =
       #if (defined(U3_CPU_aarch64) && defined(U3_OS_linux)) || defined(U3_OS_mingw)
-        const size_t siz_i = 64424509440;
+        0xf00000000;
       #else
-        const size_t siz_i = 1099511627776;
+        0x10000000000;
       #endif
 
       if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -224,13 +224,11 @@ _disk_commit(u3_disk* log_u)
 
 //! Enqueue serialized fact (feat) for persistence.
 static void
-_disk_plan(u3_disk* log_u,
-           c3_l     mug_l,
-           u3_noun    job)
+_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
   u3_feat* fet_u = c3_malloc(sizeof(*fet_u));
   fet_u->eve_d = ++log_u->sen_d;
-  fet_u->len_i = (size_t)u3_disk_etch(log_u, job, mug_l, &fet_u->hun_y);
+  fet_u->len_i = (size_t)u3_disk_etch(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
 
   c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
 }
@@ -240,7 +238,7 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
   c3_assert( (1ULL + log_u->sen_d) == tac_u->eve_d );
 
-  _disk_plan(log_u, tac_u->mug_l, tac_u->job);
+  _disk_plan(log_u, tac_u);
 
   _disk_commit(log_u);
 }
@@ -249,12 +247,15 @@ void
 u3_disk_plan_list(u3_disk* log_u, u3_noun lit)
 {
   u3_noun i, t = lit;
+  u3_fact tac_u;
 
   while ( u3_nul != t ) {
     u3x_cell(t, &i, &t);
     //  NB, boot mugs are 0
     //
-    _disk_plan(log_u, 0, i);
+    tac_u.mug_l = 0;
+    tac_u.job = i;
+    _disk_plan(log_u, &tac_u);
   }
 
   u3z(lit);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -120,11 +120,8 @@ _disk_commit_cb(uv_work_t* ted_u)
 }
 
 //! Serialize an event.
-static c3_w
-_disk_serialize_fact(u3_disk* log_u,
-                     u3_noun    eve,
-                     c3_l     mug_l,
-                     c3_y**   out_y)
+static size_t
+_disk_serialize_fact(u3_disk* log_u, u3_fact* tac_u, u3_feat* fet_u)
 {
   //  XX check version number
   //
@@ -136,14 +133,17 @@ _disk_serialize_fact(u3_disk* log_u,
   //  XX needs api redesign to limit allocations
   //
   {
-    u3_atom mat = u3qe_jam(eve);
+    u3_atom mat = u3qe_jam(tac_u->job);
     c3_w  len_w = u3r_met(3, mat);
-    c3_y* dat_y = c3_malloc(4 + len_w);
-    dat_y[0] = mug_l & 0xff;
-    dat_y[1] = (mug_l >> 8) & 0xff;
-    dat_y[2] = (mug_l >> 16) & 0xff;
-    dat_y[3] = (mug_l >> 24) & 0xff;
-    u3r_bytes(0, len_w, dat_y + 4, mat);
+
+    fet_u->hun_y = c3_malloc(4 + len_w);
+    fet_u->hun_y[0] = tac_u->mug_l & 0xff;
+    fet_u->hun_y[1] = (tac_u->mug_l >> 8) & 0xff;
+    fet_u->hun_y[2] = (tac_u->mug_l >> 16) & 0xff;
+    fet_u->hun_y[3] = (tac_u->mug_l >> 24) & 0xff;
+    u3r_bytes(0, len_w, fet_u->hun_y + 4, mat);
+
+    fet_u->len_i = 4 + len_w;
 
 #ifdef DISK_TRACE_JAM
     u3t_event_trace("king disk jam", 'E');
@@ -151,8 +151,7 @@ _disk_serialize_fact(u3_disk* log_u,
 
     u3z(mat);
 
-    *out_y = dat_y;
-    return len_w + 4;
+    return fet_u->len_i;
   }
 }
 
@@ -234,7 +233,7 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 
   u3_feat* fet_u = c3_malloc(sizeof(*fet_u));
   fet_u->eve_d = ++log_u->sen_d;
-  fet_u->len_i = (size_t)_disk_serialize_fact(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
+  fet_u->len_i = _disk_serialize_fact(log_u, tac_u, fet_u);
 
   c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
 }

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -275,23 +275,19 @@ u3_disk_async(u3_disk*     log_u,
 
 //! Parse a persisted event buffer.
 static c3_o
-_disk_sift(u3_disk* log_u,
-           size_t   len_i,
-           c3_y*    dat_y,
-           c3_l*    mug_l,
-           u3_noun*   job)
+_disk_sift(u3_disk* log_u, u3_feat* fet_u, u3_fact* tac_u)
 {
   //  XX check version
   //
 
-  if ( 4 >= len_i ) {
+  if ( 4 >= fet_u->len_i ) {
     return c3n;
   }
   else {
-    *mug_l = dat_y[0]
-           ^ (dat_y[1] <<  8)
-           ^ (dat_y[2] << 16)
-           ^ (dat_y[3] << 24);
+    tac_u->mug_l = fet_u->hun_y[0]
+                 ^ (fet_u->hun_y[1] <<  8)
+                 ^ (fet_u->hun_y[2] << 16)
+                 ^ (fet_u->hun_y[3] << 24);
 
 #ifdef DISK_TRACE_CUE
     u3t_event_trace("king disk cue", 'B');
@@ -299,7 +295,7 @@ _disk_sift(u3_disk* log_u,
 
     //  XX u3m_soft?
     //
-    *job = u3ke_cue(u3i_bytes(len_i - 4, dat_y + 4));
+    tac_u->job = u3ke_cue(u3i_bytes(fet_u->len_i - 4, fet_u->hun_y + 4));
 
 #ifdef DISK_TRACE_CUE
     u3t_event_trace("king disk cue", 'E');
@@ -323,15 +319,14 @@ _disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
   u3_disk* log_u = ven_u->log_u;
 
   {
-    u3_noun job;
-    c3_l  mug_l;
-
-    if ( c3n == _disk_sift(log_u, val_i, (c3_y*)val_p, &mug_l, &job) ) {
+    u3_feat fet_u = { .len_i = val_i, .hun_y = val_p };
+    u3_fact tac_u;
+    if ( c3n == _disk_sift(log_u, &fet_u, &tac_u) ) {
       return c3n;
     }
 
-    ven_u->mug_l = mug_l;
-    ven_u->eve   = u3nc(job, ven_u->eve);
+    ven_u->mug_l = tac_u.mug_l;
+    ven_u->eve   = u3nc(tac_u.job, ven_u->eve);
   }
 
   return c3y;
@@ -397,10 +392,8 @@ u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
     return wok_u->liv_o = c3n;
   }
 
-  if ( c3n == _disk_sift(log_u, len_i,
-                           (c3_y*)buf_v,
-                           &tac_u->mug_l,
-                           &tac_u->job) )
+  u3_feat fet_u = { .len_i = len_i, .hun_y = buf_v };
+  if ( c3n == _disk_sift(log_u, &fet_u, tac_u) )
   {
     fprintf(stderr, "disk: (%" PRIu64 "): sift fail\r\n", tac_u->eve_d);
     return wok_u->liv_o = c3n;

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -414,14 +414,11 @@ static c3_o
 _disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
 {
   c3_w  len_w = u3r_met(3, dat);
-  c3_y* byt_y = c3_malloc(len_w);
-  u3r_bytes(0, len_w, byt_y, dat);
+  c3_y  byt_y[len_w];
+  u3r_bytes(0, sizeof(byt_y), byt_y, dat);
 
-  {
-    c3_o ret_o = u3_lmdb_save_meta(log_u->mdb_u, key_c, len_w, byt_y);
-    c3_free(byt_y);
-    return ret_o;
-  }
+  c3_o ret_o = u3_lmdb_save_meta(log_u->mdb_u, key_c, sizeof(byt_y), byt_y);
+  return ret_o;
 }
 
 c3_o

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -275,7 +275,7 @@ u3_disk_async(u3_disk*     log_u,
 
 //! Parse a persisted event buffer.
 static c3_o
-_disk_sift(u3_disk* log_u, u3_feat* fet_u, u3_fact* tac_u)
+_disk_deserialize_fact(u3_disk* log_u, u3_feat* fet_u, u3_fact* tac_u)
 {
   //  XX check version
   //
@@ -321,7 +321,7 @@ _disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
   {
     u3_feat fet_u = { .len_i = val_i, .hun_y = val_p };
     u3_fact tac_u;
-    if ( c3n == _disk_sift(log_u, &fet_u, &tac_u) ) {
+    if ( c3n == _disk_deserialize_fact(log_u, &fet_u, &tac_u) ) {
       return c3n;
     }
 
@@ -393,7 +393,7 @@ u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
   }
 
   u3_feat fet_u = { .len_i = len_i, .hun_y = buf_v };
-  if ( c3n == _disk_sift(log_u, &fet_u, tac_u) )
+  if ( c3n == _disk_deserialize_fact(log_u, &fet_u, tac_u) )
   {
     fprintf(stderr, "disk: (%" PRIu64 "): sift fail\r\n", tac_u->eve_d);
     return wok_u->liv_o = c3n;

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -589,7 +589,7 @@ u3_disk_info(u3_disk* log_u)
 
     u3l_log("    batch:\n");
 
-    for ( i_w = 0; i_w < 100; i_w++ ) {
+    for ( i_w = 0; i_w < c3_arr_len(log_u->hit_w); i_w++ ) {
       len_w = log_u->hit_w[i_w];
       if ( len_w ) {
         u3l_log("      %u: %u\n", i_w, len_w);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -238,24 +238,6 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
   c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
 }
 
-void
-u3_disk_plan_list(u3_disk* log_u, u3_noun lit)
-{
-  u3_noun i, t = lit;
-  u3_fact tac_u;
-
-  while ( u3_nul != t ) {
-    u3x_cell(t, &i, &t);
-    //  NB, boot mugs are 0
-    //
-    tac_u.mug_l = 0;
-    tac_u.job = i;
-    u3_disk_plan(log_u, &tac_u);
-  }
-
-  u3z(lit);
-}
-
 c3_o
 u3_disk_sync(u3_disk* log_u)
 {

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -273,12 +273,13 @@ u3_disk_async(u3_disk*     log_u,
   log_u->sav_u.don_f = don_f;
 }
 
-c3_o
-u3_disk_sift(u3_disk* log_u,
-             size_t   len_i,
-             c3_y*    dat_y,
-             c3_l*    mug_l,
-             u3_noun*   job)
+//! Parse a persisted event buffer.
+static c3_o
+_disk_sift(u3_disk* log_u,
+           size_t   len_i,
+           c3_y*    dat_y,
+           c3_l*    mug_l,
+           u3_noun*   job)
 {
   //  XX check version
   //
@@ -325,7 +326,7 @@ _disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
     u3_noun job;
     c3_l  mug_l;
 
-    if ( c3n == u3_disk_sift(log_u, val_i, (c3_y*)val_p, &mug_l, &job) ) {
+    if ( c3n == _disk_sift(log_u, val_i, (c3_y*)val_p, &mug_l, &job) ) {
       return c3n;
     }
 
@@ -396,7 +397,7 @@ u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
     return wok_u->liv_o = c3n;
   }
 
-  if ( c3n == u3_disk_sift(log_u, len_i,
+  if ( c3n == _disk_sift(log_u, len_i,
                            (c3_y*)buf_v,
                            &tac_u->mug_l,
                            &tac_u->job) )

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -92,9 +92,6 @@ _disk_commit_done(u3_disk* log_u)
   }
 }
 
-static void
-_disk_commit(u3_disk* log_u);
-
 //! On the main thread, finish write
 static void
 _disk_commit_after_cb(uv_work_t* ted_u, c3_i sas_i)
@@ -105,7 +102,7 @@ _disk_commit_after_cb(uv_work_t* ted_u, c3_i sas_i)
 
   if ( UV_ECANCELED != sas_i ) {
     _disk_commit_done(log_u);
-    _disk_commit(log_u);
+    u3_disk_commit(log_u);
   }
 }
 
@@ -196,10 +193,9 @@ _disk_batch(u3_disk* log_u)
   }
 }
 
-//! Commit all available events, if idle.
 //! @n (1) Queue async event-batch write to happen on another thread.
-static void
-_disk_commit(u3_disk* log_u)
+void
+u3_disk_commit(u3_disk* log_u)
 {
   if ( c3n == _disk_batch(log_u) ) {
     return;
@@ -229,7 +225,7 @@ _disk_commit(u3_disk* log_u)
   }
 }
 
-//! Enqueue serialized fact (feat) for persistence.
+//! Enqueue fact for persistence.
 static void
 _disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
@@ -247,7 +243,7 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 
   _disk_plan(log_u, tac_u);
 
-  _disk_commit(log_u);
+  u3_disk_commit(log_u);
 }
 
 void

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -459,15 +459,22 @@ u3_disk_save_meta(u3_disk* log_u, const u3_meta* met_u)
   return c3y;
 }
 
-//! Copy [val_p] to atom [ptr_v] if present.
+//! Copy array to an atom.
+//!
+//! @param[out] dst_v  Address of destination atom.
+//! @param[in]  len_i  Length of source array in bytes.
+//! @param[in]  val_v  Source array.
+//!
+//! @n (1) Confirm unique, non-NULL source and destination addresses.
 static void
-_disk_meta_read_cb(void* ptr_v, size_t val_i, void* val_p)
+_disk_meta_read_cb(void* dst_v, size_t len_i, void* src_v)
 {
-  u3_weak* mat = ptr_v;
-
-  if ( val_p ) {
-    *mat = u3i_bytes(val_i, val_p);
+  // (1)
+  if ( src_v == dst_v ) {
+    return;
   }
+
+  *(u3_atom*)dst_v = u3i_bytes(len_i, src_v);
 }
 
 //! Read metadata at [key_c], deserialize.

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -648,7 +648,6 @@ u3_disk_init(c3_c* pax_c)
 
   // (2)
   snprintf(dir_c, sizeof(dir_c), "%s%s", pax_c, urb_c);
-  fprintf(stderr, "peter: %s\r\n", dir_c);
   if ( 0 == (log_u->urb_u = u3_foil_folder(dir_c)) ) {
     fprintf(stderr, "disk: failed to load %s in %s\r\n", urb_c, pax_c);
     c3_free(log_u);
@@ -657,17 +656,22 @@ u3_disk_init(c3_c* pax_c)
 
   // (3)
   snprintf(dir_c, sizeof(dir_c), "%s%s%s", pax_c, urb_c, put_c);
-  fprintf(stderr, "peter: %s\r\n", dir_c);
-  mkdir(dir_c, 0700);
+  if ( -1 == mkdir(dir_c, 0700) && EEXIST != errno ) {
+    fprintf(stderr, "disk: failed to load %s%s in %s\r\n", urb_c, put_c, pax_c);
+    c3_free(log_u);
+    return 0;
+  }
 
   // (4)
   snprintf(dir_c, sizeof(dir_c), "%s%s%s", pax_c, urb_c, get_c);
-  fprintf(stderr, "peter: %s\r\n", dir_c);
-  mkdir(dir_c, 0700);
+  if ( -1 == mkdir(dir_c, 0700) && EEXIST != errno ) {
+    fprintf(stderr, "disk: failed to load %s%s in %s\r\n", urb_c, get_c, pax_c);
+    c3_free(log_u);
+    return 0;
+  }
 
   // (5)
   snprintf(dir_c, sizeof(dir_c), "%s%s%s", pax_c, urb_c, log_c);
-  fprintf(stderr, "peter: %s\r\n", dir_c);
   if ( 0 == (log_u->com_u = u3_foil_folder(dir_c)) ) {
     fprintf(stderr, "disk: failed to load %s%s in %s\r\n", urb_c, log_c, pax_c);
     c3_free(log_u);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -119,11 +119,12 @@ _disk_commit_cb(uv_work_t* ted_u)
                                     log_u->sav_u.siz_i);
 }
 
-c3_w
-u3_disk_etch(u3_disk* log_u,
-             u3_noun    eve,
-             c3_l     mug_l,
-             c3_y**   out_y)
+//! Serialize an event.
+static c3_w
+_disk_serialize_fact(u3_disk* log_u,
+                     u3_noun    eve,
+                     c3_l     mug_l,
+                     c3_y**   out_y)
 {
   //  XX check version number
   //
@@ -233,7 +234,7 @@ u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 
   u3_feat* fet_u = c3_malloc(sizeof(*fet_u));
   fet_u->eve_d = ++log_u->sen_d;
-  fet_u->len_i = (size_t)u3_disk_etch(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
+  fet_u->len_i = (size_t)_disk_serialize_fact(log_u, tac_u->job, tac_u->mug_l, &fet_u->hun_y);
 
   c3_queue_push_back(log_u->put_u, fet_u, sizeof(*fet_u));
 }

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -1149,7 +1149,19 @@ u3_mars_boot(c3_c* dir_c, u3_noun com)
     return c3n;  //  XX cleanup
   }
 
-  u3_disk_plan_list(log_u, ova);
+  // Enqueue completed event list.
+  //
+  {
+    u3_noun i, t = ova;
+    while ( u3_nul != t ) {
+      u3x_cell(t, &i, &t);
+      // NB, boot mugs are 0
+      //
+      u3_fact tac_u = { .mug_l = 0, .job = i };
+      u3_disk_plan(log_u, &tac_u);
+    }
+    u3z(ova);
+  }
 
   if ( c3n == u3_disk_sync(log_u) ) {
     return c3n;  //  XX cleanup

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -122,6 +122,8 @@ _mars_fact(u3_mars* mar_u,
     };
 
     u3_disk_plan(mar_u->log_u, &tac_u);
+    u3_disk_commit(mar_u->log_u);
+
     u3z(job);
   }
 


### PR DESCRIPTION
This PR makes a bunch of small, functionality-independent changes, mostly to the `disk` module:
- Add `_disk_free()` to more easily free a `u3_disk` instance's resources.
- Change type of `put_u` field of `u3_disk` struct to `c3_queue *`. 
- Move `u3_feat` struct out of `disk.h` and into `disk.c`.
- Move the declaration of `u3_disk_etch()` out of `disk.h` and into `disk.c` as `_disk_serialize_fact()`.
- Move the declaration of `u3_disk_sift()` out of `disk.h` and into `disk.c` as `_disk_deserialize_fact()`.
- Remove `disk` module's dependency on `foil` module.
- Remove auto-commit functionality embedded in `u3_disk_plan()` and expose `u3_disk_commit()` in the public interface.
- Remove `u3_disk_plan_list()`  and implement looping logic at single call site in `mars.c`.
- Rewrite `u3_disk_init()` to use stack-allocated memory where possible.
- Use `u3_fact` and `u3_feat` in function interfaces in place of the structs' individual fields.