### PR TITLE
%depth-first has pattern-matching issue

### DIFF
--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -857,8 +857,8 @@
       --
     ::
         [%depth-first @ @ ~]
-      =/  count=(unit atom)  (rush i.t.t.t.t.path dem:ag)
-      =/  start=(unit atom)  (rush i.t.t.t.t.t.path dem:ag)
+      =/  count=(unit atom)  (rush i.t.t.t.t.t.path dem:ag)
+      =/  start=(unit atom)  (rush i.t.t.t.t.t.t.path dem:ag)
       ?:  ?=(~ count)
         [~ ~]
       :-  ~  :-  ~  :-  mar


### PR DESCRIPTION
support a `%depth-first` scry constructed as follows `.^(* %gx /=graph-store=/graph/<ship of resource>/<name of resource>/depth-first/<count>/<start>/graph-update-3)`

see #5586 