### PR TITLE
ames: comet communication fixes

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1757,6 +1757,8 @@
         =/  ship-state  (~(get by peers.ames-state) ship)
         ::
         ?.  ?=([~ %known *] ship-state)
+          ?:  ?=(%pawn (clan:title ship))
+            (try-next-sponsor (^sein:title ship))
           %+  enqueue-alien-todo  ship
           |=  todos=alien-agenda
           todos(packets (~(put in packets.todos) blob))

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -2,9 +2,14 @@
 /=  ames  /sys/vane/ames
 ::  construct some test fixtures
 ::
-=/  nec  (ames ~nec)
-=/  bud  (ames ~bud)
-=/  comet  (ames ~bosrym-podwyl-magnes-dacrys--pander-hablep-masrym-marbud)
+=/  nec     (ames ~nec)
+=/  bud     (ames ~bud)
+=/  marbud  (ames ~marbud)
+::
+=/  our-comet   ~bosrym-podwyl-magnes-dacrys--pander-hablep-masrym-marbud
+=/  our-comet2  ~togdut-rosled-fadlev-siddys--botmun-wictev-sapfus-marbud
+=/  comet   (ames our-comet)
+=/  comet2  (ames our-comet2)
 ::
 =.  now.nec        ~1111.1.1
 =.  eny.nec        0xdead.beef
@@ -22,8 +27,17 @@
 =/  bud-pub  pub:ex:crypto-core.ames-state.bud
 =/  bud-sec  sec:ex:crypto-core.ames-state.bud
 ::
+=.  now.marbud        ~1111.1.1
+=.  eny.marbud        0xbeef.beef
+=.  life.ames-state.marbud  4
+=.  rof.marbud  |=(* ``[%noun !>(*(list turf))])
+=.  crypto-core.ames-state.marbud  (pit:nu:crub:crypto 512 (shaz 'marbud'))
+=/  marbud-pub  pub:ex:crypto-core.ames-state.marbud
+=/  marbud-sec  sec:ex:crypto-core.ames-state.marbud
+::
 =.  now.comet        ~1111.1.1
 =.  eny.comet        0xbeef.cafe
+=.  life.ames-state.comet  1
 =.  rof.comet  |=(* ``[%noun !>(*(list turf))])
 =.  crypto-core.ames-state.comet
   %-  nol:nu:crub:crypto
@@ -31,12 +45,25 @@
   3q3td.T4UF0.d5sDL.JGpZq.S3A92.QUuWg.IHdw7.izyny.j9W92
 =/  comet-pub  pub:ex:crypto-core.ames-state.comet
 =/  comet-sec  sec:ex:crypto-core.ames-state.comet
-
+::
+=.  now.comet2        ~1111.1.1
+=.  eny.comet2        0xcafe.cafe
+=.  life.ames-state.comet2  1
+=.  rof.comet2  |=(* ``[%noun !>(*(list turf))])
+=.  crypto-core.ames-state.comet2  (pit:nu:crub:crypto 512 0v1eb4)
+=/  comet2-pub  pub:ex:crypto-core.ames-state.comet2
+=/  comet2-sec  sec:ex:crypto-core.ames-state.comet2
+::
 =/  nec-sym  (derive-symmetric-key:ames bud-pub nec-sec)
 =/  bud-sym  (derive-symmetric-key:ames nec-pub bud-sec)
 ?>  =(nec-sym bud-sym)
+=/  nec-marbud-sym  (derive-symmetric-key:ames marbud-pub nec-sec)
 ::
-=/  comet-sym  (derive-symmetric-key:ames bud-pub comet-sec)  
+=/  marbud-sym  (derive-symmetric-key:ames marbud-pub comet-sec)
+=/  marbud2-sym  (derive-symmetric-key:ames marbud-pub comet2-sec)
+=/  bud-marbud-sym  (derive-symmetric-key:ames bud-pub marbud-sec)
+::
+=/  comet-sym  (derive-symmetric-key:ames bud-pub comet-sec)
 ::
 =.  peers.ames-state.nec
   %+  ~(put by peers.ames-state.nec)  ~bud
@@ -50,6 +77,18 @@
   =.  route.peer-state  `[direct=%.y `lane:ames`[%& ~nec]]
   [%known peer-state]
 ::
+=.  peers.ames-state.nec
+  %+  ~(put by peers.ames-state.nec)  ~marbud
+  =|  =peer-state:ames
+  =.  -.peer-state
+    :*  symmetric-key=nec-marbud-sym
+        life=5
+        public-key=marbud-pub
+        sponsor=~bud
+    ==
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  [%known peer-state]
+::
 =.  peers.ames-state.bud
   %+  ~(put by peers.ames-state.bud)  ~nec
   =|  =peer-state:ames
@@ -61,12 +100,59 @@
     ==
   =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
   [%known peer-state]
+::
+=.  peers.ames-state.comet
+  %+  ~(put by peers.ames-state.comet)  ~marbud
+  =|  =peer-state:ames
+  =.  -.peer-state
+    :*  symmetric-key=marbud-sym
+        life=5
+        public-key=marbud-pub
+        sponsor=~bud
+    ==
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  [%known peer-state]
+=.  peers.ames-state.comet
+  %+  ~(put by peers.ames-state.comet)  ~bud
+  =|  =peer-state:ames
+  =.  -.peer-state
+    :*  symmetric-key=bud-marbud-sym
+        life=3
+        public-key=bud-pub
+        sponsor=~bud
+    ==
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  [%known peer-state]
+=.  peers.ames-state.comet2
+  %+  ~(put by peers.ames-state.comet2)  ~marbud
+  =|  =peer-state:ames
+  =.  -.peer-state
+    :*  symmetric-key=marbud2-sym
+        life=5
+        public-key=marbud-pub
+        sponsor=~bud
+    ==
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  [%known peer-state]
+=.  peers.ames-state.comet2
+  %+  ~(put by peers.ames-state.comet2)  ~bud
+  =|  =peer-state:ames
+  =.  -.peer-state
+    :*  symmetric-key=bud-marbud-sym
+        life=3
+        public-key=bud-pub
+        sponsor=~bud
+    ==
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  [%known peer-state]
 ::  metamorphose
 ::
 =>  .(nec +:(call:(nec) ~[//unix] ~ %born ~))
 =>  .(bud +:(call:(bud) ~[//unix] ~ %born ~))
+=>  .(comet +:(call:(comet) ~[//unix] ~ %born ~))
+=>  .(comet2 +:(call:(comet2) ~[//unix] ~ %born ~))
 ::  helper core
-::
+::
 =>
 |%
 ++  move-to-packet
@@ -222,57 +308,6 @@
       !>  (sy ,.moves3)
   ==
 ::
-++  test-comet-encounter  ^-  tang
-  ::
-  =/  lane-foo=lane:ames  [%| `@ux``@`%lane-foo]
-  ::
-  =/  =open-packet:ames
-    :*  public-key=`@`comet-pub
-        sndr=our.comet
-        sndr-life=1
-        rcvr=~bud
-        rcvr-life=3
-    ==
-  =/  packet
-    ~!  ames
-    (encode-open-packet:ames open-packet crypto-core.ames-state.comet)
-  =/  blob  (encode-packet:ames packet)
-  ::
-  =^  moves0  bud  (call bud ~[//unix] %hear lane-foo blob)
-  ::
-  =/  =plea:ames  [%g /talk [%first %post]]
-  =/  =shut-packet:ames
-    :*  bone=1
-        message-num=1
-        [%& num-fragments=1 fragment-num=0 (jam plea)]
-    ==
-  =/  =packet:ames
-    %:  encode-shut-packet:ames
-      shut-packet
-      comet-sym
-      our.comet
-      ~bud
-      sndr-life=1
-      rcvr-life=3
-    ==
-  =/  blob  (encode-packet:ames packet)
-  =^  moves1  bud  (call bud ~[//unix] %hear lane-foo blob)
-  ::
-  ;:  weld
-    %+  expect-eq
-      !>  ~
-      !>  moves0
-  ::
-    %+  expect-eq
-      !>  :~  :*  ~[//unix]  %pass  /qos  %d  %flog  %text
-                  "; {<our.comet>} is your neighbor"
-              ==
-              :*  ~[//unix]  %pass  /bone/(scot %p our.comet)/1
-                  %g  %plea  our.comet  plea
-          ==  ==
-      !>  moves1
-  ==
-::
 ++  test-message-flow  ^-  tang
   ::  ~nec -> %plea -> ~bud
   ::
@@ -308,6 +343,77 @@
     %+  expect-eq
       !>  [~[/g/talk] %give %boon [%post 'first1!!']]
       !>  (snag 0 `(list move:ames)`moves6)
+  ==
+::
+++  test-comet-message-flow  ^-  tang
+  ::  same as test-message-flow, but ~nec will send a sendkeys packet to request
+  ::  comet's self-attestation directly
+  ::
+  =^  moves0  nec    (call nec ~[/g/talk] %plea our-comet %g /talk [%get %post])
+  =^  moves1  comet  (call comet ~[//unix] %hear (snag-packet 0 moves0))
+  =^  moves2  comet
+    =/  =point:ames
+      :*  rift=1
+          life=2
+          keys=[[life=2 [crypto-suite=1 `@`nec-pub]] ~ ~]
+          sponsor=`~nec
+      ==
+    %-  take
+    :^  comet  /public-keys  ~[//unix]
+    ^-  sign:ames
+    [%jael %public-keys %full [n=[~nec point] ~ ~]]
+  ::  give comet's self-attestation to ~nec; at this point, we have established
+  ::  a channel, and can proceed as usual
+  ::
+  =^  moves3  nec    (call nec ~[//unix] %hear (snag-packet 0 moves2))
+  =^  moves4  comet  (call comet ~[//unix] %hear (snag-packet 0 moves3))
+  =^  moves5  comet  (take comet /bone/~nec/1 ~[//unix] %g %done ~)
+  =^  moves6  nec    (call nec ~[//unix] %hear (snag-packet 0 moves5))
+  =^  moves7  comet  (take comet /bone/~nec/1 ~[//unix] %g %boon [%post 'first1!!'])
+  =^  moves8  nec    (call nec ~[//unix] %hear (snag-packet 0 moves7))
+  ::
+  ;:  weld
+    %+  expect-eq
+      !>  [~[//unix] %pass /qos %d %flog %text "; ~nec is your neighbor"]
+      !>  (snag 0 `(list move:ames)`moves4)
+  ::
+    %+  expect-eq
+      !>  [~[//unix] %pass /qos %d %flog %text "; {<our-comet>} is your neighbor"]
+      !>  (snag 0 `(list move:ames)`moves6)
+  ::
+    %+  expect-eq
+      !>  [~[/g/talk] %give %boon [%post 'first1!!']]
+      !>  (snag 0 `(list move:ames)`moves8)
+  ==
+::
+++  test-comet-comet-message-flow  ^-  tang
+  ::  same as test-message-flow, but the comets need to exchange
+  ::  self-attestations to establish a channel
+  ::
+  =^  moves0  comet   (call comet ~[/g/talk] %plea our-comet2 %g /talk [%get %post])
+  =^  moves1  comet2  (call comet2 ~[//unix] %hear (snag-packet 0 moves0))
+  =^  moves2  comet   (call comet ~[//unix] %hear (snag-packet 0 moves1))
+  ::  channel is now established; comet also emitted a duplicate
+  ::  self-attestation, which we ignore
+  ::
+  =^  moves3  comet2  (call comet2 ~[//unix] %hear (snag-packet 1 moves2))
+  =^  moves4  comet2  (take comet2 /bone/(scot %p our-comet)/1 ~[//unix] %g %done ~)
+  =^  moves5  comet   (call comet ~[//unix] %hear (snag-packet 0 moves4))
+  =^  moves6  comet2  (take comet2 /bone/(scot %p our-comet)/1 ~[//unix] %g %boon [%post 'first1!!'])
+  =^  moves7  comet   (call comet ~[//unix] %hear (snag-packet 0 moves6))
+  ::
+  ;:  weld
+    %+  expect-eq
+      !>  [~[//unix] %pass /qos %d %flog %text "; {<our-comet>} is your neighbor"]
+      !>  (snag 0 `(list move:ames)`moves3)
+  ::
+    %+  expect-eq
+      !>  [~[//unix] %pass /qos %d %flog %text "; {<our-comet2>} is your neighbor"]
+      !>  (snag 0 `(list move:ames)`moves5)
+  ::
+    %+  expect-eq
+      !>  [~[/g/talk] %give %boon [%post 'first1!!']]
+      !>  (snag 0 `(list move:ames)`moves7)
   ==
 ::
 ++  test-nack  ^-  tang


### PR DESCRIPTION
This is a set of changes to ames that affect comet communication, loosely following @philipcmonk's design. Specifically:

- Self-attestation packets are now processed via `+on-publ-full`. This means that comets will respond to a self-attestation with their own self-attestation. It also fixes a bug where receiving a self-attestation would clobber existing peer state.
- Non-comets now send a special "sendkeys" packet to comets that they wish to communicate with. Technically, this is an empty `shut-packet`, encrypted with dummy key. The comet will drop this packet on the floor, but will still respond with a self-attestation.
  - When a comet wants to talk to another comet, it sends its own self-attestation rather than a sendkeys packet. The effect is the same (the receiver replies with their self-attestation), but we save a roundtrip.
- Messages addressed to unknown comets are not enqueued; instead, they are immediately sent to the comet's sponsor. (Without this, we can't talk to a comet until they talk to us first.)

So the packet exchange for planet->comet is:
-> "plz send key"
<- "here's my key"
-> "message 1 packet 1"
<- "ack 1:1"
 
and for comet->comet:
-> "here's my key"
<- "here's my key"
-> "message 1 packet 1" and "here's my key"
<- "ack 1:1"

I added some tests for galaxy-to-comet and comet-to-comet communication. The test setup is a bit bloated now; could probably use some cleaning up. It would be nice to have a pH test too, but I think that's blocked on https://github.com/urbit/urbit/pull/5578.

I think the only thing missing here is timers (and maybe acks?) for resending self-attestation/sendkeys packets. I'm not familiar with how timers work in ames, so I could use some direction there. I'd also like to test what happens if a comet receives a sendkeys packet from a known peer -- will the dummy key cause a crash? Is that okay? If not, we'll need to explicitly check for sendkey packets somehow.