### PR TITLE
interface: adds `theme-color` meta tag, removes outdated safari web app meta tag

### DIFF
--- a/pkg/interface/public/index.html
+++ b/pkg/interface/public/index.html
@@ -7,7 +7,6 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no,maximum-scale=1"/>
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-touch-fullscreen" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest"
       href='data:application/manifest+json,{
         "name": "Groups",
@@ -16,6 +15,9 @@
         "display": "standalone",
         "background_color": "%23FFFFFF",
         "theme_color": "%23000000"}' />
+    <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#1A1A1A" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#FFFFFF">
     <script src="/apps/landscape/desk.js"></script>
     <script src="/session.js"></script>
   </head>


### PR DESCRIPTION
fixes urbit/landscape#1392