### PR TITLE
hoon: updates %mcgl with an hygienic expansion

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8580,15 +8580,7 @@
       ==
     ::
         [%mcfs *]  =+(zoy=[%rock %ta %$] [%clsg [zoy [%clsg [zoy p.gen] ~]] ~])
-        [%mcgl *]
-      :^    %cnls
-          :+  %cnhp
-            q.gen
-          [%ktcl p.gen]
-        r.gen
-      :+  %brts
-        p.gen
-      s.gen
+        [%mcgl *]  [%cnls [%cnhp q ktcl+p] r [%brts p [%tsgr $+3 s]]]:gen
     ::
         [%mcsg *]                                       ::                  ;~
       |-  ^-  hoon


### PR DESCRIPTION
The macro expansion for `;<` (urbit/arvo#1150) introduces a gate, wrapping and deferring the execution of the final sub-expression `s`. Since that gate is visible to `s`, idiomatic hoon recursion cannot be straightforwardly used with `;<`:

```
> =/  a=(list (unit @))  ~[`1 `3 `4]
  =|  b=(list @t)
  |-  ^+  b
  ?~  a   b
  ;<  c=@  _biff  i.a
  =?  b  =(1 (mod c 2))  [(scot %ub c) b]
  $(a t.a)
-need.[i=u(@) t=it(u(@))]
-have.%~
nest-fail
```

`^$(a t.a)` would work, but is very fragile in this style of code -- the number of `^`s corresponds to the number of `;<` expressions between the site of the recursive call and the `|-` in question. Instead, the pattern has been to introduce loop aliases:

```
> =/  a=(list (unit @))  ~[`1 `3 `4]
  =|  b=(list @t)
  |-  ^+  b
  =*  loop  $
  ?~  a   b
  ;<  c=@  _biff  i.a
  =?  b  =(1 (mod c 2))  [(scot %ub c) b]
  loop(a t.a)
<|0b11 0b1|>
```

This PR updates the compiler to hygienically expand `;<`, with the result that both the original version and the aliased version work correctly.