### PR TITLE
%gall: integrate agents with |mass

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -840,11 +840,11 @@
   ::
   ++  mo-peek
     ~/  %mo-peek
-    |=  [dap=term =routes care=term =path]
+    |=  [veb=? dap=term =routes care=term =path]
     ^-  (unit (unit cage))
     ::
     =/  app  (ap-abed:ap dap routes)
-    (ap-peek:app care path)
+    (ap-peek:app veb care path)
   ::
   ++  mo-apply
     |=  [dap=term =routes =deal]
@@ -1246,7 +1246,7 @@
     ::
     ++  ap-peek
       ~/  %ap-peek
-      |=  [care=term tyl=path]
+      |=  [veb=? care=term tyl=path]
       ^-  (unit (unit cage))
       ::  take trailing mark off path for %x scrys
       ::
@@ -1259,6 +1259,7 @@
       =/  peek-result=(each (unit (unit cage)) tang)
         (ap-mule-peek |.((on-peek:ap-agent-core [care tyl])))
       ?:  ?=(%| -.peek-result)
+        ?.  veb  [~ ~]
         ((slog leaf+"peek bad result" p.peek-result) [~ ~])
       ::  for non-%x scries, or failed %x scries, or %x results that already
       ::  have the requested mark, produce the result as-is
@@ -1814,7 +1815,7 @@
   ?.  ?=(^ path)
     ~
   =/  =routes  [~ ship]
-  (mo-peek:mo dap routes care path)
+  (mo-peek:mo & dap routes care path)
 ::  +stay: save without cache; suspend non-%base agents
 ::
 ::    TODO: superfluous? see +molt

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1757,7 +1757,7 @@
       |=  [dap=term =yoke]
       ^-  mass
       =/  met=(list mass)
-        =/  dat  (mo-peek:mo dap [~ ship] %x /whey/noun)
+        =/  dat  (mo-peek:mo | dap [~ ship] %x /whey/mass)
         ?:  ?=(?(~ [~ ~]) dat)  ~
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
       ?~  met

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1753,8 +1753,16 @@
       (sort ~(tap by queued) aor)
     ::
     =/  running
-      =/  active  (~(run by yokes.state) |=(yoke [%.y +<]))
-      (sort ~(tap by active) aor)
+      %+  turn  (sort ~(tap by yokes.state) aor)
+      |=  [dap=term =yoke]
+      ^-  mass
+      =/  met=(list mass)
+        =/  dat  (mo-peek:mo dap [~ ship] %x /whey/noun)
+        ?:  ?=(?(~ [~ ~]) dat)  ~
+        (fall ((soft (list mass)) q.q.u.u.dat) ~)
+      ?~  met
+        dap^&+yoke
+      dap^|+(welp met dot+&+yoke ~)
     ::
     =/  maz=(list mass)
       :~  [%foreign %.y contacts.state]

--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -617,6 +617,16 @@
   |=  =path
   ^-  (unit (unit cage))
   ?+    path  (on-peek:def path)
+      [%x %whey ~]
+    =/  liv=(list mass)
+      (sort (turn ~(tap by graphs) |=([[* n=term] g=*] n^&+g)) aor)
+    =/  log=(list mass)
+      (sort (turn ~(tap by update-logs) |=([[* n=term] l=*] n^&+l)) aor)
+    =/  sil=(list mass)
+      (sort (turn ~(tap by archive) |=([[* n=term] g=*] n^&+g)) aor)
+    :^  ~  ~  %mass
+    !>(`(list mass)`[live+|+liv logs+|+log ?~(sil ~ [silo+|+sil ~])])
+  ::
     [%x %export ~]  ``noun+!>(state)
   ::
       [%x %keys ~]


### PR DESCRIPTION
This PR updates %gall to allow its agents to optionally integrate with `|mass`. %gall's `/whey` scry handler peeks into each agent , and incorporates their labels if successful/valid (with error output suppressed).

Additionally, this PR includes a basic integration with `:graph-store`. Only the resource name is displayed, which might not be sufficient. It may also be worth grouping graphs and logs instead of listing the separately. This new output should be coupled with simple instructions for listing graphs/archives, measuring their memory usage, and removing them if it becomes necessary. (All the graph-store stuff could easily be a separate PR, can easily be released piecemeal, &c.)