### PR TITLE
roller: fix handling of forced transactions

### DIFF
--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -1440,7 +1440,7 @@
     ?~  sen=(get:ors:dice sending [address nonce])
       ~?  lverb  [dap.bowl %weird-double-remove nonce+nonce]
       sending
-    ?~  nin=(find [raw-tx.diff]~ (turn txs.u.sen tail))
+    ?~  nin=(find [raw-tx.diff]~ (turn txs.u.sen (cork tail tail)))
       ~?  lverb  [dap.bowl %weird-unknown nonce+nonce]
       sending
     =.  txs.u.sen  (oust [u.nin 1] txs.u.sen)

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -1507,11 +1507,17 @@
     |=  wat=@t
     ?~  who=(slaw %p wat)  [~ ~]
     =/  [exceeded=? next-quota=@ud]  (quota-exceeded u.who)
+    =/  allow=(unit (unit @ud))      (~(get by allowances) u.who)
     :+  ~  ~
     :-  %atom
     !>  ^-  @ud
-    ?:  exceeded  0
-    (sub quota.state (dec next-quota))
+    ?:  exceeded     0
+    =/  max-quota=@  quota.state
+    ?:  &(?=(^ allow) ?=(~ u.allow))
+      max-quota
+    =?  max-quota  &(?=(^ allow) ?=(^ u.allow))
+      u.u.allow
+    (sub max-quota (dec next-quota))
   ::
   ++  allowance
     |=  wat=@t

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -550,6 +550,7 @@
         =/  cards=(list card)  (send-roll:do address nonce)
         =?  sending
           ?&  ?=(~ cards)
+              (has:ors:dice sending [address nonce])
               =(0 (lent txs:(got:ors:dice sending [address nonce])))
           ==
           ~&  >  "empty sending, removing {<[nonce address]>}"

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -526,8 +526,12 @@
 ++  process-rpc
   |=  [id=@t params=(map @t json) action=l2-tx over-quota=$-(@p ?)]
   ^-  [(unit cage) response:rpc]
-  ?.  =((lent ~(tap by params)) 5)
+  ?.  ?|  =((lent ~(tap by params)) 4)
+          =((lent ~(tap by params)) 5)
+      ==
     [~ ~(params error:json-rpc id)]
+  =?  params  =((lent ~(tap by params)) 4)
+    (~(put by params) 'force' b+|)
   =+  ^-  $:  sig=(unit @)
               from=(unit [=ship proxy:naive])
               addr=(unit @ux)

--- a/pkg/arvo/lib/azimuth-roll-rpc.hoon
+++ b/pkg/arvo/lib/azimuth-roll-rpc.hoon
@@ -179,6 +179,12 @@
         ^-  (unit @ud)
         ?~  nonce=(~(get by params) 'nonce')  ~
         (ni u.nonce)
+      ::
+      ++  force
+        |=  params=(map @t json)
+        ^-  (unit ?)
+        ?~  force=(~(get by params) 'force')  ~
+        (bo u.force)
       --
     ::
     ++  to-json
@@ -520,15 +526,16 @@
 ++  process-rpc
   |=  [id=@t params=(map @t json) action=l2-tx over-quota=$-(@p ?)]
   ^-  [(unit cage) response:rpc]
-  ?.  =((lent ~(tap by params)) 4)
+  ?.  =((lent ~(tap by params)) 5)
     [~ ~(params error:json-rpc id)]
   =+  ^-  $:  sig=(unit @)
               from=(unit [=ship proxy:naive])
               addr=(unit @ux)
+              force=(unit ?)
           ==
     =,  from-json
-    [(sig params) (from params) (address params)]
-  ?:  |(?=(~ sig) ?=(~ from) ?=(~ addr))
+    [(sig params) (from params) (address params) (force params)]
+  ?:  |(?=(~ sig) ?=(~ from) ?=(~ addr) ?=(~ force))
     [~ ~(parse error:json-rpc id)]
   ?:  (over-quota ship.u.from)
     `[%error id '-32002' 'Max tx quota exceeded']
@@ -537,7 +544,7 @@
   =+  (gen-tx-octs:lib u.tx)
   :_  [%result id (hex:to-json 32 (hash-tx:lib p q))]
   %-  some
-  roller-action+!>([%submit | u.addr u.sig %don u.tx])
+  roller-action+!>([%submit u.force u.addr u.sig %don u.tx])
 ::
 ++  nonce
   |=  [id=@t params=(map @t json) scry=$-([ship proxy:naive] (unit @))]

--- a/pkg/arvo/lib/dice.hoon
+++ b/pkg/arvo/lib/dice.hoon
@@ -68,13 +68,13 @@
   ?.  (verify-sig-and-nonce:naive verifier chain-t nas raw-tx)
     =+  [force ~ nas indices]
     ?.  verb  -
-    ~&  >>>  [verb+verb %verify-sig-and-nonce %failed tx.raw-tx]  -
+    ~&  >>>  [force+force %verify-sig-and-nonce %failed tx.raw-tx]  -
   =^  effects-1  points.nas
     (increment-nonce:naive nas from.tx.raw-tx)
   ?~  nex=(receive-tx:naive nas tx.raw-tx)
     =+  [force ~ ?:(force nas cache) indices]
     ?.  verb  -
-    ~&  >>>  [verb+verb %receive-tx %failed]  -
+    ~&  >>>  [force+force %receive-tx %failed]  -
   =*  new-nas   +.u.nex
   =/  effects   (welp effects-1 -.u.nex)
   =^  updates   indices

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -85,7 +85,7 @@
 +$  hist-tx  [p=time q=roll-tx]
 +$  roll-tx  [=ship =status hash=keccak type=l2-tx]
 +$  pend-tx  [force=? =address:naive =time =raw-tx:naive]
-+$  send-tx  [next-gas-price=@ud sent=? txs=(list raw-tx:naive)]
++$  send-tx  [next-gas-price=@ud sent=? txs=(list [force=? =raw-tx:naive])]
 +$  part-tx
   $%  [%raw raw=octs]
       [%don =tx:naive]

--- a/pkg/arvo/sur/dice.hoon
+++ b/pkg/arvo/sur/dice.hoon
@@ -85,7 +85,11 @@
 +$  hist-tx  [p=time q=roll-tx]
 +$  roll-tx  [=ship =status hash=keccak type=l2-tx]
 +$  pend-tx  [force=? =address:naive =time =raw-tx:naive]
-+$  send-tx  [next-gas-price=@ud sent=? txs=(list [force=? =raw-tx:naive])]
++$  send-tx
+  $:  next-gas-price=@ud
+      sent=?
+      txs=(list [=address:naive force=? =raw-tx:naive])
+  ==
 +$  part-tx
   $%  [%raw raw=octs]
       [%don =tx:naive]


### PR DESCRIPTION
This PR fixes the way the roller handled "forced" transactions (i.e. transactions that had a force flag indicating that they should be included in the next batch even if they fail to apply to the roller's predicted state), specially when it relates to the roller's transaction history. This PR also modifies the roller's state to keep track of this forced transactions when the are included in the sending map, so when they fail, they are still considered as part of the batch.

%roller-rpc and it's TS client [v0.1.15](https://www.npmjs.com/package/@urbit/roller-api/v/0.1.15) have been updated to support this.

The contents of the PR are currently deployed to ~roller-dozzod-dozzod and used with the latest version of Bridge.

(Note: this PR is built on top of the [roller/quota-fix](https://github.com/urbit/urbit/compare/roller/quota-fix) branch that has a small fix for retrieving the quota of a ship)