### PR TITLE
interface: use single sig in NotificationText

### DIFF
--- a/pkg/interface/src/views/apps/notifications/notification.tsx
+++ b/pkg/interface/src/views/apps/notifications/notification.tsx
@@ -8,7 +8,7 @@ import {
 } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import React, { useCallback } from 'react';
-import { useHovering } from '~/logic/lib/util';
+import { deSig, useHovering } from '~/logic/lib/util';
 import useLocalState from '~/logic/state/local';
 import { StatelessAsyncAction } from '~/views/components/StatelessAsyncAction';
 import { SwipeMenu } from '~/views/components/SwipeMenu';
@@ -38,7 +38,7 @@ const NotificationText = ({ contents, ...rest }: NotificationTextProps) => {
           return (
             <Mention
               key={idx}
-              ship={content.ship}
+              ship={deSig(content.ship)}
               first={idx === 0}
               {...rest}
             />

--- a/pkg/interface/src/views/components/ProfileOverlay.tsx
+++ b/pkg/interface/src/views/components/ProfileOverlay.tsx
@@ -34,11 +34,14 @@ const FixedOverlay = styled(Col)`
   transition: all 0.1s ease-out;
 `;
 
-type ProfileOverlayProps = BoxProps & {
-  ship: string;
-  children?: ReactNode;
-  color?: string;
-};
+interface ProfileOverlayProps extends BoxProps {
+  /**
+   * A valid patp (without sig)
+   */
+  ship: string,
+  children?: ReactNode,
+  color?: string,
+}
 
 const selSettings = (s: SettingsState) => [s.calm.hideAvatars, s.calm.hideNicknames];
 


### PR DESCRIPTION
# Changes

The `ProfileOverlay` component expects a `ship` arg as a patp without the sig. This deSigs the ship value used in `NotificationText`.

This closes urbit/landscape#1376

# Preview

![image](https://user-images.githubusercontent.com/16504501/155629765-6ddb6182-2d39-408e-aaf7-980bd5e7c442.png)
