### PR TITLE
interface: fix subscription reconnect issues

### DIFF
--- a/pkg/grid/src/state/base.ts
+++ b/pkg/grid/src/state/base.ts
@@ -4,7 +4,7 @@ import { compose } from 'lodash/fp';
 import _ from 'lodash';
 import create, { GetState, SetState, UseStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-import Urbit, { SubscriptionRequestInterface } from '@urbit/http-api';
+import Urbit, { FatalError, SubscriptionRequestInterface } from '@urbit/http-api';
 import { Poke } from '@urbit/api';
 import api from './api';
 import { clearStorageMigration, createStorageKey, storageVersion, useMockData } from './util';
@@ -107,7 +107,9 @@ export function createSubscription(
     path,
     event: e,
     err: () => {},
-    quit: () => {}
+    quit: () => {
+      throw new FatalError("subscription clogged");
+    }
   };
   // TODO: err, quit handling (resubscribe?)
   return request;


### PR DESCRIPTION
Restores subscription reconnect issues by correctly throwing a
FatalError so that subscriptions are correctly restarted.

This was removed in a refactor, probably by accident
