### PR TITLE
c3: add binary file module for easy persistent storage of arbitrary data

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -1,6 +1,7 @@
 include config.mk
 include $(foreach dir,$(compat),$(wildcard compat/$(dir)/*.mk))
 
+c 	 = $(wildcard c/*.c)
 jets = jets/tree.c $(wildcard jets/*/*.c)
 noun = $(wildcard noun/*.c)
 ur   = $(wildcard ur/*.c)
@@ -12,7 +13,7 @@ bench  = $(wildcard bench/*.c)
 
 compat := $(foreach dir,$(compat),$(wildcard compat/$(dir)/*.c))
 
-common  = $(jets) $(noun) $(ur) $(vere) $(compat)
+common  = $(c) $(jets) $(noun) $(ur) $(vere) $(compat)
 headers = $(shell find include -type f)
 
 common_objs = $(shell echo $(common) | sed 's/\.c/.o/g')

--- a/pkg/urbit/c/bile.c
+++ b/pkg/urbit/c/bile.c
@@ -1,0 +1,192 @@
+//! @file bile.c
+
+#include "c/bile.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/stat.h>
+
+#include "c/defs.h"
+
+//==============================================================================
+// Macros
+//==============================================================================
+
+//! Error-handling wrapper for system calls that return >=0 on success
+//! and <0 on failure.
+//!
+//! It's unclear whether `strerror(errno)` is a portable solution for reporting
+//! error messages.
+//!
+//! @param[in] system_call     System call to execute.
+//! @param[in] failure_action  Statement to execute after logging failure.
+#define try_syscall(system_call, failure_action, ...)                          \
+  do {                                                                         \
+    if ( 0 > (system_call) ) {                                                 \
+      fprintf(stderr, "syscall: " __VA_ARGS__);                                \
+      c3_c* msg_c = strerror(errno);                                           \
+      if ( !msg_c ) {                                                          \
+        msg_c = "Unknown error";                                               \
+      };                                                                       \
+      fprintf(stderr,                                                          \
+              " (%s) [%s:%s():%d]\r\n",                                        \
+              msg_c,                                                           \
+              __FILE__,                                                        \
+              __func__,                                                        \
+              __LINE__);                                                       \
+      failure_action;                                                          \
+    }                                                                          \
+  } while ( 0 )
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+c3_bile*
+c3_bile_open(const c3_path* const pax_u)
+{
+  if ( !pax_u ) {
+    goto fail;
+  }
+
+  c3_bile* bil_u = c3_calloc(sizeof(*bil_u));
+
+  bil_u->pax_u = c3_path_fp(pax_u);
+
+  try_syscall(bil_u->fid_i = open(bil_u->pax_u->str_c, O_RDWR | O_CREAT, 0666),
+              goto free_file,
+              "failed to open %s",
+              bil_u->pax_u->str_c);
+
+  struct stat buf_u;
+  try_syscall(fstat(bil_u->fid_i, &buf_u),
+              goto close_file,
+              "failed to get %s stats",
+              bil_u->pax_u->str_c);
+
+  bil_u->len_i = buf_u.st_size;
+  goto succeed;
+
+close_file:
+  close(bil_u->fid_i);
+free_file:
+  c3_free(bil_u->pax_u);
+  c3_free(bil_u);
+fail:
+  return NULL;
+
+succeed:
+  return bil_u;
+}
+
+//! @n (1) Seek to the end of the file to ensure append-only behavior.
+//! @n (2) Attempt the write again if we were interrupted by a signal.
+//! @n (3) Writing failed partway through, so clear clear the file of any data
+//!        from the partial write.
+c3_t
+c3_bile_put_raw(c3_bile* const    bil_u,
+                const void* const dat_v,
+                const size_t      len_i)
+{
+  if ( !dat_v ) {
+    goto fail;
+  }
+
+  if ( bil_u->off_i != bil_u->len_i ) { // (1)
+    try_syscall(lseek(bil_u->fid_i, bil_u->len_i, SEEK_SET), goto fail);
+    bil_u->off_i = bil_u->len_i;
+  }
+
+  const c3_y* dat_y = dat_v;
+  ssize_t     lef_i = len_i;
+  ssize_t     wri_i;
+  while ( 0 < lef_i ) {
+    if ( -1 == (wri_i = write(bil_u->fid_i, dat_y, lef_i)) ) {
+      if ( EINTR == errno ) { // (2)
+        continue;
+      }
+      else {
+        goto abandon_write;
+      }
+    }
+    else {
+      dat_y += wri_i;
+      lef_i -= wri_i;
+    }
+  }
+  bil_u->len_i += len_i;
+  bil_u->off_i = bil_u->len_i;
+  goto succeed;
+
+abandon_write: // (3)
+  try_syscall(truncate(bil_u->pax_u->str_c, bil_u->len_i), goto fail);
+  try_syscall(lseek(bil_u->fid_i, bil_u->len_i, SEEK_SET), goto fail);
+  bil_u->off_i = bil_u->len_i;
+fail:
+  return 0;
+
+succeed:
+  return 1;
+}
+
+//! @n (1) If we're at the end of the file (or past it), seek back to the
+//!        beginning.
+//! @n (2) Attempt the read again if we were interrupted by a signal.
+c3_t
+c3_bile_get_raw(c3_bile* const bil_u, void* const dat_v, const size_t len_i)
+{
+  if ( !dat_v ) {
+    goto fail;
+  }
+
+  if ( bil_u->len_i <= bil_u->off_i ) { // (1)
+    try_syscall(lseek(bil_u->fid_i, 0, SEEK_SET), goto fail);
+    bil_u->off_i = 0;
+  }
+
+  c3_y*   dat_y = dat_v;
+  ssize_t lef_i = len_i;
+  ssize_t rea_i;
+  while ( 0 < lef_i ) {
+    rea_i = read(bil_u->fid_i, dat_y, lef_i);
+    if ( -1 == rea_i ) {
+      if ( EINTR == errno ) { // (2)
+        continue;
+      }
+      else {
+        goto abandon_read;
+      }
+    }
+    else if ( 0 == rea_i ) {
+      break;
+    }
+    else {
+      dat_y += rea_i;
+      lef_i -= rea_i;
+    }
+  }
+  bil_u->off_i += len_i;
+  goto succeed;
+
+abandon_read:
+  try_syscall(lseek(bil_u->fid_i, bil_u->off_i, SEEK_SET), goto fail);
+fail:
+  return 0;
+
+succeed:
+  return 1;
+}
+
+void
+c3_bile_close(c3_bile* const bil_u)
+{
+  if ( !bil_u ) {
+    return;
+  }
+
+  close(bil_u->fid_i);
+  c3_free(bil_u->pax_u);
+}
+
+#undef try_syscall

--- a/pkg/urbit/c/path.c
+++ b/pkg/urbit/c/path.c
@@ -1,0 +1,132 @@
+//! @file path.c
+
+#include "c/path.h"
+
+#include "c/defs.h"
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+//! Path separator.
+static const c3_c pax_sep_c[] = "/";
+
+//==============================================================================
+// Static functions
+//==============================================================================
+
+static inline c3_t
+_is_empty_token(const c3_c* const tok_c)
+{
+  return !tok_c || 0 == strcmp("", tok_c) || 0 == strcmp(".", tok_c);
+}
+
+static inline c3_t
+_is_root(const c3_c* const tok_c)
+{
+  return 0 == strcmp(pax_sep_c, tok_c);
+}
+
+static inline c3_t
+_is_parent(const c3_c* const tok_c)
+{
+  return 0 == strcmp("..", tok_c);
+}
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! @n (1) Allocate 32 bytes for the path string as a default.
+c3_path*
+c3_path_fa(const c3_c** tok_c, const size_t tok_i)
+{
+  static const size_t cap_i = 32; // (1)
+  c3_path*            pax_u = c3_calloc(sizeof(*pax_u) + cap_i);
+  pax_u->cap_i              = cap_i;
+  if ( tok_c ) {
+    for ( size_t idx_i = 0; idx_i < tok_i; idx_i++ ) {
+      c3_path_push(pax_u, tok_c[idx_i]);
+    }
+  }
+  return pax_u;
+}
+
+c3_path*
+c3_path_fp(const c3_path* const pax_u)
+{
+  return pax_u ? c3_path_fv(1, pax_u->str_c) : c3_path_fv(0);
+}
+
+c3_path*
+c3_path_fv(const size_t tok_i, ...)
+{
+  if ( 0 == tok_i ) {
+    return c3_path_fa(NULL, 0);
+  }
+  const c3_c* tok_c[tok_i];
+  va_list     arg_u;
+  va_start(arg_u, tok_i);
+  for ( size_t idx_i = 0; idx_i < tok_i; idx_i++ ) {
+    tok_c[idx_i] = va_arg(arg_u, const c3_c*);
+  }
+  va_end(arg_u);
+  return c3_path_fa(tok_c, tok_i);
+}
+
+//! @n (1) The root directory is its own parent.
+//! @n (2) Double the needed size to minimize future allocations.
+void
+c3_path_push(c3_path* pax_u, const c3_c* const tok_c)
+{
+  if ( !pax_u || _is_empty_token(tok_c) ) {
+    return;
+  }
+
+  if ( _is_parent(tok_c) ) {
+    if ( !_is_root(pax_u->str_c) ) { // (1)
+      c3_path_pop(pax_u);
+    }
+    return;
+  }
+
+  size_t tok_i = sizeof(pax_sep_c) + strlen(tok_c);
+  if ( pax_u->cap_i - pax_u->len_i < tok_i ) {
+    size_t cap_i = 2 * (pax_u->cap_i + tok_i); // (2)
+    pax_u        = c3_realloc(pax_u, sizeof(*pax_u) + cap_i);
+    pax_u->cap_i = cap_i;
+  }
+
+  if ( 0 < pax_u->len_i && !_is_root(pax_u->str_c) ) {
+    strcat(pax_u->str_c, pax_sep_c);
+  }
+  strcat(pax_u->str_c, tok_c);
+
+  pax_u->len_i = strlen(pax_u->str_c);
+}
+
+//! @n (1) This is a path of the form `some-file-or-directory`.
+//! @n (2) This is a path of the form `/some-file-or-directory`.
+void
+c3_path_pop(c3_path* const pax_u)
+{
+  if ( !pax_u || 0 == pax_u->len_i ) {
+    return;
+  }
+
+  if ( _is_root(pax_u->str_c) ) {
+    *pax_u->str_c = '\0';
+    pax_u->len_i  = 0;
+    return;
+  }
+
+  c3_c* sep_c = strrchr(pax_u->str_c, *pax_sep_c);
+  if ( !sep_c ) { // (1)
+    sep_c = pax_u->str_c;
+  }
+  else if ( sep_c == pax_u->str_c ) { // (2)
+    sep_c++;
+  }
+  *sep_c       = '\0';
+  pax_u->len_i = strlen(pax_u->str_c);
+}

--- a/pkg/urbit/include/c/all.h
+++ b/pkg/urbit/include/c/all.h
@@ -10,6 +10,7 @@
 
 #include "c/portable.h"
 #include "c/types.h"
+#include "c/bile.h"
 #include "c/defs.h"
 #include "c/motes.h"
 #include "c/path.h"

--- a/pkg/urbit/include/c/all.h
+++ b/pkg/urbit/include/c/all.h
@@ -12,5 +12,6 @@
 #include "c/types.h"
 #include "c/defs.h"
 #include "c/motes.h"
+#include "c/path.h"
 
 #endif /* ifndef C3_ALL_H */

--- a/pkg/urbit/include/c/bile.h
+++ b/pkg/urbit/include/c/bile.h
@@ -1,0 +1,89 @@
+//! @file bile.h
+//!
+//! File containing a single blob of arbitrary binary data up to 2^32 bytes in
+//! size.
+//!
+//! @note mnemonic: [b]inary f[ile] -> bile
+
+#ifndef C3_BILE_H
+#define C3_BILE_H
+
+#include "c/portable.h"
+#include "c/types.h"
+#include "c/path.h"
+
+//==============================================================================
+// Types
+//==============================================================================
+
+//! Binary file handle.
+//!
+//! Must only be created via c3_bile_open() and disposed of via
+//! c3_bile_close().
+typedef struct {
+  c3_i     fid_i; //!< file descriptor
+  size_t   len_i; //!< length of file in bytes
+  size_t   off_i; //!< offset into file that file descriptor is at
+  c3_path* pax_u; //!< path to file
+} c3_bile;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! Open/create a binary file.
+//!
+//! @param[in] pax_u  Path handle of binary file.
+//!
+//! @return NULL  `pax_u` is NULL.
+//! @return NULL  File could not be opened/created.
+//! @return NULL  File size could not be determined.
+//! @return       Binary file handle.
+c3_bile*
+c3_bile_open(const c3_path* const pax_u);
+
+//! Append a raw byte array to a binary file.
+//!
+//! If a call to c3_bile_put_raw() fails, the effects of any partial writes will
+//! be abandoned so that the binary file is left in a consistent state.
+//!
+//! @param[in] bil_u  Binary file handle.
+//! @param[in] dat_v  Raw byte array.
+//! @param[in] len_i  Length of `dat_v` in bytes.
+//!
+//! @return 0  `dat_v` is NULL.
+//! @return 0  Failed to write data to binary file.
+//! @return 1  Success.
+c3_t
+c3_bile_put_raw(c3_bile* const    bil_u,
+                const void* const dat_v,
+                const size_t      len_i);
+
+//! Read a raw byte array from a binary file.
+//!
+//! The read occurs from the beginning of the file if c3_bile_get_raw() has not
+//! been called on the binary file since c3_bile_open() was called *or* if the
+//! last call to c3_bile_get_raw() reached EOF. The exact starting position of
+//! the read can be determined by checking the `off_i` field of the c3_bile
+//! handle. If a call to c3_bile_get_raw() fails, the read offset will be
+//! restored to its previous location as if the call was never attempted.
+//!
+//! @param[in]  bil_u  Binary file handle.
+//! @param[out] dat_v  Destination address to write raw byte array to. Must have
+//!                    enough space for `len_i` bytes.
+//! @param[in]  len_i  Length of `dat_v` in bytes.
+//!
+//! @return 0  `dat_v` is NULL.
+//! @return 0  Failed to read data from binary file.
+//! @return 1  Success.
+c3_t
+c3_bile_get_raw(c3_bile* const bil_u, void* const dat_v, const size_t len_i);
+
+//! Gracefully dispose of a binary file's resources. Does not free the binary
+//! file handle itself.
+//!
+//! @param[in] bil_u  Binary file handle.
+void
+c3_bile_close(c3_bile* const bil_u);
+
+#endif /* ifndef C3_BILE_H */

--- a/pkg/urbit/include/c/path.h
+++ b/pkg/urbit/include/c/path.h
@@ -1,0 +1,100 @@
+//! @file path.h
+//!
+//! Canonical-ish path. All references to empty components, `.`, and
+//! `..` are removed, but symlinks are not resolved. The filesystem is not
+//! consulted when reducing a path. As a result, a path like
+//! `fanfun-mocbud/../../../` is reduced to an empty path because it resolves to
+//! the grandparent directory of `fanfun-mocbud`, which cannot be known without
+//! reading from the filesystem.
+
+#ifndef C3_PATH_H
+#define C3_PATH_H
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#include "c/portable.h"
+#include "c/types.h"
+
+//==============================================================================
+// Types
+//==============================================================================
+
+//! Path handle.
+typedef struct {
+  size_t cap_i;   //!< number of bytes allocated for `str_c`
+  size_t len_i;   //!< length of `str_c` (equivalent to `strlen(str_c)`)
+  c3_c   str_c[]; //!< path string (null-terminated)
+} c3_path;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! Determine if two paths are equivalent.
+//!
+//! @param[in] lef_u  Path handle.
+//! @param[in] rih_u  Path handle.
+//!
+//! @return 0  Paths don't match.
+//! @return 1  Paths match.
+static inline c3_t
+c3_path_eq(const c3_path* const lef_u, const c3_path* const rih_u)
+{
+  return lef_u && rih_u && 0 == strcmp(lef_u->str_c, rih_u->str_c);
+}
+
+//! Construct a path from an array of strings.
+//!
+//! @note mnemonic: `c3_path` [f]rom [a]rray -> `c3_path_fa`.
+//!
+//! @param[in] tok_c  Array of path components. Must be valid C strings. If
+//!                   NULL, an empty path is created.
+//! @param[in] tok_i  Number of elements in `toks_c`. If 0, an empty path is
+//!                   created.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fa(const c3_c** toks_c, const size_t tok_i);
+
+//! Construct a path from an existing path.
+//!
+//! @note mnemonic: `c3_path` [f]rom [p]ath -> `c3_path_fp`.
+//!
+//! @param[in] pax_u  Path handle. If NULL, an empty path is created.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fp(const c3_path* const pax_u);
+
+//! Construct a path from a variadic argument sequence.
+//!
+//! @note mnemonic: `c3_path` [f]rom [v]ariadic -> `c3_path_fv`.
+//!
+//! @param[in] tok_i  Number of components of the path. If 0, an empty path is
+//!                   created.
+//! @param[in] ...    Components of the path. Must be valid C string.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fv(const size_t tok_i, ...);
+
+//! Push a component onto the end of a path.
+//!
+//! Pushing `.`, the empty string, or NULL is a no-op. Pushing `..` is
+//! equivalent to calling c3_path_pop() except in the case where the path is `/`
+//! (i.e. `/..` is always `/`).
+//!
+//! @param[in] pax_u  Path handle.
+//! @param[in] tok_c  Path component to append to the path.
+void
+c3_path_push(c3_path* pax_u, const c3_c* const tok_c);
+
+//! Pop a component from the end of a path.
+//!
+//! @param[in] pax_u  Path handle.
+void
+c3_path_pop(c3_path* const pax_u);
+
+#endif /* ifndef C3_PATH_H */

--- a/pkg/urbit/tests/bile_tests.c
+++ b/pkg/urbit/tests/bile_tests.c
@@ -1,0 +1,157 @@
+//! @file bile_tests.c
+
+#include "c/bile.h"
+
+#include "c/defs.h"
+#include "c/portable.h"
+#include "c/types.h"
+
+static inline void
+_cleanup(c3_path* const pax_u, c3_bile* bil_u)
+{
+  c3_free(pax_u);
+  unlink(bil_u->pax_u->str_c);
+  c3_bile_close(bil_u);
+  c3_free(bil_u);
+}
+
+static void
+_test_bile_open(void)
+{
+  {
+    c3_path* const pax_u = c3_path_fv(3, "/", "tmp", "giraffe.bin");
+    c3_bile*       bil_u = c3_bile_open(pax_u);
+    c3_assert(bil_u);
+    c3_assert(0 == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+    _cleanup(pax_u, bil_u);
+  }
+}
+
+static void
+_test_bile_put_get_raw(void)
+{
+  // Put once, get once.
+  {
+    c3_path* const pax_u = c3_path_fv(3, "/", "tmp", "elephant.bin");
+    c3_bile*       bil_u = c3_bile_open(pax_u);
+    c3_assert(bil_u);
+    c3_assert(0 == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+
+    static c3_c inn_c[] = "nile river";
+    c3_assert(c3_bile_put_raw(bil_u, inn_c, sizeof(inn_c)));
+
+    c3_assert(sizeof(inn_c) == bil_u->len_i);
+
+    c3_c out_c[bil_u->len_i];
+    c3_assert(c3_bile_get_raw(bil_u, out_c, sizeof(out_c)));
+    c3_assert(sizeof(inn_c) == bil_u->len_i);
+    c3_assert(0 == strcmp(inn_c, out_c));
+
+    _cleanup(pax_u, bil_u);
+  }
+
+  // Put three times, get three times.
+  {
+    c3_path* const pax_u = c3_path_fv(3, "/", "tmp", "gazelle.bin");
+    c3_bile*       bil_u = c3_bile_open(pax_u);
+    c3_assert(bil_u);
+    c3_assert(0 == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+
+    static c3_c in1_c[] = "zambezi river";
+    c3_assert(c3_bile_put_raw(bil_u, in1_c, sizeof(in1_c)));
+    c3_assert(sizeof(in1_c) == bil_u->len_i);
+
+    static c3_c in2_c[] = "lake victoria";
+    c3_assert(c3_bile_put_raw(bil_u, in2_c, sizeof(in2_c)));
+    c3_assert(sizeof(in1_c) + sizeof(in2_c) == bil_u->len_i);
+
+    static c3_c in3_c[] = "great rift valley";
+    c3_assert(c3_bile_put_raw(bil_u, in3_c, sizeof(in3_c)));
+    c3_assert(sizeof(in1_c) + sizeof(in2_c) + sizeof(in3_c) == bil_u->len_i);
+
+    c3_c ou1_c[sizeof(in1_c)];
+    c3_assert(c3_bile_get_raw(bil_u, ou1_c, sizeof(ou1_c)));
+    c3_assert(0 == strcmp(in1_c, ou1_c));
+
+    c3_c ou2_c[sizeof(in2_c)];
+    c3_assert(c3_bile_get_raw(bil_u, ou2_c, sizeof(ou2_c)));
+    c3_assert(0 == strcmp(in2_c, ou2_c));
+
+    c3_c ou3_c[sizeof(in3_c)];
+    c3_assert(c3_bile_get_raw(bil_u, ou3_c, sizeof(ou3_c)));
+    c3_assert(0 == strcmp(in3_c, ou3_c));
+
+    _cleanup(pax_u, bil_u);
+  }
+
+  // Put once, close, get once.
+  {
+    c3_path* const pax_u = c3_path_fv(3, "/", "tmp", "hippo.bin");
+    c3_bile*       bil_u = c3_bile_open(pax_u);
+    c3_assert(bil_u);
+    c3_assert(0 == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+
+    static c3_c inn_c[] = "bandama river";
+    c3_assert(c3_bile_put_raw(bil_u, inn_c, sizeof(inn_c)));
+
+    c3_assert(sizeof(inn_c) == bil_u->len_i);
+
+    c3_bile_close(bil_u);
+
+    c3_assert(bil_u = c3_bile_open(pax_u));
+    c3_assert(sizeof(inn_c) == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+
+    c3_c out_c[sizeof(inn_c)];
+    c3_assert(c3_bile_get_raw(bil_u, out_c, sizeof(out_c)));
+    c3_assert(sizeof(inn_c) == bil_u->len_i);
+    c3_assert(0 == strcmp(inn_c, out_c));
+
+    _cleanup(pax_u, bil_u);
+  }
+
+  // Put once, get once, put once, get once.
+  {
+    c3_path* const pax_u = c3_path_fv(3, "/", "tmp", "crocodile.bin");
+    c3_bile*       bil_u = c3_bile_open(pax_u);
+    c3_assert(bil_u);
+    c3_assert(0 == bil_u->len_i);
+    c3_assert(c3_path_eq(pax_u, bil_u->pax_u));
+
+    static c3_c in1_c[] = "okavango river";
+    c3_assert(c3_bile_put_raw(bil_u, in1_c, sizeof(in1_c)));
+    c3_assert(sizeof(in1_c) == bil_u->len_i);
+
+    c3_c ou1_c[sizeof(in1_c)];
+    c3_assert(c3_bile_get_raw(bil_u, ou1_c, sizeof(ou1_c)));
+    c3_assert(0 == strcmp(in1_c, ou1_c));
+
+    static c3_c in2_c[] = "volta river";
+    c3_assert(c3_bile_put_raw(bil_u, in2_c, sizeof(in2_c)));
+    c3_assert(sizeof(in1_c) + sizeof(in2_c) == bil_u->len_i);
+
+    c3_assert(c3_bile_get_raw(bil_u, ou1_c, sizeof(ou1_c)));
+    c3_assert(0 == strcmp(in1_c, ou1_c));
+
+    c3_c ou2_c[sizeof(in2_c)];
+    c3_assert(c3_bile_get_raw(bil_u, ou2_c, sizeof(ou2_c)));
+    c3_assert(0 == strcmp(in2_c, ou2_c));
+
+    _cleanup(pax_u, bil_u);
+  }
+}
+
+int
+main(int argc, char* argv[])
+{
+  _test_bile_open();
+  _test_bile_put_get_raw();
+
+  fprintf(stderr, "test_bile: ok\r\n");
+
+  return 0;
+}

--- a/pkg/urbit/tests/path_tests.c
+++ b/pkg/urbit/tests/path_tests.c
@@ -1,0 +1,238 @@
+//! @file path_tests.c
+
+#include "c/path.h"
+
+#include "c/defs.h"
+#include "c/portable.h"
+#include "c/types.h"
+
+static void
+_test_path_fv(void)
+{
+  // Empty path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(0));
+    c3_assert(0 == strcmp("", pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with one component.
+  {
+    static const c3_c* const exp_c = "fanfun-mocbud";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "fanfun-mocbud"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with one component.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "/"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with two components.
+  {
+    static const c3_c* const exp_c = "~/master-morzod";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "~", "master-morzod"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with two components.
+  {
+    static const c3_c* const exp_c = "/silsyn-wathep";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "/", "silsyn-wathep"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with more than two components.
+  {
+    static const c3_c* const exp_c
+      = "a/really/long/relative/path/with_underscores/and-dashes";
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(7,
+                                 "a",
+                                 "really",
+                                 "long",
+                                 "relative",
+                                 "path",
+                                 "with_underscores",
+                                 "and-dashes"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with more than two components.
+  {
+    static const c3_c* const exp_c
+      = "/a/really/long/ABSOLUTE/path/with_underscores/and-dashes";
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(8,
+                                 "/",
+                                 "a",
+                                 "really",
+                                 "long",
+                                 "ABSOLUTE",
+                                 "path",
+                                 "with_underscores",
+                                 "and-dashes"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute non-canonical path with three components.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(3, "/", "tmp", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative non-canonical path with five components.
+  {
+    static const c3_c* const exp_c = "fanfun-mocbud";
+    c3_path*                 pax_u;
+    c3_assert(pax_u
+              = c3_path_fv(5, "fanfun-mocbud", ".urb", "log", "..", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute non-canonical path with two components.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "/", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+}
+
+static void
+_test_path_push_pop(void)
+{
+  // Absolute path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "/"));
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_push(pax_u, "fanfun");
+    c3_assert(0 == strcmp("/fanfun", pax_u->str_c));
+
+    c3_path_push(pax_u, "mocbud");
+    c3_assert(0 == strcmp("/fanfun/mocbud", pax_u->str_c));
+
+    c3_path_push(pax_u, "some-moon-name");
+    c3_assert(0 == strcmp("/fanfun/mocbud/some-moon-name", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/fanfun/mocbud", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/fanfun", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("", pax_u->str_c));
+    c3_assert(0 == pax_u->len_i);
+
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+
+    c3_free(pax_u);
+  }
+
+  // Push special components onto relative path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "~", "fanfun-mocbud"));
+
+    c3_path_push(pax_u, "its-snack-time");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, ".");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, "");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, NULL);
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("~/fanfun-mocbud", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("~", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("", pax_u->str_c));
+
+    c3_path_push(pax_u, "/");
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_free(pax_u);
+  }
+
+  // Start with empty path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(0));
+
+    c3_path_push(pax_u, "a");
+    c3_assert(0 == strcmp("a", pax_u->str_c));
+
+    c3_path_push(pax_u, "b");
+    c3_assert(0 == strcmp("a/b", pax_u->str_c));
+
+    c3_path_push(pax_u, "c");
+    c3_assert(0 == strcmp("a/b/c", pax_u->str_c));
+
+    c3_path_push(pax_u, "d");
+    c3_assert(0 == strcmp("a/b/c/d", pax_u->str_c));
+
+    c3_path_push(pax_u, "e");
+    c3_assert(0 == strcmp("a/b/c/d/e", pax_u->str_c));
+
+    c3_path_push(pax_u, "f");
+    c3_assert(0 == strcmp("a/b/c/d/e/f", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+
+    c3_assert(0 == strcmp("", pax_u->str_c));
+
+    c3_free(pax_u);
+  }
+}
+
+int
+main(int argc, char* argv[])
+{
+  _test_path_fv();
+  _test_path_push_pop();
+
+  fprintf(stderr, "test_path: ok\r\n");
+
+  return 0;
+}


### PR DESCRIPTION
Write/read arbitrary byte arrays to/ from a file. Features:
- Simple interface
- Handles retries of partial reads and writes, which is a risk associated with the `read()` and `write()` system calls (respectively).

This interface has at least two cases (that I can think of) in the runtime:
(1) Event log metadata storage in the new epoch-based event log. Storing event log metadata in each epoch's LMDB instance is unnecessarily redundant, and having a full-blown LMDB instance specifically for four pieces of metadata (ship name, lifecycle length, whether the ship is fake, and version number) is overkill. One or more binary files containing the metadata is simpler and easier to interact with.
(2) Snapshot file management. The current snapshot implementation in [events.c](https://github.com/urbit/urbit/tree/peter/file/pkg/urbit/noun/events.c) uses the raw `read()` and `write()` system calls to read/write snapshot patch and image files, which are already binary files. Using the `c3_bile_*` interface in the snapshot module will reduce the complexity of a vital module.

More generally, it's a useful primitive that I suspect will come in handy in the future.

Tests:
See [bile_tests.c](https://github.com/urbit/urbit/tree/peter/file/pkg/urbit/tests/bile_tests.c).