### PR TITLE
c3: reimplement c3_list_* macros as inline functions

### DIFF
--- a/pkg/urbit/c/list.c
+++ b/pkg/urbit/c/list.c
@@ -38,31 +38,29 @@ c3_list_push(c3_list* const    lis_u,
   else {
     if ( C3_LIST_FRONT == end_i ) {
       lis_u->fro_u->pre_u = nod_u;
-      nod_u->nex_u = lis_u->fro_u;
-      lis_u->fro_u = nod_u;
+      nod_u->nex_u        = lis_u->fro_u;
+      lis_u->fro_u        = nod_u;
     }
     else {
       lis_u->bak_u->nex_u = nod_u;
-      nod_u->pre_u = lis_u->bak_u;
-      lis_u->bak_u = nod_u;
+      nod_u->pre_u        = lis_u->bak_u;
+      lis_u->bak_u        = nod_u;
     }
   }
   lis_u->len_i++;
 }
 
 c3_list_node*
-c3_list_peek(const c3_list* const lis_u,
-             const c3_list_end    end_i)
+c3_list_peek(const c3_list* const lis_u, const c3_list_end end_i)
 {
   if ( 0 == c3_list_len(lis_u) ) {
     return NULL;
   }
-  return ( C3_LIST_FRONT == end_i ) ? lis_u->fro_u : lis_u->bak_u;
+  return (C3_LIST_FRONT == end_i) ? lis_u->fro_u : lis_u->bak_u;
 }
 
 c3_list_node*
-c3_list_pop(c3_list* const    lis_u,
-            const c3_list_end end_i)
+c3_list_pop(c3_list* const lis_u, const c3_list_end end_i)
 {
   if ( 0 == c3_list_len(lis_u) ) {
     return NULL;
@@ -70,7 +68,7 @@ c3_list_pop(c3_list* const    lis_u,
 
   c3_list_node* nod_u;
   if ( C3_LIST_FRONT == end_i ) {
-    nod_u = lis_u->fro_u; 
+    nod_u        = lis_u->fro_u;
     lis_u->fro_u = lis_u->fro_u->nex_u;
     if ( !lis_u->fro_u ) {
       lis_u->bak_u = NULL;
@@ -80,7 +78,7 @@ c3_list_pop(c3_list* const    lis_u,
     }
   }
   else {
-    nod_u = lis_u->bak_u;
+    nod_u        = lis_u->bak_u;
     lis_u->bak_u = lis_u->bak_u->pre_u;
     if ( !lis_u->bak_u ) {
       lis_u->fro_u = NULL;

--- a/pkg/urbit/include/c/list.h
+++ b/pkg/urbit/include/c/list.h
@@ -16,16 +16,16 @@
 
 //!< Doubly-linked list node.
 typedef struct _c3_list_node {
-  struct _c3_list_node* nex_u;    //!< next node
-  struct _c3_list_node* pre_u;    //!< previous node
-  c3_y                  dat_y[];  //!< payload data
+  struct _c3_list_node* nex_u;   //!< next node
+  struct _c3_list_node* pre_u;   //!< previous node
+  c3_y                  dat_y[]; //!< payload data
 } c3_list_node;
 
 //!< Doubly-linked list handle.
 typedef struct {
-  c3_list_node* fro_u;  //!< node at front of list
-  c3_list_node* bak_u;  //!< node at back of list
-  size_t        len_i;  //!< number of nodes in list
+  c3_list_node* fro_u; //!< node at front of list
+  c3_list_node* bak_u; //!< node at back of list
+  size_t        len_i; //!< number of nodes in list
 } c3_list;
 
 //! Sentinel values used to indicate the end of the list to operate on.
@@ -39,44 +39,34 @@ typedef enum {
 //==============================================================================
 
 //! Number of nodes in `lis`.
-#define c3_list_len(lis)                                                       \
-  ((lis) ? (lis)->len_i : 0)
+#define c3_list_len(lis)             ((lis) ? (lis)->len_i : 0)
 
 //! Get back node from `lis`.
-#define c3_list_peekb(lis)                                                     \
-  c3_list_peek(lis, C3_LIST_BACK)
+#define c3_list_peekb(lis)           c3_list_peek(lis, C3_LIST_BACK)
 
 //! Get front node from `lis`.
-#define c3_list_peekf(lis)                                                     \
-  c3_list_peek(lis, C3_LIST_FRONT)
+#define c3_list_peekf(lis)           c3_list_peek(lis, C3_LIST_FRONT)
 
 //! Push a new node onto the back of `lis`.
-#define c3_list_pushb(lis, dat, siz)                                           \
-  c3_list_push(lis, C3_LIST_BACK, dat, siz)
+#define c3_list_pushb(lis, dat, siz) c3_list_push(lis, C3_LIST_BACK, dat, siz)
 
 //! Push a new node onto the front of `lis`.
-#define c3_list_pushf(lis, dat, siz)                                           \
-  c3_list_push(lis, C3_LIST_FRONT, dat, siz)
+#define c3_list_pushf(lis, dat, siz) c3_list_push(lis, C3_LIST_FRONT, dat, siz)
 
 //! Pop back node from `lis`.
-#define c3_list_popb(lis)                                                      \
-  c3_list_pop(lis, C3_LIST_BACK)
+#define c3_list_popb(lis)            c3_list_pop(lis, C3_LIST_BACK)
 
 //! Pop front node from `lis`.
-#define c3_list_popf(lis)                                                      \
-  c3_list_pop(lis, C3_LIST_FRONT)
+#define c3_list_popf(lis)            c3_list_pop(lis, C3_LIST_FRONT)
 
 //! Get the successor node of `nod`. NULL if `nod` is the back of the list.
-#define c3_list_next(nod)                                                      \
-  ((nod) ? (nod)->nex_u : NULL)
+#define c3_list_next(nod)            ((nod) ? (nod)->nex_u : NULL)
 
 //! Get the predecessor node of `nod`. NULL if `nod` is the front of the list.
-#define c3_list_prev(nod)                                                      \
-  ((nod) ? (nod)->pre_u : NULL)
+#define c3_list_prev(nod)            ((nod) ? (nod)->pre_u : NULL)
 
 //! Extract the payload data from `nod` as a raw pointer. MUST NOT be freed.
-#define c3_list_data(nod)                                                      \
-  ((void*)((nod)->dat_y))
+#define c3_list_data(nod)            ((void*)((nod)->dat_y))
 
 //==============================================================================
 // Functions
@@ -118,21 +108,19 @@ c3_list_push(c3_list* const    lis_u,
 //! @return NULL  `lis_u` is empty.
 //! @return       Specified end node of `lis_u`. MUST NOT be freed by caller.
 c3_list_node*
-c3_list_peek(const c3_list* const lis_u,
-             const c3_list_end    end_i);
+c3_list_peek(const c3_list* const lis_u, const c3_list_end end_i);
 
 //! Remove an end node from `lis_u`.
 //!
 //! @param[in] lis_u  If NULL, behavior is undefined.
 //! @param[in] end_i  If C3_LIST_FRONT, pop the front of `lis_u`.
-//                    If C3_LIST_BACK, pop the back of `lis_u`.
-//                    If neither C3_LIST_FRONT nor C3_LIST_BACK, behavior is
-//                    undefined.
+// If C3_LIST_BACK, pop the back of `lis_u`.
+// If neither C3_LIST_FRONT nor C3_LIST_BACK, behavior is
+// undefined.
 //
 //! @return NULL  `lis_u` is empty.
 //! @return       Specified end node of `lis_u`. MUST be freed by caller.
 c3_list_node*
-c3_list_pop(c3_list* const    lis_u,
-            const c3_list_end end_i);
+c3_list_pop(c3_list* const lis_u, const c3_list_end end_i);
 
 #endif /* ifndef C3_LIST_H */

--- a/pkg/urbit/include/c/list.h
+++ b/pkg/urbit/include/c/list.h
@@ -14,59 +14,32 @@
 // Types
 //==============================================================================
 
-//!< Doubly-linked list node.
+//! Doubly-linked list node.
+//!
+//! The next, previous, and data fields should never be accessed
+//! directly for compatibility reasons. Instead, use c3_list_next(),
+//! c3_list_prev(), and c3_list_data() (respectively).
 typedef struct _c3_list_node {
   struct _c3_list_node* nex_u;   //!< next node
   struct _c3_list_node* pre_u;   //!< previous node
   c3_y                  dat_y[]; //!< payload data
 } c3_list_node;
 
-//!< Doubly-linked list handle.
+//! Doubly-linked list handle.
+//!
+//! The length field should never be accessed directly for compatibility
+//! reasons. Instead, use c3_list_len().
 typedef struct {
   c3_list_node* fro_u; //!< node at front of list
   c3_list_node* bak_u; //!< node at back of list
   size_t        len_i; //!< number of nodes in list
 } c3_list;
 
-//! Sentinel values used to indicate the end of the list to operate on.
+//! Sentinel values used to indicate which end of the list to operate on.
 typedef enum {
   C3_LIST_FRONT = 0,
   C3_LIST_BACK  = 1,
 } c3_list_end;
-
-//==============================================================================
-// Macros
-//==============================================================================
-
-//! Number of nodes in `lis`.
-#define c3_list_len(lis)             ((lis) ? (lis)->len_i : 0)
-
-//! Get back node from `lis`.
-#define c3_list_peekb(lis)           c3_list_peek(lis, C3_LIST_BACK)
-
-//! Get front node from `lis`.
-#define c3_list_peekf(lis)           c3_list_peek(lis, C3_LIST_FRONT)
-
-//! Push a new node onto the back of `lis`.
-#define c3_list_pushb(lis, dat, siz) c3_list_push(lis, C3_LIST_BACK, dat, siz)
-
-//! Push a new node onto the front of `lis`.
-#define c3_list_pushf(lis, dat, siz) c3_list_push(lis, C3_LIST_FRONT, dat, siz)
-
-//! Pop back node from `lis`.
-#define c3_list_popb(lis)            c3_list_pop(lis, C3_LIST_BACK)
-
-//! Pop front node from `lis`.
-#define c3_list_popf(lis)            c3_list_pop(lis, C3_LIST_FRONT)
-
-//! Get the successor node of `nod`. NULL if `nod` is the back of the list.
-#define c3_list_next(nod)            ((nod) ? (nod)->nex_u : NULL)
-
-//! Get the predecessor node of `nod`. NULL if `nod` is the front of the list.
-#define c3_list_prev(nod)            ((nod) ? (nod)->pre_u : NULL)
-
-//! Extract the payload data from `nod` as a raw pointer. MUST NOT be freed.
-#define c3_list_data(nod)            ((void*)((nod)->dat_y))
 
 //==============================================================================
 // Functions
@@ -78,6 +51,34 @@ typedef enum {
 //!          disposal.
 c3_list*
 c3_list_init(void);
+
+//! Get number of nodes in a list.
+static inline size_t
+c3_list_len(const c3_list* const lis_u)
+{
+  return lis_u ? lis_u->len_i : 0;
+}
+
+//! Get the successor node of a list node.
+static inline c3_list_node*
+c3_list_next(const c3_list_node* const nod_u)
+{
+  return nod_u->nex_u;
+}
+
+//! Get the predecessor node of a list node.
+static inline c3_list_node*
+c3_list_prev(const c3_list_node* const nod_u)
+{
+  return nod_u->pre_u;
+}
+
+//! Get the payload data from a list node.
+static inline void*
+c3_list_data(const c3_list_node* const nod_u)
+{
+  return (void*)nod_u->dat_y;
+}
 
 //! Add a new node onto the end of `lis_u`.
 //!
@@ -97,6 +98,20 @@ c3_list_push(c3_list* const    lis_u,
              const void* const dat_v,
              const size_t      siz_i);
 
+//! Push a new node onto the back of a list. See c3_list_push().
+static inline void
+c3_list_pushb(c3_list* const lis_u, const void* const dat_v, const size_t siz_i)
+{
+  c3_list_push(lis_u, C3_LIST_BACK, dat_v, siz_i);
+}
+
+//! Push a new node onto the front of a list. See c3_list_push().
+static inline void
+c3_list_pushf(c3_list* const lis_u, const void* const dat_v, const size_t siz_i)
+{
+  c3_list_push(lis_u, C3_LIST_FRONT, dat_v, siz_i);
+}
+
 //! Get an end node from `lis_u`.
 //!
 //! @param[in] lis_u  If NULL, behavior is undefined.
@@ -110,6 +125,20 @@ c3_list_push(c3_list* const    lis_u,
 c3_list_node*
 c3_list_peek(const c3_list* const lis_u, const c3_list_end end_i);
 
+//! Get back node from a list. See c3_list_peek().
+static inline c3_list_node*
+c3_list_peekb(const c3_list* const lis_u)
+{
+  return c3_list_peek(lis_u, C3_LIST_BACK);
+}
+
+//! Get front node from a list. See c3_list_peek().
+static inline c3_list_node*
+c3_list_peekf(const c3_list* const lis_u)
+{
+  return c3_list_peek(lis_u, C3_LIST_FRONT);
+}
+
 //! Remove an end node from `lis_u`.
 //!
 //! @param[in] lis_u  If NULL, behavior is undefined.
@@ -122,5 +151,19 @@ c3_list_peek(const c3_list* const lis_u, const c3_list_end end_i);
 //! @return       Specified end node of `lis_u`. MUST be freed by caller.
 c3_list_node*
 c3_list_pop(c3_list* const lis_u, const c3_list_end end_i);
+
+//! Pop back node from a list. See c3_list_pop().
+static inline c3_list_node*
+c3_list_popb(c3_list* const lis_u)
+{
+  return c3_list_pop(lis_u, C3_LIST_BACK);
+}
+
+//! Pop front node from a list. See c3_list_pop().
+static inline c3_list_node*
+c3_list_popf(c3_list* const lis_u)
+{
+  return c3_list_pop(lis_u, C3_LIST_FRONT);
+}
 
 #endif /* ifndef C3_LIST_H */

--- a/pkg/urbit/tests/list_tests.c
+++ b/pkg/urbit/tests/list_tests.c
@@ -2,11 +2,11 @@
 
 #include "c/list.h"
 
+#include "c/defs.h"
 #include "c/portable.h"
 #include "c/types.h"
-#include "c/defs.h"
 
-#define _arrlen(arr) (sizeof(arr)/sizeof(arr[0]))
+#define _arrlen(arr) (sizeof(arr) / sizeof(arr[0]))
 
 static void
 _test_init(void)
@@ -40,7 +40,7 @@ _test_push_back(void)
 {
   // Push a bunch of numbers.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
     c3_assert(lis_u = c3_list_init());
     c3_assert(!c3_list_peekb(lis_u));
@@ -59,9 +59,9 @@ _test_push_back(void)
 
   // Push a bunch of strings.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
-    static char* strs_c[] = {
+    static char*  strs_c[] = {
       "antonio",
       "bingbing",
       "catherine",
@@ -90,7 +90,7 @@ _test_push_front(void)
 {
   // Push a bunch of numbers.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
     c3_assert(lis_u = c3_list_init());
     c3_assert(!c3_list_peekf(lis_u));
@@ -109,9 +109,9 @@ _test_push_front(void)
 
   // Push a bunch of strings.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
-    static char* strs_c[] = {
+    static char*  strs_c[] = {
       "antonio",
       "bingbing",
       "catherine",
@@ -140,7 +140,7 @@ _test_push_mixed(void)
 {
   // Push even numbers onto the front and odd numbers onto the back.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
     c3_assert(lis_u = c3_list_init());
     size_t len_i = 100;
@@ -163,7 +163,7 @@ _test_pop_back(void)
 {
   // Push a bunch of numbers onto the front and then pop them off the back.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
     c3_assert(lis_u = c3_list_init());
     c3_assert(!c3_list_peekf(lis_u));
@@ -194,9 +194,9 @@ _test_pop_back(void)
 
   // Push a bunch of strings onto the front and then pop them off the back.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
-    static char* strs_c[] = {
+    static char*  strs_c[] = {
       "antonio",
       "bingbing",
       "catherine",
@@ -238,7 +238,7 @@ _test_pop_front(void)
 {
   // Push a bunch of numbers onto the back and then pop them off the front.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
     c3_assert(lis_u = c3_list_init());
     c3_assert(!c3_list_peekb(lis_u));
@@ -269,11 +269,12 @@ _test_pop_front(void)
 
   // Push a bunch of strings.
   {
-    c3_list* lis_u;
+    c3_list*      lis_u;
     c3_list_node* nod_u;
-    static char* strs_c[] = {
+    static char*  strs_c[] = {
       "antonio",
-      "bingbing", "catherine",
+      "bingbing",
+      "catherine",
       "deandre",
       "emir",
     };
@@ -318,7 +319,7 @@ _test_iter(void)
     }
 
     c3_list_node* nod_u = c3_list_peekf(lis_u);
-    size_t idx_i = 0;
+    size_t        idx_i = 0;
     while ( nod_u ) {
       c3_assert(idx_i++ == *(size_t*)c3_list_data(nod_u));
       nod_u = c3_list_next(nod_u);
@@ -334,7 +335,7 @@ _test_iter(void)
     }
 
     c3_list_node* nod_u = c3_list_peekb(lis_u);
-    size_t idx_i = 0;
+    size_t        idx_i = 0;
     while ( nod_u ) {
       c3_assert(idx_i++ == *(size_t*)c3_list_data(nod_u));
       nod_u = c3_list_prev(nod_u);


### PR DESCRIPTION
Reimplement the `c3_list_len()`, `c3_list_next()`, `c3_list_prev()`, and `c3_list_data()` macros as inline functions. There is no performance penalty for doing so, we get the added benefit of type safety and a generally more clear interface.

Tests:
All tests in [lists_tests.c](https://github.com/urbit/urbit/tree/peter/list/pkg/urbit/tests/list_tests.c) pass.