### PR TITLE
groups: Fix markdown styling around ship names in chat messages

### DIFF
--- a/pkg/interface/src/views/components/MentionText.tsx
+++ b/pkg/interface/src/views/components/MentionText.tsx
@@ -40,8 +40,9 @@ export function MentionText(props: MentionTextProps) {
 export function Mention(props: {
   ship: string;
   first?: boolean;
+  emphasis?: 'bold' | 'italic';
 } & PropFunc<typeof Text>) {
-  const { ship, first = false, ...rest } = props;
+  const { ship, first = false, emphasis, ...rest } = props;
   const contact = useContact(`~${deSig(ship)}`);
   const showNickname = useShowNickname(contact);
   const name = showNickname ? contact?.nickname : cite(ship);
@@ -51,8 +52,10 @@ export function Mention(props: {
         marginLeft={first? 0 : 1}
         marginRight={1}
         px={1}
+        bold={emphasis === 'bold' ? true : false}
         bg='washedBlue'
         color='blue'
+        fontStyle={emphasis === 'italic' ? 'italic' : undefined}
         fontSize={showNickname ? 1 : 0}
         mono={!showNickname}
         title={showNickname ? cite(ship) : contact?.nickname}

--- a/pkg/npm/api/graph/types.ts
+++ b/pkg/npm/api/graph/types.ts
@@ -41,6 +41,7 @@ export interface AppReference {
 
 export interface MentionContent {
   mention: string;
+  emphasis?: 'bold' | 'italic';
 }
 export type Content =
   | TextContent


### PR DESCRIPTION
Fixes https://github.com/urbit/landscape/issues/1134

Note that this bypasses remark, which seems necessary for our purposes (and we can just style `<Mention />` directly), but I could be wrong.

To test: send messages like these in any chat:
```
yo *~zod*, what's up?
yo *~zod*
hey **~zod**
hey **~zod**, how've you been?
```