### PR TITLE
hoon: move $cape, $wine definitions to layer four

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6608,6 +6608,27 @@
           ==                                            ::
 +$  what  (unit (pair cord (list sect)))                ::  help slogan/section
 +$  wing  (list limb)                                   ::  search path
++$  cape  (pair (map @ud wine) wine)                    ::
++$  wine                                                ::
+          $@  $?  %noun                                 ::
+                  %path                                 ::
+                  %type                                 ::
+                  %void                                 ::
+                  %wall                                 ::
+                  %wool                                 ::
+                  %yarn                                 ::
+              ==                                        ::
+          $%  [%mato p=term]                            ::
+              [%core p=(list @ta) q=wine]               ::
+              [%face p=term q=wine]                     ::
+              [%list p=term q=wine]                     ::
+              [%pear p=term q=@]                        ::
+              [%bcwt p=(list wine)]                     ::
+              [%plot p=(list wine)]                     ::
+              [%stop p=@ud]                             ::
+              [%tree p=term q=wine]                     ::
+              [%unit p=term q=wine]                     ::
+          ==                                            ::
 ::
 ::  +block: abstract identity of resource awaited
 ::
@@ -10893,29 +10914,6 @@
     ==
   --
 ++  us                                                  ::  prettyprinter
-  =>  |%
-      +$  cape  [p=(map @ud wine) q=wine]               ::
-      +$  wine                                          ::
-                $@  $?  %noun                           ::
-                        %path                           ::
-                        %type                           ::
-                        %void                           ::
-                        %wall                           ::
-                        %wool                           ::
-                        %yarn                           ::
-                    ==                                  ::
-                $%  [%mato p=term]                      ::
-                    [%core p=(list @ta) q=wine]         ::
-                    [%face p=term q=wine]               ::
-                    [%list p=term q=wine]               ::
-                    [%pear p=term q=@]                  ::
-                    [%bcwt p=(list wine)]               ::
-                    [%plot p=(list wine)]               ::
-                    [%stop p=@ud]                       ::
-                    [%tree p=term q=wine]               ::
-                    [%unit p=term q=wine]               ::
-                ==                                      ::
-      --
   |_  sut=type
   ++  dash
     |=  [mil=tape lim=char lam=tape]


### PR DESCRIPTION
The modernisation of syntax that occurred in a539d986 evidently had the perverse effect of ballooning the size of the type/nock pair produced by +mint in certain cases (namely, when compiling the compiler itself), entirely due to the presence of these definitions in the subject of +us, the prettyprinter core.

Some benchmarks:

```
edf82f compiler compiling edf82f compiler:
> (met 3 (jam jnock))
1.643.757

edf82f compiler compiling edf82f compiler w/L4 cape/wine:
> (met 3 (jam jnock))
508.725

edf82f compiler w/L4 cape/wine compiling edf82f compiler:
> (met 3 (jam jnock))
631.855

edf82f compiler w/L4 cape/wine compiling edf82f compiler w/L4 cape/wine:
> (met 3 (jam jnock))
508.707
```

The ballooning in the size of the produced type/Nock seems to be unnecessary, as ship operation using the modified compiler appears to be unaffected, and the test suite continues to pass.