### PR TITLE
groups: handle unsigged group links in join

### DIFF
--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -229,6 +229,18 @@ export function deSig(ship: string): string {
   return ship.replace('~', '');
 }
 
+export function preSig(ship: string): string {
+  if (!ship) {
+    return '';
+  }
+
+  if (ship.startsWith('~')) {
+    return ship;
+  }
+
+  return '~'.concat(ship);
+}
+
 export function uxToHex(ux: string) {
   if (ux.length > 2 && ux.substr(0, 2) === '0x') {
     const value = ux.substr(2).replace('.', '').padStart(6, '0');

--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -234,11 +234,11 @@ export function preSig(ship: string): string {
     return '';
   }
 
-  if (ship.startsWith('~')) {
-    return ship;
+  if (ship.trim().startsWith('~')) {
+    return ship.trim();
   }
 
-  return '~'.concat(ship);
+  return '~'.concat(ship.trim());
 }
 
 export function uxToHex(ux: string) {

--- a/pkg/interface/src/views/landscape/components/Join/Join.tsx
+++ b/pkg/interface/src/views/landscape/components/Join/Join.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   ManagedTextInputField,
   ManagedCheckboxField,
-  ContinuousProgressBar,
+  ContinuousProgressBar
 } from '@tlon/indigo-react';
 import { Formik, Form } from 'formik';
 import React, { useEffect, useState } from 'react';
@@ -20,6 +20,7 @@ import airlock from '~/logic/api';
 import { joinError, joinLoad, JoinProgress } from '@urbit/api';
 import { useQuery } from '~/logic/lib/useQuery';
 import { JoinKind, JoinDesc, JoinSkeleton } from './Skeleton';
+import { preSig } from '~/logic/lib/util';
 
 interface InviteWithUid extends Invite {
   uid: string;
@@ -32,7 +33,7 @@ interface FormSchema {
 
 const initialValues = {
   autojoin: false,
-  shareContact: false,
+  shareContact: false
 };
 
 function JoinForm(props: {
@@ -173,7 +174,6 @@ function JoinError(props: {
     useGroupState.getState().abortJoin(desc.group);
     dismiss();
   };
-  
 
   return (
     <JoinSkeleton modal={modal} title={title} desc={desc}>
@@ -272,7 +272,7 @@ export function JoinPrompt(props: JoinPromptProps) {
   };
 
   const onSubmit = async ({ link }: PromptFormSchema) => {
-    const path = `/ship/${link}`;
+    const path = `/ship/${preSig(link)}`;
     history.push({
       search: appendQuery({ 'join-path': path })
     });


### PR DESCRIPTION
Fixes: https://github.com/urbit/landscape/issues/1404

Adds a new func to utils, "preSig", which takes a string and checks for a sig, returning that string if the sig already exists, otherwise returning a sigged string.