### PR TITLE
npm: add preSig func to npm lib

### DIFF
--- a/pkg/npm/api/lib/lib.ts
+++ b/pkg/npm/api/lib/lib.ts
@@ -141,6 +141,18 @@ export function dateToDa(d: Date, mil: boolean = false): string {
   );
 }
 
+export function preSig(ship: string): string {
+  if (!ship) {
+    return '';
+  }
+
+  if (ship.trim().startsWith('~')) {
+    return ship.trim();
+  }
+
+  return '~'.concat(ship.trim());
+}
+
 export function deSig(ship: string): string | null {
   if (!ship) {
     return null;


### PR DESCRIPTION
Adds the preSig func originally added in https://github.com/urbit/urbit/pull/5632
