### PR TITLE
ames: fix %dangling-bone error

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b187510f9f6ab95c9dd53889121e92db349633c113049e9ef5bdb0b879390e89
-size 9489162
+oid sha256:fc24e71a9368f6f76344c364e76fe91baea7eeb2abbc5c9f272b2b94cdd3292f
+size 9623047

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -342,8 +342,8 @@
   =/  =pass
     (pass-from-eth:azimuth [32^crypt 32^auth suite]:keys.net)
   ^-  (list [@p udiff:point])
-  :*  [ship id %keys [life.keys.net suite.keys.net pass] %.y]
-      [ship id %rift rift.net %.y]
+  :*  [ship id %rift rift.net %.y]
+      [ship id %keys [life.keys.net suite.keys.net pass] %.y]
       [ship id %spon ?:(has.sponsor.net `who.sponsor.net ~)]
       udiffs
   ==

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -342,8 +342,8 @@
   =/  =pass
     (pass-from-eth:azimuth [32^crypt 32^auth suite]:keys.net)
   ^-  (list [@p udiff:point])
-  :*  [ship id %rift rift.net %.y]
-      [ship id %keys [life.keys.net suite.keys.net pass] %.y]
+  :*  [ship id %keys [life.keys.net suite.keys.net pass] %.y]
+      [ship id %rift rift.net %.y]
       [ship id %spon ?:(has.sponsor.net `who.sponsor.net ~)]
       udiffs
   ==

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -530,6 +530,7 @@
     ::  where an index is specified, the array is generally sorted by those.
     ::
     ::  { life: 123,
+    ::    rift: 0,
     ::    route: { direct: true, lane: 'something' },
     ::    qos: { kind: 'status', last-contact: 123456 },  // ms timestamp
     ::    flows: { forward: [snd, rcv, ...], backward: [snd, rcv, ...] }
@@ -590,6 +591,9 @@
       |=  peer-state
       %-  pairs
       :~  'life'^(numb life)
+          ::  TODO: needs to be updated in /pkg/interface/dbug
+          ::
+          'rift'^(numb rift)
         ::
           :-  'route'
           %+  maybe  route

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -59,7 +59,7 @@
           [r=@uxD g=@uxD b=@uxD]                        ::  24bit true color
 +$  turf  (list @t)                                     ::  domain, tld first
 ::                                                      ::::
-::::                      ++ethereum-types                ::  eth surs for jael
+::::                    ++ethereum-types                  ::  eth surs for jael
   ::                                                    ::::
 ++  ethereum-types
   |%
@@ -73,7 +73,7 @@
   ++  events  (set event-id)
   --
 ::                                                      ::::
-::::                      ++azimuth-types                 ::  az surs for jael
+::::                    ++azimuth-types                   ::  az surs for jael
   ::                                                    ::::
 ++  azimuth-types
   =,  ethereum-types
@@ -153,7 +153,7 @@
       [%plea =ship =plea:ames]
   ==
 ::                                                      ::::
-::::                      ++http                        ::
+::::                    ++http                          ::
   ::                                                    ::::
 ::  http: shared representations of http concepts
 ::
@@ -340,7 +340,7 @@
     ==
   --
 ::                                                      ::::
-::::                      ++ames                          ::  (1a) network
+::::                    ++ames                            ::  (1a) network
   ::                                                    ::::
 ++  ames  ^?
   |%
@@ -513,6 +513,7 @@
   +$  peer-state
     $:  $:  =symmetric-key
             =life
+            =rift
             =public-key
             sponsor=ship
         ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1220,8 +1220,8 @@
     ?~  parsed=(parse-bone-wire wire)
       ::  no-op
       ::
-      =/  =tape  "ames dropping malformed wire: {(spud wire)}"
-      (emit duct %pass /malformed-wire %d %flog %text tape)
+      ~>  %slog.0^leaf/"ames: dropping malformed wire: {(spud wire)}"
+      event-core
     ?>  ?=([@ her=ship *] u.parsed)
     =*  her          her.u.parsed
     =/  =peer-state  (got-peer-state her)
@@ -1233,20 +1233,19 @@
         ==
       ::  ignore events from an old rift
       ::
-      ?.  odd.veb  event-core
-      (log "ames dropping old rift wire: {(spud wire)}")
+      %-  %^  trace  odd.veb  her
+          |.("dropping old rift wire: {(spud wire)}")
+      event-core
     =/  =bone
       ?-(u.parsed [%new *] bone.u.parsed, [%old *] bone.u.parsed)
-    =?  event-core.peer-core  &(odd.veb ?=([%old *] u.parsed))
-      (log "ames parsing old wire format: {(spud wire)}")
+    =?  peer-core  ?=([%old *] u.parsed)
+      %-  %^  trace  odd.veb  her
+          |.("parsing old wire: {(spud wire)}")
+      peer-core
     ?~  error
       (send-ack bone)
     (send-nack bone u.error)
     ::
-    ++  log
-      |=  =tape
-      ^+  event-core
-      (emit duct %pass /on-take-done-parse-wire %d %flog %text tape)
     ::  if processing succeded, send positive ack packet and exit
     ::
     ++  send-ack
@@ -1525,9 +1524,9 @@
   ++  on-take-boon
     |=  [=wire payload=*]
     ^+  event-core
-    |^
     ?~  parsed=(parse-bone-wire wire)
-      (log "ames dropping malformed wire: {(spud wire)}")
+      ~>  %slog.0^leaf/"ames: dropping malformed wire: {(spud wire)}"
+      event-core
     ::
     ?>  ?=([@ her=ship *] u.parsed)
     =*  her          her.u.parsed
@@ -1540,19 +1539,16 @@
         ==
       ::  ignore events from an old rift
       ::
-      ?.  odd.veb  event-core
-      (log "ames dropping old rift wire: {(spud wire)}")
+      %-  %^  trace  odd.veb  her
+          |.("dropping old rift wire: {(spud wire)}")
+      event-core
     =/  =bone
       ?-(u.parsed [%new *] bone.u.parsed, [%old *] bone.u.parsed)
-    =?  event-core.peer-core  &(odd.veb ?=([%old *] u.parsed))
-      (log "ames parsing old wire: {(spud wire)}")
+    =?  peer-core  ?=([%old *] u.parsed)
+      %-  %^  trace  odd.veb  her
+          |.("parsing old wire: {(spud wire)}")
+      peer-core
     abet:(on-memo:peer-core bone payload %boon)
-    ::
-    ++  log
-      |=  =tape
-      ^+  event-core
-      (emit duct %pass /on-take-boon-parse-wire %d %flog %text tape)
-    --
   ::  +on-plea: handle request to send message
   ::
   ++  on-plea

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1240,7 +1240,7 @@
       (log "ames dropping old rift wire: {(spud wire)}")
     =/  =bone
       ?-(u.parsed [%new *] bone.u.parsed, [%old *] bone.u.parsed)
-    =?  event-core  &(odd.veb ?=([%old *] u.parsed))
+    =?  event-core.peer-core  &(odd.veb ?=([%old *] u.parsed))
       (log "ames parsing old wire format: {(spud wire)}")
     ?~  error
       (send-ack bone)
@@ -1536,6 +1536,7 @@
     =*  her          her.u.parsed
     =/  =peer-state  (got-peer-state her)
     =/  =channel     [[our her] now channel-state -.peer-state]
+    =/  peer-core    (make-peer-core peer-state channel)
     ::
     ?:  ?&  ?=([%new *] u.parsed)
             (lth rift.u.parsed rift.peer-state)
@@ -1546,9 +1547,9 @@
       (log "ames dropping old rift wire: {(spud wire)}")
     =/  =bone
       ?-(u.parsed [%new *] bone.u.parsed, [%old *] bone.u.parsed)
-    =?  event-core  &(odd.veb ?=([%old *] u.parsed))
+    =?  event-core.peer-core  &(odd.veb ?=([%old *] u.parsed))
       (log "ames parsing old wire: {(spud wire)}")
-    abet:(on-memo:(make-peer-core peer-state channel) bone payload %boon)
+    abet:(on-memo:peer-core bone payload %boon)
     ::
     ++  log
       |=  =tape

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -782,7 +782,7 @@
 ::
 =<  =*  adult-gate  .
     =|  queued-events=(qeu queued-event)
-    =|  cached-state=[?(%5 %~) ames-state-5]
+    =|  cached-state=(unit [%5 ames-state-5])
     ::
     |=  [now=@da eny=@ rof=roof]
     =*  larval-gate  .
@@ -800,13 +800,14 @@
         ~|(%ames-larval-call-dud (mean tang.u.dud))
       ::
       =/  update-ready=?
-        ?&  ?=([%5 *] cached-state)
+        ?&  ?=(^ cached-state)
             ?=(~ queued-events)
         ==
       ?:  update-ready
         =.  ames-state.adult-gate
-          (state-5-to-6:load:adult-core +.cached-state)
-        =.  -.cached-state  %~
+          ?>  ?=(^ cached-state)
+          (state-5-to-6:load:adult-core +.u.cached-state)
+        =.  cached-state  ~
         ~>  %slog.1^leaf/"ames: metamorphosis reload"
         [~ adult-gate]
       ::  %born: set .unix-duct and start draining .queued-events
@@ -882,13 +883,14 @@
           %take  (take:adult-core [wire duct ~ sign]:+.first-event)
         ==
       =/  update-ready=?
-        ?&  ?=([%5 *] cached-state)
+        ?&  ?=(^ cached-state)
             ?=(~ queued-events)
         ==
       ?:  update-ready
         =.  ames-state.adult-gate
-          (state-5-to-6:load:adult-core +.cached-state)
-        =.  -.cached-state  %~
+          ?>  ?=(^ cached-state)
+          (state-5-to-6:load:adult-core +.u.cached-state)
+        =.  cached-state  ~
         ~>  %slog.1^leaf/"ames: metamorphosis reload"
         [moves adult-gate]
       ::  .queued-events has been cleared; metamorphose
@@ -937,7 +939,7 @@
         larval-gate
       ::
           [%5 %adult *]
-        =.  cached-state  [%5 state.old]
+        =.  cached-state  `[%5 state.old]
         ~>  %slog.1^leaf/"ames: larva reload"
         larval-gate
       ::
@@ -1068,11 +1070,10 @@
     ?.  ?=(%known -.ship-state)
       ship-state
     =/  peer-state=peer-state-5  +.ship-state
-    =|  =rift
-    =/  scry=(unit (unit cage))
+    =/  =rift
+      ;;  @ud
+      =<  q.q  %-  need  %-  need
       (rof ~ %j `beam`[[our %rift %da now] /(scot %p ship)])
-    =?  rift  ?=([~ ~ ^] scry)
-      ;;(@ud q.q:u.u.scry)
     =/  =^peer-state
       :_  +.peer-state
       =,  -.peer-state

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -219,9 +219,6 @@
     ~
   ?+    wire  ~
       [%bone @ @ ~]
-    ::  later on we drop events that come in an old wire but
-    ::  tracking it here let us print a notification to the user
-    ::
     `[%old `@p`(slav %p i.t.wire) `@ud`(slav %ud i.t.t.wire)]
   ::
       [%bone @ @ @ ~]
@@ -2568,8 +2565,6 @@
   ++  on-done
     |=  [=message-num =ack]
     ^+  message-pump
-    ~?  (gte message-num next.state)
-      "unsent message from the future"^[message-num next.state current.state]
     ::  unsent messages from the future should never get acked
     ::
     ?>  (lth message-num next.state)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -114,9 +114,9 @@
   ^+  same
   ?.  verb
     same
-  :: ?.  =>  [ship=ship ships=ships in=in]
-  ::     ~+  |(=(~ ships) (~(has in ships) ship))
-  ::   same
+  ?.  =>  [ship=ship ships=ships in=in]
+      ~+  |(=(~ ships) (~(has in ships) ship))
+    same
   (slog leaf/"ames: {(scow %p ship)}: {(print)}" ~)
 ::  +qos-update-text: notice text for if connection state changes
 ::
@@ -208,19 +208,20 @@
 ++  parse-bone-wire
   |=  =wire
   ^-  %-  unit
-      $%  [%new her=ship =rift =bone]
-          [%old her=ship =bone]
+      $%  [%old her=ship =bone]
+          [%new her=ship =rift =bone]
       ==
   ?.  ?|  ?=([%bone @ @ @ ~] wire)
           ?=([%bone @ @ ~] wire)
       ==
-    ::  ignore malformed wires?
+    ::  ignore malformed wires
     ::
-    ~&  >>>  malformed-wire+wire
     ~
   ?+    wire  ~
       [%bone @ @ ~]
-    ~&  >>  old-wire+wire
+    ::  later on we drop events that come in an old wire but
+    ::  tracking it here let us print a notification to the user
+    ::
     `[%old `@p`(slav %p i.t.wire) `@ud`(slav %ud i.t.t.wire)]
   ::
       [%bone @ @ @ ~]
@@ -588,6 +589,36 @@
 ::
 +$  naxplanation  [=message-num =error]
 ::
++$  ames-state-4  ames-state-5
++$  ames-state-5
+  $:  peers=(map ship ship-state-5)
+      =unix=duct
+      =life
+      crypto-core=acru:ames
+      =bug
+  ==
+::
++$  ship-state-4  ship-state-5
++$  ship-state-5
+  $%  [%alien alien-agenda]
+      [%known peer-state-5]
+  ==
+::
++$  peer-state-5
+  $:  $:  =symmetric-key
+          =life
+          =public-key
+          sponsor=ship
+      ==
+      route=(unit [direct=? =lane])
+      =qos
+      =ossuary
+      snd=(map bone message-pump-state)
+      rcv=(map bone message-sink-state)
+      nax=(set [=bone =message-num])
+      heeds=(set duct)
+  ==
+::
 +|  %statics
 ::
 ::  $ames-state: state for entire vane
@@ -751,8 +782,7 @@
 ::
 =<  =*  adult-gate  .
     =|  queued-events=(qeu queued-event)
-    =|  larval-bit=_|
-    =|  cached-state=*
+    =|  cached-state=[?(%5 %~) ames-state-5]
     ::
     |=  [now=@da eny=@ rof=roof]
     =*  larval-gate  .
@@ -761,35 +791,22 @@
     ::  +call: handle request $task
     ::
     ++  call
-      =>  |%
-          +$  old-state  ames-state-4-5:load:adult-core
-          --
       |=  [=duct dud=(unit goof) wrapped-task=(hobo task)]
-      ~&  call-larva+duct
       ::
       =/  =task  ((harden task) wrapped-task)
-      ~&  task+task
-      ::
       ::  reject larval error notifications
       ::
       ?^  dud
         ~|(%ames-larval-call-dud (mean tang.u.dud))
       ::
-      ~&  cach+?=([%5 *] cached-state)
-      ~&  queu+?=(~ queued-events)
-      =/  from-adult=?
+      =/  update-ready=?
         ?&  ?=([%5 *] cached-state)
             ?=(~ queued-events)
-            :: ?=(^ unix-duct:;;(old-state +.cached-state))
         ==
-      =?  ames-state.adult-gate  from-adult
-          ~&  "state update to 6"
-          (state-5-to-6:load:adult-core ;;(old-state +.cached-state))
-      ::=?  larval-bit  from-adult  %.y
-      ::
-      ::?:  &(larval-bit ?=(~ queued-events))
-      ?:  from-adult
-        =.  cached-state  ~
+      ?:  update-ready
+        =.  ames-state.adult-gate
+          (state-5-to-6:load:adult-core +.cached-state)
+        =.  -.cached-state  %~
         ~>  %slog.1^leaf/"ames: metamorphosis reload"
         [~ adult-gate]
       ::  %born: set .unix-duct and start draining .queued-events
@@ -864,6 +881,16 @@
           %call  (call:adult-core [duct ~ wrapped-task]:+.first-event)
           %take  (take:adult-core [wire duct ~ sign]:+.first-event)
         ==
+      =/  update-ready=?
+        ?&  ?=([%5 *] cached-state)
+            ?=(~ queued-events)
+        ==
+      ?:  update-ready
+        =.  ames-state.adult-gate
+          (state-5-to-6:load:adult-core +.cached-state)
+        =.  -.cached-state  %~
+        ~>  %slog.1^leaf/"ames: metamorphosis reload"
+        [moves adult-gate]
       ::  .queued-events has been cleared; metamorphose
       ::
       ?~  queued-events
@@ -878,23 +905,20 @@
     ++  scry  scry:adult-core
     ++  stay  [%6 %larva queued-events ames-state.adult-gate]
     ++  load
-      =>  |%
-          +$  old-state  ames-state-4-5:load:adult-core
-          --
       |=  $=  old
           $%  $:  %4
               $%  $:  %larva
                       events=(qeu queued-event)
-                      state=old-state
+                      state=ames-state-4
                   ==
-                  [%adult state=old-state]
+                  [%adult state=ames-state-4]
               ==  ==
               $:  %5
               $%  $:  %larva
                       events=(qeu queued-event)
-                      state=old-state
+                      state=ames-state-5
                   ==
-                  [%adult state=old-state]
+                  [%adult state=ames-state-5]
               ==  ==
               $:  %6
               $%  $:  %larva
@@ -903,7 +927,6 @@
                   ==
                   [%adult state=_ames-state.adult-gate]
           ==  ==  ==
-      ~&  %larval-state-loaded
       ?-    old
           [%4 %adult *]  (load:adult-core %4 state.old)
       ::
@@ -914,21 +937,18 @@
         larval-gate
       ::
           [%5 %adult *]
-        ~&  [%5 %adult unix-duct.state.old]
         =.  cached-state  [%5 state.old]
-        ~>  %slog.1^leaf/"ames: larva: reload"
+        ~>  %slog.1^leaf/"ames: larva reload"
         larval-gate
       ::
           [%5 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  queued-events  events.old
-        =.  adult-gate     (load:adult-core %5 state.old)
         larval-gate
       ::
           [%6 %adult *]  (load:adult-core %6 state.old)
       ::
           [%6 %larva *]
-        ~&  larva+-.old
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  queued-events  events.old
         =.  adult-gate     (load:adult-core %6 state.old)
@@ -1009,52 +1029,24 @@
 ::
 ++  load
   =<  |=  $=  old-state
-        $%  [%4 ames-state-4-5]
-            [%5 ames-state-4-5]
-            [%6 ^ames-state]
-        ==
+          $%  [%4 ames-state-4]
+              [%5 ames-state-5]
+              [%6 ^ames-state]
+          ==
       ^+  ames-gate
-      ~&  %load-adult
       =?  old-state  ?=(%4 -.old-state)  %5^(state-4-to-5 +.old-state)
-      :: =?  old-state  ?=(%5 -.old-state)  %6^(state-5-to-6 +.old-state)
+      ::  XX  this would crash with ames-state-5 but load is never
+      ::  called with it -- the upgrade is handled by the larval load
       ::
       ?>  ?=(%6 -.old-state)
       ames-gate(ames-state +.old-state)
   |%
-  +$  ames-state-4-5
-    $:  peers=(map ship ship-state-4-5)
-        =unix=duct
-        =life
-        crypto-core=acru:ames
-        =bug
-    ==
-  ::
-  +$  ship-state-4-5
-    $%  [%alien alien-agenda]
-        [%known peer-state-4-5]
-    ==
-  ::
-  +$  peer-state-4-5
-    $:  $:  =symmetric-key
-            =life
-            =public-key
-            sponsor=ship
-        ==
-        route=(unit [direct=? =lane])
-        =qos
-        =ossuary
-        snd=(map bone message-pump-state)
-        rcv=(map bone message-sink-state)
-        nax=(set [=bone =message-num])
-        heeds=(set duct)
-    ==
-  ::
   ++  state-4-to-5
-    |=  ames-state=ames-state-4-5
-    ^-  ames-state-4-5
+    |=  ames-state=ames-state-4
+    ^-  ames-state-4
     =.  peers.ames-state
       %-  ~(run by peers.ames-state)
-      |=  ship-state=ship-state-4-5
+      |=  ship-state=ship-state-4
       ?.  ?=(%known -.ship-state)
         ship-state
       =.  snd.ship-state
@@ -1067,21 +1059,20 @@
     ames-state
   ::
   ++  state-5-to-6
-    |=  ames-state=ames-state-4-5
+    |=  ames-state=ames-state-5
     ^-  ^^ames-state
     :_  +.ames-state
     %-  ~(rut by peers.ames-state)
-    |=  [=ship ship-state=ship-state-4-5]
+    |=  [=ship ship-state=ship-state-5]
     ^-  ^ship-state
     ?.  ?=(%known -.ship-state)
       ship-state
-    =/  peer-state=peer-state-4-5  +.ship-state
+    =/  peer-state=peer-state-5  +.ship-state
     =|  =rift
     =/  scry=(unit (unit cage))
       (rof ~ %j `beam`[[our %rift %da now] /(scot %p ship)])
     =?  rift  ?=([~ ~ ^] scry)
       ;;(@ud q.q:u.u.scry)
-    ~&  ship^rift
     =/  =^peer-state
       :_  +.peer-state
       =,  -.peer-state
@@ -1231,30 +1222,28 @@
     ?~  parsed=(parse-bone-wire wire)
       ::  no-op?
       ::
-      ~&  >>>  "error parsing wire"
-      event-core
+      =/  =tape  "; ames dropping malformed wire"
+      (emit duct %pass /parse-wire %d %flog %text tape)
     ?>  ?=([@ her=ship *] u.parsed)
     =*  her  her.u.parsed
     =/  =peer-state  (got-peer-state her)
-    =/  =channel
-      :^  [our her]  now  channel-state
-      =,  -.peer-state
-      [symmetric-key life rift public-key sponsor]
+    =/  =channel     [[our her] now channel-state -.peer-state]
+
     =/  peer-core    (make-peer-core peer-state channel)
     |^
     ?-    u.parsed
         [%old *]
-      ::  XX ignore events from old wire instead of sending nack?
+      ::  ignore events from old wire
       ::
-      :: event-core
-      (send-nack bone.u.parsed [%old-wire ~[(spat wire)]])
+      =/  =tape  "; ames dropping old wire format"
+      (emit duct %pass /parse-wire %d %flog %text tape)
     ::
         [%new *]
       ?:  (lth rift.u.parsed rift.peer-state)
-        ::  XX ignore events from an old rift instead of sending nack?
+        ::  ignore events from an old rift
         ::
-        :: event-core
-        (send-nack bone.u.parsed [%old-rift ~])
+        =/  =tape  "; ames dropping wire with old rift ({<rift.u.parsed>})"
+        (emit duct %pass /parse-wire %d %flog %text tape)
       ?~  error
         (send-ack bone.u.parsed)
       (send-nack bone.u.parsed u.error)
@@ -1264,20 +1253,15 @@
     ++  send-ack
       |=  =bone
       ^+  event-core
-      ~&  send-ack+wire
       abet:(run-message-sink:peer-core bone %done ok=%.y)
     ::  failed; send message nack packet
     ::
     ++  send-nack
       |=  [=bone =^error]
       ^+  event-core
-      ~&  send-nack+[wire error]
       =.  event-core  abet:(run-message-sink:peer-core bone %done ok=%.n)
       =/  =^peer-state  (got-peer-state her)
-      =/  =^channel
-        :^  [our her]  now  channel-state
-        =,  -.peer-state
-        [symmetric-key life rift public-key sponsor]
+      =/  =^channel     [[our her] now channel-state -.peer-state]
       ::  construct nack-trace message, referencing .failed $message-num
       ::
       =/  failed=message-num  last-acked:(~(got by rcv.peer-state) bone)
@@ -1542,30 +1526,27 @@
   ++  on-take-boon
     |=  [=wire payload=*]
     ^+  event-core
-    ~&  on-take-boon+wire
     ::
     ?~  parsed=(parse-bone-wire wire)
-      ::  no-op?
-      ::
-      event-core
+      =/  =tape  "; ames dropping malformed wire"
+      (emit duct %pass /parse-wire %d %flog %text tape)
     ::
     ?>  ?=([@ her=ship *] u.parsed)
     =/  =peer-state  (got-peer-state her.u.parsed)
-    =/  =channel
-      :^  [our her.u.parsed]  now  channel-state
-      =,  -.peer-state
-      [symmetric-key life rift public-key sponsor]
+    =/  =channel     [[our her.u.parsed] now channel-state -.peer-state]
     ::
     ?-    u.parsed
         [%old *]
-      event-core
+      =/  =tape  "; ames dropping old wire"
+      (emit duct %pass /parse-wire %d %flog %text tape)
     ::
         [%new *]
       =,  u.parsed
       ?:  (lth rift rift.peer-state)
-        ::  ignore events from an old rift ?
+        ::  ignore events from an old rift
         ::
-        event-core
+        =/  =tape  "; ames dropping wire with old rift ({<rift>})"
+        (emit duct %pass /parse-wire %d %flog %text tape)
       abet:(on-memo:(make-peer-core peer-state channel) bone payload %boon)
     ==
   ::  +on-plea: handle request to send message
@@ -1586,7 +1567,7 @@
     =/  =channel     [[our ship] now channel-state -.peer-state]
     ::
     =^  =bone  ossuary.peer-state  (bind-duct ossuary.peer-state duct)
-    %-  %^  trace  &  ship
+    %-  %^  trace  msg.veb  ship
         |.  ^-  tape
         =/  sndr  [our our-life.channel]
         =/  rcvr  [ship her-life.channel]
@@ -1651,7 +1632,6 @@
   ::
   ++  on-publ
     |=  [=wire =public-keys-result]
-    ~&  [wire public-keys-result]
     ^+  event-core
     ::
     |^  ^+  event-core
@@ -1844,13 +1824,12 @@
       ?~  ship-state=(~(get by peers.ames-state) ship)
         ::  print error here? %rift was probably called before %keys
         ::
-        ~&  >>  on-publ-rift+[ship %missing-state]
+        ~>  %slog.1^leaf/"ames: missing peer-state on-publ-rift"
         event-core
       ?:  ?=([%alien *] u.ship-state)
         ::  ignore aliens
         ::
         event-core
-      ~&  ship^rift
       =/  =peer-state       +.u.ship-state
       =.  rift.peer-state   rift
       =.  peers.ames-state  (~(put by peers.ames-state) ship %known peer-state)
@@ -2150,7 +2129,6 @@
       ::
       =+  ?~  dud  ~
           %.  ~
-          ~&  >>>  bone+bone
           %+  slog  leaf+"ames: {<her.channel>} ack crashed {<mote.u.dud>}"
           ?.  msg.veb  ~
           :-  >[bone=bone message-num=message-num meat=meat]:shut-packet<
@@ -2207,7 +2185,6 @@
     ++  on-wake
       |=  [=bone error=(unit tang)]
       ^+  peer-core
-      ~&  wake-bone+bone
       ::  if we previously errored out, print and reset timer for later
       ::
       ::    This really shouldn't happen, but if it does, make sure we
@@ -2649,11 +2626,9 @@
       $(current.state +(current.state))
     ::
         %nack
-      ~&  >>>  %nack
       message-pump
     ::
         %naxplanation
-      ~&  >>>  %naxplanation
       =.  message-pump  (give %done current.state `error.u.cur)
       $(current.state +(current.state))
     ==

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -341,9 +341,8 @@
   =^  moves2  bud  (call bud ~[//unix] %hear (snag-packet 0 moves1))
   =^  moves3  bud  (take bud /bone/~nec/1 ~[//unix] %g %done ~)
   %+  expect-eq
-    !>  :^  ~[//unix]  %pass  /on-take-done-parse-wire
-        [%d %flog %text "ames parsing old wire format: /bone/~nec/1"]
-    !>  (snag 0 `(list move:ames)`moves3)
+    !>  1
+    !>  (lent `(list move:ames)`moves3)
 ::
 ++  test-dangling-bone  ^-  tang
   =^  moves0  bud  (call bud ~[/g/hood] %spew [%odd]~)
@@ -359,15 +358,12 @@
     ^-  sign:ames
     [%jael %public-keys %diff who=~nec %rift from=0 to=1]
   ::  %gall has a pending wire with the old rift, so sending a gift to
-  ::  %ames on it will drop that request, and print a message to the user
+  ::  %ames on it will drop that request, not producing any moves
   ::
   =^  moves3  bud  (take bud /bone/~nec/0/1 ~[//unix] %g %done ~)
   ::
   %+  expect-eq
-    !>  %-  sy
-        :_  ~
-        :^  ~[//unix]  %pass  /on-take-done-parse-wire
-        [%d %flog %text "ames dropping old rift wire: /bone/~nec/0/1"]
+    !>  ~
     !>  (sy ,.moves3)
 ::
 ++  test-ames-flow-with-new-rift  ^-  tang

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -341,10 +341,8 @@
   =^  moves2  bud  (call bud ~[//unix] %hear (snag-packet 0 moves1))
   =^  moves3  bud  (take bud /bone/~nec/1 ~[//unix] %g %done ~)
   %+  expect-eq
-    !>  %-  sy
-        :_  ~
-        :^  ~[//unix]  %pass  /on-take-done-parse-wire
-        [%d %flog %text "ames dropping old wire format: /bone/~nec/1"]
+    !>  :^  ~[//unix]  %pass  /on-take-done-parse-wire
+        [%d %flog %text "ames parsing old wire format: /bone/~nec/1"]
     !>  (snag 0 `(list move:ames)`moves3)
 ::
 ++  test-dangling-bone  ^-  tang

--- a/pkg/arvo/tests/sys/vane/ames.hoon
+++ b/pkg/arvo/tests/sys/vane/ames.hoon
@@ -3,8 +3,8 @@
 /=  jael  /sys/vane/jael
 ::  construct some test fixtures
 ::
-=/  nec  (ames ~nec)
-=/  bud  (ames ~bud)
+=/  nec    (ames ~nec)
+=/  bud    (ames ~bud)
 =/  comet  (ames ~bosrym-podwyl-magnes-dacrys--pander-hablep-masrym-marbud)
 ::
 =.  now.nec        ~1111.1.1
@@ -287,7 +287,7 @@
   =^  moves4  nec  (call nec ~[//unix] %hear (snag-packet 0 moves3))
   ::  ~bud -> %boon -> ~nec
   ::
-  =^  moves5  bud  (take bud /bone/~nec/0/1 ~[//unix] %g %boon [%post 'first1!!'])
+  =^  moves5  bud  (take bud /bone/~nec/0/1 ~[//unix] %g %boon [%post 'first1'])
   =^  moves6  nec  (call nec ~[//unix] %hear (snag-packet 0 moves5))
   ::  ~nec -> %done -> ~bud (just make sure ~bud doesn't crash on ack)
   ::
@@ -296,7 +296,8 @@
   ;:  weld
     %+  expect-eq
       !>  :~  [~[//unix] %pass /qos %d %flog %text "; ~nec is your neighbor"]
-              [~[//unix] %pass /bone/~nec/0/1 %g %plea ~nec %g /talk [%get %post]]
+              :^  ~[//unix]  %pass  /bone/~nec/0/1
+              [%g %plea ~nec %g /talk [%get %post]]
           ==
       !>  moves2
   ::
@@ -309,7 +310,7 @@
       !>  (sy ,.moves4)
   ::
     %+  expect-eq
-      !>  [~[/g/talk] %give %boon [%post 'first1!!']]
+      !>  [~[/g/talk] %give %boon [%post 'first1']]
       !>  (snag 0 `(list move:ames)`moves6)
   ==
 ::
@@ -335,14 +336,19 @@
     !>  (snag 1 `(list move:ames)`moves5)
 ::
 ++  test-old-ames-wire  ^-  tang
-  =^  moves1  bud  (take bud /bone/~nec/1 ~[//unix] %g %done ~)
+  =^  moves0  bud  (call bud ~[/g/hood] %spew [%odd]~)
+  =^  moves1  nec  (call nec ~[/g/talk] %plea ~bud %g /talk [%get %post])
+  =^  moves2  bud  (call bud ~[//unix] %hear (snag-packet 0 moves1))
+  =^  moves3  bud  (take bud /bone/~nec/1 ~[//unix] %g %done ~)
   %+  expect-eq
     !>  %-  sy
         :_  ~
-        [~[//unix] %pass /parse-wire %d %flog %text "; ames dropping old wire format"]
-    !>  (sy ,.moves1)
-:: ::
+        :^  ~[//unix]  %pass  /on-take-done-parse-wire
+        [%d %flog %text "ames dropping old wire format: /bone/~nec/1"]
+    !>  (snag 0 `(list move:ames)`moves3)
+::
 ++  test-dangling-bone  ^-  tang
+  =^  moves0  bud  (call bud ~[/g/hood] %spew [%odd]~)
   ::  ~nec -> %plea -> ~bud
   ::
   =^  moves1  nec  (call nec ~[/g/talk] %plea ~bud %g /talk [%get %post])
@@ -362,18 +368,12 @@
   %+  expect-eq
     !>  %-  sy
         :_  ~
-        :*   ~[//unix]
-             %pass
-             /parse-wire
-             %d
-             %flog
-             %text
-             "; ames dropping wire with old rift (0)"
-        ==
+        :^  ~[//unix]  %pass  /on-take-done-parse-wire
+        [%d %flog %text "ames dropping old rift wire: /bone/~nec/0/1"]
     !>  (sy ,.moves3)
 ::
 ++  test-ames-flow-with-new-rift  ^-  tang
-  ::  ~bunecd receives a gift from %jael with ~bud's new rift
+  ::  ~nec receives a gift from %jael with ~bud's new rift
   ::
   =^  moves1  nec
     %-  take
@@ -400,7 +400,8 @@
   ;:  weld
     %+  expect-eq
       !>  :~  [~[//unix] %pass /qos %d %flog %text "; ~nec is your neighbor"]
-              [~[//unix] %pass /bone/~nec/0/1 %g %plea ~nec %g /talk [%get %post]]
+              :^  ~[//unix]  %pass  /bone/~nec/0/1
+              [%g %plea ~nec %g /talk [%get %post]]
           ==
       !>  moves3
   ::


### PR DESCRIPTION
This PR modifies ames' state to track the rift of a peer, including it in the wire that is used to interact with client vanes.

New wire format: `^-([@t ship=@ rift=@ bone=@ ~] /bone/~zod/0/1)`

Old wire formats are still parsed, but ames no-ops when dealing with them. In order to update the state properly, scrying the rifts out of `%jael`, ames regresses into the larval state, and upon receiving a `+call` or a `+take`, and if there are not more pending events to process, scries the rifts and updates the state, evolving then into adult ames.

This has been tested using the included unit tests and deploying it in a live ship, and two of its moons, that successfully apply the OTA and can continue messaging each other.

Next would be to test this in a ship that has the issue described here https://github.com/urbit/urbit/issues/2359. I've confirmed that this happens in the L2 `~roller`, but since that's an infrastructure-critical ship, it's probably better to test it somewhere else (although it's not really connected to the rest of the ames network, so maybe it's fine?)