### PR TITLE
hoon: hook up $+ for shorthand type rendering

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -679,7 +679,9 @@
       [%face ^]  a(q $(a q.a))
       [%cell ^]  a(p $(a p.a), q $(a q.a))
       [%fork *]  a(p (silt (turn ~(tap in p.a) |=(b=type ^$(a b)))))
-      [%hint *]  !!
+      [%hint *]  ?.  ?=(%know -.q.p.a)  $(a q.a)
+                 ?@  p.q.p.a  [(cat 3 '#' mark.p.q.p.a)]~
+                 [(rap 3 '#' auth.p.q.p.a (spat type.p.q.p.a) ~)]~
       [%core ^]  `wain`/core
       [%hold *]  a(p $(a p.a))
     ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -7781,7 +7781,7 @@
       [%bcgl *]  $(mod q.mod)
       [%bcgr *]  $(mod q.mod)
       [%bckt *]  $(mod q.mod)
-      [%bcls *]  $(mod q.mod)
+      [%bcls *]  [%note [%know p.mod] $(mod q.mod)]
       [%bcmc *]  ::  borrow sample
                  ::
                  [%tsgl [%$ 6] p.mod]
@@ -7832,7 +7832,7 @@
       [%bchp *]  (decorate (function:clear p.mod q.mod))
       [%bcmc *]  (decorate (home [%tsgl [%limb %$] p.mod]))
       [%bcsg *]  [%ktls example(mod q.mod) (home p.mod)]
-      [%bcls *]  (decorate example(mod q.mod))
+      [%bcls *]  (decorate [%note [%know p.mod] example(mod q.mod)])
       [%bcts *]  (decorate [%ktts p.mod example:clear(mod q.mod)])
       [%bcdt *]  (decorate (home (interface %gold p.mod q.mod)))
       [%bcfs *]  (decorate (home (interface %iron p.mod q.mod)))
@@ -8189,7 +8189,7 @@
           relative:clear(mod q.mod)
         relative:clear(mod p.mod)
       ::
-        [%bcls *]  relative(mod q.mod)
+        [%bcls *]  [%note [%know p.mod] relative(mod q.mod)]
         [%bcdt *]  (decorate (home (interface %gold p.mod q.mod)))
         [%bcfs *]  (decorate (home (interface %iron p.mod q.mod)))
         [%bczp *]  (decorate (home (interface %lead p.mod q.mod)))
@@ -10906,6 +10906,7 @@
                     [%stop p=@ud]                       ::
                     [%tree p=term q=wine]               ::
                     [%unit p=term q=wine]               ::
+                    [%name p=stud q=wine]               ::
                 ==                                      ::
       --
   |_  sut=type
@@ -10996,6 +10997,11 @@
           [%unit *]
         =^  cox  gid  $(q.ham q.q.ham)
         :_(gid [%rose [" " (weld (trip p.q.ham) "(") ")"] cox ~])
+      ::
+          [%name *]
+        :_  gid
+        ?@  p.q.ham  (cat 3 '#' mark.p.q.ham)
+        (rap 3 '#' auth.p.q.ham (spat type.p.q.ham) ~)
       ==
     --
   ::
@@ -11183,6 +11189,9 @@
       ?~  wal
         ~
       [~ %rose [[' ' ~] ['[' ~] [']' ~]] [%leaf '~' ~] u.wal ~]
+    ::
+        [%name *]
+      $(q.ham q.q.ham)
     ==
   ::
   ++  doge
@@ -11287,7 +11296,9 @@
       ==
     ::
         [%hint *]
-      $(sut q.sut)
+      =+  yad=$(sut q.sut)
+      ?.  ?=(%know -.q.p.sut)  yad
+      [p.yad [%name p.q.p.sut q.yad]]
     ::
         [%face *]
       =+  yad=$(sut q.sut)
@@ -13002,6 +13013,7 @@
                   ['=' (rune tis %bcts exqg)]
                   ['?' (rune wut %bcwt exqs)]
                   [';' (rune mic %bcmc expa)]
+                  ['+' (rune lus %bcls exqg)]
               ==
             ==
         :-  '%'
@@ -13072,6 +13084,7 @@
                   ['-' (stag %ktcl (rune hep %bchp exqb))]
                   ['=' (stag %ktcl (rune tis %bcts exqg))]
                   ['?' (stag %ktcl (rune wut %bcwt exqs))]
+                  ['+' (stag %ktcl (rune lus %bcls exqg))]
                   ['.' (rune dot %kttr exqa)]
                   [',' (rune com %ktcl exqa)]
               ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11001,7 +11001,7 @@
           [%name *]
         :_  gid
         ?@  p.q.ham  (cat 3 '#' mark.p.q.ham)
-        (rap 3 '#' auth.p.q.ham (spat type.p.q.ham) ~)
+        (rap 3 '#' auth.p.q.ham '+' (spat type.p.q.ham) ~)
       ==
     --
   ::


### PR DESCRIPTION
Too often when dealing with big types the compiler traces and other such outputs become hard to read. Wrapping a type as $+(shorthand big-type) will now print #shorthand in place of the type.

To be clear, the changes here are simply connecting the last few dots of a system that's already implemented. I've been using this for a little bit in development, and it behaves fine.