### PR TITLE
c3: add file path module for easy path manipulation

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -1,6 +1,7 @@
 include config.mk
 include $(foreach dir,$(compat),$(wildcard compat/$(dir)/*.mk))
 
+c 	 = $(wildcard c/*.c)
 jets = jets/tree.c $(wildcard jets/*/*.c)
 noun = $(wildcard noun/*.c)
 ur   = $(wildcard ur/*.c)
@@ -12,7 +13,7 @@ bench  = $(wildcard bench/*.c)
 
 compat := $(foreach dir,$(compat),$(wildcard compat/$(dir)/*.c))
 
-common  = $(jets) $(noun) $(ur) $(vere) $(compat)
+common  = $(c) $(jets) $(noun) $(ur) $(vere) $(compat)
 headers = $(shell find include -type f)
 
 common_objs = $(shell echo $(common) | sed 's/\.c/.o/g')

--- a/pkg/urbit/c/path.c
+++ b/pkg/urbit/c/path.c
@@ -1,0 +1,132 @@
+//! @file path.c
+
+#include "c/path.h"
+
+#include "c/defs.h"
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+//! Path separator.
+static const c3_c pax_sep_c[] = "/";
+
+//==============================================================================
+// Static functions
+//==============================================================================
+
+static inline c3_t
+_is_empty_token(const c3_c* const tok_c)
+{
+  return !tok_c || 0 == strcmp("", tok_c) || 0 == strcmp(".", tok_c);
+}
+
+static inline c3_t
+_is_root(const c3_c* const tok_c)
+{
+  return 0 == strcmp(pax_sep_c, tok_c);
+}
+
+static inline c3_t
+_is_parent(const c3_c* const tok_c)
+{
+  return 0 == strcmp("..", tok_c);
+}
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! @n (1) Allocate 32 bytes for the path string as a default.
+c3_path*
+c3_path_fa(const c3_c** tok_c, const size_t tok_i)
+{
+  static const size_t cap_i = 32; // (1)
+  c3_path*            pax_u = c3_calloc(sizeof(*pax_u) + cap_i);
+  pax_u->cap_i              = cap_i;
+  if ( tok_c ) {
+    for ( size_t idx_i = 0; idx_i < tok_i; idx_i++ ) {
+      c3_path_push(pax_u, tok_c[idx_i]);
+    }
+  }
+  return pax_u;
+}
+
+c3_path*
+c3_path_fp(const c3_path* const pax_u)
+{
+  return pax_u ? c3_path_fv(1, pax_u->str_c) : c3_path_fv(0);
+}
+
+c3_path*
+c3_path_fv(const size_t tok_i, ...)
+{
+  if ( 0 == tok_i ) {
+    return c3_path_fa(NULL, 0);
+  }
+  const c3_c* tok_c[tok_i];
+  va_list     arg_u;
+  va_start(arg_u, tok_i);
+  for ( size_t idx_i = 0; idx_i < tok_i; idx_i++ ) {
+    tok_c[idx_i] = va_arg(arg_u, const c3_c*);
+  }
+  va_end(arg_u);
+  return c3_path_fa(tok_c, tok_i);
+}
+
+//! @n (1) The root directory is its own parent.
+//! @n (2) Double the needed size to minimize future allocations.
+void
+c3_path_push(c3_path* pax_u, const c3_c* const tok_c)
+{
+  if ( !pax_u || _is_empty_token(tok_c) ) {
+    return;
+  }
+
+  if ( _is_parent(tok_c) ) {
+    if ( !_is_root(pax_u->str_c) ) { // (1)
+      c3_path_pop(pax_u);
+    }
+    return;
+  }
+
+  size_t tok_i = sizeof(pax_sep_c) + strlen(tok_c);
+  if ( pax_u->cap_i - pax_u->len_i < tok_i ) {
+    size_t cap_i = 2 * (pax_u->cap_i + tok_i); // (2)
+    pax_u        = c3_realloc(pax_u, sizeof(*pax_u) + cap_i);
+    pax_u->cap_i = cap_i;
+  }
+
+  if ( 0 < pax_u->len_i && !_is_root(pax_u->str_c) ) {
+    strcat(pax_u->str_c, pax_sep_c);
+  }
+  strcat(pax_u->str_c, tok_c);
+
+  pax_u->len_i = strlen(pax_u->str_c);
+}
+
+//! @n (1) This is a path of the form `some-file-or-directory`.
+//! @n (2) This is a path of the form `/some-file-or-directory`.
+void
+c3_path_pop(c3_path* const pax_u)
+{
+  if ( !pax_u || 0 == pax_u->len_i ) {
+    return;
+  }
+
+  if ( _is_root(pax_u->str_c) ) {
+    *pax_u->str_c = '\0';
+    pax_u->len_i  = 0;
+    return;
+  }
+
+  c3_c* sep_c = strrchr(pax_u->str_c, *pax_sep_c);
+  if ( !sep_c ) { // (1)
+    sep_c = pax_u->str_c;
+  }
+  else if ( sep_c == pax_u->str_c ) { // (2)
+    sep_c++;
+  }
+  *sep_c       = '\0';
+  pax_u->len_i = strlen(pax_u->str_c);
+}

--- a/pkg/urbit/include/c/all.h
+++ b/pkg/urbit/include/c/all.h
@@ -12,5 +12,6 @@
 #include "c/types.h"
 #include "c/defs.h"
 #include "c/motes.h"
+#include "c/path.h"
 
 #endif /* ifndef C3_ALL_H */

--- a/pkg/urbit/include/c/path.h
+++ b/pkg/urbit/include/c/path.h
@@ -1,0 +1,100 @@
+//! @file path.h
+//!
+//! Canonical-ish path. All references to empty components, `.`, and
+//! `..` are removed, but symlinks are not resolved. The filesystem is not
+//! consulted when reducing a path. As a result, a path like
+//! `fanfun-mocbud/../../../` is reduced to an empty path because it resolves to
+//! the grandparent directory of `fanfun-mocbud`, which cannot be known without
+//! reading from the filesystem.
+
+#ifndef C3_PATH_H
+#define C3_PATH_H
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#include "c/portable.h"
+#include "c/types.h"
+
+//==============================================================================
+// Types
+//==============================================================================
+
+//! Path handle.
+typedef struct {
+  size_t cap_i;   //!< number of bytes allocated for `str_c`
+  size_t len_i;   //!< length of `str_c` (equivalent to `strlen(str_c)`)
+  c3_c   str_c[]; //!< path string (null-terminated)
+} c3_path;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! Determine if two paths are equivalent.
+//!
+//! @param[in] lef_u  Path handle.
+//! @param[in] rih_u  Path handle.
+//!
+//! @return 0  Paths don't match.
+//! @return 1  Paths match.
+static inline c3_t
+c3_path_eq(const c3_path* const lef_u, const c3_path* const rih_u)
+{
+  return lef_u && rih_u && 0 == strcmp(lef_u->str_c, rih_u->str_c);
+}
+
+//! Construct a path from an array of strings.
+//!
+//! @note mnemonic: `c3_path` [f]rom [a]rray -> `c3_path_fa`.
+//!
+//! @param[in] tok_c  Array of path components. Must be valid C strings. If
+//!                   NULL, an empty path is created.
+//! @param[in] tok_i  Number of elements in `toks_c`. If 0, an empty path is
+//!                   created.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fa(const c3_c** toks_c, const size_t tok_i);
+
+//! Construct a path from an existing path.
+//!
+//! @note mnemonic: `c3_path` [f]rom [p]ath -> `c3_path_fp`.
+//!
+//! @param[in] pax_u  Path handle. If NULL, an empty path is created.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fp(const c3_path* const pax_u);
+
+//! Construct a path from a variadic argument sequence.
+//!
+//! @note mnemonic: `c3_path` [f]rom [v]ariadic -> `c3_path_fv`.
+//!
+//! @param[in] tok_i  Number of components of the path. If 0, an empty path is
+//!                   created.
+//! @param[in] ...    Components of the path. Must be valid C string.
+//!
+//! @return  Path handle. Must be freed by caller.
+c3_path*
+c3_path_fv(const size_t tok_i, ...);
+
+//! Push a component onto the end of a path.
+//!
+//! Pushing `.`, the empty string, or NULL is a no-op. Pushing `..` is
+//! equivalent to calling c3_path_pop() except in the case where the path is `/`
+//! (i.e. `/..` is always `/`).
+//!
+//! @param[in] pax_u  Path handle.
+//! @param[in] tok_c  Path component to append to the path.
+void
+c3_path_push(c3_path* pax_u, const c3_c* const tok_c);
+
+//! Pop a component from the end of a path.
+//!
+//! @param[in] pax_u  Path handle.
+void
+c3_path_pop(c3_path* const pax_u);
+
+#endif /* ifndef C3_PATH_H */

--- a/pkg/urbit/tests/path_tests.c
+++ b/pkg/urbit/tests/path_tests.c
@@ -1,0 +1,238 @@
+//! @file path_tests.c
+
+#include "c/path.h"
+
+#include "c/defs.h"
+#include "c/portable.h"
+#include "c/types.h"
+
+static void
+_test_path_fv(void)
+{
+  // Empty path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(0));
+    c3_assert(0 == strcmp("", pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with one component.
+  {
+    static const c3_c* const exp_c = "fanfun-mocbud";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "fanfun-mocbud"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with one component.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "/"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with two components.
+  {
+    static const c3_c* const exp_c = "~/master-morzod";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "~", "master-morzod"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with two components.
+  {
+    static const c3_c* const exp_c = "/silsyn-wathep";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "/", "silsyn-wathep"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative canonical path with more than two components.
+  {
+    static const c3_c* const exp_c
+      = "a/really/long/relative/path/with_underscores/and-dashes";
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(7,
+                                 "a",
+                                 "really",
+                                 "long",
+                                 "relative",
+                                 "path",
+                                 "with_underscores",
+                                 "and-dashes"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute canonical path with more than two components.
+  {
+    static const c3_c* const exp_c
+      = "/a/really/long/ABSOLUTE/path/with_underscores/and-dashes";
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(8,
+                                 "/",
+                                 "a",
+                                 "really",
+                                 "long",
+                                 "ABSOLUTE",
+                                 "path",
+                                 "with_underscores",
+                                 "and-dashes"));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute non-canonical path with three components.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(3, "/", "tmp", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid relative non-canonical path with five components.
+  {
+    static const c3_c* const exp_c = "fanfun-mocbud";
+    c3_path*                 pax_u;
+    c3_assert(pax_u
+              = c3_path_fv(5, "fanfun-mocbud", ".urb", "log", "..", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+
+  // Valid absolute non-canonical path with two components.
+  {
+    static const c3_c* const exp_c = "/";
+    c3_path*                 pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "/", ".."));
+    c3_assert(0 == strcmp(exp_c, pax_u->str_c));
+    c3_free(pax_u);
+  }
+}
+
+static void
+_test_path_push_pop(void)
+{
+  // Absolute path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(1, "/"));
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_push(pax_u, "fanfun");
+    c3_assert(0 == strcmp("/fanfun", pax_u->str_c));
+
+    c3_path_push(pax_u, "mocbud");
+    c3_assert(0 == strcmp("/fanfun/mocbud", pax_u->str_c));
+
+    c3_path_push(pax_u, "some-moon-name");
+    c3_assert(0 == strcmp("/fanfun/mocbud/some-moon-name", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/fanfun/mocbud", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/fanfun", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_assert(0 == strcmp("", pax_u->str_c));
+    c3_assert(0 == pax_u->len_i);
+
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+
+    c3_free(pax_u);
+  }
+
+  // Push special components onto relative path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(2, "~", "fanfun-mocbud"));
+
+    c3_path_push(pax_u, "its-snack-time");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, ".");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, "");
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, NULL);
+    c3_assert(0 == strcmp("~/fanfun-mocbud/its-snack-time", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("~/fanfun-mocbud", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("~", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("", pax_u->str_c));
+
+    c3_path_push(pax_u, "/");
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_path_push(pax_u, "..");
+    c3_assert(0 == strcmp("/", pax_u->str_c));
+
+    c3_free(pax_u);
+  }
+
+  // Start with empty path.
+  {
+    c3_path* pax_u;
+    c3_assert(pax_u = c3_path_fv(0));
+
+    c3_path_push(pax_u, "a");
+    c3_assert(0 == strcmp("a", pax_u->str_c));
+
+    c3_path_push(pax_u, "b");
+    c3_assert(0 == strcmp("a/b", pax_u->str_c));
+
+    c3_path_push(pax_u, "c");
+    c3_assert(0 == strcmp("a/b/c", pax_u->str_c));
+
+    c3_path_push(pax_u, "d");
+    c3_assert(0 == strcmp("a/b/c/d", pax_u->str_c));
+
+    c3_path_push(pax_u, "e");
+    c3_assert(0 == strcmp("a/b/c/d/e", pax_u->str_c));
+
+    c3_path_push(pax_u, "f");
+    c3_assert(0 == strcmp("a/b/c/d/e/f", pax_u->str_c));
+
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+    c3_path_pop(pax_u);
+
+    c3_assert(0 == strcmp("", pax_u->str_c));
+
+    c3_free(pax_u);
+  }
+}
+
+int
+main(int argc, char* argv[])
+{
+  _test_path_fv();
+  _test_path_push_pop();
+
+  fprintf(stderr, "test_path: ok\r\n");
+
+  return 0;
+}


### PR DESCRIPTION
Add `c3_path` type for easily creating and manipulating file paths. We currently use `snprintf` in many places to build up file paths, which is at best a hassle and at worst prone to buffer overflow bugs. The `c3_path` module provides a path abstraction that is lightweight and easy to use. Only a single heap allocation is required in many cases, and the module attempts to minimize the overhead of reallocations by doubling the newly needed allocation size upon reallocation. The `c3_path` type will be used in the new epoch-based event log system and also in an upcoming redesign of `unix.c`. It can also be used to simplify to `events.c`. 

Interface:
- `c3_path* c3_path_fa(const c3_c** toks_c, const size_t tok_i)`: create a path from an array of strings.
- `c3_path* c3_path_fv(const size_t tok_i, ...)`: create a path from a variadic list of string arguments.
- `void c3_path_push(c3_path* pax_u, const c3_c* const tok_c)`: push a new component onto the end of a path.
- `void c3_path_pop(c3_path* const pax_u)`: pop a component from the end of a path.

Tests:
See [path_tests.c](https://github.com/urbit/urbit/tree/peter/path/pkg/urbit/tests/path_tests.c).