### PR TITLE
grid/search: fix progress display

### DIFF
--- a/pkg/grid/src/nav/search/Apps.tsx
+++ b/pkg/grid/src/nav/search/Apps.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import fuzzy from 'fuzzy';
 import { Treaty } from '@urbit/api';
 import { ShipName } from '../../components/ShipName';
-import useDocketState, { useAllyTreaties, useAllies } from '../../state/docket';
+import { useAllyTreaties } from '../../state/docket';
 import { useLeapStore } from '../Nav';
 import { AppList } from '../../components/AppList';
 import { addRecentDev } from './Home';
@@ -19,14 +19,12 @@ export const Apps = ({ match }: AppsProps) => {
   }));
   const provider = match?.params.ship;
   const { treaties, status } = useAllyTreaties(provider);
-  const allies = useAllies();
-  const isAllied = provider in allies;
 
   useEffect(() => {
-    if (Object.keys(allies).length > 0 && !isAllied) {
-      useDocketState.getState().addAlly(provider);
+    if (provider) {
+      addRecentDev(provider);
     }
-  }, [allies, isAllied, provider]);
+  }, [provider]);
 
   const results = useMemo(() => {
     if (!treaties) {
@@ -74,12 +72,8 @@ export const Apps = ({ match }: AppsProps) => {
     }
   }, [results]);
 
-  useEffect(() => {
-    if (provider) {
-      useDocketState.getState().fetchAllyTreaties(provider);
-      addRecentDev(provider);
-    }
-  }, [provider]);
+  const showNone =
+    status === 'error' || ((status === 'success' || status === 'initial') && results?.length === 0);
 
   return (
     <div className="dialog-inner-container md:px-6 md:py-8 h4 text-gray-400">
@@ -107,12 +101,11 @@ export const Apps = ({ match }: AppsProps) => {
           <p>That&apos;s it!</p>
         </>
       )}
-      {status === 'error' ||
-        ((status === 'success' || status === 'initial') && results?.length === 0 && (
-          <h2>
-            Unable to find software developed by <ShipName name={provider} className="font-mono" />
-          </h2>
-        ))}
+      {showNone && (
+        <h2>
+          Unable to find software developed by <ShipName name={provider} className="font-mono" />
+        </h2>
+      )}
     </div>
   );
 };

--- a/pkg/grid/src/state/docket.ts
+++ b/pkg/grid/src/state/docket.ts
@@ -1,6 +1,6 @@
 import create, { SetState } from 'zustand';
 import produce from 'immer';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { omit, pick } from 'lodash';
 import {
   Allies,
@@ -27,7 +27,7 @@ import {
 import api from './api';
 import { mockAllies, mockCharges, mockTreaties } from './mock-data';
 import { fakeRequest, normalizeUrbitColor, useMockData } from './util';
-import { useAsyncCall } from '../logic/useAsyncCall';
+import { Status, useAsyncCall } from '../logic/useAsyncCall';
 
 export interface ChargeWithDesk extends Charge {
   desk: string;
@@ -269,17 +269,38 @@ export function useAllies() {
 
 export function useAllyTreaties(ship: string) {
   const allies = useAllies();
-  const { call: fetchTreaties, status } = useAsyncCall(() =>
-    useDocketState.getState().fetchAllyTreaties(ship)
-  );
+  const isAllied = ship in allies;
+  const [status, setStatus] = useState<Status>('initial');
+  const [treaties, setTreaties] = useState<Treaties>();
 
   useEffect(() => {
-    if (ship in allies) {
-      fetchTreaties();
+    if (Object.keys(allies).length > 0 && !isAllied) {
+      setStatus('loading');
+      useDocketState.getState().addAlly(ship);
     }
-  }, [ship, allies]);
+  }, [allies, isAllied, ship]);
 
-  const treaties = useDocketState(
+  useEffect(() => {
+    async function fetchTreaties() {
+      if (isAllied) {
+        setStatus('loading');
+        try {
+          const newTreaties = await useDocketState.getState().fetchAllyTreaties(ship);
+
+          if (Object.keys(newTreaties).length > 0) {
+            setTreaties(newTreaties);
+            setStatus('success');
+          }
+        } catch {
+          setStatus('error');
+        }
+      }
+    }
+
+    fetchTreaties();
+  }, [ship, isAllied]);
+
+  const storeTreaties = useDocketState(
     useCallback(
       (s) => {
         const charter = s.allies[ship];
@@ -289,7 +310,24 @@ export function useAllyTreaties(ship: string) {
     )
   );
 
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setStatus('error');
+    }, 30 * 1000); // wait 30 secs before timing out
+
+    if (Object.keys(storeTreaties).length > 0) {
+      setTreaties(storeTreaties);
+      setStatus('success');
+      clearTimeout(timeout);
+    }
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [storeTreaties]);
+
   return {
+    isAllied,
     treaties,
     status
   };


### PR DESCRIPTION
This fixes the progress display so that we actually show progress for the full duration of the requests involved, instead of bailing early after the first request (requires two). It also introduces a timeout of 30 secs in case the second request is taking too long.