### PR TITLE
clay, ford: Reduce memory usage

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c29577dc949ac0689ba3c97ad13b812ea6c3c6cc9d255b770d2da95fd9af84b9
-size 23121802
+oid sha256:5c963ce1b61ac0948971e34f963fec6afa960d7c74f32392306b411d8bffd4fd
+size 23236383

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5044,14 +5044,51 @@
     %+  turn  (sort ~(tap by dos.rom.ruf) aor)
     |=  [=desk =dojo]
     :+  desk  %|
+    |^
     :~  ankh+&+ank.dom.dojo
         mime+&+mim.dom.dojo
-        ford-files+&+files.fod.dom.dojo
-        ford-naves+&+naves.fod.dom.dojo
-        ford-marks+&+marks.fod.dom.dojo
-        ford-casts+&+casts.fod.dom.dojo
-        ford-tubes+&+tubes.fod.dom.dojo
+        ford-files+|+files
+        ford-naves+|+naves
+        ford-marks+|+marks
+        ford-casts+|+casts
+        ford-tubes+|+tubes
     ==
+    ++  marks
+      ^-  (list mass)
+      %+  turn  (sort ~(tap by marks.fod.dom.dojo) aor)
+      |=  [=mark res=*]
+      ^-  mass
+      [mark %& res]
+    ::
+    ++  casts
+      ^-  (list mass)
+      %+  turn  (sort ~(tap by casts.fod.dom.dojo) aor)
+      |=  [=mars res=*]
+      ^-  mass
+      [`@t`(rap 3 [a '-' b ~]:mars) %& res]
+    ::
+    ++  naves
+      ^-  (list mass)
+      %+  turn  (sort ~(tap by naves.fod.dom.dojo) aor)
+      |=  [=mark res=*]
+      ^-  mass
+      [mark %& res]
+    ::
+    ++  tubes
+      ^-  (list mass)
+      %+  turn  (sort ~(tap by tubes.fod.dom.dojo) aor)
+      |=  [=mars res=*]
+      ^-  mass
+      [`@t`(rap 3 [a '-' b ~]:mars) %& res]
+    ::
+
+    ++  files
+      ^-  (list mass)
+      %+  turn  (sort ~(tap by files.fod.dom.dojo) aor)
+      |=  [=path res=*]
+      ^-  mass
+      [(spat path) %& res]
+    --
   :~  domestic+|+domestic
       foreign+&+hoy.ruf
       :+  %object-store  %|

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -9,6 +9,17 @@
 ::  worth noting that many of the clay-related structures are defined in zuse.
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+=/  bud
+  ^~
+  =/  zuse  !>(..zuse)
+  :*  zuse=zuse
+      nave=(slap zuse !,(*hoon nave:clay))
+      cork=(slap zuse !,(*hoon cork))
+      same=(slap zuse !,(*hoon same))
+      mime=(slap zuse !,(*hoon mime))
+      cass=(slap zuse !,(*hoon cass:clay))
+  ==
+::
 |=  our=ship
 =,  clay
 =>  |%
@@ -548,7 +559,7 @@
         :_  nub
         ^-  vase  ::  vase of nave
         %+  slap
-          (with-faces deg+deg tub+tub but+but cor+cor nave+!>(nave) ~)
+          (with-faces deg+deg tub+tub but+but cor+cor nave+nave.bud ~)
         !,  *hoon
         =/  typ  _+<.cor
         =/  dif  diff:deg
@@ -569,7 +580,7 @@
         --
       :_  nub
       ^-  vase  ::  vase of nave
-      %+  slap  (slop (with-face cor+cor) !>(..zuse))
+      %+  slap  (slop (with-face cor+cor) zuse.bud)
       !,  *hoon
       =/  typ  _+<.cor
       =/  dif  _*diff:grad:cor
@@ -612,9 +623,10 @@
         =.  marks.cache.nub  (~(put by marks.cache.nub) mak [dais.res top])
         [dais.res nub]
       =^  nav=vase  nub  (build-nave mak)
-      :: ~>  %slog.0^leaf/"ford: make dais {<mak>}"
+      ::~>  %slog.0^leaf/"ford: make dais {<mak>}"
       :_  nub
       ^-  dais
+      =>  [..zuse nav=nav]
       |_  sam=vase
       ++  diff
         |=  new=vase
@@ -633,8 +645,8 @@
         =/  res=vase
           %+  slam  (slap nav limb/%mash)
           %+  slop
-            :(slop !>(ship.a) !>(desk.a) diff.a)
-          :(slop !>(ship.b) !>(desk.b) diff.b)
+            :(slop =>([..zuse ship.a] !>(+)) =>([..zuse desk.a] !>(+)) diff.a)
+          :(slop =>([..zuse ship.b] !>(+)) =>([..zuse desk.b] !>(+)) diff.b)
         ?~  q.res
           ~
         `(slap res !,(*hoon ?>((^ .) u)))
@@ -652,7 +664,7 @@
       ^-  [vase state]
       ~|  error-building-cast+[a b]
       ?:  =([%mime %hoon] [a b])
-        :_(nub !>(|=(m=mime q.q.m)))
+        :_(nub =>(..zuse !>(|=(m=mime q.q.m))))
       ?^  got=(~(get by casts.cache.nub) [a b])
         =?  stack.nub  ?=(^ stack.nub)
           stack.nub(i (~(uni in i.stack.nub) dez.u.got))
@@ -696,7 +708,7 @@
       ?:  ?=(%& -.rab)
         (compose-casts a !<(mark p.rab) b)
       ?:  ?=(%noun b)
-        :_(nub !>(|=(* +<)))
+        :_(nub same.bud)
       ~|(no-cast-from+[a b] !!)
     ::
     ++  compose-casts
@@ -706,7 +718,7 @@
       =^  dos=vase  nub  (build-cast y z)
       :_  nub
       %+  slap
-        (with-faces uno+uno dos+dos cork+!>(cork) ~)
+        (with-faces uno+uno dos+dos cork+=>([..zuse cork] !>(+)) ~)
       !,(*hoon (cork uno dos))
     ::  +build-tube: produce a $tube mark conversion gate from .a to .b
     ::
@@ -728,7 +740,7 @@
         [tube.res nub]
       =^  gat=vase  nub  (build-cast a b)
       :: ~>  %slog.0^leaf/"ford: make tube {<a>} -> {<b>}"
-      :_(nub |=(v=vase (slam gat v)))
+      :_(nub =>([..zuse gat=gat] |=(v=vase (slam gat v))))
     ::
     ++  lobe-to-page
       |=  =lobe
@@ -761,7 +773,7 @@
       ?:  =(%hoon p.page)
         :_(nub [%hoon -:!>(*@t) q.page])
       ?:  =(%mime p.page)
-        :_(nub [%mime !>(;;(mime q.page))])
+        :_(nub [%mime =>([..zuse ;;(mime q.page)] !>(+))])
       =^  =dais  nub  (build-dais p.page)
       :_(nub [p.page (vale:dais q.page)])
     ::
@@ -784,7 +796,7 @@
         =/  txt=wain  (to-wain:format ;;(@t q.old))
         =+  ;;(dif=(urge cord) q.diff)
         =/  new=@t  (of-wain:format (lurk:differ txt dif))
-        :_(nub [%hoon !>(new)])
+        :_(nub [%hoon =>([..zuse new] !>(+))])
       =^  dys=dais  nub  (build-dais p.old)
       =^  syd=dais  nub  (build-dais p.diff)
       :_(nub [p.old (~(pact dys (vale:dys q.old)) (vale:syd q.diff))])
@@ -858,7 +870,7 @@
     ::
     ++  run-pile
       |=  =pile
-      =/  sut=vase  !>(..zuse)
+      =/  sut=vase  zuse.bud
       =^  sut=vase  nub  (run-tauts sut %sur sur.pile)
       =^  sut=vase  nub  (run-tauts sut %lib lib.pile)
       =^  sut=vase  nub  (run-raw sut raw.pile)


### PR DESCRIPTION
This fixes a space leak where the entire ford/clay core would be
included in the ford cache. Heavily reduces memory usage by clay,
reducing total usage from 100-200MB to around 10MB per-desk.

Also heavily reduces the size of clay results, they now jam to about 1MB instead of ~20MB