### PR TITLE
grid: fix loop caused by useEffect in tilegrid

### DIFF
--- a/pkg/grid/src/tiles/TileGrid.tsx
+++ b/pkg/grid/src/tiles/TileGrid.tsx
@@ -46,11 +46,7 @@ export const TileGrid = ({ menu }: TileGridProps) => {
     } else if (order.length > chargeKeys.length && chargeKeys.length !== 0) {
       useSettingsState
         .getState()
-        .putEntry(
-          'tiles',
-          'order',
-          uniq(order.filter((key) => !(key in charges)).concat(chargeKeys))
-        );
+        .putEntry('tiles', 'order', uniq(order.filter((key) => key in charges).concat(chargeKeys)));
     }
   }, [charges, order]);
 


### PR DESCRIPTION
Fixes loop discovered while I was reviewing https://github.com/urbit/urbit/pull/5653

This bug is live in production.

To reproduce the bug: install an app (like %hodl from ~dister-datder-sonnet) and remove it.