### PR TITLE
graph-store: drop unnecessary logs

### DIFF
--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -10,16 +10,17 @@
       [%2 network:zero:store]
       [%3 network:one:store]
       [%4 network:store]
-      state-5
+      [%5 network:store]
+      state-6
   ==
-::
-+$  state-5  [%5 network:store]
+::-
++$  state-6  [%6 network:store]
 ++  orm      orm:store
 ++  orm-log  orm-log:store
 ++  mar      %graph-update-3
 --
 ::
-=|  state-5
+=|  state-6
 =*  state  -
 ::
 %-  agent:dbug
@@ -81,7 +82,21 @@
       (gas:orm-log ~ [now.bowl logged-update] ~)
     ==
   ::
-    %5  [cards this(state old)]
+      %5
+    %_  $
+      -.old  %6
+    ::
+        update-logs.old
+      %-  ~(rut by update-logs.old)
+      |=  [=resource:store =update-log:store]
+      ^-  update-log:store
+      ?:  =(our.bowl entity.resource)
+        update-log
+      %+  gas:orm-log  *update-log:store
+      (scag 2 (tap:orm-log update-log))
+    ==
+  ::
+    %6  [cards this(state old)]
   ==
 ::
 ++  on-watch

--- a/pkg/landscape/lib/graph-store.hoon
+++ b/pkg/landscape/lib/graph-store.hoon
@@ -758,9 +758,9 @@
   --
 ++  import
   |=  [arc=* our=ship]
-  ^-  (quip card:agent:gall [%5 network])
+  ^-  (quip card:agent:gall [%6 network])
   |^
-  =/  sty  [%5 (remake-network ;;(tree-network +.arc))]
+  =/  sty  [%6 (remake-network ;;(tree-network +.arc))]
   :_  sty
   %+  turn  ~(tap by graphs.sty)
   |=  [rid=resource =marked-graph]


### PR DESCRIPTION
Drops unnecessary logs for subscribers, to reduce memory usage. In local
testing, this incurred a 20% improvement in graph-store memory usage.
Note that publishers still retain the entire history, for backlog and
resubscribe purposes. Subscribers still retain a handful of updates so
that they can resubscribe upon kick correctly.