### PR TITLE
helm: add poke to helm to allow self-breaching moons

### DIFF
--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -109,6 +109,17 @@
     this
   (emit %pass / %arvo %j %moon u.sed)
 ::
+++  poke-moon-breach
+  |=  =ship
+  ?>  ?|  =(our src):bowl
+          =(src.bowl ship)
+      ==
+  ?>  =(%earl (clan:title ship))
+  ?>  =(our.bowl (sein:title our.bowl now.bowl ship))
+  =/  =rift
+    +(.^(rift j+/(scot %p our.bowl)/rift/(scot %da now.bowl)/(scot %p ship)))
+  abet:(emit %pass / %arvo %j %moon ship *id:block:jael %rift rift %.n)
+::
 ++  poke-code
   |=  act=?(~ %reset)
   =<  abet
@@ -225,6 +236,7 @@
 ++  poke
   |=  [=mark =vase]
   ?>  ?|  ?=(%helm-hi mark)
+          ?=(%helm-moon-breach mark)
           =(our src):bowl
       ==
   ?+  mark  ~|([%poke-helm-bad-mark mark] !!)
@@ -242,6 +254,7 @@
     %helm-mass             =;(f (f !<(_+<.f vase)) poke-mass)
     %helm-meld             =;(f (f !<(_+<.f vase)) poke-meld)
     %helm-moon             =;(f (f !<(_+<.f vase)) poke-moon)
+    %helm-moon-breach      =;(f (f !<(_+<.f vase)) poke-moon-breach)
     %helm-pack             =;(f (f !<(_+<.f vase)) poke-pack)
     %helm-pass             =;(f (f !<(_+<.f vase)) poke-pass)
     %helm-rekey            =;(f (f !<(_+<.f vase)) poke-rekey)

--- a/pkg/arvo/mar/helm-moon-breach.hoon
+++ b/pkg/arvo/mar/helm-moon-breach.hoon
@@ -1,0 +1,12 @@
+|_  mun=ship
+::
+++  grad  %noun
+++  grab
+  |%
+  ++  noun  ship
+  --
+++  grow
+  |%
+  ++  noun  mun
+  --
+--


### PR DESCRIPTION
Intended use is for transitory moons to be able to breach themselves on
startup.

If you run a moon without persistence, then every time the program is
restarted, it must be breached.  This lets the moon breach itself
instead of requiring direct interaction with the planet.  The moon
should reserve the first bone for this purpose, and then every time it
starts up, it should send [%helm-moon-breach ~moon-name] to hood on the
planet.