### PR TITLE
hoon: plug type leak in compiler bootstrap

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9052,7 +9052,7 @@
     ::
     ^-  type
     ~+
-    ~=  sut
+    =-  ?.(=(sut -) - sut)
     ?+  sut      sut
       [%cell *]  [%cell burp(sut p.sut) burp(sut q.sut)]
       [%core *]  :+  %core

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9066,7 +9066,7 @@
                   ==
       [%face *]  [%face p.sut burp(sut q.sut)]
       [%fork *]  [%fork (~(run in p.sut) |=(type burp(sut +<)))]
-      [%hint *]  (hint p.sut burp(sut q.sut))
+      [%hint *]  (hint [burp(sut p.p.sut) q.p.sut] burp(sut q.sut))
       [%hold *]  [%hold burp(sut p.sut) q.sut]
     ==
   ::


### PR DESCRIPTION
This PR plugs a long-standing type-quote leak in bootstrapping the compiler. Newly compiled copies of the compiler could end up holding a reference to the old compiler (transitively), and this would show up as a space leak when upgrading hoon+arvo, and ever-growing pills.

While it's not a new problem, it has not been consistently present. I had "plugged" the leak once before (in #1847), by moving an experimental pretty-printer out of `hoon.hoon` and into userspace. At the time, I suspected an interaction between vase literals (ie, "type-quoting") and an unusual pattern of pinning in that pretty-printer, but was unable to find a precise reproduction. Much later, around or after the final continuity breach, I noticed that the space-leak was back. I tracked it down to core compilations (vase literals inside of the seminoun in the coil inside of vase literals ...), but couldn't come up with a fix (other than removing all vase literals from hoon.hoon). @jtobin found the missing link in #5623. Several features from the last round of hoon compiler changes (released in 2019) combine to create this leak: a completely new mold system (`$spec`, `+ax`, `+$`), constant folding (via `^~`), and a type-hint designed to unify inline documentation and support the generation of molds from types.

Hoon's constant propagation involves a representation for partially-known nouns (`$seminoun`), and a nock interpreter for the same (`+musk`). Core batteries are known to be constant, and `seminoun` representations of them are included in the `%core` type, thereby supporting compile-time evaluation. But cores aren't known until they've been compiled; to support recursive arms, the `seminoun` is lazily generated via gates that close over the compiler state. When vase-literals are emitted (ie, the representation of `$type` is "quoted" into the compiler output), the type is `burp`-ed to "expel any undigested seminouns" and avoid leaking compiler state through those gates.

The `%hint` type adds "annotations" to types -- including documentation (`%help`), standard names (`%know`), and "structures" (`%made`). Each annotation wraps a product type, and additionally includes the subject type for that expression. None of these are exposed to developers yet, but they are implemented in the compiler, automatically included in `+$` and `+*` (mold-builder, not alias) arms. Since structure annotations contain the type of the mold gate (and `%core` types include the battery), recovering the mold itself is fairly straightforward.

Given that context, the bug itself is simple -- `+burp` didn't properly handle *both* types in `%hint` (introduced here: https://github.com/urbit/urbit/commit/54a03b49178b16a76a04e5668ba4b66876be0871#diff-16921564ac83642f49026067dc653b1539a5fdf6517ce94baef8aff869e81a36L8226). And previous occurrences of the leak and their (partial) fixes are also clear -- this bug in `+burp` was only "activated" if a `%hint` type closed over a `%core` type that was still in the process of being compiled. And that only happened if molds were defined with new syntax and then used within that same core (as was done in the new pretty-printer, and the syntax modernization effort that went into the last breach).

Additionally, this PR replaces the `~=` in `+burp` with a manual approximation in hoon, as `~=` has not been supported since we switched to the bytecode interpreter. This increases structural sharing in vase literals, reducing the size of hoon from 16 to 6 MB on my machine (melding further reduces that to 4 MB). 

This PR should supersede #5623 once verified.

#5641 is also relevant.