### PR TITLE
Groups: respect garden's browser settings in groups.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "lerna": "^4.0.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.3.2"
+      },
+      "engines": {
+        "node": "16.14.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/pkg/interface/package-lock.json
+++ b/pkg/interface/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
+				"@fingerprintjs/fingerprintjs": "^3.3.3",
 				"@radix-ui/react-dialog": "^0.1.0",
 				"@reach/disclosure": "^0.10.5",
 				"@reach/menu-button": "^0.10.5",
@@ -112,6 +113,9 @@
 				"webpack": "^4.46.0",
 				"webpack-cli": "^3.3.12",
 				"webpack-dev-server": "^3.11.2"
+			},
+			"engines": {
+				"node": "16.14.0"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -2279,6 +2283,14 @@
 			},
 			"peerDependencies": {
 				"react": "^16.14.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@fingerprintjs/fingerprintjs": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.3.tgz",
+			"integrity": "sha512-HH6KqZnopF3NIXypYG4f2qxoSRmGCSzp81wJMfWjSTtvsX3cAg12RFJcm+a6Az3XadcZUrXKW3p5Dv0wyCUeuA==",
+			"dependencies": {
+				"tslib": "^2.0.1"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -33511,6 +33523,14 @@
 			"dev": true,
 			"requires": {
 				"@figspec/components": "^0.1.1"
+			}
+		},
+		"@fingerprintjs/fingerprintjs": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.3.tgz",
+			"integrity": "sha512-HH6KqZnopF3NIXypYG4f2qxoSRmGCSzp81wJMfWjSTtvsX3cAg12RFJcm+a6Az3XadcZUrXKW3p5Dv0wyCUeuA==",
+			"requires": {
+				"tslib": "^2.0.1"
 			}
 		},
 		"@hapi/hoek": {

--- a/pkg/interface/package.json
+++ b/pkg/interface/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@fingerprintjs/fingerprintjs": "^3.3.3",
     "@radix-ui/react-dialog": "^0.1.0",
     "@reach/disclosure": "^0.10.5",
     "@reach/menu-button": "^0.10.5",

--- a/pkg/interface/src/logic/state/gardenSettings.ts
+++ b/pkg/interface/src/logic/state/gardenSettings.ts
@@ -1,0 +1,173 @@
+import f from 'lodash/fp';
+import _ from 'lodash';
+import {
+  BaseState,
+  createState,
+  createSubscription,
+  reduceStateN,
+  optReduceState
+} from '~/logic/state/base';
+import airlock from '~/logic/api';
+import {
+  getDeskSettings,
+  SettingsUpdate,
+  Value,
+  Poke,
+  putEntry as doPutEntry
+} from '@urbit/api';
+import { UseStore } from 'zustand';
+
+export interface ShortcutMapping {
+  cycleForward: string;
+  cycleBack: string;
+  navForward: string;
+  navBack: string;
+  hideSidebar: string;
+  readGroup: string;
+}
+
+export interface GardenSettingsState {
+  browserSettings: {
+    settings: string;
+  };
+  loaded: boolean;
+  getAll: () => Promise<void>;
+  putEntry: (bucket: string, key: string, value: Value) => Promise<void>;
+}
+
+function putBucket(
+  json: SettingsUpdate,
+  state: GardenSettingsState
+): GardenSettingsState {
+  const data = _.get(json, 'put-bucket', false);
+  if (data) {
+    state[data['bucket-key']] = data.bucket;
+  }
+  return state;
+}
+
+function delBucket(
+  json: SettingsUpdate,
+  state: GardenSettingsState
+): GardenSettingsState {
+  const data = _.get(json, 'del-bucket', false);
+  if (data) {
+    delete state[data['bucket-key']];
+  }
+  return state;
+}
+
+function putEntry(json: SettingsUpdate, state: any): GardenSettingsState {
+  const data: Record<string, string> = _.get(json, 'put-entry', false);
+  if (data) {
+    if (!state[data['bucket-key']]) {
+      state[data['bucket-key']] = {};
+    }
+    state[data['bucket-key']][data['entry-key']] = data.value;
+  }
+  return state;
+}
+
+function delEntry(json: SettingsUpdate, state: any): GardenSettingsState {
+  const data = _.get(json, 'del-entry', false);
+  if (data) {
+    delete state[data['bucket-key']][data['entry-key']];
+  }
+  return state;
+}
+
+export async function pokeOptimisticallyN<A, S extends {}>(
+  state: UseStore<S & BaseState<S>>,
+  poke: Poke<any>,
+  reduce: ((a: A, fn: S & BaseState<S>) => S & BaseState<S>)[]
+) {
+  let num: string | undefined = undefined;
+  try {
+    num = optReduceState(state, poke.json, reduce);
+    await airlock.poke(poke);
+    state.getState().removePatch(num);
+  } catch (e) {
+    console.error(e);
+    if (num) {
+      state.getState().rollback(num);
+    }
+  }
+}
+
+const reduceUpdate = [putBucket, delBucket, putEntry, delEntry];
+
+export const selectSettingsState = <
+  K extends keyof (GardenSettingsState & BaseState<GardenSettingsState>)
+>(
+  keys: K[]
+) => f.pick<BaseState<GardenSettingsState> & GardenSettingsState, K>(keys);
+
+// @ts-ignore investigate zustand types
+const useGardenSettingsState = createState<SettingsState>(
+  'Settings',
+  (set, get) => ({
+    browserSettings: {
+      settings: ''
+    },
+    loaded: false,
+    getAll: async () => {
+      const result = (await airlock.scry(getDeskSettings('garden'))).desk;
+
+      const newState = {
+        ..._.mergeWith(get(), result, (obj, src) =>
+          _.isArray(src) ? src : undefined
+        ),
+        loaded: true
+      };
+      set(newState);
+    },
+    // getAll: async () => {
+    // const { desk } = await airlock.scry(getDeskSettings('garden'));
+    // get().set((s) => {
+    // for (const bucket in desk) {
+    // s[bucket] = { ...(s[bucket] || {}), ...desk[bucket] };
+    // }
+    // get().set(s)
+    // });
+    // },
+    putEntry: async (bucket: string, entry: string, value: Value) => {
+      const poke = doPutEntry('garden', bucket, entry, value);
+      pokeOptimisticallyN(useGardenSettingsState, poke, reduceUpdate);
+    }
+  }),
+  [],
+  [
+    (set, get) =>
+      createSubscription('settings-store', '/desk/garden', (e) => {
+        const data = _.get(e, 'settings-event', false);
+        if (data) {
+          reduceStateN(get(), data, reduceUpdate);
+          set({ loaded: true });
+        }
+      })
+  ]
+);
+
+const selBrowserSettings = (s: GardenSettingsState) =>
+  s.browserSettings.settings;
+export function useBrowserSettings() {
+  const settings = useGardenSettingsState(selBrowserSettings);
+  console.log({ settings });
+  return settings !== '' ? JSON.parse(settings) : [];
+}
+
+export function useProtocolHandling(browserId: string) {
+  const settings = useBrowserSettings();
+  const { protocolHandling = false } =
+    settings.filter((el: any) => el.browserId === browserId)[0] ?? false;
+  return protocolHandling;
+}
+
+export function useBrowserNotifications(browserId: string) {
+  const settings = useBrowserSettings();
+  const { browserNotifications = false } =
+    settings.filter((el: any) => el.browserId === browserId)[0] ?? false;
+  return browserNotifications;
+}
+
+export default useGardenSettingsState;

--- a/pkg/interface/src/logic/state/local.tsx
+++ b/pkg/interface/src/logic/state/local.tsx
@@ -11,6 +11,7 @@ import { clearStorageMigration, createStorageKey, storageVersion, wait } from '~
 export type SubscriptionStatus = 'connected' | 'disconnected' | 'reconnecting';
 
 export interface LocalState {
+  browserId: string;
   theme: 'light' | 'dark' | 'auto';
   hideAvatars: boolean;
   hideNicknames: boolean;
@@ -42,6 +43,7 @@ export const selectLocalState =
   <K extends keyof LocalState>(keys: K[]) => f.pick<LocalState, K>(keys);
 
 const useLocalState = create<LocalStateZus>(persist((set, get) => ({
+  browserId: '',
   dark: false,
   mobile: false,
   breaks: {
@@ -129,6 +131,11 @@ function withLocalState<P, S extends keyof LocalState, C extends React.Component
 const selOsDark = (s: LocalState) => s.dark;
 export function useOsDark() {
   return useLocalState(selOsDark);
+}
+
+const selBrowserId = (s: LocalState) => s.browserId;
+export function useBrowserId() {
+  return useLocalState(selBrowserId);
 }
 
 export { useLocalState as default, withLocalState };

--- a/pkg/interface/src/views/App.tsx
+++ b/pkg/interface/src/views/App.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { Router, withRouter } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
+import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import gcpManager from '~/logic/lib/gcpManager';
 import { svgDataURL } from '~/logic/lib/util';
 import history from '~/logic/lib/history';
@@ -36,6 +37,13 @@ function ensureValidHex(color) {
   return parsedColor.startsWith('#') ? parsedColor : `#${parsedColor}`;
 }
 
+const getId = async () => {
+  const fpPromise = FingerprintJS.load();
+  const fp = await fpPromise;
+  const result = await fp.get();
+  return result.visitorId;
+};
+
 interface RootProps {
   display: SettingsState['display'];
 }
@@ -48,7 +56,7 @@ const Root = styled.div<RootProps>`
   padding-right: env(safe-area-inset-right, 0px);
   padding-top: env(safe-area-inset-top, 0px);
   padding-bottom: env(safe-area-inset-bottom, 0px);
-  
+
   margin: 0;
   ${p => p.display.backgroundType === 'url' ? `
     background-image: url('${p.display.background}');
@@ -96,6 +104,10 @@ const App: React.FunctionComponent = () => {
   React.useEffect(() => {
     bootstrapApi();
     getShallowChildren(`~${window.ship}`, 'dm-inbox');
+
+    getId().then((value) => {
+      useLocalState.setState({ browserId: value });
+    });
 
     getAll();
     gcpManager.start();

--- a/pkg/interface/src/views/apps/permalinks/embed.tsx
+++ b/pkg/interface/src/views/apps/permalinks/embed.tsx
@@ -1,15 +1,40 @@
-import { BaseAnchor, Box, BoxProps, Button, Center, Col, H3, Icon, Image, Row, Text } from '@tlon/indigo-react';
-import { Association, GraphNode, resourceFromPath, GraphConfig, Treaty, deSig } from '@urbit/api';
+import {
+  BaseAnchor,
+  Box,
+  BoxProps,
+  Button,
+  Center,
+  Col,
+  H3,
+  Icon,
+  Image,
+  Row,
+  Text
+} from '@tlon/indigo-react';
+import {
+  Association,
+  GraphNode,
+  resourceFromPath,
+  GraphConfig,
+  Treaty,
+  deSig
+} from '@urbit/api';
 import React, { useCallback, useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Link, useLocation } from 'react-router-dom';
+import api from '~/logic/api';
 import {
-  getPermalinkForGraph, GraphPermalink as IGraphPermalink, parsePermalink,
+  getPermalinkForGraph,
+  GraphPermalink as IGraphPermalink,
+  parsePermalink,
   AppPermalink as IAppPermalink
 } from '~/logic/lib/permalinks';
+import useGardenSettingsState, {
+  useProtocolHandling
+} from '~/logic/state/gardenSettings';
 import { getModuleIcon, GraphModule } from '~/logic/lib/util';
 import { useVirtualResizeProp } from '~/logic/lib/virtualContext';
-import useGraphState  from '~/logic/state/graph';
+import useGraphState from '~/logic/state/graph';
 import useMetadataState from '~/logic/state/metadata';
 import { GroupLink } from '~/views/components/GroupLink';
 import { TranscludedNode } from './TranscludedNode';
@@ -17,6 +42,7 @@ import styled from 'styled-components';
 import Author from '~/views/components/Author';
 import useDocketState, { useTreaty } from '~/logic/state/docket';
 import { createJoinParams } from '~/views/landscape/components/Join/Join';
+import { useBrowserId } from '~/logic/state/local';
 
 function Placeholder(type) {
   const lines = (type) => {
@@ -30,8 +56,8 @@ function Placeholder(type) {
     }
   };
   return (
-    <Box p='12px 12px 6px'>
-      <Row mb='6px' height="4">
+    <Box p="12px 12px 6px">
+      <Row mb="6px" height="4">
         <Box
           backgroundColor="washedGray"
           size="4"
@@ -46,7 +72,7 @@ function Placeholder(type) {
         />
       </Row>
       {_.times(lines(type), i => (
-        <Row margin="6px" ml='32px' height="4">
+        <Row margin="6px" ml="32px" height="4">
           <Box
             backgroundColor="washedGray"
             height="4"
@@ -59,7 +85,7 @@ function Placeholder(type) {
   );
 }
 
-function GroupPermalink(props: { group: string; }) {
+function GroupPermalink(props: { group: string }) {
   const { group } = props;
   return (
     <GroupLink
@@ -80,22 +106,28 @@ function GraphPermalink(
     full?: boolean;
   }
 ) {
-  const { full = false, showOurContact, pending, graph, group, index, transcluded } = props;
+  const {
+    full = false,
+    showOurContact,
+    pending,
+    graph,
+    group,
+    index,
+    transcluded
+  } = props;
   const location = useLocation();
   const { ship, name } = resourceFromPath(graph);
   const node = useGraphState(
-    useCallback(s => s.looseNodes?.[`${deSig(ship)}/${name}`]?.[index] as GraphNode, [
-      graph,
-      index
-    ])
+    useCallback(
+      s => s.looseNodes?.[`${deSig(ship)}/${name}`]?.[index] as GraphNode,
+      [graph, index]
+    )
   );
   const [errored, setErrored] = useState(false);
   const [loading, setLoading] = useState(false);
   const getNode = useGraphState(s => s.getNode);
   const association = useMetadataState(
-    useCallback(s => s.associations.graph[graph] as Association | null, [
-      graph
-    ])
+    useCallback(s => s.associations.graph[graph] as Association | null, [graph])
   );
 
   useVirtualResizeProp(Boolean(node));
@@ -118,23 +150,19 @@ function GraphPermalink(
   const showTransclusion = Boolean(association && node && transcluded < 1);
   const permalink = (() => {
     const link = `/perma${getPermalinkForGraph(group, graph, index).slice(16)}`;
-    return (!association && !loading)
-      ? { search: createJoinParams('groups', group, link)  } :  link;
+    return !association && !loading
+      ? { search: createJoinParams('groups', group, link) }
+      : link;
   })();
 
-  const [nodeGroupHost, nodeGroupName] = association?.group.split('/').slice(-2) ?? ['Unknown', 'Unknown'];
+  const [nodeGroupHost, nodeGroupName] = association?.group
+    .split('/')
+    .slice(-2) ?? ['Unknown', 'Unknown'];
   const [nodeChannelHost, nodeChannelName] = association?.resource
     .split('/')
     .slice(-2) ?? ['Unknown', 'Unknown'];
-  const [
-    locChannelName,
-    locChannelHost,
-    ,
-    ,
-    ,
-    locGroupName,
-    locGroupHost
-  ] = location.pathname.split('/').reverse();
+  const [locChannelName, locChannelHost, , , , locGroupName, locGroupHost] =
+    location.pathname.split('/').reverse();
 
   const isInSameResource =
     locChannelHost === nodeChannelHost &&
@@ -156,7 +184,10 @@ function GraphPermalink(
         e.stopPropagation();
       }}
     >
-      {loading && association && !errored && Placeholder((association.metadata.config as GraphConfig).graph)}
+      {loading &&
+        association &&
+        !errored &&
+        Placeholder((association.metadata.config as GraphConfig).graph)}
       {showTransclusion && index && !loading && (
         <TranscludedNode
           transcluded={transcluded + 1}
@@ -169,7 +200,9 @@ function GraphPermalink(
         <PermalinkDetails
           known
           showTransclusion={showTransclusion}
-          icon={getModuleIcon((association.metadata.config as GraphConfig).graph as GraphModule)}
+          icon={getModuleIcon(
+            (association.metadata.config as GraphConfig).graph as GraphModule
+          )}
           title={association.metadata.title}
         />
       )}
@@ -177,11 +210,13 @@ function GraphPermalink(
         <PermalinkDetails
           known
           showTransclusion={showTransclusion}
-          icon={getModuleIcon((association.metadata.config as GraphConfig).graph as GraphModule)}
+          icon={getModuleIcon(
+            (association.metadata.config as GraphConfig).graph as GraphModule
+          )}
           title={association.metadata.title}
         />
       )}
-      {isInSameResource && transcluded !== 2 && !loading && <Row height='2' />}
+      {isInSameResource && transcluded !== 2 && !loading && <Row height="2" />}
       {!association && !loading && (
         <PermalinkDetails
           icon="Groups"
@@ -245,14 +280,21 @@ const AppSkeleton = props => (
 
 function AppPermalink({ link, ship, desk }: Omit<IAppPermalink, 'type'>) {
   const treaty = useTreaty(ship, desk);
-  const hasProtocolHandling = Boolean(window?.navigator?.registerProtocolHandler);
-  const href = hasProtocolHandling ? link : `/apps/grid/perma?ext=${link}`;
+  const browserId = useBrowserId();
+  const protocolHandling = useProtocolHandling(browserId);
+  const href = protocolHandling ? link : `/apps/grid/perma?ext=${link}`;
 
   useEffect(() => {
     if (!treaty) {
       useDocketState.getState().requestTreaty(ship, desk);
     }
   }, [treaty, ship, desk]);
+
+  useEffect(() => {
+    const { initialize, getAll } = useGardenSettingsState.getState();
+    initialize(api);
+    getAll();
+  }, []);
 
   return (
     <Row
@@ -265,14 +307,22 @@ function AppPermalink({ link, ship, desk }: Omit<IAppPermalink, 'type'>) {
     >
       <AppTile display={['none', 'block']} {...treaty} />
       <Col flex="1">
-        <Row flexDirection={['row', 'column']} alignItems={['center', 'start']} marginBottom={2}>
+        <Row
+          flexDirection={['row', 'column']}
+          alignItems={['center', 'start']}
+          marginBottom={2}
+        >
           <AppTile display={['block', 'none']} {...treaty} />
           <Col>
-            <H3 color="black">{ treaty?.title || '%' + desk }</H3>
+            <H3 color="black">{treaty?.title || '%' + desk}</H3>
             <Author ship={treaty?.ship || ship} showImage dontShowTime={true} />
           </Col>
         </Row>
-        {treaty && <ClampedText marginBottom={2} color="gray">{treaty.info}</ClampedText>}
+        {treaty && (
+          <ClampedText marginBottom={2} color="gray">
+            {treaty.info}
+          </ClampedText>
+        )}
         {!treaty && (
           <>
             <AppSkeleton />
@@ -318,7 +368,7 @@ function PermalinkDetails(props: {
       <Row gapX="2" alignItems="center">
         <Box width={4} height={4}>
           <Center width={4} height={4}>
-            <Icon icon={icon} color='gray' />
+            <Icon icon={icon} color="gray" />
           </Center>
         </Box>
         <Text gray mono={!known}>
@@ -356,8 +406,6 @@ export function PermalinkEmbed(props: {
         />
       );
     case 'app':
-      return (
-        <AppPermalink {...permalink} />
-      );
+      return <AppPermalink {...permalink} />;
   }
 }

--- a/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/NotificationPref.tsx
@@ -1,11 +1,10 @@
 import {
-  Button,
   Col,
   ManagedToggleSwitchField as Toggle, Text
 } from '@tlon/indigo-react';
 import { Form, FormikHelpers } from 'formik';
 import _ from 'lodash';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { isWatching } from '~/logic/lib/hark';
 import useHarkState from '~/logic/state/hark';
 import { FormikOnBlur } from '~/views/components/FormikOnBlur';
@@ -72,8 +71,6 @@ export function NotificationPreferences() {
     }
   }, [graphConfig, dnd]);
 
-  const [notificationsAllowed, setNotificationsAllowed] = useState('Notification' in window && Notification.permission !== 'default');
-
   return (
     <>
     <BackButton />
@@ -90,14 +87,6 @@ export function NotificationPreferences() {
       <FormikOnBlur initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
           <Col gapY="4">
-            {notificationsAllowed || !('Notification' in window)
-              ? null
-              : <Button alignSelf='flex-start' onClick={() => {
-                Notification.requestPermission().then(() => {
-                  setNotificationsAllowed(Notification.permission !== 'default');
-                });
-              }}>Allow Browser Notifications</Button>
-            }
             <Toggle
               label="Do not disturb"
               id="dnd"

--- a/pkg/interface/src/views/landscape/components/Content.tsx
+++ b/pkg/interface/src/views/landscape/components/Content.tsx
@@ -2,7 +2,6 @@ import { Box } from '@tlon/indigo-react';
 import React, { Suspense, useCallback, useEffect } from 'react';
 import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { useLocalStorageState } from '~/logic/lib/useLocalStorageState';
 import { PermalinkRoutes } from '~/views/apps/permalinks/app';
 import { useShortcut } from '~/logic/state/settings';
 import { Loading } from '~/views/components/Loading';
@@ -56,22 +55,6 @@ export const Content = () => {
     e.stopImmediatePropagation();
     history.goBack();
   }, [history.goBack]));
-
-  const [hasProtocol, setHasProtocol] = useLocalStorageState(
-    'registeredProtocol', false
-  );
-
-  useEffect(() => {
-    if(!hasProtocol && window?.navigator?.registerProtocolHandler) {
-      try {
-        window.navigator.registerProtocolHandler('web+urbitgraph', '/perma?ext=%s', 'Urbit Links');
-        console.log('registered protocol');
-        setHasProtocol(true);
-      } catch (e) {
-        console.log(e);
-      }
-    }
-  }, [hasProtocol]);
 
   return (
     <Container>


### PR DESCRIPTION
This builds on this PR: https://github.com/urbit/urbit/pull/5660
(Which requires this PR: https://github.com/urbit/urbit/pull/5656)
And addresses this issue: https://github.com/urbit/landscape/issues/1409

Now that we're storing browser preferences on the ship we can pull those preferences out of garden/grid's settings store into other apps. We could similarly extract out the notifications and theme preferences and then remove those settings toggles from the Groups UI.

Note that this is loading the gardenSettings outside of the bootstrap at the moment and in the AppPermalink component (the only place in the app where we use it, for now). Should we stick this in bootstrap or just load these settings as we need them (@arthyn, related to our discussion on app performance and state hydration)?

Todo:
- [x] Make sure the protocol handler settings are respected universally in groups.
- [x] Apply the same thing to notifications, remove notifications settings toggle from groups.