### PR TITLE
repo: fix build on mingw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,5 +111,5 @@ jobs:
           CACHIX_CACHE: ares
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - run: make build/urbit build/urbit-worker
+      - run: mingw32-make build/urbit build/urbit-worker
       - run: build/urbit -l -d -B ../../bin/solid.pill -F bus && curl -f --data '{"source":{"dojo":"+hood/exit"},"sink":{"app":"hood"}}' http://localhost:12321

--- a/pkg/ent/configure
+++ b/pkg/ent/configure
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+: "${MAKE:=make}"
+
 log () {
   echo "$@" >&2;
 }
@@ -14,7 +16,7 @@ do
 
     log "Trying IMPL=$IMPL"
 
-    if IMPL=$impl make >/dev/null 2>/dev/null
+    if IMPL=$impl ${MAKE} >/dev/null 2>/dev/null
     then sed -i 's|$(error IMPL must be set)|IMPL='"$impl"'|' Makefile
          log "IMPL=$IMPL works"
          exit 0

--- a/pkg/urbit/compat/poor-mans-nix-shell.sh
+++ b/pkg/urbit/compat/poor-mans-nix-shell.sh
@@ -9,6 +9,8 @@ markfil=.$1~
 depdirs=
 nixpath=${NIX_STORE-../build}
 
+: "${MAKE:=make}"
+
 # LDFLAGS doesn't like absolute paths
 if [ "${nixpath:0:1}" == "/" ]
 then
@@ -84,7 +86,7 @@ buildnixdep () {
     [ -e $patch ] && patch -d $dir -p 1 <$patch
     pushd $dir
     eval "$cmdprep"
-    eval make "$cmdmake"
+    eval ${MAKE} "$cmdmake"
     touch $markfil
     popd
   fi

--- a/pkg/urbit/configure
+++ b/pkg/urbit/configure
@@ -109,6 +109,8 @@ case $(tr A-Z a-z <<< $os) in
      mpkgs=(cmake curl gcc jq make)
      pacman -S --needed autoconf automake-wrapper libtool patch ${mpkgs[@]/#/mingw-w64-x86_64-}
 
+     export MAKE=mingw32-make
+
      . compat/poor-mans-nix-shell.sh mingw
      compat/create-include-files.sh 'stat -c %s' /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
 


### PR DESCRIPTION
Apparently at some point `make` went away on the mingw system. `mingw32-make` still exists and does the trick though.