### PR TITLE
spider: fix child threads

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -101,7 +101,6 @@
     ~
   $(trie u.son, yarn t.yarn)
 ::
-::
 ++  has-yarn
   |=  [=trie =yarn]
   !=(~ (get-yarn trie yarn))
@@ -648,7 +647,6 @@
 ::
 ++  yarn-to-byk
   |=  [=yarn =bowl:gall]
-
   =/  [* * =desk]
     ~|  "no desk associated with {<tid>}"
      %-  ~(got by serving.state)  (yarn-to-tid yarn)
@@ -666,5 +664,4 @@
     %cc
     /(scot %p our.bowl)/[desk]/(scot %da now.bowl)/[from]/[to]
   ==
-
 --

--- a/pkg/arvo/mar/thread-done.hoon
+++ b/pkg/arvo/mar/thread-done.hoon
@@ -1,0 +1,11 @@
+|_  res=*
+++  grab
+  |%
+  ++  noun  *
+  --
+++  grow
+  |%
+  ++  noun  res
+  --
+++  grad  %noun
+--

--- a/pkg/arvo/mar/thread-done.hoon
+++ b/pkg/arvo/mar/thread-done.hoon
@@ -1,1 +1,1 @@
-/home/poprox/Dropbox/Tlon/urbit/pkg/base-dev/mar/thread-done.hoon
+../../base-dev/mar/thread-done.hoon

--- a/pkg/arvo/mar/thread-done.hoon
+++ b/pkg/arvo/mar/thread-done.hoon
@@ -1,11 +1,1 @@
-|_  res=*
-++  grab
-  |%
-  ++  noun  *
-  --
-++  grow
-  |%
-  ++  noun  res
-  --
-++  grad  %noun
---
+/home/poprox/Dropbox/Tlon/urbit/pkg/base-dev/mar/thread-done.hoon

--- a/pkg/arvo/mar/thread-fail.hoon
+++ b/pkg/arvo/mar/thread-fail.hoon
@@ -1,0 +1,11 @@
+|_  err=*
+++  grab
+  |%
+  ++  noun  (pair term tang)
+  --
+++  grow
+  |%
+  ++  noun  err
+  --
+++  grad  %noun
+--

--- a/pkg/arvo/mar/thread-fail.hoon
+++ b/pkg/arvo/mar/thread-fail.hoon
@@ -1,11 +1,1 @@
-|_  err=*
-++  grab
-  |%
-  ++  noun  (pair term tang)
-  --
-++  grow
-  |%
-  ++  noun  err
-  --
-++  grad  %noun
---
+/home/poprox/Dropbox/Tlon/urbit/pkg/base-dev/mar/thread-fail.hoon

--- a/pkg/arvo/mar/thread-fail.hoon
+++ b/pkg/arvo/mar/thread-fail.hoon
@@ -1,1 +1,1 @@
-/home/poprox/Dropbox/Tlon/urbit/pkg/base-dev/mar/thread-fail.hoon
+../../base-dev/mar/thread-fail.hoon

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -748,7 +748,7 @@
   ^-  form:m
   ;<  =bowl:spider  bind:m  get-bowl
   =/  tid  (scot %ta (cat 3 'strand_' (scot %uv (sham file eny.bowl))))
-  =/  poke-vase  !>([`tid.bowl `tid file args])
+  =/  poke-vase  !>([`tid.bowl `tid byk.bowl file args])
   ;<  ~      bind:m  (watch-our /awaiting/[tid] %spider /thread-result/[tid])
   ;<  ~      bind:m  (poke-our %spider %spider-start poke-vase)
   ;<  ~      bind:m  (sleep ~s0)  ::  wait for thread to start

--- a/pkg/base-dev/mar/thread-done.hoon
+++ b/pkg/base-dev/mar/thread-done.hoon
@@ -1,0 +1,11 @@
+|_  res=*
+++  grab
+  |%
+  ++  noun  *
+  --
+++  grow
+  |%
+  ++  noun  res
+  --
+++  grad  %noun
+--

--- a/pkg/base-dev/mar/thread-fail.hoon
+++ b/pkg/base-dev/mar/thread-fail.hoon
@@ -1,0 +1,11 @@
+|_  err=*
+++  grab
+  |%
+  ++  noun  (pair term tang)
+  --
+++  grow
+  |%
+  ++  noun  err
+  --
+++  grad  %noun
+--

--- a/pkg/garden/desk.docket-0
+++ b/pkg/garden/desk.docket-0
@@ -1,10 +1,10 @@
 :~  title+'System'
     info+'An app launcher for Urbit.'
     color+0xee.5432
-    glob-http+['https://bootstrap.urbit.org/glob-0v7.c3i0g.i6ruv.refhu.n0qc8.dmpil.glob' 0v7.c3i0g.i6ruv.refhu.n0qc8.dmpil]
+    glob-http+['https://bootstrap.urbit.org/glob-0v4.t104r.h4pr1.kc9bu.0f8nq.urrhk.glob' 0v4.t104r.h4pr1.kc9bu.0f8nq.urrhk]
     ::glob-ames+~zod^0v0
     base+'grid'
-    version+[1 1 1]
+    version+[1 1 2]
     website+'https://tlon.io'
     license+'MIT'
 ==


### PR DESCRIPTION
this is a band-aid for #5442.

adds `%thread-done` and `%thread-fail` marks so that child threads work.
also fixes `await-thread:strandio` and removes some blank lines from
`app/spider.hoon`

`%thread-done` loses the type of the result, so you'll need to use `;;` to
get it back. the right way to fix this is to have threads produce cages
instead of vases according to @philipcmonk 