### PR TITLE
hoon: fix +uno:by when map is null

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1453,7 +1453,6 @@
 ++  by                                                  ::  map engine
   ~/  %by
   =|  a=(tree (pair))  ::  (map)
-  =*  node  ?>(?=(^ a) n.a)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
@@ -1717,14 +1716,14 @@
     =+  b=a
     |@
     ++  $
-      |=  meg=$-([_p:node _q:node _q:node] _q:node)
+      |*  meg=$-([* * *] *)
       |-  ^+  a
       ?~  b
         a
       ?~  a
         b
       ?:  =(p.n.b p.n.a)
-        :+  [p.n.a (meg p.n.a q.n.a q.n.b)]
+        :+  [p.n.a `_?>(?=(^ a) q.n.a)`(meg p.n.a q.n.a q.n.b)]
           $(b l.b, a l.a)
         $(b r.b, a r.a)
       ?:  (mor p.n.a p.n.b)


### PR DESCRIPTION
This should be merged before next/arvo is released, because #5612 uses +uno.

This crashed at runtime when `a` is null because it tried to instantiate
`meg`, and that means bunting its argument, and that calls `node`, where
the assert failed.

Wet gates use the bunt of their formal argument, so we use that.