### PR TITLE
groups: fix issue with wrapping urls in notes

### DIFF
--- a/pkg/interface/src/views/components/TruncatedText.tsx
+++ b/pkg/interface/src/views/components/TruncatedText.tsx
@@ -2,9 +2,7 @@ import { Text } from '@tlon/indigo-react';
 import styled from 'styled-components';
 
 export const TruncatedText = styled(Text)`
-  white-space: pre;
-  text-overflow: ellipsis;
-  overflow: hidden;
   min-width: 0;
+  overflow-wrap: anywhere;
 `;
 


### PR DESCRIPTION
Fixes this: https://github.com/urbit/landscape/issues/1408

Now looks like this: 
![image](https://user-images.githubusercontent.com/1221094/161328538-e92aa51e-7b10-42b3-af24-7d04512c1b52.png)
