### PR TITLE
interface: use object-fit:cover

### DIFF
--- a/pkg/interface/src/views/components/RemoteContent/embed.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/embed.tsx
@@ -87,7 +87,7 @@ export function RemoteContentImageEmbed(
         height="192px"
         maxWidth="192px"
         width="100%"
-        objectFit="contain"
+        objectFit="cover"
         borderRadius={2}
         onError={onError}
         {...props}


### PR DESCRIPTION
This aligns image embeds with the wishes of the design team, by zooming
and cropping the image to fill the entire container