### PR TITLE
build: fix, upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,10 @@ on:
       - 'pkg/ge-additions/**'
       - 'pkg/libaes_siv/**'
       - 'pkg/urbit/**'
+      - 'pkg/urcrypt/**'
       - 'bin/**'
       - 'nix/**'
+      - default.nix
   pull_request:
     paths:
       - 'pkg/arvo/**'
@@ -51,8 +53,10 @@ on:
       - 'pkg/ge-additions/**'
       - 'pkg/libaes_siv/**'
       - 'pkg/urbit/**'
+      - 'pkg/urcrypt/**'
       - 'bin/**'
       - 'nix/**'
+      - default.nix
 
 jobs:
   urbit:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -3,7 +3,7 @@ name: release-docker
 on:
   release: null
   push:
-    tags: ['urbit-v*']
+    tags: 'urbit-v[0-9]+.[0-9]+'
 
 jobs:
   upload:

--- a/default.nix
+++ b/default.nix
@@ -109,7 +109,6 @@ let
 
     urbit-debug = urbit.override { enableDebug = true; };
     urbit-tests = libLocal.testFakeShip {
-      inherit herb;
       inherit arvo;
 
       urbit = urbit-debug;

--- a/nix/lib/test-fake-ship.nix
+++ b/nix/lib/test-fake-ship.nix
@@ -1,16 +1,16 @@
-{ lib, stdenvNoCC, cacert, python3, bootFakeShip }:
+{ lib, stdenvNoCC, curl, python3, bootFakeShip }:
 
-{ urbit, herb, arvo ? null, pill, ship ? "bus", arguments ? urbit.meta.arguments
+{ urbit, arvo ? null, pill, ship ? "bus", arguments ? urbit.meta.arguments
 , doCheck ? true }:
 
 stdenvNoCC.mkDerivation {
   name = "test-${ship}";
 
-  src = bootFakeShip { inherit urbit herb arvo pill ship; };
+  src = bootFakeShip { inherit urbit arvo pill ship; };
 
   phases = [ "unpackPhase" "buildPhase" "checkPhase" ];
 
-  buildInputs = [ cacert urbit herb python3 ];
+  buildInputs = [ curl python3 urbit ];
 
   unpackPhase = ''
     cp -R $src ./pier
@@ -25,6 +25,22 @@ stdenvNoCC.mkDerivation {
     # Sledge Hammer!
     # See: https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959
     python3 -c $'import os\n[os.set_blocking(i, True) for i in range(3)]\n'
+
+    port=$(cat ./pier/.http.ports | grep loopback | tr -s ' ' '\n' | head -n 1)
+
+    lensd() {
+      # -f elided, this can hit server-side timeouts
+      curl -s                                                              \
+        --data "{\"source\":{\"dojo\":\"$1\"},\"sink\":{\"stdout\":null}}" \
+        "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    }
+
+    lensa() {
+      # -f elided, this can hit server-side timeouts
+      curl -s                                                              \
+        --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}"  \
+        "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    }
 
     tail -F urbit-output >&2 &
 
@@ -41,69 +57,69 @@ stdenvNoCC.mkDerivation {
 
     #  measure initial memory usage
     #
-    herb ./pier -d '~&  ~  ~&  %init-mass-start  ~'
-    herb ./pier -p hood -d '+hood/mass'
-    herb ./pier -d '~&  ~  ~&  %init-mass-end  ~'
+    lensd '~&  ~  ~&  %init-mass-start  ~'
+    lensa hood '+hood/mass'
+    lensd '~&  ~  ~&  %init-mass-end  ~'
 
     #  run the unit tests
     #
-    herb ./pier -d '~&  ~  ~&  %test-unit-start  ~'
-    herb ./pier -d '####-test %/tests ~'
-    herb ./pier -d '~&  ~  ~&  %test-unit-end  ~'
+    lensd '~&  ~  ~&  %test-unit-start  ~'
+    lensd '-test %/tests ~'
+    lensd '~&  ~  ~&  %test-unit-end  ~'
 
     #  use the :test app to build all agents, generators, and marks
     #
-    herb ./pier -p hood -d '+hood/start %test'
+    lensa hood '+hood/start %test'
 
-    herb ./pier -d '~&  ~  ~&  %test-agents-start  ~'
-    herb ./pier -p test -d '%agents'
-    herb ./pier -d '~&  ~  ~&  %test-agents-end  ~'
+    lensd '~&  ~  ~&  %test-agents-start  ~'
+    lensa test '%agents'
+    lensd '~&  ~  ~&  %test-agents-end  ~'
 
-    herb ./pier -d '~&  ~  ~&  %test-generators-start  ~'
-    herb ./pier -p test -d '%generators'
-    herb ./pier -d '~&  ~  ~&  %test-generators-end  ~'
+    lensd '~&  ~  ~&  %test-generators-start  ~'
+    lensa test '%generators'
+    lensd '~&  ~  ~&  %test-generators-end  ~'
 
-    herb ./pier -d '~&  ~  ~&  %test-marks-start  ~'
-    herb ./pier -p test -d '%marks'
-    herb ./pier -d '~&  ~  ~&  %test-marks-end  ~'
+    lensd '~&  ~  ~&  %test-marks-start  ~'
+    lensa test '%marks'
+    lensd '~&  ~  ~&  %test-marks-end  ~'
 
     #  measure memory usage post tests
     #
-    herb ./pier -d '~&  ~  ~&  %test-mass-start  ~'
-    herb ./pier -p hood -d '+hood/mass'
-    herb ./pier -d '~&  ~  ~&  %test-mass-end  ~'
+    lensd '~&  ~  ~&  %test-mass-start  ~'
+    lensa hood '+hood/mass'
+    lensd '~&  ~  ~&  %test-mass-end  ~'
 
     #  defragment the loom
     #
-    herb ./pier -d '~&  ~  ~&  %pack-start  ~'
-    herb ./pier -p hood -d '+hood/pack'
-    herb ./pier -d '~&  ~  ~&  %pack-end  ~'
+    lensd '~&  ~  ~&  %pack-start  ~'
+    lensa hood '+hood/pack'
+    lensd '~&  ~  ~&  %pack-end  ~'
 
     #  reclaim space within arvo
     #
-    herb ./pier -d '~&  ~  ~&  %trim-start  ~'
-    herb ./pier -p hood -d '+hood/trim'
-    herb ./pier -d '~&  ~  ~&  %trim-end  ~'
+    lensd '~&  ~  ~&  %trim-start  ~'
+    lensa hood '+hood/trim'
+    lensd '~&  ~  ~&  %trim-end  ~'
 
     #  measure memory usage pre |meld
     #
-    herb ./pier -d '~&  ~  ~&  %trim-mass-start  ~'
-    herb ./pier -p hood -d '+hood/mass'
-    herb ./pier -d '~&  ~  ~&  %trim-mass-end  ~'
+    lensd '~&  ~  ~&  %trim-mass-start  ~'
+    lensa hood '+hood/mass'
+    lensd '~&  ~  ~&  %trim-mass-end  ~'
 
     #  globally deduplicate
     #
-    herb ./pier -d '~&  ~  ~&  %meld-start  ~'
-    herb ./pier -p hood -d '+hood/meld'
-    herb ./pier -d '~&  ~  ~&  %meld-end  ~'
+    lensd '~&  ~  ~&  %meld-start  ~'
+    lensa hood '+hood/meld'
+    lensd '~&  ~  ~&  %meld-end  ~'
 
     #  measure memory usage post |meld
     #
-    herb ./pier -d '~&  ~  ~&  %meld-mass-start  ~'
-    herb ./pier -p hood -d '+hood/mass'
-    herb ./pier -d '~&  ~  ~&  %meld-mass-end  ~'
+    lensd '~&  ~  ~&  %meld-mass-start  ~'
+    lensa hood '+hood/mass'
+    lensd '~&  ~  ~&  %meld-mass-end  ~'
 
-    herb ./pier -p hood -d '+hood/exit'
+    lensa hood '+hood/exit'
 
     cleanup
 
@@ -128,6 +144,8 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out
 
     cp test-output-* $out/
+
+    set +x
   '';
 
   checkPhase = ''
@@ -168,6 +186,4 @@ stdenvNoCC.mkDerivation {
   # Fix 'bind: operation not permitted' when nix.useSandbox = true on darwin.
   # See https://github.com/NixOS/nix/blob/5f6840fbb49ae5b534423bd8a4360646ee93dbaf/src/libstore/build.cc#L2961
   __darwinAllowLocalNetworking = true;
-
-  meta = { platforms = [ "x86_64-linux" ]; };
 }

--- a/nix/pkgs/pill/brass.nix
+++ b/nix/pkgs/pill/brass.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, herb
+{ lib, stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, curl
 , withRopsten ? false }:
 
 let
@@ -7,13 +7,13 @@ let
 
 in {
   build = import ./builder.nix {
-    inherit stdenvNoCC urbit herb;
+    inherit stdenvNoCC urbit curl;
 
     name = "brass" + lib.optionalString withRopsten "-ropsten";
     builder = ./brass.sh;
     arvo = if withRopsten then arvo.ropsten else arvo;
     pier = bootFakeShip {
-      inherit urbit herb;
+      inherit urbit;
 
       pill = solid.lfs;
       ship = "zod";

--- a/nix/pkgs/pill/brass.sh
+++ b/nix/pkgs/pill/brass.sh
@@ -15,9 +15,26 @@ cleanup () {
 
 trap cleanup EXIT
 
-header "running herb +brass"
+header "running +brass"
 
-herb ./pier -P brass.pill -d '+brass'
-herb ./pier -p hood -d '+hood/exit'
+port=$(cat ./pier/.http.ports | grep loopback | tr -s ' ' '\n' | head -n 1)
+
+lensa() {
+  # -f elided, this can hit server-side timeouts
+  curl -s                                                              \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}"  \
+    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+}
+
+lensf() {
+  # -f elided, this can hit server-side timeouts
+  d=$(echo $1 | sed 's/\./\//g')
+  curl -sJO                                                                   \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"output-pill\":\"$d\"}}" \
+    "http://localhost:$port"
+}
+
+lensf brass.pill '+brass'
+lensa hood '+hood/exit'
 
 stopNest

--- a/nix/pkgs/pill/builder.nix
+++ b/nix/pkgs/pill/builder.nix
@@ -1,9 +1,9 @@
-{ stdenvNoCC, urbit, arvo, herb, name, builder, pier }:
+{ stdenvNoCC, urbit, arvo, curl, name, builder, pier }:
 
 stdenvNoCC.mkDerivation {
   name = "${name}.pill";
   src = pier;
-  buildInputs = [ urbit herb ];
+  buildInputs = [ curl urbit ];
   dontUnpack = true;
 
   buildPhase = builtins.readFile builder;

--- a/nix/pkgs/pill/ivory.nix
+++ b/nix/pkgs/pill/ivory.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, herb, xxd
+{ lib, stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, curl, xxd
 , withRopsten ? false }:
 
 let
@@ -7,13 +7,13 @@ let
 
 in {
   build = import ./builder.nix {
-    inherit stdenvNoCC urbit herb;
+    inherit stdenvNoCC urbit curl;
 
     name = "ivory" + lib.optionalString withRopsten "-ropsten";
     builder = ./ivory.sh;
     arvo = if withRopsten then arvo.ropsten else arvo;
     pier = bootFakeShip {
-      inherit urbit herb;
+      inherit urbit;
 
       pill = solid.lfs;
       ship = "zod";

--- a/nix/pkgs/pill/ivory.sh
+++ b/nix/pkgs/pill/ivory.sh
@@ -15,9 +15,26 @@ cleanup () {
 
 trap cleanup EXIT
 
-header "running herb +ivory"
+header "running +ivory"
 
-herb ./pier -P ivory.pill -d '+ivory'
-herb ./pier -p hood -d '+hood/exit'
+port=$(cat ./pier/.http.ports | grep loopback | tr -s ' ' '\n' | head -n 1)
+
+lensa() {
+  # -f elided, this can hit server-side timeouts
+  curl -s                                                              \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}"  \
+    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+}
+
+lensf() {
+  # -f elided, this can hit server-side timeouts
+  d=$(echo $1 | sed 's/\./\//g')
+  curl -sJO                                                                   \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"output-pill\":\"$d\"}}" \
+    "http://localhost:$port"
+}
+
+lensf ivory.pill '+ivory'
+lensa hood '+hood/exit'
 
 stopNest

--- a/nix/pkgs/pill/solid.nix
+++ b/nix/pkgs/pill/solid.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, herb }:
+{ stdenvNoCC, fetchGitHubLFS, bootFakeShip, solid, urbit, arvo, curl }:
 
 let
 
@@ -8,12 +8,12 @@ in {
   inherit lfs;
 
   build = import ./builder.nix {
-    inherit stdenvNoCC urbit arvo herb;
+    inherit stdenvNoCC urbit arvo curl;
 
     name = "solid";
     builder = ./solid.sh;
     pier = bootFakeShip {
-      inherit urbit herb;
+      inherit urbit;
 
       arvo = null;
       pill = solid.lfs;

--- a/nix/pkgs/pill/solid.sh
+++ b/nix/pkgs/pill/solid.sh
@@ -17,47 +17,68 @@ cleanup () {
 
 trap cleanup EXIT
 
-# Update pill strategy to ensure correct staging
-herb ./pier -p hood -d "+hood/mount /=home="
+port=$(cat ./pier/.http.ports | grep loopback | tr -s ' ' '\n' | head -n 1)
 
-until [ -d ./pier/home ]; do
+lensa() {
+  # -f elided, this can hit server-side timeouts
+  curl -s                                                              \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}"  \
+    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+}
+
+lensf() {
+  # -f elided, this can hit server-side timeouts
+  d=$(echo $1 | sed 's/\./\//g')
+  curl -sJO                                                                   \
+    --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"output-pill\":\"$d\"}}" \
+    "http://localhost:$port"
+}
+
+header "updating %base"
+
+# Update pill strategy to ensure correct staging
+lensa hood "+hood/mount /=base="
+
+until [ -d ./pier/base ]; do
   sleep 1
 done
 
 # Update :lens, :dojo and dependencies
 # FIXME: reduce this list
-cp $ARVO/app/lens.hoon   ./pier/home/app/
-cp $ARVO/app/dojo.hoon   ./pier/home/app/
-cp $ARVO/lib/plume.hoon  ./pier/home/lib/
-cp $ARVO/lib/server.hoon ./pier/home/lib/
-cp $ARVO/lib/sole.hoon   ./pier/home/lib/
-cp $ARVO/lib/xray.hoon   ./pier/home/lib/
-cp $ARVO/lib/pprint.hoon ./pier/home/lib/      
+cp $ARVO/app/lens.hoon   ./pier/base/app/
+cp $ARVO/app/dojo.hoon   ./pier/base/app/
+cp $ARVO/lib/plume.hoon  ./pier/base/lib/
+cp $ARVO/lib/server.hoon ./pier/base/lib/
+cp $ARVO/lib/sole.hoon   ./pier/base/lib/
+cp $ARVO/lib/xray.hoon   ./pier/base/lib/
+cp $ARVO/lib/pprint.hoon ./pier/base/lib/
 
-mkdir -p ./pier/home/mar/lens/
+mkdir -p ./pier/base/mar/lens/
 
-cp $ARVO/mar/lens/*      ./pier/home/mar/lens/
+cp $ARVO/mar/lens/*      ./pier/base/mar/lens/
 
-cp $ARVO/sur/lens.hoon   ./pier/home/sur/
-cp $ARVO/sur/plum.hoon   ./pier/home/sur/
-cp $ARVO/sur/sole.hoon   ./pier/home/sur/
-cp $ARVO/sur/xray.hoon   ./pier/home/sur/
+cp $ARVO/sur/lens.hoon   ./pier/base/sur/
+cp $ARVO/sur/plum.hoon   ./pier/base/sur/
+cp $ARVO/sur/sole.hoon   ./pier/base/sur/
+cp $ARVO/sur/xray.hoon   ./pier/base/sur/
 
 # Update +solid and its dependencies
-cp $ARVO/lib/pill.hoon   ./pier/home/lib/
-cp $ARVO/gen/solid.hoon  ./pier/home/gen/
+cp $ARVO/lib/pill.hoon   ./pier/base/lib/
+cp $ARVO/gen/solid.hoon  ./pier/base/gen/
 
-chmod -R u+rw ./pier/home/
+chmod -R u+rw ./pier/base/
 
-herb ./pier -p hood -d "+hood/commit %home"
-herb ./pier -p hood -d "+hood/unmount %home"
+lensa hood "+hood/commit %base"
+lensa hood "+hood/unmount %base"
 
 # FIXME: horrible hack to ensure the update is applied first
 sleep 10
 
+header "updating %stage"
+
 # Stage new desk for pill contents
-herb ./pier -p hood -d '+hood/merge %stage our %home'
-herb ./pier -p hood -d "+hood/mount /=stage="
+lensa hood '+hood/merge %stage our %base'
+lensa hood "+hood/mount /=stage="
 
 until [ -d ./pier/stage ]; do
   sleep 1
@@ -67,9 +88,12 @@ rm -rf ./pier/stage
 cp -r $ARVO ./pier/stage
 chmod -R u+rw ./pier/stage
 
-herb ./pier -p hood -d "+hood/commit %stage"
-herb ./pier -p hood -d "+hood/unmount %stage"
-herb ./pier -P solid.pill -d '+solid /=stage=/sys, =dub &'
-herb ./pier -p hood -d '+hood/exit'
+lensa hood "+hood/commit %stage"
+lensa hood "+hood/unmount %stage"
+
+header "running +solid"
+
+lensf solid.pill '+solid /=stage=/sys, =dub &'
+lensa hood '+hood/exit'
 
 stopNest

--- a/nix/pkgs/urbit/default.nix
+++ b/nix/pkgs/urbit/default.nix
@@ -16,7 +16,7 @@ let
 
   # See https://github.com/urbit/urbit/issues/5561
   oFlags =
-    if stdenv.hostPlatform.system == "aarch64-darwin"
+    if stdenv.isDarwin
     then (if enableDebug then [ "-O0" "-g" ] else [ "-O3" ])
     else [ (if enableDebug then "-O0" else "-O3") "-g" ];
 

--- a/nix/sources-pmnsh.json
+++ b/nix/sources-pmnsh.json
@@ -43,10 +43,10 @@
             "prepare": "./autogen.sh && ./configure --disable-shared --enable-benchmark=no --enable-exhaustive-tests=no --enable-experimental --enable-module-ecdh --enable-module-recovery --enable-module-schnorrsig --enable-tests=yes CFLAGS=-DSECP256K1_API="
         },
         "repo": "secp256k1",
-        "rev": "7973576f6e3ab27d036a09397152b124d747f4ae",
-        "sha256": "0vjk55dv0mkph4k6bqgkykmxn05ngzvhc4rzjnvn33xzi8dzlvah",
+        "rev": "5dcc6f8dbdb1850570919fc9942d22f728dbc0af",
+        "sha256": "x9qG2S6tBSRseWaFIN9N2fRpY1vkv8idT3d3rfJnmaU",
         "type": "tarball",
-        "url": "https://github.com/bitcoin-core/secp256k1/archive/7973576f6e3ab27d036a09397152b124d747f4ae.tar.gz",
+        "url": "https://github.com/bitcoin-core/secp256k1/archive/5dcc6f8dbdb1850570919fc9942d22f728dbc0af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "uv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -73,15 +73,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-21.11",
+        "branch": "master",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573095944e7c1d58d30fc679c81af63668b54056",
-        "sha256": "07s5cwhskqvy82b4rld9b14ljc0013pig23i3jx3l3f957rk95pg",
+        "rev": "376d67e1cd05d5ac8a64a3f47f17b80fb6394792",
+        "sha256": "1l4ai1dppwdbkkjbvnavsivr5kx00b3q8640pilpnifskfmfc8mp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/573095944e7c1d58d30fc679c81af63668b54056.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/376d67e1cd05d5ac8a64a3f47f17b80fb6394792.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "softfloat3": {

--- a/pkg/urcrypt/urcrypt/secp256k1.c
+++ b/pkg/urcrypt/urcrypt/secp256k1.c
@@ -215,9 +215,7 @@ urcrypt_secp_schnorr_sign(urcrypt_secp_context* context,
   if ( 1 != secp256k1_keypair_create(context->secp, &keypair, key) ) {
     return -1;
   }
-  if ( 1 != secp256k1_schnorrsig_sign(context->secp, out_sig, msg, &keypair,
-                                      secp256k1_nonce_function_bip340, aux) )
-  {
+  if ( 1 != secp256k1_schnorrsig_sign(context->secp, out_sig, msg, &keypair, aux) ) {
     return -1;
   }
 
@@ -240,7 +238,7 @@ urcrypt_secp_schnorr_veri(urcrypt_secp_context* context,
   if ( 1 != secp256k1_xonly_pubkey_parse(context->secp, &pubkey, pub) ) {
     return false;
   }
-  if ( 1 != secp256k1_schnorrsig_verify(context->secp, sig, msg, &pubkey) ) {
+  if ( 1 != secp256k1_schnorrsig_verify(context->secp, sig, msg, 32, &pubkey) ) {
     return false;
   }
   return true;


### PR DESCRIPTION
This PR upgrades nixpkgs to latest master, which results in the following dependency upgrades:

```
gmp:     6.2.0  -> 6.2.1
sigsegv: 2.12   -> 2.14
openssl: 1.1.1g -> 1.1.1n
libuv:   1.40.0 -> 1.43.0
lmdb:    0.9.25 -> 0.9.29
curl:    7.72.0 -> 7.81.0
```

Most notably, this change upgrades secp256k1 (which is unversioned), and includes breaking changes to its API for schnorr signatures, which necessitates changes to urcrypt. It also upgrades LLVM from version 7 to 11 (which took about 16 hours, since the darwin `stdenv` embeds it three (3) times).

#5561 showed up again, and is apparently not M1 specific; it occurs on macos x86_64 as well (and is probably just a clang bug).

I was unable to get `herb` to build inside nix (issues with `pytest-forked` and python2), so I removed `herb` from our test suite. The pill builders are now broken, but it looks like they've been unused since at least the software-distribution upgrade in arvo.

Finally, I've tweaked the github-actions build triggers, and specifically tried to prevent "releasing" the docker image on pre-release tags. I also tried to embed the statically-linked urbit binary in the docker image, but the obvious `--arg enableStatic true` led to re-bootstrapping the universe. I'm open to suggestions ...

/cc @frodwith (re:urcrypt)

