### PR TITLE
eth-watcher: implement optional to-block parameter

### DIFF
--- a/pkg/arvo/app/azimuth-tracker.hoon
+++ b/pkg/arvo/app/azimuth-tracker.hoon
@@ -93,6 +93,7 @@
     ^-  config:eth-watcher
     :*  url.state  =(%czar (clan:title our))  ~m5  ~m30
         launch:contracts:azimuth
+        ~
         ~[azimuth:contracts:azimuth]
         ~
         (topics whos.state)

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -443,6 +443,7 @@
     ^-  config:eth-watcher
     :*  url.state  =(%czar (clan:title our.bowl))  refresh  ~h30
         (max launch.net ?:(=(net.state %default) +(last-snap) 0))
+        ~
         ~[azimuth.net]
         ~[naive.net]
         (topics whos.state)

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -8,7 +8,7 @@
 =>  |%
     +$  card  card:agent:gall
     +$  app-state
-      $:  %5
+      $:  %6
           dogs=(map path watchdog)
       ==
     ::
@@ -133,14 +133,16 @@
   ::
   =?  old-state  ?=(%4 -.old-state)
     %-  (slog leaf+"upgrading eth-watcher from %4" ~)
-    ^-  app-state
+    ^-  app-state-5
     %=    old-state
         -  %5
         dogs
       %-  ~(run by dogs.old-state)
       |=  dog=watchdog-4
+      ^-  watchdog-5
       %=  dog
           -
+        ^-  config-5
         =,  -.dog
         [url eager refresh-rate timeout-time from contracts ~ topics]
       ::
@@ -160,10 +162,56 @@
       ==
     ==
   ::
-  [cards-1 this(state ?>(?=(%5 -.old-state) old-state))]
+  =?  old-state  ?=(%5 -.old-state)
+    %-  (slog leaf+"upgrading eth-watcher from %5" ~)
+    ^-  app-state
+    %=    old-state
+        -  %6
+        dogs
+      %-  ~(run by dogs.old-state)
+      |=  dog=watchdog-5
+      ^-  watchdog
+      %=  dog
+          -
+        ^-  config
+        =,  -.dog
+        [url eager refresh-rate refresh-rate from ~ contracts batchers topics]
+      ::
+          running
+        ?~  running.dog  ~
+        `[now.bowl tid.u.running.dog]
+      ==
+    ==
+  ::
+  [cards-1 this(state ?>(?=(%6 -.old-state) old-state))]
   ::
   +$  app-states
-    $%(app-state-0 app-state-1 app-state-2 app-state-3 app-state-4 app-state)
+    $%(app-state-0 app-state-1 app-state-2 app-state-3 app-state-4 app-state-5 app-state)
+  ::
+  +$  app-state-5
+    $:  %5
+        dogs=(map path watchdog-5)
+    ==
+  ::
+  +$  watchdog-5
+    $:  config-5
+        running=(unit [since=@da =tid:spider])
+        =number:block
+        =pending-logs
+        =history
+        blocks=(list block)
+    ==
+  ::
+  +$  config-5
+    $:  url=@ta
+        eager=?
+        refresh-rate=@dr
+        timeout-time=@dr
+        from=number:block
+        contracts=(list address:ethereum)
+        batchers=(list address:ethereum)
+        =topics
+    ==
   ::
   +$  app-state-4
     $:  %4
@@ -529,6 +577,12 @@
       ::  if not (or no longer) running, start a new thread
       ::
       ?^  running.dog
+        `dog
+      :: if reached the to-block, don't start a new thread
+      ::
+      ?:  ?&  ?=(^ to.dog)
+              (gte number.dog u.to.dog)
+          ==
         `dog
       ::
       =/  new-tid=@ta

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -210,6 +210,7 @@
       refresh-rate
       timeout-time
       public:mainnet-contracts
+      ~
       ~[azimuth delegated-sending]:mainnet-contracts
       ~
       ~

--- a/pkg/arvo/sur/eth-watcher.hoon
+++ b/pkg/arvo/sur/eth-watcher.hoon
@@ -9,6 +9,7 @@
       ::  refresh-rate: rate at which to check for updates
       ::  timeout-time: time an update check is allowed to take
       ::  from: oldest block number to look at
+      ::  to: optional newest block number to look at
       ::  contracts: contract addresses to look at
       ::  topics: event descriptions to look for
       ::
@@ -17,6 +18,7 @@
       refresh-rate=@dr
       timeout-time=@dr
       from=number:block
+      to=(unit number:block)
       contracts=(list address:ethereum)
       batchers=(list address:ethereum)
       =topics

--- a/pkg/arvo/ted/eth-watcher.hoon
+++ b/pkg/arvo/ted/eth-watcher.hoon
@@ -13,7 +13,8 @@
 =/  m  (strand:strandio ,vase)
 ^-  form:m
 ;<  =latest=block  bind:m  (get-latest-block:ethio url.pup)
-;<  pup=watchpup   bind:m  (zoom pup number.id.latest-block)
+=+  last=number.id.latest-block
+;<  pup=watchpup   bind:m  (zoom pup last (min last (fall to.pup last)))
 =|  vows=disavows
 ;<  pup=watchpup   bind:m  (fetch-batches pup)
 ::?.  eager.pup
@@ -79,7 +80,7 @@
 ::    at a safe distance -- 100 blocks ago is probably sufficient.
 ::
 ++  zoom
-  |=  [pup=watchpup =latest=number:block]
+  |=  [pup=watchpup =latest=number:block up-to=number:block]
   =/  m  (strand:strandio ,watchpup)
   ^-  form:m
   =/  zoom-margin=number:block  30
@@ -87,7 +88,11 @@
   ?:  (lth latest-number (add number.pup zoom-margin))
     (pure:m pup)
   =/  up-to-number=number:block
-    (min (add 10.000.000 number.pup) (sub latest-number zoom-margin))
+    ;:  min
+      (add 10.000.000 number.pup)
+      (sub latest-number zoom-margin)
+      up-to
+    ==
   |-
   =*  loop  $
   ?:  (gth number.pup up-to-number)


### PR DESCRIPTION
As discussed out of band with @yosoyubik and @Fang-, I need this feature because my custom `/app/gaze` that produces events for the [network explorer](https://network.urbit.org/)  runs out of memory when processing a massive batch of logs.