### PR TITLE
strandio: fix +await-thread %thread-fail handling

### DIFF
--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -756,6 +756,6 @@
   ;<  ~      bind:m  (take-kick /awaiting/[tid])
   ?+  p.cage  ~|([%strange-thread-result p.cage file tid] !!)
     %thread-done  (pure:m %& q.cage)
-    %thread-fail  (pure:m %| !<([term tang] q.cage))
+    %thread-fail  (pure:m %| ;;([term tang] q.q.cage))
   ==
 --


### PR DESCRIPTION
Due to the clunky hack to fix child threads in #5670, data validated by the `%thread-fail` mark is just a raw noun, so we need to use `;;` instead of `!<` on the `[term tang]` in the `cage`.

In response to: https://github.com/urbit/urbit/pull/5671#pullrequestreview-929497298