### PR TITLE
links: image thumbnail fills entire grid item

### DIFF
--- a/pkg/interface/src/views/apps/links/components/LinkBlockItem.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkBlockItem.tsx
@@ -34,11 +34,12 @@ export interface LinkBlockItemProps {
   node: GraphNode;
   size?: CenterProps['height'];
   border?: CenterProps['border'];
+  objectFit?: string;
   summary?: boolean;
 }
 
 export function LinkBlockItem(props: LinkBlockItemProps & CenterProps) {
-  const { node, summary, size, m, border = 1, ...rest } = props;
+  const { node, summary, size, m, border = 1, objectFit, ...rest } = props;
   const { post, children } = node;
   const { contents, index, author } = post;
 
@@ -90,7 +91,12 @@ export function LinkBlockItem(props: LinkBlockItemProps & CenterProps) {
           />
         )
       ) : isImage ? (
-        <RemoteContentImageEmbed url={url} />
+          <RemoteContentImageEmbed
+            url={url}
+            tall
+            stretch
+            objectFit={objectFit ? objectFit : "cover"}
+          />
       ) : isAudio ? (
         <AudioPlayer title={title} url={url} />
       ) : isOembed ? (

--- a/pkg/interface/src/views/apps/links/components/LinkDetail.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkDetail.tsx
@@ -27,7 +27,6 @@ export function LinkDetail(props: LinkDetailProps) {
   return (
     /*  @ts-ignore indio props?? */
     <Row height="100%" width="100%" flexDirection={['column', 'column', 'row']} {...rest}>
-      <LinkBlockItem minWidth="0" minHeight="0" height={['50%', '50%', '100%']} width={['100%', '100%', 'calc(100% - 350px)']} flexGrow={0} border={0} node={node} />
       <LinkBlockItem
         minWidth="0"
         minHeight="0"

--- a/pkg/interface/src/views/apps/links/components/LinkDetail.tsx
+++ b/pkg/interface/src/views/apps/links/components/LinkDetail.tsx
@@ -28,6 +28,16 @@ export function LinkDetail(props: LinkDetailProps) {
     /*  @ts-ignore indio props?? */
     <Row height="100%" width="100%" flexDirection={['column', 'column', 'row']} {...rest}>
       <LinkBlockItem minWidth="0" minHeight="0" height={['50%', '50%', '100%']} width={['100%', '100%', 'calc(100% - 350px)']} flexGrow={0} border={0} node={node} />
+      <LinkBlockItem
+        minWidth="0"
+        minHeight="0"
+        height={["50%", "50%", "100%"]}
+        width={["100%", "100%", "calc(100% - 350px)"]}
+        flexGrow={0}
+        border={0}
+        node={node}
+        objectFit="contain"
+      />
       <Col
         minHeight="0"
         flexShrink={1}

--- a/pkg/interface/src/views/components/RemoteContent/embed.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/embed.tsx
@@ -44,13 +44,14 @@ function onStopProp<T extends HTMLElement>(e: MouseEvent<T>) {
 
 type ImageProps = PropFunc<typeof BaseImage> & {
   objectFit?: string;
+  stretch?: boolean;
 };
 
 const Image = styled.img(system({ objectFit: true }), ...allSystemStyle);
 export function RemoteContentImageEmbed(
   props: ImageProps & RemoteContentEmbedProps
 ) {
-  const { url, ...rest } = props;
+  const { url, stretch, ...rest } = props;
   const [noCors, setNoCors] = useState(false);
   const { hovering, bind } = useHovering();
   // maybe images aren't set up for CORS embeds
@@ -59,7 +60,13 @@ export function RemoteContentImageEmbed(
   }, []);
 
   return (
-    <Box height="100%" width="100%" position="relative" {...bind} {...rest}>
+    <Box
+      height={stretch ? "100%" : "192px"}
+      width={stretch ? "100%" : "192px"}
+      position="relative"
+      {...bind}
+      {...rest}
+    >
       <BaseAnchor
         position="absolute"
         top={2}
@@ -84,8 +91,8 @@ export function RemoteContentImageEmbed(
         referrerPolicy="no-referrer"
         flexShrink={0}
         src={url}
-        height="192px"
-        maxWidth="192px"
+        height={stretch ? "100%" : "192px"}
+        maxWidth={stretch ? "100%" : "192px"}
         width="100%"
         objectFit="cover"
         borderRadius={2}


### PR DESCRIPTION
Adds an optional "stretch" prop to image thumbnails to correctly fill the grid items in Collections.

![image](https://user-images.githubusercontent.com/748181/162224527-a79f2de2-1133-4888-9d11-38f9e34347ae.png)

Also changes the object-fit in the Collections item detail view to show the whole image, uncropped.

![image](https://user-images.githubusercontent.com/748181/162225012-5c1d83b7-98aa-4776-9b45-3469acb5c7b6.png)

fixes urbit/landscape#1313