### PR TITLE
groups: show group settings menu when pressing settings cog on mobile

### DIFF
--- a/pkg/interface/src/logic/lib/useMedia.ts
+++ b/pkg/interface/src/logic/lib/useMedia.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useMedia = (mediaQuery: string) => {
+  const [match, setMatch] = useState(false);
+
+  const update = useCallback((e: MediaQueryListEvent) => {
+    setMatch(e.matches);
+  }, []);
+
+  useEffect(() => {
+    const query = window.matchMedia(mediaQuery);
+
+    query.addEventListener('change', update);
+    update({ matches: query.matches } as MediaQueryListEvent);
+    return () => {
+      query.removeEventListener('change', update);
+    };
+  }, [update]);
+
+  return match;
+};

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -77,7 +77,8 @@ export function GroupSwitcher(props: {
   isAdmin: any;
 }) {
   const { workspace, isAdmin } = props;
-  const isMobile = useMedia('(max-width: 639px)')
+  const isMobile = useMedia('(max-width: 639px)');
+  const path = isMobile ? '/popover' : '/popover/settings';
   const associations = useMetadataState(state => state.associations);
   const title = getTitleFromWorkspace(associations, workspace);
   const metadata = (workspace.type === 'home' || workspace.type  === 'messages')
@@ -146,26 +147,14 @@ export function GroupSwitcher(props: {
                       />
                       <Text> Participants</Text>
                     </GroupSwitcherItem>
-                    {isMobile ? (
-                      <GroupSwitcherItem to={navTo('/popover')}>
-                        <Icon
-                          mr={2}
-                          color="gray"
-                          icon="Gear"
-                        />
-                        <Text> Group Settings</Text>
-                      </GroupSwitcherItem>
-
-                      ) : (
-                      <GroupSwitcherItem to={navTo('/popover/settings')}>
-                        <Icon
-                          mr={2}
-                          color="gray"
-                          icon="Gear"
-                        />
-                        <Text> Group Settings</Text>
-                      </GroupSwitcherItem>
-                    )}
+                    <GroupSwitcherItem to={navTo(path)}>
+                      <Icon
+                        mr={2}
+                        color="gray"
+                        icon="Gear"
+                      />
+                      <Text> Group Settings</Text>
+                    </GroupSwitcherItem>
                     {isAdmin && (<GroupSwitcherItem bottom to={navTo('/invites')}>
                       <Icon
                         mr={2}
@@ -195,15 +184,9 @@ export function GroupSwitcher(props: {
                     ml='12px'
                   />
                 </Link>)}
-                {isMobile ? (
-                  <Link to={navTo('/popover')}>
-                    <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
-                  </Link>
-                  ) : (
-                  <Link to={navTo('/popover/settings')}>
-                    <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
-                  </Link>
-                )}
+                <Link to={navTo(path)}>
+                  <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
+                </Link>
               </>
             )}
           </Row>

--- a/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSwitcher.tsx
@@ -10,6 +10,7 @@ import { Link } from 'react-router-dom';
 import { uxToHex } from '~/logic/lib/util';
 import { getTitleFromWorkspace } from '~/logic/lib/workspace';
 import useMetadataState from '~/logic/state/metadata';
+import { useMedia } from '~/logic/lib/useMedia';
 import { Workspace } from '~/types/workspace';
 import { Dropdown } from '~/views/components/Dropdown';
 import { MetadataIcon } from './MetadataIcon';
@@ -76,6 +77,7 @@ export function GroupSwitcher(props: {
   isAdmin: any;
 }) {
   const { workspace, isAdmin } = props;
+  const isMobile = useMedia('(max-width: 639px)')
   const associations = useMetadataState(state => state.associations);
   const title = getTitleFromWorkspace(associations, workspace);
   const metadata = (workspace.type === 'home' || workspace.type  === 'messages')
@@ -144,14 +146,26 @@ export function GroupSwitcher(props: {
                       />
                       <Text> Participants</Text>
                     </GroupSwitcherItem>
-                    <GroupSwitcherItem to={navTo('/popover/settings')}>
-                      <Icon
-                        mr={2}
-                        color="gray"
-                        icon="Gear"
-                      />
-                      <Text> Group Settings</Text>
-                    </GroupSwitcherItem>
+                    {isMobile ? (
+                      <GroupSwitcherItem to={navTo('/popover')}>
+                        <Icon
+                          mr={2}
+                          color="gray"
+                          icon="Gear"
+                        />
+                        <Text> Group Settings</Text>
+                      </GroupSwitcherItem>
+
+                      ) : (
+                      <GroupSwitcherItem to={navTo('/popover/settings')}>
+                        <Icon
+                          mr={2}
+                          color="gray"
+                          icon="Gear"
+                        />
+                        <Text> Group Settings</Text>
+                      </GroupSwitcherItem>
+                    )}
                     {isAdmin && (<GroupSwitcherItem bottom to={navTo('/invites')}>
                       <Icon
                         mr={2}
@@ -181,9 +195,15 @@ export function GroupSwitcher(props: {
                     ml='12px'
                   />
                 </Link>)}
-                <Link to={navTo('/popover/settings')}>
-                  <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
-                </Link>
+                {isMobile ? (
+                  <Link to={navTo('/popover')}>
+                    <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
+                  </Link>
+                  ) : (
+                  <Link to={navTo('/popover/settings')}>
+                    <Icon color='gray' display="inline-block" ml={'12px'} icon="Gear" />
+                  </Link>
+                )}
               </>
             )}
           </Row>


### PR DESCRIPTION
Fixes: https://github.com/urbit/landscape/issues/1426

Added the useMedia hook that we use in grid to groups, added an isMobile check to the GroupSwitcher in order to navigate to just the popover route on mobile so we can see the menu rather than going straight to the notifications section of the settings screen.