### PR TITLE
build: wip depend on libecc in urcrypt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -79,6 +79,8 @@ let
 
     libaes_siv = callPackage ./nix/pkgs/libaes_siv { inherit (pkgsNative) cmake; };
 
+    libecc = callPackage ./nix/pkgs/libecc { };
+
     murmur3 = callPackage ./nix/pkgs/murmur3 { };
 
     softfloat3 = callPackage ./nix/pkgs/softfloat3 { };

--- a/nix/pkgs/libecc/default.nix
+++ b/nix/pkgs/libecc/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, sources, bc, rsync, enableParallelBuilding ? true }:
+
+stdenv.mkDerivation {
+  pname = "libecc";
+  version = sources.libecc.rev;
+  src = sources.libecc;
+
+  preBuild = ''
+    buildFlagsArray+=(WNOERROR=1);
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+    cp build/*.a $out/lib/
+    rsync -rv --prune-empty-dirs --include '*/' --include '**/*.h' --exclude '**/*' src/ $out/include/
+  '';
+
+  nativeBuildInputs =
+    [ bc rsync ];
+
+  inherit enableParallelBuilding;
+}

--- a/nix/pkgs/urcrypt/default.nix
+++ b/nix/pkgs/urcrypt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoreconfHook, pkgconfig
-, libaes_siv, openssl, secp256k1
+, libaes_siv, libecc, openssl, secp256k1
 , enableStatic ? stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
@@ -17,5 +17,5 @@ stdenv.mkDerivation rec {
     [ autoreconfHook pkgconfig ];
 
   propagatedBuildInputs =
-    [ openssl secp256k1 libaes_siv ];
+    [ openssl secp256k1 libaes_siv libecc ];
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -21,6 +21,18 @@
         "url": "https://github.com/h2o/h2o/archive/v2.2.6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "libecc": {
+      "branch": "master",
+      "description": "library for elliptic curve cryptography",
+      "homepage": "https://github.com/ANSSI-FR/libecc",
+      "owner": "ANSSI-FR",
+      "repo": "libecc",
+      "rev": "v0.9.5.1",
+      "sha256": "026lacdlfsmw2hvlw331fmf22lrnfw7181w6a1rz33a8bnfiy734",
+      "type": "tarball",
+      "url": "https://github.com/ANSSI-FR/libecc/archive/v0.9.5.1.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "libaes_siv": {
         "branch": "master",
         "description": null,


### PR DESCRIPTION
libecc doesn't have an install target; in particular there's no
provision for making the header files available. Just hand-roll an rsync
to grab them.

TODO: pmnsh, probably need a way to depend on rsync (maybe also bc?)
from Windows.