### PR TITLE
groups: fix join/leave notification toggle

### DIFF
--- a/pkg/interface/src/views/components/StatelessAsyncToggle.tsx
+++ b/pkg/interface/src/views/components/StatelessAsyncToggle.tsx
@@ -1,7 +1,7 @@
 import {
-  LoadingSpinner, StatelessToggleSwitchField as Toggle,
-
-  Text
+  Box,
+  Icon,
+  LoadingSpinner, StatelessToggleSwitchField as Toggle
 } from '@tlon/indigo-react';
 import React, { ReactElement } from 'react';
 import { useStatelessAsyncClickable } from '~/logic/lib/useStatelessAsyncClickable';
@@ -22,11 +22,17 @@ export function StatelessAsyncToggle({
   } = useStatelessAsyncClickable(onClick, name);
 
   return state === 'error' ? (
-    <Text>Error</Text>
+    <Box width={5} textAlign='center' title='Something went wrong...'>
+      <Icon icon='ExclaimationMarkBold' />
+    </Box>
   ) : state === 'loading' ? (
-    <LoadingSpinner foreground={'white'} background="gray" />
+    <Box width={5} textAlign='center'>
+      <LoadingSpinner foreground={'white'} background="gray" />
+    </Box>
   ) : state === 'success' ? (
-    <Text mx={2}>Done</Text>
+    <Box width={5} textAlign='center' title='Success'>
+      <Icon icon='CheckmarkBold' />
+    </Box>
   ) : (
     <Toggle onClick={handleClick} {...rest} />
   );

--- a/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/Personal.tsx
@@ -34,8 +34,8 @@ export function GroupPersonalSettings(props: {
       >
         <StatelessAsyncToggle selected={watching} onClick={onClick} />
         <Col>
-          <Label>Notify me on group activity</Label>
-          <Label mt={2} gray>Send me notifications when this group changes</Label>
+          <Label>Notify me on participant activity</Label>
+          <Label mt={2} gray>When a user joins or leaves this group, send me a notification</Label>
         </Col>
       </BaseLabel>
     </Col>


### PR DESCRIPTION
Adjusts the "Group Notifications" toggle copy to reflect reality.

![image](https://user-images.githubusercontent.com/748181/162463949-12ddaeec-409e-451d-9dfd-c6500ddd64eb.png)

Also makes some minor refinements to the StatelessAsyncToggle such that state changes don't cause layout jumps and/or rely on words like "Saved" or "Done," which may be confusing when used in non-matching contexts.

Off:
![image](https://user-images.githubusercontent.com/748181/162464204-4a56ee81-2a47-40bd-9d05-30b4c0a0f06f.png)

Loading:
![image](https://user-images.githubusercontent.com/748181/162464314-3fd70a04-7d3d-47fc-ab42-0a1feacb2c81.png)

Success (tooltip shown):
![image](https://user-images.githubusercontent.com/748181/162464804-68e44645-36af-4a87-9b82-17f0db806e4e.png)

Error (tooltip shown):
![image](https://user-images.githubusercontent.com/748181/162464592-0d5c5039-a46e-4ba6-8cf4-9cff728c577a.png)

On:
![image](https://user-images.githubusercontent.com/748181/162465112-778ae162-a2aa-49d6-9899-2cc1ff835178.png)

fixes urbit/landscape#1012