### PR TITLE
groups: various copy and design fixes

### DIFF
--- a/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
+++ b/pkg/interface/src/views/apps/chat/components/ChatMessage.tsx
@@ -290,18 +290,18 @@ const MessageActions = ({ onReply, onDelete, msg, isAdmin, permalink }) => {
 
   return (
     <Box
-      borderRadius={1}
+      borderRadius={2}
       backgroundColor='white'
       border='1px solid'
       borderColor='lightGray'
       position='absolute'
-      top='-12px'
+      top='-16px'
       right={2}
     >
       <Row>
         <Box
-          padding={1}
-          size={'24px'}
+          padding={2}
+          size={5}
           cursor='pointer'
           onClick={() => onReply(msg)}
         >
@@ -342,7 +342,7 @@ const MessageActions = ({ onReply, onDelete, msg, isAdmin, permalink }) => {
               </Col>
             }
           >
-            <Box padding={1} size={'24px'} cursor='pointer'>
+            <Box padding={2} size={5} cursor='pointer'>
               <Icon icon='Menu' size={3} />
             </Box>
           </Dropdown>

--- a/pkg/interface/src/views/apps/settings/components/lib/BackgroundPicker.tsx
+++ b/pkg/interface/src/views/apps/settings/components/lib/BackgroundPicker.tsx
@@ -28,7 +28,7 @@ export function BackgroundPicker(): ReactElement {
           <ImageInput
             ml={5}
             id="bgUrl"
-            placeholder="Drop or upload a file, or paste a link here"
+            placeholder="Drop or upload a file, or paste an image URL here"
             name="bgUrl"
           />
         </Col>

--- a/pkg/interface/src/views/components/CommentItem.tsx
+++ b/pkg/interface/src/views/components/CommentItem.tsx
@@ -128,6 +128,7 @@ return false;
                   {(window.ship == post?.author && !disabled) ? (
                     <ActionLink
                       color="blue"
+                      bg="white"
                       to={{
                         pathname: props.baseUrl,
                         search: `?edit=${commentIndex}`

--- a/pkg/interface/src/views/components/ImageInput.tsx
+++ b/pkg/interface/src/views/components/ImageInput.tsx
@@ -42,7 +42,7 @@ const prompt = (
         style={{ pointerEvents: 'none' }}
         onSelect={e => e.preventDefault}
       >
-        Paste a link here
+        Paste an image URL here
         {canUpload ? (
           <>
             , or

--- a/pkg/interface/src/views/components/StatelessUrlInput.tsx
+++ b/pkg/interface/src/views/components/StatelessUrlInput.tsx
@@ -59,10 +59,10 @@ export function StatelessUrlInput(props: StatelessUrlInputProps) {
                 >
                   upload
                 </Text>{' '}
-                a file, or paste a link here
+                a file, or paste a URL here
               </>
             ) : (
-              'Paste a link here'
+              'Paste a URL here'
             )}
           </Text>
         </Box>

--- a/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
+++ b/pkg/interface/src/views/landscape/components/GroupSettings/GroupFeed.tsx
@@ -66,8 +66,7 @@ export function GroupFeedSettings(props: {
             <Col>
               <Label>Enable Group Feed</Label>
               <Label gray mt={1}>
-                Disabling the Group Feed archives the content and is not
-                viewable to anyone
+                Disabling the Group Feed permanently removes its contents
               </Label>
             </Col>
           </BaseLabel>


### PR DESCRIPTION
A fun survey of tiny, annoying issues.

- Adjusts the size of the buttons in the chat message actions menu.
- Eliminates the white background in dark mode for editing a comment.
- Replaces "link" with "URL" or "image URL" in link and image inputs.
- Changes the Group Feed toggle help text to reflect reality.

fixes urbit/landscape#1377
fixes urbit/landscape#1328
fixes urbit/landscape#1161
fixes urbit/landscape#1045