### PR TITLE
u3: improve %bout time printing

### DIFF
--- a/pkg/urbit/include/noun/allocate.h
+++ b/pkg/urbit/include/noun/allocate.h
@@ -677,6 +677,11 @@
           void
           u3a_lop(c3_w lab_w);
 
+        /* u3a_print_time: print microsecond time.
+        */
+          void
+          u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d);
+
         /* u3a_print_memory(): print memory amount.
         */
           void

--- a/pkg/urbit/noun/allocate.c
+++ b/pkg/urbit/noun/allocate.c
@@ -1922,6 +1922,27 @@ u3a_discount_noun(u3_noun som)
   }
 }
 
+/* u3a_print_time: print microsecond time.
+*/
+void
+u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d)
+{
+  c3_assert( 0 != str_c );
+
+  c3_w sec_w = (mic_d / 1000000);
+  c3_w mec_w = (mic_d % 1000000) / 1000;
+  c3_w mic_w = (mic_d % 1000);
+
+  if ( sec_w ) {
+    sprintf(str_c, "%s s/%d.%03d.%03d", cap_c, sec_w, mec_w, mic_w);
+  }
+  else if ( mec_w ) {
+    sprintf(str_c, "%s ms/%d.%03d", cap_c, mec_w, mic_w);
+  }
+  else {
+    sprintf(str_c, "%s \xc2\xb5s/%d", cap_c, mic_w);
+  }
+}
 
 /* u3a_print_memory: print memory amount.
 */

--- a/pkg/urbit/noun/nock.c
+++ b/pkg/urbit/noun/nock.c
@@ -1736,8 +1736,8 @@ _n_hilt_hind(u3_noun tok, u3_noun pro)
   u3_noun p_tok, q_tok;
   if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__bout == p_tok) ) {
     u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(q_tok));
-    c3_c    str_c[64];
-    snprintf(str_c, 63, "took %" PRIu64 "\xc2\xb5s", u3r_chub(0, delta) );
+    c3_c str_c[64];
+    u3a_print_time(str_c, "took", u3r_chub(0, delta));
     u3t_slog(u3nc(0, u3i_string(str_c)));
     u3z(delta);
   }
@@ -1820,7 +1820,7 @@ _n_hint_hind(u3_noun tok, u3_noun pro)
 
     // format the timing report
     c3_c str_c[64];
-    snprintf(str_c, 63, "took %" PRIu64 "\xc2\xb5s", u3r_chub(0, delta) );
+    u3a_print_time(str_c, "took", u3r_chub(0, delta));
 
     // join the timing report with the original tank from q_q_tok like so:
     // "q_q_tok: report"


### PR DESCRIPTION
<img width="612" alt="image" src="https://user-images.githubusercontent.com/3829764/162643198-df1ea46a-c830-4434-b9b1-d87014f24e62.png">

<img width="173" alt="image" src="https://user-images.githubusercontent.com/3829764/162643628-db421727-f44b-47df-8939-c5c61c180b37.png">

If we ever come up with a good `@dr` sub-second notation, we could consider using that instead. Until that time, this should be more readable than what we have now.

(Not very excited about how the interface here is subtly inconsistent with `u3a_print_memory`, but didn't want to make a bigger change. Maybe there's C magic I don't have that can bridge the gap, idk!)