### PR TITLE
eth-watcher: remove obsolete zoom-margin handling

### DIFF
--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -512,15 +512,12 @@
     ^-  (quip card watchdog)
     ?:  (lth number.dog 30)
       `dog
-    =/  rel-number  (sub number.dog 30)
     =/  numbers=(list number:block)  ~(tap in ~(key by pending-logs.dog))
     =.  numbers  (sort numbers lth)
     =^  logs=(list event-log:rpc:ethereum)  dog
       |-  ^-  (quip event-log:rpc:ethereum watchdog)
       ?~  numbers
         `dog
-      ?:  (gth i.numbers rel-number)
-        $(numbers t.numbers)
       =^  rel-logs-1  dog
         =/  =loglist  (~(get ja pending-logs.dog) i.numbers)
         =.  pending-logs.dog  (~(del by pending-logs.dog) i.numbers)


### PR DESCRIPTION
The zoom margin is handled in [`/ted/eth-watcher`](https://github.com/urbit/urbit/blob/132592e32eea16eafdcc275bbd4652421d51b53e/pkg/arvo/ted/eth-watcher.hoon#L86), so this code is unnecessary. My work on #5695 revealed this problem since if you specify a `to-block` when subscribing to `/app/eth-watcher` the last batch of logs never gets released.