### PR TITLE
Images should use -webkit-optimize-contrast.

### DIFF
--- a/pkg/garden/desk.docket-0
+++ b/pkg/garden/desk.docket-0
@@ -1,10 +1,10 @@
 :~  title+'System'
     info+'An app launcher for Urbit.'
     color+0xee.5432
-    glob-http+['https://bootstrap.urbit.org/glob-0v7.c3i0g.i6ruv.refhu.n0qc8.dmpil.glob' 0v7.c3i0g.i6ruv.refhu.n0qc8.dmpil]
+    glob-http+['https://bootstrap.urbit.org/glob-0v4.t104r.h4pr1.kc9bu.0f8nq.urrhk.glob' 0v4.t104r.h4pr1.kc9bu.0f8nq.urrhk]
     ::glob-ames+~zod^0v0
     base+'grid'
-    version+[1 1 1]
+    version+[1 1 2]
     website+'https://tlon.io'
     license+'MIT'
 ==

--- a/pkg/interface/src/views/components/RemoteContent/embed.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/embed.tsx
@@ -89,6 +89,7 @@ export function RemoteContentImageEmbed(
         objectFit="contain"
         borderRadius={2}
         onError={onError}
+        style={{ imageRendering: '-webkit-optimize-contrast' }}
         {...props}
       />
     </Box>


### PR DESCRIPTION
The gains from this unobtrusive change are fairly straightforward.

![before](https://user-images.githubusercontent.com/10970247/162988190-c0282fdf-f00d-4bec-b42f-8283e395a515.png)

![after](https://user-images.githubusercontent.com/10970247/162988089-c333120f-7161-4760-8362-319a7c61248c.png)