### PR TITLE
clay: convert all blobs to pages

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -787,16 +787,6 @@
   +$  ankh  (axal [p=lobe q=cage])                      ::  fs node (new)
   +$  beam  [[p=ship q=desk r=case] s=path]             ::  global name
   +$  beak  [p=ship q=desk r=case]                      ::  path prefix
-  +$  blob                                              ::  fs blob
-    $%  [%delta p=lobe q=lobe r=page]                   ::  delta on q
-        [%direct p=lobe q=page]                         ::  immediate
-        [%dead p=lobe ~]                                ::  tombstone
-    ==                                                  ::
-  +$  blub                                              ::  over-the-wire blob
-    $%  [%delta p=lobe q=[p=mark q=lobe] r=page]        ::  delta on q
-        [%direct p=lobe q=page]                         ::  immediate
-        [%dead p=lobe ~]                                ::  tombstone
-    ==                                                  ::
   +$  cable                                             :: lib/sur/mark ref
     $:  face=(unit term)                                ::
         file-path=term                                  ::
@@ -841,7 +831,6 @@
         %meet-that                                      ::  hers if conflict
     ==                                                  ::
   +$  lobe  @uvI                                        ::  blob ref
-  +$  maki  [p=@ta q=@ta r=@ta s=path]                  ::
   +$  miso                                              ::  ankh delta
     $%  [%del ~]                                        ::  delete
         [%ins p=cage]                                   ::  insert
@@ -870,10 +859,9 @@
   +$  norm  (axal ?)                                    ::  tombstone policy
   +$  open  $-(path vase)                               ::  get prelude
   +$  page  (cask *)                                    ::  untyped cage
-  +$  plop  blub                                        ::  unvalidated blob
   +$  rang                                              ::  repository
     $:  hut=(map tako yaki)                             ::  changes
-        lat=(map lobe blob)                             ::  data
+        lat=(map lobe page)                             ::  data
     ==                                                  ::
   +$  rant                                              ::  response to request
     $:  p=[p=care q=case r=desk]                        ::  clade release book

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -169,9 +169,11 @@
 ::
 ::  New desk data.
 ::
-::  Sent to other ships to update them about a particular desk.  Includes a map
-::  of all new aeons to hashes of their commits, the most recent aeon, and sets
-::  of all new commits and data.
+::  Sent to other ships to update them about a particular desk.
+::  Includes a map of all new aeons to hashes of their commits, the most
+::  recent aeon, and sets of all new commits and data.  `bar` is always
+::  empty now because we expect you to request any data you don't have
+::  yet
 ::
 +$  nako                                                ::  subscription state
   $:  gar=(map aeon tako)                               ::  new ids
@@ -3057,11 +3059,11 @@
       =*  lobe-loop  $
       ?~  lobes
         yaki-loop(yakis t.yakis)
-      ?:  (~(has by lat.ran) lobe.i.lobes)
-        lobe-loop(lobes t.lobes)
-      ?:  =([~ %|] (~(fit ^de norm) path.i.lobes))
-        lobe-loop(lobes t.lobes)
-      =.  missing  (~(put in missing) lobe.i.lobes)
+      =?    missing
+          ?&  !(~(has by lat.ran) lobe.i.lobes)
+              !=([~ %|] (~(fit ^de norm) path.i.lobes))
+          ==
+        (~(put in missing) lobe.i.lobes)
       lobe-loop(lobes t.lobes)
     ::
     ::  Receive backfill response

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -130,14 +130,8 @@
   =/  tak  (scot %uv (~(got by hit.dom) let.dom))
   =/  yak  .^(yaki cs/~[her syd yon %yaki tak])
   =/  lob  (scot %uv (~(got by q.yak) /sys/kelvin))
-  =/  bob  .^(blob cs/~[her syd yon %blob lob])
-  ::
-  ;;  weft
-  ?-  -.bob
-    %direct  q.q.bob
-    %delta   q.r.bob
-    %dead    ~|(%tombstoned-kelvin !!)
-  ==
+  =/  peg  .^(page cs/~[her syd yon %blob lob])
+  ;;(weft q.peg)
 ::  +read-kelvin-local: read /sys/kelvin from a local desk
 ::
 ++  read-kelvin-local
@@ -165,14 +159,8 @@
   =/  fil  (~(get by q.yak) /desk/bill)
   ?~  fil  ~
   =/  lob  (scot %uv u.fil)
-  =/  bob  .^(blob cs/~[her syd yon %blob lob])
-  ::
-  ;;  (list dude)
-  ?-  -.bob
-    %direct  q.q.bob
-    %delta   q.r.bob
-    %dead    ~|(%tombstoned-bill !!)
-  ==
+  =/  peg  .^(page cs/~[her syd yon %blob lob])
+  ;;((list dude) q.peg)
 ::  +read-bill: read contents of /desk/bill manifest
 ::
 ++  read-bill


### PR DESCRIPTION
This converts the blob store from having deltas, directs, and
tombstones, to just having direct pages.  This simplifies a lot of code,
since we don't have to constantly ensure that deltas always have their
parent available.

This removes the hardcoded text diff logic from clay, which was
previously required for bootstrapping.

Over the wire, we handle both old and new requests and responses
transparently, so communication is normal in both directions across
ships which do or do not have this change.

Built on top of #5408 to take advantage of the cleanup there.