### PR TITLE
s3: adding v4 signatures for updated compatibility

### DIFF
--- a/pkg/interface/src/logic/lib/useStorage.ts
+++ b/pkg/interface/src/logic/lib/useStorage.ts
@@ -34,7 +34,8 @@ const useStorage = ({ accept = '*' } = { accept: '*' }): IuseStorage => {
       }
       client.current = new S3Client({
         credentials: s3.credentials,
-        endpoint: s3.credentials.endpoint
+        endpoint: s3.credentials.endpoint,
+        signatureVersion: 'v4'
       });
     }
   }, [gcp.token, s3.credentials]);


### PR DESCRIPTION
This PR adds the latest signature version used in most s3 providers, many of which only support v4. Notably this allows people to use [Filebase](https://filebase.com) which has a generous free tier.