### PR TITLE
Images should use -webkit-optimize-contrast.

### DIFF
--- a/pkg/interface/src/views/components/RemoteContent/embed.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/embed.tsx
@@ -97,6 +97,7 @@ export function RemoteContentImageEmbed(
         objectFit="cover"
         borderRadius={2}
         onError={onError}
+        style={{ imageRendering: '-webkit-optimize-contrast' }}
         {...props}
       />
     </Box>


### PR DESCRIPTION
(Replicated from #5712, minus the extraneous changes.) 

The gains from this unobtrusive change are fairly straightforward.

![before](https://user-images.githubusercontent.com/10970247/162988190-c0282fdf-f00d-4bec-b42f-8283e395a515.png)

![after](https://user-images.githubusercontent.com/10970247/162988089-c333120f-7161-4760-8362-319a7c61248c.png)