### PR TITLE
landscape: fix automatically watching group chats

### DIFF
--- a/pkg/landscape/app/group-view.hoon
+++ b/pkg/landscape/app/group-view.hoon
@@ -190,6 +190,11 @@
     |%
     ++  pull-action  pull-hook-action+!>([%add ship rid])
     ::
+    ++  listen-hark
+      |=  gr=resource
+      %+  poke-our:pass:io  %hark-graph-hook
+      hark-graph-hook-action+!>([%listen gr /])
+    ::
     ++  watch-md      (watch-our:(jn-pass-io /md) %metadata-store /updates)
     ++  watch-groups  (watch-our:(jn-pass-io /groups) %group-store /groups)
     ++  watch-md-nacks  (watch-our:(jn-pass-io /md-nacks) %metadata-pull-hook /nack)
@@ -436,6 +441,9 @@
       =?  jn-core  |(hidden autojoin.request)
         %-  emit-many
         (turn graphs pull-gra:pass)
+      =?  jn-core  hidden
+        %-  emit-many
+        (turn graphs listen-hark:pass)
       jn-core
       ::
       ++  feed-rid

--- a/pkg/landscape/ted/graph/create.hoon
+++ b/pkg/landscape/ted/graph/create.hoon
@@ -35,6 +35,8 @@
     (poke-our %group-store group-update-0+!>([%add-members rid (sy our.bowl ~)]))
   ;<  ~  bind:m
     (poke-our %group-push-hook push-hook-act)
+  ;<  ~  bind:m
+    (poke-our %hark-graph-hook hark-graph-hook-action+!>([%listen rid /]))
   (pure:m rid)
 --
 ::


### PR DESCRIPTION
Adds functionality in %group-view and -group-create to automatically
watch group chats when created. This appears to have gotten lost around
the time of the hark-graph-hook and group-view rewrite