### PR TITLE
landscape: remove new group from group-view on leave

### DIFF
--- a/pkg/landscape/ted/group/leave.hoon
+++ b/pkg/landscape/ted/group/leave.hoon
@@ -38,4 +38,6 @@
   (raw-poke-our %contact-pull-hook pull-hook-act)
 ;<  ~  bind:m
   (raw-poke-our %group-store remove)
+;<  ~  bind:m
+  (raw-poke-our %group-view group-view-action+!>([%done rid]))
 (pure:m !>(~))


### PR DESCRIPTION
This fixes "ghost groups" if you leave a group soon after joining