### PR TITLE
WIP: add mock http library to grid

### DIFF
--- a/pkg/grid/package-lock.json
+++ b/pkg/grid/package-lock.json
@@ -20,6 +20,7 @@
         "@types/lodash": "^4.14.172",
         "@urbit/api": "^2.1.0",
         "@urbit/http-api": "^2.1.0",
+        "@urbit/mock-http-api": "file:../../../mock-http-api",
         "big-integer": "^1.6.48",
         "classnames": "^2.3.1",
         "clipboard-copy": "^4.0.1",
@@ -77,6 +78,43 @@
         "typescript": "^4.3.2",
         "vite": "^2.6.7",
         "vite-plugin-html-config": "^1.0.5"
+      }
+    },
+    "../../../mock-http-api": {
+      "name": "@urbit/mock-http-api",
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@microsoft/fetch-event-source": "^2.0.0",
+        "browser-or-node": "^1.3.0",
+        "core-js": "^3.19.1"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.15.8",
+        "@babel/preset-env": "^7.15.8",
+        "@babel/preset-typescript": "^7.16.0",
+        "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-commonjs": "^21.0.1",
+        "@rollup/plugin-node-resolve": "^13.0.6",
+        "@types/browser-or-node": "^1.2.0",
+        "@types/eventsource": "^1.1.5",
+        "@types/jest": "^26.0.24",
+        "@types/react": "^16.9.56",
+        "@typescript-eslint/eslint-plugin": "^4.7.0",
+        "@typescript-eslint/parser": "^4.7.0",
+        "babel-jest": "^27.0.6",
+        "cross-fetch": "^3.1.4",
+        "event-target-polyfill": "0.0.3",
+        "fast-text-encoding": "^1.0.3",
+        "jest": "^27.0.6",
+        "rollup": "^2.59.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.30.0",
+        "typescript": "^3.9.7",
+        "util": "^0.12.3",
+        "web-streams-polyfill": "^3.0.3",
+        "yet-another-abortcontroller-polyfill": "0.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1489,6 +1527,10 @@
         "browser-or-node": "^1.3.0",
         "core-js": "^3.19.1"
       }
+    },
+    "node_modules/@urbit/mock-http-api": {
+      "resolved": "../../../mock-http-api",
+      "link": true
     },
     "node_modules/@urbit/vite-plugin-urbit": {
       "version": "0.7.1",
@@ -8277,6 +8319,39 @@
         "@microsoft/fetch-event-source": "^2.0.0",
         "browser-or-node": "^1.3.0",
         "core-js": "^3.19.1"
+      }
+    },
+    "@urbit/mock-http-api": {
+      "version": "file:../../../mock-http-api",
+      "requires": {
+        "@babel/core": "^7.15.8",
+        "@babel/preset-env": "^7.15.8",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.12.5",
+        "@microsoft/fetch-event-source": "^2.0.0",
+        "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-commonjs": "^21.0.1",
+        "@rollup/plugin-node-resolve": "^13.0.6",
+        "@types/browser-or-node": "^1.2.0",
+        "@types/eventsource": "^1.1.5",
+        "@types/jest": "^26.0.24",
+        "@types/react": "^16.9.56",
+        "@typescript-eslint/eslint-plugin": "^4.7.0",
+        "@typescript-eslint/parser": "^4.7.0",
+        "babel-jest": "^27.0.6",
+        "browser-or-node": "^1.3.0",
+        "core-js": "^3.19.1",
+        "cross-fetch": "^3.1.4",
+        "event-target-polyfill": "0.0.3",
+        "fast-text-encoding": "^1.0.3",
+        "jest": "^27.0.6",
+        "rollup": "^2.59.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.30.0",
+        "typescript": "^3.9.7",
+        "util": "^0.12.3",
+        "web-streams-polyfill": "^3.0.3",
+        "yet-another-abortcontroller-polyfill": "0.0.4"
       }
     },
     "@urbit/vite-plugin-urbit": {

--- a/pkg/grid/package.json
+++ b/pkg/grid/package.json
@@ -15,8 +15,8 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^0.1.5",
     "@fingerprintjs/fingerprintjs": "^3.3.3",
+    "@radix-ui/react-checkbox": "^0.1.5",
     "@radix-ui/react-dialog": "^0.0.20",
     "@radix-ui/react-dropdown-menu": "^0.0.23",
     "@radix-ui/react-icons": "^1.1.0",
@@ -27,6 +27,7 @@
     "@types/lodash": "^4.14.172",
     "@urbit/api": "^2.1.0",
     "@urbit/http-api": "^2.1.0",
+    "@urbit/mock-http-api": "file:../../../mock-http-api",
     "big-integer": "^1.6.48",
     "classnames": "^2.3.1",
     "clipboard-copy": "^4.0.1",

--- a/pkg/grid/package.json
+++ b/pkg/grid/package.json
@@ -92,5 +92,8 @@
       "prettier --write"
     ],
     "*.+{json,css,md}": "prettier --write"
+  },
+  "msw": {
+    "workerDirectory": "public"
   }
 }

--- a/pkg/grid/public/mockServiceWorker.js
+++ b/pkg/grid/public/mockServiceWorker.js
@@ -1,0 +1,338 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.39.2).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '02f4ad4a2797f85668baf196e553d929'
+const bypassHeaderName = 'x-msw-bypass'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  return self.skipWaiting()
+})
+
+self.addEventListener('activate', async function (event) {
+  return self.clients.claim()
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+// Resolve the "main" client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: serializeHeaders(clonedResponse.headers),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const requestClone = request.clone()
+  const getOriginalResponse = () => fetch(requestClone)
+
+  // Bypass mocking when the request client is not active.
+  if (!client) {
+    return getOriginalResponse()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return await getOriginalResponse()
+  }
+
+  // Bypass requests with the explicit bypass header
+  if (requestClone.headers.get(bypassHeaderName) === 'true') {
+    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
+
+    // Remove the bypass header to comply with the CORS preflight check.
+    delete cleanRequestHeaders[bypassHeaderName]
+
+    const originalRequest = new Request(requestClone, {
+      headers: new Headers(cleanRequestHeaders),
+    })
+
+    return fetch(originalRequest)
+  }
+
+  // Send the request to the client-side MSW.
+  const reqHeaders = serializeHeaders(request.headers)
+  const body = await request.text()
+
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: reqHeaders,
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body,
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_SUCCESS': {
+      return delayPromise(
+        () => respondWithMock(clientMessage),
+        clientMessage.payload.delay,
+      )
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return getOriginalResponse()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a request Promise emulates a network error.
+      throw networkError
+    }
+
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url,
+      )
+
+      return respondWithMock(clientMessage)
+    }
+  }
+
+  return getOriginalResponse()
+}
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = uuidv4()
+
+  return event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+function serializeHeaders(headers) {
+  const reqHeaders = {}
+  headers.forEach((value, name) => {
+    reqHeaders[name] = reqHeaders[name]
+      ? [].concat(reqHeaders[name]).concat(value)
+      : value
+  })
+  return reqHeaders
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(JSON.stringify(message), [channel.port2])
+  })
+}
+
+function delayPromise(cb, duration) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(cb()), duration)
+  })
+}
+
+function respondWithMock(clientMessage) {
+  return new Response(clientMessage.payload.body, {
+    ...clientMessage.payload,
+    headers: clientMessage.payload.headers,
+  })
+}
+
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/pkg/grid/src/state/api.ts
+++ b/pkg/grid/src/state/api.ts
@@ -1,5 +1,7 @@
 import Urbit from '@urbit/http-api';
+import UrbitMock from '@urbit/mock-http-api';
 import { useMockData } from './util';
+import { handlers } from './mock-handlers';
 
 declare global {
   interface Window {
@@ -7,15 +9,7 @@ declare global {
   }
 }
 
-const api = useMockData
-  ? ({
-      poke: async () => {},
-      subscribe: async () => {},
-      subscribeOnce: async () => {},
-      ship: '',
-      scry: async () => {}
-    } as unknown as Urbit)
-  : new Urbit('', '');
+const api = useMockData ? new UrbitMock('', '', handlers) : new Urbit('', '');
 if (import.meta.env.DEV || useMockData) {
   api.verbose = true;
 }

--- a/pkg/grid/src/state/docket.ts
+++ b/pkg/grid/src/state/docket.ts
@@ -1,5 +1,4 @@
 import create, { SetState } from 'zustand';
-import produce from 'immer';
 import { useCallback, useEffect, useState } from 'react';
 import { omit, pick } from 'lodash';
 import {
@@ -13,7 +12,6 @@ import {
   Treaty,
   Docket,
   Treaties,
-  chadIsRunning,
   AllyUpdateIni,
   AllyUpdateNew,
   TreatyUpdateIni,
@@ -25,8 +23,7 @@ import {
   allyShip
 } from '@urbit/api';
 import api from './api';
-import { mockAllies, mockCharges, mockTreaties } from './mock-data';
-import { fakeRequest, normalizeUrbitColor, useMockData } from './util';
+import { normalizeUrbitColor, useMockData } from './util';
 import { Status } from '../logic/useAsyncCall';
 
 export interface ChargeWithDesk extends Charge {
@@ -60,15 +57,13 @@ interface DocketState {
 }
 
 const useDocketState = create<DocketState>((set, get) => ({
-  defaultAlly: useMockData ? '~zod' : null,
+  defaultAlly: null,
   fetchDefaultAlly: async () => {
     const defaultAlly = await api.scry<string>(scryDefaultAlly);
     set({ defaultAlly });
   },
   fetchCharges: async () => {
-    const charg = useMockData
-      ? await fakeRequest(mockCharges)
-      : (await api.scry<ChargeUpdateInitial>(scryCharges)).initial;
+    const charg = (await api.scry<ChargeUpdateInitial>(scryCharges)).initial;
 
     const charges = Object.entries(charg).reduce((obj: ChargesWithDesks, [key, value]) => {
       // eslint-disable-next-line no-param-reassign
@@ -79,24 +74,18 @@ const useDocketState = create<DocketState>((set, get) => ({
     set({ charges });
   },
   fetchAllies: async () => {
-    const allies = useMockData ? mockAllies : (await api.scry<AllyUpdateIni>(scryAllies)).ini;
+    const allies = (await api.scry<AllyUpdateIni>(scryAllies)).ini;
     set({ allies });
     return allies;
   },
   fetchAllyTreaties: async (ally: string) => {
-    let treaties = useMockData
-      ? mockTreaties
-      : (await api.scry<TreatyUpdateIni>(scryAllyTreaties(ally))).ini;
+    let treaties = (await api.scry<TreatyUpdateIni>(scryAllyTreaties(ally))).ini;
     treaties = normalizeDockets(treaties);
     set((s) => ({ treaties: { ...s.treaties, ...treaties } }));
     return treaties;
   },
   requestTreaty: async (ship: string, desk: string) => {
     const { treaties } = get();
-    if (useMockData) {
-      set({ treaties: await fakeRequest(treaties) });
-      return treaties[desk];
-    }
 
     const key = `${ship}/${desk}`;
     if (key in treaties) {
@@ -116,10 +105,6 @@ const useDocketState = create<DocketState>((set, get) => ({
       throw new Error('Bad install');
     }
     set((state) => addCharge(state, desk, { ...treaty, chad: { install: null } }));
-    if (useMockData) {
-      await new Promise<void>((res) => setTimeout(() => res(), 10000));
-      set((state) => addCharge(state, desk, { ...treaty, chad: { glob: null } }));
-    }
 
     return api.poke(docketInstall(ship, desk));
   },
@@ -135,14 +120,6 @@ const useDocketState = create<DocketState>((set, get) => ({
     });
   },
   toggleDocket: async (desk: string) => {
-    if (useMockData) {
-      set(
-        produce((draft) => {
-          const charge = draft.charges[desk];
-          charge.chad = chadIsRunning(charge.chad) ? { suspend: null } : { glob: null };
-        })
-      );
-    }
     const { charges } = get();
     const charge = charges[desk];
     if (!charge) {
@@ -155,9 +132,9 @@ const useDocketState = create<DocketState>((set, get) => ({
       await api.poke(kilnSuspend(desk));
     }
   },
-  treaties: useMockData ? normalizeDockets(mockTreaties) : {},
+  treaties: {},
   charges: {},
-  allies: useMockData ? mockAllies : {},
+  allies: {},
   addAlly: async (ship) => {
     set((draft) => {
       draft.allies[ship] = [];

--- a/pkg/grid/src/state/mock-data.ts
+++ b/pkg/grid/src/state/mock-data.ts
@@ -375,3 +375,8 @@ export const mockVats = _.reduce(
   },
   { base: mockVat('base', true) } as Vats
 );
+
+export const mockSubscribeResponse = {
+  data: { ok: 'ok', response: 'subscribe' },
+  event: ''
+};

--- a/pkg/grid/src/state/mock-handlers.ts
+++ b/pkg/grid/src/state/mock-handlers.ts
@@ -27,7 +27,7 @@ export const handlers: Handler[] = [
     path: '/desk/garden',
     func: () => {
       return {
-        thing: 'A thing'
+        desk: 'garden'
       };
     }
   }

--- a/pkg/grid/src/state/mock-handlers.ts
+++ b/pkg/grid/src/state/mock-handlers.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@urbit/mock-http-api';
-import { mockAllies, mockCharges, mockVats } from './mock-data';
+import { mockAllies, mockCharges, mockSubscribeResponse, mockVats } from './mock-data';
 
 export const handlers: Handler[] = [
   {
@@ -35,5 +35,65 @@ export const handlers: Handler[] = [
         desk: 'garden'
       };
     }
+  },
+  {
+    action: 'subscribe',
+    app: 'hark-store',
+    path: '/notes',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'hark-store',
+    path: '/updates',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'docket',
+    path: '/charges',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'treaty',
+    path: '/treaties',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'treaty',
+    path: '/allies',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'hood',
+    path: '/kiln/vats',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'settings-store',
+    path: '/desk/garden',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'contact-pull-hook',
+    path: '/nacks',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'contact-store',
+    path: '/all',
+    func: () => mockSubscribeResponse
+  },
+  {
+    action: 'subscribe',
+    app: 'hark-graph-hook',
+    path: '/updates',
+    func: () => mockSubscribeResponse
   }
 ];

--- a/pkg/grid/src/state/mock-handlers.ts
+++ b/pkg/grid/src/state/mock-handlers.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@urbit/mock-http-api';
-import { mockAllies, mockCharges } from './mock-data';
+import { mockAllies, mockCharges, mockVats } from './mock-data';
 
 export const handlers: Handler[] = [
   {
@@ -21,6 +21,11 @@ export const handlers: Handler[] = [
     app: 'hood',
     path: '/kiln/lag',
     func: () => false
+  },
+  {
+    app: 'hood',
+    path: '/kiln/vats',
+    func: () => mockVats
   },
   {
     app: 'settings-store',

--- a/pkg/grid/src/state/mock-handlers.ts
+++ b/pkg/grid/src/state/mock-handlers.ts
@@ -1,0 +1,34 @@
+import { Handler } from '@urbit/mock-http-api';
+import { mockAllies, mockCharges } from './mock-data';
+
+export const handlers: Handler[] = [
+  {
+    app: 'treaty',
+    path: '/default-ally',
+    func: () => '~zod'
+  },
+  {
+    app: 'docket',
+    path: '/charges',
+    func: () => ({ initial: mockCharges })
+  },
+  {
+    app: 'treaty',
+    path: '/allies',
+    func: () => ({ ini: mockAllies })
+  },
+  {
+    app: 'hood',
+    path: '/kiln/lag',
+    func: () => false
+  },
+  {
+    app: 'settings-store',
+    path: '/desk/garden',
+    func: () => {
+      return {
+        thing: 'A thing'
+      };
+    }
+  }
+];


### PR DESCRIPTION
WIP on using new mock-http-api library in grid.

`npm run mock` works. still need to switch over a few calls to use the new mock paradigm.