### PR TITLE
Fix proposal for Groups: embeds break formatting context and more

### DIFF
--- a/pkg/interface/src/views/components/RemoteContent/index.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/index.tsx
@@ -65,9 +65,7 @@ export function RemoteContent(props: RemoteContentProps) {
   };
 
   const fallback = !renderUrl ? null : (
-    <RemoteContentWrapper {...wrapperProps}>
-      <TruncatedText>{url}</TruncatedText>
-    </RemoteContentWrapper>
+    ``
   );
 
   if (isImage && remoteContentPolicy.imageShown) {

--- a/pkg/interface/src/views/components/RemoteContent/index.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/index.tsx
@@ -1,3 +1,6 @@
+import {
+  Box,
+} from '@tlon/indigo-react';
 import { hasProvider } from 'oembed-parser';
 import React from 'react';
 import useSettingsState from '~/logic/state/settings';
@@ -64,36 +67,42 @@ export function RemoteContent(props: RemoteContentProps) {
     embedOnly: !renderUrl || tall
   };
 
-  const fallback = !renderUrl ? null : (
-    ``
-  );
+  const fallback = null;
 
   if (isImage && remoteContentPolicy.imageShown) {
     return (
-      <RemoteContentWrapper {...wrapperProps} noOp={transcluded} replaced>
-        <RemoteContentImageEmbed url={url} />
-      </RemoteContentWrapper>
+      <Box mt={1} mb={2} flexShrink={0}>
+        <RemoteContentWrapper {...wrapperProps} noOp={transcluded} replaced>
+          <RemoteContentImageEmbed url={url} />
+        </RemoteContentWrapper>
+      </Box>
     );
   } else if (isAudio && remoteContentPolicy.audioShown) {
     return (
-      <RemoteContentWrapper {...wrapperProps}>
-        <RemoteContentAudioEmbed url={url} />
-      </RemoteContentWrapper>
+      <Box mt={1} mb={2} flexShrink={0}>
+        <RemoteContentWrapper {...wrapperProps}>
+          <RemoteContentAudioEmbed url={url} />
+        </RemoteContentWrapper>
+      </Box>
     );
   } else if (isVideo && remoteContentPolicy.videoShown) {
     return (
-      <RemoteContentWrapper
-        {...wrapperProps}
-        detail={<RemoteContentVideoEmbed url={url} />}
-      >
-        <TruncatedText>{url}</TruncatedText>
-      </RemoteContentWrapper>
+      <Box mt={1} mb={2} flexShrink={0}>
+        <RemoteContentWrapper
+          {...wrapperProps}
+          detail={<RemoteContentVideoEmbed url={url} />}
+        >
+          <TruncatedText>{url}</TruncatedText>
+        </RemoteContentWrapper>
+      </Box>
     );
   } else if (isOembed && remoteContentPolicy.oembedShown) {
     return (
-      <AsyncFallback fallback={fallback}>
-        <RemoteContentOembed ref={embedRef} url={url} renderUrl={renderUrl} />
-      </AsyncFallback>
+      <Box mt={1} mb={2} flexShrink={0}>
+        <AsyncFallback fallback={fallback}>
+          <RemoteContentOembed ref={embedRef} url={url} renderUrl={renderUrl} />
+        </AsyncFallback>
+      </Box>
     );
   }
   return fallback;

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -457,9 +457,7 @@ const renderers = {
     </Box>
   ),
   'graph-url': ({ url, tall }) => (
-    <Box mt={1} mb={2} flexShrink={0}>
-      <RemoteContent key={url} url={url} tall={tall} />
-    </Box>
+     <RemoteContent key={url} url={url} tall={tall} />
   ),
   'graph-reference': ({ reference, transcluded }) => {
     const { link } = referenceToPermalink({ reference });

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -154,7 +154,7 @@ const contentToMdAst = (tall: boolean) => (
           {
             type: 'link',
             url: content.url,
-            children: [{type: 'text', value: content.url}]
+            children: [{ type: 'text', value: content.url }]
           }
         ]
       }
@@ -198,7 +198,7 @@ function stitchInline(a: any, b: any) {
       last.children.push({
         type: 'paragraph',
         children: []
-      })
+      });
     }
   }
   if (last?.children) {
@@ -302,17 +302,17 @@ function stitchAsts(asts: [StitchMode, GraphAstNode][]) {
     if (c.type === 'blockquote' && t[1].children[idx +1] !== undefined && t[1].children[idx +1].type === 'paragraph') {
         const next = idx !== t[1].children.length -1
             ? t[1].children.splice(idx +1, 1)
-            : []
+            : [];
 
         if (next.length > 0) {
-            t[1].children[idx].children.push(next[0])
+            t[1].children[idx].children.push(next[0]);
         }
-    };
+    }
 
-    let links = [];
+    const links = [];
     function addRichEmbedURL(nodes) {
       if (nodes?.children) {
-        nodes.children.filter(k => {
+        nodes.children.filter((k) => {
           if (k.type === 'link') {
             links.push({
               type: 'root',
@@ -322,9 +322,9 @@ function stitchAsts(asts: [StitchMode, GraphAstNode][]) {
                   url: k.url
                 }
               ]
-            })
+            });
           } else if (k?.children) {
-            k.children.filter(o => {
+            k.children.filter((o) => {
               if (o.type === 'link') {
                 links.push({
                   type: 'root',
@@ -334,20 +334,19 @@ function stitchAsts(asts: [StitchMode, GraphAstNode][]) {
                       url: o.url
                     }
                   ]
-                })
+                });
               }
-            })
+            });
           }
-        })
+        });
 
         nodes.children.push(...links);
       }
     }
-    addRichEmbedURL(c)
-
+    addRichEmbedURL(c);
   });
 
-  return t
+  return t;
 }
 const header = ({ children, depth, ...rest }) => {
   const level = depth;

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -147,13 +147,14 @@ const contentToMdAst = (tall: boolean) => (
     ];
   } else if ('url' in content) {
     return [
-      'block',
+      'inline',
       {
         type: 'root',
         children: [
           {
-            type: 'graph-url',
-            url: content.url
+            type: 'link',
+            url: content.url,
+            children: [{type: 'text', value: content.url}]
           }
         ]
       }

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -187,8 +187,20 @@ function stitchInline(a: any, b: any) {
   if (!a?.children) {
     throw new Error('Bad stitchInline call: missing root');
   }
+
   const lastParaIdx = a.children.length - 1;
   const last = a.children[lastParaIdx];
+
+  // wrap bare link in list-item inside a p node
+  // for better typography consistency
+  if (last?.type === 'listItem') {
+    if (last?.children.length === 0) {
+      last.children.push({
+        type: 'paragraph',
+        children: []
+      })
+    }
+  }
   if (last?.children) {
     const ros = {
       ...a,

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -271,7 +271,7 @@ function stitchInlineAfterBlock(a: Root, b: GraphMentionNode[]) {
 }
 
 function stitchAsts(asts: [StitchMode, GraphAstNode][]) {
-  return _.reduce(
+  const t = _.reduce(
     asts,
     ([prevMode, ast], [mode, val]): [StitchMode, GraphAstNode] => {
       if (prevMode === 'block' || prevMode === 'inline') {
@@ -298,6 +298,29 @@ function stitchAsts(asts: [StitchMode, GraphAstNode][]) {
     },
     ['block', { type: 'root', children: [] }] as [StitchMode, GraphAstNode]
   );
+
+  t[1].children.map(c => {
+    if (c?.children) {
+      let links = [];
+      c.children.filter(k => {
+        if (k.type === 'link') {
+          links.push({
+            type: 'root',
+            children: [
+              {
+                type: 'graph-url',
+                url: k.url
+              }
+            ]
+          })
+        }
+      })
+
+      c.children.push(...links);
+    }
+  });
+
+  return t
 }
 const header = ({ children, depth, ...rest }) => {
   const level = depth;

--- a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
+++ b/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx
@@ -446,7 +446,7 @@ const renderers = {
     );
   },
   list: ({ depth, ordered, children }) => {
-    return ordered ? <Ol>{children}</Ol> : <Ul>{children}</Ul>;
+    return ordered ? <Ol fontSize="1">{children}</Ol> : <Ul fontSize="1">{children}</Ul>;
   },
   'graph-mention': (obj) => {
     return <Mention ship={obj.ship} emphasis={obj.emphasis} />;

--- a/pkg/interface/src/views/landscape/components/Graph/blockquote.js
+++ b/pkg/interface/src/views/landscape/components/Graph/blockquote.js
@@ -120,7 +120,6 @@ function blockquote(eat, value, silent) {
 
   exit = self.enterBlock()
   contents = self.tokenizeBlock(contents.join(lineFeed), now)
-  console.log(values);
   exit()
 
   const added = add({type: 'blockquote', children: contents})


### PR DESCRIPTION
This is a follow up to https://github.com/urbit/urbit/pull/5715. The commits in the previous PR were based off of the wrong branch (`next/landscape` instead of `next/groups`). I re-applied them to this branch in order to avoid excessive diff.

To summarise, this PR:

- change links to be plain URLs
- add rich-embed URL below each plain URL link when appropriate (eg when the link is audio, video, oEmbed, etc)
- allow links to be part of a blockquote without breaking out from the syntax

Furthermore, it addresses a few more small details reported in the previous PR convo (https://github.com/urbit/urbit/pull/5715):

- set URLs in a list item to keep the same text size as the rest of the text
- avoid to display extra nodes below single URLs

This last point, while implemented "visually", is not fully implemented: the extra space is caused by this bit of code (https://github.com/afincato/urbit/blob/db6130146bb9949e249a0b668f8836297340b55a/pkg/interface/src/views/landscape/components/Graph/GraphContent.tsx#L302-L321) searching for links in the graph AST, and given that at that point we don't know yet if the link will qualify as a rich-embed, we are adding already a root node. A more comprehensive solution would be to work in tandem with the RemoteContent component.