### PR TITLE
grid: pasting shortcodes redirects to app page

### DIFF
--- a/pkg/grid/src/nav/Leap.tsx
+++ b/pkg/grid/src/nav/Leap.tsx
@@ -72,7 +72,6 @@ export const Leap = React.forwardRef(
 
     useEffect(() => {
       const newMatch = getMatch(rawInput);
-
       if (newMatch && rawInput) {
         useLeapStore.setState({ selectedMatch: newMatch });
       }
@@ -112,7 +111,7 @@ export const Leap = React.forwardRef(
 
     const navigateByInput = useCallback(
       (input: string) => {
-        const normalizedValue = input.trim().replace(/(~?[\w^_-]{3,13})\//, '$1/apps/');
+        const normalizedValue = input.trim().replace(/(~?[\w^_-]{3,13})\//, '$1/apps/$1/');
         push(`/leap/${menu}/${normalizedValue}`);
       },
       [menu]


### PR DESCRIPTION
Current behaviour when pasting, eg. `~paldev/pals` is to show the list
of all apps by ~paldev, even though the URL knows we're looking for pals
(eg. `/~paldev/apps/pals`). By reconstructing the URL to include the
host and desk twice, we can redirect straight to the app prompt, as
that's where that route exists.