### PR TITLE
docket: force a |rein %base prior to fixing #5667

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -56,8 +56,12 @@
   =?  old    ?=(?(~ ^) -.old)  [%1 old]
   =^  cards  old
     ?.  ?=(%1 -.old)  `old
+    =/  rein=cage  kiln-rein+!>([%base %.y ~ ~])
+    =/  nuke=cage  kiln-uninstall+!>(%hodl)
     :_  old(- %2)
-    [%pass /rein %agent [our.bowl %hood] %poke kiln-rein+!>([%base %.y ~ ~])]~
+    :~  [%pass /rein %agent [our.bowl %hood] %poke rein]
+        [%pass /nuke %agent [our.bowl %hood] %poke nuke]
+    ==
   ?>  ?=(%2 -.old)
   [cards this(state [old inflate-cache])]
   ::
@@ -202,7 +206,8 @@
   =^  cards  state
     ?+  wire  ~&(bad-docket-take+wire `state)
       ~  `state
-      [%rein ~]      `state
+      [%rein ~]      ~&(%reined `state)
+      [%nuke ~]      ~&(%nuked `state)
       [%kiln ~]      take-kiln
       [%charge @ *]  (take-charge i.t.wire t.t.wire)
     ==

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -63,7 +63,9 @@
         [%pass /nuke %agent [our.bowl %hood] %poke nuke]
     ==
   ?>  ?=(%2 -.old)
-  [cards this(state [old inflate-cache])]
+  =.  -.state  old
+  =.  +.state  inflate-cache
+  [cards this]
   ::
   ++  inflate-cache
     ^-  cache

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -2,8 +2,9 @@
 /+  *server, agentio, default-agent, multipart, dbug, verb
 |%
 +$  card  card:agent:gall
-+$  state-0
-  $:  ::  local
++$  app-state
+  $:  %2
+      ::  local
       charges=(map desk charge)
   ==
 ::  $cache: impermanent state
@@ -11,7 +12,7 @@
   by-base=(map term desk)
 ::
 +$  inflated-state
-  [state-0 cache]
+  [app-state cache]
 ::  +lac: toggle verbosity
 ++  lac  &
 ::
@@ -50,12 +51,15 @@
 ++  on-load
   |=  =vase
   ^-  (quip card _this)
-  =+  !<(old=state-0 vase)
-  =*  cha  ~(. ch q.byk.bowl)
   |^
-  =.  -.state  old
-  =.  +.state  inflate-cache
-  `this
+  =+  !<(old=app-states vase)
+  =?  old    ?=(?(~ ^) -.old)  [%1 old]
+  =^  cards  old
+    ?.  ?=(%1 -.old)  `old
+    :_  old(- %2)
+    [%pass /rein %agent [our.bowl %hood] %poke kiln-rein+!>([%base %.y ~ ~])]~
+  ?>  ?=(%2 -.old)
+  [cards this(state [old inflate-cache])]
   ::
   ++  inflate-cache
     ^-  cache
@@ -64,6 +68,22 @@
     |=  [=desk =charge]
     ?.  ?=(%glob -.href.docket.charge)  ~
     `:_(desk base.href.docket.charge)
+  ::
+  +$  app-states
+    $^  state-0-ket
+    $%  state-0-sig
+        state-1
+        app-state
+    ==
+  ::
+  +$  state-1  [%1 (map desk charge)]
+  +$  state-0-sig
+    $:  ~
+    ==
+  ::
+  +$  state-0-ket
+    $:  (map desk charge)
+    ==
   --
 ::
 ++  on-save  !>(-.state)
@@ -182,7 +202,8 @@
   =^  cards  state
     ?+  wire  ~&(bad-docket-take+wire `state)
       ~  `state
-      [%kiln ~]  take-kiln
+      [%rein ~]      `state
+      [%kiln ~]      take-kiln
       [%charge @ *]  (take-charge i.t.wire t.t.wire)
     ==
   [cards this]
@@ -390,7 +411,7 @@
 |_  =bowl:gall
 ++  io    ~(. agentio bowl)
 ++  pass  pass:io
-++  def  ~(. (default-agent state %|) bowl)
+++  def   ~(. (default-agent state %|) bowl)
 ::
 ++  hash-glob  sham
 ++  cg

--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -64,6 +64,8 @@
     ==
   ?>  ?=(%2 -.old)
   =.  -.state  old
+  ::  inflate-cache needs to be called after the state is set
+  ::
   =.  +.state  inflate-cache
   [cards this]
   ::


### PR DESCRIPTION
Tested this is on a ship that had `%hodl` installed before applying https://github.com/urbit/urbit/pull/5732 and all worked fine.