### PR TITLE
npm: fix libraries module setup

### DIFF
--- a/pkg/npm/api/package.json
+++ b/pkg/npm/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A library that provides bindings and types for Urbit's various userspace desks",
   "repository": {
     "type": "git",
@@ -8,8 +8,12 @@
     "directory": "pkg/npm/api"
   },
   "type": "module",
-  "main": "dist/cjs/index.js",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
+  "exports": {
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.js"
+  },
   "jsdelivr": "dist/urbit-api.min.js",
   "unpkg": "dist/urbit-api.min.js",
   "types": "dist/index.d.ts",

--- a/pkg/npm/api/rollup.config.ts
+++ b/pkg/npm/api/rollup.config.ts
@@ -60,13 +60,13 @@ export default [
     ],
     output: [
       {
-        dir: 'dist/esm',
+        file: 'dist/esm/index.js',
         format: 'esm',
         exports: 'named',
-        sourcemap: true
+        sourcemap: true,
       },
       {
-        dir: 'dist/cjs',
+        file: 'dist/cjs/index.cjs',
         format: 'cjs',
         exports: 'named',
         sourcemap: true

--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -9,8 +9,12 @@
     "directory": "pkg/npm/http-api"
   },
   "type": "module",
-  "main": "dist/cjs/index.js",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
+  "exports": {
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.js"
+  },
   "jsdelivr": "dist/urbit-http-api.min.js",
   "unpkg": "dist/urbit-http-api.min.js",
   "types": "dist/index.d.ts",

--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": {

--- a/pkg/npm/http-api/rollup.config.ts
+++ b/pkg/npm/http-api/rollup.config.ts
@@ -56,13 +56,13 @@ export default [
     ],
     output: [
       {
-        dir: 'dist/esm',
+        file: 'dist/esm/index.js',
         format: 'esm',
         exports: 'named',
         sourcemap: true,
       },
       {
-        dir: 'dist/cjs',
+        file: 'dist/cjs/index.cjs',
         format: 'cjs',
         exports: 'named',
         sourcemap: true,


### PR DESCRIPTION
This fixes an issue which causes the @urbit/api and @urbit/http-api modules to not be able to be used in CommonJS environments, because it treats the CJS builds as ESM.