### PR TITLE
ford: rewrite cache to share more builds

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1220,9 +1220,9 @@
       =^  =soak  nub
         ?^  got=(~(get by cache.nub) leak)
           =/  refs   ?:(spilt 0 1)
-          =/  tape-1  "ford: cache {<pour.leak>}: adding {<refs>}"
-          =/  tape-2  ", giving {<(add refs refs.u.got)>}"
-          %-  (slog leaf+(welp tape-1 tape-2) ~)
+          ::  %-  =/  tape-1  "ford: cache {<pour.leak>}: adding {<refs>}"
+          ::      =/  tape-2  ", giving {<(add refs refs.u.got)>}"
+          ::      (slog leaf+(welp tape-1 tape-2) ~)
           =?  cache.nub  !=(0 refs)
             (~(put by cache.nub) leak [(add refs refs.u.got) soak.u.got])
           [soak.u.got nub]
@@ -1236,9 +1236,9 @@
         ?~  deps
           [soak nub]
         =/  got  (~(got by cache.nub) i.deps)
-        %-  =/  tape-1  "ford: cache {<pour.leak>} for {<pour.i.deps>}"
-            =/  tape-2  ": bumping to ref {<refs.got>}"
-            (slog leaf+(welp tape-1 tape-2) ~)
+        ::  %-  =/  tape-1  "ford: cache {<pour.leak>} for {<pour.i.deps>}"
+        ::      =/  tape-2  ": bumping to ref {<refs.got>}"
+        ::      (slog leaf+(welp tape-1 tape-2) ~)
         =.  cache.nub  (~(put by cache.nub) i.deps got(refs +(refs.got)))
         $(deps t.deps)
       ?:  spilt

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -209,7 +209,7 @@
 ::    Refcount includes references from other items in the cache, and
 ::    from spills in each desk
 ::
-+$  ford-cache  (map leak [refs=@ud =soak])
++$  flow  (map leak [refs=@ud =soak])
 ::
 ::  New desk data.
 ::
@@ -243,7 +243,7 @@
   $:  rom=room                                          ::  domestic
       hoy=(map ship rung)                               ::  foreign
       ran=rang                                          ::  hashes
-      fad=ford-cache                                    ::  ford cache
+      fad=flow                                          ::  ford cache
       mon=(map term beam)                               ::  mount points
       hez=(unit duct)                                   ::  sync duct
       cez=(map @ta crew)                                ::  permission groups
@@ -546,7 +546,7 @@
   ++  ford
     =>  |%
         +$  state
-          $:  cache=ford-cache
+          $:  cache=flow
               cycle=(set poor)
               spill=(set leak)
               drain=(map poor leak)
@@ -555,7 +555,7 @@
         +$  args
           $:  files=(map path (each page lobe))
               file-store=(map lobe page)
-              cache=ford-cache
+              cache=flow
               spill=(set leak)
           ==
         --
@@ -1208,8 +1208,8 @@
     --
   ::
   ++  lose-leak
-    |=  [fad=ford-cache =leak]
-    ^-  ford-cache
+    |=  [fad=flow =leak]
+    ^-  flow
     ?~  got=(~(get by fad) leak)
       %-  (slog leaf+"ford: lose missing leak {<leak>}" ~)
       fad
@@ -1223,15 +1223,15 @@
     %-  (slog leaf+"ford: cache {<pour.leak>}: freeing" ~)
     =.  fad  (~(del by fad) leak)
     =/  leaks  ~(tap in deps.leak)
-    |-  ^-  ford-cache
+    |-  ^-  flow
     ?~  leaks
       fad
     =.  fad  ^$(leak i.leaks)
     $(leaks t.leaks)
   ::
   ++  lose-leaks
-    |=  [fad=ford-cache leaks=(set leak)]
-    ^-  ford-cache
+    |=  [fad=flow leaks=(set leak)]
+    ^-  flow
     =/  leaks  ~(tap in leaks)
     |-
     ?~  leaks
@@ -1430,7 +1430,7 @@
   ::
   ::  Create a ford appropriate for the aeon
   ::
-  ::  Don't forget to call +aeon-ford-cache!
+  ::  Don't forget to call +aeon-flow!
   ::
   ++  aeon-ford
     |=  yon=aeon
@@ -1439,8 +1439,8 @@
     [files lat.ran fad ?:(=(yon let.dom) fod.dom *(set leak))]
   ::  Produce ford cache appropriate for the aeon
   ::
-  ++  aeon-ford-cache
-    |*  [yon=aeon res=* fud=ford-cache fod=(set leak)]
+  ++  aeon-flow
+    |*  [yon=aeon res=* fud=flow fod=(set leak)]
     :-  res
     ^+  ..park
     ?:  &(?=(~ ref) =(let.dom yon))
@@ -1932,7 +1932,7 @@
           ==
       ^+  [built ford-args]
       =.  ford-args  cache
-      =/  [=cage fud=ford-cache fod=(set leak)]
+      =/  [=cage fud=flow fod=(set leak)]
         ::  ~>  %slog.[0 leaf/"clay: validating {(spud path)}"]
         %-  wrap:fusion
         (read-file:(ford:fusion ford-args) path)
@@ -2771,7 +2771,7 @@
     |-  ^-  [(map path (unit mime)) args:ford:fusion]
     ?~  cans
       [mim ford-args]
-    =/  [=cage fud=ford-cache fod=(set leak)]
+    =/  [=cage fud=flow fod=(set leak)]
       ~|  mime-cast-fail+i.cans
       (wrap:fusion (cast-path:(ford:fusion ford-args) i.cans %mime))
     =.  cache.ford-args  fud
@@ -3676,7 +3676,7 @@
       ^-  [(unit (unit cage)) _..park]
       =^  =vase  ..park
         ~_  leaf/"clay: %a build failed {<[syd aeon path]>}"
-        %+  aeon-ford-cache  aeon
+        %+  aeon-flow  aeon
         %-  wrap:fusion
         (build-file:(aeon-ford aeon) path)
       :_(..park [~ ~ %vase !>(vase)])
@@ -3688,7 +3688,7 @@
       ?.  ?=([@ ~] path)
         [[~ ~] ..park]
       =^  =dais  ..park
-        %+  aeon-ford-cache  aeon
+        %+  aeon-flow  aeon
         %-  wrap:fusion
         (build-dais:(aeon-ford aeon) i.path)
       :_(..park [~ ~ %dais !>(dais)])
@@ -3700,7 +3700,7 @@
       ?.  ?=([@ @ ~] path)
         [[~ ~] ..park]
       =^  =tube  ..park
-        %+  aeon-ford-cache  aeon
+        %+  aeon-flow  aeon
         %-  wrap:fusion
         (build-tube:(aeon-ford aeon) [i i.t]:path)
       :_(..park [~ ~ %tube !>(tube)])
@@ -3712,7 +3712,7 @@
       ?.  ?=([@ ~] path)
         [[~ ~] ..park]
       =^  =vase  ..park
-        %+  aeon-ford-cache  aeon
+        %+  aeon-flow  aeon
         %-  wrap:fusion
         (build-nave:(aeon-ford aeon) i.path)
       :_(..park [~ ~ %nave vase])
@@ -3724,7 +3724,7 @@
       ?.  ?=([@ @ ~] path)
         [[~ ~] ..park]
       =^  =vase  ..park
-        %+  aeon-ford-cache  aeon
+        %+  aeon-flow  aeon
         %-  wrap:fusion
         (build-cast:(aeon-ford aeon) [i i.t]:path)
       :_(..park [~ ~ %cast vase])
@@ -4005,7 +4005,7 @@
       ::  should convert any lobe to cage
       ::
       =^  =cage  ..park
-        %+  aeon-ford-cache  yon
+        %+  aeon-flow  yon
         %-  wrap:fusion
         (page-to-cage:(aeon-ford yon) u.peg)
       [``cage ..park]
@@ -4644,7 +4644,7 @@
       |=  =dojo-8
       ^-  dojo-10
       =/  dom  dom.dojo-8
-      dojo-8(dom [ank.dom let.dom hit.dom lab.dom mim.dom *ford-cache])
+      dojo-8(dom [ank.dom let.dom hit.dom lab.dom mim.dom *flow])
     ::
         hoy
       %-  ~(run by hoy.raf)
@@ -4653,7 +4653,7 @@
       |=  =rede-8
       ^-  rede-10
       =/  dom  dom.rede-8
-      rede-8(dom [ank.dom let.dom hit.dom lab.dom mim.dom *ford-cache])
+      rede-8(dom [ank.dom let.dom hit.dom lab.dom mim.dom *flow])
     ==
   ::  +raft-9-to-10: add .dist-upgraded
   ++  raft-9-to-10
@@ -4749,7 +4749,7 @@
       ==
     ::
         |3
-      :-  *ford-cache
+      :-  *flow
       %=  |3.raf
         mon  (~(run by mon.raf) |=(=beam beam(r ud+0)))
         |3   pud.raf
@@ -4868,7 +4868,7 @@
   --
 ::
 ::  We clear the ford cache by replacing it with its bunt as a literal.
-::  This nests within +ford-cache without reference to +type, +hoon, or
+::  This nests within +flow without reference to +type, +hoon, or
 ::  anything else in the sample of cache objects.  Otherwise we would be
 ::  contravariant in the those types, which makes them harder to change.
 ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -159,24 +159,26 @@
 ::  Ford build with content.
 ::
 +$  pour
-  $%  [%nave =mark]
+  $%  [%file =path]
+      [%nave =mark]
       [%dais =mark]
       [%cast =mars]
       [%tube =mars]
       ::  leafs
       ::
-      [%file =path lob=(unit lobe)]
+      [%vale =path lob=(unit lobe)]
       [%arch =path =(map path lobe)]
   ==
 ::
 ::  Ford build without content.
 ::
 +$  poor
-  $%  [%nave =mark]
+  $%  [%file =path]
+      [%nave =mark]
       [%dais =mark]
       [%cast =mars]
       [%tube =mars]
-      [%file =path]
+      [%vale =path]
       [%arch =path]
   ==
 ::
@@ -529,7 +531,7 @@
   ::
   ++  wrap
     |*  [* state:ford]
-    [+<- +<+>- +<+>+>-]  ::  [result cache.state spill.state]
+    [+<- +<+< +<+>+<]  ::  [result cache.state spill.state]
   ::
   ++  with-face  |=([face=@tas =vase] vase(p [%face face p.vase]))
   ++  with-faces
@@ -543,21 +545,12 @@
   ::
   ++  ford
     =>  |%
-        +$  build
-          $%  [%file =path]
-              [%mark =mark]
-              [%dais =mark]
-              [%cast =mars]
-              [%tube =mars]
-              [%vale =path]
-              [%poor =poor]
-          ==
         +$  state
-          $:  baked=(map path cage)
-              cache=ford-cache
-              cycle=(set build)
+          $:  cache=ford-cache
+              cycle=(set poor)
               spill=(set leak)
               drain=(map poor leak)
+              stack=(list (set leak))
           ==
         +$  args
           $:  files=(map path (each page lobe))
@@ -577,17 +570,21 @@
     ::
     ++  read-file
       |=  =path
+      (%*(. read-file-k gain |) path)
+    ::
+    ++  read-file-k
+      =/  gain  &
+      |=  =path
       ^-  [cage state]
       ~|  %error-validating^path
-      ?^  got=(~(get by baked.nub) path)
-        [u.got nub]
-      =;  [res=cage bun=state]
-        =.  nub  bun
-        =.  baked.nub  (~(put by baked.nub) path res)
-        [res nub]
+      =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) vale+path)
         ~|(cycle+vale+path^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) vale+path)
+      %-  soak-cage
+      %^  gain-leak  gain  [%vale path]
+      |=  nob=state
+      =.  nub  nob
       ::~>  %slog.0^leaf/"ford: read file {(spud path)}"
       =/  file
         ~|  %file-not-found^path
@@ -597,7 +594,9 @@
           p.file
         ~|  %tombstoned-file^path^p.file
         (~(got by file-store) p.file)
-      (validate-page path page)
+      =^  =cage  nub  (validate-page-k path page)
+      [[%cage cage] nub]
+    ::
     ::  +build-nave: build a statically typed mark core
     ::
     ++  build-nave
@@ -614,21 +613,22 @@
       =/  gain  &
       |=  mak=mark
       ~|  %error-building-mark^mak
-      %-  soak-vase
-      %^  gain-leak  gain  [%nave mak]
-      |=  nob=state
-      =.  nub  nob
-      ?:  (~(has in cycle.nub) mark+mak)
-        ~|(cycle+mark+mak^cycle.nub !!)
-      =.  cycle.nub  (~(put in cycle.nub) mark+mak)
+      =.  stack.nub  [~ stack.nub]
+      ?:  (~(has in cycle.nub) nave+mak)
+        ~|(cycle+nave+mak^cycle.nub !!)
+      =.  cycle.nub  (~(put in cycle.nub) nave+mak)
       :: ~>  %slog.0^leaf/"ford: make mark {<mak>}"
       =^  cor=vase  nub  (build-fit-k %mar mak)
       =/  gad=vase  (slap cor limb/%grad)
       ?@  q.gad
         =+  !<(mok=mark gad)
-        =^  [%vase deg=vase]  nub  $(mak mok)
+        =^  deg=vase  nub  $(mak mok, gain &)
         =^  tub=vase  nub  (build-cast-k mak mok)
         =^  but=vase  nub  (build-cast-k mok mak)
+        %-  soak-vase
+        %^  gain-leak  gain  [%nave mak]
+        |=  nob=state
+        =.  nub  nob
         :_  nub  :-  %vase
         ^-  vase  ::  vase of nave
         %+  slap
@@ -651,6 +651,10 @@
           (but (pact:deg (tub v) d))
         ++  vale  noun:grab:cor
         --
+      %-  soak-vase
+      %^  gain-leak  gain  [%nave mak]
+      |=  nob=state
+      =.  nub  nob
       :_  nub  :-  %vase
       ^-  vase  ::  vase of nave
       %+  slap  (slop (with-face cor+cor) zuse.bud)
@@ -687,14 +691,15 @@
       |=  mak=mark
       ^-  [dais state]
       ~|  %error-building-dais^mak
-      %-  soak-dais
-      %^  gain-leak  gain  [%dais mak]
-      |=  nob=state
-      =.  nub  nob
+      =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) dais+mak)
         ~|(cycle+dais+mak^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) dais+mak)
       =^  nav=vase  nub  (build-nave-k mak)
+      %-  soak-dais
+      %^  gain-leak  gain  [%dais mak]
+      |=  nob=state
+      =.  nub  nob
       ::~>  %slog.0^leaf/"ford: make dais {<mak>}"
       :_  nub  :-  %dais
       ^-  dais
@@ -740,12 +745,9 @@
       |=  [a=mark b=mark]
       ^-  [vase state]
       ~|  error-building-cast+[a b]
+      =.  stack.nub  [~ stack.nub]
       ?:  =([%mime %hoon] [a b])
         :_(nub =>(..zuse !>(|=(m=mime q.q.m))))
-      %-  soak-vase
-      %^  gain-leak  gain  [%cast a b]
-      |=  nob=state
-      =.  nub  nob
       ?:  (~(has in cycle.nub) cast+[a b])
         ~|(cycle+cast+[a b]^cycle.nub !!)
       ::  try +grow; is there a +grow core with a .b arm?
@@ -759,6 +761,10 @@
           p.lab
         ::  +grow core has .b arm; use that
         ::
+        %-  soak-vase
+        %^  gain-leak  gain  [%cast a b]
+        |=  nob=state
+        =.  nub  nob
         :_  nub  :-  %vase
         %+  slap  (with-faces cor+old ~)
         ^-  hoon
@@ -770,23 +776,35 @@
       =^  new=vase  nub  (build-fit-k %mar b)
       =/  rab  (mule |.((slap new tsgl/[limb/a limb/%grab])))
       ?:  &(?=(%& -.rab) ?=(^ q.p.rab))
+        %-  soak-vase
+        %^  gain-leak  gain  [%cast a b]
+        |=  nob=state
+        =.  nub  nob
         :_(nub vase+p.rab)
       ::  try +jump
       ::
       =/  jum  (mule |.((slap old tsgl/[limb/b limb/%jump])))
       ?:  ?=(%& -.jum)
-        (compose-casts a !<(mark p.jum) b)
+        (compose-casts gain a !<(mark p.jum) b)
       ?:  ?=(%& -.rab)
-        (compose-casts a !<(mark p.rab) b)
+        (compose-casts gain a !<(mark p.rab) b)
       ?:  ?=(%noun b)
+        %-  soak-vase
+        %^  gain-leak  gain  [%cast a b]
+        |=  nob=state
+        =.  nub  nob
         :_(nub vase+same.bud)
       ~|(no-cast-from+[a b] !!)
     ::
     ++  compose-casts
-      |=  [x=mark y=mark z=mark]
-      ^-  [[%vase vase] state]
+      |=  [gain=? x=mark y=mark z=mark]
+      ^-  [vase state]
       =^  uno=vase  nub  (build-cast-k x y)
       =^  dos=vase  nub  (build-cast-k y z)
+      %-  soak-vase
+      %^  gain-leak  gain  [%cast x z]
+      |=  nob=state
+      =.  nub  nob
       :_  nub  :-  %vase
       %+  slap
         (with-faces uno+uno dos+dos cork+=>([..zuse cork] !>(+)) ~)
@@ -802,13 +820,14 @@
       |=  [a=mark b=mark]
       ^-  [tube state]
       ~|  error-building-tube+[a b]
+      =.  stack.nub  [~ stack.nub]
+      ?:  (~(has in cycle.nub) tube+[a b])
+        ~|(cycle+tube+[a b]^cycle.nub !!)
+      =^  gat=vase  nub  (build-cast-k a b)
       %-  soak-tube
       %^  gain-leak  gain  [%tube a b]
       |=  nob=state
       =.  nub  nob
-      ?:  (~(has in cycle.nub) tube+[a b])
-        ~|(cycle+tube+[a b]^cycle.nub !!)
-      =^  gat=vase  nub  (build-cast-k a b)
       :: ~>  %slog.0^leaf/"ford: make tube {<a>} -> {<b>}"
       :_(nub [%tube =>([..zuse gat=gat] |=(v=vase (slam gat v)))])
     ::
@@ -823,6 +842,17 @@
       =^  =tube  nub  (build-tube p.page mak)
       :_(nub [mak (tube vax)])
     ::
+    ++  validate-page-k
+      |=  [=path =page]
+      ^-  [cage state]
+      ~|  validate-page-fail+path^from+p.page
+      =/  mak=mark  (head (flop path))
+      ?:  =(mak p.page)
+        (page-to-cage-k page)
+      =^  [mark vax=vase]  nub  (page-to-cage-k page)
+      =^  =tube  nub  (build-tube-k p.page mak)
+      :_(nub [mak (tube vax)])
+    ::
     ++  page-to-cage
       |=  =page
       ^-  [cage state]
@@ -831,6 +861,16 @@
       ?:  =(%mime p.page)
         :_(nub [%mime =>([..zuse ;;(mime q.page)] !>(+))])
       =^  =dais  nub  (build-dais p.page)
+      :_(nub [p.page (vale:dais q.page)])
+    ::
+    ++  page-to-cage-k
+      |=  =page
+      ^-  [cage state]
+      ?:  =(%hoon p.page)
+        :_(nub [%hoon [%atom %t ~] q.page])
+      ?:  =(%mime p.page)
+        :_(nub [%mime =>([..zuse ;;(mime q.page)] !>(+))])
+      =^  =dais  nub  (build-dais-k p.page)
       :_(nub [p.page (vale:dais q.page)])
     ::
     ++  cast-path
@@ -842,6 +882,18 @@
       ?:  =(mok mak)
         [cag nub]
       =^  =tube  nub  (build-tube mok mak)
+      ~|  error-running-cast+[path mok mak]
+      :_(nub [mak (tube q.cag)])
+    ::
+    ++  cast-path-k
+      |=  [=path mak=mark]
+      ^-  [cage state]
+      =/  mok  (head (flop path))
+      ~|  error-casting-path+[path mok mak]
+      =^  cag=cage  nub  (read-file-k path)
+      ?:  =(mok mak)
+        [cag nub]
+      =^  =tube  nub  (build-tube-k mok mak)
       ~|  error-running-cast+[path mok mak]
       :_(nub [mak (tube q.cag)])
     ::
@@ -865,137 +917,8 @@
       =/  tex=tape  (trip !<(@t q.cag))
       =/  =pile  (parse-pile path tex)
       =.  hoon.pile  !,(*hoon .)
-      =^  res=vase  nub  (run-pile pile)
+      =^  res=vase  nub  (run-prelude pile)
       res
-    ::
-    ::  TODO: should only parse prelude
-    ::  TODO: cache parsing
-    ::
-    ++  build-leak
-      |=  por=poor
-      ^-  [leak state]
-      |^  (leak-poor por)
-      ++  leak-poor
-        |=  =poor
-        ^-  [leak state]
-        ?^  got=(~(get by drain.nub) poor)
-          [u.got nub]
-        =;  [res=leak bun=state]
-          =.  nub  bun
-          =.  drain.nub  (~(put by drain.nub) poor res)
-          [res nub]
-        ~|  %error-getting-dependencies^poor
-        ?:  (~(has in cycle.nub) poor+poor)
-          ~|(cycle+poor+poor^cycle.nub !!)
-        =.  cycle.nub  (~(put in cycle.nub) poor+poor)
-        ?-    -.poor
-            %nave
-          =^  leaks  nub  (leak-mark mark.poor)
-          [[poor leaks] nub]
-        ::
-            %dais
-          =^  leaks  nub  (leak-mark mark.poor)
-          [[poor leaks] nub]
-        ::
-            %cast
-          =^  leaks-a  nub  (leak-mark a.mars.poor)
-          =^  leaks-b  nub  (leak-mark b.mars.poor)
-          [[poor (~(uni in leaks-a) leaks-b)] nub]
-        ::
-            %tube
-          =^  leaks-a  nub  (leak-mark a.mars.poor)
-          =^  leaks-b  nub  (leak-mark b.mars.poor)
-          [[poor (~(uni in leaks-a) leaks-b)] nub]
-        ::
-            %file
-          ?~  lob=(~(get by files) path.poor)
-            [[[%file path.poor ~] ~] nub]
-          =/  =lobe
-            ?-  -.u.lob
-              %&  (page-to-lobe p.u.lob)
-              %|  p.u.lob
-            ==
-          =^  cag=cage  nub  (read-file path.poor)
-          ?.  ?=(%hoon p.cag)
-            ::  could include mark definition?
-            ::
-            [[[%file path.poor `lobe] ~] nub]
-          =/  tex=tape  (trip !<(@t q.cag))
-          =/  =pile  (parse-pile path.poor tex)
-          =^  leaks  nub  (leak-pile pile)
-          [[[%file path.poor `lobe] leaks] nub]
-        ::
-            %arch
-          ::  TODO: overly conservative, should be only direct hoon
-          ::  children
-          ::
-          =/  dip  (dip-hat path.poor)
-          =^  leaks  nub  (leak-poors (turn ~(tap by dip) |=([=path *] [%file path])))
-          :_  nub  :_  leaks
-          ^-  pour
-          :+  %arch  path.poor
-          %-  ~(run by dip)
-          |=  file=(each page lobe)
-          ?-  -.file
-            %&  (page-to-lobe p.file)
-            %|  p.file
-          ==
-        ==
-      ::
-      ++  leak-poors
-        |=  poors=(list poor)
-        ^-  [(set leak) state]
-        =|  leaks=(set leak)
-        |-  ^-  [(set leak) state]
-        ?~  poors
-          [leaks nub]
-        =^  lek  nub  (leak-poor i.poors)
-        $(leaks (~(put in leaks) lek), poors t.poors)
-      ::
-      ++  leak-mark
-        |=  =mark
-        ^-  [(set leak) state]
-        (leak-poors (turn (all-fits %mar mark) |=(=path [%file path])))
-      ::
-      ++  leak-pile
-        |=  =pile
-        ^-  [(set leak) state]
-        =|  leaks=(set leak)
-        =^  leaks-a  nub
-          %-  leak-poors
-          %-  zing
-          %+  turn  sur.pile
-          |=  =taut
-          %+  turn  (all-fits %sur pax.taut)
-          |=  =path
-          [%file path]
-        =^  leaks-b  nub
-          %-  leak-poors
-          %-  zing
-          %+  turn  lib.pile
-          |=  =taut
-          %+  turn  (all-fits %lib pax.taut)
-          |=  =path
-          [%file path]
-        =^  leaks-c  nub
-          (leak-poors (turn raw.pile |=([* =path] [%file path])))
-        =^  leaks-d  nub
-          (leak-poors (turn raz.pile |=([* * =path] [%arch path])))
-        =^  leaks-e  nub
-          (leak-poors (turn maz.pile |=([* =mark] [%nave mark])))
-        =^  leaks-f  nub
-          (leak-poors (turn caz.pile |=([* =mars] [%tube mars])))
-        =^  leaks-g  nub
-          (leak-poors (turn bar.pile |=([* * =path] [%file path])))
-        :_  nub
-        %-  ~(uni in leaks-a)
-        %-  ~(uni in leaks-b)
-        %-  ~(uni in leaks-c)
-        %-  ~(uni in leaks-d)
-        %-  ~(uni in leaks-e)
-        %-  ~(uni in leaks-f)
-        leaks-g
-      --
     ::
     ++  build-dependency
       |=  dep=(each [dir=path fil=path] path)
@@ -1008,19 +931,21 @@
       =/  =path
         ?:(?=(%| -.dep) p.dep fil.p.dep)
       ~|  %error-building^path
-      %-  soak-vase
-      %^  gain-leak  gain  [%file path]
-      |=  nob=state
-      =.  nub  nob
+      =.  stack.nub  [~ stack.nub]
       ~>  %slog.0^leaf/"ford: make file {(spud path)}"
       ?:  (~(has in cycle.nub) file+path)
         ~|(cycle+file+path^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) file+path)
-      =^  cag=cage  nub  (read-file path)
+      =^  cag=cage  nub  (read-file-k path)
       ?>  =(%hoon p.cag)
       =/  tex=tape  (trip !<(@t q.cag))
       =/  =pile  (parse-pile path tex)
-      =^  res=vase  nub  (run-pile pile)
+      =^  sut=vase  nub  (run-prelude pile)
+      %-  soak-vase
+      %^  gain-leak  gain  [%file path]
+      |=  nob=state
+      =.  nub  nob
+      =/  res=vase  (road |.((slap sut hoon.pile)))
       [[%vase res] nub]
     ::
     ++  build-file
@@ -1065,7 +990,7 @@
       =^  res  nub   (build-dependency-k &+[path pax])
       $(fiz t.fiz, rez (~(put by rez) nom res))
     ::
-    ++  run-pile
+    ++  run-prelude
       |=  =pile
       =/  sut=vase  zuse.bud
       =^  sut=vase  nub  (run-tauts sut %sur sur.pile)
@@ -1075,8 +1000,7 @@
       =^  sut=vase  nub  (run-maz sut maz.pile)
       =^  sut=vase  nub  (run-caz sut caz.pile)
       =^  sut=vase  nub  (run-bar sut bar.pile)
-      =/  res=vase  (road |.((slap sut hoon.pile)))
-      [res nub]
+      [sut nub]
     ::
     ++  parse-pile
       |=  [pax=path tex=tape]
@@ -1219,7 +1143,7 @@
       |=  [sut=vase bar=(list [face=term =mark =path])]
       ^-  [vase state]
       ?~  bar  [sut nub]
-      =^  =cage  nub  (cast-path [path mark]:i.bar)
+      =^  =cage  nub  (cast-path-k [path mark]:i.bar)
       =.  p.q.cage  [%face face.i.bar p.q.cage]
       $(sut (slop q.cage sut), bar t.bar)
     ::
@@ -1269,6 +1193,36 @@
               $(p +.p, pax +.pax)
       ==  ==
     ::
+    ++  poor-to-pour
+      |=  =poor
+      ^-  pour
+      ?+    -.poor  poor
+          %vale
+        :+  %vale  path.poor
+        ?~  lob=(~(get by files) path.poor)
+          ~
+        :-  ~
+        ?-  -.u.lob
+          %&  (page-to-lobe p.u.lob)
+          %|  p.u.lob
+        ==
+      ::
+          %arch
+        =/  dip  (dip-hat path.poor)
+        :+  %arch  path.poor
+        %-  ~(run by dip)
+        |=  file=(each page lobe)
+        ?-  -.file
+          %&  (page-to-lobe p.file)
+          %|  p.file
+        ==
+      ==
+    ::
+    ++  soak-cage
+      |=  [=soak nub=state]
+      ?>  ?=(%cage -.soak)
+      [cage.soak nub]
+    ::
     ++  soak-vase
       |=  [=soak nub=state]
       ?>  ?=(%vase -.soak)
@@ -1292,21 +1246,39 @@
     ++  gain-leak
       |=  [gain=? =poor next=$-(state [soak state])]
       ^-  [soak state]
-      =^  =leak  nub  (build-leak poor)
+      ~&  [gain=gain not-top=?=([* * *] stack.nub) stack.nub]
+      =^  top=(set leak)  stack.nub  stack.nub
+      =/  =leak  [(poor-to-pour poor) top]
+      =.  cycle.nub  (~(del in cycle.nub) poor)
+      =?  stack.nub  ?=(^ stack.nub)
+        stack.nub(i (~(put in i.stack.nub) leak))
       =/  spilt  (~(has in spill.nub) leak)
-      =/  refs   (add ?:(gain 1 0) ?:(spilt 0 1))
+      %-  (slog leaf+"spilt: {<spilt>}" ~)
+      =/  refs   ?:(spilt 0 1)
       =?  spill.nub  !spilt  (~(put in spill.nub) leak)
       ?^  got=(~(get by cache.nub) leak)
         =/  tape-1  "ford: cache {<pour.leak>}: adding {<refs>}"
         =/  tape-2  ", giving {<(add refs refs.u.got)>}"
         %-  (slog leaf+(welp tape-1 tape-2) ~)
-        =.  cache.nub
+        =?  cache.nub  !=(0 refs)
           (~(put by cache.nub) leak [(add refs refs.u.got) soak.u.got])
         [soak.u.got nub]
       %-  (slog leaf+"ford: cache {<pour.leak>}: creating with {<refs>}" ~)
       =^  =soak  nub  (next nub)
       =.  cache.nub  (~(put by cache.nub) leak [refs soak])
-      [soak nub]
+      ::  If we're creating a cache entry, add refs to our dependencies
+      ::
+      =.  refs  (add refs ?:(gain 1 0))
+      =/  deps  ~(tap in deps.leak)
+      |-
+      ?~  deps
+        [soak nub]
+      =/  got  (~(got by cache.nub) i.deps)
+      %-  =/  tape-1  "ford: cache {<pour.leak>} for {<pour.i.deps>}"
+          =/  tape-2  ": bumping to ref {<refs.got>}"
+          (slog leaf+(welp tape-1 tape-2) ~)
+      =.  cache.nub  (~(put by cache.nub) i.deps got(refs +(refs.got)))
+      $(deps t.deps)
     --
   ::
   ++  lose-leak

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -180,7 +180,19 @@
 ::    Sprig is a fast-lookup index over the global ford cache.  The only
 ::    goal is to make cache hits fast.
 ::
-+$  flue  [spill=(set leak) sprig=(map poor soak)]
++$  flue  [spill=(set leak) sprig=(map mist soak)]
+::
+::  Ford build without content.
+::
++$  mist
+  $%  [%file =path]
+      [%nave =mark]
+      [%dais =mark]
+      [%cast =mars]
+      [%tube =mars]
+      [%vale =path]
+      [%arch =path]
+  ==
 ::
 ::  Ford build with content.
 ::
@@ -194,18 +206,6 @@
       ::
       [%vale =path lob=(unit lobe)]
       [%arch =path =(map path lobe)]
-  ==
-::
-::  Ford build without content.
-::
-+$  poor
-  $%  [%file =path]
-      [%nave =mark]
-      [%dais =mark]
-      [%cast =mars]
-      [%tube =mars]
-      [%vale =path]
-      [%arch =path]
   ==
 ::
 ::  Ford result.
@@ -491,9 +491,9 @@
   ::
   [deletes changes]
 ::
-++  pour-to-poor
+++  pour-to-mist
   |=  =pour
-  ^-  poor
+  ^-  mist
   ?+    -.pour  pour
       %vale  [%vale path.pour]
       %arch  [%arch path.pour]
@@ -574,8 +574,8 @@
         +$  state
           $:  cache=flow
               flue
-              cycle=(set poor)
-              drain=(map poor leak)
+              cycle=(set mist)
+              drain=(map mist leak)
               stack=(list (set leak))
           ==
         +$  args
@@ -1158,13 +1158,13 @@
               $(p +.p, pax +.pax)
       ==  ==
     ::
-    ++  poor-to-pour
-      |=  =poor
+    ++  mist-to-pour
+      |=  =mist
       ^-  pour
-      ?+    -.poor  poor
+      ?+    -.mist  mist
           %vale
-        :+  %vale  path.poor
-        ?~  lob=(~(get by files) path.poor)
+        :+  %vale  path.mist
+        ?~  lob=(~(get by files) path.mist)
           ~
         :-  ~
         ?-  -.u.lob
@@ -1173,8 +1173,8 @@
         ==
       ::
           %arch
-        =/  dip  (dip-hat path.poor)
-        :+  %arch  path.poor
+        =/  dip  (dip-hat path.mist)
+        :+  %arch  path.mist
         %-  ~(run by dip)
         |=  file=(each page lobe)
         ?-  -.file
@@ -1209,11 +1209,11 @@
       [dir.soak nub]
     ::
     ++  gain-leak
-      |=  [=poor next=$-(state [soak state])]
+      |=  [=mist next=$-(state [soak state])]
       ^-  [soak state]
       =^  top=(set leak)  stack.nub  stack.nub
-      =/  =leak  [(poor-to-pour poor) top]
-      =.  cycle.nub  (~(del in cycle.nub) poor)
+      =/  =leak  [(mist-to-pour mist) top]
+      =.  cycle.nub  (~(del in cycle.nub) mist)
       =?  stack.nub  ?=(^ stack.nub)
         stack.nub(i (~(put in i.stack.nub) leak))
       =/  spilt  (~(has in spill.nub) leak)
@@ -1245,7 +1245,7 @@
         [soak nub]
       ::  %-  (slog leaf+"ford: spilt: {<spilt>}" ~)
       =:  spill.nub  (~(put in spill.nub) leak)
-          sprig.nub  (~(put by sprig.nub) poor soak)
+          sprig.nub  (~(put by sprig.nub) mist soak)
         ==
       [soak nub]
     --
@@ -1947,10 +1947,10 @@
         ==
       =?  new  !invalid
         :-  (~(put in spill.new) i.old)
-        =/  =poor  (pour-to-poor pour.i.old)
-        ?~  got=(~(get by sprig.fod) poor)
+        =/  =mist  (pour-to-mist pour.i.old)
+        ?~  got=(~(get by sprig.fod) mist)
           sprig.new
-        (~(put by sprig.new) poor u.got)
+        (~(put by sprig.new) mist u.got)
       $(old t.old)
     ::
     ++  page-to-cord

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -180,7 +180,7 @@
 ::    Sprig is a fast-lookup index over the global ford cache.  The only
 ::    goal is to make cache hits fast.
 ::
-+$  flue  [spill=(set leak) sprig=(map mist soak)]
++$  flue  [spill=(set leak) sprig=(map mist [=leak =soak])]
 ::
 ::  Ford build without content.
 ::
@@ -600,8 +600,11 @@
       ^-  [cage state]
       ~|  %error-validating^path
       %-  soak-cage
+      %+  gain-sprig  vale+path  |.
       ?^  got=(~(get by sprig.nub) vale+path)
-        [u.got nub]
+        =?  stack.nub  ?=(^ stack.nub)
+          stack.nub(i (~(put in i.stack.nub) leak.u.got))
+        [soak.u.got nub]
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) vale+path)
         ~|(cycle+vale+path^cycle.nub !!)
@@ -628,8 +631,7 @@
       ^-  [vase state]
       ~|  %error-building-mark^mak
       %-  soak-vase
-      ?^  got=(~(get by sprig.nub) nave+mak)
-        [u.got nub]
+      %+  gain-sprig  nave+mak  |.
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) nave+mak)
         ~|(cycle+nave+mak^cycle.nub !!)
@@ -639,7 +641,7 @@
       =/  gad=vase  (slap cor limb/%grad)
       ?@  q.gad
         =+  !<(mok=mark gad)
-        =^  deg=vase  nub  $(mak mok)
+        =^  deg=vase  nub  ^$(mak mok)
         =^  tub=vase  nub  (build-cast mak mok)
         =^  but=vase  nub  (build-cast mok mak)
         %+  gain-leak  nave+mak
@@ -702,8 +704,7 @@
       ^-  [dais state]
       ~|  %error-building-dais^mak
       %-  soak-dais
-      ?^  got=(~(get by sprig.nub) dais+mak)
-        [u.got nub]
+      %+  gain-sprig  dais+mak  |.
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) dais+mak)
         ~|(cycle+dais+mak^cycle.nub !!)
@@ -753,8 +754,7 @@
       ^-  [vase state]
       ~|  error-building-cast+[a b]
       %-  soak-vase
-      ?^  got=(~(get by sprig.nub) cast+a^b)
-        [u.got nub]
+      %+  gain-sprig  cast+a^b  |.
       =.  stack.nub  [~ stack.nub]
       ?:  =([%mime %hoon] [a b])
         :_(nub [%vase =>(..zuse !>(|=(m=mime q.q.m)))])
@@ -822,8 +822,7 @@
       ^-  [tube state]
       ~|  error-building-tube+[a b]
       %-  soak-tube
-      ?^  got=(~(get by sprig.nub) tube+a^b)
-        [u.got nub]
+      %+  gain-sprig  tube+a^b  |.
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) tube+[a b])
         ~|(cycle+tube+[a b]^cycle.nub !!)
@@ -897,8 +896,7 @@
         ?:(?=(%| -.dep) p.dep fil.p.dep)
       ~|  %error-building^path
       %-  soak-vase
-      ?^  got=(~(get by sprig.nub) file+path)
-        [u.got nub]
+      %+  gain-sprig  file+path  |.
       =.  stack.nub  [~ stack.nub]
       ~>  %slog.0^leaf/"ford: make file {(spud path)}"
       ?:  (~(has in cycle.nub) file+path)
@@ -929,8 +927,7 @@
       |=  =path
       ^-  [(map @ta vase) state]
       %-  soak-arch
-      ?^  got=(~(get by sprig.nub) arch+path)
-        [u.got nub]
+      %+  gain-sprig  arch+path  |.
       %+  gain-leak  arch+path
       |=  nob=state
       =.  nub  nob
@@ -1208,6 +1205,15 @@
       ?>  ?=(%arch -.soak)
       [dir.soak nub]
     ::
+    ++  gain-sprig
+      |=  [=mist next=(trap [soak state])]
+      ^-  [soak state]
+      ?~  got=(~(get by sprig.nub) mist)
+        $:next
+      =?  stack.nub  ?=(^ stack.nub)
+        stack.nub(i (~(put in i.stack.nub) leak.u.got))
+      [soak.u.got nub]
+    ::
     ++  gain-leak
       |=  [=mist next=$-(state [soak state])]
       ^-  [soak state]
@@ -1245,7 +1251,7 @@
         [soak nub]
       ::  %-  (slog leaf+"ford: spilt: {<spilt>}" ~)
       =:  spill.nub  (~(put in spill.nub) leak)
-          sprig.nub  (~(put by sprig.nub) mist soak)
+          sprig.nub  (~(put by sprig.nub) mist leak soak)
         ==
       [soak nub]
     --

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -204,7 +204,7 @@
       [%tube =mars]
       ::  leafs
       ::
-      [%vale =path lob=(unit lobe)]
+      [%vale =path =lobe]
       [%arch =path =(map path lobe)]
   ==
 ::
@@ -923,7 +923,6 @@
     ::    such as /path/file/hoon, but not /path/more/file/hoon.
     ::
     ++  build-directory
-      =/  gain  &
       |=  =path
       ^-  [(map @ta vase) state]
       %-  soak-arch
@@ -1161,12 +1160,11 @@
       ?+    -.mist  mist
           %vale
         :+  %vale  path.mist
-        ?~  lob=(~(get by files) path.mist)
-          ~
-        :-  ~
-        ?-  -.u.lob
-          %&  (page-to-lobe p.u.lob)
-          %|  p.u.lob
+        ~|  %file-not-found-mist^path.mist
+        =/  lob  (~(got by files) path.mist)
+        ?-  -.lob
+          %&  (page-to-lobe p.lob)
+          %|  p.lob
         ==
       ::
           %arch
@@ -1180,30 +1178,11 @@
         ==
       ==
     ::
-    ++  soak-cage
-      |=  [=soak nub=state]
-      ?>  ?=(%cage -.soak)
-      [cage.soak nub]
-    ::
-    ++  soak-vase
-      |=  [=soak nub=state]
-      ?>  ?=(%vase -.soak)
-      [vase.soak nub]
-    ::
-    ++  soak-dais
-      |=  [=soak nub=state]
-      ?>  ?=(%dais -.soak)
-      [dais.soak nub]
-    ::
-    ++  soak-tube
-      |=  [=soak nub=state]
-      ?>  ?=(%tube -.soak)
-      [tube.soak nub]
-    ::
-    ++  soak-arch
-      |=  [=soak nub=state]
-      ?>  ?=(%arch -.soak)
-      [dir.soak nub]
+    ++  soak-cage  |=([s=soak n=state] ?>(?=(%cage -.s) [cage.s n]))
+    ++  soak-vase  |=([s=soak n=state] ?>(?=(%vase -.s) [vase.s n]))
+    ++  soak-dais  |=([s=soak n=state] ?>(?=(%dais -.s) [dais.s n]))
+    ++  soak-tube  |=([s=soak n=state] ?>(?=(%tube -.s) [tube.s n]))
+    ++  soak-arch  |=([s=soak n=state] ?>(?=(%arch -.s) [dir.s n]))
     ::
     ++  gain-sprig
       |=  [=mist next=(trap [soak state])]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -570,11 +570,6 @@
     ::
     ++  read-file
       |=  =path
-      (%*(. read-file-k gain |) path)
-    ::
-    ++  read-file-k
-      =/  gain  &
-      |=  =path
       ^-  [cage state]
       ~|  %error-validating^path
       =.  stack.nub  [~ stack.nub]
@@ -582,7 +577,7 @@
         ~|(cycle+vale+path^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) vale+path)
       %-  soak-cage
-      %^  gain-leak  gain  [%vale path]
+      %+  gain-leak  [%vale path]
       |=  nob=state
       =.  nub  nob
       ::~>  %slog.0^leaf/"ford: read file {(spud path)}"
@@ -594,7 +589,7 @@
           p.file
         ~|  %tombstoned-file^path^p.file
         (~(got by file-store) p.file)
-      =^  =cage  nub  (validate-page-k path page)
+      =^  =cage  nub  (validate-page path page)
       [[%cage cage] nub]
     ::
     ::  +build-nave: build a statically typed mark core
@@ -602,31 +597,21 @@
     ++  build-nave
       |=  mak=mark
       ^-  [vase state]
-      (%*(. build-nave-k gain |) mak)
-    ::
-    ::  All *-k arms gain a reference to the produced result in the
-    ::  cache.  These must not be used outside Ford, and inside they
-    ::  should be used exactly when the result will be incorporated into
-    ::  the value of another cacheable item.
-    ::
-    ++  build-nave-k
-      =/  gain  &
-      |=  mak=mark
       ~|  %error-building-mark^mak
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) nave+mak)
         ~|(cycle+nave+mak^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) nave+mak)
       :: ~>  %slog.0^leaf/"ford: make mark {<mak>}"
-      =^  cor=vase  nub  (build-fit-k %mar mak)
+      =^  cor=vase  nub  (build-fit %mar mak)
       =/  gad=vase  (slap cor limb/%grad)
       ?@  q.gad
         =+  !<(mok=mark gad)
-        =^  deg=vase  nub  $(mak mok, gain &)
-        =^  tub=vase  nub  (build-cast-k mak mok)
-        =^  but=vase  nub  (build-cast-k mok mak)
+        =^  deg=vase  nub  $(mak mok)
+        =^  tub=vase  nub  (build-cast mak mok)
+        =^  but=vase  nub  (build-cast mok mak)
         %-  soak-vase
-        %^  gain-leak  gain  [%nave mak]
+        %+  gain-leak  [%nave mak]
         |=  nob=state
         =.  nub  nob
         :_  nub  :-  %vase
@@ -652,7 +637,7 @@
         ++  vale  noun:grab:cor
         --
       %-  soak-vase
-      %^  gain-leak  gain  [%nave mak]
+      %+  gain-leak  [%nave mak]
       |=  nob=state
       =.  nub  nob
       :_  nub  :-  %vase
@@ -684,20 +669,15 @@
     ::
     ++  build-dais
       |=  mak=mark
-      (%*(. build-dais-k gain |) mak)
-    ::
-    ++  build-dais-k
-      =/  gain  &
-      |=  mak=mark
       ^-  [dais state]
       ~|  %error-building-dais^mak
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) dais+mak)
         ~|(cycle+dais+mak^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) dais+mak)
-      =^  nav=vase  nub  (build-nave-k mak)
+      =^  nav=vase  nub  (build-nave mak)
       %-  soak-dais
-      %^  gain-leak  gain  [%dais mak]
+      %+  gain-leak  [%dais mak]
       |=  nob=state
       =.  nub  nob
       ::~>  %slog.0^leaf/"ford: make dais {<mak>}"
@@ -738,11 +718,6 @@
     ::
     ++  build-cast
       |=  [a=mark b=mark]
-      (%*(. build-cast-k gain |) a b)
-    ::
-    ++  build-cast-k
-      =/  gain  &
-      |=  [a=mark b=mark]
       ^-  [vase state]
       ~|  error-building-cast+[a b]
       =.  stack.nub  [~ stack.nub]
@@ -753,7 +728,7 @@
       ::  try +grow; is there a +grow core with a .b arm?
       ::
       :: ~>  %slog.0^leaf/"ford: make cast {<a>} -> {<b>}"
-      =^  old=vase  nub  (build-fit-k %mar a)
+      =^  old=vase  nub  (build-fit %mar a)
       ?:  =/  ram  (mule |.((slap old !,(*hoon grow))))
           ?:  ?=(%| -.ram)  %.n
           =/  lab  (mule |.((slob b p.p.ram)))
@@ -762,7 +737,7 @@
         ::  +grow core has .b arm; use that
         ::
         %-  soak-vase
-        %^  gain-leak  gain  [%cast a b]
+        %+  gain-leak  [%cast a b]
         |=  nob=state
         =.  nub  nob
         :_  nub  :-  %vase
@@ -773,11 +748,11 @@
         !,(*hoon ~(grow cor v))
       ::  try direct +grab
       ::
-      =^  new=vase  nub  (build-fit-k %mar b)
+      =^  new=vase  nub  (build-fit %mar b)
       =/  rab  (mule |.((slap new tsgl/[limb/a limb/%grab])))
       ?:  &(?=(%& -.rab) ?=(^ q.p.rab))
         %-  soak-vase
-        %^  gain-leak  gain  [%cast a b]
+        %+  gain-leak  [%cast a b]
         |=  nob=state
         =.  nub  nob
         :_(nub vase+p.rab)
@@ -785,24 +760,24 @@
       ::
       =/  jum  (mule |.((slap old tsgl/[limb/b limb/%jump])))
       ?:  ?=(%& -.jum)
-        (compose-casts gain a !<(mark p.jum) b)
+        (compose-casts a !<(mark p.jum) b)
       ?:  ?=(%& -.rab)
-        (compose-casts gain a !<(mark p.rab) b)
+        (compose-casts a !<(mark p.rab) b)
       ?:  ?=(%noun b)
         %-  soak-vase
-        %^  gain-leak  gain  [%cast a b]
+        %+  gain-leak  [%cast a b]
         |=  nob=state
         =.  nub  nob
         :_(nub vase+same.bud)
       ~|(no-cast-from+[a b] !!)
     ::
     ++  compose-casts
-      |=  [gain=? x=mark y=mark z=mark]
+      |=  [x=mark y=mark z=mark]
       ^-  [vase state]
-      =^  uno=vase  nub  (build-cast-k x y)
-      =^  dos=vase  nub  (build-cast-k y z)
+      =^  uno=vase  nub  (build-cast x y)
+      =^  dos=vase  nub  (build-cast y z)
       %-  soak-vase
-      %^  gain-leak  gain  [%cast x z]
+      %+  gain-leak  [%cast x z]
       |=  nob=state
       =.  nub  nob
       :_  nub  :-  %vase
@@ -813,19 +788,14 @@
     ::
     ++  build-tube
       |=  [a=mark b=mark]
-      (%*(. build-tube-k gain |) a b)
-    ::
-    ++  build-tube-k
-      =/  gain  &
-      |=  [a=mark b=mark]
       ^-  [tube state]
       ~|  error-building-tube+[a b]
       =.  stack.nub  [~ stack.nub]
       ?:  (~(has in cycle.nub) tube+[a b])
         ~|(cycle+tube+[a b]^cycle.nub !!)
-      =^  gat=vase  nub  (build-cast-k a b)
+      =^  gat=vase  nub  (build-cast a b)
       %-  soak-tube
-      %^  gain-leak  gain  [%tube a b]
+      %+  gain-leak  [%tube a b]
       |=  nob=state
       =.  nub  nob
       :: ~>  %slog.0^leaf/"ford: make tube {<a>} -> {<b>}"
@@ -842,17 +812,6 @@
       =^  =tube  nub  (build-tube p.page mak)
       :_(nub [mak (tube vax)])
     ::
-    ++  validate-page-k
-      |=  [=path =page]
-      ^-  [cage state]
-      ~|  validate-page-fail+path^from+p.page
-      =/  mak=mark  (head (flop path))
-      ?:  =(mak p.page)
-        (page-to-cage-k page)
-      =^  [mark vax=vase]  nub  (page-to-cage-k page)
-      =^  =tube  nub  (build-tube-k p.page mak)
-      :_(nub [mak (tube vax)])
-    ::
     ++  page-to-cage
       |=  =page
       ^-  [cage state]
@@ -861,16 +820,6 @@
       ?:  =(%mime p.page)
         :_(nub [%mime =>([..zuse ;;(mime q.page)] !>(+))])
       =^  =dais  nub  (build-dais p.page)
-      :_(nub [p.page (vale:dais q.page)])
-    ::
-    ++  page-to-cage-k
-      |=  =page
-      ^-  [cage state]
-      ?:  =(%hoon p.page)
-        :_(nub [%hoon [%atom %t ~] q.page])
-      ?:  =(%mime p.page)
-        :_(nub [%mime =>([..zuse ;;(mime q.page)] !>(+))])
-      =^  =dais  nub  (build-dais-k p.page)
       :_(nub [p.page (vale:dais q.page)])
     ::
     ++  cast-path
@@ -882,18 +831,6 @@
       ?:  =(mok mak)
         [cag nub]
       =^  =tube  nub  (build-tube mok mak)
-      ~|  error-running-cast+[path mok mak]
-      :_(nub [mak (tube q.cag)])
-    ::
-    ++  cast-path-k
-      |=  [=path mak=mark]
-      ^-  [cage state]
-      =/  mok  (head (flop path))
-      ~|  error-casting-path+[path mok mak]
-      =^  cag=cage  nub  (read-file-k path)
-      ?:  =(mok mak)
-        [cag nub]
-      =^  =tube  nub  (build-tube-k mok mak)
       ~|  error-running-cast+[path mok mak]
       :_(nub [mak (tube q.cag)])
     ::
@@ -922,11 +859,6 @@
     ::
     ++  build-dependency
       |=  dep=(each [dir=path fil=path] path)
-      (%*(. build-dependency-k gain |) dep)
-    ::
-    ++  build-dependency-k
-      =/  gain  &
-      |=  dep=(each [dir=path fil=path] path)
       ^-  [vase state]
       =/  =path
         ?:(?=(%| -.dep) p.dep fil.p.dep)
@@ -936,13 +868,13 @@
       ?:  (~(has in cycle.nub) file+path)
         ~|(cycle+file+path^cycle.nub !!)
       =.  cycle.nub  (~(put in cycle.nub) file+path)
-      =^  cag=cage  nub  (read-file-k path)
+      =^  cag=cage  nub  (read-file path)
       ?>  =(%hoon p.cag)
       =/  tex=tape  (trip !<(@t q.cag))
       =/  =pile  (parse-pile path tex)
       =^  sut=vase  nub  (run-prelude pile)
       %-  soak-vase
-      %^  gain-leak  gain  [%file path]
+      %+  gain-leak  [%file path]
       |=  nob=state
       =.  nub  nob
       =/  res=vase  (road |.((slap sut hoon.pile)))
@@ -951,22 +883,18 @@
     ++  build-file
       |=  =path
       (build-dependency |+path)
-    ::
-    ++  build-file-k
-      |=  =path
-      (build-dependency-k |+path)
     ::  +build-directory: builds files in top level of a directory
     ::
     ::    this excludes files directly at /path/hoon,
     ::    instead only including files in the unix-style directory at /path,
     ::    such as /path/file/hoon, but not /path/more/file/hoon.
     ::
-    ++  build-directory-k
+    ++  build-directory
       =/  gain  &
       |=  =path
       ^-  [(map @ta vase) state]
       %-  soak-arch
-      %^  gain-leak  gain  [%arch path]
+      %+  gain-leak  [%arch path]
       |=  nob=state
       =.  nub  nob
       =/  fiz=(list @ta)
@@ -987,7 +915,7 @@
         [[%arch rez] nub]
       =*  nom=@ta    i.fiz
       =/  pax=^path  (weld path nom %hoon ~)
-      =^  res  nub   (build-dependency-k &+[path pax])
+      =^  res  nub   (build-dependency &+[path pax])
       $(fiz t.fiz, rez (~(put by rez) nom res))
     ::
     ++  run-prelude
@@ -1087,7 +1015,7 @@
       |=  [sut=vase wer=?(%lib %sur) taz=(list taut)]
       ^-  [vase state]
       ?~  taz  [sut nub]
-      =^  pin=vase  nub  (build-fit-k wer pax.i.taz)
+      =^  pin=vase  nub  (build-fit wer pax.i.taz)
       =?  p.pin  ?=(^ face.i.taz)  [%face u.face.i.taz p.pin]
       $(sut (slop pin sut), taz t.taz)
     ::
@@ -1095,7 +1023,7 @@
       |=  [sut=vase raw=(list [face=term =path])]
       ^-  [vase state]
       ?~  raw  [sut nub]
-      =^  pin=vase  nub  (build-file-k (snoc path.i.raw %hoon))
+      =^  pin=vase  nub  (build-file (snoc path.i.raw %hoon))
       =.  p.pin  [%face face.i.raw p.pin]
       $(sut (slop pin sut), raw t.raw)
     ::
@@ -1104,7 +1032,7 @@
       ^-  [vase state]
       ?~  raz  [sut nub]
       =^  res=(map @ta vase)  nub
-        (build-directory-k path.i.raz)
+        (build-directory path.i.raz)
       =;  pin=vase
         =.  p.pin  [%face face.i.raz p.pin]
         $(sut (slop pin sut), raz t.raz)
@@ -1127,7 +1055,7 @@
       |=  [sut=vase maz=(list [face=term =mark])]
       ^-  [vase state]
       ?~  maz  [sut nub]
-      =^  pin=vase  nub  (build-nave-k mark.i.maz)
+      =^  pin=vase  nub  (build-nave mark.i.maz)
       =.  p.pin  [%face face.i.maz p.pin]
       $(sut (slop pin sut), maz t.maz)
     ::
@@ -1135,7 +1063,7 @@
       |=  [sut=vase caz=(list [face=term =mars])]
       ^-  [vase state]
       ?~  caz  [sut nub]
-      =^  pin=vase  nub  (build-cast-k mars.i.caz)
+      =^  pin=vase  nub  (build-cast mars.i.caz)
       =.  p.pin  [%face face.i.caz p.pin]
       $(sut (slop pin sut), caz t.caz)
     ::
@@ -1143,16 +1071,16 @@
       |=  [sut=vase bar=(list [face=term =mark =path])]
       ^-  [vase state]
       ?~  bar  [sut nub]
-      =^  =cage  nub  (cast-path-k [path mark]:i.bar)
+      =^  =cage  nub  (cast-path [path mark]:i.bar)
       =.  p.q.cage  [%face face.i.bar p.q.cage]
       $(sut (slop q.cage sut), bar t.bar)
     ::
-    ::  +build-fit-k: build file at path, maybe converting '-'s to '/'s in path
+    ::  +build-fit: build file at path, maybe converting '-'s to '/'s in path
     ::
-    ++  build-fit-k
+    ++  build-fit
       |=  [pre=@tas pax=@tas]
       ^-  [vase state]
-      (build-file-k (fit-path pre pax))
+      (build-file (fit-path pre pax))
     ::
     ::  +fit-path: find path, maybe converting '-'s to '/'s
     ::
@@ -1244,31 +1172,29 @@
       [dir.soak nub]
     ::
     ++  gain-leak
-      |=  [gain=? =poor next=$-(state [soak state])]
+      |=  [=poor next=$-(state [soak state])]
       ^-  [soak state]
-      ~&  [gain=gain not-top=?=([* * *] stack.nub) stack.nub]
       =^  top=(set leak)  stack.nub  stack.nub
       =/  =leak  [(poor-to-pour poor) top]
       =.  cycle.nub  (~(del in cycle.nub) poor)
       =?  stack.nub  ?=(^ stack.nub)
         stack.nub(i (~(put in i.stack.nub) leak))
       =/  spilt  (~(has in spill.nub) leak)
-      %-  (slog leaf+"spilt: {<spilt>}" ~)
-      =/  refs   ?:(spilt 0 1)
+      ::  %-  (slog leaf+"ford: spilt: {<spilt>}" ~)
       =?  spill.nub  !spilt  (~(put in spill.nub) leak)
       ?^  got=(~(get by cache.nub) leak)
+        =/  refs   ?:(spilt 0 1)
         =/  tape-1  "ford: cache {<pour.leak>}: adding {<refs>}"
         =/  tape-2  ", giving {<(add refs refs.u.got)>}"
         %-  (slog leaf+(welp tape-1 tape-2) ~)
         =?  cache.nub  !=(0 refs)
           (~(put by cache.nub) leak [(add refs refs.u.got) soak.u.got])
         [soak.u.got nub]
-      %-  (slog leaf+"ford: cache {<pour.leak>}: creating with {<refs>}" ~)
+      %-  (slog leaf+"ford: cache {<pour.leak>}: creating" ~)
       =^  =soak  nub  (next nub)
-      =.  cache.nub  (~(put by cache.nub) leak [refs soak])
+      =.  cache.nub  (~(put by cache.nub) leak [1 soak])
       ::  If we're creating a cache entry, add refs to our dependencies
       ::
-      =.  refs  (add refs ?:(gain 1 0))
       =/  deps  ~(tap in deps.leak)
       |-
       ?~  deps
@@ -1957,7 +1883,7 @@
       =/  invalid
         |-  ^-  ?
         ?|  ?+    -.pour.i.old  %|
-                %file  (~(has in invalid) path.pour.i.old)
+                %vale  (~(has in invalid) path.pour.i.old)
                 %arch
               ::  TODO: overly conservative, should be only direct hoon
               ::  children


### PR DESCRIPTION
The current Ford cache is per-desk, keyed on the name of the build (eg a file at a certain path).  It's impossible to share a cache like this between desks because that name may refer to different things on different desks or at different revisions.

Since these caches aren't shared, they commonly hold exactly the same data, just generated independently.  For example, the same library used on different desks is built repeatedly, and the memory is not shared unless the user manually runs `|meld`.  For users with many apps installed, this adds significant memory pressure.

@belisarius222 and I designed a new cache which is keyed on the name of the build plus its dependencies.  This is all the input to a build except the standard library, so we when we match a key we don't need to know which desk it was on, so we can share this across desks.  When the standard library changes, we already cleared all the caches, and we continue to do that.

An important issue is reclaiming space from this cache.  Since this is a "true" cache, it's never incorrect to keep data in it, so you could use a heuristic such as "clear the whole thing every hour" or an LRU.  However, Ford has a long history of trying to use such heuristics and using exorbitant amounts of memory.  The primary innovation of the current ford cache is that its size is deterministic, and it stores no builds unless they could be generated from the head of its desk.

We extend these properties to the global cache by counting references and maintaining a per-desk set of references to builds which are still relevant to the head of that desk.  On every commit we inspect the per-desk set of references to determine which have been invalidated, and these are freed in the usual manner -- i.e. their refcount is decremented, and if it's now zero, then it's deleted from the cache and all its immediate dependencies are freed.

An alternative would be to garbage collect, which could be done on every commit to maintain determinism.  However, this scales with the size of the cache (thus, with the number of desks installed), whereas refcounting scales only with the desk in question.  Additionally, the cache is acyclic, and no manual refcounting is required -- there is precisely one place where references are gained and one where references are lost.

As a result, this cache has a "least upper bound" property: first, we minimize the number of rebuilds required; given that, we minimize the amount of memory required.  IOW, we throw away cache entries only when they become irrelevant.  An alternate approach would be a "greatest lower bound" -- throw away any cache entries that we're not certain to need.  This uses a bit less memory, but it results in more rebuilds, and it's a little more complex to implement, since it requires clients to "register" the builds they want to keep warm in the cache, even if those builds didn't become invalid.

Generating a cache key for this cache can be slow -- hundreds of milliseconds is not uncommon, and it scales with the number of transitive dependencies.  So we include a per-desk cache isomorphic to the one currently on mainnet.  This has sub-millisecond lookup speed, and is well understood.

So, to perform a build we:
- check if it's in our per-desk cache; if so, return it
- generate its dependencies
- check if it with these dependencies are in our global cache; if so, return it
- else build it

In every case, we add it to either cache if it wasn't already there, and if it wasn't in our per-desk set of references, we also add it there.