### PR TITLE
urcrypt: correct parameter ordering in urcrypt_ed_veri()

### DIFF
--- a/pkg/urcrypt/urcrypt/urcrypt.h
+++ b/pkg/urcrypt/urcrypt/urcrypt.h
@@ -39,8 +39,8 @@ void urcrypt_ed_sign(const uint8_t *message,
 // return value means the signature was (not) verified
 bool urcrypt_ed_veri(const uint8_t *message,
                      size_t length,
-                     const uint8_t signature[64],
-                     const uint8_t public[32]);
+                     const uint8_t public[32],
+                     const uint8_t signature[64]);
 
 int urcrypt_aes_ecba_en(uint8_t key[16], uint8_t block[16], uint8_t out[16]);
 int urcrypt_aes_ecba_de(uint8_t key[16], uint8_t block[16], uint8_t out[16]);


### PR DESCRIPTION
Correct the parameter order in the declaration of `urcrypt_ed_veri()` in [`urcrypt.h`](https://github.com/urbit/urbit/tree/next/vere/pkg/urcrypt/urcrypt/urcrypt.h), which does not match the definition in [`ed25519.c`](https://github.com/urbit/urbit/tree/next/vere/pkg/urcrypt/urcrypt/ed25519.c) nor the call site in [`ed_veri.c`](https://github.com/urbit/urbit/tree/next/vere/pkg/urbit/jets/e/ed_veri.c) on [`next/vere`](https://github.com/urbit/urbit/tree/next/vere).

cc @frodwith