### PR TITLE
azimuth:  use %kick poke to restart subscriptions

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -1,4 +1,4 @@
-/-  eth-watcher, *dice
+/-  eth-watcher, *dice, *hood
 /+  ethereum,
     azimuth,
     naive,
@@ -239,6 +239,11 @@
           number:(last-block-id:dice logs.state)
         ~&  >>  %no-logs-in-azimuth-state
         last-snap
+      =+  [our=(scot %p our.bowl) now=(scot %da now.bowl)]
+      =+  .^(dudes=(set [dude:gall ?]) %ge our %base now /)
+      =/  running=?  (~(has in dudes) [%eth-watcher &])
+      =/  installed=?
+        |((~(has in dudes) [%eth-watcher &]) (~(has in dudes) [%eth-watcher |]))
       :_  this
       =/  cards=(list card)
         :-  ::  %jael will re-subscribe to get all azimuth diffs
@@ -247,6 +252,21 @@
         ::  we poke eth-watcher to retrieve logs from the latest we have
         ::
         %*(start do last-snap last-block)
+      =?  cards  !running
+        ::  restart %eth-watcher
+        ::
+        ~&  >>  %starting-eth-watcher
+        =/  rein=[desk rein]  [%base %.y [%eth-watcher ~ ~] ~]
+        :_  cards
+        [%pass /rein %agent [our.bowl %hood] %poke kiln-rein+!>(rein)]
+      =?  cards  !installed
+        ::  reinstall %base desk
+        ::
+        =+  spo=(sein:title [our now our]:bowl)
+        ~&  >>  re-installing-base-from+spo
+        =/  fresh=[desk ship desk]  [%base spo %kids]
+        :_  cards
+        [%pass /fresh %agent [our.bowl %hood] %poke kiln-install+!>(fresh)]
       ::  resubscribe if we somehow get unsubscribed from eth-watcher
       ::
       ?:  (~(has by wex.bowl) [/eth-watcher our.bowl %eth-watcher])

--- a/pkg/arvo/gen/azimuth/kick.hoon
+++ b/pkg/arvo/gen/azimuth/kick.hoon
@@ -1,4 +1,5 @@
 ::  Kick azimuth
+::
 :-  %say
 |=  *
-[%azimuth-poke %listen ~ %| %azimuth]
+[%azimuth-poke %kick ~]

--- a/pkg/arvo/gen/azimuth/watch.hoon
+++ b/pkg/arvo/gen/azimuth/watch.hoon
@@ -1,4 +1,5 @@
 ::  Change node url and network for azimuth
+::
 :-  %say
 |=  [* [url=@ta net=?(%mainnet %ropsten %local %default) ~] ~]
 [%azimuth-poke %watch url net]

--- a/pkg/base-dev/lib/ethereum.hoon
+++ b/pkg/base-dev/lib/ethereum.hoon
@@ -978,5 +978,8 @@
 ::
 ++  hex-to-num
   |=  a=@t
-  (rash (rsh [3 2] a) hex)
+  ~|  %non-hex-cord
+  ?>  =((end [3 2] a) '0x')
+  =<  ?<(=(0 p) q)  %-  need
+  (de:base16:mimes:html (rsh [3 2] a))
 --


### PR DESCRIPTION
Repurposes %kick to check for a possible missing subscription to /app/eth-watcher, notify %jael to resubscribe again to /app/azimuth and re-start downloading eth-logs from the last one we have previously downloaded, instead of going all the way back to the last processed block in the azimuth snapshot.

This replaces the previous flow of running this command: `:azimuth|watch 'INFURA_NODE' %default` to get up to date with the ethereum logs with `:azimuth|kick`