### PR TITLE
eth-watcher: discard future pending logs in watchdog

### DIFF
--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -367,6 +367,17 @@
       =/  dog=watchdog
         ?:  restart  *watchdog
         (~(got by dogs.state) path.poke)
+      =+  pending=(sort ~(tap in ~(key by pending-logs.dog)) lth)
+      =?  pending-logs.dog
+          ?:  restart  |
+          ?~  pending  |
+          (gte i.pending from.config.poke)
+        ?>  ?=(^ pending)
+        ::  if there are pending logs newer than what we poke with,
+        ::  we need to clear those too avoid processing duplicates
+        ::
+        ~&  %dropping-unreleased-logs^[from+i.pending n+(lent pending)]
+        ~
       %_  dog
         -       config.poke
         number  from.config.poke


### PR DESCRIPTION
If there were pending-logs in an existing watchdog that was not fully restarted, and the number of the starting block is newer than the first in pending, when starting a new thread, those logs will be carried over to the new thread, which will then be re-downloaded and will fail to be verified in /lib/naive.

Because of the changes here https://github.com/urbit/urbit/pull/5710 this PR might not be relevant since it seems that we release (and delete) the pending logs as soon as we receive them, but it still looks like a good practice to consider this case.