### PR TITLE
pkg: don't silently skip non %tests/ test arms

### DIFF
--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -44,10 +44,6 @@
   %+  turn  ~(tap by paths-to-tests)
   |=  [=path test-arms=(list test-arm)]
   ^-  (list test)
-  ::  strip off leading 'tests' from :path
-  ::
-  ?.  ?=([%tests *] path)  ~
-  =/  path  t.path  ::NOTE  TMI
   ::  for each test, add the test's name to :path
   ::
   %+  turn  test-arms


### PR DESCRIPTION
Preserves the behavior of stripping "%tests" from test paths but keeps
tests under other directories so their test- arms are still evaluated.

Fixes [#5803](https://github.com/urbit/urbit/issues/5803)