### PR TITLE
@urbit/http-api: surface mark of updates

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -273,7 +273,7 @@ export class Urbit {
             ) {
               const funcs = this.outstandingSubscriptions.get(data.id);
               try {
-                funcs.event(data.json);
+                funcs.event(data.json, data.mark ?? 'json');
               } catch (e) {
                 console.error('Failed to call subscription event callback', e);
               }

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -148,7 +148,7 @@ export interface SubscriptionInterface {
   /**
    * Handle %fact
    */
-  event?(data: any): void;
+  event?(data: any, mark: string): void;
   /**
    * Handle %kick
    */

--- a/pkg/npm/http-api/test/default.test.ts
+++ b/pkg/npm/http-api/test/default.test.ts
@@ -131,8 +131,8 @@ describe('subscription', () => {
     await wait(600);
 
     expect(airlock.onOpen).toBeCalled();
-    expect(params.event).toHaveBeenNthCalledWith(1, firstEv);
-    expect(params.event).toHaveBeenNthCalledWith(2, secondEv);
+    expect(params.event).toHaveBeenNthCalledWith(1, firstEv, 'json');
+    expect(params.event).toHaveBeenNthCalledWith(2, secondEv, 'json');
   }, 800);
   it('should poke', async () => {
     fetchSpy = jest.spyOn(window, 'fetch');


### PR DESCRIPTION
Surfaces the mark of the subscription updates.
For this to not be `json` requires that the ship be running the upcoming kernelspace update. However this upgrade is backwards and forwards compatible, i.e. current `http-api` and these changes are compatible with both current kernel space and upcoming kernel space. How to proceed with versioning changes? Suspect a minor version bump, because type signatures have changed, albeit not very meaningfully.