### PR TITLE
pkg: -test shouldn't require a list of paths

### DIFF
--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -109,6 +109,10 @@
 =/  m  (strand ,vase)
 ^-  form:m
 =/  paz=(list path)
+  :: promote path to ~[path] if needed
+  ::
+  ?@  +<.q.arg
+    [(tail !<([~ path] arg)) ~]
   (tail !<([~ (list path)] arg))
 =/  bez=(list beam)
   (turn paz |=(p=path ~|([%test-not-beam p] (need (de-beam p)))))

--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -108,8 +108,13 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
+;<  =bowl:strand  bind:m  get-bowl:strandio
 =/  paz=(list path)
-  :: promote path to ~[path] if needed
+  :: if no args, test everything under /=base=/tests
+  ::
+  ?~  q.arg
+    ~[/(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/tests]
+  :: else cast path to ~[path] if needed
   ::
   ?@  +<.q.arg
     [(tail !<([~ path] arg)) ~]


### PR DESCRIPTION
Changes the test command to check if args contains a single path and
wraps it in a list. Now a test thread can be started without providing
a list:

    -test %/tests/lib

And passing a list still works:

    -test %/tests/lib ~

If no arg is given, `test` will run all tests under `/=base=/tests`.