### PR TITLE
jets: remove +de:sivc punt logging

### DIFF
--- a/pkg/urbit/include/c/motes.h
+++ b/pkg/urbit/include/c/motes.h
@@ -387,6 +387,7 @@
 #   define c3__ergo   c3_s4('e','r','g','o')
 #   define c3__esh    c3_s3('e','s','h')
 #   define c3__etch   c3_s4('e','t','c','h')
+#   define c3__evil   c3_s4('e','v','i','l')
 #   define c3__ex     c3_s2('e','x')
 #   define c3__exit   c3_s4('e','x','i','t')
 #   define c3__eyre   c3_s4('e','y','r','e')

--- a/pkg/urbit/jets/e/aes_siv.c
+++ b/pkg/urbit/jets/e/aes_siv.c
@@ -149,9 +149,11 @@ _cqea_siv_de(c3_y*   key_y,
     txt_y = u3r_bytes_alloc(0, txt_w, txt);
     out_y = u3a_malloc(txt_w);
 
-    ret = ( 0 != (*low_f)(txt_y, txt_w, dat_u, soc_w, key_y, iv_y, out_y) )
-      ? u3_none
-      : u3nc(0, u3i_bytes(txt_w, out_y));
+    if ( 0 != (*low_f)(txt_y, txt_w, dat_u, soc_w, key_y, iv_y, out_y) ) {
+      return u3m_bail(c3__evil);
+    }
+
+    ret = u3nc(0, u3i_bytes(txt_w, out_y));
 
     u3a_free(txt_y);
     u3a_free(out_y);

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1348,6 +1348,11 @@ u3m_soft(c3_w    mil_w,
 
       pro = u3nc(u3k(cod), u3_nul);
     }
+    //  %evil leaves no trace
+    //
+    else if ( c3__evil == cod ) {
+      pro = u3nc(u3k(cod), u3_nul);
+    }
     else {
       u3_noun mok = u3dc("mook", 2, u3k(tax));
       pro = u3nc(u3k(cod), u3k(u3t(mok)));

--- a/pkg/urbit/vere/io/ames.c
+++ b/pkg/urbit/vere/io/ames.c
@@ -52,6 +52,7 @@
       c3_d           foq_d;             //  forward queue size
       c3_d           fow_d;             //  forwarded count
       c3_d           fod_d;             //  forwards dropped count
+      c3_d           bad_d;             //  bad ciphertext count
     } sat_u;                            //
   } u3_ames;
 
@@ -768,51 +769,47 @@ _ames_cap_queue(u3_ames* sam_u)
   }
 }
 
-/* _ames_punt_goof(): print %bail error report(s).
-*/
-static void
-_ames_punt_goof(u3_noun lud)
-{
-  if ( 2 == u3qb_lent(lud) ) {
-    u3_pier_punt_goof("hear", u3k(u3h(lud)));
-    u3_pier_punt_goof("crud", u3k(u3h(u3t(lud))));
-  }
-  else {
-    u3_noun dul = lud;
-    c3_w len_w = 1;
-
-    while ( u3_nul != dul ) {
-      u3l_log("ames: bail %u\r\n", len_w++);
-      u3_pier_punt_goof("ames", u3k(u3h(dul)));
-      dul = u3t(dul);
-    }
-  }
-
-  u3z(lud);
-}
-
 /* _ames_hear_bail(): handle packet failure.
 */
 static void
 _ames_hear_bail(u3_ovum* egg_u, u3_noun lud)
 {
   u3_ames* sam_u = (u3_ames*)egg_u->car_u;
-  sam_u->sat_u.fal_d++;
+  c3_w     len_w = u3qb_lent(lud);
 
-  if (  (u3C.wag_w & u3o_verbose)
-     || (0 == (sam_u->sat_u.fal_d % 1000)) )
-  {
-    _ames_punt_goof(lud);
-    u3l_log("ames: packet failed (%" PRIu64 " total)\n\n", sam_u->sat_u.fal_d);
+  if ( (1 == len_w) && c3__evil == u3h(u3h(lud)) ) {
+    sam_u->sat_u.bad_d++;
+
+    if (  (u3C.wag_w & u3o_verbose)
+       || (0 == (sam_u->sat_u.bad_d % 100)) )
+    {
+      u3l_log("ames: heard bad crypto (%" PRIu64 " total), "
+              "check azimuth state\r\n",
+              sam_u->sat_u.bad_d);
+    }
   }
   else {
-    u3z(lud);
+    sam_u->sat_u.fal_d++;
 
-    if (  0 == (sam_u->sat_u.fal_d % 1000) )  {
-      u3l_log("ames: packet failed (%" PRIu64 " total)\n\n", sam_u->sat_u.fal_d);
+    if (  (u3C.wag_w & u3o_verbose)
+       || (0 == (sam_u->sat_u.fal_d % 100)) )
+    {
+      if ( 2 == len_w ) {
+        u3_pier_punt_goof("hear", u3k(u3h(lud)));
+        u3_pier_punt_goof("crud", u3k(u3h(u3t(lud))));
+      }
+      //  !2 traces is unusual, just print the first if present
+      //
+      else if ( len_w ) {
+        u3_pier_punt_goof("hear", u3k(u3h(lud)));
+      }
+
+      u3l_log("ames: packet failed (%" PRIu64 " total)\r\n",
+              sam_u->sat_u.fal_d);
     }
   }
 
+  u3z(lud);
   u3_ovum_free(egg_u);
 }
 

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -565,6 +565,14 @@ _serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
                                sef_u->mug_l,
                                vir));
   }
+  //  event rejected -- bad ciphertext
+  //
+  else if ( c3__evil == u3h(gon) ) {
+    sef_u->sen_d = sef_u->dun_d;
+
+    u3z(job);
+    return u3nt(c3__bail, gon, u3_nul);
+  }
   //  event rejected
   //
   else {


### PR DESCRIPTION
The "punt" logging pattern in the crypto jets was intended to surface unusual error conditions. But urcrypt and libaes-siv don't clearly distinguish between deterministic decryption failure and other errors (invalid calls, allocation failures, &c). to ensure determinism, so the relevant jets "punt" *all* errors back to the nock interpreter. And `+de:sivc` is used by ames, which means that receiving any invalid ciphertext or stale keys produces noisy, useless output: two lines of `sivc-de-punt` per packet.

The PR just removes the logging, but there are two non-trivial next steps which should be done:

- deterministic decryption failure should not punt

Accomplishing this will require review of libaes-siv and the openssl functions it depends on, and may require patches to distinguish error conditions. This is important for many reasons, not the least of which is that punting is expensive (and therefore a DOS vector).

- receipt of bad packets needs better tracking and logging

Other than the (accidentally) frequent "punt" logging, the ames driver keeps a counter of failed packets and prints every 1K (or every time with `-v`). But if we're receiving lots of invalid packets with a valid ames header, there's a good chance that we or our peer is behind on PKI state. (And if packets from a particular ip:port are consistently invalid, we probably want to stop try to process them for a while.)