### PR TITLE
ames: ping faster

### DIFF
--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -42,10 +42,10 @@
         %-  (slog leaf+"ping: strange state {<ship s>}" ~)
         `state
       ::  NAT timeouts are often pretty short for UDP entries.  5
-      ::  minutes is a common value.  We use 30 seconds, which is fairly
+      ::  minutes is a common value.  We use 25 seconds, which is fairly
       ::  aggressive, but should be safe.
       ::
-      =/  until  (add ~s30 now)
+      =/  until  (add ~s25 now)
       =.  ships.state
         (~(put by ships.state) ship u.s(ship-state [%waiting until]))
       :_  state


### PR DESCRIPTION
Previously, despite the %ping app backing off only to 30 seconds, Ames itself could back off up to 120 seconds.  For other ships this might be fine, but for pinging a sponsor, the pings should go through fast enough to keep a firewall pinhole open.  I lowered the interval from 30 to 25 seconds for this reason and special-cased sponsor pings by looking at the duct (never look at the duct, he said).

NOTE: targeted against master for now, since next/arvo looks behind and I want these commits to be easy to see.