### PR TITLE
vere: change mapsize to 500 GiB on AAarch64 Linux

### DIFF
--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -885,8 +885,11 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
     //
     {
       const size_t siz_i =
-      #if (defined(U3_CPU_aarch64) && defined(U3_OS_linux)) || defined(U3_OS_mingw)
+      #if defined(U3_OS_mingw)
         0xf00000000;
+      // 500 GiB is as large as musl on aarch64 wants to allow
+      #elif (defined(U3_CPU_aarch64) && defined(U3_OS_linux))
+        0x7d00000000;
       #else
         0x10000000000;
       #endif


### PR DESCRIPTION
Sets the mapsize for AAarch64 Linux in `pkg/urbit/vere/disk.c` to the largest size I can get to work with musl, 500 GiB.

Leaves the Windows mapsize untouched at the old default of 60 GiB because I haven't done any testing to see what the limit is there.