### PR TITLE
aqua: add %aqua-effect mark file

### DIFF
--- a/pkg/arvo/mar/aqua/effect.hoon
+++ b/pkg/arvo/mar/aqua/effect.hoon
@@ -1,0 +1,12 @@
+/-  *aquarium
+|_  af=aqua-effect
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  af
+  --
+++  grab
+  |%
+  ++  noun  aqua-effect
+  --
+--


### PR DESCRIPTION
This is needed for successful test runs, and should've gone in with #5681 but slipped through somehow. My bad!