### PR TITLE
dojo: say how to beat the %dy-edit-busy escape room

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -735,7 +735,6 @@
       ^+  +>+>
       =^  dat  say  (~(transceive sole say) cal)
       ?:  |(?=(^ per) ?=(^ pux) ?=(~ pro))
-        ~&  %dy-edit-busy
         =^  lic  say  (~(transmit sole say) dat)
         =/  tip=@t  'dojo: busy (press backspace to abort)'
         (dy-diff %mor [%det lic] [%bel ~] [%tan [tip ~]] ~)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -737,7 +737,8 @@
       ?:  |(?=(^ per) ?=(^ pux) ?=(~ pro))
         ~&  %dy-edit-busy
         =^  lic  say  (~(transmit sole say) dat)
-        (dy-diff %mor [%det lic] [%bel ~] ~)
+        =/  tip=@t  'dojo: busy (press backspace to abort)'
+        (dy-diff %mor [%det lic] [%bel ~] [%tan [tip ~]] ~)
       =>  .(per `dat)
       =/  res  (mule |.((slam u.pro !>((tufa buf.say)))))
       ?:  ?=(%| -.res)


### PR DESCRIPTION
It's too easy to get trapped in the Dojo %dy-edit-busy escape room. Just
type something like:

    -build-file /=base/gen/ls/hoon

This modifies the dojo output to tell the user how to get out.

Fixes #1462.