### PR TITLE
dojo: check =dir exists before switching

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -569,8 +569,7 @@
                       ?:  ?=([@ @ ~] pax)  ~[i.pax i.t.pax '0']
                       pax
                   ?:  =(~ .^((list path) %ct pax))
-                    =-  +>(..dy (he-diff %tan - ~))
-                    rose+[" " `~]^~[leaf+"dir does not exist:" (smyt pax)]
+                    +(..dy (he-diff %tan 'dojo: dir does not exist' ~))
                   =.  dir  (need (de-beam pax))
                   =-  +>(..dy (he-diff %tan - ~))
                   rose+[" " `~]^~[leaf+"=%" (smyt (en-beam he-beak s.dir))]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -568,6 +568,9 @@
                       ?:  ?=([@ ~] pax)  ~[i.pax %base '0']
                       ?:  ?=([@ @ ~] pax)  ~[i.pax i.t.pax '0']
                       pax
+                  ?:  =(~ .^((list path) %ct pax))
+                    =-  +>(..dy (he-diff %tan - ~))
+                    rose+[" " `~]^~[leaf+"dir does not exist:" (smyt pax)]
                   =.  dir  (need (de-beam pax))
                   =-  +>(..dy (he-diff %tan - ~))
                   rose+[" " `~]^~[leaf+"=%" (smyt (en-beam he-beak s.dir))]


### PR DESCRIPTION
Scries clay for a list of files beneath the provided path - if the response
is nil then the dir must not exist (clay abhors a vacuum).

Fixes #1559