### PR TITLE
gall: use the latest app list for %mult tasks

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c45166ff0f8ab8dc1552bcef519c77c0afa6ca52f8ed1ba31ed632012667d619
-size 8674763
+oid sha256:cdb19d3dab0bd391eda26f72ff5f569a5662df518e00ee82aeed1d1653ad5f91
+size 8662713

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdb19d3dab0bd391eda26f72ff5f569a5662df518e00ee82aeed1d1653ad5f91
-size 8662713
+oid sha256:07d3d5191f0b28c49bea21de314476865f3e1ee974d5bed8cedf13f098113921
+size 8662473

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1648,6 +1648,7 @@
     $~  [%vega ~]                                       ::
     $%  [%deal p=sock q=term r=deal]                    ::  full transmission
         [%sear =ship]                                   ::  clear pending queues
+        [%trak ~]                                       ::  update source tracking
         [%jolt =desk =dude]                             ::  (re)start agent
         [%idle =dude]                                   ::  suspend agent
         [%nuke =dude]                                   ::  delete agent

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -567,7 +567,7 @@
     ?:  ?=(%| -.res)
       (mean leaf+["gall: bad agent {<dap>}"] p.res)
     =.  mo-core  (mo-receive-core dap beak p.res)
-    (mo-subscribe-to-agent-builds now)
+    (mo-pass wire %g %trak ~)
   ::  +mo-handle-sys-lyv: handle notice that agents have been rebuilt
   ::
   ++  mo-handle-sys-lyv
@@ -962,6 +962,12 @@
       %d  (mo-give %unto %raw-fact mark.ames-response noun.ames-response)
       %x  (mo-give %unto %kick ~)
     ==
+  ::  +mo-trak: update source tracking list
+  ::
+  ++  mo-trak
+    |.
+    ^+  mo-core
+    (mo-subscribe-to-agent-builds now)
   ::  +ap: agent engine
   ::
   ::    An inner, agent-level core.  The sample refers to the agent we're
@@ -1726,6 +1732,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
+      %trak  mo-abet:(mo-trak:mo-core)
       %trim  [~ gall-payload]
       %vega  [~ gall-payload]
   ==

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -965,8 +965,6 @@
   ::  +mo-trak: update source tracking list
   ::
   ++  mo-trak
-    |.
-    ^+  mo-core
     (mo-subscribe-to-agent-builds now)
   ::  +ap: agent engine
   ::
@@ -1732,7 +1730,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
-      %trak  mo-abet:(mo-trak:mo-core)
+      %trak  mo-abet:mo-trak:mo-core
       %trim  [~ gall-payload]
       %vega  [~ gall-payload]
   ==


### PR DESCRIPTION
When %gall installs %hood, %kiln adds %jolt moves for each app on %base
(in desk.bill). %gall queues its own move to update its %mult
subscription with the arvo sources + hood.hoon. This final move ends up
clobbering the %mult path list which has been updated processing the
%jolt moves.

This changes %gall to queue a move to update its %mult list when it
installs an agent. This prevents stale lists of agent paths being sent
to %clay if %gall installs an agent which itself installs other agents.

Fixes #5308