### PR TITLE
Fix for loading buried message and collection list display

### DIFF
--- a/pkg/interface/src/views/apps/chat/ChatResource.tsx
+++ b/pkg/interface/src/views/apps/chat/ChatResource.tsx
@@ -41,18 +41,28 @@ const ChatResource = (props: ChatResourceProps): ReactElement => {
   const canWrite = group ? isWriter(group, resource, window.ship) : false;
   const [
     getNewest,
+    getNode,
     getOlderSiblings,
     getYoungerSiblings,
     addPost
   ] = useGraphState(
-    s => [s.getNewest, s.getOlderSiblings, s.getYoungerSiblings, s.addPost],
+    s => [s.getNewest, s.getNode, s.getOlderSiblings, s.getYoungerSiblings, s.addPost],
     shallow
   );
 
   useEffect(() => {
-    const count = Math.min(400, 100 + unreadCount);
+    const scrollTo = new URLSearchParams(location.search).get('msg');
+    const count = scrollTo ? 50 : Math.min(400, 100 + unreadCount);
     const { ship, name } = resourceFromPath(resource);
-    getNewest(ship, name, count);
+
+    if (scrollTo) {
+      getNode(ship, name, `/${scrollTo}`);
+      getYoungerSiblings(ship, name, count, `/${scrollTo}`);
+      getOlderSiblings(ship, name, count, `/${scrollTo}`);
+    } else {
+      getNewest(ship, name, count);
+    }
+
     setToShare(undefined);
     (async function () {
       if (group.hidden) {

--- a/pkg/interface/src/views/apps/links/LinkWindow.tsx
+++ b/pkg/interface/src/views/apps/links/LinkWindow.tsx
@@ -1,10 +1,10 @@
 import { Box, Col, Text } from '@tlon/indigo-react';
-import { Association, deSig, Graph, Group, isWriter } from '@urbit/api';
+import { Association, BigIntOrderedMap, deSig, Graph, GraphNode, Group, isWriter, markEachAsRead } from '@urbit/api';
 import bigInt, { BigInteger } from 'big-integer';
-import React, {
-  Component, ReactNode
-} from 'react';
+import React, { Component, ReactNode } from 'react';
+import useHarkState, { selHarkGraph } from '~/logic/state/hark';
 import { GraphScroller } from '~/views/components/GraphScroller';
+import airlock from '~/logic/api';
 import { LinkItem } from './components/LinkItem';
 import LinkSubmit from './components/LinkSubmit';
 
@@ -35,6 +35,22 @@ interface RendererProps {
 }
 
 class LinkWindow extends Component<LinkWindowProps, {}> {
+  componentDidMount = () => {
+    try {
+      const { association } = this.props;
+      const unreads = selHarkGraph(association.resource)(useHarkState.getState());
+      const [,,ship,name] = association.resource.split('/');
+      unreads.each.forEach((u) => {
+        airlock.poke(markEachAsRead({
+          desk: (window as any).desk,
+          path: `/graph/${ship}/${name}`
+        }, u));
+      });
+    } catch (err) {
+      console.warn(err);
+    }
+  }
+
   fetchLinks = async () => true;
 
   canWrite() {
@@ -43,18 +59,22 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
   }
 
   renderItem = React.forwardRef<HTMLDivElement>(({ index }: RendererProps, ref) => {
-    const { props } = this;
-    const { association, graph } = props;
+    const { association, graph } = this.props;
     const [, , ship, name] = association.resource.split('/');
     // @ts-ignore Uint8Array vs. BigInt mismatch?
-    const node = graph.get(index);
-    const first = graph.peekLargest()?.[0];
+    const graphArray = Array.from(graph).filter(
+      ([idx, node]) => typeof node?.post !== 'string'
+    );
+    const orm = new BigIntOrderedMap<GraphNode>().gas(graphArray);
+
+    const node = orm.get(index);
+    const first = orm.peekLargest()?.[0];
     const post = node?.post;
     if (!node || !post) {
       return null;
     }
     const linkProps = {
-      ...props,
+      ...this.props,
       node
     };
     if (this.canWrite() && index.eq(first ?? bigInt.zero)) {
@@ -88,12 +108,19 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
         <LinkItem key={index.toString()} {...linkProps} />
       </Box>
     );
-  });
+  })
 
   render() {
     const { graph, association } = this.props;
     const first = graph.peekLargest()?.[0];
     const [, , ship, name] = association.resource.split('/');
+
+    const graphArray = Array.from(graph).filter(
+      ([idx, node]) => typeof node?.post !== 'string'
+    );
+
+    const orm = new BigIntOrderedMap<GraphNode>().gas(graphArray);
+
     if (!first) {
       return (
         <Col
@@ -122,14 +149,19 @@ class LinkWindow extends Component<LinkWindowProps, {}> {
 
     return (
       <Col width="100%" height="calc(100% - 48px)" position="relative">
+        {(this.canWrite() && !orm.size) && (
+          <Col mx="auto" mt={4} maxWidth="768px" width="100%" flexShrink={0} px={3}>
+            <LinkSubmit name={name} ship={deSig(ship)} />
+          </Col>
+        )}
         {/* @ts-ignore calling @liam-fitzgerald on virtualscroller */}
         <GraphScroller
           origin="top"
           offset={0}
           style={style}
-          data={graph}
+          data={orm}
           averageHeight={100}
-          size={graph.size}
+          size={orm.size}
           pendingSize={this.props.pendingSize}
           renderer={this.renderItem}
           loadRows={this.fetchLinks}


### PR DESCRIPTION
component: Groups UI

This PR fixes 2 Groups bugs that I fixed in the course of updating EScape.

1. When going to a message that is more than 200 messages deep, the correct message is not fetched and the user is not shown the target message. This fix loads that message and the messages immediately before and after it so that the user is shown the target message.
2. When a collection is loaded in "List" view, the links are not marked as "read" and there are extraneous loading indicators at the top or bottom. Deleted links are also loaded and sometimes shown which causes the display to look/behave incorrectly.