### PR TITLE
behn: fix timers not firing

### DIFF
--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -120,6 +120,7 @@
   ++  wake
     |=  error=(unit tang)
     ^+  [moves state]
+    =.  next-wake.state  ~
     ::  no-op on spurious but innocuous unix wakeups
     ::
     ?:  =(~ timers.state)
@@ -135,7 +136,7 @@
     ::
     =/  [=timer later-timers=_timers.state]  pop-timer
     ?:  (gth date.timer now)
-      set-unix-wake(next-wake.state ~)
+      set-unix-wake
     ::  pop first timer, tell vane it has elapsed, and adjust next unix wakeup
     ::
     =<  set-unix-wake

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -192,7 +192,7 @@
     ::  if :next-wake not soon enough, reset it
     ::
     ?^  next-wake
-      ?:  (gte date.u.first u.next-wake)
+      ?:  =(date.u.first u.next-wake)
         event-core
       (emit-doze `date.u.first)
     ::  there was no unix wakeup timer; set one

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -168,9 +168,6 @@
     ::
     ?~  unix-duct.state
       event-core
-    ::  make sure we don't try to wake up in the past
-    ::
-    =?  date-unit  ?=(^ date-unit)  `(max now u.date-unit)
     ::
     %_  event-core
       next-wake.state  date-unit
@@ -192,10 +189,10 @@
       ?~  next-wake
         event-core
       (emit-doze ~)
-    ::  if :next-wake is in the past or not soon enough, reset it
+    ::  if :next-wake not soon enough, reset it
     ::
     ?^  next-wake
-      ?:  &((gte date.u.first u.next-wake) (lte now u.next-wake))
+      ?:  (gte date.u.first u.next-wake)
         event-core
       (emit-doze `date.u.first)
     ::  there was no unix wakeup timer; set one

--- a/pkg/arvo/tests/sys/vane/behn.hoon
+++ b/pkg/arvo/tests/sys/vane/behn.hoon
@@ -53,7 +53,7 @@
   =^  b  behn-gate  (call `%b wen b-arg b-out)
   ::
   =/  c-arg  [~[/vere] [%wake ~]]
-  =/  c-out=(list move)  [~[/foo] [%give [%wake ~]]]~   :: XX spurious %doze
+  =/  c-out=(list move)  [~[/foo] [%give [%wake ~]]]~
   =^  c  behn-gate  (call `%c +(wen) c-arg c-out)
   ::
   :(weld a b c)
@@ -123,7 +123,7 @@
   ::
   =/  e-arg  [~[/vere] [%wake ~]]
   =/  e-out=(list move)
-    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]         :: XX bug
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]
         [~[/foo] [%give [%wake ~]]]
     ==
   =^  e  behn-gate  (call `%e +(wen) e-arg e-out)
@@ -181,7 +181,7 @@
   ::
   =/  e-arg  [~[/vere] [%wake ~]]
   =/  e-out=(list move)
-    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]         :: XX spuriously skewed
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]
         [~[/foo] [%give [%wake ~]]]
     ==
   =^  e  behn-gate  (call `%e (add 3 wen) e-arg e-out)
@@ -206,10 +206,10 @@
   ::
   =/  d-arg  [~[/foo] [%rest (add 2 wen)]]
   =/  d-out=(list move)  [~[/vere] [%give [%doze `(add 3 wen)]]]~
-  =^  d  behn-gate  (call `%d wen d-arg d-out)          ::  XX assumes .= in +set-unix-wake
+  =^  d  behn-gate  (call `%d wen d-arg d-out)
   ::
   =/  e-arg  [~[/vere] [%wake ~]]
-  =/  e-out=(list move)  [~[/foo] [%give [%wake ~]]]~   :: XX spurious %doze
+  =/  e-out=(list move)  [~[/foo] [%give [%wake ~]]]~
   =^  e  behn-gate  (call `%e (add 4 wen) e-arg e-out)
   ::
   :(weld a b c d e)

--- a/pkg/arvo/tests/sys/vane/behn.hoon
+++ b/pkg/arvo/tests/sys/vane/behn.hoon
@@ -1,0 +1,234 @@
+/+  *test
+/=  behn-raw  /sys/vane/behn
+=/  behn-gate  (behn-raw ~bus)
+=/  scry  *roof
+=*  move  move:behn-gate
+::
+|%
+++  test-wake-no
+  ^-  tang
+  =/  wen  ~1111.1.1
+  =/  arg  [~[/vere] [%wake ~]]
+  -:(call ~ wen arg ~)
+::
+++  test-wake-no-wait
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/vere] [%wake ~]]
+  =/  b-out  ~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  (weld a b)
+::
+++  test-wake-no-born
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/foo] [%wait +(wen)]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/vere] [%wake ~]]
+  =/  b-out  ~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  (weld a b)
+::
+++  test-wake
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate
+    (call ~ wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait +(wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `+(wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/vere] [%wake ~]]
+  =/  c-out=(list move)  [~[/foo] [%give [%wake ~]]]~   :: XX spurious %doze
+  =^  c  behn-gate  (call `%c +(wen) c-arg c-out)
+  ::
+  :(weld a b c)
+::
+++  test-born
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/foo] [%wait +(wen)]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/vere] [%born ~]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `+(wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  (weld a b)
+::
+++  test-many-ordered
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait +(wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `+(wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  c-out  ~
+  =^  c  behn-gate  (call `%c wen c-arg c-out)
+  ::
+  =/  d-arg  [~[/foo] [%wait (add 3 wen)]]
+  =/  d-out  ~
+  =^  d  behn-gate  (call `%d wen d-arg d-out)
+  ::
+  =/  e-arg  [~[/vere] [%wake ~]]
+  =/  e-out=(list move)
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]
+        [~[/foo] [%give [%wake ~]]]
+    ==
+  =^  e  behn-gate  (call `%e (add 4 wen) e-arg e-out)
+  ::
+  :(weld a b c d e)
+::
+++  test-many-ordered-lag
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait +(wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `+(wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  c-out  ~
+  =^  c  behn-gate  (call `%c wen c-arg c-out)
+  ::
+  =/  d-arg  [~[/foo] [%wait (add 3 wen)]]
+  =/  d-out  ~
+  =^  d  behn-gate  (call `%d wen d-arg d-out)
+  ::
+  =/  e-arg  [~[/vere] [%wake ~]]
+  =/  e-out=(list move)
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]         :: XX bug
+        [~[/foo] [%give [%wake ~]]]
+    ==
+  =^  e  behn-gate  (call `%e +(wen) e-arg e-out)
+  ::
+  :(weld a b c d e)
+::
+++  test-many-unordered
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `(add 2 wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/foo] [%wait (add 3 wen)]]
+  =/  c-out  ~
+  =^  c  behn-gate  (call `%c wen c-arg c-out)
+  ::
+  =/  d-arg  [~[/foo] [%wait +(wen)]]
+  =/  d-out=(list move)  [~[/vere] [%give [%doze `+(wen)]]]~
+  =^  d  behn-gate  (call `%d wen d-arg d-out)
+  ::
+  =/  e-arg  [~[/vere] [%wake ~]]
+  =/  e-out=(list move)
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]
+        [~[/foo] [%give [%wake ~]]]
+    ==
+  =^  e  behn-gate  (call `%e (add 4 wen) e-arg e-out)
+  ::
+  :(weld a b c d e)
+::
+++  test-same-ordered-lag
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `(add 2 wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  c-out  ~
+  =^  c  behn-gate  (call `%c wen c-arg c-out)
+  ::
+  =/  d-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  d-out  ~
+  =^  d  behn-gate  (call `%d wen d-arg d-out)
+  ::
+  =/  e-arg  [~[/vere] [%wake ~]]
+  =/  e-out=(list move)
+    :~  [~[/vere] [%give [%doze `(add 2 wen)]]]         :: XX spuriously skewed
+        [~[/foo] [%give [%wake ~]]]
+    ==
+  =^  e  behn-gate  (call `%e (add 3 wen) e-arg e-out)
+  ::
+  :(weld a b c d e)
+::
+++  test-rest
+  ^-  tang
+  =/  wen  ~1111.1.1
+  ::
+  =/  a-arg  [~[/vere] [%born ~]]
+  =/  a-out  ~
+  =^  a  behn-gate  (call `%a wen a-arg a-out)
+  ::
+  =/  b-arg  [~[/foo] [%wait (add 2 wen)]]
+  =/  b-out=(list move)  [~[/vere] [%give [%doze `(add 2 wen)]]]~
+  =^  b  behn-gate  (call `%b wen b-arg b-out)
+  ::
+  =/  c-arg  [~[/foo] [%wait (add 3 wen)]]
+  =/  c-out  ~
+  =^  c  behn-gate  (call `%c wen c-arg c-out)
+  ::
+  =/  d-arg  [~[/foo] [%rest (add 2 wen)]]
+  =/  d-out=(list move)  [~[/vere] [%give [%doze `(add 3 wen)]]]~
+  =^  d  behn-gate  (call `%d wen d-arg d-out)          ::  XX assumes .= in +set-unix-wake
+  ::
+  =/  e-arg  [~[/vere] [%wake ~]]
+  =/  e-out=(list move)  [~[/foo] [%give [%wake ~]]]~   :: XX spurious %doze
+  =^  e  behn-gate  (call `%e (add 4 wen) e-arg e-out)
+  ::
+  :(weld a b c d e)
+::
+++  call
+  =|  lac=?
+  |=  $:  label=(unit @tas)
+          now=@da
+          args=[=duct task=(hobo task:behn)]
+          expected-moves=(list move)
+      ==
+  =/  behn-core  (behn-gate now=now eny=`@`0xdead.beef scry=scry)
+  =^  moves  behn-gate
+    (call:behn-core duct.args dud=~ task.args)
+  ::
+  ~?  !lac  moves
+  =/  output=tang
+    %+  expect-eq
+      !>  expected-moves
+      !>  moves
+  [?~(label output ?~(output ~ [u.label output])) behn-gate]
+--


### PR DESCRIPTION
This PR fixes #5747 and adds regression tests for %behn.

The bug was caused by %behn failing to emit a `%doze` effect (to set the next timer in the runtime) in certain necessary situations (itself caused by failing to clear the runtime state mirror `next-wake`, and unnecessarily comparing pending timers to the current timestamp). It also removes some unnecessary behavior: `%doze` was emitted unnecessarily, and occasionally with intentionally-skewed timestamps.