### PR TITLE
hood: fix issue w/ rein diff application

### DIFF
--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -180,9 +180,8 @@
           =rein
       ==
   ^-  [jolt=(list dude) idle=(list dude)]
-  =/  all=(list dude)  (read-bill local)
-  =/  want  (get-apps-want local all rein)
   =/  have  (get-apps-live local)
+  =/  want  (get-apps-want local have rein)
   [want (skip have ~(has in (sy want)))]
 ::
 ++  get-remote-diff


### PR DESCRIPTION
These changes address an issue in `%hood` that was causing the `|rein` (#5862) and `|start` (#5627) commands to suspend all unspecified, non-autostart agents on execution (i.e. agents not listed to start by the command and not in `%desk/desk.bill`). Now, `|rein` and `|start` properly only modify the agents specified.

The command sequence below demonstrates the new behavior:

```
~zod:dojo> +agents %base
status: running   %acme
status: running   %hood
status: running   %lens
status: archived  %skeleton-2
status: archived  %skeleton-1
status: running   %dbug
status: running   %azimuth
status: running   %ping
status: running   %dojo
status: running   %eth-watcher
status: running   %spider
status: running   %herm

~zod:dojo> |rein %base [& %skeleton-1] [& %skeleton-2]
gall: reviving %skeleton-1
gall: reviving %skeleton-2

~zod:dojo> +agents %base
status: running   %skeleton-1
status: running   %skeleton-2
status: running   %acme
status: running   %hood
status: running   %lens
status: running   %dbug
status: running   %azimuth
status: running   %ping
status: running   %dojo
status: running   %eth-watcher
status: running   %spider
status: running   %herm

~zod:dojo> |rein %base [| %skeleton-1]
>=

~zod:dojo> +agents %base
status: running   %skeleton-2
status: running   %acme
status: running   %hood
status: running   %lens
status: archived  %skeleton-1
status: running   %dbug
status: running   %azimuth
status: running   %ping
status: running   %dojo
status: running   %eth-watcher
status: running   %spider
status: running   %herm

~zod:dojo> |start %skeleton-1
>=

~zod:dojo> +agents %base
status: running   %skeleton-1
status: running   %skeleton-2
status: running   %acme
status: running   %hood
status: running   %lens
status: running   %dbug
status: running   %azimuth
status: running   %ping
status: running   %dojo
status: running   %eth-watcher
status: running   %spider
status: running   %herm
```

CC: @Fang-