### PR TITLE
http-api: prevent reuse of old subscription ids

### DIFF
--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": {

--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -235,9 +235,9 @@ export class Urbit {
             console.log('Received SSE: ', event);
           }
           if (!event.id) return;
-          this.lastEventId = parseInt(event.id, 10);
-          if (this.lastEventId - this.lastAcknowledgedEventId > 20) {
-            this.ack(this.lastEventId);
+          const eventId = parseInt(event.id, 10);
+          if (eventId - this.lastAcknowledgedEventId > 20) {
+            this.ack(eventId);
           }
 
           if (event.data && JSON.parse(event.data)) {
@@ -312,7 +312,7 @@ export class Urbit {
    *
    */
   reset() {
-    if(this.verbose) {
+    if (this.verbose) {
       console.log('resetting');
     }
     this.delete();


### PR DESCRIPTION
There's a latent bug in the http-api package which will erroneously send subscription responses with the wrong ids because they get reset mistakenly. This moves all setting of `this.lastEventId` to only the `getEventId` function so they stay consistent and ordered.