### PR TITLE
dns: transfer ship.arvo.network domains from ~zod to ~deg

### DIFF
--- a/pkg/arvo/mar/dns/complete.hoon
+++ b/pkg/arvo/mar/dns/complete.hoon
@@ -8,5 +8,14 @@
 ++  grab
   |%
   +$  noun  [ship binding]
+  ++  json
+    =,  dejs:format
+    |=  jon=json
+    %.  jon
+    %-  ot
+    :~  [%ship |=(j=json ?>(?=([%s *] j) (rash +.j fed:ag)))]
+        [%address |=(j=json ?>(?=([%s *] j) [%if (rash +.j ip4:eyre)]))]
+        [%turf (ar so)]
+    ==
   --
 --

--- a/pkg/arvo/mar/dns/request.hoon
+++ b/pkg/arvo/mar/dns/request.hoon
@@ -1,0 +1,16 @@
+/-  *dns
+|_  r=request
+++  grad  %noun
+++  grow
+  |%
+  ++  json
+    %-  pairs:enjs:format
+    :~  ['ship' (ship:enjs:format ship.r)]
+        ['address' s+(rsh 3 (scot %if +.address.r))]
+    ==
+  --
+++  grab
+  |%
+  ++  noun  request
+  --
+--

--- a/pkg/arvo/ted/dns/address.hoon
+++ b/pkg/arvo/ted/dns/address.hoon
@@ -25,7 +25,7 @@
   |=  if=@if
   =/  m  (strand ,~)
   ^-  form:m
-  =/  collector-app  `dock`[~zod %dns-collector]
+  =/  collector-app  `dock`[~deg %dns-collector]
   ;<  good=?  bind:m  (self-check-http:libdns |+if 2)
   ?.  good
     %+  strand-fail:strandio  %bail-early-self-check


### PR DESCRIPTION
As discussed with @Fang- out of band, the Foundation will take ownership of `ship.arvo.network` domains. This PR points `/ted/dns/address` to the Foundation operated `~deg` instead of Tlon operated `~zod`. It also includes some marks for my DNS automation.

I'll coordinate with @Fang- to switch DNS over when the OTA with this commit hits the network.