### PR TITLE
dojo: re-add support for ford runes

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -202,12 +202,8 @@
     %+  turn  cables
     |=  cable=cable:clay
     ^-  dojo-source
-    ::  TODO: The following *does* properly add faces to imported cores,
-    ::  but discards all their type information, making them hard to
-    ::  work with
-    ::
-    ::  =+  add-face=?~(face.cable "|=(n=* n)" ;:(weld "|=(n=* ^=(" (trip u.face.cable) " n))"))
-    ::  :^  0  %do  (scan add-face parse-hoon)
+    =+  add-face=?~(face.cable "|*(n=* n)" ;:(weld "|*(n=* ^=(" (trip u.face.cable) " n))"))
+    :^  0  %do  (scan add-face parse-hoon)
     :+  0  %dv  [-.dir `path`[base-path file-path.cable ~]]
   ::
   ++  parse-cable

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -174,8 +174,10 @@
     ::
       ;~  pfix  fas
         ;~  pose
-          (parse-variable (cold %sur hep) ;~(pfix gap (parse-ford %sur)))
-          (parse-variable (cold %lib lus) ;~(pfix gap (parse-ford %lib)))
+          (parse-variable (cold %sur hep) ;~(pfix gap (parse-cables %sur)))
+          (parse-variable (cold %lib lus) ;~(pfix gap (parse-cables %lib)))
+          ;~(pfix tis gap (parse-variable sym ;~(pfix gap parse-path)))
+          ;~(pfix cen gap (parse-variable sym ;~(pfix gap parse-mark)))
         ==
       ==
     ::
@@ -193,7 +195,7 @@
       (stag %show (cook $?(%1 %2 %3 %4 %5) (cook lent (stun [1 5] wut))))
     ==
   ::
-  ++  parse-ford
+  ++  parse-cables
     |=  base-path=@ta
     %-  cook  :_  (most ;~(plug com gaw) parse-cable)
     |=  cables=(list cable:clay)
@@ -213,6 +215,16 @@
       (cook |=([face=term tis=@ file=term] [`face file]) ;~(plug sym tis sym))
       (cook |=(a=term [`a a]) sym)
     ==
+  ::
+  ++  parse-mark
+    %-  cook  :_  ;~(pfix cen sym)
+    |=  mark=@tas
+    [0 %dv -.dir `path`[~.mar mark ~]]
+  ::
+  ++  parse-path
+    %+  cook  |=(=path [0 %dv -.dir path])
+    ;~(pfix fas (more fas sym))
+  ::
   ++  parse-source  (stag 0 parse-build)
   ++  parse-build
       %+  knee  *dojo-build  |.  ~+

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -174,8 +174,8 @@
     ::
       ;~  pfix  fas
         ;~  pose
-          (parse-variable (cold %sur hep) ;~(pfix gap parse-cables))
-          (parse-variable (cold %lib lus) ;~(pfix gap parse-cables))
+          (parse-variable (cold %sur hep) ;~(pfix gap (parse-ford %sur)))
+          (parse-variable (cold %lib lus) ;~(pfix gap (parse-ford %lib)))
         ==
       ==
     ::
@@ -193,23 +193,22 @@
       (stag %show (cook $?(%1 %2 %3 %4 %5) (cook lent (stun [1 5] wut))))
     ==
   ::
-  ++  parse-cables
-    %+  cook
-      |=  cables=(list cable:clay)
-      :+  0  %ex
-      ^-  hoon
-      ::
-      :-  %clsg
-      %+  turn  cables
-      |=  cable=cable:clay
-      ^-  hoon
-      ::
-      :+  %clhp
-        ?~  face.cable
-          [%rock %n ~]
-        [%clhp [%rock %n ~] [%sand %tas u.face.cable]]
-      [%sand %tas file-path.cable]
-    (most ;~(plug com gaw) parse-cable)
+  ++  parse-ford
+    |=  base-path=@ta
+    %-  cook  :_  (most ;~(plug com gaw) parse-cable)
+    |=  cables=(list cable:clay)
+    :+  0  %tu
+    ::
+    %+  turn  cables
+    |=  cable=cable:clay
+    ^-  dojo-source
+    ::  TODO: The following *does* properly add faces to imported cores,
+    ::  but discards all their type information, making them hard to
+    ::  work with
+    ::
+    ::  =+  add-face=?~(face.cable "|=(n=* n)" ;:(weld "|=(n=* ^=(" (trip u.face.cable) " n))"))
+    ::  :^  0  %do  (scan add-face parse-hoon)
+    :+  0  %dv  [-.dir `path`[base-path file-path.cable ~]]
   ::
   ++  parse-cable
     %+  cook  |=(a=cable:clay a)
@@ -537,8 +536,8 @@
         =.  var  (~(del by var) p.mad)
         =<  dy-amok
         ?+  p.mad  .
-          %lib  .(lib ~)
-          %sur  .(sur ~)
+          ::  %lib  .(lib ~)
+          ::  %sur  .(sur ~)
           %dir  .(dir [[our.hid %base ud+0] /])
         ==
       =+  cay=(~(got by rez) p.q.mad)
@@ -550,17 +549,17 @@
         ~|  bad-set+[p.p.mad p.q.cay]
         =<  dy-amok
         ?+  p.p.mad  .
-            %lib
-          %_    .
-              lib
-            ((dy-cast (list cable:clay) !>(*(list cable:clay))) q.cay)
-          ==
-        ::
-            %sur
-          %_    .
-              sur
-            ((dy-cast (list cable:clay) !>(*(list cable:clay))) q.cay)
-          ==
+        ::      %lib
+        ::    %_    .
+        ::        lib
+        ::      ((dy-cast (list cable:clay) !>(*(list cable:clay))) q.cay)
+        ::    ==
+        ::  ::
+        ::      %sur
+        ::    %_    .
+        ::        sur
+        ::      ((dy-cast (list cable:clay) !>(*(list cable:clay))) q.cay)
+        ::    ==
         ::
             %dir  =+  ^=  pax  ^-  path
                       =+  pax=((dy-cast path !>(*path)) q.cay)


### PR DESCRIPTION
These changes re-add support for file imports via `%ford` runes (e.g. `/+`, `/-`) to `%dojo`, since their inadvertent absence [post-fusion](https://github.com/urbit/urbit/pull/3060). To minimize changes to `%dojo`'s app data, imports are currently limited to the `/+` and `/-` runes, which import into the `lib` and `sur` variables, respectively.

## Demo ##

```
~zod:dojo> /-  *dns
~zod:dojo> (address.sur [%if *@if])
[%if if=.0.0.0.0]
~zod:dojo> /+  kg=keygen, csv
~zod:dojo> (ownership-wallet-from-ticket.kg.lib ~zod [4 ~.dozzod-dozzod-dozzod-dozzod] ~)
[ type="ownership" seed=...]
~zod:dojo> (print-rows.csv.lib `(list vase)`~[!>('a') !>('b')])
'a'
'b'
<1.tan [* <46.hgz 1.pnw %140>]>
~zod:dojo> /+
~zod:dojo> lib
-find.lib
dojo: hoon expression failed
~zod:dojo> /%  txt  %txt
~zod:dojo> =>(~(grab txt "") (noun))
<||>
~zod:dojo> /=  md  /mar/md
~zod:dojo> =>(~(grow md "") mime)
[[%text %plain ~] p=0 q=0]
```

## Tasks ##

- [X] Add support for importing via `/+` into `lib`.
- [X] Add support for importing via `/-` into `sur`.
- [x] Add support for cable expressions (e.g. `/+  kg=keygen, *csv`).
- [X] Add support for arbitrary Hoon importing via `/=`.
- [X] Add support for mark importing via `/%`.
- [ ] Add support for importing via other Ford runes (?).

Tagging: @Fang-, @joemfb 