### PR TITLE
eyre, http-api: add support for noun-based channels

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1292,7 +1292,8 @@
   ::    events since then.
   ::
   +$  channel
-    $:  ::  channel-state: expiration time or the duct currently listening
+    $:  mode=?(%json %jam)
+        ::  channel-state: expiration time or the duct currently listening
         ::
         ::    For each channel, there is at most one open EventSource
         ::    connection. A 400 is issues on duplicate attempts to connect to the

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -67,10 +67,8 @@
 ::  more structures
 ::
 |%
-++  axle
-  $:  ::  date: date at which http-server's state was updated to this data structure
-      ::
-      date=%~2020.10.18
++$  axle
+  $:  %1
       ::  server-state: state of inbound requests
       ::
       =server-state
@@ -119,9 +117,12 @@
   $%  ::  %ack: acknowledges that the client has received events up to :id
       ::
       [%ack event-id=@ud]
-      ::  %poke: pokes an application, translating :json to :mark.
+      ::  %poke: pokes an application, validating :noun against :mark
       ::
-      [%poke request-id=@ud ship=@p app=term mark=@tas =json]
+      [%poke request-id=@ud ship=@p app=term mark=@tas =noun]
+      ::  %poke-json: pokes an application, translating :json to :mark
+      ::
+      [%poke-json request-id=@ud ship=@p app=term mark=@tas =json]
       ::  %watch: subscribes to an application path
       ::
       [%subscribe request-id=@ud ship=@p app=term =path]
@@ -200,11 +201,32 @@
   (sub u.sus ack)
 ::  +parse-channel-request: parses a list of channel-requests
 ::
+++  parse-channel-request
+  |=  [mode=?(%json %jam) body=octs]
+  ^-  (each (list channel-request) @t)
+  ?-  mode
+      %json
+    ?~  maybe-json=(de-json:html q.body)
+      |+'put body not json'
+    ?~  maybe-requests=(parse-channel-request-json u.maybe-json)
+      |+'invalid channel json'
+    &+u.maybe-requests
+  ::
+      %jam
+    ?~  maybe-noun=(bind (slaw %uw q.body) cue)
+      |+'invalid request format'
+    ?~  maybe-reqs=((soft (list channel-request)) u.maybe-noun)
+      ~&  [%miss u.maybe-noun]
+      |+'invalid request data'
+    &+u.maybe-reqs
+  ==
+::  +parse-channel-request-json: parses a json list of channel-requests
+::
 ::    Parses a json array into a list of +channel-request. If any of the items
 ::    in the list fail to parse, the entire thing fails so we can 400 properly
 ::    to the client.
 ::
-++  parse-channel-request
+++  parse-channel-request-json
   |=  request-list=json
   ^-  (unit (list channel-request))
   ::  parse top
@@ -220,7 +242,9 @@
   ?:  =('ack' u.maybe-key)
     ((pe %ack (ot event-id+ni ~)) item)
   ?:  =('poke' u.maybe-key)
-    ((pe %poke (ot id+ni ship+(su fed:ag) app+so mark+(su sym) json+some ~)) item)
+    %.  item
+    %+  pe  %poke-json
+    (ot id+ni ship+(su fed:ag) app+so mark+(su sym) json+some ~)
   ?:  =('subscribe' u.maybe-key)
     %.  item
     %+  pe  %subscribe
@@ -1071,6 +1095,11 @@
         ::
         %^  return-static-data-on-duct  400  'text/html'
         (error-page 400 authenticated url.request "malformed channel url")
+      =/  mode=?(%json %jam)
+        ::TODO  go off file extention instead?
+        ?+  i.t.site.request-line  %json
+          %channel-jam  %jam
+        ==
       ::  channel-id: unique channel id parsed out of url
       ::
       =+  channel-id=i.t.t.site.request-line
@@ -1078,13 +1107,13 @@
       ?:  =('PUT' method.request)
         ::  PUT methods starts/modifies a channel, and returns a result immediately
         ::
-        (on-put-request channel-id request)
+        (on-put-request channel-id mode request)
       ::
       ?:  =('GET' method.request)
-        (on-get-request channel-id request)
+        (on-get-request channel-id mode request)
       ?:  =('POST' method.request)
         ::  POST methods are used solely for deleting channels
-        (on-put-request channel-id request)
+        (on-put-request channel-id mode request)
       ::
       ~&  %session-not-a-put
       [~ state]
@@ -1139,7 +1168,7 @@
     ::    state.
     ::
     ++  update-timeout-timer-for
-      |=  channel-id=@t
+      |=  [mode=?(%json %jam) channel-id=@t]
       ^+  ..update-timeout-timer-for
       ::  when our callback should fire
       ::
@@ -1151,7 +1180,7 @@
         %_    ..update-timeout-timer-for
             session.channel-state.state
           %+  ~(put by session.channel-state.state)  channel-id
-          [[%& expiration-time duct] 0 now ~ ~ ~ ~]
+          [mode [%& expiration-time duct] 0 now ~ ~ ~ ~]
         ::
             moves
           [(set-timeout-move channel-id expiration-time) moves]
@@ -1203,13 +1232,16 @@
     ::    client in text/event-stream format.
     ::
     ++  on-get-request
-      |=  [channel-id=@t =request:http]
+      |=  [channel-id=@t mode=?(%json %jam) =request:http]
       ^-  [(list move) server-state]
       ::  if there's no channel-id, we must 404
       ::
       ?~  maybe-channel=(~(get by session.channel-state.state) channel-id)
         %^  return-static-data-on-duct  404  'text/html'
         (error-page 404 %.y url.request ~)
+      ::
+      ::TODO  consider forbidding connection if !=(mode mode.u.maybe-channel)
+      ::
       ::  when opening an event-stream, we must cancel our timeout timer
       ::  if there's no duct already bound. Else, kill the old request
       ::  and replace it
@@ -1254,8 +1286,10 @@
         =/  sign
           (channel-event-to-sign u.maybe-channel request-id channel-event)
         ?~  sign  $
-        ?~  jive=(sign-to-json u.maybe-channel request-id u.sign)  $
-        $(events [(event-json-to-wall id +.u.jive) events])
+        =/  said
+          (sign-to-tape u.maybe-channel(mode mode) request-id u.sign)
+        ?~  said  $
+        $(events [(event-tape-to-wall id +.u.said) events])
       ::  send the start event to the client
       ::
       =^  http-moves  state
@@ -1287,13 +1321,18 @@
       ::
       =/  heartbeat-time=@da  (add now ~s20)
       =/  heartbeat  (set-heartbeat-move channel-id heartbeat-time)
-      ::  clear the event queue, record the duct for future output and
-      ::  record heartbeat-time for possible future cancel
+      ::  clear the event queue, record the mode & duct for future output,
+      ::  and record heartbeat-time for possible future cancel
       ::
       =.  session.channel-state.state
         %+  ~(jab by session.channel-state.state)  channel-id
         |=  =channel
-        channel(events ~, state [%| duct], heartbeat (some [heartbeat-time duct]))
+        %_  channel
+          mode       mode
+          events     ~
+          state      [%| duct]
+          heartbeat  (some [heartbeat-time duct])
+        ==
       ::
       [[heartbeat :(weld http-moves cancel-moves moves)] state]
     ::  +acknowledge-events: removes events before :last-event-id on :channel-id
@@ -1318,26 +1357,23 @@
     ::    a set of commands in JSON format in the body of the message.
     ::
     ++  on-put-request
-      |=  [channel-id=@t =request:http]
+      |=  [channel-id=@t mode=?(%json %jam) =request:http]
       ^-  [(list move) server-state]
       ::  error when there's no body
       ::
       ?~  body.request
         %^  return-static-data-on-duct  400  'text/html'
         (error-page 400 %.y url.request "no put body")
-      ::  if the incoming body isn't json, this is a bad request, 400.
+      ::  if we cannot parse requests from the body, give an error
       ::
-      ?~  maybe-json=(de-json:html q.u.body.request)
+      =/  maybe-requests=(each (list channel-request) @t)
+        (parse-channel-request mode u.body.request)
+      ?:  ?=(%| -.maybe-requests)
         %^  return-static-data-on-duct  400  'text/html'
-        (error-page 400 %.y url.request "put body not json")
-      ::  parse the json into an array of +channel-request items
-      ::
-      ?~  maybe-requests=(parse-channel-request u.maybe-json)
-        %^  return-static-data-on-duct  400  'text/html'
-        (error-page 400 %.y url.request "invalid channel json")
+        (error-page 400 & url.request (trip p.maybe-requests))
       ::  while weird, the request list could be empty
       ::
-      ?:  =(~ u.maybe-requests)
+      ?:  =(~ p.maybe-requests)
         %^  return-static-data-on-duct  400  'text/html'
         (error-page 400 %.y url.request "empty list of actions")
       ::  check for the existence of the channel-id
@@ -1346,10 +1382,10 @@
       ::    :channel-timeout from now. if we have one which has a timer, update
       ::    that timer.
       ::
-      =.  ..on-put-request  (update-timeout-timer-for channel-id)
+      =.  ..on-put-request  (update-timeout-timer-for mode channel-id)
       ::  for each request, execute the action passed in
       ::
-      =+  requests=u.maybe-requests
+      =+  requests=p.maybe-requests
       ::  gall-moves: put moves here first so we can flop for ordering
       ::
       ::    TODO: Have an error state where any invalid duplicate subscriptions
@@ -1380,7 +1416,7 @@
           requests  t.requests
         ==
       ::
-          %poke
+          ?(%poke %poke-json)
         ::
         =.  gall-moves
           :_  gall-moves
@@ -1388,7 +1424,12 @@
           :^  duct  %pass  /channel/poke/[channel-id]/(scot %ud request-id.i.requests)
           =,  i.requests
           :*  %g  %deal  `sock`[our ship]  app
-              `task:agent:gall`[%poke-as mark %json !>(json)]
+              ^-  task:agent:gall
+              :+  %poke-as  mark
+              ?-  -.i.requests
+                %poke       [%noun !>(noun)]
+                %poke-json  [%json !>(json)]
+              ==
           ==
         ::
         $(requests t.requests)
@@ -1521,18 +1562,16 @@
       ::  if conversion succeeds, we *can* send it. if the client is actually
       ::  connected, we *will* send it immediately.
       ::
-      =/  jive=(unit (quip move json))
-        (sign-to-json u.channel request-id sign)
-      =/  json=(unit json)
-        ?~(jive ~ `+.u.jive)
-      =?  moves  ?=(^ jive)
-        (weld moves -.u.jive)
-      =*  sending  &(?=([%| *] state.u.channel) ?=(^ json))
+      =/  said=(unit (quip move tape))
+        (sign-to-tape u.channel request-id sign)
+      =?  moves  ?=(^ said)
+        (weld moves -.u.said)
+      =*  sending  &(?=([%| *] state.u.channel) ?=(^ said))
       ::
       =/  next-id  next-id.u.channel
       ::  if we can send it, store the event as unacked
       ::
-      =?  events.u.channel  ?=(^ json)
+      =?  events.u.channel  ?=(^ said)
         %-  ~(put to events.u.channel)
         [next-id request-id (sign-to-channel-event sign)]
       ::  if it makes sense to do so, send the event to the client
@@ -1548,11 +1587,11 @@
         ::
             ^=  data
             %-  wall-to-octs
-            (event-json-to-wall next-id (need json))
+            (event-tape-to-wall next-id +:(need said))
         ::
             complete=%.n
         ==
-      =?  next-id  ?=(^ json)  +(next-id)
+      =?  next-id  ?=(^ said)  +(next-id)
       ::  update channel's unacked counts, find out if clogged
       ::
       =^  clogged  unacked.u.channel
@@ -1560,7 +1599,7 @@
         ::  and of course don't count events we can't send as unacked.
         ::
         ?:  ?|  !?=(%fact -.sign)
-                ?=(~ json)
+                ?=(~ said)
             ==
           [| unacked.u.channel]
         =/  num=@ud
@@ -1573,7 +1612,7 @@
       ::  if we're clogged, or we ran into an event we can't serialize,
       ::  kill this gall subscription.
       ::
-      =*  kicking    |(clogged ?=(~ json))
+      =*  kicking    |(clogged ?=(~ said))
       =?  moves      kicking
         :_  moves
         ::NOTE  this shouldn't crash because we
@@ -1603,8 +1642,8 @@
         ::
             ^=  data
             %-  wall-to-octs
-            %+  event-json-to-wall  next-id
-            +:(need (sign-to-json u.channel request-id %kick ~))
+            %+  event-tape-to-wall  next-id
+            +:(need (sign-to-tape u.channel request-id %kick ~))
         ::
             complete=%.n
         ==
@@ -1657,6 +1696,17 @@
       ?:  ?=(%| -.res)
         ((slog leaf+"eyre: stale fact of mark {(trip have)}" ~) ~)
       `[%fact have p.res]
+    ::  +sign-to-tape: render sign from request-id in specified mode
+    ::
+    ++  sign-to-tape
+      |=  [=channel request-id=@ud =sign:agent:gall]
+      ^-  (unit (quip move tape))
+      ?-  mode.channel
+        %json  %+  bind  (sign-to-json channel request-id sign)
+               |=((quip move json) [+<- (en-json:html +<+)])
+        %jam   =-  `[~ (scow %uw (jam -))]
+               [request-id (sign-to-channel-event sign)]
+      ==
     ::  +sign-to-json: render sign from request-id as json channel event
     ::
     ++  sign-to-json
@@ -1725,12 +1775,12 @@
         ==
       ==
     ::
-    ++  event-json-to-wall
-      ~%  %eyre-json-to-wall  ..part  ~
-      |=  [event-id=@ud =json]
+    ++  event-tape-to-wall
+      ~%  %eyre-tape-to-wall  ..part  ~
+      |=  [event-id=@ud =tape]
       ^-  wall
       :~  (weld "id: " (format-ud-as-integer event-id))
-          (weld "data: " (en-json:html json))
+          (weld "data: " tape)
           ""
       ==
     ::
@@ -2037,6 +2087,8 @@
     ::
     =/  request-line  (parse-request-line url)
     =/  parsed-url=(list @t)  site.request-line
+    =?  parsed-url  ?=([%'~' %channel-jam *] parsed-url)
+      parsed-url(i.t %channel)
     ::
     =/  bindings  bindings.state
     |-
@@ -2494,6 +2546,9 @@
     ::
     ?^  error.sign
       [[duct %slip %d %flog %crud %wake u.error.sign]~ http-server-gate]
+    ::NOTE  we are not concerned with expiring channels that are still in
+    ::      use. we require acks for messages, which bump their session's
+    ::      timer. channels have their own expiry timer, too.
     ::  remove cookies that have expired
     ::
     =*  sessions  sessions.authentication-state.server-state.ax
@@ -2531,9 +2586,59 @@
 ::  +load: migrate old state to new state (called on vane reload)
 ::
 ++  load
-  |=  old=axle
-  ^+  ..^$
-  ..^$(ax old)
+  |^  |=  old=axle-any
+      ^+  ..^^$
+      ?-  -.old
+        %1            ..^^$(ax old)
+        %~2020.10.18  $(old (axle-0-to-1 old))
+      ==
+  ::
+  +$  axle-any
+    $%  axle
+        axle-0
+    ==
+  ::
+  ++  axle-0-to-1
+    |=  ax=axle-0
+    ^-  axle
+    :-  %1
+    ^-  server-state
+    ::TODO  add /~/channel-jam binding
+    %=  server-state.ax
+        session.channel-state
+      (~(run by session.channel-state.server-state.ax) (lead %json))
+    ==
+  ::
+  +$  axle-0
+    $:  %~2020.10.18
+        $=  server-state
+    $:  bindings=(list [=binding =duct =action])
+        =cors-registry
+        connections=(map duct outstanding-connection)
+        =authentication-state
+        channel-state=channel-state-0
+        domains=(set turf)
+        =http-config
+        ports=[insecure=@ud secure=(unit @ud)]
+        outgoing-duct=duct
+    ==  ==
+  ::
+  +$  channel-state-0
+    $:  session=(map @t channel-0)
+        duct-to-key=(map duct @t)
+    ==
+  ::
+  +$  channel-0
+    $:  state=(each timer duct)
+        next-id=@ud
+        last-ack=@da
+        events=(qeu [id=@ud request-id=@ud =channel-event])
+        unacked=(map @ud @ud)
+        subscriptions=(map @ud [ship=@p app=term =path duc=duct])
+        heartbeat=(unit timer)
+    ==
+  --
+
 ::  +stay: produce current state
 ::
 ++  stay  `axle`ax

--- a/pkg/interface/webterm/Buffer.tsx
+++ b/pkg/interface/webterm/Buffer.tsx
@@ -13,7 +13,7 @@ import useTermState from './state';
 import React from 'react';
 import { Box, Col } from '@tlon/indigo-react';
 import { makeTheme } from './lib/theme';
-import { showBlit, csi, hasBell } from './lib/blit';
+import { showBlit, csi, hasBell, getBlit } from './lib/blit';
 import { DEFAULT_SESSION, RESIZE_DEBOUNCE_MS, RESIZE_THRESHOLD_PX } from './constants';
 import { retry } from './lib/retry';
 
@@ -181,8 +181,13 @@ export default function Buffer({ name, selected, dark }: BufferProps) {
     //
     const initSubscription = async () => {
       const subscriptionId = await api.subscribe({
-        app: 'herm', path: '/session/' + name + '/view',
-        event: (e) => {
+        app: 'herm', path: ['session', name, 'view', 0],
+        event: (m, n) => {
+          if (m !== 'blit') {
+            console.log('unexpected mark', m, n.toString());
+            return;
+          }
+          const e = getBlit(n);
           showBlit(ses.term, e);
           //NOTE  getting selected from state because selected prop is stale
           if (hasBell(e) && (useTermState.getState().selected !== name)) {

--- a/pkg/interface/webterm/lib/blit.ts
+++ b/pkg/interface/webterm/lib/blit.ts
@@ -1,7 +1,57 @@
 import { Terminal } from 'xterm';
 import { saveAs } from 'file-saver';
-import { Blit, Stub, Stye } from '@urbit/api/term';
+import { Blit, Stub, Stye, Tint } from '@urbit/api/term';
 import { stye } from '../lib/stye';
+
+import { enjs } from '@urbit/http-api';
+
+const getTint = (noun): Tint => {
+  return enjs.bucwut([
+    enjs.nill,
+    enjs.cord,
+    enjs.pairs([
+      { nom: 'r', get: enjs.numb },
+      { nom: 'g', get: enjs.numb },
+      { nom: 'b', get: enjs.numb }
+    ])
+  ])(noun);
+};
+
+const getStye = (noun): Stye => {
+  return enjs.pairs([
+    { nom: 'deco', get: enjs.tree(enjs.bucwut([enjs.nill, enjs.cord])) },
+    { nom: 'back', get: getTint },
+    { nom: 'fore', get: getTint }
+  ])(noun);
+};
+
+const getText = (noun): string => {
+  const utf32 = enjs.numb(noun);
+  return String.fromCharCode(utf32);
+};
+
+const getStub = (noun): Stub => {
+  return enjs.pair('stye', getStye, 'text', enjs.array(getText))(noun);
+};
+
+export const getBlit = (noun): Blit => {
+  return enjs.frond([
+    { tag: 'bel', get: () => true },
+    { tag: 'clr', get: () => true },
+    { tag: 'hop', get: enjs.bucwut([
+      enjs.numb,
+      enjs.pair('x', enjs.numb, 'y', enjs.numb)
+    ]) },
+    { tag: 'klr', get: enjs.array(getStub) },
+    { tag: 'mor', get: enjs.array(getBlit) },
+    { tag: 'nel', get: () => true },
+    { tag: 'put', get: enjs.array(getText) },
+    { tag: 'sag', get: enjs.pair('path', enjs.cord, 'file', enjs.cord) },
+    { tag: 'sav', get: enjs.pair('path', enjs.cord, 'file', enjs.cord) },
+    { tag: 'url', get: enjs.cord },
+    { tag: 'wyp', get: () => true }
+  ])(noun);
+};
 
 export const csi = (cmd: string, ...args: number[]) => {
   return '\x1b[' + args.join(';') + cmd;

--- a/pkg/interface/webterm/package.json
+++ b/pkg/interface/webterm/package.json
@@ -9,6 +9,7 @@
     "@reach/menu-button": "^0.10.5",
     "@tlon/indigo-react": "^1.2.23",
     "@urbit/api": "^1.1.1",
+     "@urbit/aura": "^0.4.0",
     "@urbit/http-api": "^1.2.1",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",

--- a/pkg/npm/api/term/lib.ts
+++ b/pkg/npm/api/term/lib.ts
@@ -2,11 +2,67 @@ import { Scry } from '../../http-api/src'
 import { Poke } from '../../http-api/src/types';
 import { Belt, Task, SessionTask } from './types';
 
-export const pokeTask = (session: string, task: Task): Poke<SessionTask> => ({
-  app: 'herm',
-  mark: 'herm-task',
-  json: { session, ...task }
-});
+const beltToNoun = (bet) => {
+  if (typeof bet === 'string') {
+    return bet;
+  } else
+  if ('aro' in bet) {
+    return ['aro', bet.aro];
+  } else
+  if ('bac' in bet) {
+    return ['bac', 0];
+  } else
+  if ('del' in bet) {
+    return ['del', 0];
+  } else
+  if ('hit' in bet) {
+    return ['hit', bet.hit.x, bet.hit.y];
+  } else
+  if ('ret' in bet) {
+    return ['ret', 0];
+  } else
+  if ('mod' in bet) {
+    return ['mod', bet.mod.mod, beltToNoun(bet.mod.key)];
+  } else
+  if ('txt' in bet) {
+    return ['txt', [...bet.txt, 0]];
+  } else {
+    console.log('strange belt', bet);
+    return 0;
+  }
+}
+
+export const pokeTask = (session: string, task: Task): Poke<SessionTask> => {
+  let non: any = 0;
+  if ('belt' in task) {
+    // [%belt p=belt]
+    non = ['belt', beltToNoun(task.belt)];
+  } else
+  if ('blew' in task) {
+    // [%blew p=blew]
+    non = ['blew', task.blew.w, task.blew.h];
+  } else
+  if ('hail' in task) {
+    // [%hail ~]
+    non = ['hail', 0];
+  } else
+  if ('open' in task) {
+    // [%open p=dude:gall q=(list gill:gall)]
+    non = ['open', task.open.term, [...task.open.apps.map(a => {
+      return [a.who, a.app];  //TODO  a.who as Atom
+    }), 0]];
+  } else
+  if ('shut' in task) {
+    // [%shut ~]
+    non = ['shut', 0];
+  }
+
+  return {
+    app: 'herm',
+    mark: 'herm-task',
+    noun: [session, non],
+  }
+};
 
 export const pokeBelt = (
   session: string,

--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -60,7 +60,9 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@microsoft/fetch-event-source": "^2.0.0",
+    "@urbit/aura": "file:../../../../aura-js",
     "browser-or-node": "^1.3.0",
-    "core-js": "^3.19.1"
+    "core-js": "^3.19.1",
+    "urbit-ob": "^5.0.1"
   }
 }

--- a/pkg/npm/http-api/src/index.ts
+++ b/pkg/npm/http-api/src/index.ts
@@ -1,3 +1,5 @@
+import { enjs } from './nockjs/noun';
 export * from './types';
 import { Urbit } from './Urbit';
+export { enjs };
 export { Urbit as default, Urbit };

--- a/pkg/npm/http-api/src/nockjs/TODO
+++ b/pkg/npm/http-api/src/nockjs/TODO
@@ -1,0 +1,42 @@
+* a noun is an atom or a cell. DONE
+* mugs. DONE
+* unifying equals. DONE
+* dorky embedded DSL for nouns. DONE
+* some kind of real hashmap (needed for memoization at least). DONE
+* nock->js compiler (THE REALLY INTERESTING PART). DONE (at least, v1)
+* decrement. DONE
+* port random-noun tests to tape-check. DONE
+* jam/cue for pill reading (makes testing easier). DONE
+* add. DONE
+* jets (basic binding). DONE
+* ackerman. DONE
+* atom-gates.pill
+* ALL jets (ref: jaque)
+* boot ivory pill
+^--- call urbit library functions from js! great success!
+* boot fakezod (brass pill) to dojo
+* prevalence (on-disk in node, IndexedDB in brower)
+* expose basic vere-slave interface as a library
+  i.e. send me pokes, i handle all persistence and send you io 
+^--- candidate vere backend
+     urbit in the browser
+* urbit over webrtc?
+
+At this point, we have a working vere backend, as well as a full
+"urbit in the browser".  Performance is unlikely to be as good as jaque,
+but will likely be quite accepatable (especially for in-browser things).
+
+At the very least, using an ivory pill to compile and run hoon from the
+browser will ease client-side programming tasks.
+
+--- future implementation ideas
+
+it would be feasible to add profiling code to the compiled javascript,
+specifically in callsites (9), so that the 9 would run say 100 times and
+then recompile itself with a check and a direct call to the most called
+battery. this would also enable loop finding in tail position where the
+most called battery is the one being compiled. (important here not to
+use the 2 compiler cache, but to have a generated call site per battery)
+
+it would be cool to profile that single optimization, all other things 
+being equal. it should be the most important one.

--- a/pkg/npm/http-api/src/nockjs/bits.js
+++ b/pkg/npm/http-api/src/nockjs/bits.js
@@ -1,0 +1,333 @@
+var noun = require('./noun.js'),
+    BigInteger = require('jsbn').BigInteger,
+    zero = noun.Atom.yes,
+    one  = noun.Atom.no;
+
+// a is native, returns native
+function met(a, b) {
+  var bits = b.number.bitLength(),
+      full = bits >>> a,
+      part = (full << a) !== bits;
+
+  return part ? full + 1 : full;
+}
+
+function gth(a, b) {
+  return a.number.compareTo(b.number) > 0;
+}
+
+function lth(a, b) {
+  return a.number.compareTo(b.number) < 0;
+}
+
+function gte(a, b) {
+  return a.number.compareTo(b.number) >= 0;
+}
+
+function lte(a, b) {
+  return a.number.compareTo(b.number) <= 0;
+}
+
+function add(a, b) {
+  return new noun.Atom.Atom(a.number.add(b.number));
+}
+
+function dec(a) {
+  return sub(a, one);
+}
+
+function bex(a) {
+  return new noun.Atom.Atom(BigInteger.ONE.shiftLeft(a.number.intValue()));
+}
+
+function sub(a, b) {
+  var r = a.number.subtract(b.number);
+  if ( r.signum < 0 ) {
+    throw new Error("subtract underflow");
+  }
+  else {
+    return new noun.Atom.Atom(r);
+  }
+}
+
+function lsh(a, b, c) {
+  var bits = b.number.shiftLeft(a.number.intValue()).intValue();
+  return new noun.Atom.Atom(c.number.shiftLeft(bits));
+}
+
+function rsh(a, b, c) {
+  var bits = b.number.shiftLeft(a.number.intValue()).intValue();
+  return new noun.Atom.Atom(c.number.shiftRight(bits));
+}
+
+// to/from little-endian 32-bit word array, as used in vere
+// TODO: efficiency is horrible here, but can be improved using internals
+function bytesToWords(bytes) {
+  var len   = bytes.length,
+      trim  = len % 4;
+  var i, b, w;
+
+	if ( trim > 0 ) {
+    len += (4-trim);
+    for ( i = 0; i < trim; ++i ) {
+      bytes.push(0);
+    }
+	}
+
+  var size = len >> 2;
+  var words = new Array(size);
+  for ( i = 0, b = 0; i < size; ++i ) {
+    w =  (bytes[b++] << 0)  & 0x000000FF;
+    w ^= (bytes[b++] << 8)  & 0x0000FF00;
+    w ^= (bytes[b++] << 16) & 0x00FF0000;
+    w ^= (bytes[b++] << 24) & 0xFF000000;
+    words[i] = w;
+  }
+  return words;
+};
+
+function wordsToBytes(words) {
+  var buf = [];
+  var w, i, b;
+  for ( i = 0, b = 0; i < words.length; ++i ) {
+    w = words[i];
+    buf[b++] = 0xff & (w & 0x000000FF);
+    buf[b++] = 0xff & ((w & 0x0000FF00) >>> 8);
+    buf[b++] = 0xff & ((w & 0x00FF0000) >>> 16);
+    buf[b++] = 0xff & ((w & 0xFF000000) >>> 24);
+  }
+  // or here. one of the 'get rid of extra zeros' functions.
+  while ( buf[--b] === 0 ) {
+    buf.pop();
+  }
+  return buf;
+};
+
+function bytesToAtom(bytes) {
+  var byt, parts = [];
+  for ( var i = bytes.length - 1; i >= 0; --i ) {
+    byt = bytes[i] & 0xff;
+    parts.push(byt < 16 ? ("0" + byt.toString(16)) : byt.toString(16));
+  }
+  return new noun.Atom.Atom(new BigInteger(parts.join(''), 16));
+}
+
+function atomToBytes(atom) {
+  return atom.bytes();
+}
+
+function atomToWords(atom) {
+  return bytesToWords(atomToBytes(atom));
+}
+
+function wordsToAtom(words) {
+  return bytesToAtom(wordsToBytes(words));
+}
+
+var malt = wordsToAtom;
+
+// XX: INTERNAL
+function slaq(bloq, len) {
+  return new Array(((len << bloq) + 31) >>> 5);
+}
+
+// src is atom, all others native
+function chop(met, fum, wid, tou, dst, src) {
+  var buf = atomToWords(src),
+      len = buf.length,
+      i, j, san, mek, baf, bat, hut, san,
+      wuf, wut, waf, raf, wat, rat, hop;
+
+  if ( met < 5 ) {
+    san = 1 << met;
+    mek = ((1 << san) - 1);
+    baf = fum << met;
+    bat = tou << met;
+
+    for ( i = 0; i < wid; ++i ) {
+      waf = baf >>> 5;
+      raf = baf & 31;
+      wat = bat >>> 5;
+      rat = bat & 31;
+      hop = ((waf >= len) ? 0 : buf[waf]);
+      hop = ((hop >>> raf) & mek);
+      dst[wat] ^= hop << rat;
+      baf += san;
+      bat += san;
+    }
+  }
+  else {
+    hut = met - 5;
+    san = 1 << hut;
+
+    for ( i = 0; i < wid; ++i ) {
+      wuf = (fum + i) << hut;
+      wut = (tou + i) << hut;
+
+      for ( j = 0; j < san; ++j ) {
+        dst[wut + j] ^= ((wuf + j) >= len)
+                      ? 0
+                      : buf[wuf + j];
+      }
+    }
+  }
+}
+
+function cut(a, b, c, d) {
+  var ai = a.number.intValue(),
+      bi = b.number.intValue(),
+      ci = c.number.intValue();
+
+  var len = met(ai, d);
+  if ( zero.equals(c) || bi >= len ) {
+    return zero;
+  }
+  if ( bi + ci > len ) {
+    ci = len - b;
+  }
+  if ( 0 === bi && ci === len ) {
+    return d;
+  }
+  else {
+    var sal = slaq(ai, ci);
+    chop(ai, bi, ci, 0, sal, d);
+    return malt(sal);
+  }
+}
+
+var maxCat = noun.Atom.fromInt(0xffffffff);
+var catBits = noun.Atom.fromInt(32);
+
+function end(a, b, c) {
+  if ( gth(a, catBits) ) {
+    throw new Error("Fail");
+  }
+  else if ( gth(b, maxCat) ) {
+    return c;
+  }
+	else {
+    var ai = a.number.intValue(),
+        bi = b.number.intValue(),
+       len = met(ai, c);
+
+    if ( 0 === bi ) {
+      return zero;
+    }
+    else if ( bi >= len ) {
+      return c;
+    }
+    else {
+      var sal = slaq(ai, bi);
+      chop(ai, 0, bi, 0, sal, c);
+      return malt(sal);
+    }
+	}
+}
+
+function mix(a, b) {
+  return new noun.Atom.Atom(a.number.xor(b.number));
+}
+
+function cat(a, b, c) {
+	if ( gth(a, catBits) ) {
+		throw new Error("Fail");
+	}
+	else {
+		var ai = a.number.intValue(),
+       lew = met(ai, b),
+       ler = met(ai, c),
+       all = lew + ler;
+
+    if ( 0 === all ) {
+      return zero;
+    }
+    else {
+      var sal = slaq(ai, all);
+      chop(ai, 0, lew, 0, sal, b);
+      chop(ai, 0, ler, lew, sal, c);
+      return malt(sal);
+    }
+	}
+}
+
+function can(a, b) {
+  if ( gth(a, catBits) ) {
+    throw new Error("Fail");
+  }
+  else {
+    var ai = a.number.intValue(),
+      tot = 0,
+      cab = b,
+      pos, i_cab, pi_cab, qi_cab;
+
+    // measure
+    while ( true ) {
+      if ( zero.equals(cab) ) {
+        break;
+      }
+      if ( !cab.deep ) {
+        throw new Error("Fail");
+      }
+      i_cab = cab.head;
+      if ( !i_cab.deep ) {
+        throw new Error("Fail");
+      }
+      pi_cab = i_cab.head;
+      qi_cab = i_cab.tail;
+      if ( gth(pi_cab, maxCat) ) {
+        throw new Error("Fail");
+      }
+      if ( qi_cab.deep ) {
+        throw new Error("Fail");
+      }
+      if ( (tot + pi_cab) < tot ) {
+        throw new Error("Fail");
+      }
+      tot += pi_cab;
+      cab = cab.tail;
+    }
+    if ( 0 === tot ) {
+      return zero;
+    }
+    var sal = slaq(ai, tot);
+
+    // chop the list atoms in
+    cab = b;
+    pos = 0;
+    while ( !zero.equals(cab) ) {
+      i_cab  = cab.head;
+      pi_cab = i_cab.head.number.intValue();
+      qi_cab = i_cab.tail;
+
+      chop(ai, 0, pi_cab, pos, sal, qi_cab);
+      pos += pi_cab;
+      cab = cab.tail;
+    }
+    return malt(sal);
+  }
+}
+
+module.exports = {
+  met: met,
+  cut: cut,
+	add: add,
+	sub: sub,
+  dec: dec,
+  gth: gth,
+  lth: lth,
+  gte: gte,
+  lte: lte,
+  bex: bex,
+  lsh: lsh,
+  rsh: rsh,
+  end: end,
+  mix: mix,
+  cat: cat,
+  can: can,
+  bytesToWords: bytesToWords,
+  wordsToBytes: wordsToBytes,
+  bytesToAtom: bytesToAtom,
+  atomToBytes: atomToBytes,
+  atomToWords: atomToWords,
+  wordsToAtom: wordsToAtom,
+};

--- a/pkg/npm/http-api/src/nockjs/compiler.js
+++ b/pkg/npm/http-api/src/nockjs/compiler.js
@@ -1,0 +1,726 @@
+var noun = require('./noun.js'),
+    NounMap = require('./hamt.js').NounMap,
+    list = require('./list.js'),
+    Noun = noun.Noun,
+    Atom = noun.Atom.Atom,
+    Cell = noun.Cell,
+    MEMO = noun.dwim("memo"),
+    SLOG = noun.dwim("slog"),
+    FAST = noun.dwim("fast"),
+    SPOT = noun.dwim("spot"),
+    MEAN = noun.dwim("mean"),
+    HUNK = noun.dwim("hunk"),
+    LOSE = noun.dwim("lose");
+
+function Statement() {
+}
+
+function Block() {
+  Statement.call(this);
+  this.statements = [];
+}
+Block.prototype = Object.create(Statement.prototype);
+Block.prototype.constructor = Block;
+
+Block.prototype.append = function(st) {
+  this.statements.push(st);
+}
+
+Block.prototype.toJs = function() {
+  var sts   = this.statements;
+  var parts = new Array(sts.length);
+  for ( var i = 0; i < sts.length; ++i) {
+    parts[i] = sts[i].toJs();
+  }
+  return parts.join('');
+};
+
+function Assignment(name, expr) {
+  Statement.call(this);
+  this.name = name;
+  this.expr = expr;
+}
+Assignment.prototype = Object.create(Statement.prototype);
+Assignment.prototype.constructor = Assignment;
+
+Assignment.prototype.toJs = function() {
+  return "var " + this.name + " = " + this.expr.toJs() + ";";
+}
+
+function Expression() {
+}
+
+function Cons(head, tail) {
+  Expression.call(this);
+  this.head = head;
+  this.tail = tail;
+}
+Cons.prototype = Object.create(Expression.prototype);
+Cons.prototype.constructor = Cons;
+
+Cons.prototype.toJs = function() {
+  return "context.cons(" + this.head + ", " + this.tail + ")";
+};
+
+function Frag(axis, name) {
+  Expression.call(this);
+  this.axis = axis;
+  this.name = name;
+}
+Frag.prototype = Object.create(Expression.prototype);
+Frag.prototype.constructor = Frag;
+
+Frag.prototype.toJs = function() {
+  var parts = [this.name];
+  for ( var ax = this.axis; ax > 1; ax = ax.mas() ) {
+    parts.push( ( 2 === ax.cap().valueOf() ) ? "head" : "tail" );
+  }
+  return parts.join(".");
+};
+
+function Bail() {
+  Statement.call(this);
+}
+Bail.prototype = Object.create(Statement.prototype);
+Bail.prototype.constructor = Bail;
+
+Bail.prototype.toJs = function() {
+  return "throw new Error(\"Bail\")";
+};
+
+function Identity(name) {
+  Expression.call(this);
+  this.name = name;
+}
+Identity.prototype = Object.create(Expression.prototype);
+Identity.prototype.constructor = Identity;
+
+Identity.prototype.toJs = function() {
+  return this.name;
+};
+
+function Constant(index) {
+  Expression.call(this);
+  this.index = index;
+}
+Constant.prototype = Object.create(Expression.prototype);
+Constant.prototype.constructor = Constant;
+
+Constant.prototype.toJs = function() {
+  return "constants[" + this.index + "]";
+};
+
+function Nock(subject, formula, tail) {
+  Expression.call(this);
+  this.subject = subject;
+  this.formula = formula;
+  this.tail    = tail;
+}
+Nock.prototype = Object.create(Expression.prototype);
+Nock.prototype.constructor = Nock;
+
+Nock.prototype.toJs = function() {
+  var f = this.formula;
+  var targetCode = "(" + f + ".hasOwnProperty('target') ? " + f + 
+    ".target : (" + f + ".target = context.compile(" + this.formula + ")))";
+  return this.tail ?
+    "context.trampoline(" + targetCode + ", " + this.subject + ")" :
+    targetCode + "(" + this.subject + ")";
+};
+
+function Deep(name) {
+  Expression.call(this);
+  this.name = name;
+}
+Deep.prototype = Object.create(Expression.prototype);
+Deep.prototype.constructor = Deep;
+
+Deep.prototype.toJs = function() {
+  return this.name +".deep ? context.yes : context.no";
+};
+
+function Bump(name) {
+  Expression.call(this);
+  this.name = name;
+}
+Bump.prototype = Object.create(Expression.prototype);
+Bump.prototype.constructor = Bump;
+
+Bump.prototype.toJs = function() {
+  return this.name + ".bump()";
+};
+
+function Same(one, two) {
+  Expression.call(this);
+  this.one = one;
+  this.two = two;
+}
+Same.prototype = Object.create(Expression.prototype);
+Same.prototype.constructor = Same;
+
+Same.prototype.toJs = function() {
+  return "(" + this.one + ".equals(" + this.two + ")" + " ? context.yes : context.no)";
+};
+
+function If(test, yes, no) {
+  Statement.call(this);
+  this.test = test;
+  this.yes  = yes;
+  this.no   = no;
+}
+If.prototype = Object.create(Statement.prototype);
+If.prototype.constructor = If;
+
+If.prototype.toJs = function() {
+  return "if(" + this.test + ".loob()){" +
+    this.yes.toJs() + "}else{" + this.no.toJs() + "}";
+};
+
+function Kick(axis, core, tail) {
+  Expression.call(this)
+  this.axis = axis;
+  this.core = core;
+  this.tail = tail;
+}
+Kick.prototype = Object.create(Expression.prototype);
+Kick.prototype.constructor = Kick;
+
+Kick.prototype.toJs = function() {
+  var axis = this.axis.shortCode();
+
+  return "(function (cor) {" +
+           "var pro, tgt, bus, arms, bat = cor.head, has = false;" +
+           "if ( bat.hasOwnProperty('loc') && (tgt = bat.loc.jets[" + axis + "]) && bat.loc.fine(cor) ) {" +
+             "return tgt(cor);" +
+           "}" +
+           "if ( bat.hasOwnProperty('arms') ) {" +
+             "arms = bat.arms;" +
+             "has = arms.hasOwnProperty('" + axis + "');" + 
+           "}" +
+           "else arms = bat.arms = {};" +
+           "tgt = (has ? arms['" + axis + "'] : (arms['" + axis + "'] = context.compile(" +
+             new Frag(this.axis, "bat").toJs() + ")));" +
+           "bus = cor;" +
+           (this.tail ? "pro = context.trampoline(tgt, bus);" :
+             "while (true) {" +
+               "pro = tgt(bus);" +
+               "if ( context.isTrampoline(pro) ) {" +
+                 "tgt = pro.target;" +
+                 "bus = pro.subject;" +
+               "}" +
+               "else break;" +
+             "}") +
+           "return pro;" +
+         "})(" + this.core + ")";
+};
+
+function GetMemo(name) {
+  Expression.call(this);
+  this.name = name;
+}
+GetMemo.prototype = Object.create(Expression.prototype);
+GetMemo.prototype.constructor = GetMemo;
+
+GetMemo.prototype.toJs = function() {
+  return "context.getMemo(" + this.name + ")";
+};
+
+function PutMemo(key, val) {
+  Statement.call(this);
+  this.key = key;
+  this.val = val;
+}
+PutMemo.prototype = Object.create(Statement.prototype);
+PutMemo.prototype.constructor = PutMemo;
+
+function Push(name) {
+  Statement.call(this);
+  this.name = name;
+}
+Push.prototype = Object.create(Statement.prototype);
+Push.prototype.constructor = Push;
+
+Push.prototype.toJs = function() {
+  return "context.stackPush(" + this.name + ");";
+};
+
+function Pop() {
+  Statement.call(this);
+}
+Pop.prototype = Object.create(Statement.prototype);
+Pop.prototype.constructor = Pop;
+
+Pop.prototype.toJs = function() {
+  return "context.stackPop()";
+};
+
+function Fast(clue, core) {
+  Statement.call(this);
+  this.clue = clue;
+  this.core = core;
+}
+
+Fast.prototype.toJs = function() {
+  return "context.register(" + this.core + ", " + this.clue + ");";
+}
+
+function Slog(name) {
+  Statement.call(this);
+  this.name = name;
+}
+
+Slog.prototype.toJs = function() {
+  return "context.slog(" + this.name + ")";
+};
+
+function compile(formula, subject, product, fresh, constants, block, tail) {
+  var op, arg, one, two, odd;
+  if ( !(formula instanceof Cell )) {
+    throw new Error("invalid formula");
+  }
+  op = formula.head;
+  arg = formula.tail;
+  if ( op instanceof Cell ) {
+    one = fresh();
+    two = fresh();
+    compile(op, subject, one, fresh, constants, block, false);
+    compile(arg, subject, two, fresh, constants, block, false);
+    block.append(new Assignment(product, new Cons(one, two)));
+  }
+  else switch ( op.valueOf() ) {
+    case 0:
+      if ( 0 === arg ) {
+        block.append(new Bail());
+      }
+      else if ( 1 === arg ) {
+        block.append(new Identity(subject));
+      }
+      else {
+        block.append(new Assignment(product, new Frag(arg, subject)));
+      }
+      break;
+    case 1:
+      constants.push(arg);
+      block.append(new Assignment(product, new Constant(constants.length - 1)));
+      break;
+    case 2:
+      one = fresh();
+      two = fresh();
+      compile(arg.head, subject, one, fresh, constants, block, false);
+      compile(arg.tail, subject, two, fresh, constants, block, false);
+      block.append(new Assignment(product, new Nock(one, two, tail)));
+      break;
+    case 3:
+      one = fresh();
+      compile(arg, subject, one, fresh, constants, block, false);
+      block.append(new Assignment(product, new Deep(one)));
+      break;
+    case 4:
+      one = fresh();
+      compile(arg, subject, one, fresh, constants, block, false);
+      block.append(new Assignment(product, new Bump(one)));
+      break;
+    case 5:
+      one = fresh();
+      two = fresh();
+      compile(arg.head, subject, one, fresh, constants, block, false);
+      compile(arg.tail, subject, two, fresh, constants, block, false);
+      block.append(new Assignment(product, new Same(one, two)));
+      break;
+    case 6:
+      odd = fresh();
+      one = new Block();
+      two = new Block();
+      compile(arg.head, subject, odd, fresh, constants, block, false);
+      compile(arg.tail.head, subject, product, fresh, constants, one, tail);
+      compile(arg.tail.tail, subject, product, fresh, constants, two, tail);
+      block.append(new If(odd, one, two));
+      break;
+    case 7:
+      one = fresh();
+      compile(arg.head, subject, one, fresh, constants, block, false);
+      compile(arg.tail, one, product, fresh, constants, block, tail);
+      break;
+    case 8:
+      one = fresh();
+      two = fresh();
+      compile(arg.head, subject, one, fresh, constants, block, false);
+      block.append(new Assignment(two, new Cons(one, subject)));
+      compile(arg.tail, two, product, fresh, constants, block, tail);
+      break;
+    case 9:
+      odd = arg.head;
+      if ( 2 === odd.cap().valueOf() ) {
+        one = fresh();
+        two = odd.mas();
+        compile(arg.tail, subject, one, fresh, constants, block, false);
+        block.append(new Assignment(product, new Kick(two, one, tail)));
+      }
+      else {
+        compile(noun.dwim([7, arg.tail, 2, [0, 1], 0, odd]),
+          subject, product, fresh, constants, block, tail);
+      }
+      break;
+    case 10:
+      var hint = arg.head;
+      if ( !(arg.head instanceof Cell) ) {
+        // no recognized static hints
+        compile(arg.tail, subject, product, fresh, constants, block, tail);
+      }
+      else {
+        var zep = hint.head;
+        var clu = fresh();
+        compile(hint.tail, subject, clu, fresh, constants, block, false);
+        if ( zep.equals(MEMO) ) {
+          var key = fresh();
+          var got = fresh();
+          odd = fresh();
+          one = new Block();
+          two = new Block();
+          var konst = fresh();
+          block.append(new Assignment(konst, new Constant(hint.tail)));
+          block.append(new Assignment(key, new Cons(subject, konst)));
+          block.append(new Assignment(got, new GetMemo(two)));
+          block.append(new Assignment(odd, new Deep(got)));
+          one.append(new Assignment(product, new Frag(noun.dwim(3), got)));
+          compile(arg.tail, subject, product, fresh, two, false);
+          two.append(new PutMemo(key, product));
+          block.append(new If(odd, one, two));
+        }
+        else if ( zep.equals(SLOG) ) {
+          block.append(new Slog(clu));
+          compile(arg.tail, subject, product, fresh, constants, block, tail);
+        }
+        else if ( zep.equals(FAST) ) {
+          compile(arg.tail, subject, product, fresh, constants, block, false);
+          block.append(new Fast(clu, product));
+        }
+        else if ( zep.equals(SPOT) ||
+                  zep.equals(MEAN) ||
+                  zep.equals(HUNK) ||
+                  zep.equals(LOSE) ) {
+          one = fresh();
+          two = fresh();
+          block.append(new Assignment(one, new Constant(zep)));
+          block.append(new Assignment(two, new Cons(one, clu)));
+          block.append(new Push(two));
+          compile(arg.tail, subject, product, fresh, constants, block, false);
+          block.append(new Pop());
+        }
+        else {
+          // unrecognized
+          compile(arg.tail, subject, product, fresh, constants, block, tail);
+        }
+      }
+      break;
+    case 11:
+      one = fresh();
+      two = fresh();
+      compile(arg.head, subject, one, fresh, constants, block, false);
+      compile(arg.tail, subject, two, fresh, constants, block, false);
+      block.append(new Assignment(product, new Esc(one, two)));
+      break;
+    default:
+      throw new Error("invalid opcode");
+  }
+}
+
+function Trampoline(target, subject) {
+  this.target = target;
+  this.subject = subject;
+}
+
+function genFine(loc) {
+  var constants = [], out = [], i;
+  for ( i = 0; !loc.isStatic; ++i ) {
+    out.push("if(!constants[" + i + "].equals(a.head)){return false;}");
+    constants.push(loc.noun);
+    out.push("a=" + new Frag(loc.axisToParent, "a").toJs() + ";");
+    loc = loc.parentLoc;
+  }
+  out.push("return constants[" + i + "].equals(a);");
+  constants.push(loc.noun);
+  var body = 'return function(a){' + out.join('') + 'return true;};';
+  var builder = new Function('constants', body);
+  return builder(constants);
+}
+
+var three = noun.dwim(3);
+function Location(context, name, label, axisToParent, hooks, noun, parentLoc) {
+  this.name = name;
+  this.label = label;
+  this.parentLoc = parentLoc;
+  this.axisToParent = axisToParent;
+  this.fragToParent = Noun.fragmenter(axisToParent);
+  this.nameToAxis = hooks;
+  this.axisToName = {};
+  this.isStatic = ( null === parentLoc || (three.equals(axisToParent) && parentLoc.isStatic) );
+  if ( this.isStatic ) {
+    this.noun = noun;
+  }
+  else {
+    this.noun = noun.head;
+    this.noun.mug();
+  }
+  for ( var k in hooks ) {
+    if ( hooks.hasOwnProperty(k) ) {
+      this.axisToName[hooks[k].shortCode()] = k;
+    }
+  }
+  this.jets = {};
+  var drivers = context.drivers[label];
+  if ( drivers && drivers.length > 0 ) {
+    for ( var i = 0; i < drivers.length; ++i ) {
+      var d = drivers[i];
+      if ( d instanceof AxisArm ) {
+        this.jets[d.axis.mas().shortCode()] = d.fn;
+      }
+      else {
+        this.jets[nameToAxis[d.name].mas().shortCode()] = d.fn;
+      }
+    }
+  }
+  this.fine = genFine(this);
+}
+
+function Clue(name, parentAxis, hooks) {
+  this.name = name;
+  this.parentAxis = parentAxis;
+  this.hooks = hooks;
+}
+
+function JetDriver(label, fn) {
+  this.label = label;
+  this.fn = fn;
+}
+
+function AxisArm(label, axis, fn) {
+  JetDriver.call(this, label, fn);
+  this.axis = axis;
+}
+AxisArm.prototype = Object.create(JetDriver.prototype);
+AxisArm.prototype.constructor = AxisArm;
+
+function NamedArm(label, name, fn) {
+  JetDriver.call(this, label, fn);
+  this.name = name;
+}
+NamedArm.prototype = Object.create(JetDriver.prototype);
+NamedArm.prototype.constructor = NamedArm;
+
+var two = noun.dwim(2);
+function collectFromCore(prefix, spec, out) {
+  var name = spec[0], arms = spec[1], children = spec[2],
+      labl = prefix + "/" + name;
+  if ( arms instanceof Function ) {
+    out[labl] = [new AxisArm(labl, two, arms)];
+  }
+  else {
+    var all = [];
+    for ( var k in arms ) {
+      if ( arms.hasOwnProperty(k) ) {
+        all.push(( 'number' === typeof(k) ) ?
+          new AxisArm(labl, noun.dwim(k), arms[k]) :
+          new NamedArm(labl, k, arms[k]));
+      }
+    }
+    out[labl] = all;
+  }
+  if ( children ) {
+    for ( var i = 0; i < children.length; ++i ) {
+      collectFromCore(labl, children[i], out);
+    }
+  }
+}
+
+function Context(drivers) {
+  this.memo    = new NounMap();
+  this.clues   = new NounMap();
+  this.dash    = new NounMap();
+  this.tax     = noun.Atom.yes;
+  this.drivers = {};
+  if ( drivers ) {
+    collectFromCore('', drivers, this.drivers);
+  }
+}
+
+Context.prototype.yes = noun.Atom.yes;
+Context.prototype.no = noun.Atom.no;
+Context.prototype.cons = function (h, t) {
+  return new Cell(h, t);
+};
+
+Context.prototype.trampoline = function(tgt, bus) {
+  return new Trampoline(tgt, bus);
+};
+
+Context.prototype.isTrampoline = function(a) {
+  return (a instanceof Trampoline);
+};
+
+Context.prototype.compile = function(cell) {
+  var i = 0;
+  var fresh = function() {
+    return "v" + ++i;
+  };
+  var body = new Block();
+  var constants = [];
+  compile(cell, "subject", "product", fresh, constants, body, true);
+  var text = "return function(subject){" + body.toJs() + "return product;}";
+  var builder = new Function("context", "constants", text);
+  return cell.target = builder(this, constants);
+};
+
+Context.prototype.nock = function(subject, formula) {
+  var product, target;
+  if ( !formula.hasOwnProperty("target") ) {
+    this.compile(formula);
+  }
+  target = formula.target;
+  while ( true ) {
+    product = target(subject);
+    if ( product instanceof Trampoline ) {
+      subject = product.subject;
+      target  = product.target;
+    }
+    else {
+      return product;
+    }
+  }
+};
+
+Context.prototype.getMemo = function(key) {
+  return this.memo.get(key);
+}
+
+Context.prototype.putMemo = function(key, val) {
+  this.memo.insert(key, val);
+};
+
+Context.prototype.stackPush = function(item) {
+  this.tax = new Cell(item, this.tax);
+};
+
+Context.prototype.stackPop = function() {
+  this.tax = this.tax.tail;
+}
+
+Context.prototype.slog = function(item) {
+  // TODO: don't rewrite ++wash again, just call the kernel
+  console.log(item);
+};
+
+function chum(n) {
+  if ( n.deep ) {
+    return Atom.cordToString(n.head) + n.tail.number.shortValue().toString(10);
+  }
+  else {
+    return Atom.cordToString(n);
+  }
+}
+
+var ten = noun.dwim(10);
+function skipHints(formula) {
+  while ( true ) {
+    if ( formula.deep ) {
+      if ( ten.equals(formula.head) ) {
+        formula = formula.tail.tail;
+        continue;
+      }
+    }
+    return formula;
+  }
+}
+
+var zero = noun.dwim(0), constant_zero = noun.dwim(1,0);
+function parseParentAxis(noun) {
+  var f = skipHints(noun);
+  if ( constant_zero.equals(f) ) {
+    return zero;
+  }
+  else if ( !zero.equals(f.head) ) {
+    throw new Error("weird formula head");
+  }
+  else if ( 3 != f.tail.cap().valueOf() ) {
+    throw new Error("weird parent axis");
+  }
+  return f.tail;
+}
+
+var nine = noun.dwim(9), constant_frag = noun.dwim(0,1);
+function parseHookAxis(nock) {
+  var f = skipHints(nock),
+     op = f.head;
+  if ( !op.deep ) {
+    if ( zero.equals(op) ) {
+      if ( !f.tail.deep ) {
+        return f.tail;
+      }
+    }
+    else if ( nine.equals(op) ) {
+      var rest = f.tail;
+      if ( !rest.head.deep && constant_frag.equals(rest.tail) ) {
+        return rest.head;
+      }
+    }
+  }
+  return null;
+}
+
+function parseHooks(noun) {
+  var o = {};
+  list.forEach(noun, function(c) {
+    var term = Atom.cordToString(c.head),
+        axis = parseHookAxis(c.tail);
+    if ( null != axis ) {
+      o[term] = axis;
+    }
+  });
+  return o;
+}
+
+Context.prototype.parseClue = function(raw) {
+  var clue = this.clues.get(raw);
+  if ( clue === undefined ) {
+    var name = chum(raw.head),
+        parentAxis = parseParentAxis(raw.tail.head),
+        hooks = parseHooks(raw.tail.tail);
+    clue = new Clue(name, parentAxis, hooks);
+    this.clues.insert(raw, clue);
+  }
+  return clue;
+}
+
+Context.prototype.register = function(core, raw) {
+  var bat = core.head;
+  var loc = this.dash.get(bat);
+  if ( undefined === loc ) {
+    try {
+      var clue = this.parseClue(raw);
+      if ( zero.equals(clue.parentAxis) ) {
+        loc = new Location(this, clue.name, '/' + clue.name, zero, clue.hooks, core, null);
+      }
+      else {
+        var parentCore    = core.at(clue.parentAxis),
+            parentBattery = parentCore.head,
+            parentLoc     = this.dash.get(parentBattery);
+        if ( undefined === parentLoc ) {
+          console.log('register: invalid parent for ' + clue.name);
+        }
+        else {
+          var label = parentLoc.label + "/" + clue.name;
+          loc = new Location(this, clue.name, label, clue.parentAxis, clue.hooks, core, parentLoc);
+        }
+      }
+      bat.loc = loc;
+      this.dash.insert(bat, loc);
+    }
+    catch (e) {
+      console.log(e);
+    }
+  }
+};
+
+module.exports = {
+  Context: Context,
+}

--- a/pkg/npm/http-api/src/nockjs/hamt.js
+++ b/pkg/npm/http-api/src/nockjs/hamt.js
@@ -1,0 +1,137 @@
+/* keys can be any noun, values aren't constrained */
+
+function Slot() {
+}
+
+function Node() {
+  Slot.call(this);
+  this.slots = new Array(32);
+}
+Node.prototype = Object.create(Slot.prototype);
+Node.prototype.constructor = Node;
+
+Node.prototype.insert = function(key, val, lef, rem) {
+  var inx;
+  lef -= 5;
+  inx = rem >>> lef;
+  rem &= ((1 << lef) - 1);
+
+  this.slots[inx] = ( undefined === this.slots[inx] )
+                  ? new Single(key, val)
+                  : this.slots[inx].insert(key, val, lef, rem);
+  return this;
+};
+
+Node.prototype.get = function(key, lef, rem) {
+  var inx, sot;
+  lef -= 5;
+  inx = rem >>> lef;
+  rem &= ((1 << lef) - 1);
+  sot = this.slots[inx];
+
+  return ( undefined === sot ) ? undefined : sot.get(key, lef, rem);
+};
+
+function Bucket() {
+  this.singles = [];
+}
+Bucket.prototype = Object.create(Slot.prototype);
+Bucket.prototype.constructor = Bucket;
+
+Bucket.prototype.insert = function(key, val, lef, rem) {
+  var s, a = this.singles;
+
+  for ( var i = 0; i < a.length; ++i ) {
+    s = a[i];
+    if ( s.key.equals(key) ) {
+      s.val = val;
+      return this;
+    }
+  }
+  a.push(new Single(key, val));
+  return this;
+};
+
+Bucket.prototype.get = function(key, lef, rem) {
+  var s, a = this.singles;
+
+  for ( var i = 0; i < a.length; ++i ) {
+    s = a[i];
+    if ( s.key.equals(key) ) {
+      return s.val;
+    }
+  }
+
+  return undefined;
+};
+
+function Single(key, val) {
+  Slot.call(this);
+  this.key = key;
+  this.val = val;
+}
+Single.prototype = Object.create(Slot.prototype);
+Single.prototype.constructor = Single;
+
+Single.prototype.insert = function(key, val, lef, rem) {
+  if ( this.key.equals(key) ) {
+    this.val = val;
+    return this;
+  }
+  else {
+    var n, rom = this.key.mug() & ((1 << lef) - 1);
+
+    if ( lef > 0 ) {
+      n = new Node();
+    }
+    else {
+      n = new Bucket();
+    }
+    n.insert(this.key, this.val, lef, rom);
+    n.insert(key, val, lef, rem);
+    return n;
+  }
+};
+
+Single.prototype.get = function(key, lef, rem) {
+  if ( this.key.equals(key) ) {
+    return this.val;
+  }
+  else {
+    return undefined;
+  }
+};
+
+function NounMap() {
+  this.slots = new Array(64);
+}
+
+NounMap.prototype.insert = function(key, val) {
+  var m    = key.mug();
+  var inx  = m >>> 25;
+  var sot  = this.slots;
+  if ( undefined === sot[inx] ) {
+    sot[inx] = new Single(key, val);
+  }
+  else {
+    var rem  = m & ((1 << 25) - 1);
+    sot[inx] = sot[inx].insert(key, val, 25, rem);
+  }
+};
+
+NounMap.prototype.get = function(key) {
+  var m = key.mug();
+  var inx = m >>> 25;
+  var sot = this.slots[inx];
+  if ( undefined === sot ) {
+    return undefined;
+  }
+  else {
+    var rem  = m & ((1 << 25) - 1);
+    return sot.get(key, 25, rem);
+  }
+};
+
+module.exports = {
+  NounMap: NounMap
+};

--- a/pkg/npm/http-api/src/nockjs/list.js
+++ b/pkg/npm/http-api/src/nockjs/list.js
@@ -1,0 +1,40 @@
+var noun = require('./noun.js'),
+    Cell = noun.Cell,
+    zero = noun.Atom.yes;
+
+function flop(a) {
+	var b = zero;
+
+	while ( true ) {
+		if ( zero.equals(a) ) {
+			return b;
+		}
+		else if ( !a.deep ) {
+      throw new Error("Bail");
+		}
+		else {
+      b = new Cell(a.head, b);
+      a = a.tail;
+		}
+	}
+}
+
+function forEach(n, f) {
+  while ( true ) {
+    if ( zero.equals(n) ) {
+      return;
+    }
+    else if ( !n.deep ) {
+      throw new Error("Bail");
+    }
+    else {
+      f(n.head);
+      n = n.tail;
+    }
+  }
+}
+
+module.exports = {
+  flop: flop,
+  forEach: forEach,
+};

--- a/pkg/npm/http-api/src/nockjs/noun.js
+++ b/pkg/npm/http-api/src/nockjs/noun.js
@@ -1,0 +1,479 @@
+var BigInteger = require('jsbn').BigInteger;
+
+function Noun() {
+  this._mug = 0;
+}
+
+Noun.prototype.loob = function () {
+  throw new Error("Bail");
+};
+
+Noun.prototype.toString = function() {
+  var parts = [];
+  this.pretty(parts, false);
+  return parts.join('');
+};
+
+Noun.prototype.mug = function () {
+  if ( 0 === this._mug ) {
+    this._mug = this.calculateMug();
+  }
+  return this._mug;
+};
+
+Noun.prototype.mugged = function () {
+  return 0 !== this._mug;
+};
+
+Noun.prototype.deep = false;
+Noun.prototype.bump = function () {
+  throw new Error("Bail");
+}
+
+Noun.prototype.equals = function(o) {
+  if ( this === o ) {
+    return true;
+  }
+
+  if ( this instanceof Cell ) {
+    if ( o instanceof Cell) {
+      return this.unify(o);
+    }
+    else {
+      return false;
+    }
+  }
+  else {
+    if ( o instanceof Cell ) {
+      return false;
+    }
+    else if (0 === this.number.compareTo(o.number)) {
+      o.number = this.number;
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+};
+
+
+function _mug_fnv(has_w) {
+  return Math.imul(has_w, 16777619);
+}
+
+function _mug_out(has_w) {
+  return (has_w >>> 31) ^ (has_w & 0x7fffffff);
+}
+
+function _mug_both(lef_w, rit_w) {
+  var bot_w = _mug_fnv(lef_w ^ _mug_fnv(rit_w));
+  var out_w = _mug_out(bot_w);
+
+  if ( 0 != out_w ) {
+    return out_w;
+  }
+  else {
+    return _mug_both(lef_w, ++rit_w);
+  }
+}
+
+function Cell(head, tail) {
+  Noun.call(this);
+  this.head = head;
+  this.tail = tail;
+}
+Cell.prototype = Object.create(Noun.prototype);
+Cell.prototype.constructor = Cell;
+Cell.prototype.deep = true;
+
+Cell.prototype.pretty = function(out, tail) {
+  if ( !tail ) {
+    out.push('[');
+  }
+  this.head.pretty(out, false);
+  out.push(' ');
+  this.tail.pretty(out, true);
+  if ( !tail ) {
+    out.push(']');
+  }
+};
+
+Cell.prototype.calculateMug = function() {
+  return _mug_both(this.head.mug(), this.tail.mug());
+};
+
+Cell.prototype.unify = function(o) {
+  if ( this === o ) {
+    return true;
+  }
+
+  if ( o.mugged() ) {
+    if ( this.mugged() ) {
+      if ( this.mug() != o.mug() ) {
+        return false;
+      }
+    }
+    else {
+      return o.unify(this);
+    }
+  }
+
+  if ( this.head.equals(o.head) ) {
+    o.head = this.head;
+    if ( this.tail.equals(o.tail) ) {
+      o._mug = this._mug;
+      o.tail = this.tail;
+      return true;
+    }
+  }
+
+  return false;
+};
+
+function Atom(number) {
+  Noun.call(this);
+  this.number = number;
+}
+Atom.prototype = Object.create(Noun.prototype);
+Atom.prototype.constructor = Atom;
+
+var small = new Array(256);
+(function() {
+  var i, bi;
+  for ( i = 0; i < 256; ++i ) {
+    bi = new BigInteger();
+    bi.fromInt(i);
+    small[i] = new Atom(bi);
+  }
+})();
+
+var fragCache = {
+  0: function(a) {
+    throw new Error("Bail");
+  },
+  1: function(a) {
+    return a;
+  },
+};
+var one = small[1];
+Noun.fragmenter = function(a) {
+  var s = a.shortCode();
+  if ( fragCache.hasOwnProperty(s) ) {
+    return fragCache[s];
+  }
+  else {
+    for ( var parts = ['a']; !one.equals(a); a = a.mas() ) {
+      parts.push( ( 2 === a.cap().valueOf() ) ? 'head' : 'tail' );
+    }
+    return fragCache[s] = new Function('a', 'return ' + parts.join('.') + ';');
+  }
+}
+
+Noun.prototype.at = function(a) {
+  return Noun.fragmenter(a)(this);
+};
+
+var shortBi = new BigInteger();
+shortBi.fromInt(65536);
+
+Atom.prototype.bytes = function() {
+  var bytes = this.number.toByteArray();
+  var r = [];
+  for ( var i = bytes.length-1; i >= 0; --i ) {
+    r.push(bytes[i]&0xff);
+  }
+  return r;
+}
+
+Atom.cordToString = function(c) {
+  var bytes = c.bytes(),
+      chars = [];
+
+  for ( var i = 0; i < bytes.length; ++i ) {
+    chars.push(String.fromCharCode(bytes[i]));
+  }
+  return chars.join('');
+};
+
+Atom.prototype.pretty = function(out, tail) {
+  if ( this.number.compareTo(shortBi) < 0 ) {
+    return out.push(this.number.toString(10));
+  }
+  else {
+    var tap = [], isTa = true, isTas = true, bytes = this.number.toByteArray();
+    for ( var i = bytes.length - 1; i >= 0; --i) {
+      var c = bytes[i];
+      if ( isTa && ((c < 32) || (c > 127)) ) {
+        isTa = false;
+        isTas = false;
+        break;
+      }
+      else if ( isTas && !((c > 47 && c < 58) ||  // digits
+                           (c > 96 && c < 123) || // lowercase letters
+                            c === 45) ) {         // -
+        isTas = false;
+      }
+      tap.push(String.fromCharCode(c));
+    }
+    if ( isTas ) {
+      out.push('%');
+      out.push.apply(out, tap);
+    }
+    else if ( isTa ) {
+      out.push("'");
+      out.push.apply(out, tap);
+      out.push("'");
+    }
+    else {
+      out.push("0x");
+      out.push(this.number.toString(16));
+    }
+  }
+};
+
+Atom.prototype.loob = function() {
+  switch ( this.number.intValue() ) {
+    case 0:
+      return true;
+    case 1:
+      return false;
+    default:
+      throw new Error("Bail");
+  }
+};
+
+Atom.prototype.bump = function() {
+  return new Atom(this.number.add(BigInteger.ONE));
+};
+
+var ida  = i(1);
+var heda = i(2);
+var tala = i(3);
+
+Atom.prototype.cap = function() {
+  switch (this.number.intValue()) {
+    case 0:
+    case 1:
+      throw new Error("Bail");
+    default:
+    return this.number.testBit(this.number.bitLength() - 2) ? tala : heda;
+  }
+};
+
+Atom.prototype.mas = function() {
+  switch (this.number.intValue()) {
+    case 0:
+    case 1:
+      throw new Error("Bail");
+    case 2:
+    case 3:
+      return ida;
+    default:
+      var n = this.number;
+      var l = n.bitLength() - 2;
+      var addTop = new BigInteger();
+      addTop.fromInt(1 << l);
+      var mask = new BigInteger();
+      mask.fromInt((1 << l)-1);
+      return new Atom(n.and(mask).xor(addTop));
+  }
+};
+
+Atom.prototype.calculateMug = function() {
+	var a = this.number.toByteArray();
+	var b, c, d, e, f, bot;
+	for ( e = a.length - 1, b = (2166136261|0); ; ++b ) {
+    c = b;
+    bot = ( 0 === a[0] ) ? 1 : 0;
+		for ( d = e; d >= bot; --d ) {
+      c = _mug_fnv(c ^ (0xff & a[d]));
+		}
+    f = _mug_out(c);
+    if ( 0 !== f ) {
+      return f;
+    }
+	}
+};
+
+Atom.prototype.shortCode = function() {
+  return this.number.toString(36); // max supported by BigInteger
+};
+
+function s(str, radix) {
+	return new Atom(new BigInteger(str, radix));
+}
+
+function i(num) {
+  if ( num < 256 ) {
+    return small[num];
+  }
+  else {
+    var bi = new BigInteger();
+    bi.fromInt(num);
+    return new Atom(bi);
+  }
+}
+
+function m(str) {
+  var i, j, octs = new Array(str.length);
+  for ( i = 0, j = octs.length - 1; i < octs.length; ++i, --j ) {
+    octs[j] = (str.charCodeAt(i) & 0xff).toString(16);
+  }
+  return new Atom(new BigInteger(octs.join(''), 16))
+}
+
+function dwim(a) {
+  var n = (arguments.length === 1 ? a : Array.apply(null, arguments));
+	if ( n instanceof Noun ) {
+		return n;
+	}
+	if ( typeof n === "number" ) {
+		return i(n);
+	}
+	else if ( Array.isArray(n) ) {
+		var cel = new Cell(dwim(n[n.length-2]), dwim(n[n.length-1]));
+		for ( var j = n.length-3; j >= 0; --j ) {
+			cel = new Cell(dwim(n[j]), cel);
+		}
+		return cel;
+	}
+	else if ( typeof n === "string" ) {
+    return m(n);
+	}
+  console.log('what do you mean??', typeof n, n instanceof Noun, n.toString(), n);
+}
+
+Atom.prototype.valueOf = function() {
+	return this.number.bitLength() <= 32
+		? this.number.intValue()
+		: this.number.toString();
+};
+
+//TODO  consider doing the dynamic args thing dwim does
+const frond = function(opts) { // {tag: string, get: function(noun)}[]
+  return function(noun) {
+    if (!(noun instanceof Cell && noun.head instanceof Atom)) {
+      throw new Error('frond: noun not cell');
+    }
+    const tag = Atom.cordToString(noun.head);
+    for (let i = 0; i < opts.length; i++) {
+      if (tag === opts[i].tag) {
+        return { [tag]: opts[i].get(noun.tail) };
+      }
+    }
+    throw new Error('frond: unknown tag', tag);
+  };
+}
+
+const pairs = function(cels) { // {nom: string, get: function(noun)}[]
+  return function(noun) {
+    let i = 0;
+    let o = {};
+    while(i < cels.length-1) {
+      if (!(noun instanceof Cell)) {
+        throw new Error('pairs: noun too shallow');
+      }
+      o[cels[i].nom] = cels[i].get(noun.head);
+      noun = noun.tail;
+      i++;
+    }
+    o[cels[i].nom] = cels[i].get(noun);
+    return o;
+  };
+}
+
+const pair = function(na, ga, nb, gb) {
+  return pairs([{nom: na, get: ga}, {nom: nb, get: gb}]);
+}
+
+const bucwut = function(opts) { // function(noun)[]
+    return function(noun) {
+      for (let i = 0; i < opts.length; i++) {
+        try {
+          const res = opts[i](noun);
+          return res;
+        } catch(e) {
+          continue;
+        }
+      }
+      throw new Error('bucwut: no matches');
+    }
+}
+
+const array = function(item) { // function(noun)
+  return function(noun) {
+    let a = [];
+    while (noun instanceof Cell) {
+      a.push(item(noun.head));
+      noun = noun.tail;
+    }
+    return a;
+  }
+}
+
+const tree = function(item) { // function(noun)
+  return function(noun) {
+    let a = [];
+    if (noun instanceof Cell) {
+      if (!(noun.tail instanceof Cell)) {
+        throw new Error('tree: malformed');
+      }
+      a = [
+        ...a,
+        item(noun.head),
+        ...tree(item)(noun.tail.head),
+        ...tree(item)(noun.tail.tail),
+      ];
+    }
+    return a;
+  }
+}
+
+const cord = function(noun) {
+  if (!(noun instanceof Atom)) {
+    throw new Error('cord: noun not atom');
+  }
+  return Atom.cordToString(noun);
+}
+
+const numb = function(noun) {
+  if (!(noun instanceof Atom)) {
+    throw new Error('numb: noun not atom');
+  }
+  return noun.valueOf();
+}
+
+const loob = function(noun) {
+  return noun.loob();
+}
+
+const nill = function(noun) {
+  if (!(noun instanceof Atom && noun.number.intValue() === 0)) {
+    throw new Error('nill: not null');
+  }
+  return null;
+}
+
+const path = array(cord);
+
+module.exports = {
+	dwim: dwim,
+	Noun: Noun,
+	Cell: Cell,
+	Atom: {
+		Atom: Atom,
+		yes:  i(0),
+		no:   i(1),
+    fromMote:   m,
+		fromInt:    i,
+		fromString: s,
+	},
+  enjs: {
+    //TODO  ship, tape, tank, time, unit
+    frond, pairs, array, cord, numb, path, pair, bucwut, nill, tree, loob
+  },
+  dejs: {
+    //TODO  dwim, list, ship, tape, time
+  }
+};

--- a/pkg/npm/http-api/src/nockjs/serial.js
+++ b/pkg/npm/http-api/src/nockjs/serial.js
@@ -1,0 +1,167 @@
+var noun    = require('./noun.js'),
+    list    = require('./list.js'),
+    Cell    = noun.Cell,
+    bits    = require('./bits.js'),
+    zero    = noun.Atom.yes,
+    one     = noun.Atom.no,
+    i       = noun.Atom.fromInt,
+    two     = i(2),
+    three   = i(3),
+    NounMap = require('./hamt.js').NounMap;
+
+function rub(a, b) {
+	var c, d, e, w, x, y, z, p, q, m;
+
+	m = bits.add(a, i(bits.met(0, b)));
+	x = a;
+
+	while ( zero.equals(bits.cut(zero, x, one, b)) ) {
+		y = bits.add(one, x);
+
+		//  Sanity check: crash if decoding more bits than available
+		if ( bits.gth(x, m) ) {
+			throw new Error("Bail");
+		}
+
+		x = y;
+	}
+
+	if ( a.equals(x) ) {
+		return new Cell(one, zero);
+	}
+
+	c = bits.sub(x, a);
+	d = bits.add(x, one);
+
+	x = bits.dec(c);
+	y = bits.bex(x);
+	z = bits.cut(zero, d, x, b);
+
+	e = bits.add(y, z);
+	w = bits.add(c, c);
+	y = bits.add(w, e);
+	z = bits.add(d, x);
+
+	p = bits.add(w, e);
+	q = bits.cut(zero, z, e, b);
+
+	return new Cell(p, q);
+}
+
+function cue_in(m, a, b) {
+  var x,c,p,q,l,u,v,w,y,p,q,d,x;
+
+  if ( zero.equals(bits.cut(zero, b, one, a)) ) {
+    x = bits.add(b, one);
+    c = rub(x, a);
+    p = bits.add(c.head, one);
+    q = c.tail;
+    m.insert(b, q);
+  }
+  else {
+    c = bits.add(two, b);
+    l = bits.add(one, b);
+
+    if ( zero.equals(bits.cut(zero, l, one, a)) ) {
+      u = cue_in(m, a, c);
+      x = bits.add(u.head, c);
+      v = cue_in(m, a, x);
+      w = new Cell(u.tail.head, v.tail.head);
+      y = bits.add(u.head, v.head);
+      p = bits.add(two, y);
+      q = w;
+      m.insert(b, q);
+    }
+    else {
+      d = rub(c, a);
+      x = m.get(d.tail);
+
+      if ( undefined === x ) {
+        throw new Error("Bail");
+      }
+
+      p = bits.add(two, d.head);
+      q = x;
+    }
+  }
+  return new Cell(p, new Cell(q, zero));
+}
+
+function cue(a) {
+  return cue_in(new NounMap(), a, zero).tail.head;
+}
+
+function mat(a) {
+	if ( zero.equals(a) ) {
+		return noun.dwim(1, 1);
+	}
+  else {
+		var b = noun.dwim(bits.met(0, a)),
+		    c = noun.dwim(bits.met(0, b)),
+		    u = bits.dec(c),
+        v = bits.add(c, c),
+        x = bits.end(zero, u, b),
+        w = bits.bex(c),
+        y = bits.lsh(zero, u, a),
+        z = bits.mix(x, y),
+        p = bits.add(v, b),
+        q = bits.cat(zero, w, z);
+    return noun.dwim(p, q);
+	}       
+}
+
+function _jam_in_pair(m, h_a, t_a, b, l) {
+	var w = noun.dwim([2, 1], l),
+      x = bits.add(two, b),
+      d = _jam_in(m, h_a, x, w),
+      y = bits.add(x, d.head),
+      e = _jam_in(m, t_a, y, d.tail.head),
+      z = bits.add(d.head, e.head);
+
+  return noun.dwim(bits.add(two, z), e.tail.head, zero);
+}
+
+function _jam_in_ptr(m, u_c, l) {
+  var d = mat(u_c),
+      x = bits.lsh(zero, two, d.tail),
+      y = bits.add(two, d.head);
+
+  return noun.dwim(y, [[y, bits.mix(three, x)], l], zero);
+}
+
+function _jam_in_flat(m, a, l) {
+	var d = mat(a),
+      x = bits.add(one, d.head);
+
+  return noun.dwim(x, [[x, bits.lsh(zero, one, d.tail)], l], zero);
+}
+
+function _jam_in(m, a, b, l) {
+  var x, c = m.get(a);
+
+  if ( undefined == c ) {
+    m.insert(a, b);
+    return a.deep ?
+      _jam_in_pair(m, a.head, a.tail, b, l) :
+      _jam_in_flat(m, a, l);
+  }
+  else if ( !a.deep && bits.met(0, a) <= bits.met(0, c) ) {
+    return _jam_in_flat(m, a, l);
+  }
+  else {
+    return _jam_in_ptr(m, c, l);
+  }
+}
+
+function jam(n) {
+  var x = _jam_in(new NounMap(), n, zero, zero),
+      q = list.flop(x.tail.head);
+
+  return bits.can(zero, q);
+}
+
+module.exports = {
+  cue: cue,
+  mat: mat,
+  jam: jam
+};

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -4,6 +4,7 @@
  * `"/updates"`
  */
 export type Path = string;
+export type NounPath = [string];
 
 /**
  * @p including leading sig, rendered as a string
@@ -67,14 +68,13 @@ export interface Poke<Action> {
    */
   app: GallAgent;
   /**
-   * Mark of the cage to be poked
-   *
+   * Mark of the noun to poke with
    */
   mark: Mark;
   /**
-   * Vase of the cage of to be poked, as JSON
+   * Noun to poke with
    */
-  json: Action;
+  noun: any;  //TODO  revisit
 }
 
 /**
@@ -144,15 +144,16 @@ export interface SubscriptionInterface {
   /**
    * Handle negative %watch-ack
    */
+  //TODO  id here is a string, but is number in most other places...
   err?(error: any, id: string): void;
   /**
    * Handle %fact
    */
-  event?(data: any): void;
+  event?(mark: string, data: any): void;
   /**
    * Handle %kick
    */
-  quit?(data: any): void;
+  quit?(): void;
 }
 
 export type OnceSubscriptionErr = 'quit' | 'nack' | 'timeout';
@@ -167,9 +168,9 @@ export interface SubscriptionRequestInterface extends SubscriptionInterface {
   /**
    * The path to which to subscribe
    * @example
-   * `"/keys"`
+   * `['keys', 0]`
    */
-  path: Path;
+  path: NounPath;
 }
 
 export interface headers {


### PR DESCRIPTION
Consider this my Resolution for JSON Independence.

For a long time now, Eyre's channels have communicated over JSON. This has had some unfortunate side-effects. Primarily, to support access over HTTP, userspace developers had to implement Arvo-side JSON conversions for all their relevant marks. This then obscured the relationship between agents and their frontends, and muddied the developer experience there in general.

The contents of this PR have been tested and proven to work, but there are unresolved dev UX and package management questions, primarily on the javascript side. Not to mention, this is based on my new-webterm branch, because webterm felt like the most practical test case for me. Hence: draft PR.

---

There are three parts of work inside:
- 20573ad updates eyre to support multiple channel "modes": `%json` and `%jam`. The latter sends and received `@uw`-encoded jammed nouns in all places where we currently use json.
- 01b00f6 changes the http-api package to use `%jam`-mode channels instead of `%json` ones. This has implications for its outward-facing interface, most notably the handling of subscription updates.
- c0b530c updates nu-webterm to be compatible with the changed http-api, as a proof of concept and indicator of what frontend codebases will need to change/add to use noun-based channels.

As mentioned, there's open questions and concerns for all of these. Let's walk through the current approach and see what is yet unresolved.

### eyre

Eyre now supports multiple channel "modes". The SSE framing is identical between the different modes, but the format of both the SSE events and client-sent requests changes depending on the mode. `%json` mode behaves as expected, unchanged. In `%jam` mode, the format is `@uw`-encoded jammed nouns. For example, the noun `[%poke-ack ~]` becomes the bytestring `0w2RIr.2mIHm.TK7U1`.

For accessing the `%json` mode, the existing channel endpoint (`/~/channel/[etc]`) can be used. To use `%jam` mode instead, access the channel under `/~/channel-jam/[etc]` instead. When a channel is opened, the "selected" mode is associated with it permanently.

Remaining questions/work:
- [ ] That endpoint path is aesthetically bankrupt. We could use the file extension to indicate the mode, but this doesn't _quite_ vibe with the usual URI semantics.
- [ ] That endpoint isn't even implemented as a separate endpoint, instead it resolves back to `/~/channel` during binding lookup, and determines the mode from the original URL later on. This should change in accordance with the answer to the path question above.
- [ ] Connecting to the same channel across multiple modes is currently allowed. But it's untested, and unclear whether this is desirable or not. PUT requests are only supported in the channel's "original" mode. Whatever we end up doing, these two should be consistent. Leaning towards disallowing multi-mode-ing.

### http-api

This PR contains a version of http-api that has been switched over to use noun-based channels exclusively. To handle nouns, we have revived @frodwith's nockjs project. (It's hard-copied in right now, I'll make a package & repo for it under @urbit soon.) To parse and render the `@uw`s, we have extended aura-js.

The http-api interface changes slightly.  
We now give nouns instead of javascript objects for subscription `%fact`s, as well as tang nouns instead of error strings in the poke-nack and watch-nack cases. `quit()` on longer gets called with any arguments, there was no data there anyway (right?).  
Subscriptions now take path nouns* instead of strings, and pokes must be specified as nouns* instead of javascript objects.

\* Notably, to avoid having to expose/use noun construction logic to clients of http-api, we also accept primitive javascript data in place of proper nockjs `Noun`s. We wrap these arguments in a `nockjs.dwim()` call, converting them to nouns in the way you would expect.  
We may still want to expose noun construction helpers, but aside from `@p` string->number conversion I haven't felt too serious a need.

To help clients deal with the nouns they receive over subscriptions, nockjs has been extended with [`enjs` helpers](https://github.com/urbit/urbit/blob/01b00f6c615e3ce563263e07e112e0841692b691/pkg/npm/http-api/src/nockjs/noun.js#L354-L458) that bear some passing resemblance to the ones from zuse we all know ~~and love~~. Some of them parse primitives, others convert lists or sets into javascript arrays, convert tuples into objects, or try any number of parsers in sequence. If they fail to match, they crash.

Remaining questions/work:

- [ ] Main question: do we want to fully deprecate JSON-based channels at some point? I certainly do! But I'm gonna need some buy-in (and nock/noun libraries in more languages).
  - Update the major version, and keep supporting the old one for a little while.
  - Release a separate http-api-nouns package, maintain the two side by side.
  - Support both modes within the same package.
- [ ] In addition to having its `Noun`s api touched up a bit, nockjs should clearly in its own package. But thinking one step further: if it's going to ship with noun<->object conversions, shouldn't it also ship with aura de/serialization? Certainly if you use http-api you're going to want to deal with nockjs.  
      It feels like there's strong relations between these three libraries. How should this be dealt with? Do they get merged, or just re-expose each other's utilities, or expect the developer to figure it out? Notable danger: a `Noun` constructed in http-api doesn't `instanceof` correctly with the `Noun` a client application independently imports.  
      (http-api already re-exposes nockjs's `enjs` stuff, but that's mostly incidental, I wanted to get up-and-running quickly.)
- [ ] Additionally, nockjs uses a different bignum library than aura-js: [`jsbn`](https://www.npmjs.com/package/jsbn) and [`big-integer`](https://www.npmjs.com/package/big-integer) respectively. Apparently `BigInt` exists natively now, and the latter uses that when available. Is native better? Should nockjs be modified to use that? Regardless, these two (and all our other libraries) should probably be consistent, and/or not strictly require their own bignum objects as input.
- [ ] None of the nouns stuff is typed right now. Unclear to me if the noun->object conversions can be made to be typed, especially where we're constructing objects based on the supplied string arguments.
- [ ] Should clients be able to bind per-mark conversion functions _when they subscribe_, so that they don't have to manually check the mark & convert as appropriate?
- [ ] We still use `.json` for scrying. Should probably change that over to `.jam` while we're at it.
- [ ] We may want to pre-render tangs in all the nack cases, or at least provide a utility for rendering tanks.

### webterm

The work here, as expected & desired, isn't actually all that interesting. It's just the diff of moving the conversion logic from the marks into the frontend.

---

cc @arthyn @liam-fitzgerald I'm gonna need some guidance on the http-api questions here. Probably worth meeting up to discuss this soon.