### PR TITLE
vere: exit correctly on fatal error

### DIFF
--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -689,18 +689,14 @@ u3_disk_exit(u3_disk* log_u)
     }
   }
 
-  //  cancel write thread
+  //  try to cancel write thread
+  //  shortcircuit cleanup if we cannot
   //
-  //    XX can deadlock when called from signal handler
-  //    XX revise SIGTSTP handling
-  //
-  if ( c3y == log_u->ted_o ) {
-    c3_i sas_i;
-
-    do {
-      sas_i = uv_cancel(&log_u->req_u);
-    }
-    while ( UV_EBUSY == sas_i );
+  if (  (c3y == log_u->ted_o)
+     && uv_cancel(&log_u->req_u) )
+  {
+    // u3l_log("disk: unable to cleanup\r\n");
+    return;
   }
 
   //  close database

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -693,7 +693,7 @@ u3_disk_exit(u3_disk* log_u)
   //  shortcircuit cleanup if we cannot
   //
   if (  (c3y == log_u->ted_o)
-     && uv_cancel(&log_u->req_u) )
+     && (0 > uv_cancel(&log_u->req_u)) )
   {
     // u3l_log("disk: unable to cleanup\r\n");
     return;

--- a/pkg/urbit/vere/io/term.c
+++ b/pkg/urbit/vere/io/term.c
@@ -1036,13 +1036,11 @@ u3_term_ef_ctlc(void)
 {
   u3_utty* uty_u = _term_main();
 
-  {
+  if ( uty_u->car_u ) {
     u3_noun wir = u3nt(c3__term, '1', u3_nul);
     u3_noun cad = u3nt(c3__belt, c3__ctl, 'c');
 
     c3_assert( 1 == uty_u->tid_l );
-    c3_assert( uty_u->car_u );
-
     _term_ovum_plan(uty_u->car_u, wir, cad);
   }
 

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -1566,7 +1566,7 @@ u3_king_done(void)
 
   //  XX remove move
   //
-  exit(0);
+  exit(u3_Host.xit_i);
 }
 
 /* u3_king_exit(): shutdown gracefully
@@ -1582,10 +1582,11 @@ u3_king_exit(void)
 void
 u3_king_bail(void)
 {
+  u3_Host.xit_i = 1;
   _king_forall_unlink(u3_pier_bail);
   _king_loop_exit();
   u3_king_done();
-  exit(1);
+  exit(u3_Host.xit_i);
 }
 
 /* u3_king_grab(): gc the daemon

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -1507,51 +1507,61 @@ u3_king_done(void)
 {
   uv_handle_t* han_u = (uv_handle_t*)&u3K.tim_u;
 
-  //  get next binary
-  //
-  if ( c3y == u3_Host.nex_o ) {
-    c3_c* pac_c;
-    c3_c* ver_c;
-
-    //  hack to ensure we only try once
+  if ( u3_Host.xit_i ) {
+    if ( c3y == u3_Host.nex_o ) {
+      u3l_log("vere: upgrade failed\r\n");
+    }
+    else if ( c3y == u3_Host.pep_o ) {
+      u3l_log("vere: prep for upgrade failed\r\n");
+    }
+  }
+  else {
+    //  get next binary
     //
-    u3_Host.nex_o = c3n;
+    if ( c3y == u3_Host.nex_o ) {
+      c3_c* pac_c;
+      c3_c* ver_c;
 
-    pac_c = _king_get_pace();
+      //  hack to ensure we only try once
+      //
+      u3_Host.nex_o = c3n;
 
-    switch ( u3_king_next(pac_c, &ver_c) ) {
-      case -2: {
-        u3l_log("vere: unable to check for next version\n");
-      } break;
+      pac_c = _king_get_pace();
 
-      case -1: {
-        u3l_log("vere: up to date\n");
-      } break;
+      switch ( u3_king_next(pac_c, &ver_c) ) {
+        case -2: {
+          u3l_log("vere: unable to check for next version\n");
+        } break;
 
-      case 0: {
-        u3l_log("vere: next (%%%s): %s\n", pac_c, ver_c);
-        _king_do_upgrade(pac_c, ver_c);
-        c3_free(ver_c);
-      } break;
+        case -1: {
+          u3l_log("vere: up to date\n");
+        } break;
 
-      default: c3_assert(0);
+        case 0: {
+          u3l_log("vere: next (%%%s): %s\n", pac_c, ver_c);
+          _king_do_upgrade(pac_c, ver_c);
+          c3_free(ver_c);
+        } break;
+
+        default: c3_assert(0);
+      }
+
+      c3_free(pac_c);
+    }
+    else if ( c3y == u3_Host.pep_o ) {
+      u3l_log("vere: ready for upgrade\n");
     }
 
-    c3_free(pac_c);
-  }
-  else if ( c3y == u3_Host.pep_o ) {
-    u3l_log("vere: ready for upgrade\n");
-  }
-
-  //  copy binary into pier on boot
-  //
-  if (  (c3y == u3_Host.ops_u.nuu)
-     && (c3y == u3_Host.ops_u.doc) )
-  {
-    //  hack to ensure we only try once
+    //  copy binary into pier on boot
     //
-    u3_Host.ops_u.nuu = c3n;
-    u3_king_dock(U3_VERE_PACE);
+    if (  (c3y == u3_Host.ops_u.nuu)
+       && (c3y == u3_Host.ops_u.doc) )
+    {
+      //  hack to ensure we only try once
+      //
+      u3_Host.ops_u.nuu = c3n;
+      u3_king_dock(U3_VERE_PACE);
+    }
   }
 
   //  XX hack, if pier's are still linked, we're not actually done

--- a/pkg/urbit/vere/pier.c
+++ b/pkg/urbit/vere/pier.c
@@ -2234,6 +2234,8 @@ u3_pier_exit(u3_pier* pir_u)
 void
 u3_pier_bail(u3_pier* pir_u)
 {
+  u3_Host.xit_i = 1;
+
   //  halt serf
   //
   if ( pir_u->god_u ) {


### PR DESCRIPTION
This PR tweaks handling of fatal errors in vere (specifically the "king" process). We now track the presence of a fatal error in global state (`u3_Host.xit_i`, already present and fit for purpose), and make sure to fail any attempted prep-for/upgrade in the presence of errors. (The absence of this logic meant that a binary upgrade could succeed even if preparatory replay failed, which could leave the pilot with a binary that refuses to run linked into the pier.) 