### PR TITLE
hoon: typed paths

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11756,7 +11756,7 @@
       (stag %clsg (more fas stem))
     ==
   ::
-  ++  stem  !:
+  ++  stem
     %+  knee  *hoon  |.  ~+
     %+  cook
       |=  iota=$%([%hoon =hoon] iota)
@@ -11773,7 +11773,7 @@
           :-  '$'      (cold %$ buc)
           :-  '0'^'9'  (slot bisk:so)
           :-  '-'      (slot tash:so)
-          :-  '.'      zust:so
+          :-  '.'      ;~(pfix dot zust:so)
           :-  '~'      (slot ;~(pfix sig ;~(pose crub:so (easy [%n ~]))))
           :-  '\''     (stag %t qut)
           :-  '['      (slip (ifix [sel ser] wide))
@@ -13141,7 +13141,12 @@
                       ^-  spec
                       :+  %bccl
                         [%leaf %tas aura]
-                      [%bcts term [%base %atom aura]]~
+                      :_  ~
+                      :+  %bcts  term
+                      ?+  aura  [%base %atom aura]
+                        %f  [%base %flag]
+                        %n  [%base %null]
+                      ==
                     ;~(plug sym ;~(pfix tis pat mota))
                   ::
                     ::  /constant
@@ -13160,12 +13165,19 @@
                     [%base %atom aura]~
                   ;~(pfix pat mota)
                 ::
+                  ::  /?
+                  ::
+                  :-  '?'
+                  (cold [%bccl [%leaf %tas %f] [%base %flag] ~] wut)
+                ::
                   ::  /~
                   ::
                   :-  '~'
                   (cold [%bccl [%leaf %tas %n] [%base %null] ~] sig)
               ==
             ::
+              ::  open-ended or fixed-length
+              ::
               ;~  pose
                 (cold [%base %noun] ;~(plug fas tar))
                 (easy %base %null)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2006,10 +2006,11 @@
 ::                                                      ::
 +$  iota                                                ::  typed path segment
   $~  [%n ~]
+  $@  @tas
   $%  [%ub @ub]  [%uc @uc]  [%ud @ud]  [%ui @ui]
       [%ux @ux]  [%uv @uv]  [%uw @uw]  [%da @da]
       [%dr @dr]  [%f ?]     [%if @if]  [%is @is]
-      [%n ~]     [%t @t]    [%ta @ta]  [%tas @tas]
+      [%n ~]     [%t @t]    [%ta @ta]  ::  @tas
       [%p @p]    [%q @q]    [%rd @rd]  [%rh @rh]
       [%rq @rq]  [%rs @rs]  [%s @s]
   ==
@@ -11755,6 +11756,7 @@
     %+  knee  *hoon  |.  ~+
     %+  cook
       |=  iota=$%([%hoon =hoon] iota)
+      ?@  iota  [%rock %tas iota]
       ?:  ?=(%hoon -.iota)  hoon.iota
       [%clhp [%rock %tas -.iota] [%sand iota]]
     |^  %-  stew
@@ -11762,9 +11764,9 @@
       :~  :-  'a'^'z'  ;~  pose
                          (spit (stag %cncl (ifix [pal par] (most ace wide))))
                          (spit (ifix [sel ser] wide))
-                         (slot (stag %tas sym))
+                         (slot sym)
                        ==
-          :-  '$'      (cold [%tas %$] buc)
+          :-  '$'      (cold %$ buc)
           :-  '0'^'9'  (slot bisk:so)
           :-  '-'      (slot tash:so)
           :-  '.'      zust:so
@@ -12859,7 +12861,6 @@
     :~
       :-  ','
         ;~  pose
-          ;~(pfix com reed)  ::NOTE  shadows /wing syntax, maybe re/move
           (stag %ktcl ;~(pfix com wyde))
           (stag %wing rope)
         ==
@@ -13035,6 +13036,8 @@
         (ifix [gal gar] (stag %tell (most ace wide)))
       :-  '>'
         (ifix [gar gal] (stag %yell (most ace wide)))
+      :-  '#'
+        ;~(pfix hax reed)
     ==
   ++  soil
     ;~  pose

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13145,6 +13145,17 @@
                     (stag %leaf (stag %tas ;~(pose sym (cold %$ buc))))
                   ==
                 ::
+                  ::  /@aura
+                  ::
+                  :-  '@'
+                  %+  cook
+                    |=  =aura
+                    ^-  spec
+                    :+  %bccl
+                      [%leaf %tas aura]
+                    [%base %atom aura]~
+                  ;~(pfix pat mota)
+                ::
                   ::  /~
                   ::
                   :-  '~'

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13132,15 +13132,23 @@
                   ;~  pose
                     ::  /name=@aura
                     ::
-                    %+  stag  %bcts
-                    ;~  plug  sym
-                    ;~  pfix  tis  pat
-                      (stag %base (stag %atom mota))
-                    ==  ==
+                    %+  cook
+                      |=  [=term =aura]
+                      ^-  spec
+                      :+  %bccl
+                        [%leaf %tas aura]
+                      [%bcts term [%base %atom aura]]~
+                    ;~(plug sym ;~(pfix tis pat mota))
+                  ::
                     ::  /constant
                     ::
-                    (stag %leaf (stag %tas sym))
+                    (stag %leaf (stag %tas ;~(pose sym (cold %$ buc))))
                   ==
+                ::
+                  ::  /~
+                  ::
+                  :-  '~'
+                  (cold [%bccl [%leaf %tas %n] [%base %null] ~] sig)
               ==
             ::
               ;~  pose

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2008,11 +2008,15 @@
   $~  [%n ~]
   $@  @tas
   $%  [%ub @ub]  [%uc @uc]  [%ud @ud]  [%ui @ui]
-      [%ux @ux]  [%uv @uv]  [%uw @uw]  [%da @da]
-      [%dr @dr]  [%f ?]     [%if @if]  [%is @is]
-      [%n ~]     [%t @t]    [%ta @ta]  ::  @tas
-      [%p @p]    [%q @q]    [%rd @rd]  [%rh @rh]
-      [%rq @rq]  [%rs @rs]  [%s @s]
+      [%ux @ux]  [%uv @uv]  [%uw @uw]
+      [%sb @sb]  [%sc @sc]  [%sd @sd]  [%si @si]
+      [%sx @sx]  [%sv @sv]  [%sw @sw]
+      [%da @da]  [%dr @dr]
+      [%f ?]     [%n ~]
+      [%if @if]  [%is @is]
+      [%t @t]    [%ta @ta]  ::  @tas
+      [%p @p]    [%q @q]
+      [%rs @rs]  [%rd @rd]  [%rh @rh]  [%rq @rq]
   ==
 ::
 ::  $tank: formatted print tree

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5987,20 +5987,37 @@
   ;~(pfix fas (most fas urs:ab))
 ::
 ++  stip                                                ::  typed path parser
-  =-  ;~(pfix fas (more fas -))
-  |^  %-  stew
-      ^.  stet  ^.  limo
-      :~  :-  'a'^'z'  (slot (stag %tas sym))
-          :-  '$'      (cold [%tas %$] buc)
-          :-  '0'^'9'  (slot bisk:so)
-          :-  '-'      (slot tash:so)
-          :-  '.'      zust:so
-          :-  '~'      (slot ;~(pfix sig ;~(pose crub:so (easy [%n ~]))))
-          :-  '\''     (stag %t qut)
-      ==
+  =<  swot
+  |%
+  ++  swot  |=(n=nail (;~(pfix fas (more fas spot)) n))
   ::
-  ++  slot  |*(r=rule (sear (soft iota) r))
+  ++  spot
+    %+  sear  (soft iota)
+    %-  stew
+    ^.  stet  ^.  limo
+    :~  :-  'a'^'z'  (stag %tas sym)
+        :-  '$'      (cold [%tas %$] buc)
+        :-  '0'^'9'  bisk:so
+        :-  '-'      tash:so
+        :-  '.'      zust:so
+        :-  '~'      ;~(pfix sig ;~(pose crub:so (easy [%n ~])))
+        :-  '\''     (stag %t qut)
+    ==
   --
+::
+++  pout
+  |=  =pith
+  ^-  path
+  %+  turn  pith
+  |=  i=iota
+  ?@(i i (scot i))
+::
+++  pave
+  |=  =path
+  ^-  pith
+  %+  turn  path
+  |=  i=@ta
+  (fall (rush i spot:stip) [%ta i])
 ::
 ::::  4n: virtualization
   ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1996,12 +1996,23 @@
 +$  knot  @ta                                           ::  ASCII text
 +$  noun  *                                             ::  any noun
 +$  path  (list knot)                                   ::  like unix path
++$  pith  (list iota)                                   ::  typed urbit path
 +$  stud                                                ::  standard name
           $@  mark=@tas                                 ::  auth=urbit
           $:  auth=@tas                                 ::  standards authority
               type=path                                 ::  standard label
           ==                                            ::
 +$  tang  (list tank)                                   ::  bottom-first error
+::                                                      ::
++$  iota                                                ::  typed path segment
+  $~  [%n ~]
+  $%  [%ub @ub]  [%uc @uc]  [%ud @ud]  [%ui @ui]
+      [%ux @ux]  [%uv @uv]  [%uw @uw]  [%da @da]
+      [%dr @dr]  [%f ?]     [%if @if]  [%is @is]
+      [%n ~]     [%t @t]    [%ta @ta]  [%tas @tas]
+      [%p @p]    [%q @q]    [%rd @rd]  [%rh @rh]
+      [%rq @rq]  [%rs @rs]  [%s @s]
+  ==
 ::
 ::  $tank: formatted print tree
 ::
@@ -5969,6 +5980,22 @@
     ?.  =(~ (rear p))  `p
     ~
   ;~(pfix fas (most fas urs:ab))
+::
+++  stip                                                ::  typed path parser
+  =-  ;~(pfix fas (more fas -))
+  |^  %-  stew
+      ^.  stet  ^.  limo
+      :~  :-  'a'^'z'  (slot (stag %tas sym))
+          :-  '$'      (cold [%tas %$] buc)
+          :-  '0'^'9'  (slot bisk:so)
+          :-  '-'      (slot tash:so)
+          :-  '.'      zust:so
+          :-  '~'      (slot ;~(pfix sig ;~(pose crub:so (easy [%n ~]))))
+          :-  '\''     (stag %t qut)
+      ==
+  ::
+  ++  slot  |*(r=rule (sear (soft iota) r))
+  --
 ::
 ::::  4n: virtualization
   ::
@@ -11719,6 +11746,44 @@
       (stag %clsg poor)
     ==
   ::
+  ++  reed
+    ;~  pfix  fas
+      (stag %clsg (more fas stem))
+    ==
+  ::
+  ++  stem  !:
+    %+  knee  *hoon  |.  ~+
+    %+  cook
+      |=  iota=$%([%hoon =hoon] iota)
+      ?:  ?=(%hoon -.iota)  hoon.iota
+      [%clhp [%rock %tas -.iota] [%sand iota]]
+    |^  %-  stew
+      ^.  stet  ^.  limo
+      :~  :-  'a'^'z'  ;~  pose
+                         (spit (stag %cncl (ifix [pal par] (most ace wide))))
+                         (spit (ifix [sel ser] wide))
+                         (slot (stag %tas sym))
+                       ==
+          :-  '$'      (cold [%tas %$] buc)
+          :-  '0'^'9'  (slot bisk:so)
+          :-  '-'      (slot tash:so)
+          :-  '.'      zust:so
+          :-  '~'      (slot ;~(pfix sig ;~(pose crub:so (easy [%n ~]))))
+          :-  '\''     (stag %t qut)
+          :-  '['      (slip (ifix [sel ser] wide))
+          :-  '('      (slip (stag %cncl (ifix [pal par] (most ace wide))))
+      ==
+    ::
+    ++  slip  |*(r=rule (stag %hoon r))
+    ++  slot  |*(r=rule (sear (soft iota) r))
+    ++  spit
+      |*  r=rule
+      %+  stag  %hoon
+      %+  cook
+        |*([a=term b=*] `hoon`[%clhp [%rock %tas a] b])
+      ;~((glue lus) sym r)
+    --
+  ::
   ++  rupl
     %+  cook
       |=  [a=? b=(list hoon) c=?]
@@ -12794,6 +12859,7 @@
     :~
       :-  ','
         ;~  pose
+          ;~(pfix com reed)  ::NOTE  shadows /wing syntax, maybe re/move
           (stag %ktcl ;~(pfix com wyde))
           (stag %wing rope)
         ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13115,6 +13115,37 @@
                 (rune col %cncl exqz)
             ==
           ==
+        :-  '#'
+          ;~  pfix  hax  fas
+            %+  stag  %bccl
+            %+  cook
+              |=  [[i=spec t=(list spec)] e=spec]
+              [i (snoc t e)]
+            ;~  plug
+              %+  most  ;~(less ;~(plug fas tar) fas)
+              %-  stew
+              ^.  stet  ^.  limo
+              :~  :-  ['a' 'z']
+                  ;~  pose
+                    ::  /name=@aura
+                    ::
+                    %+  stag  %bcts
+                    ;~  plug  sym
+                    ;~  pfix  tis  pat
+                      (stag %base (stag %atom mota))
+                    ==  ==
+                    ::  /constant
+                    ::
+                    (stag %leaf (stag %tas sym))
+                  ==
+              ==
+            ::
+              ;~  pose
+                (cold [%base %noun] ;~(plug fas tar))
+                (easy %base %null)
+              ==
+            ==
+          ==
       ==
     ++  expression
       %-  stew


### PR DESCRIPTION
Adds an `$iota` type, which is an atom tagged with its aura, where we only support auras that provide distinct & unique rendering/parsing formats.

Using that, we introduce `$pith`, the "typed path" type. It's a list of `$iota`, to be used in place of `$path`, that serializes in the same way that `$path` does. Parsing infers the elements' auras from their notation, and annotates into `$iota`s accordingly.

Because `%tas` is the common case, we support that as plain atom, instead of `[%tas %my-term]`.

The idea is that using `$pith`-style typed paths throughout the system will let us save on de/serialization costs on both performance and developer ux fronts. We already use paths extensively throughout the system (wires, subscription paths), and it seems likely this will increase in the next iteration of gall's agent model. (No, you didn't miss a memo, we haven't settled on anything yet.)

You'll note that "using `$pith`-style typed paths throughout the system" is not actually happening yet in this PR. We'll work our way up to that. The conversion functions included here (`+pout` and `+pave`) can get us started on a local level.

To make working with `$pith`s more ergonomic, we add special syntax for generating them, as well as generating patterns for matching against them.  
`#/some/~zod/'path'` will parse to `[%some [%p ~zod] [%t 'path'] ~]`.  
`?=(#/some/who=@p/@t my-pith)` will match on that.
