### PR TITLE
eyre: fix for %trim bug

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2178,7 +2178,7 @@
   ::    XX cancel active too if =(0 trim-priority) ?
   ::
   ?:  ?=(%trim -.task)
-    =/  event-args  [[eny duct now rof] server-state.ax]
+    =*  event-args  [[eny duct now rof] server-state.ax]
     =*  by-channel  by-channel:(per-server-event event-args)
     =*  channel-state  channel-state.server-state.ax
     ::
@@ -2196,8 +2196,6 @@
     ::
     =|  moves=(list (list move))
     |-  ^-  [(list move) _http-server-gate]
-    =/  event-args  [[eny duct now rof] server-state.ax]
-    =*  by-channel  by-channel:(per-server-event event-args)
     =*  channel-id  i.inactive
     ?~  inactive
       [(zing (flop moves)) http-server-gate]

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2196,6 +2196,8 @@
     ::
     =|  moves=(list (list move))
     |-  ^-  [(list move) _http-server-gate]
+    =/  event-args  [[eny duct now rof] server-state.ax]
+    =*  by-channel  by-channel:(per-server-event event-args)
     =*  channel-id  i.inactive
     ?~  inactive
       [(zing (flop moves)) http-server-gate]


### PR DESCRIPTION
Problem:
by-channel has its own copy of server-state from line 2182. discard-channel returns an altered state, with one channel removed from the state of by-channel.
but the state of by-channel isn't changing with each iteration, so %trim is only removing one channel per invocation instead of all channels.

Solution:
update by-channel on each iteration.