### PR TITLE
naive: uncomment some naive.hoon tests

### DIFF
--- a/pkg/arvo/tests/lib/naive.hoon
+++ b/pkg/arvo/tests/lib/naive.hoon
@@ -739,19 +739,19 @@
   ++  gen-rut-jar
     ^~  ^-  (jar @p event)
     =/  filter  ;:  cork
-                    (cury filter-owner %.y)
+                    ::(cury filter-owner %.y)
                     ::(cury filter-proxy %spawn)
-                    (cury filter-nonce %.y)
+                    ::(cury filter-nonce %.y)
                     ::(cury filter-rank %galaxy)
                     ::(cury filter-dominion %l1)
                     %-  cury
                     :-  filter-tx-type
-                    :*  ::%spawn
-                        ::%transfer-point
+                    :*  %spawn
+                        %transfer-point
                         %configure-keys
-                        ::%set-management-proxy
-                        ::%set-spawn-proxy
-                        ::%set-transfer-proxy
+                        %set-management-proxy
+                        %set-spawn-proxy
+                        %set-transfer-proxy
                         ~
                     ==
                 ==


### PR DESCRIPTION
I had commented out some of these tests because running the full `+test-rut` can take ~s15 to ~s30 or more depending on hardware. I did not realize that running these tests was actually part of the CI pipeline at the time, so I'm uncommenting them.

This should be uncontroversial, but since it adds a non-trivial amount of time to CI I could see an argument for not including them - but maybe that's just evading the point of CI and it takes however long it takes. Someone more experienced ought to have a better idea than me.