### PR TITLE
api: fix `@urbit/api` `term` exports

### DIFF
--- a/pkg/npm/api/index.ts
+++ b/pkg/npm/api/index.ts
@@ -22,3 +22,5 @@ export * as hood from './hood';
 export * from './hood';
 export * as docket from './docket';
 export * from './docket';
+export * as term from './term';
+export * from './term';

--- a/pkg/npm/api/package-lock.json
+++ b/pkg/npm/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbit/api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/api",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.16.0",

--- a/pkg/npm/api/term/lib.ts
+++ b/pkg/npm/api/term/lib.ts
@@ -1,5 +1,5 @@
-import { Scry } from '../http-api/src'
-import { Poke } from '../http-api/src/types';
+import { Scry } from '../../http-api/src'
+import { Poke } from '../../http-api/src/types';
 import { Belt, Task, SessionTask } from './types';
 
 export const pokeTask = (session: string, task: Task): Poke<SessionTask> => ({

--- a/pkg/npm/api/term/lib.ts
+++ b/pkg/npm/api/term/lib.ts
@@ -1,5 +1,4 @@
-import { Scry } from '../../http-api/src'
-import { Poke } from '../../http-api/src/types';
+import { Poke } from '../lib'
 import { Belt, Task, SessionTask } from './types';
 
 export const pokeTask = (session: string, task: Task): Poke<SessionTask> => ({


### PR DESCRIPTION
Replaces https://github.com/urbit/urbit/pull/5904
(wasn't based on next/npm)