### PR TITLE
gall %doff to kill subscriptions

### DIFF
--- a/pkg/arvo/gen/hood/doff.hoon
+++ b/pkg/arvo/gen/hood/doff.hoon
@@ -1,0 +1,5 @@
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [~ ~]
+    ==
+[%helm-doff ~]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -252,6 +252,11 @@
   =<  abet
   (emit %pass /helm/cors/reject %arvo %e %reject-origin origin)
 ::
+++  poke-doff
+  |=  ~
+  =<  abet
+  (emit %pass /helm/doff %arvo %g %doff ~)
+::
 ++  poke
   |=  [=mark =vase]
   ?>  ?|  ?=(%helm-hi mark)
@@ -269,6 +274,7 @@
     %helm-code             =;(f (f !<(_+<.f vase)) poke-code)
     %helm-cors-approve     =;(f (f !<(_+<.f vase)) poke-cors-approve)
     %helm-cors-reject      =;(f (f !<(_+<.f vase)) poke-cors-reject)
+    %helm-doff             =;(f (f !<(_+<.f vase)) poke-doff)
     %helm-hi               =;(f (f !<(_+<.f vase)) poke-hi)
     %helm-knob             =;(f (f !<(_+<.f vase)) poke-knob)
     %helm-pans             =;(f (f !<(_+<.f vase)) poke-pans)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1651,6 +1651,7 @@
         [%jolt =desk =dude]                             ::  (re)start agent
         [%idle =dude]                                   ::  suspend agent
         [%nuke =dude]                                   ::  delete agent
+        [%doff ~]                                       ::  kill subscriptions
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -442,8 +442,10 @@
       =/  subs  ~(tap in ~(key by boat.yok))
       |-  ^+  ap-core
       ?~  subs  ap-core
-      ~>  %slog.[0 leaf+"gall: +ap-kill-down {<dap>} {<i.subs>}"]
-      $(subs t.subs, ap-core (ap-kill-down:ap-core i.subs))
+      =+  [wyr dok]=i.subs
+      =.  wyr  :_(wyr (scot %ud (~(got by boar.yok) wyr dok)))
+      ~>  %slog.[0 leaf+"gall: +ap-kill-down {<dap>} {<dok>}"]
+      $(subs t.subs, ap-core (ap-kill-down:ap-core wyr dok))
     $(apps t.apps, mo-core ap-abet:ap-core)
   ::  +mo-receive-core: receives an app core built by %ford.
   ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -439,7 +439,7 @@
     =+  [dap yok]=[p q]:i.apps
     =/  ap-core  (ap-yoke:ap:mo-core dap [~ our] yok)
     =.  ap-core
-      =/  subs  ~(tap in ~(key by outbound.watches.yok))
+      =/  subs  ~(tap in ~(key by boat.yok))
       |-  ^+  ap-core
       ?~  subs  ap-core
       ~>  %slog.[0 leaf+"gall: +ap-kill-down {<dap>} {<i.subs>}"]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -317,6 +317,22 @@
     =/  =case  [%da now]
     =/  =wire  /sys/cor/[dap]/(scot %p ship)/[desk]/(scot case)
     (mo-pass wire %c %warp ship desk ~ %sing %a case /app/[dap]/hoon)
+  ::  +mo-doff: kill all outgoing subscriptions
+  ::
+  ++  mo-doff
+    ^+  mo-core
+    =/  apps  ~(tap by yokes.state)
+    |-  ^+  mo-core
+    ?~  apps  mo-core
+    =/  [dap yok]=[p q]:i.apps
+    =/  ap-core  (ap-yoke:ap:mo-core dap [~ our] yok)
+    =.  ap-core
+      =/  subs  ~(tap in ~(key by outbound.watches.yok))
+      |-  ^+  ap-core
+      ?~  subs  ap-core
+      ~>  %slog.[0 leaf+"gall: +ap-kill-down {<dap>} {<i.subs>}"]
+      $(subs t.subs, ap-core (ap-kill-down:ap-core i.subs))
+    $(apps t.apps, mo-core ap-abet:ap-core)
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1726,6 +1742,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
+      %doff  mo-abet:mo-doff
       %trim  [~ gall-payload]
       %vega  [~ gall-payload]
   ==

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -324,7 +324,7 @@
     =/  apps  ~(tap by yokes.state)
     |-  ^+  mo-core
     ?~  apps  mo-core
-    =/  [dap yok]=[p q]:i.apps
+    =+  [dap yok]=[p q]:i.apps
     =/  ap-core  (ap-yoke:ap:mo-core dap [~ our] yok)
     =.  ap-core
       =/  subs  ~(tap in ~(key by outbound.watches.yok))
@@ -1742,7 +1742,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
-      %doff  mo-abet:mo-doff
+      %doff  mo-abet:mo-doff:mo-core
       %trim  [~ gall-payload]
       %vega  [~ gall-payload]
   ==


### PR DESCRIPTION
Adds a `%doff` task to Gall to kill all outgoing subscriptions.  Agents will generally restart these when they get the `%kick`.  This is intended for use as a manual workaround for the gall request queue bug, to try to clear inconsistent subscription state.

User can now run `|doff` to kill all subscriptions.  This causes dojo to relink, with a benign stack trace.