### PR TITLE
vere: clean up terminal on invalid fake ship name

### DIFF
--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -578,7 +578,6 @@ _boothack_doom(void)
     if ( u3_nul == whu ) {
       u3l_log("boot: malformed -F ship %s\r\n", u3_Host.ops_u.fak_c);
       u3_king_bail();
-      exit(1);
     }
 
     bot = u3nc(c3__fake, u3k(u3t(whu)));

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -577,6 +577,10 @@ _boothack_doom(void)
 
     if ( u3_nul == whu ) {
       u3l_log("boot: malformed -F ship %s\r\n", u3_Host.ops_u.fak_c);
+      
+      u3_term_log_exit();
+      fflush(stdout);
+
       exit(1);
     }
 

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -577,10 +577,7 @@ _boothack_doom(void)
 
     if ( u3_nul == whu ) {
       u3l_log("boot: malformed -F ship %s\r\n", u3_Host.ops_u.fak_c);
-      
-      u3_term_log_exit();
-      fflush(stdout);
-
+      u3_king_bail();
       exit(1);
     }
 


### PR DESCRIPTION
Currently when creating a fake ship, if an invalid ship name is given,
then the program exits without ever cleaning up the terminal. This
results in  a bugged termianal that requires closing and repopening
or using the `reset` cmd.

This commits adds a call to `u3_term_log_exit()` and `fflush(stdout)`
before calling `exit(1)` to ensure proper cleanup.

Address issue #5914