### PR TITLE
eyre: Add cache

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1354,6 +1354,11 @@
   ::                                                    ::::
 ++  eyre  ^?
   |%
+  +$  cache-entry
+    $:  auth=?
+    $=  body
+    $%  [%payload =simple-payload:http]
+    ==  ==
   +$  gift
     $%  ::  set-config: configures the external http server
         ::
@@ -1373,6 +1378,9 @@
         ::    not allowed.
         ::
         [%bound accepted=? =binding]
+        ::  notification that a cache entry has changed
+        ::
+        [%grow =path]
     ==
   ::
   +$  task
@@ -1428,6 +1436,9 @@
         ::  %spew: set verbosity toggle
         ::
         [%spew veb=@]
+        ::  remember (or update) a cache mapping
+        ::
+        [%set-response url=@t entry=(unit cache-entry)]
     ==
   ::  +origin: request origin as specified in an Origin header
   ::

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -68,7 +68,7 @@
 ::
 |%
 +$  axle
-  $:  %~2023.2.17
+  $:  %~2023.3.16
       =server-state
   ==
 ::  +server-state: state relating to open inbound HTTP connections
@@ -84,6 +84,9 @@
       ::    the :binding into a (map (unit @t) (trie knot =action)).
       ::
       bindings=(list [=binding =duct =action])
+      ::  cache: mapping from url to versioned entry
+      ::
+      cache=(map url=@t [aeon=@ud val=(unit cache-entry)])
       ::  cors-registry: state used and managed by the +cors core
       ::
       =cors-registry
@@ -672,6 +675,11 @@
           =-  (fall - '*')
           (get-header:http 'access-control-request-headers' headers)
       ==
+    ::  handle requests to the cache
+    ::
+    =/  entry  (~(get by cache.state) url.request)
+    ?:  &(?=(^ entry) ?=(%'GET' method.request))
+      (handle-cache-req authenticated request val.u.entry)
     ::
     ?-    -.action
         %gen
@@ -764,6 +772,32 @@
       (error-response 405 "may only GET name")
     %^  return-static-data-on-duct  200  'text/plain'
     (as-octs:mimes:html (scot %p our))
+    ::
+    ++  error-response
+      |=  [status=@ud =tape]
+      ^-  (quip move server-state)
+      %^  return-static-data-on-duct  status  'text/html'
+      (error-page status authenticated url.request tape)
+    --
+  ::  +handle-cache-req: respond with cached value, 404 or 500
+  ::
+  ++  handle-cache-req
+    |=  [authenticated=? =request:http entry=(unit cache-entry)]
+    |^  ^-  (quip move server-state)
+    ?~  entry
+      (error-response 404 "cache entry for that binding was deleted")
+    ?:  &(auth.u.entry !authenticated)
+      (error-response 403 ~)
+    =*  body  body.u.entry
+    ?-    -.body
+        %payload
+      %-  handle-response
+      :*  %start
+          response-header.simple-payload.body
+          data.simple-payload.body
+          complete=%.y
+      ==
+    ==
     ::
     ++  error-response
       |=  [status=@ud =tape]
@@ -2032,6 +2066,15 @@
           %leave  ~
       ==
     --
+  ::  +set-response: remember (or update) a cache mapping
+  ::
+  ++  set-response
+    |=  [url=@t entry=(unit cache-entry)]
+    ^-  [(list move) server-state]
+    =/  aeon  ?^(prev=(~(get by cache.state) url) +(aeon.u.prev) 1)
+    =.  cache.state  (~(put by cache.state) url [aeon entry])
+    :_  state
+    [outgoing-duct.state %give %grow /cache/(scot %ud aeon)/(scot %t url)]~
   ::  +add-binding: conditionally add a pairing between binding and action
   ::
   ::    Adds =binding =action if there is no conflicting bindings.
@@ -2318,6 +2361,12 @@
     ::  save duct for future %give to unix
     ::
     =.  outgoing-duct.server-state.ax  duct
+    ::  send all cache mappings to runtime
+    ::
+    =/  cache-moves=(list move)
+      %+  turn  ~(tap by cache.server-state.ax)
+      |=  [url=@t cache-val=[aeon=@ud val=(unit cache-entry)]]
+      [duct %give %grow /cache/(scot %u aeon.cache-val)/(scot %t url)]
     ::
     :_  http-server-gate
     :*  ::  hand back default configuration for now
@@ -2328,7 +2377,7 @@
         =<  give-session-tokens
         (per-server-event [eny duct now rof] server-state.ax)
       ::
-        closed-connections
+        (zing ~[closed-connections cache-moves])
     ==
   ::
   ?:  ?=(%code-changed -.task)
@@ -2447,6 +2496,10 @@
       %spew
     =.  verb.server-state.ax  veb.task
     `http-server-gate
+  ::
+      %set-response
+    =^  moves  server-state.ax  (set-response:server +.task)
+    [moves http-server-gate]
   ==
 ::
 ++  take
@@ -2638,7 +2691,8 @@
       +$  axle-any
         $%  [%~2020.10.18 =server-state-0]
             [%~2022.7.26 =server-state-0]
-            [%~2023.2.17 =server-state]
+            [%~2023.2.17 =server-state-1]
+            [%~2023.3.16 =server-state]
         ==
       +$  server-state-0
         $:  bindings=(list [=binding =duct =action])
@@ -2651,6 +2705,18 @@
             ports=[insecure=@ud secure=(unit @ud)]
             outgoing-duct=duct
         ==
+      +$  server-state-1
+        $:  bindings=(list [=binding =duct =action])
+            =cors-registry
+            connections=(map duct outstanding-connection)
+            =authentication-state
+            =channel-state
+            domains=(set turf)
+            =http-config
+            ports=[insecure=@ud secure=(unit @ud)]
+            outgoing-duct=duct
+            verb=@
+        ==
       --
   |=  old=axle-any
   ^+  ..^$
@@ -2659,8 +2725,9 @@
     =,  server-state-0.old
     %=  ..^$
       ax  ^-  axle
-          :*  %~2023.2.17
+          :*  %~2023.3.16
               (insert-binding [[~ /~/name] outgoing-duct [%name ~]] bindings)
+              *(map url=@t [aeon=@ud val=(unit cache-entry)])
               cors-registry
               connections
               authentication-state
@@ -2676,8 +2743,9 @@
     =,  server-state-0.old
     %=  ..^$
       ax  ^-  axle
-          :*  %~2023.2.17
+          :*  %~2023.3.16
               bindings
+              *(map url=@t [aeon=@ud val=(unit cache-entry)])
               cors-registry
               connections
               authentication-state
@@ -2690,6 +2758,24 @@
     ==    ==
   ::
       %~2023.2.17
+    =,  server-state-1.old
+    %=  ..^$
+      ax  ^-  axle
+          :*  %~2023.3.16
+              bindings
+              *(map url=@t [aeon=@ud val=(unit cache-entry)])
+              cors-registry
+              connections
+              authentication-state
+              channel-state
+              domains
+              http-config
+              ports
+              outgoing-duct
+              verb
+    ==    ==
+  ::
+      %~2023.3.16
     ::  enable https redirects if certificate configured
     ::
     =.  redirect.http-config.server-state.old
@@ -2757,6 +2843,14 @@
       %-  =<  request-is-logged-in:authentication
           (per-server-event [eny *duct now rof] server-state.ax)
       %*(. *request:http header-list ['cookie' u.cookies]~)
+    ::
+        [%cache @ @ ~]
+      ?~  aeon=(slaw %ud i.t.tyl)        [~ ~]
+      ?~  url=(slaw %t i.t.t.tyl)        [~ ~]
+      ?~  entry=(~(get by cache) u.url)  [~ ~]
+      ?.  =(u.aeon aeon.u.entry)         [~ ~]
+      ?~  val=val.u.entry                [~ ~]
+      ``noun+!>(u.val)
     ==
   ?.  ?=(%$ ren)
     [~ ~]


### PR DESCRIPTION
This fulfills the first milestone of https://urbit.org/grants/eyre-scry. It adds a simple cache to eyre that maps URLs to scry paths, with the usual accessors for updating the cache. A gift is given to the runtime when a watched file changed, and the full cache is sent to the runtime on init.