### PR TITLE
clay: remove $dork

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -126,23 +126,6 @@
       fod=flue                                          ::  ford cache
   ==                                                    ::
 ::
-::  Commit state.
-::
-::  --  `del` is the paths we're deleting.
-::  --  `ink` is the insertions of hoon files (short-circuited for
-::      bootstrapping).
-::  --  `ins` is all the other insertions.
-::  --  `dif` is the diffs in `dig` applied to their files.
-::  --  `mut` is the diffs between `muc` and the original files.
-::
-+$  dork                                                ::  diff work
-  $:  del=(list path)                                   ::  deletes
-      ink=(list (pair path cage))                       ::  hoon inserts
-      ins=(list (pair path cage))                       ::  inserts
-      dif=(list (trel path lobe cage))                  ::  changes
-      mut=(list (trel path lobe cage))                  ::  mutations
-  ==                                                    ::
-::
 ::  Over-the-wire backfill request/response
 ::
 +$  fill


### PR DESCRIPTION
seems that this structure has been unused since
[e75ab631a4de5061714af1905de4a1bf1a2a951d](https://github.com/urbit/urbit/commit/e75ab631a4) and confuses
newbies trying to figure out exactly what the commit
structure is (which is how I came across this)