### PR TITLE
gall: kill old subscriptions on %doff

### DIFF
--- a/pkg/arvo/gen/hood/doff.hoon
+++ b/pkg/arvo/gen/hood/doff.hoon
@@ -1,5 +1,6 @@
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [~ ~]
+        ~
+        [dude=(unit dude:gall) ship=(unit ship)]
     ==
-[%helm-doff ~]
+[%helm-doff dude ship]

--- a/pkg/arvo/gen/hood/doff.hoon
+++ b/pkg/arvo/gen/hood/doff.hoon
@@ -1,0 +1,5 @@
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [~ ~]
+    ==
+[%helm-doff ~]

--- a/pkg/arvo/gen/hood/doff.hoon
+++ b/pkg/arvo/gen/hood/doff.hoon
@@ -1,6 +1,8 @@
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
         ~
-        [dude=(unit dude:gall) ship=(unit ship)]
+        [dude=_`dude:gall`%$ ship=_`@p`(bex 128)]
     ==
-[%helm-doff dude ship]
+=/  darg=(unit dude:gall)  ?:(=(%$ dude) ~ `dude)
+=/  sarg=(unit ^ship)      ?:(=((bex 128) ship) ~ `ship)
+[%helm-doff darg sarg]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -261,9 +261,9 @@
   (emit %pass /helm/cors/reject %arvo %e %reject-origin origin)
 ::
 ++  poke-doff
-  |=  ~
+  |=  [dude=(unit dude:gall) ship=(unit ship)]
   =<  abet
-  (emit %pass /helm/doff %arvo %g %doff ~)
+  (emit %pass /helm/doff %arvo %g %doff dude ship)
 ::
 ++  poke
   |=  [=mark =vase]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -260,6 +260,11 @@
   =<  abet
   (emit %pass /helm/cors/reject %arvo %e %reject-origin origin)
 ::
+++  poke-doff
+  |=  ~
+  =<  abet
+  (emit %pass /helm/doff %arvo %g %doff ~)
+::
 ++  poke
   |=  [=mark =vase]
   ?>  ?|  ?=(%helm-hi mark)
@@ -277,6 +282,7 @@
     %helm-code             =;(f (f !<(_+<.f vase)) poke-code)
     %helm-cors-approve     =;(f (f !<(_+<.f vase)) poke-cors-approve)
     %helm-cors-reject      =;(f (f !<(_+<.f vase)) poke-cors-reject)
+    %helm-doff             =;(f (f !<(_+<.f vase)) poke-doff)
     %helm-gall-sift        =;(f (f !<(_+<.f vase)) poke-gall-sift)
     %helm-gall-verb        =;(f (f !<(_+<.f vase)) poke-gall-verb)
     %helm-hi               =;(f (f !<(_+<.f vase)) poke-hi)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1659,6 +1659,7 @@
         [%jolt =desk =dude]                             ::  (re)start agent
         [%idle =dude]                                   ::  suspend agent
         [%nuke =dude]                                   ::  delete agent
+        [%doff ~]                                       ::  kill subscriptions
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1659,7 +1659,7 @@
         [%jolt =desk =dude]                             ::  (re)start agent
         [%idle =dude]                                   ::  suspend agent
         [%nuke =dude]                                   ::  delete agent
-        [%doff ~]                                       ::  kill subscriptions
+        [%doff dude=(unit dude) ship=(unit ship)]       ::  kill subscriptions
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2590,12 +2590,12 @@
       |=  [=bone task=message-pump-task]
       ^+  peer-core
       ?:  ?&  (~(has in closing.peer-state) bone)
-              !=(task [%memo (dedup-message (jim [%$ /flow [%cork ~]]))])
+              !=(task [%memo ^~((jim [%$ /flow [%cork ~]]))])
           ==
-        ~>  %slog.0^leaf/"ames: %memo on closing bone {<bone>}"
+        ~>  %slog.0^leaf/"ames: activity on closing bone {<bone>}"
         peer-core
       ?:  (~(has in corked.peer-state) bone)
-        ~>  %slog.0^leaf/"ames: %memo on corked bone {<bone>}"
+        ~>  %slog.0^leaf/"ames: activity on corked bone {<bone>}"
         peer-core
       ::  pass .task to the |message-pump and apply state mutations
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2589,6 +2589,14 @@
     ++  run-message-pump
       |=  [=bone task=message-pump-task]
       ^+  peer-core
+      ?:  ?&  (~(has in closing.peer-state) bone)
+              !=(task [%memo (dedup-message (jim [%$ /flow [%cork ~]]))])
+          ==
+        ~>  %slog.0^leaf/"ames: %memo on closing bone {<bone>}"
+        peer-core
+      ?:  (~(has in corked.peer-state) bone)
+        ~>  %slog.0^leaf/"ames: %memo on corked bone {<bone>}"
+        peer-core
       ::  pass .task to the |message-pump and apply state mutations
       ::
       =/  =message-pump-state

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2417,6 +2417,15 @@
     ++  on-memo
       |=  [=bone payload=* valence=?(%plea %boon)]
       ^+  peer-core
+      ?:  ?&  (~(has in closing.peer-state) bone)
+              !=(payload [%$ /flow %cork ~])
+          ==
+        ~>  %slog.0^leaf/"ames: ignoring message on closing bone {<bone>}"
+        peer-core
+      ?:  (~(has in corked.peer-state) bone)
+        ~>  %slog.0^leaf/"ames: ignoring message on corked bone {<bone>}"
+        peer-core
+      ::
       =/  =message-blob  (dedup-message (jim payload))
       =.  peer-core  (run-message-pump bone %memo message-blob)
       ::
@@ -2589,14 +2598,6 @@
     ++  run-message-pump
       |=  [=bone task=message-pump-task]
       ^+  peer-core
-      ?:  ?&  (~(has in closing.peer-state) bone)
-              !=(task [%memo ^~((jim [%$ /flow [%cork ~]]))])
-          ==
-        ~>  %slog.0^leaf/"ames: activity on closing bone {<bone>}"
-        peer-core
-      ?:  (~(has in corked.peer-state) bone)
-        ~>  %slog.0^leaf/"ames: activity on corked bone {<bone>}"
-        peer-core
       ::  pass .task to the |message-pump and apply state mutations
       ::
       =/  =message-pump-state

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -432,12 +432,15 @@
   ::  +mo-doff: kill all outgoing subscriptions
   ::
   ++  mo-doff
+    |=  [dude=(unit dude) ship=(unit ship)]
     ^+  mo-core
-    =/  apps  ~(tap by yokes.state)
+    =/  apps=(list (pair term yoke))
+      ?~  dude  ~(tap by yokes.state)
+      (drop (bind (~(get by yokes.state) u.dude) (lead u.dude)))
     |-  ^+  mo-core
     ?~  apps  mo-core
     =/  ap-core  (ap-yoke:ap:mo-core p.i.apps [~ our] q.i.apps)
-    $(apps t.apps, mo-core ap-abet:ap-doff:ap-core)
+    $(apps t.apps, mo-core ap-abet:(ap-doff:ap-core ship))
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1767,11 +1770,14 @@
     ::    request queue fix.  This includes nonce 0, which no longer exists.
     ::
     ++  ap-doff
+      |=  ship=(unit ship)
       ^+  ap-core
       =/  subs  ~(tap in ~(key by boat.yoke))
       |-  ^+  ap-core
       ?~  subs  ap-core
       =+  [wyr dok]=i.subs
+      ?.  |(?=(~ ship) =(u.ship ship.dok))
+        $(subs t.subs)
       =/  let  (~(got by boar.yoke) wyr dok)
       |-  ^+  ap-core
       ~>  %slog.[0 leaf+"gall: +ap-doff {<[agent-name wyr dok let]>}"]
@@ -1977,7 +1983,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
-      %doff  mo-abet:mo-doff:mo-core
+      %doff  mo-abet:(mo-doff:mo-core +.task)
       %spew  mo-abet:(mo-spew:mo-core veb.task)
       %sift  mo-abet:(mo-sift:mo-core dudes.task)
       %trim  [~ gall-payload]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1774,14 +1774,14 @@
       =+  [wyr dok]=i.subs
       =/  let  (~(got by boar.yoke) wyr dok)
       |-  ^+  ap-core
-      ~>  %slog.[0 leaf+"gall: +ap-doff {<agent-name>} {<dok>} {<let>}"]
+      ~>  %slog.[0 leaf+"gall: +ap-doff {<[agent-name wyr dok let]>}"]
       =.  ap-core  (ap-pass [(scot %ud let) wyr] %agent dok %leave ~)
-      =.  ap-core  (ap-pass wyr %huck dok %b %huck [%gall %unto %kick ~])
       ?.  =(0 let)
         $(let (dec let))
       ::  kill old-style subscription wire with no nonce
       ::
       =.  ap-core  (ap-pass wyr %agent dok %leave ~)
+      =.  ap-core  (ap-pass wyr %huck dok %b %huck [%gall %unto %kick ~])
       ^$(subs t.subs)
     ::  +ap-mule: run virtualized with intercepted scry, preserving type
     ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1785,9 +1785,10 @@
       ::
       =/  let  (~(got by boar.yoke) wyr dok)
       =/  non  0
+      =/  pre  "gall: +ap-doff {<[agent-name wyr dok]>}"
+      =-  ((slog leaf+"{pre} done" ~) -)
+      %-  (slog leaf+"{pre} {<,.let>} total..." ~)
       |-  ^+  ap-core
-      %-  =-  (slog leaf+- ~)
-          "gall: +ap-doff {<[agent-name wyr dok]>} {<non>}/{<,.let>}"
       =.  ap-core  (ap-pass [(scot %ud non) wyr] %agent dok %leave ~)
       ?:  (lth non let)
         $(non +(non))

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1778,15 +1778,21 @@
       =+  [wyr dok]=i.subs
       ?:  =(ship `ship.dok)
         $(subs t.subs)
-      =/  let  (~(got by boar.yoke) wyr dok)
-      |-  ^+  ap-core
-      ~>  %slog.[0 leaf+"gall: +ap-doff {<[agent-name wyr dok let]>}"]
-      =.  ap-core  (ap-pass [(scot %ud let) wyr] %agent dok %leave ~)
-      ?.  =(0 let)
-        $(let (dec let))
       ::  kill old-style subscription wire with no nonce
       ::
       =.  ap-core  (ap-pass wyr %agent dok %leave ~)
+      ::  kill new-style subscriptions at every previously-known nonce
+      ::
+      =/  let  (~(got by boar.yoke) wyr dok)
+      =/  non  0
+      |-  ^+  ap-core
+      %-  =-  (slog leaf+- ~)
+          "gall: +ap-doff {<[agent-name wyr dok]>} {<non>}/{<,.let>}"
+      =.  ap-core  (ap-pass [(scot %ud non) wyr] %agent dok %leave ~)
+      ?:  (lth non let)
+        $(non +(non))
+      ::  do the %kick last: leaves must be processed first
+      ::
       =.  ap-core  (ap-pass wyr %huck dok %b %huck [%gall %unto %kick ~])
       ^$(subs t.subs)
     ::  +ap-mule: run virtualized with intercepted scry, preserving type

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1776,7 +1776,7 @@
       |-  ^+  ap-core
       ?~  subs  ap-core
       =+  [wyr dok]=i.subs
-      ?:  =(ship `ship.dok)
+      ?:  &(?=(^ ship) !=(u.ship ship.dok))
         $(subs t.subs)
       ::  kill old-style subscription wire with no nonce
       ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1764,7 +1764,7 @@
     ::
     ::    Also kills old subscriptions that should have been killed but
     ::    were not correctly removed in prerelease versions of the
-    ::    request queue fix.
+    ::    request queue fix.  This includes nonce 0, which no longer exists.
     ::
     ++  ap-doff
       ^+  ap-core

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1776,7 +1776,7 @@
       |-  ^+  ap-core
       ?~  subs  ap-core
       =+  [wyr dok]=i.subs
-      ?.  |(?=(~ ship) =(u.ship ship.dok))
+      ?:  =(ship `ship.dok)
         $(subs t.subs)
       =/  let  (~(got by boar.yoke) wyr dok)
       |-  ^+  ap-core

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -429,6 +429,15 @@
     =/  =case  [%da now]
     =/  =wire  /sys/cor/[dap]/(scot %p ship)/[desk]/(scot case)
     (mo-pass wire %c %warp ship desk ~ %sing %a case /app/[dap]/hoon)
+  ::  +mo-doff: kill all outgoing subscriptions
+  ::
+  ++  mo-doff
+    ^+  mo-core
+    =/  apps  ~(tap by yokes.state)
+    |-  ^+  mo-core
+    ?~  apps  mo-core
+    =/  ap-core  (ap-yoke:ap:mo-core p.i.apps [~ our] q.i.apps)
+    $(apps t.apps, mo-core ap-abet:ap-doff:ap-core)
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1751,6 +1760,29 @@
         ::
         (ap-pass (ap-nonce-wire sub-wire dock) %agent dock %leave ~)
       (ap-pass sub-wire %huck dock %b %huck `sign-arvo`[%gall %unto %kick ~])
+    ::  +ap-doff: kill all outgoing subscriptions
+    ::
+    ::    Also kills old subscriptions that should have been killed but
+    ::    were not correctly removed in prerelease versions of the
+    ::    request queue fix.
+    ::
+    ++  ap-doff
+      ^+  ap-core
+      =/  subs  ~(tap in ~(key by boat.yoke))
+      |-  ^+  ap-core
+      ?~  subs  ap-core
+      =+  [wyr dok]=i.subs
+      =/  let  (~(got by boar.yoke) wyr dok)
+      |-  ^+  ap-core
+      ~>  %slog.[0 leaf+"gall: +ap-doff {<agent-name>} {<dok>} {<let>}"]
+      =.  ap-core  (ap-pass [(scot %ud let) wyr] %agent dok %leave ~)
+      =.  ap-core  (ap-pass wyr %huck dok %b %huck [%gall %unto %kick ~])
+      ?.  =(0 let)
+        $(let (dec let))
+      ::  kill old-style subscription wire with no nonce
+      ::
+      =.  ap-core  (ap-pass wyr %agent dok %leave ~)
+      ^$(subs t.subs)
     ::  +ap-mule: run virtualized with intercepted scry, preserving type
     ::
     ::    Compare +mute and +mule.  Those pass through scry, which
@@ -1945,6 +1977,7 @@
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
+      %doff  mo-abet:mo-doff:mo-core
       %spew  mo-abet:(mo-spew:mo-core veb.task)
       %sift  mo-abet:(mo-sift:mo-core dudes.task)
       %trim  [~ gall-payload]


### PR DESCRIPTION
`%doff` now kills live subscriptions and any old subscriptions that might be lingering due to prerelease bugs.  We had to modify Ames to ignore `%leave` messages sent on closing or corked bones during a `%doff`.