### PR TITLE
gall: use a fully-formed wire when sending %cork

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -834,7 +834,7 @@
       ?-  -.ames-response
         %d  (mo-give %unto %raw-fact mark.ames-response noun.ames-response)
         %x  =.  mo-core  (mo-give %unto %kick ~)
-            (mo-pass wire %a %cork ship)
+            (mo-pass [%sys wire] %a %cork ship)
       ==
     ::
         [%ames %lost *]


### PR DESCRIPTION
In response to clog notification from remote ames, we were sending a
%cork to clean up the flow. However, the wire we were using had the /sys
prefix already stripped off. Here, we put it back in.