### PR TITLE
gall: scry for nonces

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2064,6 +2064,15 @@
       acc
     (~(put in acc) [dude -.agent.yoke])
   ::
+  ?:  ?&  =(%f care)
+          =(~ path)
+          =([%$ %da now] coin)
+          =(our ship)
+      ==
+    :+  ~  ~
+    :-  %nonces  !>  ^-  (map dude @)
+    (~(run by yokes.state) |=(yoke sub-nonce))
+  ::
   ?:  ?&  =(%n care)
           ?=([@ @ ^] path)
           =([%$ %da now] coin)


### PR DESCRIPTION
Adds a `%f` scry to Gall to retrieve the sub-nonce for each agent.