### PR TITLE
gall: revive %hood and %dojo on keypress

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -917,19 +917,33 @@
     =/  running  (~(get by yokes.state) agent)
     =/  is-running  ?~(running %| ?=(%& -.agent.u.running))
     =/  is-blocked  (~(has by blocked.state) agent)
+    ::  agent is running; deliver move normally
     ::
-    ?:  |(!is-running is-blocked)
-      =/  blocked=(qeu blocked-move)
-        =/  waiting  (~(get by blocked.state) agent)
-        =/  deals  (fall waiting *(qeu blocked-move))
-        =/  deal  [hen routes &+deal]
-        (~(put to deals) deal)
-      ::
-      %-  (slog leaf+"gall: not running {<agent>} yet, got {<-.deal>}" ~)
-      %_  mo-core
-        blocked.state  (~(put by blocked.state) agent blocked)
-      ==
-    (mo-apply agent routes deal)
+    ?.  |(!is-running is-blocked)
+      (mo-apply agent routes deal)
+    ::  %hood or %dojo must run; wake them up
+    ::
+    ?:  ?=(?(%hood %dojo) agent-name)
+      ~>  %slog.2^leaf/"gall: force load {<agent-name>}"
+      =/  bek=beak  [our q.beak.yoke da+now]
+      =/  rag  (mo-scry-agent-cage agent-name q.bek da+now)
+      ?:  ?=(%| -.rag)
+        ~>  %slog.2^leaf/"gall: force load {<agent-name>} failed"
+        (mean p.rag)
+      =.  mo-core  (mo-receive-core:cor dap bek p.rag)
+      ~>  %slog.2^leaf/"gall: force load {<agent-name>} succeeded"
+      (mo-apply agent routes deal)
+    ::
+    =/  blocked=(qeu blocked-move)
+      =/  waiting  (~(get by blocked.state) agent)
+      =/  deals  (fall waiting *(qeu blocked-move))
+      =/  deal  [hen routes &+deal]
+      (~(put to deals) deal)
+    ::
+    %-  (slog leaf+"gall: not running {<agent>} yet, got {<-.deal>}" ~)
+    %_  mo-core
+      blocked.state  (~(put by blocked.state) agent blocked)
+    ==
   ::  +mo-handle-ames-request: handle %ames request message.
   ::
   ++  mo-handle-ames-request

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -923,15 +923,15 @@
       (mo-apply agent routes deal)
     ::  %hood or %dojo must run; wake them up
     ::
-    ?:  ?=(?(%hood %dojo) agent-name)
-      ~>  %slog.2^leaf/"gall: force load {<agent-name>}"
-      =/  bek=beak  [our q.beak.yoke da+now]
-      =/  rag  (mo-scry-agent-cage agent-name q.bek da+now)
+    ?:  ?=(?(%hood %dojo) agent)
+      ~>  %slog.2^leaf/"gall: force load {<agent>}"
+      =/  bek=beak  [our %base da+now]
+      =/  rag  (mo-scry-agent-cage agent q.bek da+now)
       ?:  ?=(%| -.rag)
-        ~>  %slog.2^leaf/"gall: force load {<agent-name>} failed"
+        ~>  %slog.2^leaf/"gall: force load {<agent>} failed"
         (mean p.rag)
-      =.  mo-core  (mo-receive-core:cor dap bek p.rag)
-      ~>  %slog.2^leaf/"gall: force load {<agent-name>} succeeded"
+      =.  mo-core  (mo-receive-core agent bek p.rag)
+      ~>  %slog.2^leaf/"gall: force load {<agent>} succeeded"
       (mo-apply agent routes deal)
     ::
     =/  blocked=(qeu blocked-move)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -288,8 +288,9 @@
   ++  mo-core  .
   ++  mo-abed  |=(hun=duct mo-core(hen hun))
   ++  mo-abet  [(flop moves) gall-payload]
-  ++  mo-pass  |=(p=[wire note-arvo] mo-core(moves [[hen pass+p] moves]))
   ++  mo-give  |=(g=gift mo-core(moves [[hen give+g] moves]))
+  ++  mo-pass  |=(p=[wire note-arvo] mo-core(moves [[hen pass+p] moves]))
+  ++  mo-slip  |=(p=note-arvo mo-core(moves [[hen slip+p] moves]))
   ++  mo-past
     |=  =(list [wire note-arvo])
     ?~  list
@@ -741,6 +742,15 @@
     ?.  =(nonce.u.yoke i.t.wire)
       %-  (slog leaf+"gall: got old {<+<.sign-arvo>} for {<dap>}" ~)
       mo-core
+    ::  if agent must be running, revive all needed agents then apply
+    ::
+    ?:  ?&  ?=(%| -.agent.u.yoke)
+            ?=(?(%dojo %hood) dap)
+        ==
+      =.  mo-core  (mo-pass /nowhere %g %jolt %base %hood)
+      =.  mo-core  (mo-pass /nowhere %g %jolt %base %dojo)
+      (mo-pass use+wire %b %huck sign-arvo)
+    ::
     ?.  ?=([?(%gall %behn) %unto *] sign-arvo)
       ?:  ?=(%| -.agent.u.yoke)
         %-  (slog leaf+"gall: {<dap>} dozing, dropping {<+<.sign-arvo>}" ~)
@@ -921,26 +931,12 @@
     ::
     ?.  |(!is-running is-blocked)
       (mo-apply agent routes deal)
-    ::  if agent must be running, revive all needed agents and apply
+    ::  if agent must be running, revive all needed agents then apply
     ::
     ?:  ?=(?(%hood %dojo) agent)
-      |^  ^+  mo-core
-          =.  mo-core  (force-install %hood)
-          =.  mo-core  (force-install %dojo)
-          (mo-apply agent routes deal)
-      ::
-      ++  force-install
-        |=  dap=dude
-        ^+  mo-core
-        ~>  %slog.2^leaf/"gall: force load {<dap>}"
-        ~<  %slog.2^leaf/"gall: force load {<dap>} succeeded"
-        =/  bek=beak  [our %base da+now]
-        =/  rag  (mo-scry-agent-cage dap q.bek da+now)
-        ?:  ?=(%| -.rag)
-          ~>  %slog.2^leaf/"gall: force load {<dap>} failed"
-          (mean p.rag)
-        (mo-receive-core dap bek p.rag)
-      --
+      =.  mo-core  (mo-pass /nowhere %g %jolt %base %hood)
+      =.  mo-core  (mo-pass /nowhere %g %jolt %base %dojo)
+      (mo-slip %g %deal [ship our] agent deal)
     ::
     =/  blocked=(qeu blocked-move)
       =/  waiting  (~(get by blocked.state) agent)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -921,18 +921,26 @@
     ::
     ?.  |(!is-running is-blocked)
       (mo-apply agent routes deal)
-    ::  %hood or %dojo must run; wake them up
+    ::  if agent must be running, revive all needed agents and apply
     ::
     ?:  ?=(?(%hood %dojo) agent)
-      ~>  %slog.2^leaf/"gall: force load {<agent>}"
-      =/  bek=beak  [our %base da+now]
-      =/  rag  (mo-scry-agent-cage agent q.bek da+now)
-      ?:  ?=(%| -.rag)
-        ~>  %slog.2^leaf/"gall: force load {<agent>} failed"
-        (mean p.rag)
-      =.  mo-core  (mo-receive-core agent bek p.rag)
-      ~>  %slog.2^leaf/"gall: force load {<agent>} succeeded"
-      (mo-apply agent routes deal)
+      |^  ^+  mo-core
+          =.  mo-core  (force-install %hood)
+          =.  mo-core  (force-install %dojo)
+          (mo-apply agent routes deal)
+      ::
+      ++  force-install
+        |=  dap=dude
+        ^+  mo-core
+        ~>  %slog.2^leaf/"gall: force load {<dap>}"
+        ~<  %slog.2^leaf/"gall: force load {<dap>} succeeded"
+        =/  bek=beak  [our %base da+now]
+        =/  rag  (mo-scry-agent-cage dap q.bek da+now)
+        ?:  ?=(%| -.rag)
+          ~>  %slog.2^leaf/"gall: force load {<dap>} failed"
+          (mean p.rag)
+        (mo-receive-core dap bek p.rag)
+      --
     ::
     =/  blocked=(qeu blocked-move)
       =/  waiting  (~(get by blocked.state) agent)


### PR DESCRIPTION
This is a band-aid to work around the upgrade bug where sometimes `%base` agents fail to restart.  Upon receiving a move whose target is `%base` or `%dojo`, instead of enqueueing or dropping the move, force-start `%dojo` and `%hood` and then retry the move.

I've tested this by running `|pass [%g %idle %hood]` and `|pass [%g %idle %dojo]`.  Both cases work fine as far as I can tell.  Earlier versions of this code that didn't roundtrip through Arvo had subscription problems after the revival.  Note that the `/nowhere` wire is important to use with `%jolt` to ensure resulting `%onto` agent restart notifications don't crash Gall.

I've targeted this PR at master, since that's what I based this code off of.  Happy to retarget if needed.