### PR TITLE
gen: add +gall-nonces for reading all next nonces

### DIFF
--- a/pkg/arvo/gen/gall-nonces.hoon
+++ b/pkg/arvo/gen/gall-nonces.hoon
@@ -1,0 +1,11 @@
+::  +gall-nonces: print %gall agent subscription nonces, highest-last
+::
+:-  %say
+|=  [[now=@da eny=@uvJ bec=beak] ~ ~]
+:-  %noun
+^-  (list [dude:gall @ud])
+%+  sort
+  %~  tap  by
+  ~&  bec
+  .^((map dude:gall @ud) %gf /(scot %p p.bec)//(scot %da now))
+|=([[* a=@ud] [* b=@ud]] (lth a b))

--- a/pkg/arvo/gen/gall-nonces.hoon
+++ b/pkg/arvo/gen/gall-nonces.hoon
@@ -6,6 +6,5 @@
 ^-  (list [dude:gall @ud])
 %+  sort
   %~  tap  by
-  ~&  bec
   .^((map dude:gall @ud) %gf /(scot %p p.bec)//(scot %da now))
 |=([[* a=@ud] [* b=@ud]] (lth a b))


### PR DESCRIPTION
Shows the list of agent-nonce pairs in ascending-nonce order, so that the (supposedly) most interesting ones are always easily visible.