### PR TITLE
agentio: fix `+rest` typo, attempt 2

### DIFF
--- a/pkg/base-dev/lib/agentio.hoon
+++ b/pkg/base-dev/lib/agentio.hoon
@@ -66,7 +66,7 @@
   ::
   ++  rest
     |=  p=@da
-    (arvo %b %wait p)
+    (arvo %b %rest p)
   ::
   ++  warp
     |=  [wer=ship =riff:clay]


### PR DESCRIPTION
Original post:

> The current code in agentio.hoon has +rest as a copy-paste of +wait, and thus sending a %wait rather than a %rest to Behn.

It was easier to make a new PR to target next/arvo than to rebase (which had conflicts).