### PR TITLE
gall: %rake task to clean up dead %leave's

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1660,6 +1660,7 @@
         [%idle =dude]                                   ::  suspend agent
         [%nuke =dude]                                   ::  delete agent
         [%doff dude=(unit dude) ship=(unit ship)]       ::  kill subscriptions
+        [%rake dude=(unit dude) all=?]                  ::  reclaim old subs
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1792,14 +1792,24 @@
         $(subs t.subs)
       ::
       =/  dud=(set duct)
-        =/  mod  [%gall %use agent-name run-nonce.yoke %out 0 wire]
+        =/  mod=^wire
+          :*  %gall  %use
+              agent-name
+              run-nonce.yoke
+              %out
+              (scot %p p.dock)
+              q.dock
+              '0'
+              wire
+          ==
         %-  ~(rep by by-duct.ossuary.u.per)
-        |=  [[=duct @] out=(set duct)]
+        |=  [[=duct =bone] out=(set duct)]
         ^+  out
-        ?.  ?&  ?=([* [%gall %use @ @ %out ^] *] duct)
-                =(mod i.t.duct(i.t.t.t.t.t 0))
+        ?.  ?&  ?=([* [%gall %use @ @ %out @ @ @ *] *] duct)
+                =(mod i.t.duct(i.t.t.t.t.t.t.t '0'))
             ==
           out
+        ?:  (~(has in closing.u.per) bone)  out
         ~>  %slog.0^leaf+"gall: rake {<i.t.duct>}"
         (~(put in out) duct)
       ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -421,8 +421,20 @@
       (drop (bind (~(get by yokes.state) u.dude) (lead u.dude)))
     |-  ^+  mo-core
     ?~  apps  mo-core
-    =/  ap-core  (ap-yoke:ap:mo-core p.i.apps [~ our] q.i.apps)
+    =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
     $(apps t.apps, mo-core ap-abet:(ap-doff:ap-core ship))
+  ::  +mo-rake: send %cork's for old subscriptions if needed
+  ::
+  ++  mo-rake
+    |=  [dude=(unit dude) all=?]
+    ^+  mo-core
+    =/  apps=(list (pair term yoke))
+      ?~  dude  ~(tap by yokes.state)
+      (drop (bind (~(get by yokes.state) u.dude) (lead u.dude)))
+    |-  ^+  mo-core
+    ?~  apps  mo-core
+    =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
+    $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core all))
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1765,6 +1777,44 @@
       =?  ap-core  (gte 1 (~(got by boar.yoke) wyr dok))
         (ap-pass wyr %agent dok %leave ~)
       $(subs t.subs)
+    ::  +ap-rake: clean up the dead %leave's
+    ::
+    ++  ap-rake
+      |=  all=?
+      =/  subs  ~(tap in ~(key by boat.yoke))
+      |^  ^+  ap-core
+      ?~  subs  ap-core
+      =/  [=wire =dock]  i.subs
+      =/  non  (~(got by boar.yoke) wire dock)
+      ?:  &(!all =(0 non))
+        $(subs t.subs)
+      ?~  per=(scry-peer-state p.dock)
+        $(subs t.subs)
+      ::
+      =/  dud=(set duct)
+        =/  mod  [%gall %use agent-name run-nonce.yoke %out 0 wire]
+        %-  ~(rep by by-duct.ossuary.u.per)
+        |=  [[=duct @] out=(set duct)]
+        ^+  out
+        ?.  ?&  ?=([* [%gall %use @ @ %out ^] *] duct)
+                =(mod i.t.duct(i.t.t.t.t.t 0))
+            ==
+          out
+        ~>  %slog.0^leaf+"gall: rake {<i.t.duct>}"
+        (~(put in out) duct)
+      ::
+      %-  ap-move
+      (turn ~(tap in dud) |=(d=duct [+.d %pass -.d %a %cork p.dock]))
+      ::
+      ++  scry-peer-state
+        |=  her=ship
+        ~+  ^-  (unit peer-state:ames)
+        =/  sky  (rof [~ ~] %ax [our %$ da+now] /peers/(scot %p her))
+        ?:  |(?=(~ sky) ?=(~ u.sky))
+          ~
+        =/  sat  !<(ship-state:ames q.u.u.sky)
+        ?>(?=(%known -.sat) (some +.sat))
+      --
     ::  +ap-mule: run virtualized with intercepted scry, preserving type
     ::
     ::    Compare +mute and +mule.  Those pass through scry, which
@@ -1960,6 +2010,7 @@
       %idle  mo-abet:(mo-idle:mo-core dude.task)
       %nuke  mo-abet:(mo-nuke:mo-core dude.task)
       %doff  mo-abet:(mo-doff:mo-core +.task)
+      %rake  mo-abet:(mo-rake:mo-core +.task)
       %spew  mo-abet:(mo-spew:mo-core veb.task)
       %sift  mo-abet:(mo-sift:mo-core dudes.task)
       %trim  [~ gall-payload]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1793,14 +1793,9 @@
       ::
       =/  dud=(set duct)
         =/  mod=^wire
-          :*  %gall  %use
-              agent-name
-              run-nonce.yoke
-              %out
-              (scot %p p.dock)
-              q.dock
-              '0'
-              wire
+          :*  %gall  %use  agent-name  run-nonce.yoke
+              %out  (scot %p p.dock)  q.dock
+              '0'  wire
           ==
         %-  ~(rep by by-duct.ossuary.u.per)
         |=  [[=duct =bone] out=(set duct)]


### PR DESCRIPTION
This sends a `%cork` on any old subscription ducts, which should have been corked already but might not have been if a ship had been running a prerelease version of the gall request queue fix.  h/t @joemfb 

The "all" flag should only be set if you want the ship to try to kill an old subscription at sub-nonce zero.  If your ship didn't run with a particularly old version of the gall request queue fix, then if you set `all=&`, gall will end up creating an extra Ames flow (and hopefully cleaning it up, but better not to find out).