### PR TITLE
gall: when kicked, register %cork as outstanding

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -828,6 +828,10 @@
       ?-  -.ames-response
         %d  (mo-give %unto %raw-fact mark.ames-response noun.ames-response)
         %x  =.  mo-core  (mo-give %unto %kick ~)
+            =.  outstanding.state
+              =/  key  [[%sys wire] hen]
+              %+  ~(put by outstanding.state)  key
+              (~(put to (~(gut by outstanding.state) key ~)) %cork)
             (mo-pass [%sys wire] %a %cork ship)
       ==
     ::


### PR DESCRIPTION
When ames notifies us that our subscription has been kicked, we enqueue
a cork to clean up the flow. Unlike the %leave case, however, we were
not registering the cork in the queue of outstanding comms. We would
eventually get an ack, but not know what for, and erroneously inject
%poke-acks and %watch-acks.

Here we simply add a %cork entry to the queue before sending it.