### PR TITLE
ames: don't skip closing flows in +on-stir

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1484,10 +1484,9 @@
     =/  snds=(list (list [ship bone message-pump-state]))
       %+  turn  states
       |=  [=ship peer-state]
-      %+  murn  ~(tap by snd)
+      %+  turn  ~(tap by snd)
       |=  [=bone =message-pump-state]
-      ?:  (~(has in closing) bone)  ~
-      `[ship bone message-pump-state]
+      [ship bone message-pump-state]
     =/  next-wakes
       %+  turn  `(list [ship bone message-pump-state])`(zing snds)
       |=  [=ship =bone message-pump-state]


### PR DESCRIPTION
Yes, there is a global timer for closing flows, but all that does is
enqueue a cork message. +on-stir needs to set _pump_ timers for all
flows that might still have messages to send, which includes closing
flows.