### PR TITLE
gall: don't inject potentially-fake acks

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -825,7 +825,7 @@
         %poke      (mo-give %unto %poke-ack err)
         %leave     mo-core
         %cork      mo-core
-        %missing   (mo-give:(mo-give %unto %watch-ack err) %unto %poke-ack err)
+        %missing   ~>(%slog.[3 'gall: missing'] mo-core)
       ==
     ::
         [%ames %boon *]


### PR DESCRIPTION
We shouldn't be hitting this case anymore. Injecting events into agents
which they might not expect, and might not even be real, is bad.