### PR TITLE
ames: refactor %stir, %rest stale/wrong timers

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1475,44 +1475,40 @@
   ::
   ++  on-stir
     |=  arg=@t
-    =/  states=(list [ship peer-state])
-      %+  murn  ~(tap by peers.ames-state)
-      |=  [=ship =ship-state]
-      ^-  (unit [^ship peer-state])
-      ?.  ?=(%known -.ship-state)
-        ~
-      `[ship +.ship-state]
-    =/  snds=(list (list [ship bone message-pump-state]))
-      %+  turn  states
-      |=  [=ship peer-state]
-      %+  turn  ~(tap by snd)
-      |=  [=bone =message-pump-state]
-      [ship bone message-pump-state]
-    =/  next-wakes
-      %+  turn  `(list [ship bone message-pump-state])`(zing snds)
-      |=  [=ship =bone message-pump-state]
-      [ship bone next-wake.packet-pump-state]
-    =/  next-real-wakes=(list [=ship =bone =@da])
-      %+  murn  next-wakes
-      |=  [=ship =bone tym=(unit @da)]
-      ^-  (unit [^ship ^bone @da])
-      ?~(tym ~ `[ship bone u.tym])
-    =/  timers
-      %-  silt
-      ;;  (list [@da ^duct])
-      =<  q.q  %-  need  %-  need
-      (rof ~ %bx [[our %$ da+now] /debug/timers])
-    =/  to-stir
-      %+  skip  next-real-wakes
-      |=  [=ship =bone =@da]
-      (~(has in timers) [da `^duct`~[a+(make-pump-timer-wire ship bone) /ames]])
-    ~&  [%stirring to-stir]
-    |-  ^+  event-core
-    ?~  to-stir
-      event-core
-    =/  =wire  (make-pump-timer-wire [ship bone]:i.to-stir)
-    =.  event-core  (emit duct %pass wire %b %wait da.i.to-stir)
-    $(to-stir t.to-stir)
+    ^+  event-core
+    =/  want=(set [@da ^duct])
+      %-  ~(rep by peers.ames-state)
+      |=  [[who=ship s=ship-state] acc=(set [@da ^duct])]
+      ?.  ?=(%known -.s)  acc
+      %-  ~(rep by snd.+.s)
+      |=  [[b=bone m=message-pump-state] acc=_acc]
+      =*  tim  next-wake.packet-pump-state.m
+      ?~  tim  acc
+      %-  ~(put in acc)
+      [u.tim `^duct`~[ames+(make-pump-timer-wire who b) /ames]]
+    ::
+    =/  have
+      %-  ~(gas in *(set [@da ^duct]))
+      =/  tim
+        ;;  (list [@da ^duct])
+        =<  q.q  %-  need  %-  need
+        (rof ~ %bx [[our %$ da+now] /debug/timers])
+      (skim tim |=([@da hen=^duct] ?=([[%ames %pump *] *] hen)))
+    ::
+    ::  %wait on missing flows
+    ::
+    =.  event-core
+      %-  ~(rep in (~(dif in want) have))
+      |=  [[wen=@da hen=^duct] this=_event-core]
+      ?>  ?=([^ *] hen)
+      (emit:this ~[/ames] %pass t.i.hen %b %wait wen)
+    ::
+    ::  %rest on this bullshit
+    ::
+    %-  ~(rep in (~(dif in have) want))
+    |=  [[wen=@da hen=^duct] this=_event-core]
+    ?>  ?=([^ *] hen)
+    (emit:this t.hen %pass t.i.hen %b %rest wen)
   ::  +on-crud: handle event failure; print to dill
   ::
   ++  on-crud

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1469,7 +1469,7 @@
       =.  peer-core  (run-message-pump:peer-core i.bones %prod ~)
       $(bones t.bones)
     --
-  ::  +on-stir: start timers for any flow that lack them
+  ::  +on-stir: recover from timer desync, setting new timers as needed
   ::
   ::    .arg is unused, meant to ease future debug commands
   ::
@@ -1495,7 +1495,7 @@
         (rof ~ %bx [[our %$ da+now] /debug/timers])
       (skim tim |=([@da hen=^duct] ?=([[%ames %pump *] *] hen)))
     ::
-    ::  %wait on missing flows
+    ::  set timers for flows that should have one set but don't
     ::
     =.  event-core
       %-  ~(rep in (~(dif in want) have))
@@ -1503,7 +1503,7 @@
       ?>  ?=([^ *] hen)
       (emit:this ~[/ames] %pass t.i.hen %b %wait wen)
     ::
-    ::  %rest on this bullshit
+    ::  cancel timers for flows that have one set but shouldn't
     ::
     %-  ~(rep in (~(dif in have) want))
     |=  [[wen=@da hen=^duct] this=_event-core]


### PR DESCRIPTION
As a follow up to #5961. The previous implementation used the wrong duct, and didn't cancel stale or wrong pump timers, leading to their proliferation.

Per @belisarius222, this should also traverse %ames' state and recalculate `next-wake` for each flow (maybe under a `%hard` argument). I'll work to add that, but this is ready to go as is (tested on my ship, corrected timer issues introduced by the previous version).