### PR TITLE
gall: don't add duplicate nonce in +ap-nuke

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1229,7 +1229,7 @@
           [%give %kick ~(tap in inbound-paths) ~]~
         %+  turn  ~(tap by boat.yoke)
         |=  [[=wire =dock] ? =path]
-        [%pass (ap-nonce-wire wire dock) %agent dock %leave ~]
+        [%pass wire %agent dock %leave ~]
       =^  maybe-tang  ap-core  (ap-ingest ~ |.([will *agent]))
       ap-core
     ::  +ap-from-internal: internal move to move.


### PR DESCRIPTION
This gets added in +ap-handle-peers already.  This caused outgoing subscriptions to not get cleaned up properly.

Issue introduced in c2d77a5d.