### PR TITLE
eyre: look for lowercase last-event-id header

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1228,7 +1228,7 @@
       ::  the request may include a 'Last-Event-Id' header
       ::
       =/  maybe-last-event-id=(unit @ud)
-        ?~  maybe-raw-header=(get-header:http 'Last-Event-ID' header-list.request)
+        ?~  maybe-raw-header=(get-header:http 'last-event-id' header-list.request)
           ~
         (rush u.maybe-raw-header dum:ag)
       ::  flush events older than the passed in 'Last-Event-ID'


### PR DESCRIPTION
Eyre always gets passed request headers in lowercase, so we should search for
the lowercased version of the header.

Arguably `+get-header` should lowercase keys before comparing them, but that's
a more serious behavioral change.

(Notably browser-native EventSource clients don't generally make use of this header, which explains why this has lasted as long as it has. Userland implementations might though!)

ht @joemfb for catching this.