### PR TITLE
hoon: further explore ?#, fix bugs

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8987,9 +8987,9 @@
                          ref
                        [%atom %$ ~]
             [%atom *]  ref
-            [%cell *]  =+  ^$(skin skin.skin, ref p.ref)
-                       ?:  =(%void -)  %void
-                       (cell - ^$(skin ^skin.skin, ref q.ref))
+            [%cell *]  =/  lef  ^$(skin skin.skin, ref p.ref)
+                       =/  rig  ^$(skin ^skin.skin, ref q.ref)
+                       (fork (cell lef rig) (cell lef q.ref) (cell p.ref rig) ~)
             [%core *]  =+  ^$(skin skin.skin, ref p.ref)
                        ?:  =(%void -)  %void
                        ?.  =(%noun ^skin.skin)


### PR DESCRIPTION
This PR adds `?/` and `?\` as `?#`-based versions of `?-` and `?+`. It also fixes a bug in `+lose:ar` -- the combinatorial explosion turns out to be necessary. Opening as a draft for further discussion/exploration; I'm not sure how we'll want to stage `?#`-related changes, or if the performance implications here are too dire.