### PR TITLE
interface: full width images for notebook posts

### DIFF
--- a/pkg/interface/src/views/components/RemoteContent/index.tsx
+++ b/pkg/interface/src/views/components/RemoteContent/index.tsx
@@ -1,5 +1,5 @@
 import {
-  Box,
+  Box
 } from '@tlon/indigo-react';
 import React from 'react';
 import useSettingsState from '~/logic/state/settings';
@@ -103,7 +103,7 @@ function RemoteContentInner(props: RemoteContentProps) {
     return (
       <Box mt={1} mb={2} flexShrink={0}>
         <RemoteContentWrapper {...wrapperProps} noOp={transcluded} replaced>
-          <RemoteContentImageEmbed url={url} />
+          <RemoteContentImageEmbed url={url} stretch={tall} />
         </RemoteContentWrapper>
       </Box>
     );


### PR DESCRIPTION
Adds a prop (`stretch={tall}`) to allow images in notebook posts to fill the width of the post

<img width="1552" alt="Screen Shot 2022-08-31 at 6 11 00 PM" src="https://user-images.githubusercontent.com/4127151/187794375-c94b0aeb-5e8e-4269-a8d1-1e6fa6d7e29f.png">

Notes:
- Doesn't affect messages in Groups or DMs
