### PR TITLE
vere: add pier validation subcommand, sane

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1011,7 +1011,7 @@ _cw_info(c3_i argc, c3_c* argv[])
   c3_path_push(pax_u, ".urb");
   c3_path_push(pax_u, "log");
   u3_meta met_u;
-  u3_saga* log_u = u3_saga_open(pax_u, c3n, &met_u);
+  u3_saga* log_u = u3_saga_open(pax_u, FALSE, &met_u);
 
   fprintf(stderr,
           "\r\nurbit: %s at event %" PRIu64 "\r\n",
@@ -1059,7 +1059,7 @@ _cw_sane(c3_i argc, c3_c* argv[])
     c3_path_push(pax_u, "log");
 
     u3_meta met_u;
-    sag_u = u3_saga_open(pax_u, c3y, &met_u);
+    sag_u = u3_saga_open(pax_u, TRUE, &met_u);
 
     c3_path_pop(pax_u);
     c3_path_pop(pax_u);
@@ -1208,7 +1208,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   c3_path* const pax_u = c3_path_fv(3, u3_Host.dir_c, ".urb", "log");
   u3_meta        met_u;
   u3_saga*       log_u;
-  try_saga(log_u = u3_saga_open(pax_u, c3n, &met_u),
+  try_saga(log_u = u3_saga_open(pax_u, FALSE, &met_u),
            goto free_path,
            "failed to open event log at %s\r\n",
            c3_path_str(pax_u));

--- a/pkg/urbit/include/c/motes.h
+++ b/pkg/urbit/include/c/motes.h
@@ -979,6 +979,7 @@
 #   define c3__sail   c3_s4('s','a','i','l')
 #   define c3__same   c3_s4('s','a','m','e')
 #   define c3__sand   c3_s4('s','a','n','d')
+#   define c3__sane   c3_s4('s','a','n','e')
 #   define c3__sard   c3_s4('s','a','r','d')
 #   define c3__sav    c3_s3('s','a','v')
 #   define c3__save   c3_s4('s','a','v','e')

--- a/pkg/urbit/include/vere/saga.h
+++ b/pkg/urbit/include/vere/saga.h
@@ -96,21 +96,13 @@ u3_saga_new(const c3_path* const pax_u, const u3_meta* const met_u);
 //! Load an existing event log created with u3_saga_new().
 //!
 //! @param[in]  pax_u  Root directory of event log.
+//! @param[in]  san_o  If c3y, only open if full event log passes sanity check.
 //! @param[out] met_u  Pier metadata.
 //!
 //! @return NULL  Existing event log could not be opened.
 //! @return       Handle to open event log.
 u3_saga*
-u3_saga_open(const c3_path* const pax_u, u3_meta* const met_u);
-
-//! Validate an existing event log
-//!
-//! @param[in]  pax_u  Root directory of event log.
-//!
-//! @return 0  All epochs sane.
-//! @return    Non-zero status code indicating a problem with the log.
-c3_i
-u3_saga_sane(const c3_path* const pax_u);
+u3_saga_open(const c3_path* const pax_u, c3_o san_o, u3_meta* const met_u);
 
 //! Get the ID of the last committed event in an event log.
 //!

--- a/pkg/urbit/include/vere/saga.h
+++ b/pkg/urbit/include/vere/saga.h
@@ -112,6 +112,15 @@ u3_saga_new(const c3_path* const pax_u, const u3_meta* const met_u);
 u3_saga*
 u3_saga_open(const c3_path* const pax_u, u3_meta* const met_u);
 
+//! Validate an existing event log
+//!
+//! @param[in]  pax_u  Root directory of event log.
+//!
+//! @return 0  All epochs sane.
+//! @return    Non-zero status code indicating a problem with the log.
+c3_i
+u3_saga_sane(const c3_path* const pax_u);
+
 //! Get the ID of the last committed event in an event log.
 //!
 //! @param[in] log_u  Event log handle. Must not be NULL.

--- a/pkg/urbit/include/vere/saga.h
+++ b/pkg/urbit/include/vere/saga.h
@@ -102,7 +102,7 @@ u3_saga_new(const c3_path* const pax_u, const u3_meta* const met_u);
 //! @return NULL  Existing event log could not be opened.
 //! @return       Handle to open event log.
 u3_saga*
-u3_saga_open(const c3_path* const pax_u, c3_o san_o, u3_meta* const met_u);
+u3_saga_open(const c3_path* const pax_u, c3_t san_t, u3_meta* const met_u);
 
 //! Get the ID of the last committed event in an event log.
 //!

--- a/pkg/urbit/vere/saga.c
+++ b/pkg/urbit/vere/saga.c
@@ -235,32 +235,32 @@ _check_epoc_sanity(u3_epoc* const poc_u, c3_d* const nex_d, c3_l* const mug_l)
     if ( *mug_l != u3r_mug(u3A->roc) ) {
       u3l_log("saga: snapshot for epoch %s not contiguous: mug mismatch\n",
               u3_epoc_path_str(poc_u));
-      return FALSE;
+      return 0;
     }
   }
 
   //  read the next mug from the last event in the epoch
   if ( !u3_epoc_iter_open(poc_u, u3_epoc_last_commit(poc_u)) ) {
     u3l_log("saga: failed to open epoch event log\n");
-    return FALSE;
+    return 0;
   }
   c3_y*  dat_y;
   size_t dat_i;
   if ( !u3_epoc_iter_step(poc_u, &dat_y, &dat_i) ) {
     u3l_log("saga: failed to read last event\n");
     u3_epoc_iter_close(poc_u);
-    return FALSE;
+    return 0;
   }
   u3_epoc_iter_close(poc_u);
   if ( dat_i < 4 ) {
     u3l_log("saga: malformed event, too short for mug\n");
-    return FALSE;
+    return 0;
   }
   *mug_l = dat_y[0]
          | dat_y[1] << 8
          | dat_y[2] << 16
          | dat_y[3] << 24;
-  return TRUE;
+  return 1;
 }
 
 static c3_t
@@ -518,7 +518,7 @@ u3_saga_open(const c3_path* const pax_u, c3_t san_t, u3_meta* const met_u)
   try_list(log_u->epo_u.lis_u = c3_list_init(), goto free_dir_entries);
   u3_epoc *poc_u;
   c3_w* lif_w = &met_u->lif_w;
-  c3_t  pas_t = TRUE;
+  c3_t  pas_t = 1;
   c3_d  nex_d = 0;
   c3_l  mug_l = 0;
   for ( size_t idx_i = 0; idx_i < ent_i; idx_i++ ) {

--- a/pkg/urbit/vere/saga.c
+++ b/pkg/urbit/vere/saga.c
@@ -209,12 +209,8 @@ _cmp_epocs(const void* lef_v, const void* rih_v)
   return len_i == ren_i ? strcmp(lef_c, rih_c) : len_i - ren_i;
 }
 
-static c3_o
-_check_epoc_sanity(      u3_epoc* poc_u,
-                         c3_path* pax_u,
-                   const c3_c*    ent_c,
-                         c3_d*    nex_d,
-                         c3_l*    mex_l)
+static c3_t
+_check_epoc_sanity(u3_epoc* const poc_u, c3_d* const nex_d, c3_l* const mug_l)
 {
   //  check epoch's event range for contiguousness with earlier epochs.
   //  first epoch may start at arbitrary event nr, so we don't check it.
@@ -223,49 +219,48 @@ _check_epoc_sanity(      u3_epoc* poc_u,
     u3l_log("saga: snapshot for epoch %s not contiguous: "
             "expected first event of %" PRIu64 ", got %" PRIu64 "\n",
             u3_epoc_path_str(poc_u), *nex_d, fir_d);
-    return c3n;
+    return 0;
   }
   *nex_d = u3_epoc_last_commit(poc_u) + 1;
 
   //  load the snapshot so we can validate its mug
-  if ( 0 != *mex_l ) {
+  if ( 0 != *mug_l ) {
     //NOTE  careful, will clobber all existing noun references!
-    c3_path_push(pax_u, ent_c);
-    //TODO  want _boot_from_epoc_snapshot but it ends up crashing in events.c
+    //  we want to use _boot_from_epoc_snapshot here but the boot logic is
+    //  fragile and doesn't play nice with what we're doing here.
     u3m_init();
-    u3e_load(c3_path_str(pax_u));
+    u3e_load(u3_epoc_path_str(poc_u));
     u3m_pave(c3n);
-    c3_path_pop(pax_u);
 
-    if ( *mex_l != u3r_mug(u3A->roc) ) {
+    if ( *mug_l != u3r_mug(u3A->roc) ) {
       u3l_log("saga: snapshot for epoch %s not contiguous: mug mismatch\n",
               u3_epoc_path_str(poc_u));
-      return c3n;
+      return FALSE;
     }
   }
 
   //  read the next mug from the last event in the epoch
   if ( !u3_epoc_iter_open(poc_u, u3_epoc_last_commit(poc_u)) ) {
     u3l_log("saga: failed to open epoch event log\n");
-    return c3n;
+    return FALSE;
   }
   c3_y*  dat_y;
   size_t dat_i;
   if ( !u3_epoc_iter_step(poc_u, &dat_y, &dat_i) ) {
     u3l_log("saga: failed to read last event\n");
     u3_epoc_iter_close(poc_u);
-    return c3n;
+    return FALSE;
   }
   u3_epoc_iter_close(poc_u);
   if ( dat_i < 4 ) {
     u3l_log("saga: malformed event, too short for mug\n");
-    return c3n;
+    return FALSE;
   }
-  *mex_l = dat_y[0]
+  *mug_l = dat_y[0]
          | dat_y[1] << 8
          | dat_y[2] << 16
          | dat_y[3] << 24;
-  return c3y;
+  return TRUE;
 }
 
 static c3_t
@@ -472,7 +467,7 @@ succeed:
 }
 
 u3_saga*
-u3_saga_open(const c3_path* const pax_u, c3_o san_o, u3_meta* const met_u)
+u3_saga_open(const c3_path* const pax_u, c3_t san_t, u3_meta* const met_u)
 {
   u3_saga* log_u = c3_calloc(sizeof(*log_u));
   if ( !(log_u->pax_u = c3_path_fp(pax_u)) ) {
@@ -523,17 +518,16 @@ u3_saga_open(const c3_path* const pax_u, c3_o san_o, u3_meta* const met_u)
   try_list(log_u->epo_u.lis_u = c3_list_init(), goto free_dir_entries);
   u3_epoc *poc_u;
   c3_w* lif_w = &met_u->lif_w;
-  c3_o  pas_o = c3y;
+  c3_t  pas_t = TRUE;
   c3_d  nex_d = 0;
-  c3_l  mex_l = 0;
+  c3_l  mug_l = 0;
   for ( size_t idx_i = 0; idx_i < ent_i; idx_i++ ) {
     c3_path_push(log_u->pax_u, ent_c[idx_i]);
     try_epoc(poc_u = u3_epoc_open(log_u->pax_u, lif_w), goto free_dir_entries);
     c3_path_pop(log_u->pax_u);
 
-    if ( c3y == san_o ) {
-      pas_o = _check_epoc_sanity(
-        poc_u, log_u->pax_u, ent_c[idx_i], &nex_d, &mex_l);
+    if ( san_t ) {
+      pas_t = _check_epoc_sanity(poc_u, &nex_d, &mug_l);
     }
 
     c3_list_pushb(log_u->epo_u.lis_u, poc_u, epo_siz_i);
@@ -541,7 +535,7 @@ u3_saga_open(const c3_path* const pax_u, c3_o san_o, u3_meta* const met_u)
     if ( lif_w ) {
       lif_w = NULL;
     }
-    if ( c3n == pas_o ) {
+    if ( !pas_t ) {
       goto free_dir_entries;
     }
   }

--- a/pkg/urbit/vere/saga.c
+++ b/pkg/urbit/vere/saga.c
@@ -375,7 +375,7 @@ succeed:
 }
 
 u3_saga*
-u3_saga_open(const c3_path* const pax_u, u3_meta* const met_u)
+_saga_open(const c3_path* const pax_u, u3_meta* const met_u, c3_i* san_i)
 {
   u3_saga* log_u = c3_calloc(sizeof(*log_u));
   if ( !(log_u->pax_u = c3_path_fp(pax_u)) ) {
@@ -424,16 +424,82 @@ u3_saga_open(const c3_path* const pax_u, u3_meta* const met_u)
   }
 
   try_list(log_u->epo_u.lis_u = c3_list_init(), goto free_dir_entries);
-  u3_epoc *poc_u, *pre_u;
+  u3_epoc *poc_u;
   c3_w* lif_w = &met_u->lif_w;
+  c3_d  nex_d = 0;
+  c3_l  mex_l = 0;
   for ( size_t idx_i = 0; idx_i < ent_i; idx_i++ ) {
     c3_path_push(log_u->pax_u, ent_c[idx_i]);
     try_epoc(poc_u = u3_epoc_open(log_u->pax_u, lif_w), goto free_dir_entries);
     c3_path_pop(log_u->pax_u);
+
+    if ( NULL != san_i ) {
+      //  check epoch's event range for contiguousness with earlier epochs.
+      //  first epoch may start at arbitrary event nr, so we don't check it.
+      //
+      c3_d fir_d = u3_epoc_first_commit(poc_u);
+      if ( (0 != nex_d) && (nex_d != fir_d) ) {
+        u3l_log("sane: epoch snapshot not contiguous: "
+                "expected %" PRIu64 ", got %" PRIu64 ", in %s\n",
+                nex_d, fir_d, ent_c[idx_i]);
+        *san_i = 1;
+        goto next;
+      }
+      nex_d = u3_epoc_last_commit(poc_u) + 1;
+
+      //  load the snapshot so we can validate its mug
+      //
+      if ( 0 != mex_l ) {
+        //NOTE  careful, will clobber all existing noun references!
+        c3_path_push(log_u->pax_u, ent_c[idx_i]);
+        u3m_init();
+        u3e_load(c3_path_str(log_u->pax_u));
+        u3m_pave(c3n);
+        c3_path_pop(log_u->pax_u);
+
+        if ( mex_l != u3r_mug(u3A->roc) ) {
+          u3l_log("sane: epoch snapshot not contiguous, mug mismatch in %s\n",
+                  ent_c[idx_i]);
+          *san_i = 2;
+          goto next;
+        }
+      }
+
+      //  read the next mug from the last event in the epoch
+      //
+      if ( !u3_epoc_iter_open(poc_u, u3_epoc_last_commit(poc_u)) ) {
+        u3l_log("sane: failed to open epoch event log\n");
+        *san_i = 3;
+        goto next;
+      }
+      c3_y*  dat_y;
+      size_t dat_i;
+      if ( !u3_epoc_iter_step(poc_u, &dat_y, &dat_i) ) {
+        u3l_log("sane: failed to read last event\n");
+        *san_i = 4;
+        u3_epoc_iter_close(poc_u);
+        goto next;
+      }
+      u3_epoc_iter_close(poc_u);
+      if ( dat_i < 4 ) {
+        u3l_log("sane: strange event, too short\n");
+        *san_i = 5;
+        goto next;
+      }
+      mex_l = dat_y[0]
+            | dat_y[1] << 8
+            | dat_y[2] << 16
+            | dat_y[3] << 24;
+    }
+
+next:
     c3_list_pushb(log_u->epo_u.lis_u, poc_u, epo_siz_i);
     c3_free(poc_u);
     if ( lif_w ) {
       lif_w = NULL;
+    }
+    if ( NULL != san_i && 0 != *san_i ) {
+      break;
     }
   }
 
@@ -454,6 +520,21 @@ free_event_log:
 
 succeed:
   return log_u;
+}
+
+u3_saga*
+u3_saga_open(const c3_path* const pax_u, u3_meta* const met_u)
+{
+  return _saga_open(pax_u, met_u, NULL);
+}
+
+c3_i
+u3_saga_sane(const c3_path* const pax_u)
+{
+  u3_meta met_u;
+  c3_i    san_i = 0;
+  _saga_open(pax_u, &met_u, &san_i);
+  return san_i;
 }
 
 c3_d

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -976,7 +976,7 @@ u3_mars_init(c3_c* dir_c, u3_moat* inn_u, u3_mojo* out_u, c3_d eve_d)
       goto free_mars;
     }
 
-    try_saga(mar_u->log_u = u3_saga_open(dir_u, &mar_u->met_u),
+    try_saga(mar_u->log_u = u3_saga_open(dir_u, c3n, &mar_u->met_u),
              goto free_mars,
              "failed to open event log at %s",
              c3_path_str(dir_u));


### PR DESCRIPTION
There are several ways in which a pier (here, primarily its event log)
must be sane:
- At least the latest epoch directory must exist.
- All epoch directories together must form a contiguous sequence.
- The mug of an epoch's snapshot must match the mug of the last event of
  the preceding epoch.
- The snapshots must be usable.

Since `u3_saga_open` already traverses all the epochs, we add conditional
validation logic to it. A case may be made that this validation needs to
run always on-startup. The validation logic makes sure the above
invariants are maintained, though as currently implemented it only
checks the very latest snapshot. We may or may not want to check every single snapshot contained within the pier this way.

Existing `u3_saga_open` callsites remain unchanged. We simply add a
separate `u3_saga_sane` and hook it up to the same logic under the hood.
It returns a status code, where non-zero values indicate insanity. The
program exits with this status code, for easier programmatic
sanity-checking.