### PR TITLE
hoon: use static nock formulas for boot and virtualization

### DIFF
--- a/pkg/arvo/gen/solid.hoon
+++ b/pkg/arvo/gen/solid.hoon
@@ -77,10 +77,8 @@
   ~&  %solid-double-loaded
   =/  whole-formula
     =<  +
-    .*  0
-    :+  %7
-      compiler-formula
-    [%9 2 %10 [6 %1 %noun whole-src] [%0 1]]
+    .*  [%noun whole-src]
+    [%8 compiler-formula [%9 2 %10 [6 %0 3] [%0 2]]]
   ~&  %solid-double-compiled
   whole-formula
 ::
@@ -100,24 +98,19 @@
   |=  [ovo=ovum ken=*]
   [~ (slum ken [now ovo])]
 ::
-::  kernel-formula
+::  boot-two: startup formula
 ::
 ::    We evaluate :arvo-formula (for jet registration),
 ::    then ignore the result and produce .installed
 ::
-=/  kernel-formula
-  [%7 arvo-formula %1 installed]
-::
-::  boot-two: startup formula
-::
 =/  boot-two
-  =>  [kernel-formula=** main-sequence=**]
-  !=  [.*(0 kernel-formula) main-sequence]
+  =>  *[arvo-formula=^ installed=^ tale=*]
+  !=  =+(.*(0 arvo-formula) [installed tale])
 ::
 ::  boot-ova
 ::
 =/  boot-ova=(list)
-  [aeon:eden:part boot-two kernel-formula ~]
+  [aeon:eden:part boot-two arvo-formula installed ~]
 ::
 ::  a pill is a 3-tuple of event-lists: [boot kernel userspace]
 ::

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -738,7 +738,7 @@
       ?@  epic  arvo
       %=  $
         epic  +.epic
-        arvo  .*(arvo [%9 2 %10 [6 %1 -.epic] %0 1])
+        arvo  .*([arvo -.epic] [%9 2 %10 [6 %0 3] %0 2])
       ==
     ::
     ::  +boot: event 2: bootstrap a kernel from source
@@ -773,7 +773,7 @@
       ::
       ~>  %slog.[0 leaf+"1-c (compiling compiler, wait a few minutes)"]
       =/  compiler-tool
-        .*(compiler-gate [%9 2 %10 [6 %1 noun/hoon.log] %0 1])
+        .*([compiler-gate noun/hoon.log] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  switch to the second-generation compiler.  we want to be
       ::  able to generate matching reflection nouns even if the
@@ -781,7 +781,7 @@
       ::  generate last-generation spans for `!>`, etc.
       ::
       ~>  %slog.[0 leaf+"1-d"]
-      =.  compiler-gate  .*(0 +:compiler-tool)
+      =.  compiler-gate  .*(0 +.compiler-tool)
       ::
       ::  get the span (type) of the kernel core, which is the context
       ::  of the compiler gate.  we just compiled the compiler,
@@ -791,18 +791,18 @@
       ::
       ~>  %slog.[0 leaf+"1-e"]
       =/  kernel-span
-        -:.*(compiler-gate [%9 2 %10 [6 %1 [-.compiler-tool '+>']] %0 1])
+        -:.*([compiler-gate -.compiler-tool '+>'] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  compile the arvo source against the kernel core.
       ::
       ~>  %slog.[0 leaf+"1-f"]
       =/  kernel-tool
-        .*(compiler-gate [%9 2 %10 [6 %1 [kernel-span arvo.log]] %0 1])
+        .*([compiler-gate kernel-span arvo.log] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  create the arvo kernel, whose subject is the kernel core.
       ::
       ~>  %slog.[0 leaf+"1-g"]
-      [.*(+>:compiler-gate +:kernel-tool) epic.log]
+      [.*(+>.compiler-gate +.kernel-tool) epic.log]
     --
   ::
   ::  |adapt

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6245,14 +6245,14 @@
 ++  mure
   |=  tap=(trap)
   ^-  (unit)
-  =/  ton  (mink [tap %9 2 %0 1] |=((pair) ``.*(~ [%12 1+p 1+q])))
+  =/  ton  (mink [tap %9 2 %0 1] |=(a=^ ``.*(a [%12 [%0 2] %0 3])))
   ?.(?=(%0 -.ton) ~ `product.ton)
 ::  +mute: untyped virtual
 ::
 ++  mute
   |=  tap=(trap)
   ^-  (each * (list tank))
-  =/  ton  (mock [tap %9 2 %0 1] |=((pair) ``.*(~ [%12 1+p 1+q])))
+  =/  ton  (mock [tap %9 2 %0 1] |=(a=^ ``.*(a [%12 [%0 2] %0 3])))
   ?-  -.ton
     %0  [%& p.ton]
   ::
@@ -6265,9 +6265,8 @@
 ::
 ++  slum
   ~/  %slum
-  |=  [gat=* sam=*]
-  ^-  *
-  .*(gat [%9 2 %10 [6 %1 sam] %0 1])
+  |=  sub=[gat=* sam=*]
+  .*(sub [%9 2 %10 [6 %0 3] %0 2])
 ::  +soft: virtual clam
 ::
 ++  soft

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11410,13 +11410,12 @@
   ==
 ::
 ++  slew                                                ::  get axis in vase
-  |=  [axe=@ vax=vase]  ^-  (unit vase)
-  ?.  |-  ^-  ?
-      ?:  =(1 axe)  &
-      ?.  ?=(^ q.vax)  |
-      $(axe (mas axe), q.vax .*(q.vax [0 (cap axe)]))
-    ~
-  `[(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]
+  |=  [axe=@ vax=vase]
+  =/  typ  |.  (~(peek ut p.vax) %free axe)
+  |-  ^-  (unit vase)
+  ?:  =(1 axe)  `[$:typ q.vax]
+  ?@  q.vax     ~
+  $(axe (mas axe), q.vax ?-((cap axe) %2 -.q.vax, %3 +.q.vax))
 ::
 ++  slim                                                ::  identical to seer?
   |=  old=vise  ^-  vase


### PR DESCRIPTION
This PR cleans up the boot formulas, pill generators, and various virtualization apis, making them avoid unnecessary variation in the nock formulas they use. This avoids pressure on the bytecode compiler and cache, and is just generally more correct. @frodwith has been after me to clean this sort of thing up for a long time. (The change to `+slot` is probably spurious, depending on the precise behavior of an interpreter.)

These changes may help @jtobin with some of his caching work.

I've applied to this to a running ship and tested the apis in question, built the relevant pill types and successfully booted from them all.

/cc @eamsden 