### PR TITLE
dojo dir validation: %ct scry at case da+now if imaginary case 0

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -562,15 +562,16 @@
             ((dy-cast (list cable:clay) !>(*(list cable:clay))) q.cay)
           ==
         ::
-            %dir  =+  ^=  pax  ^-  path
+            %dir  =+  ^=  bem  ^-  beam
+                      %-  need  %-  de-beam
                       =+  pax=((dy-cast path !>(*path)) q.cay)
                       ?:  ?=(~ pax)  ~[(scot %p our.hid) %base '0']
                       ?:  ?=([@ ~] pax)  ~[i.pax %base '0']
                       ?:  ?=([@ @ ~] pax)  ~[i.pax i.t.pax '0']
                       pax
-                  ?:  =(~ .^((list path) %ct pax))
+                  ?:  =(~ .^((list path) %ct (en-beam he-beam(dir bem))))
                     +(..dy (he-diff %tan 'dojo: dir does not exist' ~))
-                  =.  dir  (need (de-beam pax))
+                  =.  dir  bem
                   =-  +>(..dy (he-diff %tan - ~))
                   rose+[" " `~]^~[leaf+"=%" (smyt (en-beam he-beak s.dir))]
         ==


### PR DESCRIPTION
PR #5840 mostly fixed #1559, but introduced a new bug. before, you could safely `=dir` into a desk without a case, and it would use the nonexistent case `ud+0` as the beam for dojo state, and switch that out for da+now whenever it tries to resolve the current path. but this check causes it to fail, because `ud+0` is a nonexistent case. this uses he-beam to transform the beam in the conditional to see if the case is 0, and if it is, changes the case to da+now before it scries