### PR TITLE
http-api: authenticate doesn't enforce insecure connections

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -142,7 +142,7 @@ export class Urbit {
     code,
     verbose = false,
   }: AuthenticationInterface) {
-    const airlock = new Urbit(`http://${url}`, code);
+    const airlock = new Urbit(url.startsWith('http') ? url : `http://${url}, code);
     airlock.verbose = verbose;
     airlock.ship = ship;
     await airlock.connect();


### PR DESCRIPTION
Instead of forcing people to connect over http://, fall back gracefully to http if no protocol is given.

This is part of a fix for an issue where external (non-hosted-on-ship) clients can't use this method at all, since SameSite cookies need to be secure as per https://web.dev/samesite-cookies-explained/#samesite=none-must-be-secure. 

We also don't send SameSite nor Secure flags at all, so it defaults to `SameSite=Lax`. I don't know what to do about that part! If those are added to set-cookie in Eyre, it basically means non-HTTPS Urbit ships can't connect to not-hosted-on-ship clients; if those aren't, then Chromium-based external clients have to monkey patch incoming headers to pretend we're meeting the new spec.

See https://datatracker.ietf.org/doc/html/draft-west-cookie-incrementalism-00 for applicable spec.