### PR TITLE
http-api: If scry fails, return reject response

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -545,7 +545,12 @@ export class Urbit {
     const response = await fetch(
       `${this.url}/~/scry/${app}${path}.json`,
       this.fetchOptions
-    );
+    )
+
+    if (!response.ok) {
+      return Promise.reject(response);
+    }
+
     return await response.json();
   }
 


### PR DESCRIPTION
Will allow us to handle rejections more gracefully.