### PR TITLE
garden: fix broken treaty JSON

### DIFF
--- a/pkg/garden/lib/treaty.hoon
+++ b/pkg/garden/lib/treaty.hoon
@@ -27,7 +27,6 @@
       %da   s+(scot %da p.c)
       %tas  s+(scot %tas p.c)  
       %ud   (numb p.c)
-      %uv   s+(scot %uv p.c)
     ==
   ++  foreign-desk
     |=  [s=^ship =desk]


### PR DESCRIPTION
For some reason, a %uv case was added to the JSON serialiser for $case. $case has no such case in the union, and so this does not make sense.

