### PR TITLE
Don't print a stack trace for `read-at-aeon-fail`

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1,5 +1,4 @@
 ::  clay (4c), revision control
-!:
 ::  The way to understand Clay is to take it section-by-section:
 ::
 ::  - Data structures.  You *must* start here; make sure you understand

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4170,7 +4170,6 @@
         [~ ..park]
       ::  virtualize to catch and produce deterministic failures
       ::
-      !:
       |^  =/  res  (mule |.(read))
           ?:  ?=(%& -.res)  p.res
           %.  [[~ ~] ..park]


### PR DESCRIPTION
We shouldn't get a clay stack trace for read-at-aeon-fail because that gives us miles of clay stack trace whenever hoon compilation fails