### PR TITLE
u3: add overflow checks to u3r_met()

### DIFF
--- a/pkg/urbit/include/noun/retrieve.h
+++ b/pkg/urbit/include/noun/retrieve.h
@@ -304,6 +304,7 @@
       **   (1 << a_y).
       **
       **   For example, (a_y == 3) returns the size in bytes.
+      **   NB: (a_y) must be < 37.
       */
         c3_w
         u3r_met(c3_y    a_y,

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1061,10 +1061,7 @@ u3r_met(c3_y  a_y,
         */
         c3_w bif_w, col_w;
 
-        //  .=  35          (add 32 (dec (bex 2))))
-        //  .=  0x7ff.fffe  (rsh [0 5] (sub (bex 32) 35)))
-        //
-        if ( gal_w > 0x7fffffe ) {
+        if ( gal_w > ((UINT32_MAX - 35) >> 5) ) {
           return u3m_bail(c3__fail);
         }
 

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1023,6 +1023,7 @@ u3r_hext(u3_noun  a,
 **   (1 << a_y).
 **
 **   For example, (a_y == 3) returns the size in bytes.
+**   NB: (a_y) must be < 37.
 */
 c3_w
 u3r_met(c3_y  a_y,

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1060,8 +1060,15 @@ u3r_met(c3_y  a_y,
         //
         c3_w bif_w = (gal_w << 5) + c3_bits_word(daz_w) + ((1 << a_y) - 1);
 
+        if ( bif_w < gal_w ) {
+          return u3m_bail(c3__fail);
+        }
+
         return bif_w >> a_y;
       }
+
+      STATIC_ASSERT((UINT32_MAX > ((c3_d)u3a_maximum << 2)),
+                    "met overflow");
 
       case 3: return (gal_w << 2) + ((c3_bits_word(daz_w) +  7) >> 3);
 

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1080,6 +1080,10 @@ u3r_met(c3_y  a_y,
       default: {
         c3_y gow_y = (a_y - 5);
 
+        if ( gow_y > 31 ) {
+          return u3m_bail(c3__fail);
+        }
+
         return ((gal_w + 1) + ((1 << gow_y) - 1)) >> gow_y;
       }
     }

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1056,9 +1056,10 @@ u3r_met(c3_y  a_y,
       case 0:
       case 1:
       case 2: {
-        //  number of bits in [b], rounded up
-        //
-        c3_w bif_w = (gal_w << 5) + c3_bits_word(daz_w) + ((1 << a_y) - 1);
+        /* col_w: number of bits in (daz_w)
+        ** bif_w: number of bits in (b)
+        */
+        c3_w bif_w, col_w;
 
         //  .=  35          (add 32 (dec (bex 2))))
         //  .=  0x7ff.fffe  (rsh [0 5] (sub (bex 32) 35)))
@@ -1067,7 +1068,10 @@ u3r_met(c3_y  a_y,
           return u3m_bail(c3__fail);
         }
 
-        return bif_w >> a_y;
+        col_w = c3_bits_word(daz_w);
+        bif_w = col_w + (gal_w << 5);
+
+        return (bif_w + ((1 << a_y) - 1)) >> a_y;
       }
 
       STATIC_ASSERT((UINT32_MAX > ((c3_d)u3a_maximum << 2)),

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1025,8 +1025,8 @@ u3r_hext(u3_noun  a,
 **   For example, (a_y == 3) returns the size in bytes.
 */
 c3_w
-u3r_met(c3_y    a_y,
-          u3_atom b)
+u3r_met(c3_y  a_y,
+        u3_atom b)
 {
   c3_assert(u3_none != b);
   c3_assert(_(u3a_is_atom(b)));
@@ -1056,24 +1056,17 @@ u3r_met(c3_y    a_y,
       case 0:
       case 1:
       case 2: {
-        /* col_w: number of bits in (daz_w)
-        ** bif_w: number of bits in (b)
-        */
-        c3_w bif_w, col_w;
+        //  number of bits in [b], rounded up
+        //
+        c3_w bif_w = (gal_w << 5) + c3_bits_word(daz_w) + ((1 << a_y) - 1);
 
-        col_w = c3_bits_word(daz_w);
-        bif_w = col_w + (gal_w << 5);
+        return bif_w >> a_y;
+      }
 
-        return (bif_w + ((1 << a_y) - 1)) >> a_y;
-      }
-      case 3: {
-        return  (gal_w << 2)
-              + ((daz_w >> 24) ? 4 : (daz_w >> 16) ? 3 : (daz_w >> 8) ? 2 : 1);
-      }
-      case 4: {
-        return  (gal_w << 1)
-              + ((daz_w >> 16) ? 2 : 1);
-      }
+      case 3: return (gal_w << 2) + ((c3_bits_word(daz_w) +  7) >> 3);
+
+      case 4: return (gal_w << 1) + ((c3_bits_word(daz_w) + 15) >> 4);
+
       default: {
         c3_y gow_y = (a_y - 5);
 

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1060,7 +1060,10 @@ u3r_met(c3_y  a_y,
         //
         c3_w bif_w = (gal_w << 5) + c3_bits_word(daz_w) + ((1 << a_y) - 1);
 
-        if ( bif_w < gal_w ) {
+        //  .=  35          (add 32 (dec (bex 2))))
+        //  .=  0x7ff.fffe  (rsh [0 5] (sub (bex 32) 35)))
+        //
+        if ( gal_w > 0x7fffffe ) {
           return u3m_bail(c3__fail);
         }
 

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1081,10 +1081,6 @@ u3r_met(c3_y  a_y,
       default: {
         c3_y gow_y = (a_y - 5);
 
-        if ( gow_y > 31 ) {
-          return u3m_bail(c3__fail);
-        }
-
         return ((gal_w + 1) + ((1 << gow_y) - 1)) >> gow_y;
       }
     }

--- a/pkg/urbit/noun/retrieve.c
+++ b/pkg/urbit/noun/retrieve.c
@@ -1683,9 +1683,7 @@ u3r_mug_words(const c3_w* key_w, c3_w len_w)
     c3_w gal_w = len_w - 1;
     c3_w daz_w = key_w[gal_w];
 
-    byt_w = (gal_w << 2)
-            + ((daz_w >> 24) ? 4 : (daz_w >> 16) ? 3 : (daz_w >> 8) ? 2 : 1);
-
+    byt_w = (gal_w << 2) + ((c3_bits_word(daz_w) + 7) >> 3);
   }
 
   //  XX: assumes little-endian


### PR DESCRIPTION
This PR adds overflow checks (compile time where possible, runtime where not) to the atom measurement function `u3r_met()`. To offset the cost, it also removes so unnecessary branches. These checks could elided if `u3r_met()` returned `c3_d` instead of `c3_w` -- that change should be made, but it'll be more invasive (and have implications for allocation interfaces, which are often driven with measured values).