### PR TITLE
c3,u3: read() and write() to completion

### DIFF
--- a/pkg/urbit/c/defs.c
+++ b/pkg/urbit/c/defs.c
@@ -1,0 +1,9 @@
+/// @file defs.c
+
+#include "c/defs.h"
+
+extern inline ssize_t
+c3_read(c3_i fd_i, void* const data_v, const size_t data_len_i);
+
+extern inline ssize_t
+c3_write(c3_i fd_i, const void* const data_v, const size_t data_len_i);

--- a/pkg/urbit/c/defs.c
+++ b/pkg/urbit/c/defs.c
@@ -2,8 +2,83 @@
 
 #include "c/defs.h"
 
-extern inline ssize_t
-c3_read(c3_i fd_i, void* const data_v, const size_t data_len_i);
+ssize_t
+c3_read(c3_i fd_i, void* const data_v, const size_t data_len_i)
+{
+  static const size_t max_attempts_i    = 100;
+  size_t              attempts_i        = 0;
+  c3_y*               ptr_y             = data_v;
+  ssize_t             bytes_remaining_i = data_len_i;
 
-extern inline ssize_t
-c3_write(c3_i fd_i, const void* const data_v, const size_t data_len_i);
+  off_t cur_offset_i = lseek(fd_i, 0, SEEK_CUR);
+  if ( cur_offset_i < 0 ) {
+    return -errno;
+  }
+
+  do {
+    attempts_i++;
+    ssize_t bytes_read_i = read(fd_i, ptr_y, bytes_remaining_i);
+    if ( -1 == bytes_read_i ) {
+      if ( (EINTR == errno || EAGAIN == errno || EWOULDBLOCK == errno)
+           && attempts_i <= max_attempts_i )
+      {
+        // From the read(2) man page: "On error, -1 is returned, and errno
+        // is set to indicate the error. In this case, it is left
+        // unspecified whether the file position (if any) changes."
+        //
+        // This means that we have to restore the file cursor to the
+        // position that it was at immediately before the call to read()
+        // that failed.
+        if ( lseek(fd_i, SEEK_SET, cur_offset_i) < 0 ) {
+          return -errno;
+        }
+        continue;
+      }
+      else {
+        return -errno;
+      }
+    }
+    else if ( 0 == bytes_read_i ) {
+      break;
+    }
+    else {
+      ptr_y += bytes_read_i;
+      bytes_remaining_i -= bytes_read_i;
+      cur_offset_i += bytes_read_i;
+      attempts_i = 0;
+    }
+  } while ( bytes_remaining_i > 0 );
+
+  return data_len_i - bytes_remaining_i;
+}
+
+ssize_t
+c3_write(c3_i fd_i, const void* const data_v, const size_t data_len_i)
+{
+  static const size_t max_attempts_i    = 100;
+  size_t              attempts_i        = 0;
+  const c3_y*         ptr_y             = data_v;
+  ssize_t             bytes_remaining_i = data_len_i;
+  do {
+    attempts_i++;
+    ssize_t bytes_written_i = write(fd_i, ptr_y, bytes_remaining_i);
+    if ( -1 == bytes_written_i ) {
+      // Attempt to read again if we were interrupted by a signal.
+      if ( (EINTR == errno || EAGAIN == errno || EWOULDBLOCK == errno)
+           && attempts_i <= max_attempts_i )
+      {
+        continue;
+      }
+      else {
+        return -errno;
+      }
+    }
+    else {
+      ptr_y += bytes_written_i;
+      bytes_remaining_i -= bytes_written_i;
+      attempts_i = 0;
+    }
+  } while ( bytes_remaining_i > 0 );
+
+  return data_len_i - bytes_remaining_i;
+}

--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -181,55 +181,8 @@
       /// @return  0  `fd_i` is at EOF.
       /// @return <0  Error occurred. The error number is the absolute value of
       ///             the return value and can be fed into strerror().
-      inline ssize_t
-      c3_read(c3_i fd_i, void* const data_v, const size_t data_len_i)
-      {
-        static const size_t max_attempts_i    = 100;
-        size_t              attempts_i        = 0;
-        c3_y*               ptr_y             = data_v;
-        ssize_t             bytes_remaining_i = data_len_i;
-
-        off_t cur_offset_i = lseek(fd_i, 0, SEEK_CUR);
-        if ( cur_offset_i < 0 ) {
-          return -errno;
-        }
-
-        do {
-          attempts_i++;
-          ssize_t bytes_read_i = read(fd_i, ptr_y, bytes_remaining_i);
-          if ( -1 == bytes_read_i ) {
-            if ( (EINTR == errno || EAGAIN == errno || EWOULDBLOCK == errno)
-                 && attempts_i <= max_attempts_i )
-            {
-              // From the read(2) man page: "On error, -1 is returned, and errno
-              // is set to indicate the error. In this case, it is left
-              // unspecified whether the file position (if any) changes."
-              //
-              // This means that we have to restore the file cursor to the
-              // position that it was at immediately before the call to read()
-              // that failed.
-              if ( lseek(fd_i, SEEK_SET, cur_offset_i) < 0 ) {
-                return -errno;
-              }
-              continue;
-            }
-            else {
-              return -errno;
-            }
-          }
-          else if ( 0 == bytes_read_i ) {
-            break;
-          }
-          else {
-            ptr_y += bytes_read_i;
-            bytes_remaining_i -= bytes_read_i;
-            cur_offset_i += bytes_read_i;
-            attempts_i = 0;
-          }
-        } while ( bytes_remaining_i > 0 );
-
-        return data_len_i - bytes_remaining_i;
-      }
+      ssize_t
+      c3_read(c3_i fd_i, void* const data_v, const size_t data_len_i);
 
       /// Writes the contents of a buffer to a file.
       ///
@@ -249,35 +202,7 @@
       ///              `data_len_i`.
       /// @return <0   Error occurred. The error number is the absolute value of
       ///              the return value and can be fed into strerror().
-      inline ssize_t
-      c3_write(c3_i fd_i, const void* const data_v, const size_t data_len_i)
-      {
-        static const size_t max_attempts_i    = 100;
-        size_t              attempts_i        = 0;
-        const c3_y*         ptr_y             = data_v;
-        ssize_t             bytes_remaining_i = data_len_i;
-        do {
-          attempts_i++;
-          ssize_t bytes_written_i = write(fd_i, ptr_y, bytes_remaining_i);
-          if ( -1 == bytes_written_i ) {
-            // Attempt to read again if we were interrupted by a signal.
-            if ( (EINTR == errno || EAGAIN == errno || EWOULDBLOCK == errno)
-                 && attempts_i <= max_attempts_i )
-            {
-              continue;
-            }
-            else {
-              return -errno;
-            }
-          }
-          else {
-            ptr_y += bytes_written_i;
-            bytes_remaining_i -= bytes_written_i;
-            attempts_i = 0;
-          }
-        } while ( bytes_remaining_i > 0 );
-
-        return data_len_i - bytes_remaining_i;
-      }
+      ssize_t
+      c3_write(c3_i fd_i, const void* const data_v, const size_t data_len_i);
 
 #endif /* ifndef C3_DEFS_H */

--- a/pkg/urbit/include/c/defs.h
+++ b/pkg/urbit/include/c/defs.h
@@ -164,6 +164,8 @@
 
       /// Reads the contents of a file into memory.
       ///
+      /// @warn The file must be seekable, otherwise the behavior is undefined.
+      ///
       /// This function correctly handles the case in which read() reads fewer
       /// bytes than was requested by retrying until all bytes have been read or
       /// until an error occurs, whichever comes first.

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -1404,11 +1404,6 @@
         void
         u3_daemon_init();
 
-      /* u3_write_fd(): retry interrupts, continue partial writes, assert errors.
-      */
-        void
-        u3_write_fd(c3_i fid_i, const void* buf_v, size_t len_i);
-
         c3_w
         u3_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result);
 

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -435,7 +435,7 @@ u3m_file(c3_c* pas_c)
 {
   struct stat buf_b;
   c3_i        fid_i = c3_open(pas_c, O_RDONLY, 0644);
-  c3_w        fln_w, red_w;
+  c3_w        fln_w;
   c3_y*       pad_y;
 
   if ( (fid_i < 0) || (fstat(fid_i, &buf_b) < 0) ) {
@@ -445,10 +445,10 @@ u3m_file(c3_c* pas_c)
   fln_w = buf_b.st_size;
   pad_y = c3_malloc(buf_b.st_size);
 
-  red_w = read(fid_i, pad_y, fln_w);
+  ssize_t red_i = c3_read(fid_i, pad_y, fln_w);
   close(fid_i);
 
-  if ( fln_w != red_w ) {
+  if ( red_i != fln_w ) {
     c3_free(pad_y);
     return u3m_bail(c3__fail);
   }

--- a/pkg/urbit/noun/urth.c
+++ b/pkg/urbit/noun/urth.c
@@ -564,56 +564,14 @@ _cu_rock_save(c3_c* dir_c, c3_d eve_d, c3_d len_d, c3_y* byt_y)
 
   //  write jam-buffer into [fid_i]
   //
-  //    XX deduplicate with _write() wrapper in term.c
-  //
-  {
-    ssize_t ret_i;
-
-    while ( len_d > 0 ) {
-      c3_w lop_w = 0;
-      //  retry interrupt/async errors
-      //
-      do {
-        //  abort pathological retry loop
-        //
-        if ( 100 == ++lop_w ) {
-          fprintf(stderr, "rock: write loop: %s\r\n", strerror(errno));
-          close(fid_i);
-          //  XX unlink file?
-          //
-          return c3n;
-        }
-
-        ret_i = write(fid_i, byt_y, len_d);
-      }
-      while (  (ret_i < 0)
-            && (  (errno == EINTR)
-               || (errno == EAGAIN)
-               || (errno == EWOULDBLOCK) ));
-
-      //  assert on true errors
-      //
-      //    NB: can't call u3l_log here or we would re-enter _write()
-      //
-      if ( ret_i < 0 ) {
-        fprintf(stderr, "rock: write failed %s\r\n", strerror(errno));
-        close(fid_i);
-        //  XX unlink file?
-        //
-        return c3n;
-      }
-      //  continue partial writes
-      //
-      else {
-        len_d -= ret_i;
-        byt_y += ret_i;
-      }
-    }
+  ssize_t rit_i = c3_write(fid_i, byt_y, len_d);
+  if ( rit_i < 0 ) {
+    fprintf(stderr, "rock: write failed: %s\r\n", strerror(-rit_i));
   }
 
   close(fid_i);
 
-  return c3y;
+  return rit_i < 0 ? c3n : c3y;
 }
 
 /* u3u_cram(): globably deduplicate memory, and write a rock to disk.

--- a/pkg/urbit/vere/io/http.c
+++ b/pkg/urbit/vere/io/http.c
@@ -1692,9 +1692,13 @@ _http_write_ports_file(u3_httd* htd_u, c3_c *pax_c)
   c3_c temp[32];
   while ( 0 != htp_u ) {
     if ( 0 < htp_u->por_s ) {
-      u3_write_fd(por_i, temp, snprintf(temp, 32, "%u %s %s\n", htp_u->por_s,
-                     (c3y == htp_u->sec) ? "secure" : "insecure",
-                     (c3y == htp_u->lop) ? "loopback" : "public"));
+      c3_i len_i = snprintf(temp,
+                            32,
+                            "%u %s %s\n",
+                            htp_u->por_s,
+                            (c3y == htp_u->sec) ? "secure" : "insecure",
+                            (c3y == htp_u->lop) ? "loopback" : "public");
+      c3_assert(c3_write(por_i, temp, len_i) == len_i);
     }
 
     htp_u = htp_u->nex_u;

--- a/pkg/urbit/vere/king.c
+++ b/pkg/urbit/vere/king.c
@@ -1457,15 +1457,28 @@ _king_copy_file(c3_c* src_c, c3_c* dst_c)
     //
 #endif
 
-    {
-      size_t pag_i = 1 << 14;;
-      c3_y*  buf_y = c3_malloc(pag_i);
-      ret_i        = c3_read(src_i, buf_y, pag_i) == pag_i
-                  && c3_write(dst_i, buf_y, pag_i) == pag_i
-                       ? 0
-                       : -1;
-      err_i        = errno;
-      c3_free(buf_y);
+    { // Copy from src_i to dst_i 16K at a time.
+      c3_y buf_y[1 << 14];
+      while ( 1 ) {
+        ret_i = c3_read(src_i, buf_y, sizeof(buf_y));
+        if ( ret_i < 0 ) {
+          break;
+        }
+
+        if ( ret_i == 0 ) {
+          break;
+        }
+
+        ret_i = c3_write(dst_i, buf_y, sizeof(buf_y));
+        if ( ret_i < 0 ) {
+          break;
+        }
+      }
+
+      if ( ret_i < 0 ) {
+        err_i = -ret_i;
+        ret_i = -1;
+      }
     }
 
 done3:

--- a/pkg/urbit/vere/lord.c
+++ b/pkg/urbit/vere/lord.c
@@ -786,7 +786,7 @@ _lord_on_serf_err_cb(uv_stream_t* pyp_u,
     //  serf used to write to 2 directly
     //  this can't be any worse than that
     //
-    u3_write_fd(2, buf_u->base, siz_i);
+    c3_assert(c3_write(STDERR_FILENO, buf_u->base, siz_i) == siz_i);
   } else {
     uv_read_stop(pyp_u);
 


### PR DESCRIPTION
### Motivation

This PR replaces all instances of `read()` and `write()` (outside of the `compat` directory) with `c3_read()` and `c3_write()`. `c3_read()`/`c3_write()` are wrappers around `read()`/`write()` that correctly handle partial reads/writes. They also handle retries in the case where `read()`/`write()` returns `EINTR`, `EAGAIN`, or `EWOULDBLOCK` up to a specified maximum number of attempts. 

Incorrect handling of partial reads/writes in `events.c` is the suspected cause of our lingering snapshot corruption bug, which has tended to appear when disk space fills up. Additional work will be required to gracefully handle failed calls to `c3_read()` and `c3_write()` in `events.c`, but that work is beyond the scope of this PR.

The inclusion of `c3_read()` and `c3_write()` has the added benefit of rendering `u3_write_fd()` in `term.c` and a big chunk of `_cu_rock_save()` in `urth.c` obsolete. Both of these blocks of code have been removed.

### Test plan

To test, I booted a fake ship, exited, deleted its incremental snapshot, and then rebooted. Replay and terminal output work as expected.
```console
$ urbit -F zod -B solid.pill
$ rm zod/.urb/chk/*.bin
$ urbit zod
```