### PR TITLE
u3: optimizes u3i_edit (nock opcode 10)

### DIFF
--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -610,6 +610,7 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
 
       do {
         u3a_cell*  big_u = u3a_to_ptr(big);
+        u3_noun*     old = (u3_noun*)&(big_u->hed);
         const c3_y bit_y = u3r_bit(dep_w, axe);
 
         if ( c3n == u3a_is_cell(big) ) {
@@ -617,36 +618,20 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
         }
         else if ( c3y == u3a_is_mutable(u3R, big) ) {
           *out = big;
-
-          if ( !bit_y ) {
-            out = &(big_u->hed);
-          }
-          else {
-            out = &(big_u->tel);
-          }
-
-          big = *out;
+          out  = &(old[bit_y]);
+          big  = *out;
           big_u->mug_w = 0;
         }
         else  {
-          u3_noun  old = big;
-          u3_noun* hed;
-          u3_noun* tel;
+          u3_noun  luz = big;
+          u3_noun* new[2];
 
-          *out = u3i_defcons(&hed, &tel);
+          *out = u3i_defcons(&new[0], &new[1]);
+          out  = new[bit_y];
+          big  = u3k(old[bit_y]);
+          *(new[!bit_y]) = u3k(old[!bit_y]);
 
-          if ( !bit_y ) {
-            out  = hed;
-            big  = u3k(big_u->hed);
-            *tel = u3k(big_u->tel);
-          }
-          else {
-            out  = tel;
-            big  = u3k(big_u->tel);
-            *hed = u3k(big_u->hed);
-          }
-
-          u3z(old);
+          u3z(luz);
         }
       }
       while ( dep_w-- );

--- a/pkg/urbit/noun/imprison.c
+++ b/pkg/urbit/noun/imprison.c
@@ -606,12 +606,15 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
     case 1: break;
 
     default: {
-      c3_w dep_w = u3r_met(0, u3x_atom(axe)) - 2;
+      c3_w        dep_w = u3r_met(0, u3x_atom(axe)) - 2;
+      const c3_w* axe_w = ( c3y == u3a_is_cat(axe) )
+                        ? &axe
+                        : ((u3a_atom*)u3a_to_ptr(axe))->buf_w;
 
       do {
         u3a_cell*  big_u = u3a_to_ptr(big);
         u3_noun*     old = (u3_noun*)&(big_u->hed);
-        const c3_y bit_y = u3r_bit(dep_w, axe);
+        const c3_y bit_y = 1 & (axe_w[dep_w >> 5] >> (dep_w & 31));
 
         if ( c3n == u3a_is_cell(big) ) {
           return u3m_bail(c3__exit);


### PR DESCRIPTION
This PR optimizes our implementation of nock opcode `%10` (tree edits, `u3i_edit()`), turning it into a loop (in the style of the "tail recursion modulo cons" optimization) and removing head/tail branches.

These changes are not urgent, but I've had some version of them floating around for awhile now and have meant to open this PR. I was inspired to rewrite this after seeing @eamsden's implementation of tree edits. While I have not benchmarked these changes in detail, I also haven't noticed much of a difference with them. But the changes still seem worthwhile, even if this is not currently a significant hot spot.

These commits are probably best reviewed individually, in order.

/cc @frodwith 