### PR TITLE
vere: meld on memory pressure, if --auto-meld

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1787,6 +1787,12 @@ main(c3_i   argc,
         u3C.wag_w |= u3o_debug_ram;
       }
 
+      /*  Set auto-meld flag.
+      */
+      if ( _(u3_Host.ops_u.mel) ) {
+        u3C.wag_w |= u3o_auto_meld;
+      }
+
       /*  Set profile flag.
       */
       if ( _(u3_Host.ops_u.pro) ) {

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -167,6 +167,7 @@ _main_init(void)
   u3_Host.ops_u.tex = c3n;
   u3_Host.ops_u.tra = c3n;
   u3_Host.ops_u.veb = c3n;
+  u3_Host.ops_u.mel = c3n;
   u3_Host.ops_u.puf_c = "jam";
   u3_Host.ops_u.hap_w = 50000;
   u3_Host.ops_u.kno_w = DefaultKernel;
@@ -247,6 +248,7 @@ _main_getopt(c3_i argc, c3_c** argv)
     { "prop-file",           required_argument, NULL, 1 },
     { "prop-url",            required_argument, NULL, 2 },
     { "prop-name",           required_argument, NULL, 3 },
+    { "auto-meld",           no_argument,       NULL, 4 },
     //
     { NULL, 0, NULL, 0 },
   };
@@ -258,6 +260,10 @@ _main_getopt(c3_i argc, c3_c** argv)
     switch ( ch_i ) {
       case 1: case 2: case 3: {  //  prop-*
         _main_add_prop(ch_i, strdup(optarg));
+        break;
+      }
+      case 4: {  //  auto-meld
+        u3_Host.ops_u.mel = c3y;
         break;
       }
       case 'X': {

--- a/pkg/urbit/include/noun/options.h
+++ b/pkg/urbit/include/noun/options.h
@@ -29,7 +29,8 @@
         u3o_dryrun =        0x20,             //  don't touch checkpoint
         u3o_quiet =         0x40,             //  disable ~&
         u3o_hashless =      0x80,             //  disable hashboard
-        u3o_trace =         0x100             //  enables trace dumping
+        u3o_trace =         0x100,            //  enables trace dumping
+        u3o_auto_meld =     0x200             //  enables meld under pressure
       };
 
   /** Globals.

--- a/pkg/urbit/include/vere/mars.h
+++ b/pkg/urbit/include/vere/mars.h
@@ -28,6 +28,7 @@
         c3_d    dun_d;                    //  last event processed
         c3_l    mug_l;                    //  hash of state
         c3_o    pac_o;                    //  pack kernel
+        c3_o    mel_o;                    //  meld kernel
         c3_o    rec_o;                    //  reclaim cache
         c3_o    mut_o;                    //  mutated kerne
         u3_noun sac;                      //  space measurement

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -309,6 +309,7 @@
         c3_o    con;                        //      run conn
         c3_o    doc;                        //      dock binary in pier
         u3_even* vex_u;                     //  --prop-*, boot enhanchements
+        c3_o    mel;                        //  --auto-meld
       } u3_opts;
 
     /* u3_host: entire host.

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -289,7 +289,10 @@ _mars_sure_feck(u3_mars* mar_u, c3_w pre_w, u3_noun vir)
 
   mar_u->rec_o = c3o(mar_u->rec_o, rec_o);
   mar_u->pac_o = c3o(mar_u->pac_o, pac_o);
-  mar_u->mel_o = c3a(u3_Host.ops_u.mel, c3o(mar_u->mel_o, mel_o));
+
+  if ( u3C.wag_w & u3o_auto_meld ) {
+    mar_u->mel_o = c3o(mar_u->mel_o, mel_o);
+  }
 
   return vir;
 }

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -193,6 +193,7 @@ _mars_sure_feck(u3_mars* mar_u, c3_w pre_w, u3_noun vir)
 {
   c3_o rec_o = c3n;
   c3_o pac_o = c3n;
+  c3_o mel_o = c3n;
 
   //  intercept |mass, observe |reset
   //
@@ -263,6 +264,7 @@ _mars_sure_feck(u3_mars* mar_u, c3_w pre_w, u3_noun vir)
     }
     else if ( (pre_w > hig_w) && !(pos_w > hig_w) ) {
       pac_o = c3y;
+      mel_o = c3y;
       rec_o = c3y;
       pri   = 0;
     }
@@ -287,6 +289,7 @@ _mars_sure_feck(u3_mars* mar_u, c3_w pre_w, u3_noun vir)
 
   mar_u->rec_o = c3o(mar_u->rec_o, rec_o);
   mar_u->pac_o = c3o(mar_u->pac_o, pac_o);
+  mar_u->mel_o = c3a(u3_Host.ops_u.mel, c3o(mar_u->mel_o, mel_o));
 
   return vir;
 }
@@ -544,6 +547,13 @@ _mars_post(u3_mars* mar_u)
     u3a_print_memory(stderr, "mars: pack: gained", u3m_pack());
     u3l_log("\n");
     mar_u->pac_o = c3n;
+  }
+
+  if ( c3y == mar_u->mel_o ) {
+    u3l_log("mars: meld: starting\n");
+    u3u_meld();
+    u3l_log("mars: meld: complete\n");
+    mar_u->mel_o = c3n;
   }
 }
 


### PR DESCRIPTION
We currently automatically pack the memory when we start running out of space. We have avoided automatically melding, because it may be slow and require a significant amount of memory on the host machine.

Here, we add an --auto-meld flag that enables automatic melding, so that it can be opted into in situations/setups where it makes sense.

Have had some trouble testing this properly, but did get the auto-meld to run at some point.