### PR TITLE
u3: adds jets for printing unsigned auras

### DIFF
--- a/pkg/urbit/include/jets/q.h
+++ b/pkg/urbit/include/jets/q.h
@@ -120,6 +120,9 @@
     u3_noun u3qe_rexp(u3_noun, u3_noun);
     u3_noun u3qe_trip(u3_atom);
 
+    u3_atom u3qe_scot(u3_atom, u3_atom);
+    u3_atom u3qe_scow(u3_atom, u3_atom);
+
     u3_noun u3qea_ecba_en(u3_atom, u3_atom);
     u3_noun u3qea_ecba_de(u3_atom, u3_atom);
     u3_noun u3qea_ecbb_en(u3_atom, u3_atom);

--- a/pkg/urbit/include/noun/serial.h
+++ b/pkg/urbit/include/noun/serial.h
@@ -66,6 +66,13 @@
         u3_noun
         u3s_cue_atom(u3_atom a);
 
+      /* u3s_etch_ud_smol(): c3_d to @ud
+      **
+      **   =(26 (met 3 (scot %ud (dec (bex 64)))))
+      */
+        c3_y*
+        u3s_etch_ud_smol(c3_d a_d, c3_y hun_y[26]);
+
       /* u3s_etch_ud(): atom to @ud.
       */
         u3_atom

--- a/pkg/urbit/include/noun/serial.h
+++ b/pkg/urbit/include/noun/serial.h
@@ -99,6 +99,26 @@
         size_t
         u3s_etch_ux_c(u3_atom a, c3_c** out_c);
 
+      /* u3s_etch_uv(): atom to @uv.
+      */
+        u3_atom
+        u3s_etch_uv(u3_atom a);
+
+      /* u3s_etch_uv_c(): atom to @uv, as a malloc'd c string.
+      */
+        size_t
+        u3s_etch_uv_c(u3_atom a, c3_c** out_c);
+
+      /* u3s_etch_uw(): atom to @uw.
+      */
+        u3_atom
+        u3s_etch_uw(u3_atom a);
+
+      /* u3s_etch_uw_c(): atom to @uw, as a malloc'd c string.
+      */
+        size_t
+        u3s_etch_uw_c(u3_atom a, c3_c** out_c);
+
       /* u3s_sift_ud_bytes: parse @ud.
       */
         u3_weak

--- a/pkg/urbit/include/noun/serial.h
+++ b/pkg/urbit/include/noun/serial.h
@@ -66,6 +66,16 @@
         u3_noun
         u3s_cue_atom(u3_atom a);
 
+      /* u3s_etch_ud(): atom to @ud.
+      */
+        u3_atom
+        u3s_etch_ud(u3_atom a);
+
+      /* u3s_etch_ud_c(): atom to @ud, as a malloc'd c string.
+      */
+        size_t
+        u3s_etch_ud_c(u3_atom a, c3_c** out_c);
+
       /* u3s_sift_ud_bytes: parse @ud.
       */
         u3_weak

--- a/pkg/urbit/include/noun/serial.h
+++ b/pkg/urbit/include/noun/serial.h
@@ -1,6 +1,12 @@
 #ifndef U3_SERIAL_H
 #define U3_SERIAL_H
 
+    /*  constants
+    */
+      /* u3_dit_y: digit table for @ux/@uv/@uw.
+      */
+        extern const c3_y u3s_dit_y[64];
+
     /*  opaque handles
     */
       /* u3_cue_xeno: handle for cue-ing with an off-loom dictionary.
@@ -82,6 +88,16 @@
       */
         size_t
         u3s_etch_ud_c(u3_atom a, c3_c** out_c);
+
+      /* u3s_etch_ux(): atom to @ux.
+      */
+        u3_atom
+        u3s_etch_ux(u3_atom a);
+
+      /* u3s_etch_ux_c(): atom to @ux, as a malloc'd c string.
+      */
+        size_t
+        u3s_etch_ux_c(u3_atom a, c3_c** out_c);
 
       /* u3s_sift_ud_bytes: parse @ud.
       */

--- a/pkg/urbit/jets/e/base.c
+++ b/pkg/urbit/jets/e/base.c
@@ -3,9 +3,6 @@
 */
 #include "all.h"
 
-const c3_y hex_y[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
-                         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'  };
-
 u3_noun
 u3qe_en_base16(u3_atom len, u3_atom dat)
 {
@@ -26,8 +23,8 @@ u3qe_en_base16(u3_atom len, u3_atom dat)
       while ( len_w-- ) {
         inp_y = u3r_byte(len_w, dat);
 
-        *buf_y++ = hex_y[inp_y >> 4];
-        *buf_y++ = hex_y[inp_y & 0xf];
+        *buf_y++ = u3s_dit_y[inp_y >> 4];
+        *buf_y++ = u3s_dit_y[inp_y & 0xf];
       }
     }
 

--- a/pkg/urbit/jets/e/scot.c
+++ b/pkg/urbit/jets/e/scot.c
@@ -3,137 +3,14 @@
 */
 #include "all.h"
 
-static
-c3_y to_digit(c3_y tig)
-{
-  if (tig >= 10) {
-    return 87 + tig;
-  } else {
-    return '0' + tig;
-  }
-}
-
-static
-c3_y to_w_digit(c3_y tig)
-{
-  if (tig == 63) {
-    return '~';
-  } else if (tig == 62) {
-    return '-';
-  } else if (tig >= 36) {
-    return 29 + tig;
-  } else if (tig >= 10) {
-    return 87 + tig;
-  } else {
-    return '0' + tig;
-  }
-}
-
-static
-u3_noun
-_print_ud(u3_atom ud)
-{
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
-
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(ud);
-
-  do {
-    if (between == 3) {
-      list = u3nc('.', list);
-      between = 0;
-    }
-
-    list = u3nc(u3ka_add(u3qa_mod(ud, 10), '0'), list);
-    between++;
-    ud = u3ka_div(ud, 10);
-  } while (ud != 0);
-
-  {
-    u3_noun out = u3qc_rap(3, list);
-    u3z(list);
-    return out;
-  }
-}
-
-static
-u3_noun
-_print_uv(u3_atom uv)
-{
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
-
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(uv);
-
-  do {
-    if (between == 5) {
-      list = u3nc('.', list);
-      between = 0;
-    }
-
-    c3_y tig = u3qa_mod(uv, 32);
-    list = u3nc(to_digit(tig), list);
-    between++;
-    uv = u3ka_div(uv, 32);
-  } while (uv != 0);
-
-  list = u3nt('0', 'v', list);
-  {
-    u3_noun out = u3qc_rap(3, list);
-    u3z(list);
-    return out;
-  }
-}
-
-static
-u3_noun
-_print_uw(u3_atom uw)
-{
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
-
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(uw);
-
-  do {
-    if (between == 5) {
-      list = u3nc('.', list);
-      between = 0;
-    }
-
-    c3_y tig = u3qa_mod(uw, 64);
-    list = u3nc(to_w_digit(tig), list);
-    between++;
-    uw = u3ka_div(uw, 64);
-  } while (uw != 0);
-
-  list = u3nt('0', 'w', list);
-  {
-    u3_noun out = u3qc_rap(3, list);
-    u3z(list);
-    return out;
-  }
-}
-
 u3_atom
 u3qe_scot(u3_atom a, u3_atom b)
 {
   switch (a) {
     case c3__tas: return u3k(b);
-    // case c3__ud: return _print_ud(b);
     case c3__ud:  return u3s_etch_ud(b);
     case c3__ux:  return u3s_etch_ux(b);
-    // case c3__uv: return _print_uv(b);
     case c3__uv:  return u3s_etch_uv(b);
-    // case c3__uw: return _print_uw(b);
     case c3__uw:  return u3s_etch_uw(b);
     default:      return u3_none;
   }

--- a/pkg/urbit/jets/e/scot.c
+++ b/pkg/urbit/jets/e/scot.c
@@ -1,0 +1,148 @@
+/* j/3/scot.c
+**
+*/
+#include "all.h"
+
+static
+c3_y to_digit(c3_y tig)
+{
+  if (tig >= 10) {
+    return 87 + tig;
+  } else {
+    return '0' + tig;
+  }
+}
+
+static
+c3_y to_w_digit(c3_y tig)
+{
+  if (tig == 63) {
+    return '~';
+  } else if (tig == 62) {
+    return '-';
+  } else if (tig >= 36) {
+    return 29 + tig;
+  } else if (tig >= 10) {
+    return 87 + tig;
+  } else {
+    return '0' + tig;
+  }
+}
+
+static
+u3_noun
+_print_ud(u3_atom ud)
+{
+  // number of characters printed "between" periods.
+  c3_i between = 0;
+  u3_noun list = 0;
+
+  // increase input refcount to be consumed in u3ka_div(), which will free each
+  // intermediary state.
+  u3k(ud);
+
+  do {
+    if (between == 3) {
+      list = u3nc('.', list);
+      between = 0;
+    }
+
+    list = u3nc(u3ka_add(u3qa_mod(ud, 10), '0'), list);
+    between++;
+    ud = u3ka_div(ud, 10);
+  } while (ud != 0);
+
+  {
+    u3_noun out = u3qc_rap(3, list);
+    u3z(list);
+    return out;
+  }
+}
+
+static
+u3_noun
+_print_uv(u3_atom uv)
+{
+  // number of characters printed "between" periods.
+  c3_i between = 0;
+  u3_noun list = 0;
+
+  // increase input refcount to be consumed in u3ka_div(), which will free each
+  // intermediary state.
+  u3k(uv);
+
+  do {
+    if (between == 5) {
+      list = u3nc('.', list);
+      between = 0;
+    }
+
+    c3_y tig = u3qa_mod(uv, 32);
+    list = u3nc(to_digit(tig), list);
+    between++;
+    uv = u3ka_div(uv, 32);
+  } while (uv != 0);
+
+  list = u3nt('0', 'v', list);
+  {
+    u3_noun out = u3qc_rap(3, list);
+    u3z(list);
+    return out;
+  }
+}
+
+static
+u3_noun
+_print_uw(u3_atom uw)
+{
+  // number of characters printed "between" periods.
+  c3_i between = 0;
+  u3_noun list = 0;
+
+  // increase input refcount to be consumed in u3ka_div(), which will free each
+  // intermediary state.
+  u3k(uw);
+
+  do {
+    if (between == 5) {
+      list = u3nc('.', list);
+      between = 0;
+    }
+
+    c3_y tig = u3qa_mod(uw, 64);
+    list = u3nc(to_w_digit(tig), list);
+    between++;
+    uw = u3ka_div(uw, 64);
+  } while (uw != 0);
+
+  list = u3nt('0', 'w', list);
+  {
+    u3_noun out = u3qc_rap(3, list);
+    u3z(list);
+    return out;
+  }
+}
+
+u3_atom
+u3qe_scot(u3_atom a, u3_atom b)
+{
+  switch (a) {
+    case c3__tas: return u3k(b);
+    case c3__ud: return _print_ud(b);
+    // case c3__ud:  return u3s_etch_ud(b);
+    case c3__ux:  return u3s_etch_ux(b);
+    case c3__uv: return _print_uv(b);
+    // case c3__uv:  return u3s_etch_uv(b);
+    case c3__uw: return _print_uw(b);
+    // case c3__uw:  return u3s_etch_uw(b);
+    default:      return u3_none;
+  }
+}
+
+u3_noun
+u3we_scot(u3_noun cor)
+{
+  u3_atom a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qe_scot(u3x_atom(a), u3x_atom(b));
+}

--- a/pkg/urbit/jets/e/scot.c
+++ b/pkg/urbit/jets/e/scot.c
@@ -128,13 +128,13 @@ u3qe_scot(u3_atom a, u3_atom b)
 {
   switch (a) {
     case c3__tas: return u3k(b);
-    case c3__ud: return _print_ud(b);
-    // case c3__ud:  return u3s_etch_ud(b);
+    // case c3__ud: return _print_ud(b);
+    case c3__ud:  return u3s_etch_ud(b);
     case c3__ux:  return u3s_etch_ux(b);
-    case c3__uv: return _print_uv(b);
-    // case c3__uv:  return u3s_etch_uv(b);
-    case c3__uw: return _print_uw(b);
-    // case c3__uw:  return u3s_etch_uw(b);
+    // case c3__uv: return _print_uv(b);
+    case c3__uv:  return u3s_etch_uv(b);
+    // case c3__uw: return _print_uw(b);
+    case c3__uw:  return u3s_etch_uw(b);
     default:      return u3_none;
   }
 }

--- a/pkg/urbit/jets/e/scow.c
+++ b/pkg/urbit/jets/e/scow.c
@@ -15,22 +15,6 @@ c3_y to_digit(c3_y tig)
   }
 }
 
-static
-c3_y to_w_digit(c3_y tig)
-{
-  if (tig == 63) {
-    return '~';
-  } else if (tig == 62) {
-    return '-';
-  } else if (tig >= 36) {
-    return 29 + tig;
-  } else if (tig >= 10) {
-    return 87 + tig;
-  } else {
-    return '0' + tig;
-  }
-}
-
 // gives the characters for a four 'digit' small hex atom.
 static
 void
@@ -231,159 +215,34 @@ _print_p(u3_atom cor, u3_atom p)
   return u3nc('~', list);
 }
 
-static
-u3_noun
-_print_ud(u3_atom ud)
+u3_atom
+u3qe_scow(u3_atom a, u3_atom b)
 {
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
+  switch (a) {
+    //  XX disabled due to memory corruption
+    //  rewrite for +scot jet and test there
+    //
+    // case c3__da: return _print_da(cor, atom);
+    // case 'p':    return _print_p(cor, atom);
 
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(ud);
+    default: {
+      u3_weak dat = u3qe_scot(a, b);
+      u3_weak pro = u3_none;
 
-  do {
-    if (between == 3) {
-      list = u3nc('.', list);
-      between = 0;
+      if ( u3_none != dat ) {
+        pro = u3qc_rip(3, 1, dat);
+        u3z(dat);
+      }
+
+      return pro;
     }
-
-    list = u3nc(u3ka_add(u3qa_mod(ud, 10), '0'), list);
-    between++;
-    ud = u3ka_div(ud, 10);
-  } while (ud != 0);
-
-  return list;
-}
-
-static
-u3_noun
-_print_uv(u3_atom uv)
-{
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
-
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(uv);
-
-  do {
-    if (between == 5) {
-      list = u3nc('.', list);
-      between = 0;
-    }
-
-    c3_y tig = u3qa_mod(uv, 32);
-    list = u3nc(to_digit(tig), list);
-    between++;
-    uv = u3ka_div(uv, 32);
-  } while (uv != 0);
-
-  return u3nt('0', 'v', list);
-}
-
-static
-u3_noun
-_print_uw(u3_atom uw)
-{
-  // number of characters printed "between" periods.
-  c3_i between = 0;
-  u3_noun list = 0;
-
-  // increase input refcount to be consumed in u3ka_div(), which will free each
-  // intermediary state.
-  u3k(uw);
-
-  do {
-    if (between == 5) {
-      list = u3nc('.', list);
-      between = 0;
-    }
-
-    c3_y tig = u3qa_mod(uw, 64);
-    list = u3nc(to_w_digit(tig), list);
-    between++;
-    uw = u3ka_div(uw, 64);
-  } while (uw != 0);
-
-  return u3nt('0', 'w', list);
+  }
 }
 
 u3_noun
 u3we_scow(u3_noun cor)
 {
-  u3_atom mod;
-  u3_atom atom;
-
-  if (c3n == u3r_mean(cor, u3x_sam_2, &mod,
-                      u3x_sam_3, &atom, 0)) {
-    return u3m_bail(c3__exit);
-  }
-
-  switch (mod) {
-    case c3__da:
-      return _print_da(cor, atom);
-
-    case 'p':
-      return _print_p(cor, atom);
-
-    case c3__ud:
-      return _print_ud(atom);
-
-    case c3__uv:
-      return _print_uv(atom);
-
-    case c3__uw:
-      return _print_uw(atom);
-
-    default:
-      return u3_none;
-  }
-}
-
-u3_noun
-u3we_scot(u3_noun cor)
-{
-  u3_atom mod;
-  u3_atom atom;
-
-  if (c3n == u3r_mean(cor, u3x_sam_2, &mod,
-                      u3x_sam_3, &atom, 0)) {
-    return u3m_bail(c3__exit);
-  }
-
-  u3_noun tape;
-  switch (mod) {
-    case c3__da:
-      tape = _print_da(cor, atom);
-      break;
-
-    case 'p':
-      tape = _print_p(cor, atom);
-      break;
-
-    case c3__ud:
-      tape = _print_ud(atom);
-      break;
-
-    case c3__uv:
-      tape = _print_uv(atom);
-      break;
-
-    case c3__uw:
-      tape = _print_uw(atom);
-      break;
-
-    default:
-      return u3_none;
-  }
-
-  if (tape == u3_none) {
-    return tape;
-  }
-  u3_noun ret = u3qc_rap(3, tape);
-  u3z(tape);
-  return ret;
+  u3_atom a, b;
+  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+  return u3qe_scow(u3x_atom(a), u3x_atom(b));
 }

--- a/pkg/urbit/jets/tree.c
+++ b/pkg/urbit/jets/tree.c
@@ -1059,11 +1059,8 @@ static u3j_core _140_qua_d[] =
   { "mole", 7, _140_qua_mole_a, 0, _140_qua_mole_ha },
   { "mule", 7, _140_qua_mule_a, 0, _140_qua_mule_ha },
 
-  //  XX disabled, implicated in memory corruption
-  //  write tests and re-enable
-  //
-  // { "scot", 7, _140_qua_scot_a, 0, _140_qua_scot_ha },
-  // { "scow", 7, _140_qua_scow_a, 0, _140_qua_scow_ha },
+  { "scot", 7, _140_qua_scot_a, 0, _140_qua_scot_ha },
+  { "scow", 7, _140_qua_scow_a, 0, _140_qua_scow_ha },
   { "slaw", 7, _140_qua_slaw_a, 0, _140_qua_slaw_ha },
   {}
 };

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -1108,6 +1108,199 @@ u3s_etch_ux_c(u3_atom a, c3_c** out_c)
   return len_i;
 }
 
+//  uint div+ceil non-zero
+//
+#define _divc_nz(x, y)  (((x) + ((y) - 1)) / (y))
+
+/* _cs_etch_uv_size(): output length in @uv (and aligned bits).
+*/
+static inline size_t
+_cs_etch_uv_size(u3_atom a, c3_w* out_w)
+{
+  c3_w met_w = u3r_met(0, a);
+  c3_w sep_w = _divc_nz(met_w, 25) - 1;  //  number of separators
+  c3_w max_w = sep_w * 25;
+  c3_w end_w = 0;
+  u3r_chop(0, max_w, 25, 0, &end_w, a);
+
+  c3_w bit_w = c3_bits_word(end_w);
+  c3_w las_w = _divc_nz(bit_w, 5);       //  digits before separator
+
+  *out_w = max_w;
+  return 2 + las_w + (sep_w * 6);
+}
+
+
+/* _cs_etch_uv_bytes(): atom to @uv impl.
+*/
+static void
+_cs_etch_uv_bytes(u3_atom a, c3_w max_w, c3_y* buf_y)
+{
+  c3_w   i_w;
+  c3_w inp_w;
+
+  for ( i_w = 0; i_w < max_w; i_w += 25 ) {
+    inp_w = 0;
+    u3r_chop(0, i_w, 25, 0, &inp_w, a);
+
+    *buf_y-- = u3s_dit_y[(inp_w >>  0) & 0x1f];
+    *buf_y-- = u3s_dit_y[(inp_w >>  5) & 0x1f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 10) & 0x1f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 15) & 0x1f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 20) & 0x1f];
+    *buf_y-- = '.';
+  }
+
+  inp_w = 0;
+  u3r_chop(0, max_w, 25, 0, &inp_w, a);
+
+  while ( inp_w ) {
+    *buf_y-- = u3s_dit_y[inp_w & 0x1f];
+    inp_w >>= 5;
+  }
+
+  *buf_y-- = 'v';
+  *buf_y   = '0';
+}
+
+/* u3s_etch_uv(): atom to @uv.
+*/
+u3_atom
+u3s_etch_uv(u3_atom a)
+{
+  if ( u3_blip == a ) {
+    return c3_s3('0', 'v', '0');
+  }
+
+  u3i_slab sab_u;
+  c3_w     max_w;
+  size_t   len_i = _cs_etch_uv_size(a, &max_w);
+
+  u3i_slab_bare(&sab_u, 3, len_i);
+  sab_u.buf_w[sab_u.len_w - 1] = 0;
+
+  _cs_etch_uv_bytes(a, max_w, sab_u.buf_y + len_i - 1);
+
+  return u3i_slab_moot_bytes(&sab_u);
+}
+
+/* u3s_etch_uv_c(): atom to @uv, as a malloc'd c string.
+*/
+size_t
+u3s_etch_uv_c(u3_atom a, c3_c** out_c)
+{
+  if ( u3_blip == a ) {
+    *out_c = strdup("0v0");
+    return 3;
+  }
+
+  c3_y*  buf_y;
+  c3_w   max_w;
+  size_t len_i = _cs_etch_uv_size(a, &max_w);
+
+  buf_y = c3_malloc(1 + len_i);
+  buf_y[len_i] = 0;
+  _cs_etch_uv_bytes(a, max_w, buf_y + len_i - 1);
+
+  *out_c = (c3_c*)buf_y;
+  return len_i;
+}
+
+/* _cs_etch_uw_size(): output length in @uw (and aligned bits).
+*/
+static inline size_t
+_cs_etch_uw_size(u3_atom a, c3_w* out_w)
+{
+  c3_w met_w = u3r_met(0, a);
+  c3_w sep_w = _divc_nz(met_w, 30) - 1;  //  number of separators
+  c3_w max_w = sep_w * 30;
+  c3_w end_w = 0;
+  u3r_chop(0, max_w, 30, 0, &end_w, a);
+
+  c3_w bit_w = c3_bits_word(end_w);
+  c3_w las_w = _divc_nz(bit_w, 6);       //  digits before separator
+
+  *out_w = max_w;
+  return 2 + las_w + (sep_w * 6);
+}
+
+/* _cs_etch_uw_bytes(): atom to @uw impl.
+*/
+static void
+_cs_etch_uw_bytes(u3_atom a, c3_w max_w, c3_y* buf_y)
+{
+  c3_w   i_w;
+  c3_w inp_w;
+
+  for ( i_w = 0; i_w < max_w; i_w += 30 ) {
+    inp_w = 0;
+    u3r_chop(0, i_w, 30, 0, &inp_w, a);
+
+    *buf_y-- = u3s_dit_y[(inp_w >>  0) & 0x3f];
+    *buf_y-- = u3s_dit_y[(inp_w >>  6) & 0x3f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 12) & 0x3f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 18) & 0x3f];
+    *buf_y-- = u3s_dit_y[(inp_w >> 24) & 0x3f];
+    *buf_y-- = '.';
+  }
+
+  inp_w = 0;
+  u3r_chop(0, max_w, 30, 0, &inp_w, a);
+
+  while ( inp_w ) {
+    *buf_y-- = u3s_dit_y[inp_w & 0x3f];
+    inp_w >>= 6;
+  }
+
+  *buf_y-- = 'w';
+  *buf_y   = '0';
+}
+
+/* u3s_etch_uw(): atom to @uw.
+*/
+u3_atom
+u3s_etch_uw(u3_atom a)
+{
+  if ( u3_blip == a ) {
+    return c3_s3('0', 'w', '0');
+  }
+
+  u3i_slab sab_u;
+  c3_w     max_w;
+  size_t   len_i = _cs_etch_uw_size(a, &max_w);
+
+  u3i_slab_bare(&sab_u, 3, len_i);
+  sab_u.buf_w[sab_u.len_w - 1] = 0;
+
+  _cs_etch_uw_bytes(a, max_w, sab_u.buf_y + len_i - 1);
+
+  return u3i_slab_moot_bytes(&sab_u);
+}
+
+/* u3s_etch_uw_c(): atom to @uw, as a malloc'd c string.
+*/
+size_t
+u3s_etch_uw_c(u3_atom a, c3_c** out_c)
+{
+  if ( u3_blip == a ) {
+    *out_c = strdup("0w0");
+    return 3;
+  }
+
+  c3_y*  buf_y;
+  c3_w   max_w;
+  size_t len_i = _cs_etch_uw_size(a, &max_w);
+
+  buf_y = c3_malloc(1 + len_i);
+  buf_y[len_i] = 0;
+  _cs_etch_uw_bytes(a, max_w, buf_y + len_i - 1);
+
+  *out_c = (c3_c*)buf_y;
+  return len_i;
+}
+
+#undef _divc_nz
+
 #define DIGIT(a) ( ((a) >= '0') && ((a) <= '9') )
 #define BLOCK(a) (  ('.' == (a)[0]) \
                  && DIGIT(a[1])     \

--- a/pkg/urbit/noun/serial.c
+++ b/pkg/urbit/noun/serial.c
@@ -923,11 +923,58 @@ _cs_etch_ud_bytes(mpz_t a_mp, size_t len_i, c3_y* hun_y)
   return len_i;
 }
 
+/* u3s_etch_ud_smol(): c3_d to @ud
+**
+**   =(26 (met 3 (scot %ud (dec (bex 64)))))
+*/
+c3_y*
+u3s_etch_ud_smol(c3_d a_d, c3_y hun_y[26])
+{
+  c3_y*  buf_y = hun_y + 25;
+  c3_w     b_w;
+
+  if ( !a_d ) {
+    *buf_y-- = '0';
+  }
+  else {
+    while ( 1 ) {
+      b_w  = a_d % 1000;
+      a_d /= 1000;
+
+      if ( !a_d ) {
+        while ( b_w ) {
+          *buf_y-- = '0' + (b_w % 10);
+          b_w /= 10;
+        }
+        break;
+      }
+
+      *buf_y-- = '0' + (b_w % 10);
+      b_w /= 10;
+      *buf_y-- = '0' + (b_w % 10);
+      b_w /= 10;
+      *buf_y-- = '0' + (b_w % 10);
+      *buf_y-- = '.';
+    }
+  }
+
+  return buf_y + 1;
+}
+
 /* u3s_etch_ud(): atom to @ud.
 */
 u3_atom
 u3s_etch_ud(u3_atom a)
 {
+  c3_d a_d;
+
+  if ( c3y == u3r_safe_chub(a, &a_d) ) {
+    c3_y  hun_y[26];
+    c3_y* buf_y = u3s_etch_ud_smol(a_d, hun_y);
+    c3_w  dif_w = (c3_p)buf_y - (c3_p)hun_y;
+    return u3i_bytes(26 - dif_w, buf_y);
+  }
+
   u3i_slab sab_u;
   size_t   len_i;
   mpz_t     a_mp;
@@ -948,8 +995,23 @@ u3s_etch_ud(u3_atom a)
 size_t
 u3s_etch_ud_c(u3_atom a, c3_c** out_c)
 {
-  c3_y*  buf_y;
+  c3_d     a_d;
   size_t len_i;
+  c3_y*  buf_y;
+
+  if ( c3y == u3r_safe_chub(a, &a_d) ) {
+    c3_y  hun_y[26];
+
+    buf_y = u3s_etch_ud_smol(a_d, hun_y);
+    len_i = 26 - ((c3_p)buf_y - (c3_p)hun_y);
+
+    *out_c = c3_malloc(len_i + 1);
+    (*out_c)[len_i] = 0;
+    memcpy(*out_c, buf_y, len_i);
+
+    return len_i;
+  }
+
   mpz_t   a_mp;
   u3r_mp(a_mp, a);
 

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -10,6 +10,95 @@ _setup(void)
 }
 
 static inline c3_i
+_ud_etch(c3_d num_d, const c3_c* num_c)
+{
+  u3_atom  num = u3i_chub(num_d);
+  c3_c*  out_c;
+  size_t len_i = u3s_etch_ud_c(num, &out_c);
+  c3_i   ret_i = 1;
+
+  if ( 0 != strcmp(num_c, out_c) ) {
+    fprintf(stderr, "etch_ud: %" PRIu64 " fail; expected %s, got '%s'\r\n",
+                    num_d, num_c, out_c);
+    ret_i = 0;
+  }
+  else {
+    u3_noun out = u3s_etch_ud(num);
+    u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+    if ( c3n == u3r_sing(tou, out) ) {
+      fprintf(stderr, "etch_ud: %" PRIu64 " mismatch; expected %s\r\n", num_d, num_c);
+      u3m_p("out", out);
+      ret_i = 0;
+    }
+
+    u3z(out);
+    u3z(tou);
+  }
+
+  c3_free(out_c);
+  u3z(num);
+
+  return ret_i;
+}
+
+static c3_i
+_test_etch_ud(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _ud_etch(0, "0");
+  ret_i &= _ud_etch(1, "1");
+  ret_i &= _ud_etch(12, "12");
+  ret_i &= _ud_etch(123, "123");
+  ret_i &= _ud_etch(1234, "1.234");
+  ret_i &= _ud_etch(12345, "12.345");
+  ret_i &= _ud_etch(123456, "123.456");
+  ret_i &= _ud_etch(1234567, "1.234.567");
+  ret_i &= _ud_etch(12345678, "12.345.678");
+  ret_i &= _ud_etch(123456789, "123.456.789");
+  ret_i &= _ud_etch(100000000, "100.000.000");
+  ret_i &= _ud_etch(101101101, "101.101.101");
+  ret_i &= _ud_etch(201201201, "201.201.201");
+  ret_i &= _ud_etch(302201100, "302.201.100");
+
+  ret_i &= _ud_etch(8589934592ULL, "8.589.934.592");
+  ret_i &= _ud_etch(2305843009213693952ULL, "2.305.843.009.213.693.952");
+  ret_i &= _ud_etch(18446744073709551615ULL, "18.446.744.073.709.551.615");
+
+  {
+    c3_c* num_c = "340.282.366.920.938.463.463.374.607.431.768.211.456";
+    u3_atom num = u3qc_bex(128);
+    c3_c*  out_c;
+    size_t len_i = u3s_etch_ud_c(num, &out_c);
+
+    if ( 0 != strncmp(num_c, out_c, len_i) ) {
+      fprintf(stderr, "etch_ud: (bex 128) fail; expected %s, got '%s'\r\n",
+                      num_c, out_c);
+      ret_i = 0;
+    }
+    else {
+      u3_noun out = u3s_etch_ud(num);
+      u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+      if ( c3n == u3r_sing(tou, out) ) {
+        fprintf(stderr, "etch_ud: (bex 128) mismatch; expected %s\r\n", num_c);
+        u3m_p("out", out);
+        ret_i = 0;
+      }
+
+      u3z(out);
+      u3z(tou);
+    }
+
+    c3_free(out_c);
+    u3z(num);
+  }
+
+  return ret_i;
+}
+
+static inline c3_i
 _ud_good(c3_w num_w, const c3_c* num_c)
 {
   u3_weak out;
@@ -501,6 +590,11 @@ static c3_i
 _test_jets(void)
 {
   c3_i ret_i = 1;
+
+  if ( !_test_etch_ud() ) {
+    fprintf(stderr, "test jets: etch_ud: failed\r\n");
+    ret_i = 0;
+  }
 
   if ( !_test_sift_ud() ) {
     fprintf(stderr, "test jets: sift_ud: failed\r\n");

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -99,6 +99,96 @@ _test_etch_ud(void)
 }
 
 static inline c3_i
+_ux_etch(c3_d num_d, const c3_c* num_c)
+{
+  u3_atom  num = u3i_chub(num_d);
+  c3_c*  out_c;
+  size_t len_i = u3s_etch_ux_c(num, &out_c);
+  c3_i   ret_i = 1;
+
+  if ( 0 != strcmp(num_c, out_c) ) {
+    fprintf(stderr, "etch_ux: 0x%" PRIx64 " fail; expected %s, got '%s'\r\n",
+                    num_d, num_c, out_c);
+    ret_i = 0;
+  }
+  else {
+    u3_noun out = u3s_etch_ux(num);
+    u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+    if ( c3n == u3r_sing(tou, out) ) {
+      fprintf(stderr, "etch_ux: 0x%" PRIx64 " mismatch; expected %s\r\n", num_d, num_c);
+      u3m_p("out", out);
+      ret_i = 0;
+    }
+
+    u3z(out);
+    u3z(tou);
+  }
+
+  c3_free(out_c);
+  u3z(num);
+
+  return ret_i;
+}
+
+static c3_i
+_test_etch_ux(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _ux_etch(0x0, "0x0");
+  ret_i &= _ux_etch(0x1, "0x1");
+  ret_i &= _ux_etch(0x12, "0x12");
+  ret_i &= _ux_etch(0x123, "0x123");
+  ret_i &= _ux_etch(0x1234, "0x1234");
+  ret_i &= _ux_etch(0x12345, "0x1.2345");
+  ret_i &= _ux_etch(0x123456, "0x12.3456");
+  ret_i &= _ux_etch(0x1234567, "0x123.4567");
+  ret_i &= _ux_etch(0x12345678, "0x1234.5678");
+  ret_i &= _ux_etch(0x123456789, "0x1.2345.6789");
+  ret_i &= _ux_etch(0x100000000, "0x1.0000.0000");
+  ret_i &= _ux_etch(0x101101101, "0x1.0110.1101");
+  ret_i &= _ux_etch(0x201201201, "0x2.0120.1201");
+  ret_i &= _ux_etch(0x302201100, "0x3.0220.1100");
+
+  ret_i &= _ux_etch(0x123456789abcdefULL, "0x123.4567.89ab.cdef");
+  ret_i &= _ux_etch(0x8589934592ULL, "0x85.8993.4592");
+  ret_i &= _ux_etch(0x5843009213693952ULL, "0x5843.0092.1369.3952");
+  ret_i &= _ux_etch(0x6744073709551615ULL, "0x6744.0737.0955.1615");
+
+  {
+    c3_c* num_c = "0x1.0000.0000.0000.0000.0000.0000.0000.0000";
+    u3_atom num = u3qc_bex(128);
+    c3_c*  out_c;
+    size_t len_i = u3s_etch_ux_c(num, &out_c);
+
+    if ( 0 != strncmp(num_c, out_c, len_i) ) {
+      fprintf(stderr, "etch_ux: (bex 128) fail; expected %s, got '%s'\r\n",
+                      num_c, out_c);
+      ret_i = 0;
+    }
+    else {
+      u3_noun out = u3s_etch_ux(num);
+      u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+      if ( c3n == u3r_sing(tou, out) ) {
+        fprintf(stderr, "etch_ux: (bex 128) mismatch; expected %s\r\n", num_c);
+        u3m_p("out", out);
+        ret_i = 0;
+      }
+
+      u3z(out);
+      u3z(tou);
+    }
+
+    c3_free(out_c);
+    u3z(num);
+  }
+
+  return ret_i;
+}
+
+static inline c3_i
 _ud_good(c3_w num_w, const c3_c* num_c)
 {
   u3_weak out;
@@ -593,6 +683,11 @@ _test_jets(void)
 
   if ( !_test_etch_ud() ) {
     fprintf(stderr, "test jets: etch_ud: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_etch_ux() ) {
+    fprintf(stderr, "test jets: etch_ux: failed\r\n");
     ret_i = 0;
   }
 

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -189,6 +189,188 @@ _test_etch_ux(void)
 }
 
 static inline c3_i
+_uv_etch(c3_d num_d, const c3_c* num_c)
+{
+  u3_atom  num = u3i_chub(num_d);
+  c3_c*  out_c;
+  size_t len_i = u3s_etch_uv_c(num, &out_c);
+  c3_i   ret_i = 1;
+
+  if ( 0 != strcmp(num_c, out_c) ) {
+    fprintf(stderr, "etch_uv: 0x%" PRIx64 " fail; expected %s, got '%s'\r\n",
+                    num_d, num_c, out_c);
+    ret_i = 0;
+  }
+  else {
+    u3_noun out = u3s_etch_uv(num);
+    u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+    if ( c3n == u3r_sing(tou, out) ) {
+      fprintf(stderr, "etch_uv: 0x%" PRIx64 " mismatch; expected %s\r\n", num_d, num_c);
+      u3m_p("out", out);
+      ret_i = 0;
+    }
+
+    u3z(out);
+    u3z(tou);
+  }
+
+  c3_free(out_c);
+  u3z(num);
+
+  return ret_i;
+}
+
+static c3_i
+_test_etch_uv(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _uv_etch(0x0, "0v0");
+  ret_i &= _uv_etch(0x1, "0v1");
+  ret_i &= _uv_etch(0x10, "0vg");
+  ret_i &= _uv_etch(0x12, "0vi");
+  ret_i &= _uv_etch(0x123, "0v93");
+  ret_i &= _uv_etch(0x1234, "0v4hk");
+  ret_i &= _uv_etch(0x12345, "0v28q5");
+  ret_i &= _uv_etch(0x123456, "0v14d2m");
+  ret_i &= _uv_etch(0x1234567, "0vi6hb7");
+  ret_i &= _uv_etch(0x12345678, "0v9.38ljo");
+  ret_i &= _uv_etch(0x123456789, "0v4h.kaps9");
+  ret_i &= _uv_etch(0x100000000, "0v40.00000");
+  ret_i &= _uv_etch(0x101101101, "0v40.h0481");
+  ret_i &= _uv_etch(0x201201201, "0v80.i04g1");
+  ret_i &= _uv_etch(0x302201100, "0vc1.20480");
+
+  ret_i &= _uv_etch(0x123456789abcdefULL, "0v28.q5cu4.qnjff");
+  ret_i &= _uv_etch(0x8589934592ULL, "0vgm4.p6hci");
+  ret_i &= _uv_etch(0x5843009213693952ULL, "0v5gg.o0i89.mieai");
+  ret_i &= _uv_etch(0x6744073709551615ULL, "0v6eh.076s4.la5gl");
+
+  {
+    c3_c* num_c = "0v8.00000.00000.00000.00000.00000";
+    u3_atom num = u3qc_bex(128);
+    c3_c*  out_c;
+    size_t len_i = u3s_etch_uv_c(num, &out_c);
+
+    if ( 0 != strncmp(num_c, out_c, len_i) ) {
+      fprintf(stderr, "etch_uv: (bex 128) fail; expected %s, got '%s'\r\n",
+                      num_c, out_c);
+      ret_i = 0;
+    }
+    else {
+      u3_noun out = u3s_etch_uv(num);
+      u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+      if ( c3n == u3r_sing(tou, out) ) {
+      //   fprintf(stderr, "etch_uv: (bex 128) mismatch; expected %s\r\n", num_c);
+        u3m_p("out", out);
+        ret_i = 0;
+      }
+
+      u3z(out);
+      u3z(tou);
+    }
+
+    c3_free(out_c);
+    u3z(num);
+  }
+
+  return ret_i;
+}
+
+static inline c3_i
+_uw_etch(c3_d num_d, const c3_c* num_c)
+{
+  u3_atom  num = u3i_chub(num_d);
+  c3_c*  out_c;
+  size_t len_i = u3s_etch_uw_c(num, &out_c);
+  c3_i   ret_i = 1;
+
+  if ( 0 != strcmp(num_c, out_c) ) {
+    fprintf(stderr, "etch_uw: 0x%" PRIx64 " fail; expected %s, got '%s'\r\n",
+                    num_d, num_c, out_c);
+    ret_i = 0;
+  }
+  else {
+    u3_noun out = u3s_etch_uw(num);
+    u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+    if ( c3n == u3r_sing(tou, out) ) {
+      fprintf(stderr, "etch_uw: 0x%" PRIx64 " mismatch; expected %s\r\n", num_d, num_c);
+      u3m_p("out", out);
+      ret_i = 0;
+    }
+
+    u3z(out);
+    u3z(tou);
+  }
+
+  c3_free(out_c);
+  u3z(num);
+
+  return ret_i;
+}
+
+static c3_i
+_test_etch_uw(void)
+{
+  c3_i ret_i = 1;
+
+  ret_i &= _uw_etch(0x0, "0w0");
+  ret_i &= _uw_etch(0x1, "0w1");
+  ret_i &= _uw_etch(0x10, "0wg");
+  ret_i &= _uw_etch(0x12, "0wi");
+  ret_i &= _uw_etch(0x123, "0w4z");
+  ret_i &= _uw_etch(0x1234, "0w18Q");
+  ret_i &= _uw_etch(0x12345, "0wid5");
+  ret_i &= _uw_etch(0x123456, "0w4zhm");
+  ret_i &= _uw_etch(0x1234567, "0w18QlD");
+  ret_i &= _uw_etch(0x12345678, "0wid5pU");
+  ret_i &= _uw_etch(0x123456789, "0w4.zhmu9");
+  ret_i &= _uw_etch(0x100000000, "0w4.00000");
+  ret_i &= _uw_etch(0x101101101, "0w4.14141");
+  ret_i &= _uw_etch(0x201201201, "0w8.18181");
+  ret_i &= _uw_etch(0x302201100, "0wc.28140");
+
+  ret_i &= _uw_etch(0x123456789abcdefULL, "0w4zhmu.9GYTL");
+  ret_i &= _uw_etch(0x8589934592ULL, "0w8m.9AQmi");
+  ret_i &= _uw_etch(0x5843009213693952ULL, "0w5.x3098.jqjBi");
+  ret_i &= _uw_etch(0x6744073709551615ULL, "0w6.t41Ps.9lhol");
+
+  {
+    c3_c* num_c = "0w40.00000.00000.00000.00000";
+    u3_atom num = u3qc_bex(128);
+    c3_c*  out_c;
+    size_t len_i = u3s_etch_uw_c(num, &out_c);
+
+    if ( 0 != strncmp(num_c, out_c, len_i) ) {
+      fprintf(stderr, "etch_uw: (bex 128) fail; expected %s, got '%s'\r\n",
+                      num_c, out_c);
+      ret_i = 0;
+    }
+    else {
+      u3_noun out = u3s_etch_uw(num);
+      u3_noun tou = u3i_bytes(len_i, (c3_y*)out_c);
+
+      if ( c3n == u3r_sing(tou, out) ) {
+        fprintf(stderr, "etch_uw: (bex 128) mismatch; expected %s\r\n", num_c);
+        u3m_p("out", out);
+        ret_i = 0;
+      }
+
+      u3z(out);
+      u3z(tou);
+    }
+
+    c3_free(out_c);
+    u3z(num);
+  }
+
+  return ret_i;
+}
+
+static inline c3_i
 _ud_good(c3_w num_w, const c3_c* num_c)
 {
   u3_weak out;
@@ -688,6 +870,16 @@ _test_jets(void)
 
   if ( !_test_etch_ux() ) {
     fprintf(stderr, "test jets: etch_ux: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_etch_uv() ) {
+    fprintf(stderr, "test jets: etch_uv: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_etch_uw() ) {
+    fprintf(stderr, "test jets: etch_uw: failed\r\n");
     ret_i = 0;
   }
 


### PR DESCRIPTION
This PR supersedes (parts of) #5163 (see also #5161).

The `@ud` printer is written with an eye to #5753, and builds on the parsing work done in #4804. Further optimization of it will be an interesting research problem.

The other auras here (`@ux`, `@uv`, and `@uw`) are printed bitwise, which makes them easier to measure and allocate. Further optimizations would involve explicit bit manipulations inside the loop (as in the `+rip` jet), or maybe just inlining `u3r_chop()` in one way or another.

#### benchmarks

All measurements were taken locally, using the `%bout` hint (with wall clock time, so subject variance), running local builds at default optimization levels on my M1 Macbook. `@ux` is not included, as there is no previous jet with which to compare it. Local measurements showed it to be comparable to `@uw`. Comparisons against the hoon were not made because `|co` is heavily memoized.

##### setup:

```
> =do |*([max=@ud arg=* fun=gate] =|(i=@ud |-(?:(=(max i) ~ =+((fun arg) $(i +(i)))))))
> =wee 123.456.789
> =mid 123.456.789.123
> =big (rap 3 ['123.456.789' (reap 200 '.123.456.789')])
> (met 0 wee)
27
> (met 0 mid)
37
> (met 0 big)
19.286
>
> ~>  %bout  (do 10.000 wee same)
took ms/1.711
~
> ~>  %bout  (do 10 wee |=(a=@ (scot %ud a)))
took µs/8
~
```

- before: old, disabled tape jets
- after: this pr
- opt: this pr + #6007

##### `wee`

|  aura |     count |      before |       after |         opt |
| ----- | --------: | ----------: | ----------: | ----------: |
| `@ud` |      `10` |     `µs/14` |     `µs/11` |      `µs/8` |
| `@ud` |     `100` |     `µs/70` |     `µs/47` |     `µs/42` |
| `@ud` |   `1.000` |    `µs/628` |    `µs/393` |    `µs/388` |
| `@ud` |  `10.000` |  `ms/6.258` |  `ms/3.970` |  `ms/3.819` |
| `@ud` | `100.000` | `ms/63.444` | `ms/41.068` | `ms/38.907` |
| `@uv` |      `10` |     `µs/12` |     `µs/12` |      `µs/8` |
| `@uv` |     `100` |     `µs/56` |     `µs/68` |     `µs/44` |
| `@uv` |   `1.000` |    `µs/563` |    `µs/511` |    `µs/401` |
| `@uv` |  `10.000` |  `ms/5.187` |  `ms/5.080` |  `ms/3.952` |
| `@uv` | `100.000` | `ms/52.426` | `ms/51.393` | `ms/40.580` |
| `@uw` |      `10` |     `µs/22` |     `µs/19` |      `µs/9` |
| `@uw` |     `100` |     `µs/55` |     `µs/55` |     `µs/42` |
| `@uw` |   `1.000` |    `µs/591` |    `µs/480` |    `µs/646` |
| `@uw` |  `10.000` |  `ms/4.877` |  `ms/4.937` |  `ms/3.827` |
| `@uw` | `100.000` | `ms/51.413` | `ms/50.247` | `ms/38.732` |


##### `mid`

|  aura |     count |       before |       after |         opt |
| ----- | --------: | -----------: | ----------: | ----------: |
| `@ud` |      `10` |      `µs/19` |     `µs/17` |      `µs/8` |
| `@ud` |     `100` |     `µs/138` |     `µs/43` |     `µs/43` |
| `@ud` |   `1.000` |   `ms/1.953` |    `µs/742` |    `µs/389` |
| `@ud` |  `10.000` |  `ms/12.128` |  `ms/5.677` |  `ms/3.914` |
| `@ud` | `100.000` | `ms/120.997` | `ms/39.105` | `ms/39.517` |
| `@uv` |      `10` |      `µs/16` |     `µs/13` |      `µs/7` |
| `@uv` |     `100` |     `µs/111` |     `µs/60` |     `µs/54` |
| `@uv` |   `1.000` |   `ms/1.018` |    `µs/530` |    `µs/404` |
| `@uv` |  `10.000` |  `ms/10.110` |  `ms/5.135` |  `ms/4.019` |
| `@uv` | `100.000` | `ms/102.850` | `ms/53.917` | `ms/41.322` |
| `@uw` |      `10` |      `µs/17` |     `µs/11` |     `µs/14` |
| `@uw` |     `100` |      `µs/79` |     `µs/60` |     `µs/44` |
| `@uw` |   `1.000` |     `µs/745` |    `µs/574` |    `µs/398` |
| `@uw` |  `10.000` |   `ms/7.375` |  `ms/5.913` |  `ms/3.961` |
| `@uw` | `100.000` |  `ms/74.878` | `ms/54.106` | `ms/39.823` |

##### `big`

|  aura |     count |         before |         after |           opt |
| ----- | --------: | -------------: | ------------: | ------------: |
| `@ud` |      `10` |   `ms/331.510` |   `ms/24.168` |   `ms/24.304` |
| `@ud` |     `100` |  `s/3.334.380` |  `ms/228.244` |  `ms/229.215` |
| `@ud` |   `1.000` | `s/32.975.511` | `s/2.282.949` | `s/2.281.859` |
| `@uv` |      `10` |   `ms/219.171` |      `µs/416` |       `µs/54` |
| `@uv` |     `100` |  `s/2.200.516` |    `ms/3.989` |      `µs/405` |
| `@uv` |   `1.000` | `s/21.769.027` |   `ms/40.129` |    `ms/3.979` |
| `@uw` |      `10` |   `ms/182.902` |      `µs/452` |       `µs/45` |
| `@uw` |     `100` |  `s/1.820.838` |    `ms/4.075` |      `µs/360` |
| `@uw` |   `1.000` | `s/18.170.697` |   `ms/40.381` |    `ms/3.523` |
