### PR TITLE
ames: hotfix for pki sponsorship loss

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1997,14 +1997,15 @@
       event-core
     ::  +on-publ-sponsor: handle new or lost sponsor for peer
     ::
-    ::    TODO: handle sponsor loss
+    ::    TODO: really handle sponsor loss
     ::
     ++  on-publ-sponsor
       |=  [=ship sponsor=(unit ship)]
       ^+  event-core
       ::
       ?~  sponsor
-        ~|  %ames-lost-sponsor^our^ship  !!
+        %-  (slog leaf+"ames: {(scow %p ship)} lost sponsor, ignoring" ~)
+        event-core
       ::
       =/  state=(unit peer-state)  (get-peer-state ship)
       ?~  state


### PR DESCRIPTION
This PR addresses #6009 by setting a ship's sponsor in %ames to itself when azimuth sponsorship is lost.

Barring a state migration in %ames, the only other obvious option I see is to simply ignore sponsorship loss in %ames. This will likely impact networking more than that would, but it shouldn't entirely prevent it, and it seems better to respect the pki change. Thoughts?