### PR TITLE
mingw: adds (partial) implementations of pread/pwrite

### DIFF
--- a/pkg/urbit/compat/mingw/compat.h
+++ b/pkg/urbit/compat/mingw/compat.h
@@ -4,6 +4,8 @@
 #define mkdir(A, B) mkdir(A)
 
 int link(const char *path1, const char *path2);
+ssize_t pread(int fd, void *buf, size_t count, off_t offset);
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 char *realpath(const char *path, char *resolved_path);
 int fdatasync(int fd);
 int utimes(const char *path, const struct timeval times[2]);


### PR DESCRIPTION
This PR builds on #5889. It's a draft due to conflicts, and should wait to be reconciled with #6003.

The implementations are "partial" because `ReadFile()` and `WriteFile()` update the file position after i/o completion -- these are not spec-conformant implementations, but are fit for our single-threaded use-cases (so long as calls to their non-positioned counterparts aren't intermingled on the same file *description*).