### PR TITLE
garden: respect all zeroes in multipart content

### DIFF
--- a/pkg/garden/app/docket.hoon
+++ b/pkg/garden/app/docket.hoon
@@ -599,11 +599,11 @@
     ?:  =('desk' name)
       ::  must be a desk with existing charge
       ::
-      ?.  ((sane %ta) body)
-        [desk glob (cat 3 'invalid desk: ' body) err]
-      ?.  (~(has by charges) body)
-        [desk glob (cat 3 'unknown desk: ' body) err]
-      [body glob err]
+      ?.  ((sane %ta) q.body)
+        [desk glob (cat 3 'invalid desk: ' q.body) err]
+      ?.  (~(has by charges) q.body)
+        [desk glob (cat 3 'unknown desk: ' q.body) err]
+      [q.body glob err]
     :-  desk
     ::  all submitted files must be complete
     ::
@@ -621,8 +621,9 @@
     ::  make sure to exclude the top-level dir from the path
     ::
     :_  err
-    %+  ~(put by glob)  (slag 1 `path`u.filp)
-    [u.type (as-octs:mimes:html body)]
+    %+  ~(put by glob)
+      (slag 1 `path`u.filp)
+    [u.type body]
   ::
   ++  fip
     =,  de-purl:html

--- a/pkg/garden/lib/multipart.hoon
+++ b/pkg/garden/lib/multipart.hoon
@@ -5,7 +5,7 @@
   $:  file=(unit @t)                   ::  filename
       type=(unit mite)                 ::  content-type
       code=(unit @t)                   ::  content-transfer-encoding
-      body=@t                          ::  content
+      body=octs                        ::  content
   ==
 ::
 ++  de-request
@@ -38,12 +38,14 @@
   ++  dim   (jest (cat 3 '--' del))
   ++  nip   (jest '\0d\0a')
   ++  nab   (more fas (cook (cury rap 3) (plus qit)))
-  ++  nag   (dine ;~(less ;~(plug nip dim) next))
+  ++  nag   (pour ;~(less ;~(plug nip dim) next))
   ++  nod   (dine ;~(less doq next))
   ++  nom   (dine alp)
   ++  sip   ;~(plug nip nip)
   ++  tip   ;~(plug dim hep hep nip)
   ::
   ++  dine  |*(r=rule (cook (cury rep 3) (star r)))
+  ++  pour  |*(r=rule (cook meat (star r)))
+  ++  meat  |=(l=(list @) [(lent l) (rep 3 l)])
   --
 --


### PR DESCRIPTION
Some files, like zip files, may have trailing zero bytes, which get eaten when stored in reverse in an atom. So instead, we say `content` is an `octs`, passing the true size along.

Fixes #6012.

Not immediately obvious to me if this should go into `next/landscape` or not, considering the only changes there right now are frontend changes.