### PR TITLE
story: fix story printing

### DIFF
--- a/pkg/arvo/gen/story-list.hoon
+++ b/pkg/arvo/gen/story-list.hoon
@@ -3,6 +3,8 @@
 ::::
   ::
 /-  *story
+/$  story-to-txt  %story  %txt
+::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
         [[~] =desk ~]
@@ -15,9 +17,6 @@
   tang+[leaf+"Error: desk {<desk>} does not exist." ~]
 ?:  !.^(? %cu pax)
   tang+['Error: No story file found. Please use |story-init to create one.' ~]
-=/  story-to-txt
-  .^($-(story wain) %cf /(scot %p our)/[desk]/(scot cas)/story/txt)
-::
 =/  tale        .^(story %cx pax)
-=/  tale-text  (story-to-txt tale)
+=/  tale-text  (flop (story-to-txt tale))
 tang+tale-text

--- a/pkg/arvo/gen/story-read.hoon
+++ b/pkg/arvo/gen/story-read.hoon
@@ -48,7 +48,7 @@
   ?-    reverse-ancestors
       ~
     ::  stop here and return the current message
-    =/  msg=(list cord)  (msg-from-commit this-commit tale)
+    =/  msg=wain  (msg-from-commit this-commit tale)
     [(weld msg result.state) mergebase=~]
   ::
       [tako:clay ~]
@@ -103,8 +103,7 @@
     =/  mainline-commit
       .^(yaki:clay %cs /(scot %p our)/[syd]/(scot cas)/yaki/(scot %uv mainline))
     ::
-    =/  msg=(list cord)
-      (msg-from-commit this-commit tale)
+    =/  msg=wain  (msg-from-commit this-commit tale)
     ::
     ::  1 - process current commit
     ::  2 - recur and queue processing on all commits on the sideline
@@ -141,14 +140,9 @@
 ::
 ++  msg-from-commit
   |=  [commit=yaki:clay tale=story]
-  ^-  (list cord)
-  =/  proses  (~(get by tale) r.commit)
+  ^-  wain
+  =/  proses  (~(get ju tale) r.commit)
   ?~  proses  ~
   %-  flop    :: fixes formatting reversal in dojo
-  %-  to-wain:format
-  %-  crip
-  ;:  welp
-    (tako-to-text:lib r.commit)
-    (proses-to-text:lib u.proses)
-  ==
+  (chapter-to-text:lib r.commit proses)
 --

--- a/pkg/base-dev/lib/story.hoon
+++ b/pkg/base-dev/lib/story.hoon
@@ -38,41 +38,17 @@
 ::
 ::  Canonical textual representation
 ::
-++  tako-to-text
-  |=  [=tako:clay]
-  ^-  tape
-  "commit: {<`@uv`tako>}\0a"
-::
-++  proses-to-text
-  |=  [=proses]
-  ^-  tape
-  =/  proses-list=(list prose)  ~(tap in proses)
-  ?:  ?=(~ proses-list)  ""
-  ?:  ?=([prose ~] proses-list)
-    (prose-to-text i.proses-list)
-  %-  tail
-  %^  spin  `(list prose)`t.proses-list
-    (prose-to-text i.proses-list)
-  |=  [prz=prose state=tape]
-  ^-  [prose tape]
-  :-  prz
-  ;:  welp
-    state
-    "|||"
-    "\0a"
-    (prose-to-text prz)
-  ==
-::
-++  prose-to-text
-  |=  prz=prose
-  =/  [title=@t body=@t]  prz
-  ^-  tape
-  ;:  welp
-    "{(trip title)}"
-    "\0a\0a"
-    "{(trip body)}"
-    "\0a"
-  ==
+++  chapter-to-text
+  |=  [=tako:clay =proses]
+  ^-  wain
+  :-  (crip "commit: {<`@uv`tako>}")
+  %-  zing
+  %+  join  `wain`~['|||']
+  %+  turn  ~(tap in proses)
+  |=  prose
+  ^-  wain
+  %-  to-wain:format
+  (rap 3 title '\0a\0a' body ~)
 ::
 ::  Parsers
 ::

--- a/pkg/base-dev/mar/story.hoon
+++ b/pkg/base-dev/mar/story.hoon
@@ -46,18 +46,13 @@
     [/text/x-urb-story (as-octs:mimes:html (of-wain:format txt))]
   ++  txt
     ^-  wain
-    %-  snoc  :_  ''  :: ensures terminating newline is present
+    %-  zing
+    %+  join  `wain`~['---']
     %+  murn  ~(tap by tale)
-    |=  [[=tako:clay =proses]]
-    ^-  (unit cord)
+    |=  [=tako:clay =proses]
+    ^-  (unit wain)
     ?~  proses  ~
-    %-  some
-    %-  crip
-    ;:  welp
-      (tako-to-text tako)
-      (proses-to-text proses)
-      "---"
-    ==
+    (some (chapter-to-text tako proses))
   --
 ++  grab
   |%                                                    ::  convert from


### PR DESCRIPTION
`+story-list` produced janky indentation because the `$-(story wain)` functions encoded linefeeds in the cords of the wain and the printer doesn't like this.

Story printing functions have been changed to produce pure wains without linefeeds.

resolves #6017