### PR TITLE
aqua: make `%swap-files` poke take a desk and add it to pill

### DIFF
--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -484,11 +484,11 @@
       [%swap-files @tas]
     =/  =desk  +.val
     =.  userspace-ova.pil
-      =/  slim-dirs=(list path)
-        ~[/app /ted /gen /lib /mar /sur /hoon/sys /arvo/sys /zuse/sys]
+      ::  take all files from a userspace desk
+      =/  all-dirs=(list path)  ~[/]
       :_  ~
       %-  unix-event:pill-lib
-      %+  %*(. file-ovum:pill-lib directories slim-dirs)
+      %+  %*(. file-ovum:pill-lib directories all-dirs)
       desk  /(scot %p our.hid)/[desk]/(scot %da now.hid)
     =^  ms  state  (poke-pill pil)
     (emit-cards ms)

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -7,6 +7,7 @@
 ::    OR
 ::  :aqua &pill +solid
 ::
+::  XX: update these examples
 ::  Then try stuff:
 ::  :aqua [%init ~[~bud ~dev]]
 ::  :aqua [%dojo ~[~bud ~dev] "[our eny (add 3 5)]"]
@@ -480,14 +481,15 @@
     =^  ms  state  (poke-pill pil)
     (emit-cards ms)
   ::
-      [%swap-files ~]
+      [%swap-files @tas]
+    =/  =desk  +.val
     =.  userspace-ova.pil
       =/  slim-dirs=(list path)
         ~[/app /ted /gen /lib /mar /sur /hoon/sys /arvo/sys /zuse/sys]
       :_  ~
       %-  unix-event:pill-lib
-      %-  %*(. file-ovum:pill-lib directories slim-dirs)
-      /(scot %p our.hid)/work/(scot %da now.hid)
+      %+  %*(. file-ovum:pill-lib directories slim-dirs)
+      desk  /(scot %p our.hid)/[desk]/(scot %da now.hid)
     =^  ms  state  (poke-pill pil)
     (emit-cards ms)
   ::


### PR DESCRIPTION
Previously, attempting to use aqua's `%swap-files` poke would crash, since the scry path was malformed. The desk was also hard-coded to `%work` -- now the user inputs a desk name. I've tested the new poke, and was able to successfully add a desk to aqua's pill and spin up a new fakeship with it, which then properly installed the agents in that desk.