### PR TITLE
Add folders for pill creation.

### DIFF
--- a/pkg/base-dev/lib/pill.hoon
+++ b/pkg/base-dev/lib/pill.hoon
@@ -39,6 +39,8 @@
 ++  file-ovum
   =/  directories=(list path)
     :~  /app    ::  %gall applications
+        /dia    ::  %citadel desk templates
+        /doc    ::  documentation
         /gen    ::  :dojo generators
         /lib    ::  libraries
         /mar    ::  mark definitions


### PR DESCRIPTION
The current pill library for +brass leaves out /doc (%docs) and /dia (%citadel).

This means that brass pills based on these desks currently break on initial boot.