### PR TITLE
fix apt:in duplicate bug #6037

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1247,10 +1247,10 @@
     =|  [l=(unit) r=(unit)]
     |.  ^-  ?
     ?~  a   &
-    ?&  ?~(l & (gor n.a u.l))
-        ?~(r & (gor u.r n.a))
-        ?~(l.a & ?&((mor n.a n.l.a) $(a l.a, l `n.a)))
-        ?~(r.a & ?&((mor n.a n.r.a) $(a r.a, r `n.a)))
+    ?&  ?~(l & &((gor n.a u.l) !=(n.a u.l)))
+        ?~(r & &((gor u.r n.a) !=(u.r n.a)))
+        ?~(l.a & ?&((mor n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
+        ?~(r.a & ?&((mor n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
     ==
   ::
   ++  bif                                               ::  splits a by b

--- a/pkg/arvo/tests/sys/hoon/set.hoon
+++ b/pkg/arvo/tests/sys/hoon/set.hoon
@@ -106,6 +106,10 @@
   ::  Doesn't follow horizontal & vertical ordering
   ::
   =/  unbalanced-e=(set @)  [1 [3 ~ ~] [2 ~ ~]]
+  ::  Duplicate elements
+  ::
+  =/  has-dupes=(set @)  [1 [1 ~ ~] ~]
+  ::
   ;:  weld
     %+  expect-eq
       !>  [%b-a %.y]
@@ -125,6 +129,9 @@
     %+  expect-eq
       !>  [%u-e %.n]
       !>  [%u-e ~(apt in unbalanced-e)]
+    %+  expect-eq
+      !>  [%h-d %.n]
+      !>  [%h-d ~(apt in has-dupes)]
   ==
 ::
 ::  Test splits a in b

--- a/pkg/urbit/jets/d/in_apt.c
+++ b/pkg/urbit/jets/d/in_apt.c
@@ -13,15 +13,21 @@ _in_apt(u3_noun a, u3_weak l, u3_weak r)
     u3_noun n_a, l_a, r_a;
     u3x_trel(a, &n_a, &l_a, &r_a);
 
-    if ( (u3_none != l) && (c3n == u3qc_gor(n_a, l)) ) {
+    if ( (u3_none != l) &&
+         ( (c3y == u3r_sing(n_a, l)) || (c3n == u3qc_gor(n_a, l)) )) {
       return c3n;
     }
 
-    if ( (u3_none != r) && (c3n == u3qc_gor(r, n_a)) ) {
+    if ( (u3_none != r) &&
+         ( (c3y == u3r_sing(r, n_a)) || (c3n == u3qc_gor(r, n_a)) )) {
       return c3n;
     }
 
     if ( u3_nul != l_a ) {
+      if ( c3y == u3r_sing(n_a, u3h(l_a)) ) {
+        return c3n;
+      }
+
       if ( c3n == u3qc_mor(n_a, u3h(l_a)) ) {
         return c3n;
       }
@@ -32,6 +38,10 @@ _in_apt(u3_noun a, u3_weak l, u3_weak r)
     }
 
     if ( u3_nul != r_a ) {
+      if ( c3y == u3r_sing(n_a, u3h(r_a)) ) {
+        return c3n;
+      }
+
       if ( c3n == u3qc_mor(n_a, u3h(r_a)) ) {
         return c3n;
       }


### PR DESCRIPTION
FIX: #6037 
`apt:in` now checks for duplicates
```
> ~(apt in ^-((set) [1 [1 ~ ~] ~]))`
%.n
```