### PR TITLE
vere: check for permission error on old process kill

### DIFF
--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -592,7 +592,15 @@ u3_disk_acquire(c3_c* pax_c)
     else if (pid_w != getpid()) {
       c3_w i_w;
 
-      if ( -1 != kill(pid_w, SIGTERM) ) {
+      int ret = kill(pid_w, SIGTERM);
+
+      if ( -1 == ret && errno == EPERM ) {
+        u3l_log("disk: permission denied when trying to kill process %d!\n", pid_w);
+        kill(getpid(), SIGTERM);
+        sleep(1); c3_assert(0);
+      }
+
+      if ( -1 != ret ) {
         u3l_log("disk: stopping process %d, live in %s...\n",
                 pid_w, pax_c);
 


### PR DESCRIPTION
If you run the urbit binary as root (common in `systemd` services and similar) and happen to run the urbit binary again as a less privileged user the lockfile handling of vere fails. This is a common cause of corruption in situations like #6024. To reproduce, start a fakezod with `sudo`, then run the same fakezod as a normal user.

This PR adds an explicit check for the `kill` permission error, making the protection against dual boot situations more robust.