### PR TITLE
arvo: use breadth-first move order

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1241,7 +1241,7 @@
     ::
     ++  emit
       |=  pan=plan
-      this(run [pan run])
+      this(run (weld run pan ~))
     ::  +loop: until done
     ::
     ++  loop

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -184,7 +184,7 @@
       kel=(list (pair path (cask)))
       fil=(list (pair path (cask)))
   ==
-+$  germ  [vane=term bars=(list duct)]
++$  germ  [vane=term bars=(list [@tD duct])]
 +$  grub
   $:  ::  who: identity once we know it
       ::  eny: entropy once we learn it
@@ -337,6 +337,15 @@
       ==
     ~
   `[[q.p.i q.p.i.t]:p.u.lot u.bem]
+::
+++  rant
+  |=  [a=(list [char=@tD *]) b=tape]
+  ^-  tape
+  ?~  a
+    b
+  =.  b  [char.i.a b]
+  $(a t.a)
+::
 ::
 ++  look
   ~/  %look
@@ -1193,6 +1202,7 @@
             ::
             run=(list plan)
             out=(list ovum)
+            neb=_14
             gem=germ
             dud=(unit goof)
             $=  but  %-  unit
@@ -1275,7 +1285,7 @@
         =*  task  task.note.ball.move
         ::
         ~?  &(!lac.fad !=(%$ vane.gem))
-          :-  (runt [(lent bars.gem) '|'] "")
+          :-  (rant bars.gem "")
           :^  %pass  [vane.gem vane]
             ?:  ?=(?(%deal %deal-gall) +>-.task)
               :-  :-  +>-.task
@@ -1296,7 +1306,7 @@
         =*  task  task.note.ball.move
         ::
         ~?  !lac.fad
-          :-  (runt [(lent bars.gem) '|'] "")
+          :-  (rant bars.gem "")
           [%slip [vane.gem vane] (symp +>-.task) duct]
         ::
         (call duct vane task)
@@ -1316,7 +1326,7 @@
           ?>(?=(^ wire) wire)
         ::
         ~?  &(!lac.fad !=(%$ way) |(!=(%blit +>-.gift) !=(%d vane.gem)))
-          :-  (runt [(lent bars.gem) '|'] "")
+          :-  (rant bars.gem "")
           :^  %give  vane.gem
             ?:  ?=(%unto +>-.gift)
               [+>-.gift (symp +>+<.gift)]
@@ -1397,8 +1407,9 @@
         ;;(waif q.p.task)
       ::
       =.  way  (grow way)
-      %+  push  [way duct bars.gem]
-      ~|  bar-stack=`(list ^duct)`[duct bars.gem]
+      =.  neb  (^mod +(neb) 94)
+      %+  push  [way [(add '!' neb) duct] bars.gem]
+      ~|  bar-stack=`(list ^duct)`[duct (turn bars.gem tail)]
       %.  task
       call:(spin:(plow way) duct eny dud)
     ::  +take: retreat along call-stack
@@ -1415,12 +1426,13 @@
       ::  the caller was a vane
       ::
       =.  way  (grow way)
-      %+  push  [way duct bars.gem]
+      =.  neb  (^mod +(neb) 94)
+      %+  push  [way [(add '!' neb) duct] bars.gem]
       ::
       ::  cons source onto .gift to make a $sign
       ::
       ~|  wire=wire
-      ~|  bar-stack=`(list ^duct)`[duct bars.gem]
+      ~|  bar-stack=`(list ^duct)`[duct (turn bars.gem tail)]
       %.  [wire [vane.gem gift]]
       take:(spin:(plow way) duct eny dud)
     ::  +push: finalize an individual step

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -339,9 +339,12 @@
   `[[q.p.i q.p.i.t]:p.u.lot u.bem]
 ::
 ++  rant
-  |=  [a=(list [char=@tD *]) b=tape]
-  ^-  tape
+  |=  a=(list [char=@tD *])
+  =|  b=tape
   ?~  a
+    b
+  |-  ^-  tape
+  ?~  t.a
     b
   =.  b  [char.i.a b]
   $(a t.a)
@@ -1202,7 +1205,7 @@
             ::
             run=(list plan)
             out=(list ovum)
-            neb=_14
+            neb=_15
             gem=germ
             dud=(unit goof)
             $=  but  %-  unit
@@ -1261,7 +1264,7 @@
           ==
         abet
       ?:  =(~ q.i.run)    :: XX TMI
-        loop(run t.run)
+        loop(run t.run, neb 15)
       =.  dud  ~
       =.  gem  p.i.run
       =^  mov=move  q.i.run  q.i.run
@@ -1273,6 +1276,10 @@
       ^+  this
       ::
       ~?  &(!lac.fad ?=(^ dud))  %goof
+      =.  neb  (^mod +(neb) 94)
+      =/  bar  (add '!' neb)
+      ::
+      |-
       ::
       ?-  -.ball.move
       ::
@@ -1285,7 +1292,7 @@
         =*  task  task.note.ball.move
         ::
         ~?  &(!lac.fad !=(%$ vane.gem))
-          :-  (rant bars.gem "")
+          :-  (rant [bar duct] bars.gem)
           :^  %pass  [vane.gem vane]
             ?:  ?=(?(%deal %deal-gall) +>-.task)
               :-  :-  +>-.task
@@ -1296,7 +1303,7 @@
         ::
         ::  cons source onto wire, and wire onto duct
         ::
-        (call [[vane.gem wire] duct] vane task)
+        (call bar [[vane.gem wire] duct] vane task)
       ::
       ::  %slip: lateral move
       ::
@@ -1306,10 +1313,10 @@
         =*  task  task.note.ball.move
         ::
         ~?  !lac.fad
-          :-  (rant bars.gem "")
+          :-  (rant [bar duct] bars.gem)
           [%slip [vane.gem vane] (symp +>-.task) duct]
         ::
-        (call duct vane task)
+        (call bar duct vane task)
       ::
       ::  %give: return move
       ::
@@ -1326,14 +1333,14 @@
           ?>(?=(^ wire) wire)
         ::
         ~?  &(!lac.fad !=(%$ way) |(!=(%blit +>-.gift) !=(%d vane.gem)))
-          :-  (rant bars.gem "")
+          :-  (rant [bar duct] bars.gem)
           :^  %give  vane.gem
             ?:  ?=(%unto +>-.gift)
               [+>-.gift (symp +>+<.gift)]
             (symp +>-.gift)
           duct.move
         ::
-        (take duct wire way gift)
+        (take bar duct wire way gift)
       ::
       ::  %hurl: action with error
       ::
@@ -1398,7 +1405,7 @@
     ::  +call: advance to target
     ::
     ++  call
-      |=  [=duct way=term task=maze]
+      |=  [bar=@tD =duct way=term task=maze]
       ^+  this
       ?:  ?=(%$ way)
         ~>  %mean.'arvo: call:pith failed'
@@ -1407,15 +1414,14 @@
         ;;(waif q.p.task)
       ::
       =.  way  (grow way)
-      =.  neb  (^mod +(neb) 94)
-      %+  push  [way [(add '!' neb) duct] bars.gem]
+      %+  push  [way [bar duct] bars.gem]
       ~|  bar-stack=`(list ^duct)`[duct (turn bars.gem tail)]
       %.  task
       call:(spin:(plow way) duct eny dud)
     ::  +take: retreat along call-stack
     ::
     ++  take
-      |=  [=duct =wire way=term gift=maze]
+      |=  [bar=@tD =duct =wire way=term gift=maze]
       ^+  this
       ?:  ?=(%$ way)
         ::
@@ -1426,8 +1432,7 @@
       ::  the caller was a vane
       ::
       =.  way  (grow way)
-      =.  neb  (^mod +(neb) 94)
-      %+  push  [way [(add '!' neb) duct] bars.gem]
+      %+  push  [way [bar duct] bars.gem]
       ::
       ::  cons source onto .gift to make a $sign
       ::


### PR DESCRIPTION
There's a 7-year-old debate about depth-first vs breadth-first move
order, and it flared up again recently, and I think I've convinced
myself that breadth-first is actually importantly better than
depth-first.

Implementation-wise, I think this one-line change is best (only the change
to +emit has any effect, the rest only changes the |verb output).  The main
alternative is to change `run` from `(list plan)` to `(qeu plan)`, which
has better asymptotics if you move trees with large fanout.  However,
(1) this would need to be a deque, which we don't have yet, and (2) even
then the constants are somewhat worse, and I suspect the constants
dominate for the size of move trees we're dealing with.

I've run this on fake ships, booted fake ships from a pill, and run it
on a localhost copy of ~wicdev-wisryt.  All of this is on top of
philip/agent-clay, but that will go out either before or along with this
change.

Some background on the move order debate:

We consider computation inside Arvo to have three stacks:
- the nock stack, which gets deeper as you go deeper into a nock formula
- the duct stack, which gets deeper as you %pass along a duct.  this
  might last through multiple events and is not a true stack because you
  might pop (%give) multiple times from the same point.
- the "bar" stack, which gets deeper as you go deeper in the move tree.
  "bar" refers to its visualization in |verb.  Both %pass and %give push
  bars onto this stack, and each move sent as a result of those moves
  are one level deeper in the stack.

This change affects the bar stack.  Visually, when evaluating
depth-first an event may look like this:

```
["" %unix %belt /d/term/1 ~2022.10.27..06.32.09..30db]
["|" %pass [%dill %g] [[%deal [~zod ~zod] %hood %poke] /] ~[//term/1]]
["||" %give %gall [%unto %poke-ack] i=/dill t=~[//term/1]]
["||" %pass [%gall %g] [[%deal [~zod ~zod] %dojo %poke] /use/hood/0w2.efXKi/out/~zod/dojo/drum/phat/~zod/dojo] ~[/dill //term/1]]
["|||" %give %gall [%unto %poke-ack] i=/gall/use/hood/0w2.efXKi/out/~zod/dojo/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w2.efXKi/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["||||" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w2.efXKi/~zod/view/ t=~[/dill //term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w2.efXKi/~zod/view/ t=~[/dill //term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w2.efXKi/~zod/view/ t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w2.efXKi/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["||||" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w2.efXKi/~zod/view/ t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w2.efXKi/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w2.efXKi/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
```

While breadth-first it looks like this:

```
["" %unix %belt /d/term/1 ~2022.10.27..06.32.57..1d2c]
["|" %pass [%dill %g] [[%deal [~zod ~zod] %hood %poke] /] ~[//term/1]]
["||" %give %gall [%unto %poke-ack] i=/dill t=~[//term/1]]
["||" %pass [%gall %g] [[%deal [~zod ~zod] %dojo %poke] /use/hood/0w3.qnAr5/out/~zod/dojo/drum/phat/~zod/dojo] ~[/dill //term/1]]
["|||" %give %gall [%unto %poke-ack] i=/gall/use/hood/0w3.qnAr5/out/~zod/dojo/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w3.qnAr5/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w3.qnAr5/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w3.qnAr5/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["|||" %give %gall [%unto %fact] i=/gall/use/hood/0w3.qnAr5/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["||||" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["||||" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w3.qnAr5/~zod/view/ t=~[/dill //term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w3.qnAr5/~zod/view/ t=~[/dill //term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w3.qnAr5/~zod/view/ t=~[/dill //term/1]]
["|||||" %give %dill %blit i=/gall/use/herm/0w3.qnAr5/~zod/view/ t=~[/dill //term/1]]
```

These are the same 15 lines, and they're each at the same depth, but
they're in a different order.  Most code we write is agnostic to this
order, because there are many circumstances where this order gets
inverted compared to our expectations.


The most obvious difference is that the four %facts from dojo to hood
happen one right after the other instead of being mingled with other
moves.  If some of those intermingled moves invoked dojo (which would be
a form of reentrancy) and caused dojo to emit more facts, those facts
would be given to hood *before* the %facts which were already on the
stack to be sent to hood.  If this is textual output, then it will be in
reverse order.  The breadth-first move order fixes this problem
completely by running all the facts that were issued at the same time
before processing the moves that those themselves produced.

This leads to a very important principle: breadth-first ordering
guarantees that moves will be processed in the order they are emitted.
Depth-first ordering constantly violates this, and in the presence of
reentrancy this can cause extremely unexpected results.

The usual argument for depth-first ordering is that it feels like it
should allow greater composability.  In both cases, if A sends moves to
B and C, then A knows that the move to B will happen before the move to
C.  However, in depth-first ordering, we further know that anything that
B causes to happen will also happen before the move to C.  This means
the move to B will "fully complete", even if it delegates some of the
work to another entity.  Of course, this doesn't apply if B needs to
send something over the wire to fully complete.

Another guarantee that depth-first ordering gives you is that the first
move you send will be processed immediately, with no intervening moves.
Breadth-first ordering often will process other moves that were already
in the queue.

Overall, the guarantees that depth-first ordering gives are rarely
useful because they can be violated in practice, while the guarantees
that breadth-first ordering gives are consistent and more useful.


The second commit changes the |verb output to clearly specify the "bar"
stack.  Without this, it's not clear which moves were produced by which
moves.  The way to read this is that a move with stack `ABC` was
produced by a move with stack `AB`, so you can scan upward to find it.
This is the example from above:

```
["" %unix %belt /d/term/1 ~2022.10.27..07.38.32..876d]
["0" %pass [%dill %g] [[%deal [~zod ~zod] %hood %poke] /] ~[//term/1]]
["01" %give %gall [%unto %poke-ack] i=/dill t=~[//term/1]]
["01" %pass [%gall %g] [[%deal [~zod ~zod] %dojo %poke] /use/hood/0wUvCOt/out/~zod/dojo/drum/phat/~zod/dojo] ~[/dill //term/1]]
["013" %give %gall [%unto %poke-ack] i=/gall/use/hood/0wUvCOt/out/~zod/dojo/drum/phat/~zod/dojo t=~[/dill //term/1]]
["013" %give %gall [%unto %fact] i=/gall/use/hood/0wUvCOt/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["013" %give %gall [%unto %fact] i=/gall/use/hood/0wUvCOt/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["013" %give %gall [%unto %fact] i=/gall/use/hood/0wUvCOt/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["013" %give %gall [%unto %fact] i=/gall/use/hood/0wUvCOt/out/~zod/dojo/1/drum/phat/~zod/dojo t=~[/dill //term/1]]
["0135" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["0136" %give %gall [%unto %fact] i=/dill t=~[//term/1]]
["01359" %give %dill %blit i=/gall/use/herm/0wUvCOt/~zod/view/ t=~[/dill //term/1]]
["01359" %give %dill %blit i=/gall/use/herm/0wUvCOt/~zod/view/ t=~[/dill //term/1]]
["01359" %give %dill %blit i=/gall/use/herm/0wUvCOt/~zod/view/ t=~[/dill //term/1]]
["0136:" %give %dill %blit i=/gall/use/herm/0wUvCOt/~zod/view/ t=~[/dill //term/1]]
```

Here we can see that the dill blits are not all caused by the same move,
which was not clear with just bars in the output.  This is not as
aesthetically clean, but the information is frequently important.

NB: this |verb change requires an upgrade to arvo's state, which is not
included in this PR currently.  It's easy to do as a kelvin upgrade
(which this upgrade should do anyway) by updating the +heir type and
writing a state upgrade in +load.
