### PR TITLE
Improved eval code

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1012,15 +1012,21 @@ static void
 _cw_eval(c3_i argc, c3_c* argv[])
 {
   c3_o jam_l;
+  c3_o khan_l;
 
   switch ( argc ) {
     case 2: {
-      jam_l = c3n ;
+      jam_l = c3n;
+      khan_l = c3n;
     } break;
 
     case 3: {
       if ( 0 == strcmp(argv[2], "-j") )  {
         jam_l = c3y;
+        khan_l = c3n;
+      } else if ( 0 == strcmp(argv[2], "-jk") ) {
+        jam_l = c3y;
+        khan_l = c3y;
       } else {
         fprintf(stderr, "invalid flag\r\n");
         exit(1);
@@ -1081,41 +1087,43 @@ _cw_eval(c3_i argc, c3_c* argv[])
     u3z(res);
     u3z(gat);
   } else {
-      u3_noun sam = u3i_string(evl_c);
-      u3_noun res = u3v_wish_n(sam);
+    u3_noun sam = u3i_string(evl_c);
+    u3_noun res = u3v_wish_n(sam);
 
-      fprintf(stderr,"jamming\r\n");
+    c3_d bits = 0;
+    c3_d len_d = 0;
+    c3_y* byt_y;
 
-      c3_d bits = 0;
-      c3_d len_d = 0;
-      c3_y* byt_y;
+    bits = u3s_jam_xeno(res, &len_d, &byt_y);
 
-      bits = u3s_jam_xeno(res, &len_d, &byt_y);
-
-      //printf("bits: %d \n", bits);
-      //printf("size: %d \n", sizeof byt_y/ sizeof byt_y[0]);
-      //printf("len_d: %" PRIu64 "\n", len_d);
-      //printf("%x\n", (char*)byt_y);
-      //u3m_p("jam_n_t", res);
+    if ( c3n == khan_l ) {
       fprintf(stderr,"jammed noun: ");
-      
-      int p=len_d;
-      while (0 <p ){
-          fprintf(stderr,"%x", byt_y[--p]);
+       
+      int p=0;
+      while (p < len_d ){
+        fprintf(stdout,"\\x%2x", byt_y[p++]);
       }
-      fprintf(stderr,"\n");
+        fprintf(stderr,"\n");
+      } else {
+        fprintf(stderr,"khan jammed noun: ");
+         
+        struct khanjam{
+          c3_y zer;
+          c3_d len;
+        };
 
-      fprintf(stderr,"khan jam: ");
-      fwrite(*byt_y, sizeof(byt_y), 1, stdout);
-      /*
-      printf("%02x%08lx",0, len_d);
-      p=0;
-      while (p < len_d){
-          printf("%x", byt_y[p]);
+        struct khanjam data = {0, len_d};
+         
+        fwrite(&data, 1, 9, stdout);
+         
+
+        int p=0;
+        while (p < len_d){
+          fwrite(&(byt_y[p]), 1, 1, stdout);
           p++;
+        }
+        fprintf(stderr, "\n");
       }
-      fprintf(stderr, "\n");
-      */
     u3z(res);
     u3z(sam);
   }

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1058,41 +1058,65 @@ _cw_eval(c3_i argc, c3_c* argv[])
   }
 
   fprintf(stderr, "eval:\n");
+  if ( c3n == jam_l ) {
 
-  //  +wish for an eval gate (virtualized twice for pretty-printing)
-  //
-  u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
-  u3_noun res;
-  {
-    u3_noun sam = u3i_string(evl_c);
-    u3_noun cor = u3nc(u3k(u3h(gat)), u3nc(sam, u3k(u3t(u3t(gat)))));
-    res = u3m_soft(0, u3n_kick_on, cor);
+    //  +wish for an eval gate (virtualized twice for pretty-printing)
+    //
+    u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
+    u3_noun res;
+    {
+      u3_noun sam = u3i_string(evl_c);
+      u3_noun cor = u3nc(u3k(u3h(gat)), u3nc(sam, u3k(u3t(u3t(gat)))));
+      res = u3m_soft(0, u3n_kick_on, cor);
+    }
+  
+  
+    if ( 0 == u3h(res) ) {  //  successful execution, print output
+      u3_pier_tank(0, 0, u3k(u3t(res)));
+    }
+    else {                  //  error, print stack trace
+       u3_pier_punt_goof("eval", u3k(res));
+    }
+
+    u3z(res);
+    u3z(gat);
+  } else {
+      u3_noun sam = u3i_string(evl_c);
+      u3_noun res = u3v_wish_n(sam);
+
+      printf("jamming\r\n");
+
+      c3_d bits = 0;
+      c3_d len_d = 0;
+      c3_y* byt_y;
+
+      bits = u3s_jam_xeno(res, &len_d, &byt_y);
+
+      //printf("bits: %d \n", bits);
+      //printf("size: %d \n", sizeof byt_y/ sizeof byt_y[0]);
+      //printf("len_d: %" PRIu64 "\n", len_d);
+      //printf("%x\n", (char*)byt_y);
+      //u3m_p("jam_n_t", res);
+      printf("jammed noun: ");
+      
+      int p=len_d;
+      while (0 <p ){
+          printf("%x", byt_y[--p]);
+      }
+      printf("\n");
+
+      printf("khan jam: ");
+      printf("%x%08lx",0, len_d);
+      p=0;
+      while (p < len_d){
+          printf("%x", byt_y[p]);
+          p++;
+      }
+      printf("\n");
+   
+    u3z(res);
+    u3z(sam);
   }
-
-
-  if ( 0 == u3h(res) ) {  //  successful execution, print output
-     if ( c3y == jam_l ) {
-        printf("jamming\r\n");
-        u3_noun jam_n;
-        {
-           u3_noun sam = u3v_wish("|=(a=@t (jam a))");
-           u3_noun cor = u3nc(u3k(u3h(sam)), u3k(u3t(res)));
-           jam_n = u3m_soft(0, u3n_kick_on, cor);
-
-           u3_pier_tank(0, 0, u3t(jam_n));
-        }
-
-
-
-     }
-     u3_pier_tank(0, 0, u3k(u3t(res)));
-  }
-  else {                  //  error, print stack trace
-     u3_pier_punt_goof("eval", u3k(res));
-  }
-
-  u3z(res);
-  u3z(gat);
   free(evl_c);
 }
 

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1011,6 +1011,28 @@ _cw_eval_get_input(FILE* fil_u, size_t siz_i)
 static void
 _cw_eval(c3_i argc, c3_c* argv[])
 {
+  c3_o jam_l;
+
+  switch ( argc ) {
+    case 2: {
+      jam_l = c3n ;
+    } break;
+
+    case 3: {
+      if ( 0 == strcmp(argv[2], "-j") )  {
+        jam_l = c3y;
+      } else {
+        fprintf(stderr, "invalid flag\r\n");
+        exit(1);
+      }
+    } break;
+
+    default: {
+      fprintf(stderr, "invalid command\r\n");
+      exit(1);
+    } break;
+  }
+
   c3_c* evl_c = _cw_eval_get_input(stdin, 10);
 
   //  initialize the Loom and load the Ivory Pill
@@ -1025,7 +1047,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     u3m_boot_lite();
     sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
     if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
-      printf("lite: unable to cue ivory pill\r\n");
+      fprintf(stderr, "lite: unable to cue ivory pill\r\n");
       exit(1);
     }
     u3s_cue_xeno_done(sil_u);
@@ -1035,7 +1057,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     }
   }
 
-  printf("eval:\n");
+  fprintf(stderr, "eval:\n");
 
   //  +wish for an eval gate (virtualized twice for pretty-printing)
   //
@@ -1049,6 +1071,20 @@ _cw_eval(c3_i argc, c3_c* argv[])
 
 
   if ( 0 == u3h(res) ) {  //  successful execution, print output
+     if ( c3y == jam_l ) {
+        printf("jamming\r\n");
+        u3_noun jam_n;
+        {
+           u3_noun sam = u3v_wish("|=(a=@t (jam a))");
+           u3_noun cor = u3nc(u3k(u3h(sam)), u3k(u3t(res)));
+           jam_n = u3m_soft(0, u3n_kick_on, cor);
+
+           u3_pier_tank(0, 0, u3t(jam_n));
+        }
+
+
+
+     }
      u3_pier_tank(0, 0, u3k(u3t(res)));
   }
   else {                  //  error, print stack trace

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1084,7 +1084,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
       u3_noun sam = u3i_string(evl_c);
       u3_noun res = u3v_wish_n(sam);
 
-      printf("jamming\r\n");
+      fprintf(stderr,"jamming\r\n");
 
       c3_d bits = 0;
       c3_d len_d = 0;
@@ -1097,23 +1097,25 @@ _cw_eval(c3_i argc, c3_c* argv[])
       //printf("len_d: %" PRIu64 "\n", len_d);
       //printf("%x\n", (char*)byt_y);
       //u3m_p("jam_n_t", res);
-      printf("jammed noun: ");
+      fprintf(stderr,"jammed noun: ");
       
       int p=len_d;
       while (0 <p ){
-          printf("%x", byt_y[--p]);
+          fprintf(stderr,"%x", byt_y[--p]);
       }
-      printf("\n");
+      fprintf(stderr,"\n");
 
-      printf("khan jam: ");
+      fprintf(stderr,"khan jam: ");
+      fwrite(*byt_y, sizeof(byt_y), 1, stdout);
+      /*
       printf("%02x%08lx",0, len_d);
       p=0;
       while (p < len_d){
           printf("%x", byt_y[p]);
           p++;
       }
-      printf("\n");
-   
+      fprintf(stderr, "\n");
+      */
     u3z(res);
     u3z(sam);
   }

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1106,7 +1106,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
       printf("\n");
 
       printf("khan jam: ");
-      printf("%x%08lx",0, len_d);
+      printf("%02x%08lx",0, len_d);
       p=0;
       while (p < len_d){
           printf("%x", byt_y[p]);

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1114,7 +1114,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
         out_y[3] = ((len_d >> 16) & 0xff);
         out_y[4] = ((len_d >> 24) & 0xff);
          
-        fclose(stdout);
+        fwrite(out_y, 1, 5, stdout);
         if( ferror(stdout))
         {
            fprintf(stderr, "Write Failed : %s\n",strerror(errno) );

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1107,21 +1107,25 @@ _cw_eval(c3_i argc, c3_c* argv[])
       } else {
         fprintf(stderr,"khan jammed noun: ");
          
-        struct khanjam{
-          c3_y zer;
-          c3_d len;
-        };
-
-        struct khanjam data = {0, len_d};
+        c3_y out_y[5];
+        out_y[0] = 0x0;
+        out_y[1] = ( len_d        & 0xff);
+        out_y[2] = ((len_d >>  8) & 0xff);
+        out_y[3] = ((len_d >> 16) & 0xff);
+        out_y[4] = ((len_d >> 24) & 0xff);
          
-        fwrite(&data, 1, 9, stdout);
-         
-
-        int p=0;
-        while (p < len_d){
-          fwrite(&(byt_y[p]), 1, 1, stdout);
-          p++;
+        fclose(stdout);
+        if( ferror(stdout))
+        {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
         }
+        fwrite(byt_y, 1, len_d, stdout);
+        if( ferror(stdout))
+        {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
+        }  
         fprintf(stderr, "\n");
       }
     u3z(res);

--- a/pkg/urbit/include/noun/vortex.h
+++ b/pkg/urbit/include/noun/vortex.h
@@ -57,6 +57,11 @@
       u3_noun
       u3v_do(const c3_c* txt_c, u3_noun arg);
 
+    /* u3v_wish_n(): text expression with cache.
+    */
+      u3_noun
+      u3v_wish_n(const u3_noun txt);
+
     /* u3v_wish(): text expression with cache.
     */
       u3_noun

--- a/pkg/urbit/noun/vortex.c
+++ b/pkg/urbit/noun/vortex.c
@@ -120,6 +120,31 @@ _cv_nock_wish(u3_noun txt)
 /* u3v_wish(): text expression with cache.
 */
 u3_noun
+u3v_wish_n(u3_noun txt)
+{
+  u3t_event_trace("u3v_wish", 'b');
+  u3_weak exp = u3kdb_get(u3k(u3A->yot), u3k(txt));
+
+  if ( u3_none == exp ) {
+    exp = _cv_nock_wish(u3k(txt));
+
+    //  It's probably not a good idea to use u3v_wish()
+    //  outside the top level... (as the result is uncached)
+    //
+    if ( u3R == &u3H->rod_u ) {
+      u3A->yot = u3kdb_put(u3A->yot, u3k(txt), u3k(exp));
+    }
+  }
+
+  u3t_event_trace("u3v_wish", 'e');
+
+  u3z(txt);
+  return exp;
+}
+
+/* u3v_wish(): text expression with cache.
+*/
+u3_noun
 u3v_wish(const c3_c* str_c)
 {
   u3t_event_trace("u3v_wish", 'b');


### PR DESCRIPTION
I added the ability for the user pick two flags to pass to the eval subroutine. 

The first is the `-j` flag. This takes the result from the inputted hoon code , `+jam`'s it and outputs it as a hexadecimal string. 

The second is the `-jk` flag. This takes the result from the inputted hoon code, `+jam`'s it and outputs the noun wrapped in the proper `%khan` header (leading zero, noun size, noun) as binary data.

The proper use of the eval is as follows:
`echo "(add 2 2)" | urbit eval -jk > test.jam`

This should be the easiest way to `+jam` a noun for `%khan` use