### PR TITLE
language server: change +* to |$

### DIFF
--- a/pkg/base-dev/lib/language-server/complete.hoon
+++ b/pkg/base-dev/lib/language-server/complete.hoon
@@ -3,7 +3,8 @@
 ::
 =/  debug  |
 |%
-+*  option  [item]
+++  option
+  |$  [item]
   [term=cord detail=item]
 ::
 ::  Like +rose except also produces line number


### PR DESCRIPTION
See https://github.com/urbit/urbit/issues/6052.

This is the only use of the deprecated syntax of `+*` I was able to find in the repository.

I was going to make the changes to `+boog` to remove the `+*` parsing in the same PR, and that works fine on a ship with only `%base`. But Clay seems to run into issues with this on a regular solid pill fake ship with

```
> .^((set desk) %cd %)
{%bitcoin %base %landscape %webterm %garden %kids}
```

I haven't figured out why yet. Even though `+cat %/lib/language-server/complete/hoon` shows the change in the commit here, it still says its running into a syntax error as though it hadn't changed. I'll be adding the stack trace to https://github.com/urbit/urbit/issues/6052. In any case, it makes me pretty sure that we need to change the existing instance of `+*` first before changing `hoon.hoon`, thus the separate PR.