### PR TITLE
kiln: recursive `|rm`

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1259,8 +1259,8 @@
   =|  c=(list (unit toro))
   %+  poke-info  "removed: {<a>}"
   =-  %+  roll  -
-  |=  [a=(unit toro) b=(unit toro)]
-  (clap a b furl)
+      |=  [a=(unit toro) b=(unit toro)]
+      (clap a b furl)
   |-  ^-  (list (unit toro))
   =+  b=.^(arch %cy a)
   ?^  fil.b  (snoc c `(fray a))

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1200,15 +1200,6 @@
     abet:(spam leaf+mez ~)
   abet:(emit:(spam leaf+mez ~) %pass /kiln %arvo %c [%info u.tor])
 ::
-++  poke-infos
-  |=  [mez=tape mor=(list (unit toro))]
-  =<  abet
-  %-  emil:(spam leaf+mez ~)
-  %+  murn  mor
-  |=  tor=(unit toro)
-  ?~  tor  ~
-  `[%pass /kiln %arvo %c [%info u.tor]]
-::
 ++  poke-install
   |=  [loc=desk her=ship rem=desk]
   abet:abet:(install:vats +<)
@@ -1266,7 +1257,10 @@
 ++  poke-rm
   |=  a=path
   =|  c=(list (unit toro))
-  %+  poke-infos  "removed: {<a>}"
+  %+  poke-info  "removed: {<a>}"
+  =-  %+  roll  -
+  |=  [a=(unit toro) b=(unit toro)]
+  (clap a b furl)
   |-  ^-  (list (unit toro))
   =+  b=.^(arch %cy a)
   ?^  fil.b  (snoc c `(fray a))

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1200,6 +1200,15 @@
     abet:(spam leaf+mez ~)
   abet:(emit:(spam leaf+mez ~) %pass /kiln %arvo %c [%info u.tor])
 ::
+++  poke-infos
+  |=  [mez=tape mor=(list (unit toro))]
+  =<  abet
+  %-  emil:(spam leaf+mez ~)
+  %+  murn  mor
+  |=  tor=(unit toro)
+  ?~  tor  ~
+  `[%pass /kiln %arvo %c [%info u.tor]]
+::
 ++  poke-install
   |=  [loc=desk her=ship rem=desk]
   abet:abet:(install:vats +<)
@@ -1256,11 +1265,15 @@
 ::
 ++  poke-rm
   |=  a=path
+  =|  c=(list (unit toro))
+  %+  poke-infos  "removed: {<a>}"
+  |-  ^-  (list (unit toro))
   =+  b=.^(arch %cy a)
-  ?~  fil.b
-    =+  ~[leaf+"No such file:" leaf+"{<a>}"]
-    abet:(spam -)
-  (poke-info "removed" `(fray a))
+  ?^  fil.b  (snoc c `(fray a))
+  %-  zing
+  %+  turn  ~(tap by dir.b)
+  |=  [kid=@ta ~]
+  ^$(a (weld a /[kid]))
 ::
 ++  poke-schedule
   |=  [where=path tym=@da eve=@t]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1263,7 +1263,8 @@
       (clap a b furl)
   |-  ^-  (list (unit toro))
   =+  b=.^(arch %cy a)
-  ?^  fil.b  (snoc c `(fray a))
+  ?:  ?=([^ ~] b)  (snoc c `(fray a))  
+  =?  c  ?=(^ fil.b)  (snoc c `(fray a))
   %-  zing
   %+  turn  ~(tap by dir.b)
   |=  [kid=@ta ~]


### PR DESCRIPTION
Increments the commit number every time, is there a better way to do this?

<img width="461" alt="image" src="https://user-images.githubusercontent.com/2065299/200155234-7844e57f-4c5d-4d56-80b0-896bc8a38cb3.png">
