### PR TITLE
ames: debug print msg formatting fixes

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1247,7 +1247,7 @@
           =(%$ syd)
       ==
     ?.  for.veb.bug.ames-state  ~
-    ~>  %slog.0^leaf/"ames: scry-fail {<[why=why lot=lot now=now syd=syd]>}"
+    ~>  %slog.0^leaf/"ames: scry-fail {<why=why lot=lot now=now syd=syd>}"
     ~
   ::  /ax/protocol/version           @
   ::  /ax/peers                      (map ship ?(%alien %known))
@@ -1770,7 +1770,7 @@
         |.  ^-  tape
         =/  sndr  [our our-life.channel]
         =/  rcvr  [ship her-life.channel]
-        "plea {<sndr^rcvr^bone=bone^vane.plea^path.plea>}"
+        "plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
   ::  +on-cork: handle request to kill a flow
   ::
@@ -1791,7 +1791,7 @@
         |.  ^-  tape
         =/  sndr  [our our-life.channel]
         =/  rcvr  [ship her-life.channel]
-        "cork plea {<sndr^rcvr^bone=bone^vane.plea^path.plea>}"
+        "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
@@ -1919,14 +1919,14 @@
       ::  we shouldn't be hearing about ships we don't care about
       ::
       ?~  ship-state
-        ~>  %slog.0^leaf/"ames: breach unknown {<our^ship>}"
+        ~>  %slog.0^leaf/"ames: breach unknown {<our ship>}"
         event-core
       ::  if an alien breached, this doesn't affect us
       ::
       ?:  ?=([~ %alien *] ship-state)
-        ~>  %slog.0^leaf/"ames: breach alien {<our^ship>}"
+        ~>  %slog.0^leaf/"ames: breach alien {<our ship>}"
         event-core
-      ~>  %slog.0^leaf/"ames: breach peer {<our^ship>}"
+      ~>  %slog.0^leaf/"ames: breach peer {<our ship>}"
       ::  a peer breached; drop messaging state
       ::
       =/  =peer-state  +.u.ship-state
@@ -2582,12 +2582,12 @@
               =(~ unsent-fragments.pum)
               =(~ live.packet-pump-state.pum)
           ==
-        ~>  %slog.0^leaf/"ames: bad pump state {<[her.channel i.boz]>}"
+        ~>  %slog.0^leaf/"ames: bad pump state {<her.channel i.boz>}"
         $(boz t.boz)
       ::  no outstanding messages, so send a new %cork
       ::
       ::  TODO use +trace
-      ~>  %slog.0^leaf/"ames: recork {<[her.channel i.boz]>}"
+      ~>  %slog.0^leaf/"ames: recork {<her.channel i.boz>}"
       =/  =plea  [%$ /flow [%cork ~]]
       (on-memo i.boz plea %plea)
     ::  +got-duct: look up $duct by .bone, asserting already bound
@@ -3245,7 +3245,7 @@
         =?  packet-pump  ?=(^ static-fragment)
           %-  %+  trace  snd.veb
               =/  nums  [message-num fragment-num]:u.static-fragment.res
-              |.("dead {<nums^show:gauge>}")
+              |.("dead {<nums show:gauge>}")
           (give %send u.static-fragment.res)
         packet-pump
     ::
@@ -3366,7 +3366,7 @@
                     =(0 (mod counter.metrics.state 20))
                 ==
               same
-            (trace snd.veb |.("send: {<[fragment=fragment-num show:gauge]>}"))
+            (trace snd.veb |.("send: {<fragment=fragment-num show:gauge>}"))
         ::  .resends is backward, so fold backward and emit
         ::
         =.  packet-pump
@@ -3425,7 +3425,7 @@
     =-  =.  metrics.state  metrics.-
         =.  live.state     live.-
         ::
-        %-  (trace snd.veb |.("done {<message-num=message-num^show:gauge>}"))
+        %-  (trace snd.veb |.("done {<message-num=message-num show:gauge>}"))
         (fast-resend-after-ack message-num `fragment-num`0)
     ::
     ^+  [metrics=metrics.state live=live.state]
@@ -3563,7 +3563,7 @@
     ::
     =?  cwnd  !in-recovery  (max 2 (div cwnd 2))
     %-  %+  trace  snd.veb
-        |.("skip {<[resend=resend in-recovery=in-recovery show]>}")
+        |.("skip {<resend=resend in-recovery=in-recovery show>}")
     metrics
   ::  +on-timeout: (re)enter slow-start mode on packet loss
   ::
@@ -3657,7 +3657,7 @@
     ::
     ?:  (gte seq (add 10 last-acked.state))
       %-  %+  trace  odd.veb
-          |.("future %hear {<seq=seq^last-acked=last-acked.state>}")
+          |.("future %hear {<seq=seq last-acked=last-acked.state>}")
       message-sink
     ::
     =/  is-last-fragment=?  =(+(fragment-num) num-fragments)
@@ -3668,7 +3668,7 @@
         ::  single packet ack
         ::
         %-  %+  trace  rcv.veb
-            |.("send dupe ack {<seq=seq^fragment-num=fragment-num>}")
+            |.("send dupe ack {<seq=seq fragment-num>}")
         (give %send seq %& fragment-num)
       ::  whole message (n)ack
       ::
@@ -3688,8 +3688,8 @@
         %-  %+  trace  rcv.veb
             |.  ^-  tape
             =/  data
-              :*  her.channel  seq=seq  bone=bone
-                  fragment-num=fragment-num  num-fragments=num-fragments
+              :*  her.channel  seq=seq  bone=bone.shut-packet
+                  fragment-num  num-fragments
                   la=last-acked.state  lh=last-heard.state
               ==
             "hear last in-progress {<data>}"
@@ -3698,8 +3698,8 @@
       ::
       %-  %+  trace  rcv.veb  |.
           =/  data
-            :*  seq=seq  fragment-num=fragment-num
-                num-fragments=num-fragments  closing=closing
+            :*  seq=seq  fragment-num
+                num-fragments  closing=closing
             ==
           "send ack-1 {<data>}"
       (give %send seq %& fragment-num)
@@ -3729,7 +3729,7 @@
             "hear last dupe {<data>}"
         message-sink
       %-  %+  trace  rcv.veb
-          |.("send dupe ack {<her.channel^seq=seq^fragment-num=fragment-num>}")
+          |.("send dupe ack {<her.channel seq=seq fragment-num>}")
       (give %send seq %& fragment-num)
     ::  new fragment; store in state and check if message is done
     ::
@@ -3746,7 +3746,7 @@
     =?  message-sink  !is-last-fragment
       %-  %+  trace  rcv.veb  |.
           =/  data
-            [seq=seq fragment-num=fragment-num num-fragments=num-fragments]
+            [seq=seq fragment-num num-fragments]
           "send ack-2 {<data>}"
       (give %send seq %& fragment-num)
     ::  enqueue all completed messages starting at +(last-heard.state)


### PR DESCRIPTION
- fix `fragment-num` and `num-fragments` having duplicate faces
- fix faces being wrapped around wrong things in various places
- fix `bone` not being printed in "hear last in-progess" message
- make pretty tape interpolation style more uniform

@joemfb

resolves #6058