### PR TITLE
vere: use the urth PID in the lockfile

### DIFF
--- a/pkg/urbit/compat/mingw/compat.h
+++ b/pkg/urbit/compat/mingw/compat.h
@@ -8,6 +8,7 @@ char *realpath(const char *path, char *resolved_path);
 int fdatasync(int fd);
 int utimes(const char *path, const struct timeval times[2]);
 long sysconf(int name);
+int getppid();
 
 int kill(pid_t pid, int signum);
 

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1562,6 +1562,8 @@ _cw_boot(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
+  u3C.rol_e = u3o_mars;
+
   uv_loop_t* lup_u = u3_Host.lup_u = uv_default_loop();
   c3_c*      dir_c = argv[0];
   c3_c*      key_c = argv[1]; // XX use passkey
@@ -1631,6 +1633,8 @@ _cw_work(c3_i argc, c3_c* argv[])
     fprintf(stderr, "work: missing args\n");
     exit(1);
   }
+
+  u3C.rol_e = u3o_mars;
 
   c3_d       eve_d = 0;
   uv_loop_t* lup_u = u3_Host.lup_u = uv_default_loop();
@@ -1879,6 +1883,8 @@ main(c3_i   argc,
     //
     case 2: break;
   }
+
+  u3C.rol_e = u3o_urth;
 
   _main_self_path();
 

--- a/pkg/urbit/include/noun/options.h
+++ b/pkg/urbit/include/noun/options.h
@@ -3,13 +3,21 @@
 
   /** Data structures.
   **/
+    /* u3o_role: process role.
+    */
+      typedef enum _u3o_role {
+        u3o_sole = 0,                         //  default (util)
+        u3o_mars = 1,                         //  child
+        u3o_urth = 2                          //  parent
+      } u3o_role;
+
     /* u3o_config: process / system configuration.
     */
       typedef struct _u3o_config {
-        u3_noun who;                          //  single identity
-        c3_c*   dir_c;                        //  execution directory (pier)
-        c3_w    wag_w;                        //  flags (both ways)
-        size_t  wor_i;                        //  loom word-length (<= u3a_words)
+        u3o_role rol_e;                       //  process role
+        c3_c*    dir_c;                       //  execution directory (pier)
+        c3_w     wag_w;                       //  flags (both ways)
+        size_t   wor_i;                       //  loom words (<= u3a_words)
         void (*stderr_log_f)(c3_c*);          //  errors from c code
         void (*slog_f)(u3_noun);              //  function pointer for slog
         void (*sign_hold_f)(void);            //  suspend system signal regime

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -574,6 +574,14 @@ _disk_lock(c3_c* pax_c)
   return paf_c;
 }
 
+/* _disk_lock_pid(): PID for lockfile
+*/
+static c3_i
+_disk_lock_pid(void)
+{
+  return ( u3o_mars == u3C.rol_e ) ? getppid() : getpid();
+}
+
 /* u3_disk_acquire(): acquire a lockfile, killing anything that holds it.
 */
 static void
@@ -586,10 +594,10 @@ u3_disk_acquire(c3_c* pax_c)
   if ( NULL != (loq_u = c3_fopen(paf_c, "r")) ) {
     if ( 1 != fscanf(loq_u, "%" SCNu32, &pid_w) ) {
       u3l_log("lockfile %s is corrupt!\n", paf_c);
-      kill(getpid(), SIGTERM);
+      kill(_disk_lock_pid(), SIGTERM);
       sleep(1); c3_assert(0);
     }
-    else if (pid_w != getpid()) {
+    else if (pid_w != _disk_lock_pid()) {
       c3_w i_w;
 
       if ( -1 != kill(pid_w, SIGTERM) ) {
@@ -626,7 +634,7 @@ u3_disk_acquire(c3_c* pax_c)
     c3_assert(0);
   }
 
-  fprintf(loq_u, "%u\n", getpid());
+  fprintf(loq_u, "%u\n", _disk_lock_pid());
 
   {
     c3_i fid_i = fileno(loq_u);

--- a/pkg/urbit/vere/disk.c
+++ b/pkg/urbit/vere/disk.c
@@ -604,7 +604,7 @@ u3_disk_acquire(c3_c* pax_c)
 
       if ( -1 == ret && errno == EPERM ) {
         u3l_log("disk: permission denied when trying to kill process %d!\n", pid_w);
-        kill(getpid(), SIGTERM);
+        kill(_disk_lock_pid(), SIGTERM);
         sleep(1); c3_assert(0);
       }
 


### PR DESCRIPTION
u3 ignores SIGTERM in certain circumstances. This behavior is non-operable in the urth process, since libuv is configured to intercept SIGTERM and deliver it asynchronously on the main loop. But it is operable in the mars process. So the mars PID is a bad fit for the lockfile, which is a pidfile, and used by external scripts to shutdown vere (in CI, for example). The lockfile is managed along with the event log, which has been moved to mars.

This PR adds mars/urth/sole process roles to u3, and uses `getppid()` to create the lockfile when the process role is mars. It may well be better to change the signal-handling, but this is less risky for now.
