### PR TITLE
vere: bumps the loom max to 4GB (opt-in)

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -174,8 +174,8 @@ _main_init(void)
   u3_Host.ops_u.hap_w = 50000;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
-  u3_Host.ops_u.lut_y = u3a_bits + 2;
-  u3_Host.ops_u.lom_y = u3a_bits + 2;
+  u3_Host.ops_u.lut_y = u3a_bits + 1;
+  u3_Host.ops_u.lom_y = u3a_bits + 1;
 }
 
 /* _main_pier_run(): get pier from binary path (argv[0]), if appropriate

--- a/pkg/urbit/include/c/portable.h
+++ b/pkg/urbit/include/c/portable.h
@@ -158,24 +158,24 @@
 #     else
 #       define U3_OS_LoomBase 0x36000000
 #     endif
-#       define U3_OS_LoomBits 29
+#       define U3_OS_LoomBits 30
 #   elif defined(U3_OS_mingw)
 #       define U3_OS_LoomBase 0x28000000000
-#       define U3_OS_LoomBits 29
+#       define U3_OS_LoomBits 30
 #   elif defined(U3_OS_osx)
 #     ifdef __LP64__
 #       define U3_OS_LoomBase 0x28000000000
 #     else
 #       define U3_OS_LoomBase 0x4000000
 #     endif
-#       define U3_OS_LoomBits 29
+#       define U3_OS_LoomBits 30
 #   elif defined(U3_OS_bsd)
 #     ifdef __LP64__
 #       define U3_OS_LoomBase 0x200000000
 #     else
 #       define U3_OS_LoomBase 0x4000000
 #     endif
-#       define U3_OS_LoomBits 29
+#       define U3_OS_LoomBits 30
 #   else
 #     error "port: LoomBase"
 #   endif


### PR DESCRIPTION
This PR bumps the maximum loom size from 2GB (`2^31`) to 4GB (`2^32`). To avoid breaking any current deployments, the default loom size remains unchanged. Opt-in to the largest size with `--loom 32`. Thanks to cgy for leaving us an extra bit. More to come.

NB: this size bump is not currently opt-in across maintenance commands -- these will also need to be updated and support the `--loom` argument.