### PR TITLE
vere: implements demand paging

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -159,6 +159,15 @@ _main_init(void)
   //
   u3_Host.ops_u.has = c3y;
 
+  //  demand paging (ie, file-backed mapping for the loom)
+  //  is not yet supported on windows
+  //
+#ifdef U3_OS_mingw
+  u3_Host.ops_u.map = c3n;
+#else
+  u3_Host.ops_u.map = c3y;
+#endif
+
   u3_Host.ops_u.net = c3y;
   u3_Host.ops_u.lit = c3n;
   u3_Host.ops_u.nuu = c3n;
@@ -256,6 +265,7 @@ _main_getopt(c3_i argc, c3_c** argv)
     { "prop-name",           required_argument, NULL, 3 },
     { "auto-meld",           no_argument,       NULL, 4 },
     { "urth-loom",           required_argument, NULL, 5 },
+    { "no-demand",           no_argument,       NULL, 6 },
     //
     { NULL, 0, NULL, 0 },
   };
@@ -282,6 +292,10 @@ _main_getopt(c3_i argc, c3_c** argv)
         }
 
         u3_Host.ops_u.lut_y = lut_w;
+        break;
+      }
+      case 6: {  //  no-demand
+        u3_Host.ops_u.map = c3n;
         break;
       }
       case 'X': {
@@ -1967,6 +1981,12 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.gab) ) {
         u3C.wag_w |= u3o_debug_ram;
+      }
+
+      /*  Set no-demand flag.
+      */
+      if ( !_(u3_Host.ops_u.map) ) {
+        u3C.wag_w |= u3o_no_demand;
       }
 
       /*  Set auto-meld flag.

--- a/pkg/urbit/include/noun/options.h
+++ b/pkg/urbit/include/noun/options.h
@@ -22,16 +22,17 @@
     **  _check flags are set inside u3 and heard outside it.
     */
       enum u3o_flag {                         //  execution flags
-        u3o_debug_ram =     0x1,              //  debug: gc
-        u3o_debug_cpu =     0x2,              //  debug: profile
-        u3o_check_corrupt = 0x4,              //  check: gc memory
-        u3o_check_fatal =   0x8,              //  check: unrecoverable
-        u3o_verbose =       0x10,             //  be remarkably wordy
-        u3o_dryrun =        0x20,             //  don't touch checkpoint
-        u3o_quiet =         0x40,             //  disable ~&
-        u3o_hashless =      0x80,             //  disable hashboard
-        u3o_trace =         0x100,            //  enables trace dumping
-        u3o_auto_meld =     0x200             //  enables meld under pressure
+        u3o_debug_ram =     1 <<  0,          //  debug: gc
+        u3o_debug_cpu =     1 <<  1,          //  debug: profile
+        u3o_check_corrupt = 1 <<  2,          //  check: gc memory
+        u3o_check_fatal =   1 <<  3,          //  check: unrecoverable
+        u3o_verbose =       1 <<  4,          //  be remarkably wordy
+        u3o_dryrun =        1 <<  5,          //  don't touch checkpoint
+        u3o_quiet =         1 <<  6,          //  disable ~&
+        u3o_hashless =      1 <<  7,          //  disable hashboard
+        u3o_trace =         1 <<  8,          //  enables trace dumping
+        u3o_auto_meld =     1 <<  9,          //  enables meld under pressure
+        u3o_no_demand =     1 << 10           //  disables demand paging
       };
 
   /** Globals.

--- a/pkg/urbit/include/vere/vere.h
+++ b/pkg/urbit/include/vere/vere.h
@@ -311,6 +311,7 @@
         c3_o    con;                        //      run conn
         c3_o    doc;                        //      dock binary in pier
         u3_even* vex_u;                     //  --prop-*, boot enhanchements
+        c3_o    map;                        //  --no-demand (reversed)
         c3_o    mel;                        //  --auto-meld
       } u3_opts;
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1147,6 +1147,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
     }
     else {
       u3_ce_patch* pat_u;
+      c3_w  nor_w, sou_w;
 
       /* Load any patch files; apply them to images.
       */
@@ -1158,7 +1159,10 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         _ce_patch_delete();
       }
 
-      if ( u3P.nor_u.pgs_w + u3P.sou_u.pgs_w >= u3P.pag_w ) {
+      nor_w = u3P.nor_u.pgs_w;
+      sou_w = u3P.sou_u.pgs_w;
+
+      if ( (nor_w + sou_w) >= u3P.pag_w ) {
         fprintf(stderr, "boot: snapshot too big for loom\r\n");
         exit(1);
       }
@@ -1171,26 +1175,29 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
       */
       {
         if ( u3C.wag_w & u3o_no_demand ) {
-          _ce_loom_blit_north(u3P.nor_u.fid_i, u3P.nor_u.pgs_w);
+          _ce_loom_blit_north(u3P.nor_u.fid_i, nor_w);
         }
         else {
-          _ce_loom_mapf_north(u3P.nor_u.fid_i, u3P.nor_u.pgs_w, 0);
+          _ce_loom_mapf_north(u3P.nor_u.fid_i, nor_w, 0);
         }
 
-        _ce_loom_blit_south(u3P.sou_u.fid_i, u3P.sou_u.pgs_w);
+        _ce_loom_blit_south(u3P.sou_u.fid_i, sou_w);
 
         u3l_log("boot: protected loom\r\n");
       }
 
       /* If the images were empty, we are logically booting.
       */
-      if ( (0 == u3P.nor_u.pgs_w) && (0 == u3P.sou_u.pgs_w) ) {
+      if ( !nor_w && !sou_w ) {
         u3l_log("live: logical boot\r\n");
         nuu_o = c3y;
       }
+      else  if ( u3C.wag_w & u3o_no_demand ) {
+        u3a_print_memory(stderr, "live: loaded", (nor_w + sou_w) << u3a_page);
+      }
       else {
-        u3a_print_memory(stderr, "live: loaded",
-                         (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w) << u3a_page);
+        u3a_print_memory(stderr, "live: mapped", nor_w << u3a_page);
+        u3a_print_memory(stderr, "live: loaded", sou_w << u3a_page);
       }
     }
   }

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -751,22 +751,17 @@ _ce_patch_apply(u3_ce_patch* pat_u)
 static void
 _ce_loom_blit_north(c3_i fid_i, c3_w pgs_w)
 {
-  c3_w      i_w;
-  c3_w*   ptr_w;
-  size_t  off_i;
+  size_t  len_i = (size_t)pgs_w << (u3a_page + 2);
   ssize_t ret_i;
 
-  for ( i_w = 0; i_w < pgs_w; i_w++ ) {
-    off_i = (size_t)i_w << (u3a_page + 2);
-    ptr_w = u3_Loom + (i_w << u3a_page);
-
-    if ( pag_siz_i != (ret_i = c3_pread(fid_i, ptr_w, pag_siz_i, off_i)) ) {
+  if ( pgs_w ) {
+    if ( len_i != (ret_i = c3_pread(fid_i, u3_Loom, len_i, 0)) ) {
       if ( 0 > ret_i ) {
         fprintf(stderr, "loom: blit north read: %s\r\n", strerror(errno));
       }
       else {
         fprintf(stderr, "loom: blit north read partial (%zu of %zu bytes)\r\n",
-                        (size_t)ret_i, pag_siz_i);
+                        (size_t)ret_i, len_i);
       }
       c3_assert(0);
     }


### PR DESCRIPTION
This PR implements demand paging for the loom. Thanks to @ritfed-tabryg for the suggestion, @eamsden for many fruitful design discussions, and @mcevoypeter for the original implementation in #5940.

Demand paging is implemented on linux and macos, and turned on by default (disabled by `--no-demand`). It remains highly desirable on windows (where memory is not overcommitted), but will require changes to our "platform abstraction layer" (lol) to support CoW file-backed mappings, and further changes to the implementation to explicitly remove old mappings before establishing new ones.

The changes here differ from #5940 in key ways. The north segment of the loom (home-road heap, `north.bin`) is still in a CoW file-backed memory map, but that mapping is now reestablished after every snapshot update, ensuring that clean pages are legible to the OS and never swapped. Attempting that was always planned, but the mapping logic in #5940 was staged on/with other irrelevant changes, and needed to be moved to handle re-mapping. Once moved, it became clear it was practically equivalent to coalescing the memory protection changes on snapshot update, so that has been done as well. Mapping requires that the north and south segments be handled separately; this in turn allows the entire north segment to be read in one syscall (retried appropriately as per #6062). With or without demand paging, the number of system calls involved in updating the snapshot has been dramatically reduced. And all of these changes have been made with out compromising the generality of the north/south snapshot system for the loom.

NB: the initial, minimal implementation in #5940 was motivated by an abundance of caution with regards to the efficiency of re-mapping the loom. Further research of virtual memory (and experimentation) with the changes here has made it clear that that was unwarranted.

Next steps include adding windows support, and respecting the `--no-demand` argument in all relevant maintenance commands (ie, `meld`, `next`, `pack`, `prep`, &c).