### PR TITLE
hoon: remove old lustar parser

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2,11 +2,11 @@
 ::::    /sys/hoon                                       ::
   ::                                                    ::
 =<  ride
-=>  %140  =>
+=>  %139  =>
 ::                                                      ::
 ::::    0: version stub                                 ::
   ::                                                    ::
-~%  %k.140  ~  ~                                        ::
+~%  %k.139  ~  ~                                        ::
 |%
 ++  hoon-version  +
 --  =>
@@ -13249,30 +13249,6 @@
         ;~  pfix  (jest '+$')
           ;~  plug
             ;~(pfix gap sym)
-            ;~(pfix gap loan)
-          ==
-        ==
-      ::
-        %+  cook
-          |=  [b=term c=(list term) e=spec]
-          ^-  [term hoon]
-          :-  b
-          :+  %brtr
-            :-  %bccl
-            =-  ?>(?=(^ -) -)
-            ::  for each .term in .c, produce $=(term $~(* $-(* *)))
-            ::  ie {term}=mold
-            ::
-            %+  turn  c
-            |=  =term
-            ^-  spec
-            =/  tar  [%base %noun]
-            [%bcts term [%bcsg tar [%bchp tar tar]]]
-          [%ktcl [%made [b c] e]]
-        ;~  pfix  (jest '+*')
-          ;~  plug
-            ;~(pfix gap sym)
-            ;~(pfix gap (ifix [sel ser] (most ace sym)))
             ;~(pfix gap loan)
           ==
         ==


### PR DESCRIPTION
See #6052. This is completely different from the `+*` used at the top
of doors, and has almost entirely been replaced by `|$`. The exception is
the use of the `%made` spec, not present in `|$`. I do not see an
obvious way to change `|$` to use `%made` since this `+*` parser uses
the name of the arm in the `%made` structure, unless we change the
AST of `|$`.

This commit requires a burning a kelvin on live ships (see #6052), so
that is why this commit also bumps the kelvin down. This opens up
possibilities on how to change `|$` to use `%made` if we decide that
change is warranted.

Blocked by #6055.

Because we might want to change `|$`, and #5873 will also be
changing `+boog`, this is currently marked as a draft and probably won't
need attention again until we're thinking about burning a kelvin on
`hoon.hoon`.