### PR TITLE
drum, dojo: preserve input history after crash

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1637,12 +1637,13 @@
       ==
   ?>  ?=([%sole @ ~] path)
   =/  id  i.t.path
+  =/  old=session  (fall (~(get by hoc) id) *session)
   =?  hoc  (~(has by hoc) id)
     ~&  [%dojo-peer-replaced id]
     (~(del by hoc) id)
-  =/  =session  %*(. *session -.dir [our.hid %base ud+0])
+  =/  new=session  %*(. *session -.dir [our.hid %base ud+0])
   =^  moves  state
-    he-abet:~(he-prom he hid id ~ session)
+    he-abet:~(he-prom he hid id ~ new(var var.old))
   [moves ..on-init]
 ::
 ++  on-leave

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -66,7 +66,13 @@
 ++  on-load
   |=  =old-state=vase
   ^-  step:agent:gall
-  =+  !<(old=any-state old-state-vase)
+   =/  maybe-old=(each any-state tang)
+  (mule |.(!<(any-state old-state-vase)))
+  =/  [old=any-state bad=?]
+    ?.  ?=(%| -.maybe-old)  [p.maybe-old |]
+    =;  [sta=any-state ba=?]  [sta ba]
+    =-  %+  fall  -  ~&  >  %bad-load  [state &]
+    (mole |.([!<(any-state old-state-vase) |]))
   =/  tup=any-state-tuple
     ?+    -.old  +.old
         ?(%1 %2 %3 %4 %5 %6)

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -42,6 +42,7 @@
       off=@ud                                           ::  window offset
       kil=kill                                          ::  kill buffer
       inx=@ud                                           ::  ring index
+      hiy=(map gill:gall history)                        :: ancient input
       fug=(map gill:gall (unit target))                 ::  connections
       mir=(pair @ud stub)                               ::  mirrored terminal
   ==                                                    ::
@@ -302,6 +303,8 @@
   ^+  +>
   =+  lag=se-agon
   ?.  (~(has by fug) gyl)  +>.$
+  =/  olt=target  (fall (~(got by fug) gyl) *target)
+  =.  hiy  %+  ~(put by hiy)  gyl  (fall `hit.olt *history)
   =.  fug  (~(del by fug) gyl)
   =.  eel  ?.(pej eel (~(del in eel) gyl))
   =.  +>.$  ?.  &(?=(^ lag) !=(gyl u.lag))
@@ -358,7 +361,8 @@
   ^+  +>
   =.  +>  (se-text "[linked to {<gyl>}]")
   ?>  ?=(~ (~(got by fug) gyl))
-  (se-alas(fug (~(put by fug) gyl `*target)) gyl)
+  =/  =target  %*(. *target hit (fall (~(get by hiy) gyl) *history))
+  (se-alas(fug (~(put by fug) gyl `target)) gyl)
 ::
 ++  se-nuke                                           ::  teardown connection
   |=  gyl=gill:gall


### PR DESCRIPTION
When a crash is triggered (e.g from a bad scry) `%drum `deletes input history and `%dojo` clears out defined variables. This saves the latter in the `%drum` state instead, retrieving it when the app is relinked, and inserts the old variables into the new session for the former.