### PR TITLE
lens: do not jam export output

### DIFF
--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -135,7 +135,7 @@
   ^-  (unit (unit cage))
   ?+  path  (on-peek:def path)
     [%x %export-all ~]
-    ``noun+!>((jam (export-all our.bowl now.bowl)))
+    ``noun+!>((export-all our.bowl now.bowl))
   ==
 ++  on-agent
   |=  [=wire =sign:agent:gall]


### PR DESCRIPTION
The previous implementation of the /export-all scry jammed it's output, but the runtime jams the result when using -X and -Y. This resulted in the archive being jammed twice, which runs into #5674. This commit removes the jam on the %lens side, which fixes importing if the runtime defers cueing until the event has been injected into lens