### PR TITLE
fore: remove +cue before import

### DIFF
--- a/pkg/urbit/vere/io/fore.c
+++ b/pkg/urbit/vere/io/fore.c
@@ -78,7 +78,7 @@ _fore_inject(u3_auto* car_u, c3_c* pax_c)
 static void
 _fore_import(u3_auto* car_u, c3_c* pax_c)
 {
-  u3_noun arc = u3ke_cue(u3m_file(pax_c));
+  u3_noun arc = u3m_file(pax_c);
   u3_noun imp = u3dt("cat", 3, u3i_string("#import_"), arc);
   u3_noun siz = u3r_met(3, imp);
   u3_noun dat = u3nt(u3_nul, siz, imp);


### PR DESCRIPTION
Companion commit to 29ce47a006d27465a8d858a2b28d26ebae81adeb. By removing the double jam and double cue, we work around #5674. Makes imports work again.