### PR TITLE
u3: fixes memory corruption in inner roads

### DIFF
--- a/pkg/urbit/Makefile
+++ b/pkg/urbit/Makefile
@@ -36,6 +36,8 @@ CFLAGS := $(CFLAGS)
 
 .PHONY: all bench test clean mrproper
 
+.SECONDARY:
+
 ################################################################################
 
 all: $(all_exes)

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -85,9 +85,14 @@
       void
       u3e_foul(void);
 
-    /* u3e_init(): initialize page tracking.
+    /* u3e_init(): initialize guard page tracking.
     */
       void
       u3e_init(void);
+
+    /* u3e_ward(): reposition guard page if needed.
+    */
+      void
+      u3e_ward(u3_post low_p, u3_post hig_p);
 
 #endif /* ifndef U3_EVENTS_H */

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1230,6 +1230,8 @@ u3e_foul(void)
   memset((void*)u3P.dit_w, 0xff, sizeof(u3P.dit_w));
 }
 
+/* u3e_init(): initialize guard page tracking.
+*/
 void
 u3e_init(void)
 {
@@ -1237,5 +1239,17 @@ u3e_init(void)
 
 #ifdef U3_GUARD_PAGE
   _ce_center_guard_page();
+#endif
+}
+
+/* u3e_ward(): reposition guard page if needed.
+*/
+void
+u3e_ward(u3_post low_p, u3_post hig_p)
+{
+#ifdef U3_GUARD_PAGE
+  if ( (low_p > gar_pag_p) || (hig_p < gar_pag_p) ) {
+    _ce_center_guard_page();
+  }
 #endif
 }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -813,6 +813,7 @@ u3m_leap(c3_w pad_w)
       u3R->cap_p -= len_w;
 
       rod_u = _pave_south(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
+      u3e_ward(rod_u->cap_p, rod_u->hat_p);
 #if 0
       fprintf(stderr, "leap: from north %p (cap 0x%x), to south %p\r\n",
               u3R,
@@ -825,6 +826,7 @@ u3m_leap(c3_w pad_w)
       u3R->cap_p += len_w;
 
       rod_u = _pave_north(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
+      u3e_ward(rod_u->hat_p, rod_u->cap_p);
 #if 0
       fprintf(stderr, "leap: from south %p (cap 0x%x), to north %p\r\n",
               u3R,

--- a/pkg/urbit/tests/jam_tests.c
+++ b/pkg/urbit/tests/jam_tests.c
@@ -6,8 +6,9 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 23);
+  u3m_init(1 << 24);
   u3m_pave(c3y);
+  u3e_init();
 }
 
 static void

--- a/pkg/urbit/tests/meme_tests.c
+++ b/pkg/urbit/tests/meme_tests.c
@@ -5,9 +5,6 @@
 static void
 _setup(void)
 {
-  //  XX at 1<<24, this succeeds on mac, but bail:exit's on linux.
-  //  investigate possible u3n_prog corruption
-  //
   u3m_init(1 << 24);
   u3m_pave(c3y);
   u3e_init();
@@ -53,7 +50,7 @@ _test_nock_meme(void)
 }
 
 static c3_i
-_test_nock(void)
+_test_meme(void)
 {
   c3_i ret_i = 1;
 
@@ -72,8 +69,8 @@ main(int argc, char* argv[])
 {
   _setup();
 
-  if ( !_test_nock() ) {
-    fprintf(stderr, "test nock: failed\r\n");
+  if ( !_test_meme() ) {
+    fprintf(stderr, "test meme: failed\r\n");
     exit(1);
   }
 
@@ -81,6 +78,6 @@ main(int argc, char* argv[])
   //
   u3m_grab(u3_none);
 
-  fprintf(stderr, "test nock: ok\r\n");
+  fprintf(stderr, "test meme: ok\r\n");
   return 0;
 }

--- a/pkg/urbit/tests/nock_tests.c
+++ b/pkg/urbit/tests/nock_tests.c
@@ -8,7 +8,7 @@ _setup(void)
   //  XX at 1<<24, this succeeds on mac, but bail:exit's on linux.
   //  investigate possible u3n_prog corruption
   //
-  u3m_init(1 << 25);
+  u3m_init(1 << 24);
   u3m_pave(c3y);
   u3e_init();
 }


### PR DESCRIPTION
This PR fixes a latent memory-corruption bug introduced with the guard page in release v1.10, prs #5881 and #5882.

Those changes replaced inconsistent, ad-hoc road-stack overflow checks with an orthogonal approach: a guard page is protected in the center of the loom, moved on page faults, and used to systematically prevent the road heap and stack from running into each other (by producing a `bail:meme`). This is system is more rigorous and efficient than the prior approach, but it depends entirely on the assumption that our memory usage patterns are linear and contiguous, from either end of the loom towards the center. This assumption is violated during the creation of inner roads, since padding is added between the parent road heap and child road stack. If the guard page happens to fall into this padding, subsequent computation in the inner road is at risk of arbitrary levels of memory corruption. While such an inner road is an ephemeral memory arena, there's no guarantee that corrupted results can't make it out to the persistent state on the home road.

These changes are staged on `next/vere`, since the variable-size loom introduced there is a necessary piece of our current reproductions. The fix is confined to 5cba320a591e5152e56d2731f9e8d1523cd96e79, which has been cherry-picked onto  v1.10 (in `jb/hotfix`), and will be released to the live network ASAP. Thanks to @frodwith for crucial debugging help.

fixes #6069. may be the cause of #6066, more testing is needed to confirm.