### PR TITLE
vere: adds official arm builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
   call-vere:
     uses: ./.github/workflows/vere.yml
     with:
-      pace: 'often'
+      pace: 'edge' # XX s/b once?
       upload: >-
         ${{
         (github.ref_name == 'next/vere' && github.ref_type == 'branch')

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -74,6 +74,11 @@ jobs:
           name: ares
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      # run unit tests early on linux (x-compilation will skip them)
+      - name: build dynamic binary (and run tests)
+        if: ${{ matrix.type == 'linux' }}
+        run: nix-build -A urbit
+
       - name: build static binary
         run: |
           nix-build -A urbit        \

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -48,8 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest }
-          - { os: macos-latest }
+          - { os: ubuntu-latest, type: linux }
+          - { os: macos-latest,  type: macos }
+          - { os: buildjet-4vcpu-ubuntu-2204-arm, type: linux }
 
     runs-on: ${{ matrix.os }}
 
@@ -64,7 +65,7 @@ jobs:
         with:
           extra_nix_config: |
             system-features = nixos-test benchmark big-parallel kvm
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.type == 'linux' }}
       - uses: cachix/install-nix-action@v16
         if: ${{ matrix.os != 'ubuntu-latest' }}
 
@@ -84,7 +85,7 @@ jobs:
           cat ./urbit-derivation
 
       - name: confirm binary is mostly static
-        if: matrix.os == 'macos-latest'
+        if: matrix.type == 'macos'
         run: |
           bin="${{ env.urbit_static }}/bin/urbit"
 
@@ -117,7 +118,7 @@ jobs:
           echo -n "$version" > ./version-string
 
       - name: upload version string artifact
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.type == 'linux'
         uses: actions/upload-artifact@v3
         with:
           name: version-string

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       CACHIX_AUTH_TOKEN:
         required: false
+      GCP_CREDENTIALS:
+        required: false
       GCS_SERVICE_ACCOUNT_KEY:
         required: false
       GCS_PROJECT:
@@ -129,13 +131,14 @@ jobs:
           name: version-string
           path: version-string
 
-      - uses: google-github-actions/setup-gcloud@v0.2.0
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - uses: google-github-actions/setup-gcloud@v1
         if: inputs.upload
         with:
-          version: '290.0.1'
-          service_account_key: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
           project_id: ${{ secrets.GCS_PROJECT }}
-          export_default_credentials: true
 
       - name: upload binary to bootstrap.urbit.org
         if: inputs.upload

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -180,6 +180,7 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: mingw32-make build/urbit
+      - run: mingw32-make test
       - run: >
           build/urbit -l -d -B ../../bin/solid.pill -F bus &&
           curl -f --data '{"source":{"dojo":"+hood/exit"},"sink":{"app":"hood"}}'

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -12,7 +12,7 @@ on:
       pace:
         description: 'release pace'
         type: string
-        default: 'often'
+        default: 'edge'
         required: false
     secrets:
       CACHIX_AUTH_TOKEN:
@@ -35,7 +35,7 @@ on:
         description: 'release pace'
         type: choice
         options:
-        - often
+        - edge
         - soon
         - live
 

--- a/default.nix
+++ b/default.nix
@@ -57,7 +57,10 @@ let
       if system == "x86_64-linux" && crossSystem == null && enableStatic then
         "x86_64-unknown-linux-musl"
       else
-        crossSystem;
+        if system == "aarch64-linux" && crossSystem == null && enableStatic then
+          "aarch64-unknown-linux-musl"
+        else
+          crossSystem;
   };
 
   # Use nixpkgs' top-level/static overlay if enableStatic = true.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,7 @@ let
       (import ./overlays/native.nix)
       # Specific overrides guarded by the host platform.
       (import ./overlays/musl.nix)
+      (import ./overlays/arm.nix)
     ];
   };
 

--- a/nix/overlays/arm.nix
+++ b/nix/overlays/arm.nix
@@ -6,7 +6,7 @@ let
 
 in prev.lib.optionalAttrs isAarch64 {
   libsigsegv = prev.libsigsegv.overrideAttrs (attrs: {
-    preConfigure = (old.preConfigure or "") + ''
+    preConfigure = (prev.preConfigure or "") + ''
       sed -i 's/^CFG_FAULT=$/CFG_FAULT=fault-linux-arm.h/' configure
     '';
   });

--- a/pkg/urbit/include/c/portable.h
+++ b/pkg/urbit/include/c/portable.h
@@ -113,8 +113,7 @@
 #   if defined(U3_OS_linux)
 #     ifdef __LP64__
 #       ifdef U3_CPU_aarch64
-//  XX not yet
-//#         define U3_OS_ARCH "aarch64-linux"
+#         define U3_OS_ARCH "aarch64-linux"
 #       else
 #         define U3_OS_ARCH "x86_64-linux"
 #       endif


### PR DESCRIPTION
Opening this PR for posterity ...

This upstreams @botter-nidnul's nix patches to support static binaries for aarch64 (changes to the codebase itself had already been accepted in prior PRs). Thanks to @botter-nidnul for his years of work producing community-supported binaries!

The rest of this PR updates our github actions config to support aarch64 via buildjet.