### PR TITLE
ames: remove num-live from pump-metrics

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -716,7 +716,7 @@
                   'rtt'^(numb (div rtt ~s1))
                   'rttvar'^(numb (div rttvar ~s1))
                   'ssthresh'^(numb ssthresh)
-                  'num-live'^(numb num-live)
+                  'num-live'^(numb ~(wyt by live))
                   'cwnd'^(numb cwnd)
                   'counter'^(numb counter)
               ==

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -657,6 +657,7 @@
   ::    rto: retransmission timeout
   ::    rtt: roundtrip time estimate, low-passed using EWMA
   ::    rttvar: mean deviation of .rtt, also low-passed with EWMA
+  ::    num-live: how many packets sent, awaiting ack
   ::    ssthresh: slow-start threshold
   ::    cwnd: congestion window; max unacked packets
   ::
@@ -666,6 +667,7 @@
         rttvar=_~s1
         ssthresh=_10.000
         cwnd=_1
+        num-live=@ud
         counter=@ud
     ==
   +$  live-packet

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -657,7 +657,6 @@
   ::    rto: retransmission timeout
   ::    rtt: roundtrip time estimate, low-passed using EWMA
   ::    rttvar: mean deviation of .rtt, also low-passed with EWMA
-  ::    num-live: how many packets sent, awaiting ack
   ::    ssthresh: slow-start threshold
   ::    cwnd: congestion window; max unacked packets
   ::
@@ -667,7 +666,6 @@
         rttvar=_~s1
         ssthresh=_10.000
         cwnd=_1
-        num-live=@ud
         counter=@ud
     ==
   +$  live-packet

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -607,7 +607,9 @@
 ::    life:        our $life; how many times we've rekeyed
 ::    crypto-core: interface for encryption and signing
 ::    bug:         debug printing configuration
+::    corks(STALE):wires for cork flows pending publisher update
 ::
+::    Note: .corks is only still present for unreleased migration reasons
 ::
 +$  ames-state
   $:  peers=(map ship ship-state)
@@ -615,6 +617,7 @@
       =life
       crypto-core=acru:ames
       =bug
+      corks=(set wire)  ::TODO  unused, remove in next version of state
   ==
 ::
 +$  ames-state-4  ames-state-5
@@ -641,7 +644,7 @@
       route=(unit [direct=? =lane])
       =qos
       =ossuary
-      snd=(map bone message-pump-state-8)
+      snd=(map bone message-pump-state)
       rcv=(map bone message-sink-state)
       nax=(set [=bone =message-num])
       heeds=(set duct)
@@ -670,85 +673,18 @@
       route=(unit [direct=? =lane])
       =qos
       =ossuary
-      snd=(map bone message-pump-state-8)
+      snd=(map bone message-pump-state)
       rcv=(map bone message-sink-state)
       nax=(set [=bone =message-num])
       heeds=(set duct)
-  ==
-::
-+$  ship-state-8
-    $%  [%alien alien-agenda]
-        [%known peer-state-8]
-    ==
-::
-+$  peer-state-8
-  $:  $:  =symmetric-key
-          =life
-          =rift
-          =public-key
-          sponsor=ship
-      ==
-      route=(unit [direct=? =lane])
-      =qos
-      =ossuary
-      snd=(map bone message-pump-state-8)
-      rcv=(map bone message-sink-state)
-      nax=(set [=bone =message-num])
-      heeds=(set duct)
-      closing=(set bone)
-      corked=(set bone)
-      krocs=(set bone)
-  ==
-::
-+$  message-pump-state-8
-  $:  current=_`message-num`1
-      next=_`message-num`1
-      unsent-messages=(qeu message-blob)
-      unsent-fragments=(list static-fragment)
-      queued-message-acks=(map message-num ack)
-      packet-pump-state=packet-pump-state-8
-  ==
-::
-+$  packet-pump-state-8
-  $:  next-wake=(unit @da)
-      live=(tree [live-packet-key live-packet-val])
-      metrics=pump-metrics-8
-  ==
-::
-+$  pump-metrics-8
-  $:  rto=_~s1
-      rtt=_~s1
-      rttvar=_~s1
-      ssthresh=_10.000
-      cwnd=_1
-      num-live=@ud
-      counter=@ud
   ==
 ::
 +$  ames-state-7
-  $:  peers=(map ship ship-state-8)
+  $:  peers=(map ship ship-state)
       =unix=duct
       =life
       crypto-core=acru:ames
       =bug
-  ==
-::
-+$  ames-state-8
-  $:  peers=(map ship ship-state-8)
-      =unix=duct
-      =life
-      crypto-core=acru:ames
-      =bug
-      corks=(set wire)
-  ==
-::
-+$  cached-state
-  %-  unit
-  $%  [%5 ames-state-5]
-      [%6 ames-state-6]
-      [%7 ames-state-7]
-      [%8 ames-state-8]
-      [%9 ames-state]
   ==
 ::  $bug: debug printing configuration
 ::
@@ -905,7 +841,7 @@
 ::
 =<  =*  adult-gate  .
     =|  queued-events=(qeu queued-event)
-    =|  =cached-state
+    =|  cached-state=(unit $%([%5 ames-state-5] [%6 ames-state-6] [%7 ames-state-7] [%8 ^ames-state]))
     ::
     |=  [now=@da eny=@ rof=roof]
     =*  larval-gate  .
@@ -1027,7 +963,7 @@
     ::  lifecycle arms; mostly pass-throughs to the contained adult ames
     ::
     ++  scry  scry:adult-core
-    ++  stay  [%9 %larva queued-events ames-state.adult-gate]
+    ++  stay  [%8 %larva queued-events ames-state.adult-gate]
     ++  load
       |=  $=  old
           $%  $:  %4
@@ -1059,13 +995,6 @@
                   [%adult state=ames-state-7]
               ==  ==
               $:  %8
-              $%  $:  %larva
-                      events=(qeu queued-event)
-                      state=ames-state-8
-                  ==
-                  [%adult state=ames-state-8]
-              ==  ==
-              $:  %9
               $%  $:  %larva
                       events=(qeu queued-event)
                       state=_ames-state.adult-gate
@@ -1110,22 +1039,12 @@
         =.  queued-events  events.old
         larval-gate
       ::
-          [%8 %adult *]
-        =.  cached-state  `[%8 state.old]
-        ~>  %slog.0^leaf/"ames: larva reload"
-        larval-gate
+          [%8 %adult *]  (load:adult-core %8 state.old)
       ::
           [%8 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  queued-events  events.old
-        larval-gate
-       ::
-          [%9 %adult *]  (load:adult-core %9 state.old)
-      ::
-          [%9 %larva *]
-        ~>  %slog.1^leaf/"ames: larva: load"
-        =.  queued-events  events.old
-        =.  adult-gate     (load:adult-core %9 state.old)
+        =.  adult-gate     (load:adult-core %8 state.old)
         larval-gate
        ::
       ==
@@ -1144,9 +1063,7 @@
         ~>  %slog.0^leaf/"ames: init daily recork timer"
         :-  [[/ames]~ %pass /recork %b %wait `@da`(add now ~d1)]~
         8+(state-7-to-8:load:adult-core +.u.cached-state)
-      =?  u.cached-state  ?=(%8 -.u.cached-state)
-        9+(state-8-to-9:load:adult-core +.u.cached-state)
-      ?>  ?=(%9 -.u.cached-state)
+      ?>  ?=(%8 -.u.cached-state)
       =.  ames-state.adult-gate  +.u.cached-state
       [moz larval-core(cached-state ~)]
     --
@@ -1221,15 +1138,15 @@
   [moves ames-gate]
 ::  +stay: extract state before reload
 ::
-++  stay  [%9 %adult ames-state]
+++  stay  [%8 %adult ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load
   =<  |=  $=  old-state
-          $%  [%9 ^ames-state]
+          $%  [%8 ^ames-state]
           ==
       ^+  ames-gate
-      ?>  ?=(%9 -.old-state)
+      ?>  ?=(%8 -.old-state)
       ames-gate(ames-state +.old-state)
   ::
   |%
@@ -1245,10 +1162,10 @@
         ship-state
       =.  snd.ship-state
         %-  ~(run by snd.ship-state)
-        |=  pump=message-pump-state-8
-        =.  num-live.metrics.packet-pump-state.pump
-          ~(wyt in live.packet-pump-state.pump)
-        pump
+        |=  =message-pump-state
+        =.  num-live.metrics.packet-pump-state.message-pump-state
+          ~(wyt in live.packet-pump-state.message-pump-state)
+        message-pump-state
       ship-state
     ames-state
   ::  +state-5-to-6 called from larval-ames
@@ -1282,46 +1199,24 @@
     :_  +.ames-state
     %-  ~(run by peers.ames-state)
     |=  ship-state=ship-state-6
-    ^-  ship-state-8
+    ^-  ^ship-state
     ?.  ?=(%known -.ship-state)
       ship-state
     :-  %known
-    ^-  peer-state-8
+    ^-  peer-state
     :-  +<.ship-state
     [route qos ossuary snd rcv nax heeds ~ ~ ~]:ship-state
   ::  +state-7-to-8 called from larval-ames
   ::
   ++  state-7-to-8
     |=  ames-state=ames-state-7
-    ^-  ames-state-8
+    ^-  ^^ames-state
     :*  peers.ames-state
         unix-duct.ames-state
         life.ames-state
         crypto-core.ames-state
         bug.ames-state
         *(set wire)
-    ==
-  ::  +state-8-to-9 called from larval-ames
-  ::
-  ++  state-8-to-9
-    |=  ames-state=ames-state-8
-    ^-  ^^ames-state
-    :_  [unix-duct life crypto-core bug]:ames-state
-    %-  ~(run by peers.ames-state)
-    |=  ship-state=ship-state-8
-    ^-  ^ship-state
-    ?.  ?=(%known -.ship-state)
-      ship-state
-    %=    ship-state
-        snd
-      %-  ~(run by snd.ship-state)
-      |=  pump=message-pump-state-8
-      ^-  message-pump-state
-      =*  packet  packet-pump-state.pump
-      %=    pump
-          metrics.packet-pump-state
-        [rto rtt rttvar ssthresh cwnd counter]:metrics.packet
-      ==
     ==
   --
 ::  +scry: dereference namespace
@@ -1436,6 +1331,9 @@
     =/  res
       u.mps
     ``noun+!>(!>(res))
+  ::
+      [%corks ~]
+    ``noun+!>(~(tap in corks.ames-state))
   ==
 --
 ::  |per-event: inner event-handling core
@@ -3415,6 +3313,7 @@
     ::  update .live and .metrics
     ::
     =.  live.state     (gas:packet-queue live.state send-list)
+    =.  metrics.state  (on-sent:gauge (lent send-list))  ::  TODO remove
     ::  TMI
     ::
     =>  .(sent `(list static-fragment)`sent)
@@ -3595,7 +3494,8 @@
 ::  +make-pump-gauge: construct |pump-gauge congestion control core
 ::
 ++  make-pump-gauge
-  |=  [pump-metrics num-live=@ud now=@da =ship =bug]
+  |=  [pump-metrics live-packets=@ud now=@da =ship =bug]
+  ::  TODO rename live-packets num-live
   =*  veb  veb.bug
   =*  metrics  +<-
   |%
@@ -3617,7 +3517,16 @@
   ::
   ++  num-slots
     ^-  @ud
-    (sub-safe cwnd num-live)
+    (sub-safe cwnd live-packets)
+  ::  +on-sent: adjust metrics based on sending .num-sent fresh packets
+  ::  TODO remove
+  ::
+  ++  on-sent
+    |=  num-sent=@ud
+    ^-  pump-metrics
+    ::
+    =.  num-live  (add num-live num-sent)
+    metrics
   ::  +on-ack: adjust metrics based on a packet getting acknowledged
   ::
   ++  on-ack
@@ -3625,6 +3534,7 @@
     ^-  pump-metrics
     ::
     =.  counter  +(counter)
+    =.  num-live  (dec num-live)  :: TODO remove
     ::  if below congestion threshold, add 1; else, add avg. 1 / cwnd
     ::
     =.  cwnd
@@ -3695,7 +3605,7 @@
   ::
   ++  in-recovery
     ^-  ?
-    (gth num-live cwnd)
+    (gth live-packets cwnd)
   ::  +sub-safe: subtract with underflow protection
   ::
   ++  sub-safe
@@ -3712,6 +3622,7 @@
         rttvar=(div rttvar ms)
         ssthresh=ssthresh
         cwnd=cwnd
+        num-live=live-packets  ::  TODO remove
         num-live=num-live
         counter=counter
     ==


### PR DESCRIPTION
Tested this on two different live moons and saw no communication issues: they can talk to each other, their sponsor, install apps, join/leave/rejoin groups.

Addresses decrement-underflow error seen in #6075 and https://github.com/urbit/urbit/issues/5979#issuecomment-1275723988

Note: this updates `%lull`