### PR TITLE
u3: fix memory corruption after meld; enforce guard page invariants

### DIFF
--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -568,6 +568,9 @@ _ce_patch_compose(void)
 
     nor_w = (nwr_w + (pag_wiz_i - 1)) >> u3a_page;
     sou_w = (swu_w + (pag_wiz_i - 1)) >> u3a_page;
+
+    c3_assert(  ((gar_pag_p >> u3a_page) >= nor_w)
+             && ((gar_pag_p >> u3a_page) <= (u3P.pag_w - (sou_w + 1))) );
   }
 
 #ifdef U3_SNAPSHOT_VALIDATION

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1216,7 +1216,16 @@ u3e_yolo(void)
                      u3C.wor_i << 2,
                      (PROT_READ | PROT_WRITE)) )
   {
+    //  XX confirm recoverable errors
+    //
+    fprintf(stderr, "loom: yolo: %s\r\n", strerror(errno));
     return c3n;
+  }
+
+  if ( 0 != mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
+    fprintf(stderr, "loom: failed to protect guard page: %s\r\n",
+                    strerror(errno));
+    c3_assert(0);
   }
 
   return c3y;

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -831,6 +831,19 @@ _ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
                       pgs_w, old_w, strerror(errno));
       c3_assert(0);
     }
+
+    //  protect guard page if clobbered
+    //
+    //    NB: < pgs_w is precluded by assertion in _ce_patch_compose()
+    //
+    if ( (gar_pag_p >> u3a_page) < old_w ) {
+      fprintf(stderr, "loom: guard on remap\r\n");
+      if ( 0 != mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
+        fprintf(stderr, "loom: failed to protect guard page: %s\r\n",
+                        strerror(errno));
+        c3_assert(0);
+      }
+    }
   }
 
   _ce_loom_pure_north(pgs_w);

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1936,6 +1936,10 @@ u3m_boot_lite(size_t len_i)
   */
   u3m_pave(c3y);
 
+  /* Place the guard page.
+  */
+  u3e_init();
+
   /* Initialize the jet system.
   */
   u3j_boot(c3y);


### PR DESCRIPTION
This PR fixes another latent memory-corruption bug introduced in v1.10 (see #6072 for context, the bug was introduced in #5881 and #5882).

`|meld` modifies every page of the persistent state, so tracking the pages that it touches is not worthwhile. It's optimized to turn off page-tracking, in such a way that a subsequent snapshot update will restore it. But this optimization has the unfortunate side effect of removing the guard page (which it pre-dates), for the duration of the process (ie, restarting the ship would restore it, and running `meld` as a subcommand does not risk corruption).

This PR restores the guard page after turning off (all other) page tracking, and maintains or asserts other relevant invariants of the guard page system.

Fixes #6078.