### PR TITLE
vere: handle errors during replay

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1300,9 +1300,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
   u3C.wag_w |= u3o_hashless;
   u3m_boot(u3_Host.dir_c, u3a_bytes);
 
-  pre_w = u3a_open(u3R);
-  u3u_meld();
-  u3a_print_memory(stderr, "urbit: meld: gained", (u3a_open(u3R) - pre_w));
+  u3a_print_memory(stderr, "mars: meld: gained", u3u_meld());
 
   u3e_save();
   u3_disk_exit(log_u);

--- a/pkg/urbit/include/noun/urth.h
+++ b/pkg/urbit/include/noun/urth.h
@@ -5,7 +5,7 @@
     **/
       /* u3u_meld(): globally deduplicate memory.
       */
-        void
+        c3_w
         u3u_meld(void);
 
       /* u3u_cram(): globably deduplicate memory, and write a rock to disk.

--- a/pkg/urbit/noun/urth.c
+++ b/pkg/urbit/noun/urth.c
@@ -429,15 +429,17 @@ _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
 /* u3u_meld(): globally deduplicate memory.
 */
 #ifdef U3_MEMORY_DEBUG
-void
+c3_w
 u3u_meld(void)
 {
   fprintf(stderr, "u3: unable to meld under U3_MEMORY_DEBUG\r\n");
+  return 0;
 }
 #else
-void
+c3_w
 u3u_meld(void)
 {
+  c3_w       pre_w = u3a_open(u3R);
   ur_root_t* rot_u;
   ur_nvec_t  cod_u;
 
@@ -449,6 +451,8 @@ u3u_meld(void)
   //
   ur_nvec_free(&cod_u);
   ur_root_free(rot_u);
+
+  return (u3a_open(u3R) - pre_w);
 }
 #endif
 

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -512,7 +512,7 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
 
         case c3__meld: {
           u3z(jar);
-          u3u_meld();
+          u3a_print_memory(stderr, "mars: meld: gained", u3u_meld());
         } break;
       }
 
@@ -553,9 +553,9 @@ _mars_post(u3_mars* mar_u)
   }
 
   if ( c3y == mar_u->mel_o ) {
-    u3l_log("mars: meld: starting\n");
-    u3u_meld();
-    u3l_log("mars: meld: complete\n");
+    fprintf(stderr, "mars: meld: starting\n");
+    u3a_print_memory(stderr, "mars: meld: gained", u3u_meld());
+    fprintf(stderr, "mars: meld: complete\n");
     mar_u->mel_o = c3n;
   }
 }

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -869,6 +869,8 @@ _mars_do_boot(u3_disk* log_u, c3_d eve_d)
 
   u3l_log("--------------- bootstrap starting ----------------\r\n");
 
+  u3l_log("boot: 1-%u\r\n", u3qb_lent(eve));
+
   if ( c3n == u3v_boot(eve) ) {
     return c3n;
   }


### PR DESCRIPTION
This PR modifies the replay logic (in mars, unreleased) to explicitly enumerate errors during replay, print appropriate messages and/or stack traces, and retry `bail:meme` after `pack` (or `meld`, if run with `--auto-meld`). Targets #6079, as it was in the development of this feature that those issues were discovered.