### PR TITLE
u3: improve snapshot error handling (for hotfix release)

### DIFF
--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -226,8 +226,9 @@ _ce_center_guard_page(void)
   if ( -1 == mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
     fprintf(stderr,
             "loom: failed to protect the guard page "
-            "(base address %p)\r\n",
-            u3a_into(gar_pag_p));
+            "(base address %p): %s\r\n",
+            u3a_into(gar_pag_p),
+            strerror(errno));
     goto fail;
   }
 
@@ -611,6 +612,7 @@ _ce_patch_save_page(u3_ce_patch* pat_u,
                         pag_siz_i,
                         PROT_READ) )
     {
+      fprintf(stderr, "loom: patch mprotect: %s\r\n", strerror(errno));
       c3_assert(0);
     }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -436,7 +436,8 @@ _ce_patch_delete(void)
 static c3_o
 _ce_patch_verify(u3_ce_patch* pat_u)
 {
-  c3_w i_w;
+  ssize_t ret_i;
+  c3_w      i_w;
 
   if ( u3e_version != pat_u->con_u->ver_y ) {
     fprintf(stderr, "loom: patch version mismatch: have %u, need %u\r\n",
@@ -454,8 +455,13 @@ _ce_patch_verify(u3_ce_patch* pat_u)
       fprintf(stderr, "loom: patch seek: %s\r\n", strerror(errno));
       return c3n;
     }
-    if ( -1 == read(pat_u->mem_i, mem_w, pag_siz_i) ) {
-      fprintf(stderr, "loom: patch read: %s\r\n", strerror(errno));
+    if ( pag_siz_i != (ret_i = read(pat_u->mem_i, mem_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: patch partial read: %zu\r\n", (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: patch read fail: %s\r\n", strerror(errno));
+      }
       return c3n;
     }
     {
@@ -717,7 +723,8 @@ _ce_image_resize(u3e_image* img_u, c3_w pgs_w)
 static void
 _ce_patch_apply(u3_ce_patch* pat_u)
 {
-  c3_w i_w;
+  ssize_t ret_i;
+  c3_w      i_w;
 
   //  resize images
   //
@@ -751,8 +758,14 @@ _ce_patch_apply(u3_ce_patch* pat_u)
       off_w = (u3a_pages - (pag_w + 1));
     }
 
-    if ( -1 == read(pat_u->mem_i, mem_w, pag_siz_i) ) {
-      fprintf(stderr, "loom: patch apply read: %s\r\n", strerror(errno));
+    if ( pag_siz_i != (ret_i = read(pat_u->mem_i, mem_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: patch apply partial read: %zu\r\n",
+                        (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: patch apply read: %s\r\n", strerror(errno));
+      }
       c3_assert(0);
     }
     else {
@@ -782,13 +795,20 @@ _ce_image_blit(u3e_image* img_u,
     return;
   }
 
-  c3_w i_w;
-  c3_w siz_w = pag_siz_i;
+  ssize_t ret_i;
+  c3_w      i_w;
+  c3_w    siz_w = pag_siz_i;
 
   lseek(img_u->fid_i, 0, SEEK_SET);
   for ( i_w = 0; i_w < img_u->pgs_w; i_w++ ) {
-    if ( -1 == read(img_u->fid_i, ptr_w, siz_w) ) {
-      fprintf(stderr, "loom: image blit read: %s\r\n", strerror(errno));
+    if ( siz_w != (ret_i = read(img_u->fid_i, ptr_w, siz_w)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: image blit partial read: %zu\r\n",
+                        (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: image blit read: %s\r\n", strerror(errno));
+      }
       c3_assert(0);
     }
 
@@ -814,15 +834,21 @@ _ce_image_fine(u3e_image* img_u,
                c3_w*        ptr_w,
                c3_ws        stp_ws)
 {
-  c3_w i_w;
-  c3_w buf_w[pag_wiz_i];
+  ssize_t ret_i;
+  c3_w      i_w;
+  c3_w    buf_w[pag_wiz_i];
 
   lseek(img_u->fid_i, 0, SEEK_SET);
   for ( i_w=0; i_w < img_u->pgs_w; i_w++ ) {
     c3_w mem_w, fil_w;
 
-    if ( -1 == read(img_u->fid_i, buf_w, pag_siz_i) ) {
-      fprintf(stderr, "loom: image fine read: %s\r\n", strerror(errno));
+    if ( pag_siz_i != (ret_i = read(img_u->fid_i, buf_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: image fine partial read: %zu\r\n", (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: image fine read: %s\r\n", strerror(errno));
+      }
       c3_assert(0);
     }
     mem_w = u3r_mug_words(ptr_w, pag_wiz_i);
@@ -848,7 +874,8 @@ _ce_image_fine(u3e_image* img_u,
 static c3_o
 _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
 {
-  c3_w i_w;
+  ssize_t ret_i;
+  c3_w      i_w;
 
   //  resize images
   //
@@ -869,8 +896,14 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
     c3_w mem_w[pag_wiz_i];
     c3_w off_w = i_w;
 
-    if ( -1 == read(fom_u->fid_i, mem_w, pag_siz_i) ) {
-      fprintf(stderr, "loom: image copy read: %s\r\n", strerror(errno));
+    if ( pag_siz_i != (ret_i = read(fom_u->fid_i, mem_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: image copy partial read: %zu\r\n",
+                        (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: image copy read: %s\r\n", strerror(errno));
+      }
       return c3n;
     }
     else {

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1118,6 +1118,13 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         _ce_patch_delete();
       }
 
+      //  detect snapshots from a larger loom
+      //
+      if ( (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w + 1) >= u3a_pages ) {
+        fprintf(stderr, "boot: snapshot too big for loom\r\n");
+        exit(1);
+      }
+
       //  mark all pages dirty (pages in the snapshot will be marked clean)
       //
       u3e_foul();

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -558,7 +558,10 @@ _ce_patch_write_page(u3_ce_patch* pat_u,
 {
   ssize_t ret_i;
 
-  c3_assert(-1 != lseek(pat_u->mem_i, pgc_w * pag_siz_i, SEEK_SET));
+  if ( -1 == lseek(pat_u->mem_i, pgc_w * pag_siz_i, SEEK_SET) ) {
+    fprintf(stderr, "loom: patch page seek: %s\r\n", strerror(errno));
+    c3_assert(0);
+  }
 
   if ( pag_siz_i != (ret_i = write(pat_u->mem_i, mem_w, pag_siz_i)) ) {
     if ( 0 < ret_i ) {
@@ -826,7 +829,11 @@ _ce_image_blit(u3e_image* img_u,
   c3_w      i_w;
   c3_w    siz_w = pag_siz_i;
 
-  lseek(img_u->fid_i, 0, SEEK_SET);
+  if ( -1 == lseek(img_u->fid_i, 0, SEEK_SET) ) {
+    fprintf(stderr, "loom: image blit seek 0: %s\r\n", strerror(errno));
+    c3_assert(0);
+  }
+
   for ( i_w = 0; i_w < img_u->pgs_w; i_w++ ) {
     if ( siz_w != (ret_i = read(img_u->fid_i, ptr_w, siz_w)) ) {
       if ( 0 < ret_i ) {
@@ -865,7 +872,11 @@ _ce_image_fine(u3e_image* img_u,
   c3_w      i_w;
   c3_w    buf_w[pag_wiz_i];
 
-  lseek(img_u->fid_i, 0, SEEK_SET);
+  if ( -1 == lseek(img_u->fid_i, 0, SEEK_SET) ) {
+    fprintf(stderr, "loom: image fine seek 0: %s\r\n", strerror(errno));
+    c3_assert(0);
+  }
+
   for ( i_w=0; i_w < img_u->pgs_w; i_w++ ) {
     c3_w mem_w, fil_w;
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -432,11 +432,17 @@ _ce_patch_delete(void)
 {
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
-  c3_unlink(ful_c);
+   snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
+  if ( unlink(ful_c) ) {
+    fprintf(stderr, "loom: failed to delete control.bin: %s\r\n",
+                    strerror(errno));
+  }
 
   snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
-  c3_unlink(ful_c);
+  if ( unlink(ful_c) ) {
+    fprintf(stderr, "loom: failed to remove memory.bin: %s\r\n",
+                    strerror(errno));
+  }
 }
 
 /* _ce_patch_verify(): check patch data mug.

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1075,7 +1075,15 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
 {
   //  require that our page size is a multiple of the system page size.
   //
-  c3_assert(0 == (1 << (2 + u3a_page)) % sysconf(_SC_PAGESIZE));
+  {
+    size_t sys_i = sysconf(_SC_PAGESIZE);
+
+    if ( pag_siz_i % sys_i ) {
+      fprintf(stderr, "loom: incompatible system page size (%zuKB)\r\n",
+                      sys_i >> 10);
+      exit(1);
+    }
+  }
 
   u3P.dir_c = dir_c;
   u3P.nor_u.nam_c = "north";

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -590,6 +590,11 @@ _find_home(void)
 
   u3H = (void *)((mem_w + len_w) - siz_w);
   u3R = &u3H->rod_u;
+
+  //  this looks risky, but there are no legitimate scenarios
+  //  where it's wrong
+  //
+  u3R->cap_p = u3R->mat_p = u3a_words - c3_wiseof(*u3H);
 }
 
 /* u3m_pave(): instantiate or activate image.


### PR DESCRIPTION
This PR is a minimal back-port of the snapshot error handling fixes (and error message improvements) from #6062 and #6063 (without the overall feature set of either). Opened for visibility, as this is a bigger diff than the other hotfix changes (and newly written, whereas the other changes are mostly just cherry-picked from elsewhere).