### PR TITLE
Fix npm README typo: setings -> settings

### DIFF
--- a/pkg/npm/api/README.md
+++ b/pkg/npm/api/README.md
@@ -24,7 +24,7 @@ With:
 import UrbitInterface from '@urbit/http-api';
 import { settings } from '@urbit/api';
 const api: UrbitInterface = useApi();
-api.poke(setings.putEntry(bucket, key, value));
+api.poke(settings.putEntry(bucket, key, value));
 ```
 
 You may import single functions


### PR DESCRIPTION
Replacement for #6030 to get around issues with merge commits in a fork I don't have access to fix.