### PR TITLE
http-api: use /~/name endpoint if cookie not legible

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -200,8 +200,13 @@ export class Urbit {
         throw new Error('Login failed with status ' + response.status);
       }
 
+      const cookie = response.headers.get('set-cookie');
+
+      if (!this.ship && cookie) {
+        this.ship = new RegExp(/urbauth-~([\w-]+)/).exec(cookie)[1];
+      }
+
       if (!isBrowser) {
-        const cookie = response.headers.get('set-cookie');
         this.cookie = cookie;
       }
 

--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -196,7 +196,7 @@ export class Urbit {
         console.log('Received authentication response', response);
       }
 
-      if (response.status !== 204) {
+      if (response.status >= 200 && response.status < 300) {
         throw new Error('Login failed with status ' + response.status);
       }
 


### PR DESCRIPTION
Subset of #5918 that includes _just_ the `Urbit.ts` changes. This should be able to go out to frontends right now and retain their existing behavior, while preparing them for the full release of #5918 at some point in the future.