### PR TITLE
grid: distinguish app sync from system install

### DIFF
--- a/pkg/grid/src/components/ShipName.tsx
+++ b/pkg/grid/src/components/ShipName.tsx
@@ -3,11 +3,12 @@ import React, { HTMLAttributes } from 'react';
 
 type ShipNameProps = {
   name: string;
+  truncate?: boolean;
 } & HTMLAttributes<HTMLSpanElement>;
 
-export const ShipName = ({ name, ...props }: ShipNameProps) => {
+export const ShipName = ({ name, truncate = true, ...props }: ShipNameProps) => {
   const separator = /([_^-])/;
-  const citedName = cite(name);
+  const citedName = truncate ? cite(name) : name;
 
   if (!citedName) {
     return null;

--- a/pkg/grid/src/nav/preferences/AppPrefs.tsx
+++ b/pkg/grid/src/nav/preferences/AppPrefs.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import SourceSetter from '../../components/SourceSetter';
 import { useCharge } from '../../state/docket';
-import { usePike } from '../../state/kiln';
+import useKilnState, { usePike } from '../../state/kiln';
 import { getAppName } from '../../state/util';
-import SourceSyncer from '../../components/SourceSyncer';
 
 export const AppPrefs = ({ match }: RouteComponentProps<{ desk: string }>) => {
   const { desk } = match.params;
   const charge = useCharge(desk);
   const appName = getAppName(charge);
   const pike = usePike(desk);
-  const syncShip = pike?.sync?.ship;
+  const srcShip = pike?.sync?.ship;
+  const { toggleSync } = useKilnState();
 
   return (
-    <SourceSyncer
+    <SourceSetter
       appName={appName}
+      toggleSrc={toggleSync}
+      srcDesk={desk}
+      srcShip={srcShip}
       title={`${appName} Settings`}
-      syncDesk={desk}
-      syncShip={syncShip}
     />
   );
 };

--- a/pkg/grid/src/nav/preferences/SystemUpdatePrefs.tsx
+++ b/pkg/grid/src/nav/preferences/SystemUpdatePrefs.tsx
@@ -1,15 +1,22 @@
 import _ from 'lodash';
 import React from 'react';
-import SourceSyncer from '../../components/SourceSyncer';
-import { usePike } from '../../state/kiln';
+import SourceSetter from '../../components/SourceSetter';
+import useKilnState, { usePike } from '../../state/kiln';
 
 export const SystemUpdatePrefs = () => {
   const desk = 'base';
   const appName = 'your Urbit';
   const pike = usePike(desk);
-  const syncShip = pike?.sync?.ship;
+  const srcShip = pike?.sync?.ship;
+  const { toggleInstall } = useKilnState();
 
   return (
-    <SourceSyncer appName={appName} title="System Updates" syncDesk={desk} syncShip={syncShip} />
+    <SourceSetter
+      appName={appName}
+      toggleSrc={toggleInstall}
+      srcDesk={desk}
+      srcShip={srcShip}
+      title="System Updates"
+    />
   );
 };

--- a/pkg/grid/src/state/kiln.ts
+++ b/pkg/grid/src/state/kiln.ts
@@ -1,4 +1,13 @@
-import { scryLag, getPikes, Pikes, Pike, kilnUnsync, kilnSync } from '@urbit/api';
+import {
+  scryLag,
+  getPikes,
+  Pikes,
+  Pike,
+  kilnUnsync,
+  kilnSync,
+  kilnUninstall,
+  kilnInstall
+} from '@urbit/api';
 import create from 'zustand';
 import produce from 'immer';
 import { useCallback } from 'react';
@@ -12,6 +21,7 @@ interface KilnState {
   lag: boolean;
   fetchLag: () => Promise<void>;
   fetchPikes: () => Promise<void>;
+  toggleInstall: (desk: string, ship: string) => Promise<void>;
   toggleSync: (desk: string, ship: string) => Promise<void>;
   set: (s: KilnState) => void;
   initializeKiln: () => Promise<void>;
@@ -32,6 +42,13 @@ const useKilnState = create<KilnState>((set, get) => ({
   fetchLag: async () => {
     const lag = await api.scry<boolean>(scryLag);
     set({ lag });
+  },
+  toggleInstall: async (desk: string, ship: string) => {
+    const synced = !!get().pikes[desk].sync;
+    await (useMockData
+      ? fakeRequest('')
+      : api.poke(synced ? kilnUninstall(desk) : kilnInstall(ship, desk)));
+    await get().fetchPikes();
   },
   toggleSync: async (desk: string, ship: string) => {
     const synced = !!get().pikes[desk].sync;


### PR DESCRIPTION
# Context

By using `%kiln-install` instead of `%kiln-sync` for System Updates, this ensures that the `%kids` desk is also updated.

Also, address UX feedback: render the entire source ship's patp to avoid ambiguity. (as opposed to truncating a moon's name).

# Preview

## Render Entire Source's Patp

![image](https://user-images.githubusercontent.com/16504501/203183594-d0d5e0ef-00ac-498d-9f4f-622971701375.png)
