### PR TITLE
jael: send updates to all "general" pubkey subs

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -736,12 +736,10 @@
   ++  subscribers-on-ship
     |=  =ship
     ^-  (set duct)
-    =/  specific-subs  (~(get ju ney.zim) ship)
-    =/  general-subs=(set duct)
-      ?:  ?=(?(%czar %king %duke) (clan:title ship))
-        nel.zim
-      ~
-    (~(uni in specific-subs) general-subs)
+    ::  union of general and ship-specific subs
+    ::
+    %-  ~(uni in nel.zim)
+    (~(get ju ney.zim) ship)
   ::
   ++  feed
     |_  ::  hen: subscription source


### PR DESCRIPTION
As discussed with @philipcmonk out of band, it's strange that the "general" `%public-keys` subscription excludes moons. Jael may not track all moons in existence, but it should certainly still tell you about the ones it knows about. In most cases, those are the only ones you care about anyway.