### PR TITLE
groups: migration prep

### DIFF
--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -112,7 +112,7 @@
         |=  [r=resource:store m=marked-graph:store]
         ^-  card
         =/  pax  /(rap 3 'archive-' (scot %p entity.r) '-' name.r ~)/noun
-        =/  =cage  drum-put+!>([pax (jam m)])
+        =/  =cage  drum-put+!>([pax (jam r m)])
         [%pass /archive %agent [our.bowl %hood] %poke cage]
       ==
     ==

--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -11,10 +11,10 @@
       [%3 network:one:store]
       [%4 network:store]
       [%5 network:store]
-      state-6
+      [%6 network:store]
   ==
 ::-
-+$  state-6  [%6 network:store]
++$  state-7  [%7 network:store]
 ++  orm      orm:store
 ++  orm-log  orm-log:store
 ++  mar      %graph-update-3
@@ -96,7 +96,23 @@
       (scag 2 (tap:orm-log update-log))
     ==
   ::
-    %6  [cards this(state old)]
+      %6
+    %_  $
+        -.old  %7
+        archive.old  ~
+        cards
+      ;:  welp
+        cards
+      ::
+        %+  turn  ~(tap by archive.old)
+        |=  [r=resource:store m=marked-graph:store]
+        ^-  card
+        =/  pax  /(rap 3 'archive-'(scot %p entity.r) '-' name.r)/noun
+        =/  =cage  drum-put+!>([pax (jam m)])
+        [%pass /archive %agent [our.bowl %hood] %poke cage]
+    ==
+  ::
+      %7  [cards this(state old)]
   ==
 ::
 ++  on-watch

--- a/pkg/landscape/app/graph-store.hoon
+++ b/pkg/landscape/app/graph-store.hoon
@@ -12,6 +12,7 @@
       [%4 network:store]
       [%5 network:store]
       [%6 network:store]
+      state-7
   ==
 ::-
 +$  state-7  [%7 network:store]
@@ -20,7 +21,7 @@
 ++  mar      %graph-update-3
 --
 ::
-=|  state-6
+=|  state-7
 =*  state  -
 ::
 %-  agent:dbug
@@ -104,12 +105,16 @@
       ;:  welp
         cards
       ::
+        (nuke-groups:upgrade:store bowl)
+      ::
+        ^-  (list card)
         %+  turn  ~(tap by archive.old)
         |=  [r=resource:store m=marked-graph:store]
         ^-  card
-        =/  pax  /(rap 3 'archive-'(scot %p entity.r) '-' name.r)/noun
+        =/  pax  /(rap 3 'archive-' (scot %p entity.r) '-' name.r ~)/noun
         =/  =cage  drum-put+!>([pax (jam m)])
         [%pass /archive %agent [our.bowl %hood] %poke cage]
+      ==
     ==
   ::
       %7  [cards this(state old)]

--- a/pkg/landscape/lib/graph-store.hoon
+++ b/pkg/landscape/lib/graph-store.hoon
@@ -528,6 +528,21 @@
 ::
 ++  upgrade
   |%
+  ++  nuke-groups
+    |=  =bowl:gall
+    |^  ^-  (list card:agent:gall)
+    ?.  .^(? (gall-scry %u %groups))
+      ~
+    =+  .^(=desk (gall-scry %d %groups))
+    :~  [%pass /nuke %agent [our.bowl %hood] %poke kiln-nuke+!>([desk &])]
+        [%pass /nuke %agent [our.bowl %hood] %poke kiln-uninstall+!>(desk)]
+    ==
+    ::
+    ++  gall-scry
+      |=  [=care:clay dap=dude:gall]
+      ^-  path
+      /(cat 3 %g care)/(scot %p our.bowl)/[dap]/(scot %da now.bowl)
+    --
   ::
   ::  +two
   ::
@@ -758,9 +773,9 @@
   --
 ++  import
   |=  [arc=* our=ship]
-  ^-  (quip card:agent:gall [%6 network])
+  ^-  (quip card:agent:gall [%7 network])
   |^
-  =/  sty  [%6 (remake-network ;;(tree-network +.arc))]
+  =/  sty  [%7 (remake-network ;;(tree-network +.arc))]
   :_  sty
   %+  turn  ~(tap by graphs.sty)
   |=  [rid=resource =marked-graph]

--- a/pkg/landscape/ted/graph/recover-archive.hoon
+++ b/pkg/landscape/ted/graph/recover-archive.hoon
@@ -1,0 +1,19 @@
+/-  spider, graph=graph-store, met=metadata-store, *group, group-store, push-hook
+/+  strandio, resource, graph-view
+=>
+|%
+++  strand  strand:spider
+++  poke  poke:strandio
+++  poke-our   poke-our:strandio
+--
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<([~ pax=path] arg)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+=+  .^([rid=resource mar=marked-graph:graph] %cx pax)
+;<  ~  bind:m 
+  (poke-our:strandio %graph-store %graph-update-3 !>([now.bowl %add-graph p.mar q.mar &]))
+(pure:m *vase)


### PR DESCRIPTION
- Nukes all groups 2 agents, ensure a clean slate, even if users used the alpha
- Wipes archives, backing them up to `.urb/put`
- Adds tooling for recovering graphs from the backup