### PR TITLE
base-dev: remove `+fact-curry` from lib/agentio

### DIFF
--- a/pkg/base-dev/lib/agentio.hoon
+++ b/pkg/base-dev/lib/agentio.hoon
@@ -93,11 +93,6 @@
     (arvo %e %connect binding app)
   --
 ::
-++  fact-curry
-  |*  [=mark =mold]
-  |=  [paths=(list path) fac=mold]
-  (fact mark^!>(fac) paths)
-::
 ++  fact-kick
   |=  [=path =cage]
   ^-  (list card)


### PR DESCRIPTION
Closes #5992.

Because of how wet gates handle types, the vase created by `+fact-curry` is unusable and there's no real way to fix it. Hence removal.