### PR TITLE
Fix Comment: `arvo` comment for `|of` reads `|de`

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -415,7 +415,7 @@
     ==
   --
 ::
-::  |de: axal engine
+::  |of: axal engine
 ::
 ++  of
   =|  fat=(axal)


### PR DESCRIPTION
I'm not sure if `|de` has some connotation - it's mentioned that this core would be called `de` in prior commits but it doesn't seem to be named that here. Until it switches to `de`, putting it in parity with `+of`