### PR TITLE
clay: 417 hotfixes

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4549,8 +4549,11 @@
         |=  [=desk =bill]
         leaf+"goad: output: {<desk>}: {<bill>}"
     =^  agents  ..abet  (build-agents sat)
-    =.  ..abet
-      (build-marks (turn (skip sat |=([desk =bill] =(bill ~))) head))
+    ::  TODO: enable if we can reduce memory usage
+    ::
+    ::  =.  ..abet
+    ::    (build-marks (turn (skip sat |=([desk =bill] =(bill ~))) head))
+    ::
     =.  ..abet  tare                                    ::  [tare] >
     (emit hen %pass /lu/load %g %load agents)
   ::  +override: apply rein to bill

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -880,7 +880,7 @@
         (page-to-cage page)
       =^  [mark vax=vase]  nub  (page-to-cage page)
       =^  =tube  nub  (build-tube p.page mak)
-      :_(nub [mak (road |.((tube vax)))])
+      :_(nub [mak (tube vax)])
     ::
     ++  page-to-cage
       |=  =page
@@ -902,7 +902,7 @@
         [cag nub]
       =^  =tube  nub  (build-tube mok mak)
       ~|  error-running-cast+[path mok mak]
-      :_(nub [mak (road |.((tube q.cag)))])
+      :_(nub [mak (tube q.cag)])
     ::
     ++  run-pact
       |=  [old=page diff=page]
@@ -948,7 +948,7 @@
       %+  gain-leak  file+path
       |=  nob=state
       =.  nub  nob
-      =/  res=vase  (road |.((slap sut hoon.pile)))
+      =/  res=vase  (slap sut hoon.pile)
       [[%vase res] nub]
     ::
     ++  build-file

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4944,6 +4944,25 @@
         =/  den  ((de now rof hen ruf) our desk.arg.req)
         abet:(stay:den ver.arg.req)
       [moves ..^$]
+    ::
+        [%trim ~]
+      =:    fad.ruf      *flow
+            dos.rom.ruf
+          %-  ~(run by dos.rom.ruf)
+          |=  =dojo
+          dojo(fod.dom *flue)
+        ::
+            hoy.ruf
+          %-  ~(run by hoy.ruf)
+          |=  =rung
+          %=    rung
+              rus
+            %-  ~(run by rus.rung)
+            |=  =rede
+            rede(fod.dom *flue)
+          ==
+        ==
+      [~ ..^$]
     ==
   ::
       %tire
@@ -4955,25 +4974,7 @@
     [hen %give %tire %& tore:(lu now rof hen ruf)]~
   ::
       %tomb  (tomb-clue:tomb hen clue.req)
-      %trim
-    =:    fad.ruf      *flow
-          dos.rom.ruf
-        %-  ~(run by dos.rom.ruf)
-        |=  =dojo
-        dojo(fod.dom *flue)
-      ::
-          hoy.ruf
-        %-  ~(run by hoy.ruf)
-        |=  =rung
-        %=    rung
-            rus
-          %-  ~(run by rus.rung)
-          |=  =rede
-          rede(fod.dom *flue)
-        ==
-      ==
-    [~ ..^$]
-  ::
+      %trim  [~ ..^$]
       %vega
     ::  wake all desks, then send pending notifications
     ::


### PR DESCRIPTION
These are hotfixes for a prerelease of 417.  Recompiling all apps (as necessary for upgrading Clay) took too much memory to complete on ~wicdev-wisryt (>600 MB), these address that issue.

First, we stop adding explicit road transitions in Clay.  These were added in d1b4af89fea7922deb7f7660a08f82e34a89ae66 to avoid the issue where the memoization cache would accumulate entries for all compilations within a road, becoming far too large.  Six days later the memoization cache was capped in #3041, rendering the road transitions unnecessary, but since performance was acceptable, we did not revisit that decision.

Since the memoization cache is capped, it actually requires less memory to do all compilations in the same road.  This way, internal fragmentation (free lists) gets reused, and we don't have to constantly copy results between roads.

This reduces memory usage on ~wicdev-wisryt to 471MB.

Second, we stop eagerly building the marks (see https://github.com/urbit/urbit/pull/6092#discussion_r1028422573).  This would be a nice feature, but removing this reduces memory usage to 320MB.

Finally, we stop automatically clearing the cache on %trim.  This doesn't typically save memory because gall has a copy of the results of the compilation.  However, it means that anything that triggers a %goad must recompile all apps, which is memory-intensive.  It's very important that %trim do no harm.  The functionality is moved into a %stir debug command.