### PR TITLE
grid: new clay + kiln integration  

### DIFF
--- a/pkg/grid/src/nav/notifications/Inbox.tsx
+++ b/pkg/grid/src/nav/notifications/Inbox.tsx
@@ -13,7 +13,7 @@ function renderNotification(notification: Notification, key: string, lid: HarkLi
       return <RuntimeLagNotification key={key} />;
     }
     if (notification.bin.path === '/blocked' && notification.bin.place.path === '/desk/base') {
-      return <BaseBlockedNotification key={key} />;
+      return <BaseBlockedNotification key={key} bin={notification.bin} lid={lid} />;
     }
     if (notification.bin.place.path === '/onboard') {
       return <OnboardingNotification key={key} lid={lid} />;

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -64,6 +64,8 @@ export const BaseBlockedNotification = ({ bin, lid }: { bin: HarkBin, lid: HarkL
     }
 
     await toggleInstall('base', otaSponsor);
+    await useHarkStore.getState().archiveNote(bin, lid);
+
     push('/leap/upgrading');
   }, []);
 

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -1,6 +1,6 @@
 import { pick, partition } from 'lodash';
 import React, { useCallback } from 'react';
-import { kilnBump, Pike } from '@urbit/api';
+import { HarkBin, HarkLid, kilnBump, Pike } from '@urbit/api';
 import { useHistory } from 'react-router-dom';
 import { AppList } from '../../components/AppList';
 import { Button } from '../../components/Button';
@@ -12,6 +12,7 @@ import useKilnState, { usePike } from '../../state/kiln';
 
 import { NotificationButton } from './NotificationButton';
 import { disableDefault } from '../../state/util';
+import { useHarkStore } from '../../state/hark';
 
 export const RuntimeLagNotification = () => (
   <section
@@ -41,7 +42,7 @@ function pikeIsBlocked(newKelvin: number, pike: Pike) {
   return !pike.wefts?.find(({ kelvin }) => kelvin === newKelvin);
 }
 
-export const BaseBlockedNotification = () => {
+export const BaseBlockedNotification = ({ bin, lid }: { bin: HarkBin, lid: HarkLid }) => {
   const basePike = usePike('base');
   const { push } = useHistory();
   // TODO: assert weft.name === 'zuse'??
@@ -68,6 +69,8 @@ export const BaseBlockedNotification = () => {
 
   const handleArchiveApps = useCallback(async () => {
     await api.poke(kilnBump());
+    await useHarkStore.getState().archiveNote(bin, lid);
+
     push('/leap/upgrading');
   }, []);
 

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -98,7 +98,7 @@ export const BaseBlockedNotification = () => {
           >
             <h2 className="h4">Skip System Update</h2>
             <p>
-              Skipping the application fo an incoming System Update will grant you the ability to
+              Skipping the application for an incoming System Update will grant you the ability to
               continue using incompatible apps at the cost of an urbit that&apos;s not up to date.
             </p>
             <p>

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -51,14 +51,23 @@ export const BaseBlockedNotification = () => {
     const [b, u] = partition(Object.entries(s.pikes), ([, pike]) => pikeIsBlocked(newKelvin, pike));
     return [b.map(([d]) => d), u.map(([d]) => d)] as const;
   });
+  const { toggleInstall } = useKilnState();
 
   const blockedCharges = Object.values(pick(charges, blocked));
   const count = blockedCharges.length;
 
-  const handlePauseOTAs = useCallback(() => {}, []);
+  const handlePauseOTAs = useCallback(async () => {
+    const otaSponsor = basePike?.sync?.ship;
+    if (!otaSponsor) {
+      return;
+    }
+
+    await toggleInstall('base', otaSponsor);
+    push('/leap/upgrading');
+  }, []);
 
   const handleArchiveApps = useCallback(async () => {
-    api.poke(kilnBump());
+    await api.poke(kilnBump());
     push('/leap/upgrading');
   }, []);
 

--- a/pkg/grid/src/tiles/Tile.tsx
+++ b/pkg/grid/src/tiles/Tile.tsx
@@ -26,6 +26,7 @@ export const Tile: FunctionComponent<TileProps> = ({ charge, desk, disabled = fa
   const loading = !disabled && 'install' in chad;
   const suspended = disabled || 'suspend' in chad;
   const hung = 'hung' in chad;
+  // TODO should held zest be considered inactive? suspended? also, null sync?
   const active = !disabled && chadIsRunning(chad);
   const link = getAppHref(href);
   const backgroundColor = suspended ? suspendColor : active ? tileColor || 'purple' : suspendColor;
@@ -56,6 +57,9 @@ export const Tile: FunctionComponent<TileProps> = ({ charge, desk, disabled = fa
     >
       <div>
         <div className="absolute z-10 top-4 left-4 sm:top-6 sm:left-6 flex items-center">
+          {pike?.zest === 'held' && !disabled && (
+            <Bullet className="w-4 h-4 text-orange-500 dark:text-black" />
+          )}
           {!active && (
             <>
               {loading && <Spinner className="h-6 w-6 mr-2" />}
@@ -65,9 +69,6 @@ export const Tile: FunctionComponent<TileProps> = ({ charge, desk, disabled = fa
             </>
           )}
         </div>
-        {pike?.zest === 'held' && !disabled && (
-          <Bullet className="absolute z-10 top-5 left-5 sm:top-7 sm:left-7 w-4 h-4 text-orange-500 dark:text-black" />
-        )}
         <TileMenu
           desk={desk}
           chad={chad}


### PR DESCRIPTION
# Context

This PR addresses a few straggler issues in the integration between Grid and new Clay / Kiln (aka [Agents in Clay](https://roadmap.urbit.org/project/agents-in-clay)).

# Changes

- [x] fix bullet + tile title layout in Grid
- [x] user can disable system updates (ie, unsync from %base) in system notification
- [x] dismiss "n apps blocked system update" notification after update

# Preview

## Before

![image](https://user-images.githubusercontent.com/16504501/204542140-8dfc84ea-9daa-43d5-8b8d-7d4685417fb8.png)

## After 

![Screenshot from 2022-11-29 05-27-50](https://user-images.githubusercontent.com/16504501/204542058-d140d5d6-ef56-47e2-a30c-3cbbb736db40.png)
