### PR TITLE
groups: removing notify

### DIFF
--- a/pkg/landscape/desk.bill
+++ b/pkg/landscape/desk.bill
@@ -29,7 +29,6 @@
     %metadata-hook
     %metadata-pull-hook
     %metadata-push-hook
-    %notify
     %observe-hook
     %sane
     %weather


### PR DESCRIPTION
This is currently under contention for agent name with new groups, and unused in current groups.