### PR TITLE
u3: document and enforce snapshot system invariants

### DIFF
--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -99,10 +99,10 @@
 static u3p(c3_w) gar_pag_p;
 
 //! Urbit page size in 4-byte words.
-static const size_t pag_wiz_i = (size_t)1 << u3a_page;
+#define pag_wiz_i  ((size_t)1 << u3a_page)
 
 //! Urbit page size in bytes.
-static const size_t pag_siz_i = (size_t)1 << (u3a_page + 2);
+#define pag_siz_i  ((size_t)1 << (u3a_page + 2))
 
 #ifdef U3_SNAPSHOT_VALIDATION
 /* Image check.

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -50,6 +50,28 @@
 //!   - memory protections (and file-backed mappings) are re-established.
 //!   - patch files are deleted.
 //!
+//! ### invariants
+//!
+//!  definitions:
+//!    - a clean page is PROT_READ and 0 in the bitmap
+//!    - a dirty page is (PROT_READ|PROT_WRITE) and 1 in the bitmap
+//!    - the guard page is PROT_NONE and 1 in the bitmap (XX assumed)
+//!
+//!  assumptions:
+//!    - all memory access patterns are outside-in, a page at a time
+//!      - ad-hoc exceptions are supported by calling u3e_ward()
+//!
+//!  - there is a single guard page, between the segments
+//!  - dirty pages only become clean by being:
+//!    - loaded from a snapshot during initialization
+//!    - present in a snapshot after save
+//!  - clean pages only become dirty by being:
+//!    - modified (and caught by the fault handler)
+//!    - orphaned due to segment truncation (explicitly dirtied)
+//!  - at points of quiescence (initialization, after save)
+//!    - all pages of the north and south segments are clean
+//!    - all other pages are dirty
+//!
 //! ### limitations
 //!
 //!   - loom page size is fixed (16 KB), and must be a multiple of the

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -75,14 +75,13 @@
 //! ### limitations
 //!
 //!   - loom page size is fixed (16 KB), and must be a multiple of the
-//!     system page size. (can the size vary at runtime give south.bin's
-//!     reversed order? alternately, if system page size > ours, the fault
-//!     handler could dirty N pages at a time.)
-//!   - update atomicity is suspect: patch application must either
-//!     completely succeed or leave on-disk segments intact. unapplied
-//!     patches can be discarded (triggering event replay), but once
-//!     patch application begins it must succeed.
-//!     may require integration into the overall signal-handling regime.
+//!     system page size.
+//!   - update atomicity is crucial:
+//!     - patch application must either completely succeed or
+//!       leave on-disk segments (memory image) intact.
+//!     - unapplied patches can be discarded (triggering event replay),
+//!       but once patch application begins it must succeed.
+//!     - may require integration into the overall signal-handling regime.
 //!   - many errors are handled with assertions.
 //!
 //! ### enhancements

--- a/pkg/urbit/tests/events_tests.c
+++ b/pkg/urbit/tests/events_tests.c
@@ -1,0 +1,238 @@
+#include "all.h"
+
+/* _setup(): prepare for tests.
+*/
+static void
+_setup(void)
+{
+  //  NB: no loom
+  //
+  u3P.pag_w = u3a_pages;
+}
+
+static c3_w
+_check_north_clean(void)
+{
+  c3_w i_w, pag_w, blk_w, bit_w;
+
+  for ( i_w = 0; i_w < u3P.pag_w; i_w++ ) {
+    pag_w = i_w;
+    blk_w = pag_w >> 5;
+    bit_w = pag_w & 31;
+
+    if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
+      break;
+    }
+  }
+
+  return i_w;
+}
+
+static c3_w
+_check_north_dirty(c3_w pgs_w, c3_w max_w)
+{
+  c3_w i_w, pag_w, blk_w, bit_w;
+
+  for ( i_w = 0; i_w < max_w; i_w++ ) {
+    pag_w = i_w + pgs_w;
+    blk_w = pag_w >> 5;
+    bit_w = pag_w & 31;
+
+    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
+      break;
+    }
+  }
+
+  return i_w;
+}
+
+static c3_w
+_check_south_clean(void)
+{
+  c3_w i_w, pag_w, blk_w, bit_w;
+
+  for ( i_w = 0; i_w < u3P.pag_w; i_w++ ) {
+    pag_w = u3P.pag_w - (i_w + 1);
+    blk_w = pag_w >> 5;
+    bit_w = pag_w & 31;
+
+    if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
+      break;
+    }
+  }
+
+  return i_w;
+}
+
+static c3_w
+_check_south_dirty(c3_w pgs_w, c3_w max_w)
+{
+  c3_w i_w, pag_w, blk_w, bit_w;
+
+  for ( i_w = 0; i_w < max_w; i_w++ ) {
+    pag_w = u3P.pag_w - (i_w + pgs_w + 1);
+    blk_w = pag_w >> 5;
+    bit_w = pag_w & 31;
+
+    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
+      break;
+    }
+  }
+
+  return i_w;
+}
+
+void
+_ce_loom_track_north(c3_w pgs_w, c3_w dif_w);
+void
+_ce_loom_track_south(c3_w pgs_w, c3_w dif_w);
+
+static c3_i
+_test_tracking(void)
+{
+  c3_w ret_w;
+
+  u3e_foul();
+
+  if ( 0 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north init %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 0 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south init %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(100, 0);
+  _ce_loom_track_south(1, 0);
+
+  if ( 100 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean a %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 1 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean a %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(75, 25);
+  _ce_loom_track_south(2, 0);
+
+  if ( 75 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean b %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 25 != (ret_w = _check_north_dirty(75, 25)) ) {
+    fprintf(stderr, "test events track north dirty b %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 2 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean b %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(55, 20);
+  _ce_loom_track_south(1, 1);
+
+  if ( 55 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean c %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 20 != (ret_w = _check_north_dirty(55, 20)) ) {
+    fprintf(stderr, "test events track north dirty c %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 1 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean c %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 1 != (ret_w = _check_south_dirty(1, 1)) ) {
+    fprintf(stderr, "test events track north dirty c %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(255, 0);
+  _ce_loom_track_south(48, 0);
+
+  if ( 255 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean d %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 48 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean d %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(213, 42);
+  _ce_loom_track_south(15, 33);
+
+  if ( 213 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean e %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 42 != (ret_w = _check_north_dirty(213, 42)) ) {
+    fprintf(stderr, "test events track north dirty e %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 15 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean e %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 33 != (ret_w = _check_south_dirty(15, 33)) ) {
+    fprintf(stderr, "test events track north dirty e %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(200, 13);
+  _ce_loom_track_south(10, 5);
+
+  if ( 200 != (ret_w = _check_north_clean()) ) {
+    fprintf(stderr, "test events track north clean f %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 13 != (ret_w = _check_north_dirty(200, 13)) ) {
+    fprintf(stderr, "test events track north dirty f %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 10 != (ret_w = _check_south_clean()) ) {
+    fprintf(stderr, "test events track south clean f %u\r\n", ret_w);
+    return 0;
+  }
+
+  if ( 5 != (ret_w = _check_south_dirty(10, 5)) ) {
+    fprintf(stderr, "test events track north dirty f %u\r\n", ret_w);
+    return 0;
+  }
+
+  return 1;
+}
+
+/* main(): run all test cases.
+*/
+int
+main(int argc, char* argv[])
+{
+   _setup();
+
+  if ( !_test_tracking() ) {
+    fprintf(stderr, "test_events: tracking: failed\r\n");
+    exit(1);
+  }
+
+  fprintf(stderr, "test_events: ok\n");
+
+  return 0;
+}


### PR DESCRIPTION
This PR fixes an unreleased bug introduced in #6063, whereby snapshots could be corrupted when they were resized.

The bug was caused by a discrepancy between memory protections and page metadata (not unlike #6125), and was introduced while refactoring an earlier version that failed to maintain the invariant that only pages within the snapshot could be clean (harmlessly, because there was no discrepancy). So this PR also includes documentation of the key invariants of the snapshot system. Thanks to @belisarius222 for his assistance formulating and reviewing these invariants. Further localization of these comments (a la #6085) would be highly desirable.

Finally, this PR replaces `static const` page sizes with macros, to avoid the proliferation of VLAs introduced in #5881. Thanks to @barter-simsum for pointing this out in #6077.