### PR TITLE
ames: add |close-flows

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55f1bcccf861b3a2247aabb6ec3349829272ef8c36cfc8a16ff0930aac87a24d
-size 5748196
+oid sha256:511564074c56329460e238ebb4881ff4dd9d642ac6d0804bbd9aaa17adc2f8ee
+size 5732943

--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:511564074c56329460e238ebb4881ff4dd9d642ac6d0804bbd9aaa17adc2f8ee
-size 5732943
+oid sha256:2035ef65290065edbd99a86f9f5a36978617bc1983131fa474a9a5c0e91dc15d
+size 5998440

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -1,12 +1,9 @@
 ::  |close-flows: corks all stale ames flows
 ::
-::    It runs in dry mode by default, printing the flows that can be closed:
-::
-::      |close-flows, =dry |
+::    It runs in dry mode by default, printing the flows that can be closed.
+::    To actually close the flows, run with |close-flows, =dry |
 ::
 :-  %say
-|=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=~ dry=?]
-    ==
+|=  [^ [dry=?]]
 ::
 [%helm-kroc dry]

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -71,7 +71,7 @@
 ?~  duct  ~
 ::  inspect the wires in the duct, looking for subscriptions
 ::
-?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ ~] i.duct)
+?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] i.duct)
   $(duct t.duct)
 ::  extra security check so we know that the nonce is a number
 ::

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -25,7 +25,7 @@
   ==
 ::
 =;  krocs=(list [=ship =bone])
-    helm-ames-kroc+[krocs dry-run]
+  helm-ames-kroc+[krocs dry-run]
 ::
 %-  zing
 %+  turn  peers
@@ -38,12 +38,12 @@
   %-  ~(gas in *(set @))
   %+  turn
     %+  sort  ~(tap by by-bone.ossuary.peer-state)
-    |=  [[a=@ *] [b=@ *]]  (lth a b)
+    |=  [[a=@ *] [b=@ *]]  (lte a b)
   head
 ::
 =/  nacks=(list bone)
   %+  turn
-    (sort ~(tap by rcv.peer-state) |=([[a=@ *] [b=@ *]] (lth a b)))
+    (sort ~(tap by rcv.peer-state) |=([[a=@ *] [b=@ *]] (lte a b)))
   head
 ::
 ^-  (list [@p @ud])

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -1,0 +1,73 @@
+::  |close-flows: sends a %cork to all ships that have nacked a %watch
+::
+::    It runs in dry mode by default, printing the number of flows that
+::    can be closed. To actually send the corks, run as:
+::
+::      |close-flows, =dry-run |
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [arg=~ dry-run=?]
+    ==
+::
+=/  peers-map
+  .^  (map ship ?(%alien %known))
+      %ax  /(scot %p p.bec)//(scot %da now)/peers
+  ==
+=/  peers=(list ship)
+  %+  murn  ~(tap by peers-map)
+  |=  [=ship val=?(%alien %known)]
+  ?:  =(ship p.bec)
+    ~  ::  this is weird, but we saw it
+  ?-  val
+    %alien  ~
+    %known  (some ship)
+  ==
+::
+=;  krocs=(list [=ship =bone])
+    helm-ames-kroc+[krocs dry-run]
+::
+%-  zing
+%+  turn  peers
+|=  =ship
+=+  .^  =ship-state:ames
+        %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
+    ==
+=/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+=/  forward-flows=(set @)
+  %-  ~(gas in *(set @))
+  %+  turn
+    %+  sort  ~(tap by by-bone.ossuary.peer-state)
+    |=  [[a=@ *] [b=@ *]]  (lth a b)
+  head
+::
+=/  nacks=(list bone)
+  %+  turn
+    (sort ~(tap by rcv.peer-state) |=([[a=@ *] [b=@ *]] (lth a b)))
+  head
+::
+^-  (list [@p @ud])
+%+  murn  nacks
+|=  =bone
+?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
+  ::  not a naxplanation ack bone
+  ::
+  ~
+::  by only corking forward flows that have received
+::  a nack we avoid corking the current subscription
+::
+=+  target=(mix 0b10 bone)
+::  make sure that the nack bone has a forward flow
+::
+?.  (~(has in forward-flows) target)  ~
+?~  duct=(~(get by by-bone.ossuary.peer-state) target)
+  ~
+=/  =wire  (snag 1 u.duct)
+::  only wires with nonces are subscriptions
+::
+?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ ~] wire)
+  ~
+::  extra security check so we know that the nonce is a number
+::
+?~  (rush i.t.t.t.t.t.t.t.wire dem)  ~
+`[ship target]

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -34,21 +34,10 @@
         %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
     ==
 =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
-=/  forward-flows=(set @)
-  %-  ~(gas in *(set @))
-  %+  turn
-    %+  sort  ~(tap by by-bone.ossuary.peer-state)
-    |=  [[a=@ *] [b=@ *]]  (lte a b)
-  head
-::
-=/  nacks=(list bone)
-  %+  turn
-    (sort ~(tap by rcv.peer-state) |=([[a=@ *] [b=@ *]] (lte a b)))
-  head
 ::
 ^-  (list [@p @ud])
-%+  murn  nacks
-|=  =bone
+%+  murn  ~(tap by rcv.peer-state)
+|=  [=bone *]
 ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
   ::  not a naxplanation ack bone
   ::
@@ -59,7 +48,6 @@
 =+  target=(mix 0b10 bone)
 ::  make sure that the nack bone has a forward flow
 ::
-?.  (~(has in forward-flows) target)  ~
 ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
   ~
 =;  =wire

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -1,4 +1,11 @@
-::  |close-flows: sends a %cork to all ships that have nacked a %watch
+::  (TODO: rename) |close-flows: shows how many stale ames flows can be closed
+::                (each ames flow is represented by its first bone)
+::
+::    Run in verbose mode my default, to turn of: |close-flows, =veb |
+::
+::    TODO:
+::    corks all ames flows that are in a stale state due to some
+::    previous unhandled errors
 ::
 ::    It runs in dry mode by default, printing the number of flows that
 ::    can be closed. To actually send the corks, run as:
@@ -7,13 +14,12 @@
 ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=~ dry-run=?]
+        [arg=~ dry=? veb=?]
     ==
 ::
 =/  peers-map
-  .^  (map ship ?(%alien %known))
-      %ax  /(scot %p p.bec)//(scot %da now)/peers
-  ==
+  .^((map ship ?(%alien %known)) %ax /(scot %p p.bec)//(scot %da now)/peers)
+::
 =/  peers=(list ship)
   %+  murn  ~(tap by peers-map)
   |=  [=ship val=?(%alien %known)]
@@ -24,44 +30,75 @@
     %known  (some ship)
   ==
 ::
-=;  krocs=(list [=ship =bone])
-  helm-ames-kroc+[krocs dry-run]
+=/  agents-map
+  .^  (list [app=term sub-nonce=@ud run-nonce=@t =boat:gall =boar:gall])
+    %gr  (scot %p p.bec)  %base  (scot %da now)  ~
+  ==
 ::
-%-  zing
-%+  turn  peers
-|=  =ship
-=+  .^  =ship-state:ames
-        %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
-    ==
-=/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+|^  ~?  veb  "{<~(wyt in nacks)>} flows from %nacking %watches"
+    ~?  veb  "{<~(wyt in resubs)>} flows from stale resubscriptions"
+    :+  %helm-ames-kroc  dry
+    ~(tap in (~(uni in nacks) resubs))
 ::
-^-  (list [@p @ud])
-%+  murn  ~(tap by rcv.peer-state)
-|=  [=bone *]
-?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
-  ::  not a naxplanation ack bone
+++  resubs
+  =+  peers=(~(gas in *(set ship)) peers)
+  %+  roll  agents-map
+  |=  $:  [app=term next-nonce=@ run-nonce=@t =boat:gall =boar:gall]
+          resubs=(set [ship bone])
+      ==
+  =/  subs  ~(tap in ~(key by boat))
+  ?~  subs  resubs
+  =/  [=wire =dock]    i.subs
+  =/  sub=@ud  (~(got by boar) wire dock)
+  ::  ignores subscription with nonce=0, this is handled by +ap-rake
+  ::  XX TODO handle also here?
   ::
-  ~
-::  by only corking forward flows that have received
-::  a nack we avoid corking the current subscription
+  ?:  =(sub 0)  resubs
+  ::  skip current subscription
+  ::
+  ?.  (lth sub (dec next-nonce))  resubs
+  ?:  !(~(has in peers) p.dock)   resubs
+  =+  .^  =ship-state:ames
+          %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p p.dock)
+      ==
+  =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+  %-  ~(rep by by-duct.ossuary.peer-state)
+  |=  [[=duct =bone] resubs=_resubs]
+   =+  sub-nonce=(scot %ud sub)
+   =/  mod=^wire
+    :*  %gall  %use  app  run-nonce
+        %out  (scot %p p.dock)  q.dock
+        sub-nonce  wire
+    ==
+  ?.  ?&  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] duct)
+          =(mod i.t.duct(i.t.t.t.t.t.t.t sub-nonce))
+      ==
+    resubs
+  (~(put in resubs) [p.dock bone])
 ::
-=+  target=(mix 0b10 bone)
-::  make sure that the nack bone has a forward flow
-::
-?~  duct=(~(get by by-bone.ossuary.peer-state) target)
-  ~
-=;  =wire
-  ?~(wire ~ `[ship target])
-::  TMI
-::
-=>  .(duct `^duct`duct)
-|-  ^-  wire
-?~  duct  ~
-::  inspect the wires in the duct, looking for subscriptions
-::
-?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] i.duct)
-  $(duct t.duct)
-::  extra security check so we know that the nonce is a number
-::
-?~  (rush i.t.t.t.t.t.t.t.i.duct dem)  ~
-i.duct
+++  nacks
+  %+  roll  peers
+  |=  [=ship nacks=(set [ship bone])]
+  =+  .^  =ship-state:ames
+          %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
+      ==
+  =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+  ::
+  %+  roll  ~(tap by rcv.peer-state)
+  |=  [[=bone *] nacks=_nacks]
+  ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
+    ::  not a naxplanation ack bone
+    ::
+    nacks
+  ::  by only corking forward flows that have received
+  ::  a nack we avoid corking the current subscription
+  ::
+  =+  target=(mix 0b10 bone)
+  ::  make sure that the nack bone has a forward flow
+  ::
+  ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
+    nacks
+  ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] duct)
+    nacks
+  (~(put in nacks) [ship target])
+--

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -62,12 +62,18 @@
 ?.  (~(has in forward-flows) target)  ~
 ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
   ~
-=/  =wire  (snag 1 u.duct)
-::  only wires with nonces are subscriptions
+=;  =wire
+  ?~(wire ~ `[ship target])
+::  TMI
 ::
-?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ ~] wire)
-  ~
+=>  .(duct `^duct`duct)
+|-  ^-  wire
+?~  duct  ~
+::  inspect the wires in the duct, looking for subscriptions
+::
+?.  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ ~] i.duct)
+  $(duct t.duct)
 ::  extra security check so we know that the nonce is a number
 ::
-?~  (rush i.t.t.t.t.t.t.t.wire dem)  ~
-`[ship target]
+?~  (rush i.t.t.t.t.t.t.t.i.duct dem)  ~
+i.duct

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -1,104 +1,12 @@
-::  (TODO: rename) |close-flows: shows how many stale ames flows can be closed
-::                (each ames flow is represented by its first bone)
+::  |close-flows: corks all stale ames flows
 ::
-::    Run in verbose mode my default, to turn of: |close-flows, =veb |
+::    It runs in dry mode by default, printing the flows that can be closed:
 ::
-::    TODO:
-::    corks all ames flows that are in a stale state due to some
-::    previous unhandled errors
-::
-::    It runs in dry mode by default, printing the number of flows that
-::    can be closed. To actually send the corks, run as:
-::
-::      |close-flows, =dry-run |
+::      |close-flows, =dry |
 ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=~ dry=? veb=?]
+        [arg=~ dry=?]
     ==
 ::
-=/  peers-map
-  .^((map ship ?(%alien %known)) %ax /(scot %p p.bec)//(scot %da now)/peers)
-::
-=/  peers=(list ship)
-  %+  murn  ~(tap by peers-map)
-  |=  [=ship val=?(%alien %known)]
-  ?:  =(ship p.bec)
-    ~  ::  this is weird, but we saw it
-  ?-  val
-    %alien  ~
-    %known  (some ship)
-  ==
-::
-=/  agents-map
-  .^  (list [app=term sub-nonce=@ud run-nonce=@t =boat:gall =boar:gall])
-    %gr  (scot %p p.bec)  %base  (scot %da now)  ~
-  ==
-::
-|^  ~?  veb  "{<~(wyt in nacks)>} flows from %nacking %watches"
-    ~?  veb  "{<~(wyt in resubs)>} flows from stale resubscriptions"
-    :+  %helm-ames-kroc  dry
-    ~(tap in (~(uni in nacks) resubs))
-::
-++  resubs
-  =+  peers=(~(gas in *(set ship)) peers)
-  %+  roll  agents-map
-  |=  $:  [app=term next-nonce=@ run-nonce=@t =boat:gall =boar:gall]
-          resubs=(set [ship bone])
-      ==
-  =/  subs  ~(tap in ~(key by boat))
-  ?~  subs  resubs
-  =/  [=wire =dock]    i.subs
-  =/  sub=@ud  (~(got by boar) wire dock)
-  ::  ignores subscription with nonce=0, this is handled by +ap-rake
-  ::  XX TODO handle also here?
-  ::
-  ?:  =(sub 0)  resubs
-  ::  skip current subscription
-  ::
-  ?.  (lth sub (dec next-nonce))  resubs
-  ?:  !(~(has in peers) p.dock)   resubs
-  =+  .^  =ship-state:ames
-          %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p p.dock)
-      ==
-  =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
-  %-  ~(rep by by-duct.ossuary.peer-state)
-  |=  [[=duct =bone] resubs=_resubs]
-   =+  sub-nonce=(scot %ud sub)
-   =/  mod=^wire
-    :*  %gall  %use  app  run-nonce
-        %out  (scot %p p.dock)  q.dock
-        sub-nonce  wire
-    ==
-  ?.  ?&  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] duct)
-          =(mod i.t.duct(i.t.t.t.t.t.t.t sub-nonce))
-      ==
-    resubs
-  (~(put in resubs) [p.dock bone])
-::
-++  nacks
-  %+  roll  peers
-  |=  [=ship nacks=(set [ship bone])]
-  =+  .^  =ship-state:ames
-          %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
-      ==
-  =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
-  ::
-  %+  roll  ~(tap by rcv.peer-state)
-  |=  [[=bone *] nacks=_nacks]
-  ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
-    ::  not a naxplanation ack bone
-    ::
-    nacks
-  ::  by only corking forward flows that have received
-  ::  a nack we avoid corking the current subscription
-  ::
-  =+  target=(mix 0b10 bone)
-  ::  make sure that the nack bone has a forward flow
-  ::
-  ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
-    nacks
-  ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] duct)
-    nacks
-  (~(put in nacks) [ship target])
---
+[%helm-kroc dry]

--- a/pkg/arvo/gen/hood/close-flows.hoon
+++ b/pkg/arvo/gen/hood/close-flows.hoon
@@ -4,6 +4,6 @@
 ::    To actually close the flows, run with |close-flows, =dry |
 ::
 :-  %say
-|=  [^ [dry=?]]
+|=  [^ arg=~ dry=?]
 ::
 [%helm-kroc dry]

--- a/pkg/arvo/gen/stale-flows.hoon
+++ b/pkg/arvo/gen/stale-flows.hoon
@@ -139,5 +139,3 @@
   ~?  =(%1 veb)  "[bone={<target>} nonce={<nonce>} agent={<app>}] {<path>}"
   (~(put in nacks) [ship target])
 --
-
-

--- a/pkg/arvo/gen/stale-flows.hoon
+++ b/pkg/arvo/gen/stale-flows.hoon
@@ -1,0 +1,145 @@
+::  +stale-flows: prints number of ames flows that can be closed
+::
+::    |stale-flows, =veb %0  :: TODO
+::    |stale-flows, =veb %1  :: flows from nacking initial subscriptions
+::    |stale-flows, =veb %2  :: stale flows that keep (re)trying to connect
+::    |stale-flows, =veb %21 :: ... per app (only forward)
+::    |stale-flows, =veb %3  :: stale resubscriptions
+::    |stale-flows, =veb %31 :: (TODO) ... per app
+::
+=>  |%
+    +$  subs  (jar path [ship bone @])
+    +$  pags  (jar app=term [dst=term =ship =path])  ::  per-agent
+    +$  naks  (set [ship bone])
+    ::  verbosity:
+    ::
+
+    ::
+    +$  veb  ?(%0 %1 %2 %21 %3 %31)
+    ::
+    ++  resubs
+      |=  [=subs =veb]
+      ^-  @
+      ::=/  sorted
+      ::  %+  sort  ~(tap by subs)
+      ::  |=([a=(list *) b=(list *)] (lte (lent a) (lent b)))
+      %+  roll  ~(tap by subs)::sorted
+      |=  [[k=path v=(list [ship bone @])] num=@]
+      ~?  &(=(%3 veb) (gth (lent v) 1))
+        "#{<(dec (lent v))>} stale resubs on {<k>}"
+      ?.  (gth (lent v) 1)  num
+      (add (lent v) num)
+    --
+::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [arg=~ dry=? =veb]
+    ==
+::
+=/  peers-map
+  .^((map ship ?(%alien %known)) %ax /(scot %p p.bec)//(scot %da now)/peers)
+::
+=/  peers=(list ship)
+  %+  murn  ~(tap by peers-map)
+  |=  [=ship val=?(%alien %known)]
+  ?:  =(ship p.bec)
+    ~  ::  this is weird, but we saw it
+  ?-  val
+    %alien  ~
+    %known  (some ship)
+  ==
+::
+=;  [[=subs =pags backward=@ forward=@] =naks]
+    :-  %tang  %-  flop
+    %+  weld
+      :~  leaf+"#{<~(wyt in naks)>} flows from %nacking %watches"
+          leaf+"#{<backward>} backward flows with >10 retries"
+          leaf+"#{<forward>} forward flows with >10 retries"
+          leaf+"#{<(resubs subs veb)>} stale resubscriptions"
+      ==
+    ?.  =(%21 veb)  ~
+    :-  leaf+"----------------------------------"
+    %+  turn  ~(tap by pags)
+    |=  [app=term v=(list [dst=term =ship =path])]
+    :-  %leaf
+    %+  weld  "#{<(lent v)>} flows for {<app>} with >10 retries"
+    ?.  =(1 (lent v))  ~
+    ?>  ?=(^ v)
+    " on {<ship.i.v>} to {<dst.i.v>} at {<path.i.v>}"
+::
+%+  roll  peers
+|=  [=ship [=subs p=pags b=@ f=@] n=naks]
+=+  .^  =ship-state:ames
+        %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
+    ==
+=/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+::
+|^  [stale nacks]
+::
+++  stale
+  %+  roll  ~(tap by snd.peer-state)
+  |=  [[=bone message-pump-state:ames] subs=_subs pags=_p backward=_b forward=_f]
+  =,  packet-pump-state
+  :-  ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)  subs
+      ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
+        subs
+      =/  =wire           i.t.u.duct
+      =/  nonce=(unit @)  (rush i.t.t.t.t.t.t.t.i.t.u.duct dem)
+      %-  ~(add ja subs)
+      :_  [ship bone ?~(nonce 0 u.nonce)]  :: 0, 1?
+      ?~  nonce  wire
+      ::  don't include the sub-nonce in the key
+      ::
+      (weld (scag 7 wire) (slag 8 wire))
+  %+  roll  ~(tap in live)
+  |=  [[* [packet-state:ames *]] pags=_pags out=[b=_backward f=_forward]]
+  ::
+  ::  only forward flows
+  ::
+  =?  pags  &(=(0 (end 0 bone)) (gth retries 10))
+    ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)
+      pags
+    ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
+      pags
+    =/  =wire  i.t.u.duct
+    (~(add ja pags) (snag 2 wire) (snag 8 wire) ship (slag 9 wire))
+  ::
+  ~?  &(=(%2 veb) (gth retries 10))
+    =+  arrow=?:(=(0 (end 0 bone)) "<-" "->")
+    "{arrow} ({(cite:title ship)}) bone #{<bone>}, retries: #{<retries>}"
+  :-  pags
+  =?  out  (gth retries 10)
+    ?:  =(0 (end 0 bone))
+      [b.out +(f.out)]
+    [+(b.out) f.out]
+  out
+::
+++  nacks
+  %+  roll  ~(tap by rcv.peer-state)
+  |=  [[=bone *] nacks=_n]
+  ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
+    ::  not a naxplanation ack bone
+    ::
+    nacks
+  ::  by only corking forward flows that have received
+  ::  a nack we avoid corking the current subscription
+  ::
+  =+  target=(mix 0b10 bone)
+  ::  make sure that the nack bone has a forward flow
+  ::
+  ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
+    nacks
+  ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
+    nacks
+  =/  =wire      i.t.u.duct
+  ?>  ?=([%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] wire)
+  =/  app=term   i.t.t.wire
+  =/  nonce=@
+    =-  ?~(- 0 u.-)
+    (rush i.t.t.t.t.t.t.t.wire dem)
+  =/  =path      t.t.t.t.t.t.t.t.wire
+  ~?  =(%1 veb)  "[bone={<target>} nonce={<nonce>} agent={<app>}] {<path>}"
+  (~(put in nacks) [ship target])
+--
+
+

--- a/pkg/arvo/gen/stale-flows.hoon
+++ b/pkg/arvo/gen/stale-flows.hoon
@@ -59,7 +59,9 @@
       ==
     ?.  =(%21 veb)  ~
     :-  leaf+"----------------------------------"
-    %+  turn  ~(tap by pags)
+    %+  turn  %+  sort  ~(tap by pags)
+              |=  [[* v=(list)] [* w=(list)]]
+              (gth (lent v) (lent w))
     |=  [app=term v=(list [dst=term =ship =path])]
     :-  %leaf
     %+  weld  "#{<(lent v)>} flows for {<app>} with >10 retries"

--- a/pkg/arvo/gen/stale-flows.hoon
+++ b/pkg/arvo/gen/stale-flows.hoon
@@ -1,19 +1,15 @@
 ::  +stale-flows: prints number of ames flows that can be closed
 ::
-::    |stale-flows, =veb %0  :: TODO
 ::    |stale-flows, =veb %1  :: flows from nacking initial subscriptions
 ::    |stale-flows, =veb %2  :: stale flows that keep (re)trying to connect
 ::    |stale-flows, =veb %21 :: ... per app (only forward)
 ::    |stale-flows, =veb %3  :: stale resubscriptions
-::    |stale-flows, =veb %31 :: (TODO) ... per app
 ::
 =>  |%
     +$  subs  (jar path [ship bone @])
     +$  pags  (jar app=term [dst=term =ship =path])  ::  per-agent
     +$  naks  (set [ship bone])
-    ::  verbosity:
-    ::
-
+    ::  verbosity
     ::
     +$  veb  ?(%0 %1 %2 %21 %3 %31)
     ::
@@ -50,24 +46,24 @@
   ==
 ::
 =;  [[=subs =pags backward=@ forward=@] =naks]
-    :-  %tang  %-  flop
-    %+  weld
-      :~  leaf+"#{<~(wyt in naks)>} flows from %nacking %watches"
-          leaf+"#{<backward>} backward flows with >10 retries"
-          leaf+"#{<forward>} forward flows with >10 retries"
-          leaf+"#{<(resubs subs veb)>} stale resubscriptions"
-      ==
-    ?.  =(%21 veb)  ~
-    :-  leaf+"----------------------------------"
-    %+  turn  %+  sort  ~(tap by pags)
-              |=  [[* v=(list)] [* w=(list)]]
-              (gth (lent v) (lent w))
-    |=  [app=term v=(list [dst=term =ship =path])]
-    :-  %leaf
-    %+  weld  "#{<(lent v)>} flows for {<app>} with >10 retries"
-    ?.  =(1 (lent v))  ~
-    ?>  ?=(^ v)
-    " on {<ship.i.v>} to {<dst.i.v>} at {<path.i.v>}"
+  :-  %tang  %-  flop
+  %+  weld
+    :~  leaf+"#{<~(wyt in naks)>} flows from %nacking %watches"
+        leaf+"#{<backward>} backward flows with >10 retries"
+        leaf+"#{<forward>} forward flows with >10 retries"
+        leaf+"#{<(resubs subs veb)>} stale resubscriptions"
+    ==
+  ?.  =(%21 veb)  ~
+  :-  leaf+"----------------------------------"
+  %+  turn  %+  sort  ~(tap by pags)
+            |=  [[* v=(list)] [* w=(list)]]
+            (gth (lent v) (lent w))
+  |=  [app=term v=(list [dst=term =ship =path])]
+  :-  %leaf
+  %+  weld  "#{<(lent v)>} flows for {<app>} with >10 retries"
+  ?.  =(1 (lent v))  ~
+  ?>  ?=(^ v)
+  " on {<ship.i.v>} to {<dst.i.v>} at {<path.i.v>}"
 ::
 %+  roll  peers
 |=  [=ship [=subs p=pags b=@ f=@] n=naks]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -246,7 +246,7 @@
   (emit %pass /helm %arvo %a %stir '')
 ::
 ++  poke-ames-kroc
-  |=  [krocs=(list [=ship =bone]) dry=?]  =<  abet
+  |=  [dry=? krocs=(list [=ship =bone])]  =<  abet
   ?~  krocs  (flog %text "No %ames flow ready to be close")
   %-  emil    ^-  (list card)
   ::  TODO: extend closing flow overview

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -249,12 +249,17 @@
   |=  [krocs=(list [=ship =bone]) dry=?]  =<  abet
   ?~  krocs  (flog %text "No %ames flow ready to be close")
   %-  emil    ^-  (list card)
+  ::  TODO: extend closing flow overview
+  ::
   :-  [%pass /di %arvo %d %flog text+"Closing {<(lent krocs)>} ames flows"]
-  ?:  dry  ~
-  %+  turn  krocs
-  |=  [=ship =bone]
-  ^-  card
-  [%pass /helm %arvo %a %kroc ship bone]
+  ::  XX uncomment when updating %lull to include a %kroc task to ames
+  ::
+  ~
+  :: ?:  dry  ~
+  :: %+  turn  krocs
+  :: |=  [=ship =bone]
+  :: ^-  card
+  :: [%pass /helm %arvo %a %kroc ship bone]
 ::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -247,10 +247,7 @@
 ::
 ++  poke-kroc
   |=  dry=?  =<  abet
-  %-  emil    ^-  (list card)
-  :~  [%pass /helm/kroc %arvo %a %kroc dry]
-      [%pass /helm/rake %arvo %g %rake ~ %r dry]
-  ==
+  (emit [%pass /helm/kroc %arvo %a %kroc dry])
 ::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -245,21 +245,12 @@
   |=  ~  =<  abet
   (emit %pass /helm %arvo %a %stir '')
 ::
-++  poke-ames-kroc
-  |=  [dry=? krocs=(list [=ship =bone])]  =<  abet
-  ?~  krocs  (flog %text "No %ames flow ready to be close")
+++  poke-kroc
+  |=  dry=?  =<  abet
   %-  emil    ^-  (list card)
-  ::  TODO: extend closing flow overview
-  ::
-  :-  [%pass /di %arvo %d %flog text+"Closing {<(lent krocs)>} ames flows"]
-  ::  XX uncomment when updating %lull to include a %kroc task to ames
-  ::
-  ~
-  :: ?:  dry  ~
-  :: %+  turn  krocs
-  :: |=  [=ship =bone]
-  :: ^-  card
-  :: [%pass /helm %arvo %a %kroc ship bone]
+  :~  [%pass /helm/kroc %arvo %a %kroc dry]
+      [%pass /helm/rake %arvo %g %rake ~ %r dry]
+  ==
 ::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet
@@ -296,7 +287,7 @@
     %helm-ames-sift        =;(f (f !<(_+<.f vase)) poke-ames-sift)
     %helm-ames-verb        =;(f (f !<(_+<.f vase)) poke-ames-verb)
     %helm-ames-wake        =;(f (f !<(_+<.f vase)) poke-ames-wake)
-    %helm-ames-kroc        =;(f (f !<(_+<.f vase)) poke-ames-kroc)
+    %helm-kroc             =;(f (f !<(_+<.f vase)) poke-kroc)
     %helm-atom             =;(f (f !<(_+<.f vase)) poke-atom)
     %helm-automass         =;(f (f !<(_+<.f vase)) poke-automass)
     %helm-cancel-automass  =;(f (f !<(_+<.f vase)) poke-cancel-automass)

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -245,6 +245,17 @@
   |=  ~  =<  abet
   (emit %pass /helm %arvo %a %stir '')
 ::
+++  poke-ames-kroc
+  |=  [krocs=(list [=ship =bone]) dry=?]  =<  abet
+  ?~  krocs  (flog %text "No %ames flow ready to be close")
+  %-  emil    ^-  (list card)
+  :-  [%pass /di %arvo %d %flog text+"Closing {<(lent krocs)>} ames flows"]
+  ?:  dry  ~
+  %+  turn  krocs
+  |=  [=ship =bone]
+  ^-  card
+  [%pass /helm %arvo %a %kroc ship bone]
+::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet
   (emit %pass /helm %arvo %d %knob error-tag level)
@@ -280,6 +291,7 @@
     %helm-ames-sift        =;(f (f !<(_+<.f vase)) poke-ames-sift)
     %helm-ames-verb        =;(f (f !<(_+<.f vase)) poke-ames-verb)
     %helm-ames-wake        =;(f (f !<(_+<.f vase)) poke-ames-wake)
+    %helm-ames-kroc        =;(f (f !<(_+<.f vase)) poke-ames-kroc)
     %helm-atom             =;(f (f !<(_+<.f vase)) poke-atom)
     %helm-automass         =;(f (f !<(_+<.f vase)) poke-automass)
     %helm-cancel-automass  =;(f (f !<(_+<.f vase)) poke-cancel-automass)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -371,7 +371,6 @@
         [%heed =ship]
         [%jilt =ship]
         [%cork =ship]
-        [%kroc =ship =bone]
         $>(%plea vane-task)
     ::
         $>(%born vane-task)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -352,6 +352,7 @@
   ::    %heed: track peer's responsiveness; gives %clog if slow
   ::    %jilt: stop tracking peer's responsiveness
   ::    %cork: request to delete message flow
+  ::    %kroc: request to delete message flow on a specific bone
   ::    %plea: request to send message
   ::
   ::    System and Lifecycle Tasks
@@ -370,6 +371,7 @@
         [%heed =ship]
         [%jilt =ship]
         [%cork =ship]
+        [%kroc =ship =bone]
         $>(%plea vane-task)
     ::
         $>(%born vane-task)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -352,7 +352,7 @@
   ::    %heed: track peer's responsiveness; gives %clog if slow
   ::    %jilt: stop tracking peer's responsiveness
   ::    %cork: request to delete message flow
-  ::    %kroc: request to delete message flow on a specific bone
+  ::    %kroc: request to delete stale message flows
   ::    %plea: request to send message
   ::
   ::    System and Lifecycle Tasks
@@ -371,6 +371,7 @@
         [%heed =ship]
         [%jilt =ship]
         [%cork =ship]
+        [%kroc dry=?]
         $>(%plea vane-task)
     ::
         $>(%born vane-task)
@@ -1809,7 +1810,7 @@
         [%load =load]                                   ::  load agent
         [%nuke =dude]                                   ::  delete agent
         [%doff dude=(unit dude) ship=(unit ship)]       ::  kill subscriptions
-        [%rake dude=(unit dude) all=?]                  ::  reclaim old subs
+        [%rake dude=(unit dude) mode=?(%o %z %r) dry=?] ::  reclaim old subs
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1810,7 +1810,7 @@
         [%load =load]                                   ::  load agent
         [%nuke =dude]                                   ::  delete agent
         [%doff dude=(unit dude) ship=(unit ship)]       ::  kill subscriptions
-        [%rake dude=(unit dude) mode=?(%o %z %r) dry=?] ::  reclaim old subs
+        [%rake dude=(unit dude) all=?]                  ::  reclaim old subs
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1919,7 +1919,6 @@
         "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
   ::  +on-kroc: explicitly cork a flow on the provided bone
-  ::    TODO: refactor
   ::
   ++  on-kroc
     |=  [=ship =bone]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1933,17 +1933,19 @@
     ::
     =/  subs=(jar path [bone sub-nonce=@])
       %+  roll  ~(tap by snd.peer-state)
-      |=  [[=bone *] subs=(jar path [bone sub-nonce=@])]
-      ?:  (~(has in closing.peer-state) bone)
+      |=  [[=forward=bone *] subs=(jar path [bone sub-nonce=@])]
+      ?:  (~(has in closing.peer-state) forward-bone)
         subs
-      ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)
+      ?~  duct=(~(get by by-bone.ossuary.peer-state) forward-bone)
         subs
       ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
         subs
       =/  =wire           i.t.u.duct
       =/  nonce=(unit @)  (rush (snag 7 wire) dem)
       %-  ~(add ja subs)
-      :_  [bone ?~(nonce 0 u.nonce)]  :: 0 for old pre-nonce subscriptions
+      ::  0 for old pre-nonce subscriptions
+      ::
+      :_  [forward-bone ?~(nonce 0 u.nonce)]
       ?~  nonce  wire
       ::  don't include the sub-nonce in the key
       ::
@@ -1967,10 +1969,10 @@
     ::  we can safely cork the current subscription
     ::  if it received a nack on a backward bone
     ::
-    =+  target=(mix 0b10 bone)
+    =+  backward-bone=(mix 0b10 bone)
     ::  not a naxplanation ack bone
     ::
-    ?.  &(=(0 (end 0 target)) =(1 (end 0 (rsh 0 target))))
+    ?.  =(2 (mod backward-bone 4))
       |
     %.  !dry
     (trace |(dry odd.veb) ship |.((weld "failed %watch plea " log)))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1183,7 +1183,6 @@
       %vega  on-vega:event-core
       %plea  (on-plea:event-core [ship plea]:task)
       %cork  (on-cork:event-core ship.task)
-      %kroc  (on-kroc:event-core ship.task bone.task)
     ==
   ::
   [moves ames-gate]
@@ -1449,7 +1448,6 @@
   ~%  %event-gate  ..per-event  ~
   |=  [[now=@da eny=@ rof=roof] =duct =ames-state]
   =*  veb  veb.bug.ames-state
-  =|  cork-bone=(unit bone)  ::  modified by +on-kroc
   ~%  %event-core  ..$  ~
   |%
   ++  event-core  .
@@ -1901,15 +1899,7 @@
     =/  =peer-state  +.u.ship-state
     =/  =channel     [[our ship] now channel-state -.peer-state]
     ::
-    =/  [=bone ossuary=_ossuary.peer-state]
-      ?^  cork-bone  [u.cork-bone ossuary.peer-state]
-      (bind-duct ossuary.peer-state duct)
-    =.  ossuary.peer-state  ossuary
-    ::
-    ?.  (~(has by by-bone.ossuary.peer-state) bone)
-      %.  event-core
-      %^  trace  odd.veb  ship
-      |.("trying to cork {<bone=bone>}, not in the ossuary, ignoring")
+    =^  bone  ossuary.peer-state  (bind-duct ossuary.peer-state duct)
     ::
     =.  closing.peer-state  (~(put in closing.peer-state) bone)
     %-  %^  trace  msg.veb  ship
@@ -1918,12 +1908,6 @@
         =/  rcvr  [ship her-life.channel]
         "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
-  ::  +on-kroc: explicitly cork a flow on the provided bone
-  ::
-  ++  on-kroc
-    |=  [=ship =bone]
-    ^+  event-core
-    (%*(on-cork . cork-bone `bone) ship)
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
   ++  on-take-wake

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1183,6 +1183,7 @@
       %vega  on-vega:event-core
       %plea  (on-plea:event-core [ship plea]:task)
       %cork  (on-cork:event-core ship.task)
+      %kroc  (on-kroc:event-core dry.task)
     ==
   ::
   [moves ames-gate]
@@ -1448,6 +1449,7 @@
   ~%  %event-gate  ..per-event  ~
   |=  [[now=@da eny=@ rof=roof] =duct =ames-state]
   =*  veb  veb.bug.ames-state
+  =|  cork-bone=(unit bone)  ::  modified by +on-kroc
   ~%  %event-core  ..$  ~
   |%
   ++  event-core  .
@@ -1899,7 +1901,15 @@
     =/  =peer-state  +.u.ship-state
     =/  =channel     [[our ship] now channel-state -.peer-state]
     ::
-    =^  bone  ossuary.peer-state  (bind-duct ossuary.peer-state duct)
+    =/  [=bone ossuary=_ossuary.peer-state]
+      ?^  cork-bone  [u.cork-bone ossuary.peer-state]
+      (bind-duct ossuary.peer-state duct)
+    =.  ossuary.peer-state  ossuary
+    ::
+    ?.  (~(has by by-bone.ossuary.peer-state) bone)
+      %.  event-core
+      %^  trace  odd.veb  ship
+      |.("trying to cork {<bone=bone>}, not in the ossuary, ignoring")
     ::
     =.  closing.peer-state  (~(put in closing.peer-state) bone)
     %-  %^  trace  msg.veb  ship
@@ -1908,6 +1918,36 @@
         =/  rcvr  [ship her-life.channel]
         "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
+  ::  +on-kroc: cork all stale flows from failed subscriptions
+  ::
+  ++  on-kroc
+    |=  dry=?
+    ^+  event-core
+    %+  roll  ~(tap by peers.ames-state)
+    |=  [[=ship =ship-state] core=_event-core]
+    ?.  ?=(%known -.ship-state)  core
+    =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+    ::
+    %+  roll  ~(tap by rcv.peer-state)
+    |=  [[=bone *] core=_core]
+    ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
+      ::  not a naxplanation ack bone
+      ::
+      core
+    ::  by only corking forward flows that have received
+    ::  a nack we avoid corking the current subscription
+    ::
+    =+  target=(mix 0b10 bone)
+    ::  make sure that the nack bone has a forward flow
+    ::
+    ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
+      core
+    ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
+      core
+    %-  %^  trace  |(dry odd.veb)  ship
+        |.("kroc failed %watch plea {<bone=target>}")
+    ?:  dry  core
+    (%*(on-cork core cork-bone `target) ship)
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
   ++  on-take-wake

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1928,10 +1928,6 @@
       ?.  dry  core
       %.(core (slog leaf/"ames: #{<corks>} flows can be corked" ~))
     ::
-    =/  dudes  ;;  (map dude:gall nonce=@)
-      =<  q.q  %-  need  %-  need
-      (rof ~ %gf `beam`[[our %$ da+now] /])
-    ::
     %+  roll  ~(tap by peers.ames-state)
     |=  [[=ship =ship-state] corks=@ core=_event-core]
     ?.  ?=(%known -.ship-state)
@@ -1959,27 +1955,25 @@
     %+  roll  ~(tap by subs)
     |=  [[=wire flows=(list [bone sub-nonce=@])] corks=_corks core=_core]
     ::
-    %+  roll  flows
-    |=  [[=bone sub-nonce=@] corks=_corks core=_core]
-    =/  app=term      ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
-    =/  last-nonce=@  (dec (~(got by dudes) app))
-    =/  =path         (slag 7 wire)
-    =/  log=tape      "[bone={<bone>} agent={<app>}] {<path>}"
+    %-  tail
+    %+  roll  (sort flows |=([[@ n=@] [@ m=@]] (lte n m)))
+    |=  [[=bone nonce=@] resubs=_(lent flows) corks=_corks core=_core]
+    =/  app=term  ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
+    =/  =path     (slag 7 wire)
+    =/  log=tape  "[bone={<bone>} agent={<app>} nonce={<nonce>}] {<path>}"
     =;  corkable=?
       =?  corks  corkable  +(corks)
       =?  core   &(corkable !dry)  (%*(on-cork core cork-bone `bone) ship)
-      corks^core
-    ::  checks if this a stale re-subscriptions
+      (dec resubs)^corks^core
+    ::  checks if this is a stale re-subscription
     ::
-    ?:  &((gth sub-nonce 0) (lth sub-nonce last-nonce))
+    ?.  =(resubs 1)
       %.  &
       (trace &(dry odd.veb) ship |.((weld "stale %watch plea " log)))
-    ::  we can safely cork the current subscription
-    ::  if it received a nack on a backward bone
+    ::  the current subscription can be safely corked if there
+    ::  is a flow with a naxplanation ack  on a backward bone
     ::
     =+  backward-bone=(mix 0b10 bone)
-    ::  the backward bone is a naxplanation ack bone and we have a flow for it
-    ::
     ?.  =(2 (mod backward-bone 4))
       |
     ?~  (~(get by rcv.peer-state) backward-bone)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1183,6 +1183,7 @@
       %vega  on-vega:event-core
       %plea  (on-plea:event-core [ship plea]:task)
       %cork  (on-cork:event-core ship.task)
+      %kroc  (on-kroc:event-core ship.task bone.task)
     ==
   ::
   [moves ames-gate]
@@ -1907,6 +1908,31 @@
         =/  sndr  [our our-life.channel]
         =/  rcvr  [ship her-life.channel]
         "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
+    abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
+  ::  +on-kroc: explicitly cork a flow on the provided bone
+  ::    TODO: refactor
+  ::
+  ++  on-kroc
+    |=  [=ship =bone]
+    ^+  event-core
+    =/  =plea       [%$ /flow [%cork ~]]
+    =/  ship-state  (~(get by peers.ames-state) ship)
+    ?.  ?=([~ %known *] ship-state)
+      %+  enqueue-alien-todo  ship
+      |=  todos=alien-agenda
+      todos(messages [[duct plea] messages.todos])
+    =/  =peer-state  +.u.ship-state
+    ?.  (~(has by by-bone.ossuary.peer-state) bone)
+      ~&  >>>  %dont-have-it^ship^bone
+      event-core
+    =/  =channel  [[our ship] now channel-state -.peer-state]
+    ::
+    =.  closing.peer-state  (~(put in closing.peer-state) bone)
+    %-  %^  trace  msg.veb  ship
+        |.  ^-  tape
+        =/  sndr  [our our-life.channel]
+        =/  rcvr  [ship her-life.channel]
+        "cork plea {<sndr^rcvr^bone=bone^vane.plea^path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1928,15 +1928,15 @@
       ?.  dry  core
       %.(core (slog leaf/"ames: #{<corks>} flows can be corked" ~))
     ::
+    =/  dudes  ;;  (map dude:gall nonce=@)
+      =<  q.q  %-  need  %-  need
+      (rof ~ %gf `beam`[[our %$ da+now] /])
+    ::
     %+  roll  ~(tap by peers.ames-state)
     |=  [[=ship =ship-state] corks=@ core=_event-core]
     ?.  ?=(%known -.ship-state)
       corks^core
     =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
-    =/  dudes  ;;  (map dude:gall nonce=@)
-      =<  q.q  %-  need  %-  need
-      (rof ~ %gf `beam`[[our %$ da+now] /])
-    ::
     =/  subs=(jar path [bone sub-nonce=@])
       %+  roll  ~(tap by snd.peer-state)
       |=  [[=forward=bone *] subs=(jar path [bone sub-nonce=@])]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1978,9 +1978,11 @@
     ::  if it received a nack on a backward bone
     ::
     =+  backward-bone=(mix 0b10 bone)
-    ::  not a naxplanation ack bone
+    ::  the backward bone is a naxplanation ack bone and we have a flow for it
     ::
     ?.  =(2 (mod backward-bone 4))
+      |
+    ?~  (~(get by rcv.peer-state) backward-bone)
       |
     %.  &
     (trace &(dry odd.veb) ship |.((weld "failed %watch plea " log)))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1934,11 +1934,14 @@
     =/  subs=(jar path [bone sub-nonce=@])
       %+  roll  ~(tap by snd.peer-state)
       |=  [[=bone *] subs=(jar path [bone sub-nonce=@])]
-      ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)  subs
+      ?:  (~(has in closing.peer-state) bone)
+        subs
+      ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)
+        subs
       ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
         subs
       =/  =wire           i.t.u.duct
-      =/  nonce=(unit @)  (rush i.t.t.t.t.t.t.t.i.t.u.duct dem)
+      =/  nonce=(unit @)  (rush (snag 7 wire) dem)
       %-  ~(add ja subs)
       :_  [bone ?~(nonce 0 u.nonce)]  :: 0 for old pre-nonce subscriptions
       ?~  nonce  wire
@@ -1950,14 +1953,15 @@
     ::
     %+  roll  flows
     |=  [[=bone sub-nonce=@] core=_core]
-    ?:  (~(has in closing.peer-state) bone)  core
-    =/  app=term   ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
-    =/  nonce=@ud  (dec (~(got by dudes) app))
-    =/  =path      (slag 7 wire)
-    =/  log=tape   "[bone={<bone>} nonce={<sub-nonce>} agent={<app>}] {<path>}"
+    =/  app=term      ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
+    =/  last-nonce=@  (dec (~(got by dudes) app))
+    =/  =path         (slag 7 wire)
+    =/  log=tape      "[bone={<bone>} nonce={<sub-nonce>} agent={<app>}] {<path>}"
     =;  corkable=?
       ?.(corkable core (%*(on-cork core cork-bone `bone) ship))
-    ?:  &((gth sub-nonce 0) (lth sub-nonce nonce))
+    ::  checks if this a stale re-subscriptions
+    ::
+    ?:  &((gth sub-nonce 0) (lth sub-nonce last-nonce))
       %.  !dry
       (trace |(dry odd.veb) ship |.((weld "stale %watch plea " log)))
     ::  we can safely cork the current subscription

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1931,19 +1931,22 @@
       =<  q.q  %-  need  %-  need
       (rof ~ %gf `beam`[[our %$ da+now] /])
     ::
-    =/  subs=(jar path [bone nonce=@])
+    =/  subs=(jar path [bone sub-nonce=@])
       %+  roll  ~(tap by snd.peer-state)
-      |=  [[=bone *] subs=(jar path [bone nonce=@])]
+      |=  [[=bone *] subs=(jar path [bone sub-nonce=@])]
       ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)  subs
       ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
         subs
-      =/  nonce=@  (rash i.t.t.t.t.t.t.t.i.t.u.duct dem)
-      =/  =wire    i.t.u.duct
+      =/  =wire           i.t.u.duct
+      =/  nonce=(unit @)  (rush i.t.t.t.t.t.t.t.i.t.u.duct dem)
+      %-  ~(add ja subs)
+      :_  [bone ?~(nonce 0 u.nonce)]  :: 0 for old pre-nonce subscriptions
+      ?~  nonce  wire
       ::  don't include the sub-nonce in the key
       ::
-      (~(add ja subs) (weld (scag 7 wire) (slag 8 wire)) [bone nonce])
+      (weld (scag 7 wire) (slag 8 wire))
     %+  roll  ~(tap by subs)
-    |=  [[=wire flows=(list [bone @])] core=_core]
+    |=  [[=wire flows=(list [bone sub-nonce=@])] core=_core]
     ::
     %+  roll  flows
     |=  [[=bone sub-nonce=@] core=_core]
@@ -1954,13 +1957,11 @@
     =/  log=tape   "[bone={<bone>} nonce={<sub-nonce>} agent={<app>}] {<path>}"
     =;  corkable=?
       ?.(corkable core (%*(on-cork core cork-bone `bone) ship))
-    ::  check if the current subscription also failed
-    ::
-    ?.  =(sub-nonce nonce)
+    ?:  &((gth sub-nonce 0) (lth sub-nonce nonce))
       %.  !dry
       (trace |(dry odd.veb) ship |.((weld "stale %watch plea " log)))
     ::  we can safely cork the current subscription
-    ::  if it received a nack on backward bone
+    ::  if it received a nack on a backward bone
     ::
     =+  target=(mix 0b10 bone)
     ::  not a naxplanation ack bone

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1918,7 +1918,7 @@
         =/  rcvr  [ship her-life.channel]
         "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
     abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
-  ::  +on-kroc: cork all stale flows from failed subscriptions
+  ::  +on-kroc: cork all flows from failed subscriptions
   ::
   ++  on-kroc
     |=  dry=?
@@ -1927,27 +1927,48 @@
     |=  [[=ship =ship-state] core=_event-core]
     ?.  ?=(%known -.ship-state)  core
     =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
+    =/  dudes  ;;  (map dude:gall nonce=@)
+      =<  q.q  %-  need  %-  need
+      (rof ~ %gf `beam`[[our %$ da+now] /])
     ::
-    %+  roll  ~(tap by rcv.peer-state)
-    |=  [[=bone *] core=_core]
-    ?.  &(=(0 (end 0 bone)) =(1 (end 0 (rsh 0 bone))))
-      ::  not a naxplanation ack bone
+    =/  subs=(jar path [bone nonce=@])
+      %+  roll  ~(tap by snd.peer-state)
+      |=  [[=bone *] subs=(jar path [bone nonce=@])]
+      ?~  duct=(~(get by by-bone.ossuary.peer-state) bone)  subs
+      ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
+        subs
+      =/  nonce=@  (rash i.t.t.t.t.t.t.t.i.t.u.duct dem)
+      =/  =wire    i.t.u.duct
+      ::  don't include the sub-nonce in the key
       ::
-      core
-    ::  by only corking forward flows that have received
-    ::  a nack we avoid corking the current subscription
+      (~(add ja subs) (weld (scag 7 wire) (slag 8 wire)) [bone nonce])
+    %+  roll  ~(tap by subs)
+    |=  [[=wire flows=(list [bone @])] core=_core]
+    ::
+    %+  roll  flows
+    |=  [[=bone sub-nonce=@] core=_core]
+    ?:  (~(has in closing.peer-state) bone)  core
+    =/  app=term   ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
+    =/  nonce=@ud  (dec (~(got by dudes) app))
+    =/  =path      (slag 7 wire)
+    =/  log=tape   "[bone={<bone>} nonce={<sub-nonce>} agent={<app>}] {<path>}"
+    =;  corkable=?
+      ?.(corkable core (%*(on-cork core cork-bone `bone) ship))
+    ::  check if the current subscription also failed
+    ::
+    ?.  =(sub-nonce nonce)
+      %.  !dry
+      (trace |(dry odd.veb) ship |.((weld "stale %watch plea " log)))
+    ::  we can safely cork the current subscription
+    ::  if it received a nack on backward bone
     ::
     =+  target=(mix 0b10 bone)
-    ::  make sure that the nack bone has a forward flow
+    ::  not a naxplanation ack bone
     ::
-    ?~  duct=(~(get by by-bone.ossuary.peer-state) target)
-      core
-    ?.  ?=([* [%gall %use sub=@ @ %out @ @ nonce=@ pub=@ *] *] u.duct)
-      core
-    %-  %^  trace  |(dry odd.veb)  ship
-        |.("kroc failed %watch plea {<bone=target>}")
-    ?:  dry  core
-    (%*(on-cork core cork-bone `target) ship)
+    ?.  &(=(0 (end 0 target)) =(1 (end 0 (rsh 0 target))))
+      |
+    %.  !dry
+    (trace |(dry odd.veb) ship |.((weld "failed %watch plea " log)))
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
   ++  on-take-wake

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1449,6 +1449,7 @@
   ~%  %event-gate  ..per-event  ~
   |=  [[now=@da eny=@ rof=roof] =duct =ames-state]
   =*  veb  veb.bug.ames-state
+  =|  cork-bone=(unit bone)  ::  modified by +on-kroc
   ~%  %event-core  ..$  ~
   |%
   ++  event-core  .
@@ -1900,7 +1901,15 @@
     =/  =peer-state  +.u.ship-state
     =/  =channel     [[our ship] now channel-state -.peer-state]
     ::
-    =^  =bone  ossuary.peer-state  (bind-duct ossuary.peer-state duct)
+    =/  [=bone ossuary=_ossuary.peer-state]
+      ?^  cork-bone  [u.cork-bone ossuary.peer-state]
+      (bind-duct ossuary.peer-state duct)
+    =.  ossuary.peer-state  ossuary
+    ::
+    ?.  (~(has by by-bone.ossuary.peer-state) bone)
+      %.  event-core
+      %^  trace  odd.veb  ship
+      |.("trying to cork {<bone=bone>}, not in the ossuary, ignoring")
     ::
     =.  closing.peer-state  (~(put in closing.peer-state) bone)
     %-  %^  trace  msg.veb  ship
@@ -1915,25 +1924,7 @@
   ++  on-kroc
     |=  [=ship =bone]
     ^+  event-core
-    =/  =plea       [%$ /flow [%cork ~]]
-    =/  ship-state  (~(get by peers.ames-state) ship)
-    ?.  ?=([~ %known *] ship-state)
-      %+  enqueue-alien-todo  ship
-      |=  todos=alien-agenda
-      todos(messages [[duct plea] messages.todos])
-    =/  =peer-state  +.u.ship-state
-    ?.  (~(has by by-bone.ossuary.peer-state) bone)
-      ~&  >>>  %dont-have-it^ship^bone
-      event-core
-    =/  =channel  [[our ship] now channel-state -.peer-state]
-    ::
-    =.  closing.peer-state  (~(put in closing.peer-state) bone)
-    %-  %^  trace  msg.veb  ship
-        |.  ^-  tape
-        =/  sndr  [our our-life.channel]
-        =/  rcvr  [ship her-life.channel]
-        "cork plea {<sndr^rcvr^bone=bone^vane.plea^path.plea>}"
-    abet:(on-memo:(make-peer-core peer-state channel) bone plea %plea)
+    (%*(on-cork . cork-bone `bone) ship)
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
   ++  on-take-wake

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1967,7 +1967,7 @@
     =/  log=tape      "[bone={<bone>} agent={<app>}] {<path>}"
     =;  corkable=?
       =?  corks  corkable  +(corks)
-      =?  core   &(corkable !dry) (%*(on-cork core cork-bone `bone) ship)
+      =?  core   &(corkable !dry)  (%*(on-cork core cork-bone `bone) ship)
       corks^core
     ::  checks if this a stale re-subscriptions
     ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1923,9 +1923,15 @@
   ++  on-kroc
     |=  dry=?
     ^+  event-core
+    ::
+    =;  [corks=@ core=_event-core]
+      ?.  dry  core
+      %.(core (slog leaf/"ames: #{<corks>} flows can be corked" ~))
+    ::
     %+  roll  ~(tap by peers.ames-state)
-    |=  [[=ship =ship-state] core=_event-core]
-    ?.  ?=(%known -.ship-state)  core
+    |=  [[=ship =ship-state] corks=@ core=_event-core]
+    ?.  ?=(%known -.ship-state)
+      corks^core
     =/  =peer-state:ames  ?>(?=(%known -.ship-state) +.ship-state)
     =/  dudes  ;;  (map dude:gall nonce=@)
       =<  q.q  %-  need  %-  need
@@ -1951,21 +1957,23 @@
       ::
       (weld (scag 7 wire) (slag 8 wire))
     %+  roll  ~(tap by subs)
-    |=  [[=wire flows=(list [bone sub-nonce=@])] core=_core]
+    |=  [[=wire flows=(list [bone sub-nonce=@])] corks=_corks core=_core]
     ::
     %+  roll  flows
-    |=  [[=bone sub-nonce=@] core=_core]
+    |=  [[=bone sub-nonce=@] corks=_corks core=_core]
     =/  app=term      ?>(?=([%gall %use sub=@ *] wire) i.t.t.wire)
     =/  last-nonce=@  (dec (~(got by dudes) app))
     =/  =path         (slag 7 wire)
-    =/  log=tape      "[bone={<bone>} nonce={<sub-nonce>} agent={<app>}] {<path>}"
+    =/  log=tape      "[bone={<bone>} agent={<app>}] {<path>}"
     =;  corkable=?
-      ?.(corkable core (%*(on-cork core cork-bone `bone) ship))
+      =?  corks  corkable  +(corks)
+      =?  core   &(corkable !dry) (%*(on-cork core cork-bone `bone) ship)
+      corks^core
     ::  checks if this a stale re-subscriptions
     ::
     ?:  &((gth sub-nonce 0) (lth sub-nonce last-nonce))
-      %.  !dry
-      (trace |(dry odd.veb) ship |.((weld "stale %watch plea " log)))
+      %.  &
+      (trace &(dry odd.veb) ship |.((weld "stale %watch plea " log)))
     ::  we can safely cork the current subscription
     ::  if it received a nack on a backward bone
     ::
@@ -1974,8 +1982,8 @@
     ::
     ?.  =(2 (mod backward-bone 4))
       |
-    %.  !dry
-    (trace |(dry odd.veb) ship |.((weld "failed %watch plea " log)))
+    %.  &
+    (trace &(dry odd.veb) ship |.((weld "failed %watch plea " log)))
   ::  +on-take-wake: receive wakeup or error notification from behn
   ::
   ++  on-take-wake

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -244,7 +244,7 @@
   ::  +mo-rake: send %cork's for old subscriptions if needed
   ::
   ++  mo-rake
-    |=  [dude=(unit dude) mode=?(%o %z %r) dry=?]
+    |=  [dude=(unit dude) all=?]
     ^+  mo-core
     =/  apps=(list (pair term yoke))
       ?~  dude  ~(tap by yokes.state)
@@ -252,7 +252,7 @@
     |-  ^+  mo-core
     ?~  apps  mo-core
     =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
-    $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core mode dry))
+    $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core all))
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1512,49 +1512,36 @@
       =?  ap-core  (gte 1 (~(got by boar.yoke) wyr dok))
         (ap-pass wyr %agent dok %leave ~)
       $(subs t.subs)
-    ::  +ap-rake: clean up the dead subscriptions
-    ::
-    ::    =mode %o: kill old pre-nonce subscriptions
-    ::    =mode %z: kill old pre-nonce subscriptions, including sub-nonce = 0
-    ::    =mode %r: kills all stale resubscription flows
+    ::  +ap-rake: clean up the dead %leave's
     ::
     ++  ap-rake
-      |=  [mode=?(%o %z %r) dry=?]
+      |=  all=?
       =/  subs  ~(tap in ~(key by boat.yoke))
       |^  ^+  ap-core
       ?~  subs  ap-core
       =/  [=wire =dock]  i.subs
-      =/  non=@ud  (~(got by boar.yoke) wire dock)
-      ~&  [mode sub-nonce=sub-nonce.yoke nonce=non]
-      ?.  &(=(%zer mode) =(0 non))
+      =/  non  (~(got by boar.yoke) wire dock)
+      ?:  &(!all =(0 non))
         $(subs t.subs)
       ?~  per=(scry-peer-state p.dock)
         $(subs t.subs)
-      ::  skip current subscription in %res mode
       ::
-      ?.  ?&  =(%res mode)
-              !=(sub-nonce.yoke 0)
-              (lth non (dec sub-nonce.yoke))
-          ==
-        $(subs t.subs)
-      ::
-      =/  sub-nonce=@t  ?.(=(%res mode) '0' (scot %ud non))
       =/  dud=(set duct)
         =/  mod=^wire
           :*  %gall  %use  agent-name  run-nonce.yoke
               %out  (scot %p p.dock)  q.dock
-              sub-nonce  wire
+              '0'  wire
           ==
         %-  ~(rep by by-duct.ossuary.u.per)
         |=  [[=duct =bone] out=(set duct)]
         ^+  out
         ?.  ?&  ?=([* [%gall %use @ @ %out @ @ @ *] *] duct)
-                =(mod i.t.duct(i.t.t.t.t.t.t.t sub-nonce))
+                =(mod i.t.duct(i.t.t.t.t.t.t.t '0'))
             ==
           out
         ?:  (~(has in closing.u.per) bone)  out
         ~>  %slog.0^leaf+"gall: rake {<i.t.duct>}"
-        ?:(dry out (~(put in out) duct))
+        (~(put in out) duct)
       ::
       %-  ap-move
       (turn ~(tap in dud) |=(d=duct [+.d %pass -.d %a %cork p.dock]))
@@ -2001,19 +1988,6 @@
     ?~  nonce=(~(get by boar.u.yok) [wire ship term])
       [~ ~]
     [~ ~ atom+!>(u.nonce)]
-  ::
-  ?:  ?&  =(%r care)
-          ?=(~ path)
-          =([%$ %da now] coin)
-          =(our ship)
-      ==
-    =|  agents=(list [app=term sub-nonce=@ud run-nonce=@t =boat =boar])
-    :+  ~  ~
-    :-  %noun  !>  ^+  agents
-    %+  roll  ~(tap by yokes.state)
-    |=  [[agent=term =yoke] agents=_agents]
-    :_  agents
-    [agent [sub-nonce run-nonce boat boar]:yoke]
   ::
   ?.  =(our ship)
     ~

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1989,6 +1989,19 @@
       [~ ~]
     [~ ~ atom+!>(u.nonce)]
   ::
+  ?:  ?&  =(%r care)
+          ?=(~ path)
+          =([%$ %da now] coin)
+          =(our ship)
+      ==
+    =|  agents=(list [app=term sub-nonce=@ud run-nonce=@t =boat =boar])
+    :+  ~  ~
+    :-  %noun  !>  ^+  agents
+    %+  roll  ~(tap by yokes.state)
+    |=  [[agent=term =yoke] agents=_agents]
+    :_  agents
+    [agent [sub-nonce run-nonce boat boar]:yoke]
+  ::
   ?.  =(our ship)
     ~
   ?.  =([%$ %da now] coin)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -244,7 +244,7 @@
   ::  +mo-rake: send %cork's for old subscriptions if needed
   ::
   ++  mo-rake
-    |=  [dude=(unit dude) all=?]
+    |=  [dude=(unit dude) mode=?(%o %z %r) dry=?]
     ^+  mo-core
     =/  apps=(list (pair term yoke))
       ?~  dude  ~(tap by yokes.state)
@@ -252,7 +252,7 @@
     |-  ^+  mo-core
     ?~  apps  mo-core
     =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
-    $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core all))
+    $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core mode dry))
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
   ::    Presuming we receive a good core, we first check to see if the agent
@@ -1512,36 +1512,49 @@
       =?  ap-core  (gte 1 (~(got by boar.yoke) wyr dok))
         (ap-pass wyr %agent dok %leave ~)
       $(subs t.subs)
-    ::  +ap-rake: clean up the dead %leave's
+    ::  +ap-rake: clean up the dead subscriptions
+    ::
+    ::    =mode %o: kill old pre-nonce subscriptions
+    ::    =mode %z: kill old pre-nonce subscriptions, including sub-nonce = 0
+    ::    =mode %r: kills all stale resubscription flows
     ::
     ++  ap-rake
-      |=  all=?
+      |=  [mode=?(%o %z %r) dry=?]
       =/  subs  ~(tap in ~(key by boat.yoke))
       |^  ^+  ap-core
       ?~  subs  ap-core
       =/  [=wire =dock]  i.subs
-      =/  non  (~(got by boar.yoke) wire dock)
-      ?:  &(!all =(0 non))
+      =/  non=@ud  (~(got by boar.yoke) wire dock)
+      ~&  [mode sub-nonce=sub-nonce.yoke nonce=non]
+      ?.  &(=(%zer mode) =(0 non))
         $(subs t.subs)
       ?~  per=(scry-peer-state p.dock)
         $(subs t.subs)
+      ::  skip current subscription in %res mode
       ::
+      ?.  ?&  =(%res mode)
+              !=(sub-nonce.yoke 0)
+              (lth non (dec sub-nonce.yoke))
+          ==
+        $(subs t.subs)
+      ::
+      =/  sub-nonce=@t  ?.(=(%res mode) '0' (scot %ud non))
       =/  dud=(set duct)
         =/  mod=^wire
           :*  %gall  %use  agent-name  run-nonce.yoke
               %out  (scot %p p.dock)  q.dock
-              '0'  wire
+              sub-nonce  wire
           ==
         %-  ~(rep by by-duct.ossuary.u.per)
         |=  [[=duct =bone] out=(set duct)]
         ^+  out
         ?.  ?&  ?=([* [%gall %use @ @ %out @ @ @ *] *] duct)
-                =(mod i.t.duct(i.t.t.t.t.t.t.t '0'))
+                =(mod i.t.duct(i.t.t.t.t.t.t.t sub-nonce))
             ==
           out
         ?:  (~(has in closing.u.per) bone)  out
         ~>  %slog.0^leaf+"gall: rake {<i.t.duct>}"
-        (~(put in out) duct)
+        ?:(dry out (~(put in out) duct))
       ::
       %-  ap-move
       (turn ~(tap in dud) |=(d=duct [+.d %pass -.d %a %cork p.dock]))


### PR DESCRIPTION
Adds `|close-flows`, a %hood generator that sends a %cork to all ships that have nacked a %watch (e.g. we tried to subscribe, and the publisher crashed or rejected our subscription, but we didn't properly %cork the flow). This issue is fixed in https://github.com/urbit/urbit/pull/6102, and this PR depends on it in order to work properly.

The tool runs in dry mode by default, printing the number of flows that can be closed. To actually send the corks, run as:

`|close-flows, =dry |`

(possible fix for https://github.com/urbit/urbit/issues/6065, that will alleviate _some_ memory pressure in %ames)

PS: this updates %lull in its current form by adding a %kroc task to ames—the names is taken but we currently don't use the %kroc gift and the $krocs set so we should probably remove that.