### PR TITLE
grid: only block on live apps

### DIFF
--- a/pkg/garden/desk.docket-0
+++ b/pkg/garden/desk.docket-0
@@ -1,7 +1,7 @@
 :~  title+'System'
     info+'An app launcher for Urbit.'
     color+0xee.5432
-    glob-http+['https://bootstrap.urbit.org/glob-0v7.oqalc.b9vf3.5ft2u.2f86m.7oa8v.glob' 0v7.oqalc.b9vf3.5ft2u.2f86m.7oa8v]
+    glob-http+['https://bootstrap.urbit.org/glob-0vm65f9.defur.eqhgj.62ls6.9v9lf.glob' 0vm65f9.defur.eqhgj.62ls6.9v9lf]
     ::glob-ames+~zod^0v0
     base+'grid'
     version+[1 1 6]

--- a/pkg/grid/src/nav/notifications/SystemNotification.tsx
+++ b/pkg/grid/src/nav/notifications/SystemNotification.tsx
@@ -39,7 +39,7 @@ export const RuntimeLagNotification = () => (
 );
 
 function pikeIsBlocked(newKelvin: number, pike: Pike) {
-  return !pike.wefts?.find(({ kelvin }) => kelvin === newKelvin);
+  return pike.zest === 'live' && !pike.wefts?.find(({ kelvin }) => kelvin === newKelvin);
 }
 
 export const BaseBlockedNotification = ({ bin, lid }: { bin: HarkBin, lid: HarkLid }) => {
@@ -127,10 +127,9 @@ export const BaseBlockedNotification = ({ bin, lid }: { bin: HarkBin, lid: HarkL
             className="space-y-6 text-base tracking-tight"
             containerClass="w-full max-w-md"
           >
-            <h2 className="h4">Archive ({count}) Apps and Apply System Update</h2>
+            <h2 className="h4">Suspend ({count}) Apps and Apply System Update</h2>
             <p>
-              The following apps will be archived until their developer provides a compatible update
-              to your system.
+              The following apps will be suspended until their developer provides an update.
             </p>
             <AppList
               apps={blockedCharges}
@@ -143,7 +142,7 @@ export const BaseBlockedNotification = ({ bin, lid }: { bin: HarkBin, lid: HarkL
                 Cancel
               </DialogClose>
               <DialogClose as={Button} variant="caution" onClick={handleArchiveApps}>
-                Archive Apps
+                Suspend Apps and Upgrade
               </DialogClose>
             </div>
           </DialogContent>


### PR DESCRIPTION
The old predicate checked whether we have a commit-in-waiting for the next kelvin.  We add a check that the desk is even live -- we don't want to block on suspended apps.