### PR TITLE
u3: refactors snapshot system interface

### DIFF
--- a/pkg/urbit/bench/ur_bench.c
+++ b/pkg/urbit/bench/ur_bench.c
@@ -7,9 +7,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 24);
-  u3m_pave(c3y);
-  u3e_init();
+  u3m_boot_lite(1 << 24);
 }
 
 /* _ames_writ_ex(): |hi packet from fake ~zod to fake ~nec

--- a/pkg/urbit/compat/mingw/seh_handler.c
+++ b/pkg/urbit/compat/mingw/seh_handler.c
@@ -12,7 +12,7 @@ EXCEPTION_DISPOSITION _mingw_exception_filter(
 {
     if (ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
         ExceptionRecord->ExceptionInformation[0] == 1 &&
-        u3e_fault((void*)ExceptionRecord->ExceptionInformation[1], 1))
+        u3m_fault((void*)ExceptionRecord->ExceptionInformation[1], 1))
     {
         return ExceptionContinueExecution;
     }

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1452,7 +1452,7 @@ _cw_cram(c3_i argc, c3_c* argv[])
 
   //  save even on failure, as we just did all the work of deduplication
   //
-  u3e_save();
+  u3m_save();
   u3_disk_exit(log_u);
 
   if ( c3n == ret_o ) {
@@ -1545,7 +1545,7 @@ _cw_queu(c3_i argc, c3_c* argv[])
       exit(1);
     }
 
-    u3e_save();
+    u3m_save();
     u3_disk_exit(log_u);
 
     fprintf(stderr, "urbit: queu: rock loaded at event %" PRIu64 "\r\n", eve_d);
@@ -1623,7 +1623,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
   u3u_meld();
   u3a_print_memory(stderr, "urbit: meld: gained", (u3a_open(u3R) - pre_w));
 
-  u3e_save();
+  u3m_save();
   u3_disk_exit(log_u);
   u3m_stop();
 }
@@ -1763,7 +1763,7 @@ _cw_pack(c3_i argc, c3_c* argv[])
   u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
   u3a_print_memory(stderr, "urbit: pack: gained", u3m_pack());
 
-  u3e_save();
+  u3m_save();
   u3_disk_exit(log_u);
   u3m_stop();
 }

--- a/pkg/urbit/include/all.h
+++ b/pkg/urbit/include/all.h
@@ -11,7 +11,6 @@
 #   include "noun/aliases.h"   //  general u3
 
 #   include "noun/allocate.h"  //  u3a: allocation
-#   include "noun/events.h"    //  u3e: persistence
 #   include "noun/hashtable.h" //  u3h: hashtables
 #   include "noun/imprison.h"  //  u3i: noun construction
 #   include "noun/jets.h"      //  u3j: jet control

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -65,7 +65,7 @@
       c3_i
       u3e_fault(void* adr_v, c3_i ser_i);
 
-    /* u3e_save():
+    /* u3e_save(): update the checkpoint.
     */
       void
       u3e_save(void);

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -73,7 +73,7 @@
     /* u3e_live(): start the persistence system.  Return c3y if no image.
     */
       c3_o
-      u3e_live(c3_o nuu_o, c3_c* dir_c);
+      u3e_live(c3_c* dir_c);
 
     /* u3e_yolo(): disable dirty page tracking, read/write whole loom.
     */

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -77,7 +77,7 @@
     /* u3e_save(): update the checkpoint.
     */
       void
-      u3e_save(void);
+      u3e_save(u3_post low_p, u3_post hig_p);
 
     /* u3e_live(): start the persistence system.  Return c3y if no image.
     */

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -39,7 +39,7 @@
     /* u3e_pool: entire memory system.
     */
       typedef struct _u3e_pool {
-        c3_c*     dir_c;                     //  path to
+        c3_c*     dir_c;                     //  checkpoint dir
         c3_w      dit_w[u3a_pages >> 5];     //  touched since last save
         c3_w      pag_w;                     //  number of pages (<= u3a_pages)
         u3e_image nor_u;                     //  north segment

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -80,11 +80,6 @@
       c3_o
       u3e_yolo(void);
 
-    /* u3e_foul(): dirty all the pages of the loom.
-    */
-      void
-      u3e_foul(void);
-
     /* u3e_init(): initialize guard page tracking.
     */
       void

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -42,6 +42,7 @@
         c3_c*     dir_c;                     //  checkpoint dir
         c3_w      dit_w[u3a_pages >> 5];     //  touched since last save
         c3_w      pag_w;                     //  number of pages (<= u3a_pages)
+        c3_w      gar_w;                     //  guard page
         u3e_image nor_u;                     //  north segment
         u3e_image sou_u;                     //  south segment
       } u3e_pool;

--- a/pkg/urbit/include/noun/events.h
+++ b/pkg/urbit/include/noun/events.h
@@ -47,6 +47,14 @@
         u3e_image sou_u;                     //  south segment
       } u3e_pool;
 
+    /* u3e_flaw: loom fault result.
+    */
+      typedef enum {
+        u3e_flaw_sham = 0,                  //  bogus state
+        u3e_flaw_base = 1,                  //  vm fail (mprotect)
+        u3e_flaw_meme = 2,                  //  bail:meme
+        u3e_flaw_good = 3                   //  handled
+      } u3e_flaw;
 
   /** Globals.
   **/
@@ -61,10 +69,10 @@
 
   /** Functions.
   **/
-    /* u3e_fault(): handle a memory event with libsigsegv protocol.
+    /* u3e_fault(): handle a memory fault.
     */
-      c3_i
-      u3e_fault(void* adr_v, c3_i ser_i);
+      u3e_flaw
+      u3e_fault(u3_post low_p, u3_post hig_p, u3_post off_p);
 
     /* u3e_save(): update the checkpoint.
     */

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -127,7 +127,7 @@
       /* u3m_water(): produce high and low watermarks.  Asserts u3R == u3H.
       */
         void
-        u3m_water(c3_w *low_w, c3_w *hig_w);
+        u3m_water(u3_post* low_p, u3_post* hig_p);
 
       /* u3m_pretty(): dumb prettyprint to string.  RETAIN.
       */

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -44,6 +44,11 @@
         void
         u3m_save(void);
 
+      /* u3m_ward(): tend the guard page.
+      */
+        void
+        u3m_ward(void);
+
       /* u3m_init(): start the environment.
       */
         void

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -34,6 +34,16 @@
         c3_i
         u3m_bail(c3_m how_m) __attribute__((noreturn));
 
+      /* u3m_fault(): handle a memory event with libsigsegv protocol.
+      */
+        c3_i
+        u3m_fault(void* adr_v, c3_i ser_i);
+
+      /* u3m_save(): update the checkpoint.
+      */
+        void
+        u3m_save(void);
+
       /* u3m_init(): start the environment.
       */
         void

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1382,7 +1382,7 @@ void
 u3e_ward(u3_post low_p, u3_post hig_p)
 {
 #ifdef U3_GUARD_PAGE
-  c3_w nop_w = (low_p - 1) >> u3a_page;
+  c3_w nop_w = low_p >> u3a_page;
   c3_w sop_w = hig_p >> u3a_page;
   c3_w pag_w = u3P.gar_w;
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1243,8 +1243,10 @@ u3e_save(void)
 /* u3e_live(): start the checkpointing system.
 */
 c3_o
-u3e_live(c3_o nuu_o, c3_c* dir_c)
+u3e_live(c3_c* dir_c)
 {
+  c3_o nuu_o = c3n;
+
   //  XX demand paging is not supported on windows
   //
 #ifdef U3_OS_mingw

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -91,6 +91,7 @@
 //!
 
 #include "all.h"
+#include "noun/events.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1339,6 +1339,10 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         u3a_print_memory(stderr, "live: mapped", nor_w << u3a_page);
         u3a_print_memory(stderr, "live: loaded", sou_w << u3a_page);
       }
+
+#ifdef U3_GUARD_PAGE
+      _ce_center_guard_page();
+#endif
     }
   }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -285,16 +285,7 @@ _ce_image_open(u3e_image* img_u)
   c3_i mod_i = O_RDWR | O_CREAT;
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb/chk", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb/chk/%s.bin", u3P.dir_c, img_u->nam_c);
+  snprintf(ful_c, 8192, "%s/%s.bin", u3P.dir_c, img_u->nam_c);
   if ( -1 == (img_u->fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
     return c3n;
@@ -381,19 +372,13 @@ _ce_patch_create(u3_ce_patch* pat_u)
 {
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/control.bin", u3P.dir_c);
   if ( -1 == (pat_u->ctl_i = c3_open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
     fprintf(stderr, "loom: patch c3_open control.bin: %s\r\n", strerror(errno));
     c3_assert(0);
   }
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/memory.bin", u3P.dir_c);
   if ( -1 == (pat_u->mem_i = c3_open(ful_c, O_RDWR | O_CREAT | O_EXCL, 0600)) ) {
     fprintf(stderr, "loom: patch c3_open memory.bin: %s\r\n", strerror(errno));
     c3_assert(0);
@@ -407,13 +392,13 @@ _ce_patch_delete(void)
 {
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/control.bin", u3P.dir_c);
   if ( unlink(ful_c) ) {
     fprintf(stderr, "loom: failed to delete control.bin: %s\r\n",
                     strerror(errno));
   }
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/memory.bin", u3P.dir_c);
   if ( unlink(ful_c) ) {
     fprintf(stderr, "loom: failed to remove memory.bin: %s\r\n",
                     strerror(errno));
@@ -489,18 +474,12 @@ _ce_patch_open(void)
   c3_c ful_c[8193];
   c3_i ctl_i, mem_i;
 
-  snprintf(ful_c, 8192, "%s", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb", u3P.dir_c);
-  c3_mkdir(ful_c, 0700);
-
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/control.bin", u3P.dir_c);
   if ( -1 == (ctl_i = c3_open(ful_c, O_RDWR)) ) {
     return 0;
   }
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/memory.bin", u3P.dir_c);
+  snprintf(ful_c, 8192, "%s/memory.bin", u3P.dir_c);
   if ( -1 == (mem_i = c3_open(ful_c, O_RDWR)) ) {
     close(ctl_i);
 
@@ -1143,7 +1122,9 @@ _ce_backup(void)
   c3_i mod_i = O_RDWR | O_CREAT; // XX O_TRUNC ?
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
+  //  XX move directory creation?
+  //
+  snprintf(ful_c, 8192, "%s/.urb/bhk", u3C.dir_c);
 
   if ( c3_mkdir(ful_c, 0700) ) {
     if ( EEXIST != errno ) {
@@ -1152,14 +1133,14 @@ _ce_backup(void)
     return;
   }
 
-  snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, nop_u.nam_c);
+  snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3C.dir_c, nop_u.nam_c);
 
   if ( -1 == (nop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
     return;
   }
 
-  snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, sop_u.nam_c);
+  snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3C.dir_c, sop_u.nam_c);
 
   if ( -1 == (sop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
@@ -1171,9 +1152,9 @@ _ce_backup(void)
   {
 
     c3_unlink(ful_c);
-    snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, nop_u.nam_c);
+    snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3C.dir_c, nop_u.nam_c);
     c3_unlink(ful_c);
-    snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
+    snprintf(ful_c, 8192, "%s/.urb/bhk", u3C.dir_c);
     c3_rmdir(ful_c);
   }
 

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -1328,7 +1328,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
 
       //  mark all pages dirty (pages in the snapshot will be marked clean)
       //
-      u3e_foul();
+      _ce_loom_track_north(0, u3P.pag_w);
 
       /* Write image files to memory; reinstate protection.
       */
@@ -1387,15 +1387,11 @@ u3e_yolo(void)
     c3_assert(0);
   }
 
-  return c3y;
-}
+  //  mark all pages dirty
+  //
+  _ce_loom_track_north(0, u3P.pag_w);
 
-/* u3e_foul(): dirty all the pages of the loom.
-*/
-void
-u3e_foul(void)
-{
-  memset((void*)u3P.dit_w, 0xff, sizeof(u3P.dit_w));
+  return c3y;
 }
 
 /* u3e_init(): initialize guard page tracking.

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -840,6 +840,7 @@ _ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
       c3_assert(0);
     }
 
+#ifdef U3_GUARD_PAGE
     //  protect guard page if clobbered
     //
     //    NB: < pgs_w is precluded by assertion in _ce_patch_compose()
@@ -852,6 +853,7 @@ _ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
         c3_assert(0);
       }
     }
+#endif
 
     _ce_loom_track_north(pgs_w, dif_w);
   }
@@ -888,6 +890,7 @@ _ce_loom_protect_south(c3_w pgs_w, c3_w old_w)
       c3_assert(0);
     }
 
+#ifdef U3_GUARD_PAGE
     //  protect guard page if clobbered
     //
     //    NB: > pgs_w is precluded by assertion in _ce_patch_compose()
@@ -900,6 +903,7 @@ _ce_loom_protect_south(c3_w pgs_w, c3_w old_w)
         c3_assert(0);
       }
     }
+#endif
 
     _ce_loom_track_south(pgs_w, dif_w);
   }
@@ -949,6 +953,7 @@ _ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
       c3_assert(0);
     }
 
+#ifdef U3_GUARD_PAGE
     //  protect guard page if clobbered
     //
     //    NB: < pgs_w is precluded by assertion in _ce_patch_compose()
@@ -961,6 +966,7 @@ _ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
         c3_assert(0);
       }
     }
+#endif
 
     _ce_loom_track_north(pgs_w, dif_w);
   }
@@ -1369,11 +1375,13 @@ u3e_yolo(void)
     return c3n;
   }
 
+#ifdef U3_GUARD_PAGE
   if ( 0 != mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
     fprintf(stderr, "loom: failed to protect guard page: %s\r\n",
                     strerror(errno));
     c3_assert(0);
   }
+#endif
 
   //  mark all pages dirty
   //

--- a/pkg/urbit/noun/events.c
+++ b/pkg/urbit/noun/events.c
@@ -880,8 +880,9 @@ _ce_loom_protect_south(c3_w pgs_w, c3_w old_w)
 
   if ( old_w > pgs_w ) {
     c3_w dif_w = old_w - pgs_w;
+    c3_w off_w = u3P.pag_w - old_w;
 
-    if ( 0 != mprotect((void*)(u3_Loom + ((u3P.pag_w - old_w) << u3a_page)),
+    if ( 0 != mprotect((void*)(u3_Loom + (off_w << u3a_page)),
                        (size_t)dif_w << (u3a_page + 2),
                        (PROT_READ | PROT_WRITE)) )
     {
@@ -893,9 +894,9 @@ _ce_loom_protect_south(c3_w pgs_w, c3_w old_w)
 #ifdef U3_GUARD_PAGE
     //  protect guard page if clobbered
     //
-    //    NB: > pgs_w is precluded by assertion in _ce_patch_compose()
+    //    NB: >= pgs_w is precluded by assertion in _ce_patch_compose()
     //
-    if ( (gar_pag_p >> u3a_page) >= (u3a_pages - (old_w + 1)) ) {
+    if ( (gar_pag_p >> u3a_page) >= off_w ) {
       fprintf(stderr, "loom: guard on reprotect\r\n");
       if ( 0 != mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
         fprintf(stderr, "loom: failed to protect guard page: %s\r\n",

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1867,6 +1867,8 @@ u3m_boot(c3_c* dir_c, size_t len_i)
 {
   c3_o nuu_o;
 
+  u3C.dir_c = dir_c;
+
   /* Activate the loom.
   */
   u3m_init(len_i);

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -814,7 +814,6 @@ u3m_leap(c3_w pad_w)
       u3R->cap_p -= len_w;
 
       rod_u = _pave_south(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
-      u3e_ward(rod_u->cap_p, rod_u->hat_p);
 #if 0
       fprintf(stderr, "leap: from north %p (cap 0x%x), to south %p\r\n",
               u3R,
@@ -827,7 +826,6 @@ u3m_leap(c3_w pad_w)
       u3R->cap_p += len_w;
 
       rod_u = _pave_north(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
-      u3e_ward(rod_u->hat_p, rod_u->cap_p);
 #if 0
       fprintf(stderr, "leap: from south %p (cap 0x%x), to north %p\r\n",
               u3R,
@@ -849,6 +847,7 @@ u3m_leap(c3_w pad_w)
   */
   {
     u3R = rod_u;
+    u3m_ward();
     _pave_parts();
   }
 #ifdef U3_MEMORY_DEBUG
@@ -1759,6 +1758,16 @@ u3m_save(void)
   c3_assert(u3R == &u3H->rod_u);
 
   return u3e_save(low_p, hig_p);
+}
+
+/* u3m_ward(): tend the guard page.
+*/
+void
+u3m_ward(void)
+{
+  u3_post low_p, hig_p;
+  u3m_water(&low_p, &hig_p);
+  return u3e_ward(low_p, hig_p);
 }
 
 /* _cm_signals(): set up interrupts, etc.

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -2,6 +2,7 @@
 **
 */
 #include "all.h"
+#include "noun/events.h"
 #include "rsignal.h"
 #include "vere/vere.h"
 #include <errno.h>
@@ -1686,6 +1687,22 @@ _cm_limits(void)
 # endif
 }
 
+/* u3m_fault(): handle a memory event with libsigsegv protocol.
+*/
+c3_i
+u3m_fault(void* adr_v, c3_i ser_i)
+{
+  return u3e_fault(adr_v, ser_i);
+}
+
+/* u3m_save(): update the checkpoint.
+*/
+void
+u3m_save(void)
+{
+  return u3e_save();
+}
+
 /* _cm_signals(): set up interrupts, etc.
 */
 static void
@@ -1701,7 +1718,7 @@ _cm_signals(void)
   //  filter (see compat/mingw/seh_handler.c) that handles both memory
   //  access and stack overflow exceptions. It calls u3e_fault directly.
 # else
-  if ( 0 != sigsegv_install_handler(u3e_fault) ) {
+  if ( 0 != sigsegv_install_handler(u3m_fault) ) {
     u3l_log("boot: sigsegv install failed\n");
     exit(1);
   }

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -594,7 +594,7 @@ _find_home(void)
   //  this looks risky, but there are no legitimate scenarios
   //  where it's wrong
   //
-  u3R->cap_p = u3R->mat_p = u3C.wor_i - c3_wiseof(*u3H);
+  u3R->cap_p = u3R->mat_p = u3a_outa(u3H);
 }
 
 /* u3m_pave(): instantiate or activate image.

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1916,10 +1916,6 @@ u3m_boot(c3_c* dir_c, size_t len_i)
   */
   u3m_pave(nuu_o);
 
-  /* Place the guard page.
-  */
-  u3e_init();
-
   /* Initialize the jet system.
   */
   {

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1875,7 +1875,35 @@ u3m_boot(c3_c* dir_c, size_t len_i)
 
   /* Activate the storage system.
   */
-  nuu_o = u3e_live(c3n, dir_c);
+  {
+    c3_c ful_c[8193];
+
+    snprintf(ful_c, 8192, "%s", dir_c);
+    if ( c3_mkdir(ful_c, 0700) ) {
+      if ( EEXIST != errno ) {
+        fprintf(stderr, "loom: pier create: %s\r\n", strerror(errno));
+        c3_assert(0);
+      }
+    }
+
+    snprintf(ful_c, 8192, "%s/.urb", dir_c);
+    if ( c3_mkdir(ful_c, 0700) ) {
+      if ( EEXIST != errno ) {
+        fprintf(stderr, "loom: .urb create: %s\r\n", strerror(errno));
+        c3_assert(0);
+      }
+    }
+
+    snprintf(ful_c, 8192, "%s/.urb/chk", dir_c);
+    if ( c3_mkdir(ful_c, 0700) ) {
+      if ( EEXIST != errno ) {
+        fprintf(stderr, "loom: .urb/chk create: %s\r\n", strerror(errno));
+        c3_assert(0);
+      }
+    }
+
+    nuu_o = u3e_live(c3n, strdup(ful_c));
+  }
 
   /* Activate tracing.
   */

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -522,6 +522,8 @@ _pave_north(c3_w* mem_w, c3_w siz_w, c3_w len_w)
   //    the stack starts at the end of the memory segment,
   //    minus space for the road structure [siz_w]
   //
+  //    NB: the returned road is "above" the stack
+  //
   c3_w* rut_w = mem_w;
   c3_w* mat_w = ((mem_w + len_w) - siz_w);
   c3_w* cap_w = mat_w;
@@ -539,6 +541,8 @@ _pave_south(c3_w* mem_w, c3_w siz_w, c3_w len_w)
   //    the heap starts at the end of the memory segment;
   //    the stack starts at the base memory pointer [mem_w],
   //    and ends after the space for the road structure [siz_w]
+  //
+  //    NB: the returned road is *on* the stack
   //
   c3_w* rut_w = (mem_w + len_w);
   c3_w* mat_w = mem_w;

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1919,7 +1919,7 @@ u3m_boot(c3_c* dir_c, size_t len_i)
       }
     }
 
-    nuu_o = u3e_live(c3n, strdup(ful_c));
+    nuu_o = u3e_live(strdup(ful_c));
   }
 
   /* Activate tracing.

--- a/pkg/urbit/noun/urth.c
+++ b/pkg/urbit/noun/urth.c
@@ -416,10 +416,6 @@ _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
   //
   u3A->eve_d = eve_d;
 
-  //  mark all pages dirty
-  //
-  u3e_foul();
-
   *tor_u = rot_u;
   *doc_u = cod_u;
 
@@ -846,10 +842,6 @@ u3u_uncram(c3_c* dir_c, c3_d eve_d)
   //  restore event number
   //
   u3A->eve_d = eve_d;
-
-  //  mark all pages dirty
-  //
-  u3e_foul();
 
   //  leave rocks on disk
   //

--- a/pkg/urbit/noun/urth.c
+++ b/pkg/urbit/noun/urth.c
@@ -2,6 +2,7 @@
 **
 */
 #include "all.h"
+#include "noun/events.h"
 #include "ur/ur.h"
 #include <errno.h>
 #include <fcntl.h>

--- a/pkg/urbit/tests/ames_tests.c
+++ b/pkg/urbit/tests/ames_tests.c
@@ -6,8 +6,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 22);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 22);
 }
 
 /* _test_ames(): spot check ames helpers

--- a/pkg/urbit/tests/events_tests.c
+++ b/pkg/urbit/tests/events_tests.c
@@ -92,7 +92,12 @@ _test_tracking(void)
 {
   c3_w ret_w;
 
-  u3e_foul();
+  _ce_loom_track_north(0, u3P.pag_w);
+
+  if ( u3P.pag_w != (ret_w = _check_north_dirty(0, u3P.pag_w)) ) {
+    fprintf(stderr, "test events track north dirty all %u\r\n", ret_w);
+    return 0;
+  }
 
   if ( 0 != (ret_w = _check_north_clean()) ) {
     fprintf(stderr, "test events track north init %u\r\n", ret_w);
@@ -214,6 +219,13 @@ _test_tracking(void)
 
   if ( 5 != (ret_w = _check_south_dirty(10, 5)) ) {
     fprintf(stderr, "test events track north dirty f %u\r\n", ret_w);
+    return 0;
+  }
+
+  _ce_loom_track_north(0, u3P.pag_w);
+
+  if ( u3P.pag_w != (ret_w = _check_north_dirty(0, u3P.pag_w)) ) {
+    fprintf(stderr, "test events track north dirty all %u\r\n", ret_w);
     return 0;
   }
 

--- a/pkg/urbit/tests/events_tests.c
+++ b/pkg/urbit/tests/events_tests.c
@@ -1,4 +1,5 @@
 #include "all.h"
+#include "noun/events.h"
 
 /* _setup(): prepare for tests.
 */

--- a/pkg/urbit/tests/hashtable_tests.c
+++ b/pkg/urbit/tests/hashtable_tests.c
@@ -9,8 +9,7 @@ c3_w _ch_skip_slot(c3_w mug_w, c3_w lef_w);
 static void
 _setup(void)
 {
-  u3m_init(1 << 26);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 26);
 }
 
 /* _test_bit_manipulation():

--- a/pkg/urbit/tests/jam_tests.c
+++ b/pkg/urbit/tests/jam_tests.c
@@ -6,9 +6,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 24);
-  u3m_pave(c3y);
-  u3e_init();
+  u3m_boot_lite(1 << 24);
 }
 
 static void

--- a/pkg/urbit/tests/jet_tests.c
+++ b/pkg/urbit/tests/jet_tests.c
@@ -5,8 +5,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 20);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 20);
 }
 
 static inline c3_i

--- a/pkg/urbit/tests/meme_tests.c
+++ b/pkg/urbit/tests/meme_tests.c
@@ -5,9 +5,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 24);
-  u3m_pave(c3y);
-  u3e_init();
+  u3m_boot_lite(1 << 24);
 }
 
 static u3_noun

--- a/pkg/urbit/tests/meme_tests.c
+++ b/pkg/urbit/tests/meme_tests.c
@@ -5,10 +5,7 @@
 static void
 _setup(void)
 {
-  //  XX at 1<<24, this succeeds on mac, but bail:exit's on linux.
-  //  investigate possible u3n_prog corruption
-  //
-  u3m_init(1 << 25);
+  u3m_init(1 << 24);
   u3m_pave(c3y);
   u3e_init();
 }
@@ -53,7 +50,7 @@ _test_nock_meme(void)
 }
 
 static c3_i
-_test_nock(void)
+_test_meme(void)
 {
   c3_i ret_i = 1;
 
@@ -72,8 +69,8 @@ main(int argc, char* argv[])
 {
   _setup();
 
-  if ( !_test_nock() ) {
-    fprintf(stderr, "test nock: failed\r\n");
+  if ( !_test_meme() ) {
+    fprintf(stderr, "test meme: failed\r\n");
     exit(1);
   }
 
@@ -81,6 +78,6 @@ main(int argc, char* argv[])
   //
   u3m_grab(u3_none);
 
-  fprintf(stderr, "test nock: ok\r\n");
+  fprintf(stderr, "test meme: ok\r\n");
   return 0;
 }

--- a/pkg/urbit/tests/mug_tests.c
+++ b/pkg/urbit/tests/mug_tests.c
@@ -5,8 +5,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 20);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 20);
 }
 
 /* _test_mug(): spot check u3r_mug hashes.

--- a/pkg/urbit/tests/newt_tests.c
+++ b/pkg/urbit/tests/newt_tests.c
@@ -6,8 +6,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 20);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 20);
 }
 
 /* _newt_encode(): synchronous serialization into a single buffer, for test purposes

--- a/pkg/urbit/tests/noun_tests.c
+++ b/pkg/urbit/tests/noun_tests.c
@@ -8,8 +8,7 @@
 static void
 _setup(void)
 {
-  u3m_init(1 << 20);
-  u3m_pave(c3y);
+  u3m_boot_lite(1 << 20);
 }
 
 /* _test_u3r_chop: "extract bit slices from atom"

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -200,7 +200,7 @@ _serf_grab(u3_noun sac)
       c3_c* wen_c = u3r_string(wen);
 
       c3_c nam_c[2048];
-      snprintf(nam_c, 2048, "%s/.urb/put/mass", u3P.dir_c);
+      snprintf(nam_c, 2048, "%s/.urb/put/mass", u3C.dir_c);
 
       struct stat st;
       if ( -1 == stat(nam_c, &st) ) {
@@ -839,7 +839,7 @@ _serf_writ_live_exit(u3_serf* sef_u, c3_w cod_w)
       c3_c* wen_c = u3r_string(wen);
 
       c3_c nam_c[2048];
-      snprintf(nam_c, 2048, "%s/.urb/put/profile", u3P.dir_c);
+      snprintf(nam_c, 2048, "%s/.urb/put/profile", u3C.dir_c);
 
       struct stat st;
       if ( -1 == stat(nam_c, &st) ) {

--- a/pkg/urbit/worker/serf.c
+++ b/pkg/urbit/worker/serf.c
@@ -883,7 +883,7 @@ _serf_writ_live_save(u3_serf* sef_u, c3_d eve_d)
     exit(1);
   }
 
-  u3e_save();
+  u3m_save();
 }
 
 /* u3_serf_live(): apply %live command [com], producing *ret on c3y.
@@ -954,7 +954,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
         return c3n;
       }
 
-      u3e_save();
+      u3m_save();
       u3_serf_grab();
 
       *ret = u3nc(c3__live, u3_nul);


### PR DESCRIPTION
This PR builds on #6126 and refactors the interface to the snapshot system (`events.c`), further isolating it from the rest of u3.

- `events.h` has been removed from `all.h` and should no longer to be directly called. Instead, use the wrapper functions in `manage.h` (`u3m_save()`, `u3m_ward()`, &c). The high/low watermarks used throughout the snapshot system have been normalized, and a number of small errors (off-by-one, &c) have been corrected.

- The `.urb/chk/` directories inside the pier are now created at a higher level, with paths passed in.

- The guard page system now operates by page index instead of "post" (word-offset into the loom). The rounding logic (my suggestion in #5881) was ill-considered and has been removed. It was intended to reduce faults by biasing the guard page towards the stack, but instead complicated the logic, and admitted the possibility of premature `bail:meme` ("talk to your doctor about premature memes").

- Some confusing and/or verbose printfs have been removed (say goodbye to "address out of loom!", "not enough memory to recenter the guard page", &c).