### PR TITLE
Fix build break typo in azimuth

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -4,7 +4,7 @@
     naive,
     dice,
     default-agent,
-/   verb,
+    verb,
     dbug
 ::  To update, run from dojo:
 ::    -azimuth-snap-state %default 'version-0'


### PR DESCRIPTION
Fixes typo introduced in [36deb95411d0a94c3aa6e772adc2b4ae2f946764](https://github.com/urbit/urbit/commit/0e16d82a46ea569e04326ba497b99f93b7ddc751)

This is a copy of https://github.com/urbit/urbit/pull/6148 made to just clean up the commit message since I don't have access to the third party repo fork to do it there.

We should typically not commit directly to master to avoid this class of problem in the future, more details are in this comment: https://github.com/urbit/urbit/pull/6148#issuecomment-1353638486

