### PR TITLE
vere: support ctrl-z in play command

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1780,6 +1780,17 @@ _cw_play_slog(u3_noun hod)
   u3z(hod);
 }
 
+/* _cw_play_exit(): exit immediately.
+*/
+static void
+_cw_play_exit(c3_i int_i)
+{
+  //  explicit fprintf to avoid allocation in u3l_log
+  //
+  fprintf(stderr, "\r\n[received keyboard stop signal, exiting]\r\n");
+  raise(SIGINT);
+}
+
 /* _cw_play(): replay events, but better.
 */
 static void
@@ -1859,9 +1870,15 @@ _cw_play(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  //  XX handle SIGTSTP so that the lockfile is not orphaned?
-  //
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c); // XX s/b try_aquire lock
+
+#if !defined(U3_OS_mingw)
+  //  Handle SIGTSTP as if it was SIGINT.
+  //
+  //    Configured here using signal() so as to be immediately available.
+  //
+  signal(SIGTSTP, _cw_play_exit);
+#endif
 
   if ( c3y == mel_o ) {
     u3C.wag_w |= u3o_auto_meld;

--- a/pkg/urbit/worker/mars.c
+++ b/pkg/urbit/worker/mars.c
@@ -174,7 +174,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d)
       fprintf(stderr, "mars: boot fail\r\n");
       //  XX exit code, cb
       //
-      exit(1);;
+      exit(1);
     }
 
     mar_u->sen_d = mar_u->dun_d = lif_w;
@@ -231,6 +231,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d)
             //  XX check loom size, suggest --loom X
             //  XX exit code, cb
             //
+            u3_disk_exit(log_u);
             exit(1);
           }
 
@@ -254,6 +255,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d)
           u3m_save();
           //  XX exit code, cb
           //
+          u3_disk_exit(log_u);
           exit(1);
         }
       }


### PR DESCRIPTION
This PR enhances #6159 with explicit cleanup (of the lockfile, specifically), and an accommodation to the muscle memory of urbit devs everywhere. Opened from my fork to test our CI against external PRs.