### PR TITLE
vere: minor fixes for replay tools

### DIFF
--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1472,12 +1472,14 @@ _cw_cram(c3_i argc, c3_c* argv[])
 static void
 _cw_queu(c3_i argc, c3_c* argv[])
 {
-  c3_i ch_i, lid_i;
-  c3_w arg_w;
+  c3_i   ch_i, lid_i;
+  c3_w  arg_w;
+  c3_c* roc_c = 0;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
+    { "loom",        required_argument, NULL, c3__loom },
+    { "no-demand",   no_argument,       NULL, 6 },
+    { "replay-from", required_argument, NULL, 'r' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1500,6 +1502,10 @@ _cw_queu(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.lom_y = lom_w;
       } break;
 
+      case 'r': {
+        roc_c = strdup(optarg);
+      } break;
+
       case '?': {
         fprintf(stderr, "invalid argument\r\n");
         exit(1);
@@ -1507,9 +1513,13 @@ _cw_queu(c3_i argc, c3_c* argv[])
     }
   }
 
+  if ( !roc_c ) {
+    fprintf(stderr, "invalid command, -r $EVENT required\r\n");
+    exit(1);
+  }
+
   //  argv[optind] is always "queu"
   //
-
   if ( !u3_Host.dir_c ) {
     if ( optind + 1 < argc ) {
       u3_Host.dir_c = argv[optind + 1];
@@ -1527,11 +1537,10 @@ _cw_queu(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  c3_c* eve_c;
-  c3_d  eve_d;
+  c3_d eve_d;
 
-  if ( 1 != sscanf(eve_c, "%" PRIu64 "", &eve_d) ) {
-    fprintf(stderr, "urbit: queu: invalid number '%s'\r\n", eve_c);
+  if ( 1 != sscanf(roc_c, "%" PRIu64 "", &eve_d) ) {
+    fprintf(stderr, "urbit: queu: invalid number '%s'\r\n", roc_c);
     exit(1);
   }
   else {

--- a/pkg/urbit/daemon/main.c
+++ b/pkg/urbit/daemon/main.c
@@ -1885,16 +1885,21 @@ _cw_play(c3_i argc, c3_c* argv[])
   }
 
   u3C.wag_w |= u3o_hashless;
-  u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
-  u3C.slog_f = _cw_play_slog;
 
   if ( c3y == ful_o ) {
     u3l_log("mars: preparing for full replay\r\n");
+    u3m_init((size_t)1 << u3_Host.ops_u.lom_y);
+    u3e_live(u3m_pier(u3_Host.dir_c));
     u3e_yolo();
     u3m_pave(c3y);
     u3j_boot(c3y);
     u3A->eve_d = 0;
   }
+  else {
+    u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
+  }
+
+  u3C.slog_f = _cw_play_slog;
 
   {
     u3_mars mar_u = {

--- a/pkg/urbit/include/noun/manage.h
+++ b/pkg/urbit/include/noun/manage.h
@@ -8,6 +8,11 @@
         c3_d
         u3m_boot(c3_c* dir_c, size_t len_i);
 
+      /* u3m_pier(): make a pier.
+      */
+        c3_c*
+        u3m_pier(c3_c* dir_c);
+
       /* u3m_boot_lite(): start without checkpointing.
       */
         c3_d

--- a/pkg/urbit/noun/manage.c
+++ b/pkg/urbit/noun/manage.c
@@ -1961,6 +1961,42 @@ u3m_stop()
   c3_free(u3D.ray_u);
 }
 
+/* u3m_pier(): make a pier.
+*/
+c3_c*
+u3m_pier(c3_c* dir_c)
+{
+  c3_c ful_c[8193];
+
+  u3C.dir_c = dir_c;
+
+  snprintf(ful_c, 8192, "%s", dir_c);
+  if ( c3_mkdir(ful_c, 0700) ) {
+    if ( EEXIST != errno ) {
+      fprintf(stderr, "loom: pier create: %s\r\n", strerror(errno));
+      c3_assert(0);
+    }
+  }
+
+  snprintf(ful_c, 8192, "%s/.urb", dir_c);
+  if ( c3_mkdir(ful_c, 0700) ) {
+    if ( EEXIST != errno ) {
+      fprintf(stderr, "loom: .urb create: %s\r\n", strerror(errno));
+      c3_assert(0);
+    }
+  }
+
+  snprintf(ful_c, 8192, "%s/.urb/chk", dir_c);
+  if ( c3_mkdir(ful_c, 0700) ) {
+    if ( EEXIST != errno ) {
+      fprintf(stderr, "loom: .urb/chk create: %s\r\n", strerror(errno));
+      c3_assert(0);
+    }
+  }
+
+  return strdup(ful_c);
+}
+
 /* u3m_boot(): start the u3 system. return next event, starting from 1.
 */
 c3_d
@@ -1968,43 +2004,13 @@ u3m_boot(c3_c* dir_c, size_t len_i)
 {
   c3_o nuu_o;
 
-  u3C.dir_c = dir_c;
-
   /* Activate the loom.
   */
   u3m_init(len_i);
 
   /* Activate the storage system.
   */
-  {
-    c3_c ful_c[8193];
-
-    snprintf(ful_c, 8192, "%s", dir_c);
-    if ( c3_mkdir(ful_c, 0700) ) {
-      if ( EEXIST != errno ) {
-        fprintf(stderr, "loom: pier create: %s\r\n", strerror(errno));
-        c3_assert(0);
-      }
-    }
-
-    snprintf(ful_c, 8192, "%s/.urb", dir_c);
-    if ( c3_mkdir(ful_c, 0700) ) {
-      if ( EEXIST != errno ) {
-        fprintf(stderr, "loom: .urb create: %s\r\n", strerror(errno));
-        c3_assert(0);
-      }
-    }
-
-    snprintf(ful_c, 8192, "%s/.urb/chk", dir_c);
-    if ( c3_mkdir(ful_c, 0700) ) {
-      if ( EEXIST != errno ) {
-        fprintf(stderr, "loom: .urb/chk create: %s\r\n", strerror(errno));
-        c3_assert(0);
-      }
-    }
-
-    nuu_o = u3e_live(strdup(ful_c));
-  }
+  nuu_o = u3e_live(u3m_pier(dir_c));
 
   /* Activate tracing.
   */


### PR DESCRIPTION
This PR makes the full replay command (`play -f`) work in the presence of arbitrary snapshot corruption (requiring special initialization). And it fixes the argument parsing of the `queu` command, which has been broken since the binary consolidation in v1.9.