### PR TITLE
clay: fix %open %s scry endpoint

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4246,7 +4246,7 @@
           (page-to-cage:(aeon-ford yon) u.peg)
         ``cage+[-:!>(*^cage) cage]
       ::
-          %open  ``open+!>(prelude:(aeon-ford yon))
+          %open  ``open+!>((prelude:(aeon-ford yon) t.pax))
           %late  !!  :: handled in +aver
           %case  !!  :: handled in +aver
           %base-tako


### PR DESCRIPTION
%open %s scry currently returns the whole +prelude gate. This fixes it so it correctly builds and returns the prelude in a vase.

resolves #6181 