### PR TITLE
gitattributes: remove export-ignores

### DIFF
--- a/pkg/arvo/.gitattributes
+++ b/pkg/arvo/.gitattributes
@@ -1,2 +1,0 @@
-.gitattributes export-ignore
-tests export-ignore


### PR DESCRIPTION
We no longer need to omit `pkg/arvo/tests` from this repo's export archives (@jtobin confirmed in chat a couple weeks ago), and I need the folder to be bundled in archives for CI in the [new repo](https://github.com/urbit/vere).