### PR TITLE
http-api: Optional ship param for subscriptions

### DIFF
--- a/pkg/npm/http-api/src/Urbit.ts
+++ b/pkg/npm/http-api/src/Urbit.ts
@@ -474,9 +474,8 @@ export class Urbit {
       err: () => {},
       event: () => {},
       quit: () => {},
-      app: params.app,
-      path: params.path,
-      ship: params.ship ? params.ship : this.ship,
+      ship: this.ship,
+      ...params,
     };
 
     const message: Message = {

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -170,6 +170,27 @@ export interface SubscriptionRequestInterface extends SubscriptionInterface {
    * `"/keys"`
    */
   path: Path;
+  /**
+   * The ship to subscribe to, without the leading tilde
+   * @example
+   * `"sampel-palnet"`
+   */  
+  ship?: string;
+}
+
+export interface SubscribeOnceOptionalParams {
+  /**
+   * The ship to subscribe to, without the leading tilde
+   * @example
+   * `"sampel-palnet"`
+   */  
+  ship?: string;
+  /**
+   * Optional timeout before ending subscription
+   * @example
+   * `1000`
+   */
+  timeout?: number;
 }
 
 export interface headers {

--- a/pkg/npm/http-api/src/types.ts
+++ b/pkg/npm/http-api/src/types.ts
@@ -175,7 +175,7 @@ export interface SubscriptionRequestInterface extends SubscriptionInterface {
    * @example
    * `"sampel-palnet"`
    */  
-  ship?: string;
+  ship?: PatpNoSig;
 }
 
 export interface SubscribeOnceOptionalParams {
@@ -184,7 +184,7 @@ export interface SubscribeOnceOptionalParams {
    * @example
    * `"sampel-palnet"`
    */  
-  ship?: string;
+  ship?: PatpNoSig;
   /**
    * Optional timeout before ending subscription
    * @example


### PR DESCRIPTION
The [documentation for http-api subscriptions](https://developers.urbit.org/guides/additional/http-api-guide#subscribe) describes a ship parameter for the subscription, defaulting to `api.ship` if not specified.  This is not supported by the JS library (it always uses `api.ship`) which is confusing.

Also, if you wanted to subscribe to different ships in the same application, you would need to toggle `api.ship` somehow.  Rather than fix the documentation, it makes more sense to support this.

Tagging @sigilante, hopefully you can help me get this through soon.  And let me know if I can help update the docs.