### PR TITLE
kiln: add `once` flag to |install

### DIFF
--- a/pkg/arvo/gen/hood/install.hoon
+++ b/pkg/arvo/gen/hood/install.hoon
@@ -8,7 +8,7 @@
 ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [[her=@p rem=desk ~] local=@tas]
+        [[her=@p rem=desk ~] local=@tas once=_|]
     ==
 =/  loc=desk  ?:(=(%$ local) rem local)
-[%kiln-install loc her rem]
+[%kiln-install loc her rem once]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -687,7 +687,7 @@
   abet:(emit:(spam leaf+mez ~) %pass /kiln %arvo %c [%info u.tor])
 ::
 ++  poke-install
-  |=  [loc=desk her=ship rem=desk]
+  |=  [loc=desk her=ship rem=desk once=?]
   =+  .^(=rock:tire %cx /(scot %p our)//(scot %da now)/tire)
   =/  =zest
     ?~  got=(~(get by rock) loc)
@@ -703,6 +703,8 @@
     abet:(spam (render "already syncing" loc her rem ~) ~)
   ?:  =([our loc] [her rem])
     abet
+  ?:  once
+    abet:abet:(merge:(work loc) her rem da+now %only-that)
   =/  sun  (sync loc her rem)
   ~>  %slog.(fmt "beginning install into {here:sun}")
   =<  abet:abet:init


### PR DESCRIPTION
It's often useful to |merge a desk, but if you're still getting updates from your sync source, you may get overwritten in the future.  In this case, you want to merge and clear the sync source.  With this change, you can do this with:

```
|install ~ship %desk, =once &
```