### PR TITLE
Extend btc-provider API to fetch block transactions

### DIFF
--- a/pkg/bitcoin/app/btc-provider.hoon
+++ b/pkg/bitcoin/app/btc-provider.hoon
@@ -180,6 +180,7 @@
       %tx-from-pos    [%get-tx-from-pos height.act pos.act merkle.act]
       %fee            [%get-fee block.act]
       %psbt           [%update-psbt psbt.act]
+      %block-txs      [%get-block-txs blockhash.act]
     ==
   ::
   ++  req-card
@@ -339,6 +340,11 @@
       ?>  ?=([%update-psbt *] r)
       :_  state
       ~[(send-update:hc [%.y %psbt +.r] ship)]
+      ::
+        %block-txs
+      ?>  ?=([%get-block-txs *] r)
+      :_  state
+      ~[(send-update:hc [%.y %block-txs +.r] ship)]
     ==
   ::
   ++  connection-error

--- a/pkg/bitcoin/lib/btc.hoon
+++ b/pkg/bitcoin/lib/btc.hoon
@@ -438,6 +438,9 @@
       ::
         %update-psbt
       [id.res (so res.res)]
+      ::
+        %get-block-txs
+      [id.res (block-txs res.res)]
     ==
     ::
     ++  address-info
@@ -501,6 +504,11 @@
       %-  ot
       :~  [%tx-hash (cu from-cord:hxb:bcu so)]
           [%merkle (ar (cu from-cord:hxb:bcu so))] 
+      ==
+    ++  block-txs
+      %-  ot
+      :~  [%blockhash (cu from-cord:hxb:bcu so)]
+          [%txs (ar raw-tx)]
       ==
     --
   --
@@ -572,6 +580,11 @@
     %-  get-request
     %+  mk-url  '/updatepsbt/'
     %-  en:base64:mimes:html  [(lent (trip psbt.ract)) psbt.ract]
+    ::
+      %get-block-txs
+    %-  get-request
+    %+  mk-url  '/getblocktxs/'
+    (to-cord:hxb:bcu blockhash.ract)
   ==
   ++  mk-url
     |=  [base=@t params=@t]

--- a/pkg/bitcoin/sur/btc-provider.hoon
+++ b/pkg/bitcoin/sur/btc-provider.hoon
@@ -38,6 +38,7 @@
       [%tx-from-pos height=@ud pos=@ud merkle=?]
       [%fee block=@ud]
       [%psbt psbt=@t]
+      [%block-txs blockhash=hexb]
   ==
 ::
 +$  result
@@ -51,6 +52,7 @@
       [%tx-from-pos tx-hash=hexb merkle=(list hexb)]
       [%fee fee=@rd]
       [%psbt psbt=@t]
+      [%block-txs blockhash=hexb txs=(list [txid=hexb rawtx=hexb])]
   ==
 +$  error
   $%  [%not-connected status=@ud]
@@ -79,6 +81,7 @@
         [%get-tx-from-pos height=@ud pos=@ud merkle=?]
         [%get-fee block=@ud]
         [%update-psbt psbt=@t]
+        [%get-block-txs blockhash=hexb]
     ==
   ::
   +$  result
@@ -94,6 +97,7 @@
         [%get-tx-from-pos tx-hash=hexb merkle=(list hexb)]
         [%get-fee fee=@rd]
         [%update-psbt psbt=@t]
+        [%get-block-txs blockhash=hexb txs=(list [txid=hexb rawtx=hexb])]
     ==
   --
 --


### PR DESCRIPTION
**Dependent on [this PR](https://github.com/urbit/urbit-bitcoin-rpc/pull/31) to `urbit/urbit-bitcoin-rpc`.**

- Adds a `block-txs` node RPC request flow to `%btc-provider` that fetches a complete list of raw transactions by blockhash

Volt, an implementation of Bitcoin [Lightning payments on Urbit](https://urbit.org/grants/volt-lightning-on-urbit), needs to find and categorize a transaction spending one of its channels as cooperative, forced, or malicious, and in the last case match the raw transaction to a specific revocation signature. Compared to alternative solutions (making thousands of redundant RPC requests, modifying the existing `getblockinfo` structure, fetching and parsing the entire raw block or verbose transaction JSON) this one has no impact on existing usage, a small code footprint, and provides functionality that will also be useful for future Bitcoin use-cases other than Lightning.