### PR TITLE
clay: Drop foreign %wris responses

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -464,6 +464,7 @@
       $:  %clay                                         ::
           $>  $?  %mere                                 ::
                   %writ                                 ::
+                  %wris                                 ::
               ==                                        ::
           gift                                          ::
       ==                                                ::
@@ -5822,6 +5823,7 @@
     [mos ..^$]
   ::
   ?:  ?=([%foreign-warp *] tea)
+    ?:  ?=(%wris +<.hin)  ~&  %dropping-wris  `..^$
     ?>  ?=(%writ +<.hin)
     :_  ..^$
     [hen %give %boon `(unit rand)`(bind `riot`p.hin rant-to-rand)]~
@@ -5973,6 +5975,7 @@
       %boon  !!
       %lost  !!
       %unto  !!
+      %wris  ~&  %strange-wris  !!
       %writ
     %-  (slog leaf+"clay: strange writ (expected on upgrade to Fusion)" ~)
     [~ ..^$]


### PR DESCRIPTION
This flow is not supported, and it was causing issues releasing 416.  This change just drops the responses to avoid crashing, but at some point we should either support this flow or reject the request in the first place.