### PR TITLE
http-api: make http api work in node context

### DIFF
--- a/pkg/npm/http-api/package.json
+++ b/pkg/npm/http-api/package.json
@@ -55,7 +55,7 @@
     "jest": "^27.0.6",
     "rollup": "^2.59.0",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup-plugin-typescript2": "^0.34.1",
     "typescript": "^3.9.7",
     "util": "^0.12.3",
     "web-streams-polyfill": "^3.0.3",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@microsoft/fetch-event-source": "^2.0.0",
+    "@fortaine/fetch-event-source": "^3.0.6",
     "browser-or-node": "^1.3.0",
     "core-js": "^3.19.1"
   }


### PR DESCRIPTION
`http-api` does not work in node because it uses `@microsoft/fetch-event-source`. Luckily this helpful dude [made a PR](https://github.com/Azure/fetch-event-source/pull/28) with a fix. I would expect it to be merged in but we should use his fork for now because `http-api` not working on the server side is untenable.

I had to bump another dependency as well for ESM reasons.