### PR TITLE
chat-cli: put it to rest

### DIFF
--- a/pkg/landscape/app/chat-hook.hoon
+++ b/pkg/landscape/app/chat-hook.hoon
@@ -49,7 +49,10 @@
     =|  cards=(list card)
     |-
     ?:  ?=(%11 -.old)
-      [cards this(state old)]
+      :_  this(state old)
+      :_  cards
+      :+  %pass  /cli-cleanup
+      [%agent [our.bol %hood] %poke %drum-unlink !>([%$ our.bol %chat-cli])]
     =.  cards
       :_  cards
       =-  [%pass /self-poke %agent [our.bol %chat-hook] %poke -]

--- a/pkg/landscape/desk.bill
+++ b/pkg/landscape/desk.bill
@@ -5,7 +5,6 @@
     %group-store
     %invite-store
     %s3-store
-    %chat-cli
     %chat-hook
     %chat-view
     %clock


### PR DESCRIPTION
Old groups software, no longer supported. Don't want this to be re-linked and confuse people just trying to use their dojo.

Confirmed that this works cleanly even if chat-cli is in the forefront when this logic runs. Used the /app/chat-hook because it seems most appropriate, and I don't trust changing logic of graph-store or w/e. Repeated runs of this will just no-op.

Closes #6229.