### PR TITLE
acme: handle https redirect in self-check

### DIFF
--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -584,7 +584,7 @@
       ~|  [%no-next-domain idx=idx]
       (head (skim pending |=([turf idx=@ud ?] =(idx ^idx))))
     ::  XX should confirm that :turf points to us
-    ::  confirms that domain exists
+    ::  confirms that domain exists (and an urbit is on the standard port)
     ::
     =/  sec=?  p:.^(hart:eyre %e /(scot %p our.bow)/host/(scot %da now.bow))
     =/  =purl

--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -584,10 +584,11 @@
       ~|  [%no-next-domain idx=idx]
       (head (skim pending |=([turf idx=@ud ?] =(idx ^idx))))
     ::  XX should confirm that :turf points to us
-    ::  confirms that domain exists (and an urbit is on :80)
+    ::  confirms that domain exists
     ::
+    =/  sec=?  p:.^(hart:eyre %e /(scot %p our.bow)/host/(scot %da now.bow))
     =/  =purl
-        :-  [sec=| por=~ host=[%& turf.next]]
+        :-  [sec=sec por=~ host=[%& turf.next]]
         [[ext=~ path=/'~debug'] query=~]
     =/  =wire
       (acme-wire try %validate-domain /idx/(scot %ud idx.next))
@@ -754,9 +755,8 @@
     ?>  ?=(%wake sas.u.rod)
     =*  aut  u.active.aut.u.rod
     =/  pat=path  /'.well-known'/acme-challenge/[tok.cal.aut]
-    ::  note: requires port 80, just as the ACME service will
-    ::
-    =/  url=purl  [[sec=| por=~ hos=[%& dom.aut]] [ext=~ pat] hed=~]
+    =/  sec=?  p:.^(hart:eyre %e /(scot %p our.bow)/host/(scot %da now.bow))
+    =/  url=purl  [[sec=sec por=~ hos=[%& dom.aut]] [ext=~ pat] hed=~]
     ::  =/  url=purl  [[sec=| por=`8.081 hos=[%& /localhost]] [ext=~ pat] hed=~]
     ::  XX idx in wire?
     ::

--- a/pkg/arvo/lib/dns.hoon
+++ b/pkg/arvo/lib/dns.hoon
@@ -36,7 +36,7 @@
   ;<  ~                     bind:m  (backoff:strandio try ~h1)
   ;<  rep=(unit httr:eyre)  bind:m  (hiss-request:strandio hiss)
   ?:  ?&  ?=(^ rep)
-          |(=(200 p.u.rep) =(307 p.u.rep))
+          |(=(200 p.u.rep) =(307 p.u.rep) =(301 p.u.rep))
       ==
     (pure:m &)
   ?.  ?|  ?=(~ rep)


### PR DESCRIPTION
also: libdns handle 301 redirect during self-check

when https redirects were implemented in eyre, the initial cert configuration worked ok. However, when trying to renew, it couldn't handle the now-enabled 301 redirects. This changes it so it just directly makes https requests for the self-checks if https is enabled in eyre

resolves #6234 