### PR TITLE
ames: put "is ok"/"not responding" behind |ames-verb

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -436,7 +436,7 @@
   +$  address  @uxaddress
   ::  $verb: verbosity flag for ames
   ::
-  +$  verb  ?(%snd %rcv %odd %msg %ges %for %rot)
+  +$  verb  ?(%snd %rcv %odd %msg %ges %for %rot %kay)
   ::  $blob: raw atom to or from unix, representing a packet
   ::
   +$  blob  @uxblob


### PR DESCRIPTION
Fixes #6245

Respects both `|ames-verb %kay` and `|ames-sift`