### PR TITLE
kiln: Keep %kids desk in sync after kelvin update

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1157,7 +1157,7 @@
       ::
       ~>  %slog.(fmt "finished downloading update for {here}")
       =.  let  +(let)
-      ::  If nothing changed, just advance
+      ::  If nothing changed, just ensure %kids is up-to-date and advance
       ::
       ?.  (get-remote-diff our syd now [her sud (dec let)])
         =<  next

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1160,8 +1160,15 @@
       ::  If nothing changed, just advance
       ::
       ?.  (get-remote-diff our syd now [her sud (dec let)])
-        ~>  %slog.(fmt "remote is identical to {here}, skipping")
-        next
+        =<  next
+        ?~  kid
+          ~>  %slog.(fmt "remote is identical to {here}, skipping")
+          ..abet
+        ?.  (get-remote-diff our u.kid now [her sud (dec let)])
+          ~>  %slog.(fmt "remote is identical to {here}, skipping")
+          ..abet
+        ~>  %slog.(fmt "remote is identical to {here}, merging into {<u.kid>}")
+        (merg /kids u.kid)
       ::  Else start merging, but also immediately start listening to
       ::  the next revision.  Now, all errors should no-op -- we're
       ::  already waiting for the next revision.
@@ -1188,7 +1195,7 @@
       ::
       ?~  kid
         ..abet
-      ~>  %slog.(fmt "kids merge into {<kid>}")
+      ~>  %slog.(fmt "kids merge into {<u.kid>}")
       (merg /kids u.kid)
     ::
         %kids


### PR DESCRIPTION
This is the fourth option described in #6244.

Fixes #6244