### PR TITLE
webterm: safer printf rendering

### DIFF
--- a/pkg/interface/webterm/lib/blit.ts
+++ b/pkg/interface/webterm/lib/blit.ts
@@ -58,15 +58,15 @@ export const showBlit = (term: Terminal, blit: Blit) => {
 
 export const showSlog = (term: Terminal, slog: string) => {
   //  set scroll region to exclude the bottom line,
-  //  scroll up one line,
-  //  move cursor to start of the newly created whitespace,
+  //  move cursor to bottom left of the scroll region,
+  //  print a newline to move everything up a line,
   //  set text to grey,
   //  print the slog,
   //  restore color, scroll region, and cursor.
   //
   term.write(csi('r', 1, term.rows - 1)
-           + csi('S', 1)
            + csi('H', term.rows - 1, 1)
+           + '\n'
            + csi('m', 90)
            + slog
            + csi('m', 0)


### PR DESCRIPTION
As it turns out, the exact behavior of the 'S' CSI command is not "move contents up into scrollback", but rather "delete the top line(s), move other contents up". This behavior leads webterm to eat into outputs whenever it renders slogs.

Xterm(.js), when given a newline character at the bottom of a scroll region, does produce the desired behavior of bumping the top line away into scrollback, instead of obliterating it.

This implementation now diverges from vere's, which is unfortunate, but the alternative is making webterm track the contents of the bottom-most line of the default session, which seems rather ridiculous by comparison.

Fixes #6257.