### PR TITLE
dojo: match hoon.hoon %know %hint printing style

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -709,7 +709,7 @@
       [%hint *]  ?+    q.p.a  $(a q.a)
                      [%know *]
                    ?@  p.q.p.a  [(cat 3 '#' mark.p.q.p.a)]~
-                   [(rap 3 '#' auth.p.q.p.a (spat type.p.q.p.a) ~)]~
+                   [(rap 3 '#' auth.p.q.p.a '+' (spat type.p.q.p.a) ~)]~
                  ::
                      [%help *]
                    [summary.crib.p.q.p.a]~


### PR DESCRIPTION
Hoon.hoon got the separating `+` added in 13d1c28 (part of #5641), but dojo was never updated to match. Here, we pass it on.

Super tiny change, so figured I should PR against the release candidate. Of course this logic really shouldn't live in two places, but here we are.