### PR TITLE
clay: fix +parse-pile syntax error output for EOF

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1012,9 +1012,15 @@
       %-  mean  %-  flop
       =/  lyn  p.hair
       =/  col  q.hair
+      =/  lyns=wain  (to-wain:format (crip tex))
+      =/  prev-lyn=@ud  (dec lyn)
+      ?:  (gth (lent lyns) prev-lyn)
+        :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
+            leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
+            leaf+(runt [(dec col) '-'] "^")
+        ==
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
-          leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
-          leaf+(runt [(dec col) '-'] "^")
+          leaf+"file missing a terminator"
       ==
     ::
     ++  pile-rule


### PR DESCRIPTION
When the parser reaches the end of the file and errors out there, no syntax error is output. This PR detects this case and handles it by printing the correct `[lyn col]` and a message about hitting the end of the file.

For a test case, try building these three file variants: 
1. will build correctly (it has no errors).
2. will error out correctly, with "syntax error" output
3. will error out silently on master, but print "syntax error" output, as expected, in this PR.

```hoon
::  /lib/my-test/hoon case 1
|%
++  arm-0  ~
++  arm-1
  |%
  ++  arm-1-0  ~
  --  ::  dev correctly ended the core in +arm-1
--
```

```hoon
::  /lib/my-test/hoon case 2
|%
++  arm-0  ~
++  arm-1
  |%
  ++  arm-1-0  ~
  ==  ::  dev incorrectly used `==` rather than `--` to end the core in +arm-1
--
```

```hoon
::  /lib/my-test/hoon case 3
|%
++  arm-0  ~
++  arm-1
  |%
  ++  arm-1-0  ~
--  ::  dev neglected to `--` the core in +arm-1
```

On master, builds look like:
```
::  case 1
> =a -build-file /=base=/lib/my-test/hoon

::  case 2
> |commit %base
>=
: /~nec/base/3/lib/my-test/hoon
clay: read-at-aeon fail [desk=%base care=%a case=[%da p=~2023.2.3..00.28.08..ce15] path=/lib/my-test/hoon]
syntax error at [6 3] in /lib/my-test/hoon
  ==
--^
[%error-building /lib/my-test/hoon]
clay: %a build failed [%base 3 /lib/my-test/hoon]
> =a -build-file /=base=/lib/my-test/hoon
thread failed: %build-file
[[p=~nec q=%base r=[%da p=~2023.2.3..00.28.08..ce15]] s=/lib/my-test/hoon]

::  case 3
> |commit %base
>=
: /~nec/base/4/lib/my-test/hoon
clay: read-at-aeon fail [desk=%base care=%a case=[%da p=~2023.2.3..00.28.18..9d3c] path=/lib/my-test/hoon]
[%error-building /lib/my-test/hoon]
clay: %a build failed [%base 4 /lib/my-test/hoon]
> =a -build-file /=base=/lib/my-test/hoon
thread failed: %build-file
[[p=~nec q=%base r=[%da p=~2023.2.3..00.28.18..9d3c]] s=/lib/my-test/hoon]
```

Using this PR, the first two cases (correct behavior) are unchanged and the third case looks like:

```
clay: read-at-aeon fail [desk=%base care=%a case=[%da p=~2023.2.3..00.50.38..453d] path=/lib/my-test/hoon]
syntax error at [7 1] in /lib/my-test/hoon
file missing a terminator
[%error-building /lib/my-test/hoon]
clay: %a build failed [%base 9 /lib/my-test/hoon]
> =a -build-file /=base=/lib/my-test/hoon
thread failed: %build-file
[[p=~nec q=%base r=[%da p=~2023.2.3..00.50.38..453d]] s=/lib/my-test/hoon]
```

EDIT: update intro