### PR TITLE
clay: fix +parse-pile syntax error output for EOF

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -964,9 +964,15 @@
       %-  mean  %-  flop
       =/  lyn  p.hair
       =/  col  q.hair
+      =/  lyns=wain  (to-wain:format (crip tex))
+      =/  prev-lyn=@ud  (dec lyn)
+      ?:  (gth (lent lyns) prev-lyn)
+        :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
+            leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
+            leaf+(runt [(dec col) '-'] "^")
+        ==
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
-          leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
-          leaf+(runt [(dec col) '-'] "^")
+          leaf+"file missing a terminator"
       ==
     ::
     ++  pile-rule


### PR DESCRIPTION
Fixes #6287 

When the parser reaches the end of the file and errors out there, no syntax error is output. This PR detects this case and handles it by printing the correct [lyn col] and a message about hitting the end of the file.