### PR TITLE
gen: forbid bad |new-desk names

### DIFF
--- a/pkg/arvo/gen/hood/new-desk.hoon
+++ b/pkg/arvo/gen/hood/new-desk.hoon
@@ -8,6 +8,7 @@
         [from=$~(%base desk) hard=_|]
     ==
 ::
+?>  ((sane %tas) desk)
 =;  make-new-desk
   ?.  ?&  !hard
           (~(has in .^((set ^desk) %cd (en-beam bek(q %$) /))) desk)


### PR DESCRIPTION
Minimal change to protect against #6266 

Ideally clay should do this, but we should get one or the other in asap before bad things happen.