### PR TITLE
webterm: v1.1.1

### DIFF
--- a/pkg/webterm/desk.docket-0
+++ b/pkg/webterm/desk.docket-0
@@ -1,9 +1,9 @@
 :~  title+'Terminal'
     info+'A web interface to your Urbit\'s command line.'
     color+0x2e.4347
-    glob-http+['https://bootstrap.urbit.org/glob-0v5.hvjci.n7c4h.1onl6.34g14.fut7c.glob' 0v5.hvjci.n7c4h.1onl6.34g14.fut7c]
+    glob-http+['https://bootstrap.urbit.org/glob-0vep1vb.e09fv.h88mg.endg6.3mip6.glob' 0vep1vb.e09fv.h88mg.endg6.3mip6]
     base+'webterm'
-    version+[1 1 0]
+    version+[1 1 1]
     website+'https://tlon.io'
     license+'MIT'
 ==


### PR DESCRIPTION
For release with a new glob that includes #6258.