### PR TITLE
clay: desk name sanity check

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4827,7 +4827,7 @@
   ::
       %merg                                               ::  direct state up
     ?:  =(%$ des.req)
-      ~&(%merg-no-desk !!)
+      ~|(%merg-no-desk !!)
     ?.  ((sane %tas) des.req)
       ~|([%merg-bad-desk-name des.req] !!)
     =^  mos  ruf
@@ -4837,9 +4837,9 @@
   ::
       %fuse
     ?:  =(%$ des.req)
-      ~&(%fuse-no-desk !!)
+      ~|(%fuse-no-desk !!)
     ?.  ((sane %tas) des.req)
-      ~&([%fuse-bad-desk-name des.req] !!)
+      ~|([%fuse-bad-desk-name des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(start-fuse:den bas.req con.req)
@@ -4886,7 +4886,7 @@
   ::
       %park
     ?.  ((sane %tas) des.req)
-      ~&([%park-bad-desk des.req] !!)
+      ~|([%park-bad-desk des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(park:den | & [yok ran]:req)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4829,7 +4829,7 @@
     ?:  =(%$ des.req)
       ~&(%merg-no-desk !!)
     ?.  ((sane %tas) des.req)
-      ~&(%merg-bad-desk-name !!)
+      ~|([%merg-bad-desk-name des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(start-merge:den her.req dem.req cas.req how.req)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4828,6 +4828,8 @@
       %merg                                               ::  direct state up
     ?:  =(%$ des.req)
       ~&(%merg-no-desk !!)
+    ?.  ((sane %tas) des.req)
+      ~&(%merg-bad-desk-name !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(start-merge:den her.req dem.req cas.req how.req)
@@ -4836,6 +4838,8 @@
       %fuse
     ?:  =(%$ des.req)
       ~&(%fuse-no-desk !!)
+    ?.  ((sane %tas) des.req)
+      ~&(%fuse-bad-desk-name !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(start-fuse:den bas.req con.req)
@@ -4881,6 +4885,8 @@
     [(weld moves-1 moves-2) ..^^$]
   ::
       %park
+    ?.  ((sane %tas) des.req)
+      ~&(%park-bad-desk !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(park:den | & [yok ran]:req)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4839,7 +4839,7 @@
     ?:  =(%$ des.req)
       ~&(%fuse-no-desk !!)
     ?.  ((sane %tas) des.req)
-      ~&(%fuse-bad-desk-name !!)
+      ~&([%fuse-bad-desk-name des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(start-fuse:den bas.req con.req)
@@ -4886,7 +4886,7 @@
   ::
       %park
     ?.  ((sane %tas) des.req)
-      ~&(%park-bad-desk !!)
+      ~&([%park-bad-desk des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
       abet:(park:den | & [yok ran]:req)


### PR DESCRIPTION
Ensures no desk with an illegal name can be created by sanity checking in `%fuse`, `%park`, and `%merge`.

Prevents the cause of #6266 but doesn't fix ships with bad desk names already.

Replaces #6290.