### PR TITLE
%base: add type restricting userspace moves to subset of arvo moves

### DIFF
--- a/pkg/arvo/app/acme.hoon
+++ b/pkg/arvo/app/acme.hoon
@@ -370,15 +370,15 @@
   ::
   ++  on-agent  on-agent:def
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
     =^  cards  state
-      ?+    wire  (on-arvo:def wire sign-arvo)
+      ?+    wire  (on-arvo:def wire sign-user)
           [%acme *]
-        ?+  +<.sign-arvo  (on-arvo:def wire sign-arvo)
-          %http-response  (http-response:ac wire +>.sign-arvo)
-          %wake           (wake:ac wire +>.sign-arvo)
-          %bound          (bound:ac wire +>.sign-arvo)
+        ?+  +<.sign-user  (on-arvo:def wire sign-user)
+          %http-response  (http-response:ac wire +>.sign-user)
+          %wake           (wake:ac wire +>.sign-user)
+          %bound          (bound:ac wire +>.sign-user)
         ==
       ==
     [cards this]

--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -110,7 +110,7 @@
   ++  on-agent  on-agent:def
   ::
   ++  on-arvo
-    |=  [=wire sign=sign-arvo]
+    |=  [=wire sign=sign-user:agent:gall]
     ^-  step:agent:gall
     ?+  wire  (on-arvo:def wire sign)
         [%wait @ ~]

--- a/pkg/arvo/app/azimuth-rpc.hoon
+++ b/pkg/arvo/app/azimuth-rpc.hoon
@@ -95,12 +95,12 @@
     ==
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
-    ?+  sign-arvo  (on-arvo:def wire sign-arvo)
+    ?+  sign-user  (on-arvo:def wire sign-user)
         [%eyre %bound *]
-      ~?  !accepted.sign-arvo
-        [dap.bowl 'bind rejected!' binding.sign-arvo]
+      ~?  !accepted.sign-user
+        [dap.bowl 'bind rejected!' binding.sign-user]
       [~ this]
     ==
   ::

--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -393,17 +393,17 @@
     (jael-update:do (to-udiffs:do effects))
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
-    ?:  &(=(/al wire) ?=(%arow +<.sign-arvo))
-      ?-    -.p.sign-arvo
+    |=  [=wire =sign-user:agent:gall]
+    ?:  &(=(/al wire) ?=(%arow +<.sign-user))
+      ?-    -.p.sign-user
           %&  `this
           %|
-        %-  (slog 'loading azimuth snapshot failed! still trying' p.p.sign-arvo)
+        %-  (slog 'loading azimuth snapshot failed! still trying' p.p.sign-user)
         [~[(init-timer (add ~s10 now.bowl))] this]
       ==
-    ?.  &(=(/init wire) ?=(%wake +<.sign-arvo))
-      (on-arvo:def wire sign-arvo)
-    ?^  error.sign-arvo
+    ?.  &(=(/init wire) ?=(%wake +<.sign-user))
+      (on-arvo:def wire sign-user)
+    ?^  error.sign-user
       %-  (slog 'azimuth: failed to initialize!' ~)
       `this
     :_  this

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -64,12 +64,12 @@
     handle-http-request:do
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
-    ?.  ?=([%eyre %bound *] sign-arvo)
-      (on-arvo:def wire sign-arvo)
-    ~?  !accepted.sign-arvo
-      [dap.bowl "bind rejected!" binding.sign-arvo]
+    ?.  ?=([%eyre %bound *] sign-user)
+      (on-arvo:def wire sign-user)
+    ~?  !accepted.sign-user
+      [dap.bowl "bind rejected!" binding.sign-user]
     [~ this]
   ::
   ++  on-peek   on-peek:def

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -709,7 +709,7 @@
       [%hint *]  ?+    q.p.a  $(a q.a)
                      [%know *]
                    ?@  p.q.p.a  [(cat 3 '#' mark.p.q.p.a)]~
-                   [(rap 3 '#' auth.p.q.p.a '+' (spat type.p.q.p.a) ~)]~
+                   [(rap 3 '#' auth.p.q.p.a (spat type.p.q.p.a) ~)]~
                  ::
                      [%help *]
                    [summary.crib.p.q.p.a]~
@@ -1740,7 +1740,7 @@
   [moves ..on-init]
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  (quip card:agent:gall _..on-init)
   ?>  ?=([@ @ *] wire)
   =/  =id  [(slav %p i.wire) i.t.wire]
@@ -1748,9 +1748,9 @@
   =/  he-full  ~(. he hid id ~ session)
   =^  moves  state
     =<  he-abet
-    ?+    +<.sign-arvo  ~|([%dojo-bad-take +<.sign-arvo] !!)
-        %writ           (he-writ:he-full t.t.wire +>.sign-arvo)
-        %http-response  (he-http-response:he-full t.t.wire +>.sign-arvo)
+    ?+    +<.sign-user  ~|([%dojo-bad-take +<.sign-user] !!)
+        %writ           (he-writ:he-full t.t.wire +>.sign-user)
+        %http-response  (he-http-response:he-full t.t.wire +>.sign-user)
     ==
   [moves ..on-init]
 ::  if dojo fails unexpectedly, kill whatever each session is working on

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -549,9 +549,9 @@
   --
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  (quip card agent:gall)
-  ?+    +<.sign-arvo  ~|([%strange-sign-arvo -.sign-arvo] !!)
+  ?+    +<.sign-user  ~|([%strange-sign-user -.sign-user] !!)
       %wake
     ?.  ?=([%timer *] wire)  ~&  weird-wire=wire  [~ this]
     =*  path  t.wire
@@ -559,7 +559,7 @@
       [~ this]
     =/  dog=watchdog
       (~(got by dogs.state) path)
-    ?^  error.sign-arvo
+    ?^  error.sign-user
       ::  failed, try again.  maybe should tell user if fails more than
       ::  5 times.
       ::

--- a/pkg/arvo/app/gaze.hoon
+++ b/pkg/arvo/app/gaze.hoon
@@ -156,9 +156,9 @@
     ==
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
-    ?+  +<.sign-arvo  ~|([dap.bowl %strange-arvo-sign +<.sign-arvo] !!)
+    ?+  +<.sign-user  ~|([dap.bowl %strange-arvo-sign +<.sign-user] !!)
         %wake
       ?:  =(/export wire)
         [[wait-export:do export:do] this]

--- a/pkg/arvo/app/herm.hoon
+++ b/pkg/arvo/app/herm.hoon
@@ -52,21 +52,21 @@
   [(pass-session ses %view ~)]~
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  (quip card:agent:gall _this)
   ~|  wire
-  ?+  wire  (on-arvo:def wire sign-arvo)
+  ?+  wire  (on-arvo:def wire sign-user)
     [%tube *]  [~ this]  ::  we no longer care about these
   ::
     ::  pass on dill blits for the session
     ::
       [%dill @ ~]
     =*  ses  i.t.wire
-    ?.  ?=([%dill %blit *] sign-arvo)
-      ~|  [%unexpected-sign [- +<]:sign-arvo]
+    ?.  ?=([%dill %blit *] sign-user)
+      ~|  [%unexpected-sign [- +<]:sign-user]
       !!
     :_  this
-    %+  turn  p.sign-arvo
+    %+  turn  p.sign-user
     |=  =blit:dill
     [%give %fact [%session ses %view ~]~ %blit !>(blit)]
   ::

--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -121,7 +121,7 @@
   ==
 ::
 ++  on-arvo
-  |=  [=wire syn=sign-arvo]
+  |=  [=wire syn=sign-user:agent:gall]
   ^-  step:agent:gall
   ?+  wire  ~|([%hood-bad-wire wire] !!)
     [%helm *]  =^(c helm.state (take-arvo:helm-core t.wire syn) [c this])

--- a/pkg/arvo/app/language-server.hoon
+++ b/pkg/arvo/app/language-server.hoon
@@ -98,12 +98,12 @@
   ++  on-agent  on-agent:def
   ++  on-arvo
     ^+  on-arvo:*agent:gall
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
     =^  cards  state
-      ?+  sign-arvo  (on-arvo:def wire sign-arvo)
+      ?+  sign-user  (on-arvo:def wire sign-user)
         [%eyre %bound *]  `state
-        [%clay *]  (handle-build:lsp wire +.sign-arvo)
+        [%clay *]  (handle-build:lsp wire +.sign-user)
       ==
     [cards this]
   ::

--- a/pkg/arvo/app/lens.hoon
+++ b/pkg/arvo/app/lens.hoon
@@ -270,10 +270,10 @@
   --
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  (quip card:agent:gall _this)
-  ?.  ?=(%bound +<.sign-arvo)
-    (on-arvo:def wire sign-arvo)
+  ?.  ?=(%bound +<.sign-user)
+    (on-arvo:def wire sign-user)
   [~ this]
 ::
 ++  on-fail   on-fail:def

--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -194,11 +194,11 @@
 ::  +on-arvo: handle timer firing
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  [(list card) _this]
   ?+    wire  !!
       [%ping-wait @ @ ~]
-    ?>  ?=(%wake +<.sign-arvo)
+    ?>  ?=(%wake +<.sign-user)
     =/  =ship      (slav %p i.t.wire)
     =/  until=@da  (slav %da i.t.t.wire)
     =/  s  (~(get by ships.state) ship)
@@ -207,7 +207,7 @@
     ?.  =([%waiting until] ship-state.u.s)
       `this
     =.  ships.state  (~(put by ships.state) ship u.s(ship-state [%idle ~]))
-    %-  (print-error "ping: wake" error.sign-arvo)
+    %-  (print-error "ping: wake" error.sign-user)
     =^  cards  state
       (send-ping our.bowl now.bowl ship)
     [cards this]
@@ -215,13 +215,13 @@
       [%jael @ ~]
     ::  whenever we get an update from Jael, kick
     ::
-    ?>  ?=(%public-keys +<.sign-arvo)
+    ?>  ?=(%public-keys +<.sign-user)
     :_  this
     [%pass /delay %arvo %b %wait now.bowl]~
   ::  Delayed until next event so that ames can clear its state
   ::
       [%delay ~]
-    ?>  ?=(%wake +<.sign-arvo)
+    ?>  ?=(%wake +<.sign-user)
     on-init
   ==
 ::

--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -95,12 +95,12 @@
     ==
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
-    ?+  sign-arvo  (on-arvo:def wire sign-arvo)
+    ?+  sign-user  (on-arvo:def wire sign-user)
         [%eyre %bound *]
-      ~?  !accepted.sign-arvo
-        [dap.bowl 'bind rejected!' binding.sign-arvo]
+      ~?  !accepted.sign-user
+        [dap.bowl 'bind rejected!' binding.sign-user]
       [~ this]
     ==
   ::

--- a/pkg/arvo/app/roller.hoon
+++ b/pkg/arvo/app/roller.hoon
@@ -587,20 +587,20 @@
     ==
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
-    ?+    wire  (on-arvo:def wire sign-arvo)
+    ?+    wire  (on-arvo:def wire sign-user)
         [%timer ~]
-      ?+  +<.sign-arvo  (on-arvo:def wire sign-arvo)
+      ?+  +<.sign-user  (on-arvo:def wire sign-user)
         %wake  =^(cards state (on-timer:do &) [cards this])
       ==
         [%quota-timer ~]
-      ?+  +<.sign-arvo  (on-arvo:def wire sign-arvo)
+      ?+  +<.sign-user  (on-arvo:def wire sign-user)
         %wake  =^(cards state on-quota-timer:do [cards this])
       ==
     ::
         [%predict ~]
-      ?+    +<.sign-arvo  (on-arvo:def wire sign-arvo)
+      ?+    +<.sign-user  (on-arvo:def wire sign-user)
           %wake
         =^  effects  state
           (predicted-state canonical):do
@@ -610,7 +610,7 @@
         [%resend @ @ ~]
       =/  [address=@ux nonce=@ud]
         [(slav %ux i.t.wire) (slav %ud i.t.t.wire)]
-      ?+    +<.sign-arvo  (on-arvo:def wire sign-arvo)
+      ?+    +<.sign-user  (on-arvo:def wire sign-user)
           %wake
         =/  cards=(list card)  (send-roll:do address nonce)
         =?  sending

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -215,12 +215,12 @@
   ::
   ++  on-arvo
     ~/  %on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card _this)
     =^  cards  state
-      ?+  wire  (on-arvo:def wire sign-arvo)
-        [%thread @ *]  (handle-sign:sc i.t.wire t.t.wire sign-arvo)
-        [%build @ ~]   (handle-build:sc i.t.wire sign-arvo)
+      ?+  wire  (on-arvo:def wire sign-user)
+        [%thread @ *]  (handle-sign:sc i.t.wire t.t.wire sign-user)
+        [%build @ ~]   (handle-build:sc i.t.wire sign-user)
         [%bind ~]      `state
       ==
     [cards this]
@@ -285,12 +285,12 @@
 ::
 ++  handle-sign
   ~/  %handle-sign
-  |=  [=tid =wire =sign-arvo]
+  |=  [=tid =wire =sign-user:agent:gall]
   =/  yarn  (~(get by tid.state) tid)
   ?~  yarn
     %-  (slog leaf+"spider got sign for non-existent {<tid>}" ~)
     `state
-  (take-input u.yarn ~ %sign wire sign-arvo)
+  (take-input u.yarn ~ %sign wire sign-user)
 ::
 ++  on-agent
   |=  [=tid =wire =sign:agent:gall]
@@ -356,14 +356,14 @@
 ::
 ++  handle-build
   ~/  %handle-build
-  |=  [=tid =sign-arvo]
+  |=  [=tid =sign-user:agent:gall]
   ^-  (quip card ^state)
   =/  =yarn  (~(got by tid.state) tid)
   =.  starting.state
     (~(jab by starting.state) yarn |=([=trying =vase] [%none vase]))
-  ~|  sign+[- +<]:sign-arvo
-  ?>  ?=([?(%behn %clay) %writ *] sign-arvo)
-  =/  =riot:clay  p.sign-arvo
+  ~|  sign+[- +<]:sign-user
+  ?>  ?=([?(%behn %clay) %writ *] sign-user)
+  =/  =riot:clay  p.sign-user
   ?~  riot
     (thread-fail-not-running tid %build-thread-error *tang)
   ?.  ?=(%vase p.r.u.riot)

--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -113,18 +113,18 @@
         ~>(%slog.[0 tank] same)
       --
   ::
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  [(list card) _this]
   ?.  ?&  ?=([%build *] wire)
-          ?=([%clay %writ *] sign-arvo)
+          ?=([%clay %writ *] sign-user)
       ==
-    (on-arvo:def wire sign-arvo)
+    (on-arvo:def wire sign-user)
   =/  =path  t.wire
   ?+    path  ~|(path+path !!)
       [%app *]
     =/  ok
-      ?~  p.sign-arvo  |
-      (~(nest ut -:!>(*agent:gall)) | -:!<(vase q.r.u.p.sign-arvo))
+      ?~  p.sign-user  |
+      (~(nest ut -:!>(*agent:gall)) | -:!<(vase q.r.u.p.sign-user))
     %-  (report path ok)
     =?  app-ok.state  !ok  %.n
     =.  app.state  (~(del in app.state) path)
@@ -133,7 +133,7 @@
     [~ this]
   ::
       [%mar *]
-    =/  ok  ?=(^ p.sign-arvo)
+    =/  ok  ?=(^ p.sign-user)
     %-  (report path ok)
     =?  mar-ok.state  !ok  %.n
     =.  mar.state  (~(del in mar.state) path)
@@ -142,7 +142,7 @@
     [~ this]
   ::
       [%gen *]
-    =/  ok  ?=(^ p.sign-arvo)
+    =/  ok  ?=(^ p.sign-user)
     %-  (report path ok)
     =?  gen-ok.state  !ok  %.n
     =.  gen.state  (~(del in gen.state) path)

--- a/pkg/arvo/app/time.hoon
+++ b/pkg/arvo/app/time.hoon
@@ -25,7 +25,7 @@
 ++  on-peek   on-peek:def
 ++  on-agent  on-agent:def
 ++  on-arvo
-  |=  [=wire sign=sign-arvo]
+  |=  [=wire sign=sign-user:agent:gall]
   ^-  (quip card _this)
   ?+    wire  !!
       [@ ~]

--- a/pkg/arvo/gen/hood/pass.hoon
+++ b/pkg/arvo/gen/hood/pass.hoon
@@ -1,3 +1,3 @@
 :-  %say
-|=  [^ [=note-arvo ~] ~]
-[%helm-pass note-arvo]
+|=  [^ [=user-note:agent:gall ~] ~]
+[%helm-pass user-note]

--- a/pkg/arvo/gen/hood/tomb.hoon
+++ b/pkg/arvo/gen/hood/tomb.hoon
@@ -49,7 +49,7 @@
       ~
     [[ship desk tako (~(gut by tom) tako nor) p.n.q.yaki] ~ ~]
   --
-^-  (list note-arvo)
+^-  (list user-note:agent:gall)
 %+  welp
   %+  murn  ~(tap in norms)
   |=  [=ship =desk =tako =norm =path]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -158,14 +158,14 @@
   (emit %pass /pack %arvo %d %flog %pack ~)
 ::
 ++  poke-pans
-  |=  pans=(list note-arvo)
+  |=  pans=(list user-note:agent:gall)
   ?~  pans  abet
   =.  this  (emit %pass /helm/pans %arvo i.pans)
   $(pans t.pans)
 ::
 ++  poke-pass
-  |=  =note-arvo  =<  abet
-  (emit %pass /helm/pass %arvo note-arvo)
+  |=  =user-note:agent:gall  =<  abet
+  (emit %pass /helm/pass %arvo user-note)
 ::
 ++  take-wake-automass
   |=  [way=wire error=(unit tang)]
@@ -245,10 +245,6 @@
   |=  ~  =<  abet
   (emit %pass /helm %arvo %a %stir '')
 ::
-++  poke-kroc
-  |=  dry=?  =<  abet
-  (emit [%pass /helm/kroc %arvo %a %kroc dry])
-::
 ++  poke-knob
   |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet
   (emit %pass /helm %arvo %d %knob error-tag level)
@@ -284,7 +280,6 @@
     %helm-ames-sift        =;(f (f !<(_+<.f vase)) poke-ames-sift)
     %helm-ames-verb        =;(f (f !<(_+<.f vase)) poke-ames-verb)
     %helm-ames-wake        =;(f (f !<(_+<.f vase)) poke-ames-wake)
-    %helm-kroc             =;(f (f !<(_+<.f vase)) poke-kroc)
     %helm-atom             =;(f (f !<(_+<.f vase)) poke-atom)
     %helm-automass         =;(f (f !<(_+<.f vase)) poke-automass)
     %helm-cancel-automass  =;(f (f !<(_+<.f vase)) poke-cancel-automass)
@@ -323,14 +318,14 @@
   (flog %text "bound: {<success>}")
 ::
 ++  take-arvo
-  |=  [=wire =sign-arvo]
-  ?+  wire  ~|([%helm-bad-take-wire wire +<.sign-arvo] !!)
+  |=  [=wire =sign-user:agent:gall]
+  ?+  wire  ~|([%helm-bad-take-wire wire +<.sign-user] !!)
     [%automass *]     %+  take-wake-automass  t.wire
-                      ?>(?=(%wake +<.sign-arvo) +>.sign-arvo)
+                      ?>(?=(%wake +<.sign-user) +>.sign-user)
     [%serv *]         %+  take-bound  t.wire
-                      ?>(?=(%bound +<.sign-arvo) +>.sign-arvo)
+                      ?>(?=(%bound +<.sign-user) +>.sign-user)
     [%moon-breach *]  %+  take-wake-moon-breach  t.wire
-                      ?>(?=(%wake +<.sign-arvo) +>.sign-arvo)
+                      ?>(?=(%wake +<.sign-user) +>.sign-user)
     [%pass *]         abet
   ==
 --

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -864,36 +864,36 @@
   ==
 ::
 ++  take-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^+  abet
   ?-    wire
       [%sync %merg *]   abet
       [%find-ship *]    abet
       [%sync *]         abet
-      [%zinc *]         (take-sync t.wire sign-arvo)
+      [%zinc *]         (take-sync t.wire sign-user)
       [%autocommit *]   %+  take-wake-autocommit  t.wire
-                        ?>(?=(%wake +<.sign-arvo) +>.sign-arvo)
+                        ?>(?=(%wake +<.sign-user) +>.sign-user)
       [%vats *]         abet
       [%fuse-request @tas *]
                       =/  f  (fuzz i.t.wire now)
                       ?~  f
                         abet
-                      abet:abet:(take:u.f t.t.wire sign-arvo)
-      [%fuse @tas *]  ?>  ?=(%mere +<.sign-arvo)
+                      abet:abet:(take:u.f t.t.wire sign-user)
+      [%fuse @tas *]  ?>  ?=(%mere +<.sign-user)
                       =/  syd=desk  i.t.wire
-                      ?.  ?=([%| *] +>.sign-arvo)
-                        ?~  p.p.sign-arvo
+                      ?.  ?=([%| *] +>.sign-user)
+                        ?~  p.p.sign-user
                           abet
                         =/  msg=tape  "fuse merge conflict for {<syd>}"
-                        %-  (slog [leaf+msg >p.p.sign-arvo< ~])
+                        %-  (slog [leaf+msg >p.p.sign-user< ~])
                         abet
-                      %-  (slog leaf+"failed fuse for {<syd>}" p.p.sign-arvo)
+                      %-  (slog leaf+"failed fuse for {<syd>}" p.p.sign-user)
                       abet
       *
-    ?+    +<.sign-arvo
-        ((slog leaf+"kiln: strange card {<+<.sign-arvo wire>}" ~) abet)
-      %done  (done wire +>.sign-arvo)
-      %mere  (take-mere wire +>.sign-arvo)
+    ?+    +<.sign-user
+        ((slog leaf+"kiln: strange card {<+<.sign-user wire>}" ~) abet)
+      %done  (done wire +>.sign-user)
+      %mere  (take-mere wire +>.sign-user)
     ==
   ==
 ++  take  |=(way=wire ?>(?=([@ ~] way) (work i.way))) ::  general handler
@@ -1005,7 +1005,7 @@
     send-fuse:make-requests
   ::
   ++  take
-    |=  [wir=wire =sign-arvo]
+    |=  [wir=wire =sign-user:agent:gall]
     ^+  ..fuse
     ?>  =((lent wir) 3)
     =/  who=ship  (slav %p (snag 0 wir))
@@ -1015,8 +1015,8 @@
       ::  If the hash in the wire doesn't match the current request
       ::  this is a response for a previous fuse that we can ignore.
       ..take
-    ?>  ?=([?(%clay %behn) %writ *] sign-arvo)
-    =/  gif  +.sign-arvo
+    ?>  ?=([?(%clay %behn) %writ *] sign-user)
+    =/  gif  +.sign-user
     ?~  p.gif
       %-  (slog leaf+"|fuse request failed for {<src>} on <who> - cancelling")
       delete
@@ -1052,14 +1052,14 @@
   --
 ::
 ++  take-sync
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ?>  ?=([@ @ @ *] wire)
   =*  syd  i.wire
   =/  her  (slav %p i.t.wire)
   =*  sud  i.t.t.wire
   ?.  (~(has by zyn) syd her sud)
     abet
-  abet:abet:(take:(sync syd her sud) t.t.t.wire sign-arvo)
+  abet:abet:(take:(sync syd her sud) t.t.t.wire sign-user)
 ::
 ++  sync
   |=  kiln-sync
@@ -1124,7 +1124,7 @@
   ::  Instead, we do the merges to syd and kid explicitly.
   ::
   ++  take
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^+  ..abet
     ?>  ?=([@ @ *] wire)
     ?.  =(nun i.wire)
@@ -1136,21 +1136,21 @@
       ?.  =(0 let)
         ~>  %slog.(fmt "sync-bad-stage {<let>} {<wire>}")
         ..abet
-      ?>  ?=(%arow +<.sign-arvo)
-      ?:  ?=(%| -.p.sign-arvo)
+      ?>  ?=(%arow +<.sign-user)
+      ?:  ?=(%| -.p.sign-user)
         ~>  %slog.(fmt "activation failed into {here}; retrying sync")
-        %-  (slog p.p.sign-arvo)
+        %-  (slog p.p.sign-user)
         init
       ::  Now that we know the revision, start main download loop
       ::
-      =.  let  !<(@ud q.p.p.sign-arvo)
+      =.  let  !<(@ud q.p.p.sign-user)
       next
     ::
         %next
-      ?>  ?=(%arow +<.sign-arvo)
-      ?:  ?=(%| -.p.sign-arvo)
+      ?>  ?=(%arow +<.sign-user)
+      ?:  ?=(%| -.p.sign-user)
         ::  ~>  %slog.(fmt "download failed into {here}; retrying sync")
-        ::  %-  (slog p.p.sign-arvo)
+        ::  %-  (slog p.p.sign-user)
         init
       ::
       ~>  %slog.(fmt "finished downloading update for {here}")
@@ -1175,18 +1175,18 @@
       next
     ::
         %main
-      ?>  ?=(%mere +<.sign-arvo)
+      ?>  ?=(%mere +<.sign-user)
       ::  This case is maintained by superstition.  If you remove it,
       ::  carefully test that if the source ship is breached, we
       ::  correctly reset let to 0
       ::
-      ?:  ?=([%| %ali-unavailable *] p.sign-arvo)
+      ?:  ?=([%| %ali-unavailable *] p.sign-user)
         =+  "kiln: merge into {here} failed, maybe because sunk; restarting"
-        %-  (slog leaf/- p.p.sign-arvo)
+        %-  (slog leaf/- p.p.sign-user)
         init
-      ?:  ?=(%| -.p.sign-arvo)
+      ?:  ?=(%| -.p.sign-user)
         =+  "kiln: merge into {here} failed, waiting for next revision"
-        %-  (slog leaf/- p.p.sign-arvo)
+        %-  (slog leaf/- p.p.sign-user)
         ..abet
       ~>  %slog.(fmt "merge into {<syd>} succeeded")
       ::  If we have a kids desk parameter, merge into that
@@ -1197,23 +1197,23 @@
       (merg /kids u.kid)
     ::
         %kids
-      ?>  ?=(%mere +<.sign-arvo)
+      ?>  ?=(%mere +<.sign-user)
       ?~  kid
         ..abet
       ::  See %main for this case
       ::
-      ?:  ?=([%| %ali-unavailable *] p.sign-arvo)
+      ?:  ?=([%| %ali-unavailable *] p.sign-user)
         =+  "kids merge to {<u.kid>} failed, maybe peer sunk; restarting"
         ~>  %slog.(fmt -)
         init
       ::  Just notify; we've already started listening for the next
       ::  version
       ::
-      ?-  -.p.sign-arvo
+      ?-  -.p.sign-user
         %&  ~>  %slog.(fmt "kids merge to {<u.kid>} succeeded")
             ..abet
         %|  ~>  %slog.(fmt "kids merge to {<u.kid>} failed")
-            %-  (slog p.p.sign-arvo)
+            %-  (slog p.p.sign-user)
             ..abet
       ==
     ==

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1845,7 +1845,7 @@
   +$  suss  (trel dude @tas @da)                        ::  config report
   +$  well  (pair desk term)                            ::
   +$  neat
-    $%  [%arvo =note-arvo]
+    $%  [%arvo =user-note:agent]
         [%agent [=ship name=term] =deal]
         [%pyre =tang]
     ==
@@ -1870,7 +1870,7 @@
     +$  card  (wind note gift)
     +$  note
       $%  [%agent [=ship name=term] =task]
-          [%arvo note-arvo]
+          [%arvo user-note]
           [%pyre =tang]
       ==
     +$  task
@@ -1891,6 +1891,154 @@
           [%watch-ack p=(unit tang)]
           [%fact =cage]
           [%kick ~]
+      ==
+    +$  user-gift
+      $%  $>(%done gift:ames) :: kiln
+          ::
+          $>(%wake gift:behn)
+          ::
+          $>(%wris gift:clay)
+          $>(%writ gift:clay)
+          $>(%tire gift:clay)
+          $>(%hill gift:clay)
+          $>(%mere gift:clay) :: kiln
+          $>(%cruz gift:clay)
+          $>(%croz gift:clay)
+          ::
+          $>(%blit gift:dill)
+          ::
+          $>(%bound gift:eyre)
+          ::
+          $>(%unto gift:gall)
+          ::
+          $>(%http-response gift:iris)
+          ::
+          $>(%private-keys gift:jael)
+          $>(%public-keys gift:jael)
+          $>(%turf gift:jael)
+          ::
+          $>(%arow gift:khan)
+      ==
+    +$  sign-user
+      $~  [%behn %wake ~]
+      $%  $:  %ames
+        $%  $>(%done gift:ames) :: kiln
+        ==  ==
+          $:  %behn
+        $%  $>(%wake gift:behn)
+        ==  ==
+          $:  %clay
+        $%  $>(%wris gift:clay)
+            $>(%writ gift:clay)
+            $>(%tire gift:clay)
+            $>(%hill gift:clay)
+            $>(%mere gift:clay) :: kiln
+            $>(%cruz gift:clay)
+            $>(%croz gift:clay)
+        ==  ==
+          $:  %dill
+        $%  $>(%blit gift:dill)
+        ==  ==
+          $:  %eyre
+        $%  $>(%bound gift:eyre)
+        ==  ==
+          $:  %gall
+        $%  $>(%unto gift:gall)
+        ==  ==
+          $:  %iris
+        $%  $>(%http-response gift:iris)
+        ==  ==
+          $:  %jael
+        $%  $>(%private-keys gift:jael)
+            $>(%public-keys gift:jael)
+            $>(%turf gift:jael)
+        ==  ==
+          $:  %khan
+        $%  $>(%arow gift:khan)
+        ==  ==
+      ==
+    +$  user-note
+      $~  [%b %rest *@da]
+      $%  $:  %a
+        $%  $>(%sift task:ames)
+            $>(%spew task:ames)
+            $>(%stir task:ames) :: helm does this
+            $>(%prod task:ames) :: helm does this
+            $>(%snub task:ames)
+        ==  ==
+          $:  %b
+        $%  $>(%rest task:behn)
+            $>(%wait task:behn)
+        ==  ==
+          $:  %c
+        $%  $>(%dirk task:clay)
+            $>(%mont task:clay)
+            $>(%ogre task:clay)
+            $>(%cred task:clay)
+            $>(%crew task:clay)
+            $>(%crow task:clay)
+            $>(%perm task:clay)
+            $>(%park task:clay)
+            $>(%info task:clay)
+            $>(%warp task:clay)
+            $>(%rein task:clay)
+            $>(%zest task:clay)
+            $>(%tire task:clay)
+            $>(%merg task:clay) :: kiln does this
+            $>(%fuse task:clay) :: kiln does this
+            $>(%drop task:clay) :: kiln does this
+            $>(%wick task:clay) :: kiln does this
+        ==  ==
+          $:  %d
+        $%  $>(%belt task:dill)
+            $>(%blew task:dill)
+            $>(%flee task:dill)
+            $>(%hail task:dill)
+            $>(%view task:dill)
+            $>(%crud task:dill)
+            $>(%talk task:dill)
+            $>(%text task:dill)
+            $>(%flog task:dill)
+            $>(%knob task:dill) :: helm does this
+            $>(%shot task:dill) :: herm does this
+        ==  ==
+          $:  %e
+        $%  $>(%connect task:eyre)
+            $>(%disconnect task:eyre)
+            $>(%rule task:eyre)
+            $>(%approve-origin task:eyre)
+            $>(%reject-origin task:eyre)
+            $>(%serve task:eyre)
+        ==  ==
+          $:  %g
+        $%  $>(%nuke task:gall)
+            $>(%deal task:gall)
+            $>(%spew task:gall) :: helm does this
+            $>(%sift task:gall) :: helm does this
+            $>(%doff task:gall) :: helm does this
+            $>(%sear task:gall) :: kiln does this
+        ==  ==
+          $:  %i
+        $%  $>(%request task:iris)
+            $>(%cancel-request task:iris)
+        ==  ==
+          $:  %j
+        $%  $>(%moon task:jael)
+            $>(%private-keys task:jael)
+            $>(%resend task:jael)
+            $>(%rekey task:jael)
+            $>(%step task:jael)
+            $>(%meet task:jael) :: docs say this task is deprecated and does not perform any actions
+            $>(%ruin task:jael)
+            $>(%nuke task:jael)
+            $>(%public-keys task:jael)
+            $>(%turf task:jael)
+            $>(%listen task:jael) :: base desk only
+        ==  ==
+          $:  %k
+        $%  $>(%fard task:khan)
+            $>(%lard task:khan) :: kiln does this
+        ==  ==
       ==
     ++  form
       $_  ^|
@@ -1926,7 +2074,7 @@
         *(quip card _^|(..on-init))
       ::
       ++  on-arvo
-        |~  [wire sign-arvo]
+        |~  [wire sign-user]
         *(quip card _^|(..on-init))
       ::
       ++  on-fail
@@ -2299,7 +2447,7 @@
   +$  card  card:agent:gall
   +$  input
     $%  [%poke =cage]
-        [%sign =wire =sign-arvo]
+        [%sign =wire =sign-user:agent:gall]
         [%agent =wire =sign:agent:gall]
         [%watch =path]
     ==

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -42,6 +42,36 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
+::
+::  $user-move: Moves emitted by userspace.
+::
++$  user-move  [=duct move=(wind user-note:agent user-gift:agent)]
+::
++$  gall-note
+  $%  $<(%a $<(%b user-note:agent))
+      $:  %a
+    $%  $>(%sift task:ames)
+        $>(%spew task:ames)
+        $>(%cork task:ames)
+        $>(%stir task:ames)
+        $>(%prod task:ames)
+        $>(%snub task:ames)
+    ==  ==
+      $:  %b
+    $%  $>(%rest task:behn)
+        $>(%wait task:behn)
+        $>(%huck task:behn)
+    ==  ==
+  ==
+::
++$  gall-gift  $%  user-gift:agent
+                   $>(%heck gift:behn)
+               ==
+::
+::  $gall-move: Moves emitted by Gall the vane.
+::
++$  gall-move  [=duct move=(wind gall-note gall-gift)]
+::
 ::  $state-11: overall gall state, versioned
 ::
 +$  state-11  [%11 state]
@@ -610,6 +640,19 @@
         =/  =routes  [disclosing=~ attributing=ship]
         (ap-abed:ap dap routes)
       ::
+      ?>  ?=  $%
+        [%ames %done *]
+        [%behn %wake *]
+        [%clay ?(%wris %writ %tire %hill %mere %cruz %croz) *]
+        [%dill %blit *]
+        [%eyre %bound *]
+        [%gall %unto *]
+        [%iris %http-response *]
+        [%jael ?(%private-keys %public-keys %turf) *]
+        [%khan %arow *]
+      ==
+        sign-arvo
+      ::
       =.  app  (ap-generic-take:app t.t.t.wire sign-arvo)
       ap-abet:app
     ?>  ?=([%out @ @ *] t.t.wire)
@@ -865,7 +908,7 @@
     |_  $:  agent-name=term
             agent-routes=routes
             agent-duct=duct
-            agent-moves=(list move)
+            agent-moves=(list gall-move)
             agent-config=(list (each suss tang))
             =yoke
         ==
@@ -954,13 +997,13 @@
     ::
     +$  neet
       $%  neat
-          [%huck [=ship name=term] =note-arvo]
+          [%huck [=ship name=term] =gall-note]
       ==
     ::
     ++  ap-from-internal
       ~/  %ap-from-internal
       |=  card=(wind neet gift:agent)
-      ^-  (list move)
+      ^-  (list gall-move)
       ::
       ?-    -.card
           %slip  !!
@@ -983,7 +1026,7 @@
         %-  zing
         %+  turn  ducts
         |=  =duct
-        ^-  (list move)
+        ^-  (list user-move)
         ~?  &(=(duct system-duct.state) !=(agent-name %hood))
           [%agent-giving-on-system-duct agent-name -.gift]
         =/  =mark  (~(gut by marks.yoke) duct p.cage)
@@ -1031,13 +1074,13 @@
             %arvo   [(scot %p attributing.agent-routes) wire]
           ==
         ::
-        =/  =note-arvo
+        =/  =gall-note
           ?-  -.neet
-            %arvo   note-arvo.neet
-            %huck   note-arvo.neet
+            %arvo   user-note.neet
+            %huck   gall-note.neet
             %agent  [%g %deal [our ship.neet] [name deal]:neet]
           ==
-        [duct %pass wire note-arvo]~
+        [duct %pass wire gall-note]~
       ==
     ::  +ap-breach: ship breached, so forget about them
     ::
@@ -1179,7 +1222,7 @@
     ::  +ap-move: send move
     ::
     ++  ap-move
-      |=  =(list move)
+      |=  =(list gall-move)
       ap-core(agent-moves (weld (flop list) agent-moves))
     ::  +ap-give: return result.
     ::
@@ -1267,11 +1310,11 @@
     ::
     ++  ap-generic-take
       ~/  %ap-generic-take
-      |=  [=wire =sign-arvo]
+      |=  [=wire =sign-user:agent]
       ^+  ap-core
       =^  maybe-tang  ap-core
         %+  ap-ingest  ~  |.
-        (on-arvo:ap-agent-core wire sign-arvo)
+        (on-arvo:ap-agent-core wire sign-user)
       ?^  maybe-tang
         (ap-error %arvo-response u.maybe-tang)
       ap-core
@@ -1475,7 +1518,7 @@
     ::
     ++  ap-kill-up-slip
       |=  =duct
-      ^-  (list move)
+      ^-  (list user-move)
       ::
       :~  [duct %slip %g %deal [our our] agent-name %leave ~]
           [duct %give %unto %kick ~]
@@ -1597,7 +1640,7 @@
         ?:  ?=(%& -.result)
           ~
         `p.result
-      =/  ack-moves=(list move)
+      =/  ack-moves=(list gall-move)
         %-  zing
         %-  turn  :_  ap-from-internal
         ^-  (list card:agent)
@@ -1615,7 +1658,7 @@
     ++  ap-handle-result
       ~/  %ap-handle-result
       |=  result=(each step:agent tang)
-      ^-  [(list move) _ap-core]
+      ^-  [(list gall-move) _ap-core]
       ?:  ?=(%| -.result)
         `ap-core
       ::
@@ -1627,7 +1670,7 @@
     ::
     ++  ap-handle-kicks
       ~/  %ap-handle-kicks
-      |=  moves=(list move)
+      |=  moves=(list gall-move)
       ^-  bitt
       =/  quits=(list duct)
         %+  murn  moves
@@ -1644,13 +1687,13 @@
     ::
     ++  ap-handle-peers
       ~/  %ap-handle-peers
-      |=  moves=(list move)
-      ^-  [(list move) _ap-core]
-      =|  new-moves=(list move)
-      |-  ^-  [(list move) _ap-core]
+      |=  moves=(list gall-move)
+      ^-  [(list gall-move) _ap-core]
+      =|  new-moves=(list gall-move)
+      |-  ^-  [(list gall-move) _ap-core]
       ?~  moves
         [(flop new-moves) ap-core]
-      =/  =move  i.moves
+      =/  move=gall-move  i.moves
       ?:  ?=([* %pass * %g %deal * * %leave *] move)
         =/  =wire  p.move.move
         ?>  ?=([%use @ @ %out @ @ *] wire)

--- a/pkg/base-dev/lib/agentio.hoon
+++ b/pkg/base-dev/lib/agentio.hoon
@@ -27,9 +27,9 @@
     (poke-our dap.bowl cage)
   ::
   ++  arvo
-    |=  =note-arvo
+    |=  =user-note:agent:gall
     ^-  card
-    [%pass wire %arvo note-arvo]
+    [%pass wire %arvo user-note]
   ::
   ++  watch
     |=  [=dock =path]

--- a/pkg/base-dev/lib/dbug.hoon
+++ b/pkg/base-dev/lib/dbug.hoon
@@ -141,9 +141,9 @@
     [cards this]
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card:agent:gall agent:gall)
-    =^  cards  agent  (on-arvo:ag wire sign-arvo)
+    =^  cards  agent  (on-arvo:ag wire sign-user)
     [cards this]
   ::
   ++  on-fail

--- a/pkg/base-dev/lib/default-agent.hoon
+++ b/pkg/base-dev/lib/default-agent.hoon
@@ -58,8 +58,8 @@
   ==
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
-  ~|  "unexpected system response {<-.sign-arvo>} to {<dap.bowl>} on wire {<wire>}"
+  |=  [=wire =sign-user:agent:gall]
+  ~|  "unexpected system response {<-.sign-user>} to {<dap.bowl>} on wire {<wire>}"
   !!
 ::
 ++  on-fail

--- a/pkg/base-dev/lib/shoe.hoon
+++ b/pkg/base-dev/lib/shoe.hoon
@@ -106,7 +106,7 @@
     *(quip card _^|(..on-init))
   ::
   ++  on-arvo
-    |~  [wire sign-arvo]
+    |~  [wire sign-user:agent:gall]
     *(quip card _^|(..on-init))
   ::
   ++  on-fail
@@ -384,9 +384,9 @@
     [(deal cards) this]
   ::
   ++  on-arvo
-    |=  [=wire =sign-arvo]
+    |=  [=wire =sign-user:agent:gall]
     ^-  (quip card:agent:gall agent:gall)
-    =^  cards  shoe  (on-arvo:og wire sign-arvo)
+    =^  cards  shoe  (on-arvo:og wire sign-user)
     [(deal cards) this]
   ::
   ++  on-fail

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -82,14 +82,14 @@
 ::
 ::
 ::
-++  take-sign-arvo
-  =/  m  (strand ,[wire sign-arvo])
+++  take-sign-user
+  =/  m  (strand ,[wire sign-user:agent:gall])
   ^-  form:m
   |=  tin=strand-input:strand
   ?+  in.tin  `[%skip ~]
       ~  `[%wait ~]
       [~ %sign *]
-    `[%done [wire sign-arvo]:u.in.tin]
+    `[%done [wire sign-user]:u.in.tin]
   ==
 ::
 ::  Wait for a subscription update on a wire
@@ -176,9 +176,9 @@
       [~ %sign [%wait @ ~] %behn %wake *]
     ?.  |(?=(~ until) =(`u.until (slaw %da i.t.wire.u.in.tin)))
       `[%skip ~]
-    ?~  error.sign-arvo.u.in.tin
+    ?~  error.sign-user.u.in.tin
       `[%done ~]
-    `[%fail %timer-error u.error.sign-arvo.u.in.tin]
+    `[%fail %timer-error u.error.sign-user.u.in.tin]
   ==
 ::
 ++  take-poke-ack
@@ -395,7 +395,7 @@
     ['http request was cancelled by the runtime']~
     ::
       [~ %sign [%request ~] %iris %http-response %finished *]
-    `[%done client-response.sign-arvo.u.in.tin]
+    `[%done client-response.sign-user.u.in.tin]
   ==
 ::
 ::  Wait until we get an HTTP response or cancelation and unset contract
@@ -422,7 +422,7 @@
       [~ %sign [%request ~] %iris %http-response %cancel *]
     `[%done ~]
       [~ %sign [%request ~] %iris %http-response %finished *]
-    `[%done `client-response.sign-arvo.u.in.tin]
+    `[%done `client-response.sign-user.u.in.tin]
   ==
 ::
 ++  extract-body
@@ -571,7 +571,7 @@
       [~ %sign * ?(%behn %clay) %writ *]
     ?.  =(wire wire.u.in.tin)
       `[%skip ~]
-    `[%done +>.sign-arvo.u.in.tin]
+    `[%done +>.sign-user.u.in.tin]
   ==
 ::  +check-online: require that peer respond before timeout
 ::

--- a/pkg/base-dev/lib/verb.hoon
+++ b/pkg/base-dev/lib/verb.hoon
@@ -73,12 +73,12 @@
   [[(emit-event %on-agent wire -.sign) cards] this]
 ::
 ++  on-arvo
-  |=  [=wire =sign-arvo]
+  |=  [=wire =sign-user:agent:gall]
   ^-  (quip card:agent:gall agent:gall)
   %-  %+  print  bowl  |.
-      "{<dap.bowl>}: on-arvo on wire {<wire>}, {<[- +<]:sign-arvo>}"
-  =^  cards  agent  (on-arvo:ag wire sign-arvo)
-  [[(emit-event %on-arvo wire [- +<]:sign-arvo) cards] this]
+      "{<dap.bowl>}: on-arvo on wire {<wire>}, {<[- +<]:sign-user>}"
+  =^  cards  agent  (on-arvo:ag wire sign-user)
+  [[(emit-event %on-arvo wire [- +<]:sign-user) cards] this]
 ::
 ++  on-fail
   |=  [=term =tang]


### PR DESCRIPTION
During the work on #6251 it became apparent that this would be a good opportunity to add a type disallowing userspace from emitting nonsense moves like `%born`. This change is sufficiently orthogonal to warrant a PR of its own.

This PR adds the necessary types to `/sys/lull`, `/sys/vane/gall` and modifies the files in `/app` and `/lib` to use the new type `$sign-user:agent:gall` instead of `sign-arvo`. Some tests will certainly fail but I don't know how to run them locally anymore so I'll fix them when CI fails.

Note that this change will be a breaking change for all Gall apps that have implemented the `+on-arvo` arm. It will also disallow `|pass` from passing arbitrary moves, so if this goes in we will need some other escape hatch.