### PR TITLE
eyre: revert inclusion of HttpOnly header for now

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1092,7 +1092,7 @@
       ^-  @t
       %-  crip
       =;  max-age=tape
-        "urbauth-{(scow %p our)}={(scow %uv session)}; Path=/; Max-Age={max-age}; HttpOnly"
+        "urbauth-{(scow %p our)}={(scow %uv session)}; Path=/; Max-Age={max-age}"
       %-  format-ud-as-integer
       ?.  extend  0
       (div (msec:milly session-timeout) 1.000)

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -2347,5 +2347,5 @@
 ::
 ++  cookie-string
   %^  cat  3  cookie-value
-  '; Path=/; Max-Age=604800; HttpOnly'
+  '; Path=/; Max-Age=604800'
 --


### PR DESCRIPTION
#5918 got deployed prematurely to ~binnec, without giving app developers a change to update their version of `http-api`. This broke Groups and pretty much every frontend app. This PR removes the `HttpOnly` header from eyre for now, but keeps the new `/~/name` endpoint so people can use the old stuff and the new stuff for a while. We can add the header back later.