### PR TITLE
clay: render syntax errors at end of file

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -964,8 +964,14 @@
       %-  mean  %-  flop
       =/  lyn  p.hair
       =/  col  q.hair
+      ^-  (list tank)
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
-          leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
+        ::
+          =/  =wain  (to-wain:format (crip tex))
+          ?:  (gth lyn (lent wain))
+            '<<end of file>>'
+          (snag (dec lyn) wain)
+        ::
           leaf+(runt [(dec col) '-'] "^")
       ==
     ::


### PR DESCRIPTION
Previously, if the pointer for a syntax error pointed to the end of the file (and the file ended in a newline) the code snippet rendering would try to display a line _beyond_ the end of the file, causing a crash.

Here, we detect that case, and display `<<end of file>>` instead.

(Originally merged through #5812, but got lost somewhere along the way. This is a cherry-pick of the commit from there.)

Fixes #6287. Supersedes #6288. Special thanks to @hosted-fornet for catching that this was missing again.