### PR TITLE
ames: store packet bloq size in subject

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -104,6 +104,7 @@
       rot=`?`%.n  ::  routing attempts
       kay=`?`%.n  ::  is ok/not responding
   ==
+=/  packet-size  13
 =>
 ~%  %ames  ..part  ~
 |%
@@ -156,7 +157,7 @@
   |=  [=message-num =message-blob]
   ^-  (list static-fragment)
   ::
-  =/  num-fragments=fragment-num  (met 13 message-blob)
+  =/  num-fragments=fragment-num  (met packet-size message-blob)
   =|  counter=@
   ::
   |-  ^-  (list static-fragment)
@@ -180,7 +181,7 @@
       sorted
     $(index +(index), sorted [(~(got by fragments) index) sorted])
   ::
-  (cue (rep 13 (flop sorted)))
+  (cue (rep packet-size (flop sorted)))
 ::  +jim: caching +jam
 ::
 ++  jim  |=(n=* ~+((jam n)))
@@ -439,11 +440,11 @@
   ::
   =?    meat.shut-packet
       ?&  ?=(%& -.meat.shut-packet)
-          (gth (met 13 fragment.p.meat.shut-packet) 1)
+          (gth (met packet-size fragment.p.meat.shut-packet) 1)
       ==
     %_    meat.shut-packet
         fragment.p
-      (cut 13 [[fragment-num 1] fragment]:p.meat.shut-packet)
+      (cut packet-size [[fragment-num 1] fragment]:p.meat.shut-packet)
     ==
   ::
   =/  vec  ~[sndr rcvr sndr-life rcvr-life]
@@ -2724,7 +2725,7 @@
     ++  dedup-message
       |=  =message-blob
       ^+  message-blob
-      ?:  (lte (met 13 message-blob) 1)
+      ?:  (lte (met packet-size message-blob) 1)
         message-blob
       =/  peers-l=(list [=ship =ship-state])  ~(tap by peers.ames-state)
       |-  ^+  message-blob


### PR DESCRIPTION
addresses #6340
this adds a variable at the top of ames, `packet-size`, set to `13`. This
1. is better style, letting people know what `13` means in the code
2. lets `%pyro` easily modify packet size for a large boost in performance