### PR TITLE
autoprop: properly keep track of runtime version

### DIFF
--- a/pkg/autoprop/app/autoprop.hoon
+++ b/pkg/autoprop/app/autoprop.hoon
@@ -256,6 +256,7 @@
       %-  (slog 'on-wake vers failed' u.error.sign)
       [[next]~ this]
     ?:  =(rev vers)  [[next]~ this]
+    =.  vers  rev
     =/  tasks=(list @ta)  ~(tap in ~(key by make))
     =|  cards=(list card)
     |-


### PR DESCRIPTION
Autoprop has a timer that checks whether we're on a new/different runtime periodically. When we detect we are, we re-build the props, so that they may be re-published under that new version identifier.

However, we weren't updating the cached runtime version we store in state, causing every firing of this timer to re-build the props.

Here, we correctly update state if we detect a difference, so that subsequent timers don't trigger redundant rebuilds.