### PR TITLE
dill: legible %logs

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -2,8 +2,8 @@
 /+  drum=hood-drum, helm=hood-helm, kiln=hood-kiln
 |%
 +$  state
-  $~  [%25 *state:drum *state:helm *state:kiln]
-  $>(%25 any-state)
+  $~  [%26 *state:drum *state:helm *state:kiln]
+  $>(%26 any-state)
 ::
 +$  any-state
   $%  [ver=?(%1 %2 %3 %4 %5 %6) lac=(map @tas fin-any-state)]
@@ -26,6 +26,7 @@
       [%23 drum=state-4:drum helm=state-2:helm kiln=state-9:kiln]
       [%24 drum=state-4:drum helm=state-2:helm kiln=state-10:kiln]
       [%25 drum=state-5:drum helm=state-2:helm kiln=state-10:kiln]
+      [%26 drum=state-6:drum helm=state-2:helm kiln=state-10:kiln]
   ==
 +$  any-state-tuple
   $:  drum=any-state:drum
@@ -124,6 +125,7 @@
   |=  [=wire syn=sign-arvo]
   ^-  step:agent:gall
   ?+  wire  ~|([%hood-bad-wire wire] !!)
+    [%drum *]  =^(c drum.state (take-arvo:drum-core t.wire syn) [c this])
     [%helm *]  =^(c helm.state (take-arvo:helm-core t.wire syn) [c this])
     [%kiln *]  =^(c kiln.state (take-arvo:kiln-core t.wire syn) [c this])
   ==

--- a/pkg/arvo/gen/hood/knob.hoon
+++ b/pkg/arvo/gen/hood/knob.hoon
@@ -1,4 +1,4 @@
-::  Helm: Adjust vane error verbosity knob
+::  Drum: Adjust vane error verbosity knob
 ::
 /?    310
 ::
@@ -6,5 +6,5 @@
   ::
 :-  %say
 |=  [^ [error-tag=@tas level=?(%hush %soft %loud) ~] ~]
-:-  %helm-knob
+:-  %drum-knob
 [error-tag level]

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -1,14 +1,16 @@
 /-  *sole
 /+  sole
 |%
-+$  state  state-5
++$  state  state-6
 +$  any-state
   $~  *state
-  $%  state-5
+  $%  state-6
+      state-5
       state-4
       state-3
       state-2
   ==
++$  state-6  [%6 pith-5]
 +$  state-5  [%5 pith-5]
 +$  state-4  [%4 pith-4]
 +$  state-3  [%3 pith-3]
@@ -130,7 +132,9 @@
 ++  klr   klr:format
 +$  state      ^state      ::  proxy
 +$  any-state  ^any-state  ::  proxy
-++  on-init    (poke-link %$ our.hid %dojo)
+++  on-init
+  =+  out=(poke-link %$ our.hid %dojo)
+  out(- [hear-logs -.out])
 ::
 ++  prep
   |=  s=@tas
@@ -229,7 +233,9 @@
       [%mod -.b p.b]
     --
   ::
-  ?>  ?=(%5 -.old)
+  =?  moz  ?=(%5 -.old)  [hear-logs moz]
+  =?  old  ?=(%5 -.old)  old(- %6)
+  ?>  ?=(%6 -.old)
   =.  sat  old
   =.  dev  (~(gut by bin) ses *source)
   this
@@ -276,6 +282,15 @@
   =^  gyl  this  (open way)
   ~&  [%drum-quit src.hid gyl]
   (se-drop %| gyl)
+::
+++  hear-logs
+  `card:agent:gall`[%pass /drum/dill/logs %arvo %d %logs [~ ~]]
+::
+++  take-arvo
+  |=  [way=wire syn=sign-arvo]
+  ?>  =(/dill/logs way)
+  ?>  ?=(%logs +<.syn)
+  se-abet:(se-told:(prep %$) told.syn)
 ::                                                    ::  ::
 ::::                                                  ::  ::
   ::                                                  ::  ::
@@ -363,6 +378,16 @@
   ~|  [inx=inx wag=wag fug=fug eel=eel]
   `(snag inx `(list gill:gall)`wag)
 ::
+++  se-told                                           ::  render system output
+  |=  =told:dill
+  ^+  +>
+  ?-  -.told
+    %crud  =.  +>  (se-text "crud: %{(trip p.told)} event failed")
+           (se-dump q.told)
+    %talk  (se-dump (flop p.told))  ::NOTE  +se-dump flops internally
+    %text  (se-text p.told)
+  ==
+::
 ++  se-belt                                           ::  handle input
   |=  bet=dill-belt:dill
   ^+  +>
@@ -438,7 +463,7 @@
   (se-blit %mor [%hop 0] [%wyp ~] lin [%nel ~] ~)
 ::
 ++  se-dump                                           ::  print tanks
-  |=  tac=(list tank)
+  |=  tac=tang
   ^+  +>
   =/  wol=wall
     (zing (turn (flop tac) |=(a=tank (~(win re a) [0 edg]))))

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -10,14 +10,19 @@
       state-3
       state-2
   ==
-+$  state-6  [%6 pith-5]
++$  state-6  [%6 pith-6]
 +$  state-5  [%5 pith-5]
 +$  state-4  [%4 pith-4]
 +$  state-3  [%3 pith-3]
 +$  state-2  [%2 pith-2]
 ::
-+$  pith-5
++$  pith-6
   $:  bin=(map @ source)                                ::  terminals
+      nob=(map @tas ?(%hush %soft %loud))
+  ==
+::
++$  pith-5
+  $:  bin=(map @ source)
   ==
 ::
 +$  pith-4
@@ -195,11 +200,16 @@
   =^  txt  +>  ?@(arg [arg +>] [+.arg (prep -.arg)])
   se-abet:(se-blit-sys [%sav pax txt])                ::
 ::
+++  poke-knob
+  |=  [tag=@tas lev=?(%hush %soft %loud)]
+  se-abet(nob (~(put by nob) tag lev))
+::
 ++  poke
   |=  [=mark =vase]
   ?>  =(our src):hid
   ?+  mark  ~|([%poke-drum-bad-mark mark] !!)
     %dill-poke           =;(f (f !<(_+<.f vase)) poke-dill)
+    %drum-knob           =;(f (f !<(_+<.f vase)) poke-knob)
     %drum-exit           =;(f (f !<(_+<.f vase)) poke-exit)
     %drum-link           =;(f (f !<(_+<.f vase)) poke-link)
     %drum-put            =;(f (f !<(_+<.f vase)) poke-put)
@@ -234,7 +244,7 @@
     --
   ::
   =?  moz  ?=(%5 -.old)  [hear-logs moz]
-  =?  old  ?=(%5 -.old)  old(- %6)
+  =?  old  ?=(%5 -.old)  [%6 bin.old ~]
   ?>  ?=(%6 -.old)
   =.  sat  old
   =.  dev  (~(gut by bin) ses *source)
@@ -382,7 +392,10 @@
   |=  =told:dill
   ^+  +>
   ?-  -.told
-    %crud  =.  +>  (se-text "crud: %{(trip p.told)} event failed")
+    %crud  =/  lev  (~(gut by nob) p.told %loud)
+           =?  +>.$  !=(%hush lev)
+             (se-text "crud: %{(trip p.told)} event failed")
+           ?.  =(%loud lev)  +>.$
            (se-dump q.told)
     %talk  (se-dump (flop p.told))  ::NOTE  +se-dump flops internally
     %text  (se-text p.told)

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -249,10 +249,6 @@
   |=  dry=?  =<  abet
   (emit %pass /helm %arvo %a %kroc dry)
 ::
-++  poke-knob
-  |=  [error-tag=@tas level=?(%hush %soft %loud)]  =<  abet
-  (emit %pass /helm %arvo %d %knob error-tag level)
-::
 ++  poke-serve
   |=  [=binding:eyre =generator:eyre]  =<  abet
   (emit %pass /helm/serv %arvo %e %serve binding generator)
@@ -295,7 +291,6 @@
     %helm-gall-sift        =;(f (f !<(_+<.f vase)) poke-gall-sift)
     %helm-gall-verb        =;(f (f !<(_+<.f vase)) poke-gall-verb)
     %helm-hi               =;(f (f !<(_+<.f vase)) poke-hi)
-    %helm-knob             =;(f (f !<(_+<.f vase)) poke-knob)
     %helm-pans             =;(f (f !<(_+<.f vase)) poke-pans)
     %helm-mass             =;(f (f !<(_+<.f vase)) poke-mass)
     %helm-meld             =;(f (f !<(_+<.f vase)) poke-meld)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1285,7 +1285,7 @@
     ==                                                  ::
   +$  dill-belt                                         ::  arvo input
     $%  belt                                            ::  client input
-        [%cru p=@tas q=(list tank)]                     ::  echo error
+        [%cru p=@tas q=(list tank)]                     ::  errmsg (deprecated)
         [%hey ~]                                        ::  refresh
         [%rez p=@ud q=@ud]                              ::  resize, cols, rows
         [%yow p=gill:gall]                              ::  connect to app

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1232,7 +1232,7 @@
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade
         [%verb ~]                                       ::  verbose mode
-        [%knob tag=term level=?(%hush %soft %loud)]     ::  error verbosity
+        [%knob tag=term level=?(%hush %soft %loud)]     ::  deprecated removeme
         session-task                                    ::  for default session
         told                                            ::  system output
     ==                                                  ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1215,26 +1215,26 @@
         [%meld ~]                                       ::  unify memory
         [%pack ~]                                       ::  compact memory
         [%trim p=@ud]                                   ::  trim kernel state
+        [%logs =told]                                   ::  system output
     ==                                                  ::
   +$  task                                              ::  in request ->$
     $~  [%vega ~]                                       ::
     $%  [%boot lit=? p=*]                               ::  weird %dill boot
         [%crop p=@ud]                                   ::  trim kernel state
-        [%crud p=@tas q=(list tank)]                    ::  print error
         [%flog p=flog]                                  ::  wrapped error
         [%heft ~]                                       ::  memory report
         $>(%init vane-task)                             ::  after gall ready
+        [%logs p=(unit ~)]                              ::  watch system output
         [%meld ~]                                       ::  unify memory
         [%pack ~]                                       ::  compact memory
         [%seat =desk]                                   ::  install desk
         [%shot ses=@tas task=session-task]              ::  task for session
-        [%talk p=(list tank)]                           ::  print tanks
-        [%text p=tape]                                  ::  print tape
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade
         [%verb ~]                                       ::  verbose mode
         [%knob tag=term level=?(%hush %soft %loud)]     ::  error verbosity
         session-task                                    ::  for default session
+        told                                            ::  system output
     ==                                                  ::
   ::                                                    ::
   +$  session-task                                      ::  session request
@@ -1245,6 +1245,12 @@
         [%open p=dude:gall q=(list gill:gall)]          ::  setup session
         [%shut ~]                                       ::  close session
         [%view ~]                                       ::  watch session blits
+    ==                                                  ::
+  ::                                                    ::
+  +$  told                                              ::  system output
+    $%  [%crud p=@tas q=tang]                           ::  error
+        [%talk p=(list tank)]                           ::  tanks (in order)
+        [%text p=tape]                                  ::  tape
     ==                                                  ::
   ::
   ::::                                                  ::  (1d2)
@@ -1290,11 +1296,11 @@
     ==                                                  ::
   +$  flog                                              ::  sent to %dill
     $%  [%crop p=@ud]                                   ::  trim kernel state
-        [%crud p=@tas q=(list tank)]                    ::
+        $>(%crud told)                                  ::
         [%heft ~]                                       ::
         [%meld ~]                                       ::  unify memory
         [%pack ~]                                       ::  compact memory
-        [%text p=tape]                                  ::
+        $>(%text told)                                  ::
         [%verb ~]                                       ::  verbose mode
     ==                                                  ::
   ::                                                    ::

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -14,9 +14,6 @@
       eye=(jug @tas duct)                               ::  outside observers
       ear=(set duct)                                    ::  syslog listeners
       lit=?                                             ::  boot in lite mode
-      $=  veb                                           ::  vane verbosities
-      $~  (~(put by *(map @tas log-level)) %hole %soft) ::  quiet packet crashes
-      (map @tas log-level)                              ::
       egg=_|                                            ::  see +take, removeme
   ==                                                    ::
 +$  axon                                                ::  dill session
@@ -308,10 +305,13 @@
   ::
   ?:  ?=(?(%trim %vega) -.task)
     [~ ..^$]
-  ::  %knob sets a verbosity level for an error tag
+  ::  %knob used to set a verbosity level for an error tag,
+  ::  but dill no longer prints errors itself, so implementing %knob
+  ::  has become a recommendation to error printers (like drum).
+  ::  remove this when %knob gets removed from lull, next™ kelvin release.
   ::
   ?:  ?=(%knob -.task)
-    =.  veb.all  (~(put by veb.all) tag.task level.task)
+    ~&  [%dill %knob-deprecated]
     [~ ..^$]
   ::  %open opens a new dill session
   ::
@@ -408,7 +408,7 @@
   ++  axle-6-to-7
     |=  a=axle-6
     ^-  axle
-    a(- %7, |4 [~ |4.a])
+    [%7 hey dug eye ~ lit egg]:a
   ::
   +$  axle-5
     $:  %5

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -8,10 +8,11 @@
 --                                                      ::
 =>  |%                                                  ::  console protocol
 +$  axle                                                ::
-  $:  %6                                                ::
+  $:  %7                                                ::
       hey=(unit duct)                                   ::  default duct
       dug=(map @tas axon)                               ::  conversations
-      eye=(jug @tas duct)                               ::  outside listeners
+      eye=(jug @tas duct)                               ::  outside observers
+      ear=(set duct)                                    ::  syslog listeners
       lit=?                                             ::  boot in lite mode
       $=  veb                                           ::  vane verbosities
       $~  (~(put by *(map @tas log-level)) %hole %soft) ::  quiet packet crashes
@@ -400,6 +401,18 @@
   ?:  ?=(%flee -.task)
     :-  ~
     ..^$(eye.all (~(del ju eye.all) ses hen))
+  ::  %logs opens or closes a subscription to system output
+  ::
+  ?:  ?=(%logs -.task)
+    =.  ear.all
+      ?~  p.task  (~(del in ear.all) hen)
+      (~(put in ear.all) hen)
+    [~ ..^$]
+  ::  if we were $told something, give %logs to all interested parties
+  ::
+  ?:  ?=(?(%crud %talk %text) -.task)
+    :_  ..^$
+    (turn ~(tap in ear.all) (late %give %logs task))
   ::
   =/  nus
     (ax hen ses)
@@ -408,8 +421,7 @@
     ::  could be before %boot (or %boot failed)
     ::
     ~&  [%dill-call-no-session ses hen -.task]
-    =/  tan  ?:(?=(%crud -.task) q.task ~)
-    [((slog (flop tan)) ~) ..^$]
+    [~ ..^$]
   ::
   =^  moz  all  abet:(call:u.nus task)
   [moz ..^$]
@@ -417,12 +429,28 @@
 ++  load                                                ::  import old state
   =<  |=  old=any-axle
       ?-  -.old
-        %6  ..^$(all old)
+        %7  ..^$(all old)
+        %6  $(old (axle-6-to-7 old))
         %5  $(old (axle-5-to-6 old))
         %4  $(old (axle-4-to-5 old))
       ==
   |%
-  +$  any-axle  $%(axle axle-5 axle-4)
+  +$  any-axle  $%(axle axle-6 axle-5 axle-4)
+  ::
+  +$  axle-6
+    $:  %6
+        hey=(unit duct)
+        dug=(map @tas axon)
+        eye=(jug @tas duct)
+        lit=?
+        veb=(map @tas log-level)
+        egg=_|
+    ==
+  ::
+  ++  axle-6-to-7
+    |=  a=axle-6
+    ^-  axle
+    a(- %7, |4 [~ |4.a])
   ::
   +$  axle-5
     $:  %5
@@ -435,7 +463,7 @@
   ::
   ++  axle-5-to-6
     |=  a=axle-5
-    ^-  axle
+    ^-  axle-6
     :: [%6 hey `(map @tas axon)`dug eye lit veb |]
     a(- %6, veb [veb.a &])
   ::

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -98,10 +98,6 @@
         ?+    -.kyz  ~&  [%strange-kiss -.kyz]  +>
           %hail  (send %hey ~)
           %belt  (send `dill-belt`p.kyz)
-          %talk  (talk p.kyz)
-          %text  (fore (tuba p.kyz) ~)
-          %crud  ::  (send `dill-belt`[%cru p.kyz q.kyz])
-                 (crud p.kyz q.kyz)
           %blew  (send(wid p.p.kyz) %rez p.p.kyz q.p.kyz)
           %heft  (pass /whey %$ whey/~)
           %meld  (dump kyz)
@@ -116,25 +112,11 @@
         ==
       ::
       ++  crud
-        |=  [err=@tas tac=(list tank)]
-        ::  unknown errors default to %loud
-        ::
-        =/  lev=log-level  (~(gut by veb.all) err %loud)
-        ::  apply log level for this error tag
-        ::
-        ?-  lev
-          %hush  +>.$
-          %soft  (fore (tuba "crud: %{(trip err)} event failed") ~)
-          %loud  (talk leaf+"crud: %{(trip err)} event failed" (flop tac))
-        ==
-      ::
-      ++  talk
-        |=  tac=(list tank)
-        %-  fore
-        %-  zing
-        %+  turn  tac
-        |=  a=tank
-        (turn (~(win re a) [0 wid]) tuba)
+        |=  [err=@tas tac=tang]
+        =-  +>.$(moz (weld - moz))
+        %+  turn
+          ~(tap in ear.all)
+        (late %give %logs %crud err tac)
       ::
       ++  dump                                          ::  pass down to hey
         |=  git=gift
@@ -155,30 +137,6 @@
       ++  pass                                          ::  pass note
         |=  [=wire =note]
         +>(moz :_(moz [hen %pass wire note]))
-      ::
-      ++  fore                                          ::  send dill output
-        ::NOTE  there are still implicit assumptions
-        ::      about the underlying console app's
-        ::      semantics here. specifically, trailing
-        ::      newlines are important to not getting
-        ::      overwritten by the drum prompt, and a
-        ::      bottom-of-screen cursor position gives
-        ::      nicest results. a more agnostic solution
-        ::      will need to replace this arm, someday.
-        ::      perhaps +send this to .ram instead?
-        ::
-        |=  liz=(list (list @c))
-        ~?  !=(%$ ses)  [%d %foreing-in-session ses]
-        ^+  +>
-        =.  +>
-          =|  biz=(list blit)
-          |-  ^+  +>.^$
-          ?~  liz  (done %blit [%hop 0] [%wyp ~] biz)
-          $(liz t.liz, biz (welp biz [%put i.liz] [%nel ~] ~))
-        ::  since dill is acting on its own accord,
-        ::  we %hey the term app so it may clean up.
-        ::
-        (send %hey ~)
       ::
       ++  from                                          ::  receive blit
         |=  bit=dill-blit


### PR DESCRIPTION
Adds a `%logs` task to dill, which can be used to un/subscribe to system output.

All of `%crud`, `%talk` and `%text` are now considered "system output" for this purpose. Dill no longer renders those itself. This further uncouples it from drum, dill now makes no assumptions about the default session except the fact that it exists.

Drum has been updated to subscribe to these `%logs`, and will now render those in dill's stead. The visible behavior here should not have changed, they always get rendered into the default session.  
(That's a little bit of a lie. Cases where non-default sessions would experience poke-nacks or watch-nacks (in dill's interactions with the terminal handler agent) would previously get rendered in their associated sessions. I think considering those part of the "global system output" is sane though.)

(This also opens up room for questions around error handling. If the user tries doing something in a non-default session, but it fails, will they be able to see without going back to the default session? This will probably be part of the "long tail" described in #6339.)

Drum also re-implements `|knob`, for making error outputs quieter. @belisarius222 I'm having second thoughts about this one, thinking that maybe this filtering should happen on the dill level still, because it's more "global" of a setting. But doing knob at the edges instead (as in this PR rn) ensures interested subscribers are never missing out on anything, which might be the more important consideration.  
(I'll want to rip out the dill-side knob mechanism if we agree it's no longer needed.)

This intentionally does not auto-include the default duct (which goes to the runtime) in the list of `%logs` subscribers, to avoid current runtimes crying out `kick: lost %logs`. When the time comes, runtimes can inject a `%logs` task (but will need to clean up, or remember they already did so?) or we can update dill to send these to the default ducts as well.

Fixes #6339, see that for further detail.