### PR TITLE
lull, eyre: add intermediate type for /~/name endpoint

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:544744b6d1360692b83be7f3e505d0710ea6ce541912509601e81fec2a2cea2e
-size 5992253
+oid sha256:4066cd90ac7d33b3d96b1b4d611d846d941de6e538c8355047c7cafcadce0851
+size 6017832

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1558,8 +1558,9 @@
         ::
         [%scry ~]
         ::  respond with the @p the requester is authenticated as
+        ::  TODO: put this back in when we burn the next kelvin
         ::
-        [%name ~]
+        ::  [%name ~]
         ::  respond with the default file not found page
         ::
         [%four-oh-four ~]

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -75,6 +75,32 @@
       ::
       =server-state
   ==
+::
+::  +outstanding-connection-new: intermediate type to enable
+::                               /~/name endpoint without
+::                               breaking type change in lull
+::
++$  outstanding-connection-new
+    $:  ::  action: the action that had matched
+        ::
+        action=action-new
+        ::  inbound-request: the original request which caused this connection
+        ::
+        =inbound-request
+        ::  response-header: set when we get our first %start
+        ::
+        response-header=(unit response-header:http)
+        ::  bytes-sent: the total bytes sent in response
+        ::
+        bytes-sent=@ud
+    ==
+::  +action-new: intermediate type to enable /~/name endpoint
+::               without  breaking type change in lull
+::
++$  action-new
+  $%  action
+     [%name ~]
+  ==
 ::  +server-state: state relating to open inbound HTTP connections
 ::
 +$  server-state
@@ -87,13 +113,13 @@
       ::    TODO: It would be nice if we had a path trie. We could decompose
       ::    the :binding into a (map (unit @t) (trie knot =action)).
       ::
-      bindings=(list [=binding =duct =action])
+      bindings=(list [=binding =duct action=action-new])
       ::  cors-registry: state used and managed by the +cors core
       ::
       =cors-registry
       ::  connections: open http connections not fully complete
       ::
-      connections=(map duct outstanding-connection)
+      connections=(map duct outstanding-connection-new)
       ::  authentication-state: state managed by the +authentication core
       ::
       =authentication-state
@@ -580,7 +606,7 @@
     ::
     =/  act  [%app app=%lens]
     ::
-    =/  connection=outstanding-connection
+    =/  connection=outstanding-connection-new
       [act [& secure address request] ~ 0]
     ::
     =.  connections.state
@@ -604,13 +630,13 @@
       (fall (forwarded-for u.forwards) address)
     ::
     =/  host  (get-header:http 'host' headers)
-    =/  [=action suburl=@t]
+    =/  [action=action-new suburl=@t]
       (get-action-for-binding host url.request)
     ::
     =/  authenticated  (request-is-logged-in:authentication request)
     ::  record that we started an asynchronous response
     ::
-    =/  connection=outstanding-connection
+    =/  connection=outstanding-connection-new
       [action [authenticated secure address request] ~ 0]
     =.  connections.state
       (~(put by connections.state) duct connection)
@@ -1936,7 +1962,7 @@
               (session-cookie-string u.session-id &)
             headers.response-header.http-event
           ::
-          =/  connection=outstanding-connection
+          =/  connection=outstanding-connection-new
             (~(got by connections.state) duct)
           ::  if the request was a simple cors request from an approved origin
           ::  append the necessary cors headers to the response
@@ -1972,7 +1998,7 @@
           ::
           =.  connections.state
             %+  ~(jab by connections.state)  duct
-            |=  connection=outstanding-connection
+            |=  connection=outstanding-connection-new
             =+  size=?~(data.http-event 0 p.u.data.http-event)
             connection(bytes-sent (add bytes-sent.connection size))
           ::
@@ -2025,7 +2051,7 @@
   ::    Adds =binding =action if there is no conflicting bindings.
   ::
   ++  add-binding
-    |=  [=binding =action]
+    |=  [=binding action=action-new]
     ^-  [(list move) server-state]
     =^  success  bindings.state
       ::  prevent binding in reserved namespaces
@@ -2046,7 +2072,7 @@
     %_    state
         bindings
       %+  skip  bindings.state
-      |=  [item-binding=^binding item-duct=^duct =action]
+      |=  [item-binding=^binding item-duct=^duct action=action-new]
       ^-  ?
       &(=(item-binding binding) =(item-duct duct))
     ==
@@ -2054,7 +2080,7 @@
   ::
   ++  get-action-for-binding
     |=  [raw-host=(unit @t) url=@t]
-    ^-  [=action suburl=@t]
+    ^-  [action=action-new suburl=@t]
     ::  process :raw-host
     ::
     ::    If we are missing a 'Host:' header, if that header is a raw IP
@@ -2167,8 +2193,8 @@
 ::  +insert-binding: add a new binding, replacing any existing at its path
 ::
 ++  insert-binding
-  |=  $:  new=[=binding =duct =action]
-          bindings=(list [=binding =duct =action])
+  |=  $:  new=[=binding =duct action=action-new]
+          bindings=(list [=binding =duct action=action-new])
       ==
   ^+  bindings
   ?~  bindings  [new]~
@@ -2231,7 +2257,7 @@
     ::
     =.  bindings.server-state.ax
       =-  (roll - insert-binding)
-      ^-  (list [binding ^duct action])
+      ^-  (list [binding ^duct action-new])
       :~  [[~ /~/login] duct [%authentication ~]]
           [[~ /~/logout] duct [%logout ~]]
           [[~ /~/channel] duct [%channel ~]]
@@ -2609,6 +2635,31 @@
   --
 ::
 ++  http-server-gate  ..$
+::  +bindings-old: filter /~/name endpoint from bindings
+::
+++  bindings-old
+  |=  new=(list [b=binding d=duct a=action-new])
+  =|  old=(list [binding duct action])
+  |-  ^+  old
+  ?~  new  old
+  =/  l
+    ?:  ?=([%name ~] a.i.new)
+      old
+    (snoc old [b.i.new d.i.new a.i.new])
+  $(new t.new, old l)
+::  +connections-old: filter /~/name endpoint from connections
+::
+++  connections-old
+  |=  new=(map duct outstanding-connection-new)
+  =|  old=(map duct outstanding-connection)
+  =/  l=(list [d=duct o=outstanding-connection-new])  ~(tap by new)
+  |-  ^+  old
+  ?~  l  old
+  =/  x
+    ?:  ?=([%name ~] -.o.i.l)
+      old
+    (~(put by old) d.i.l o.i.l)
+  $(l t.l, old x)
 ::  +load: migrate old state to new state (called on vane reload)
 ::
 ++  load
@@ -2663,9 +2714,9 @@
   =*  who  p.why
   ?:  =(tyl /whey)
     =/  maz=(list mass)
-      :~  bindings+&+bindings.server-state.ax
+      :~  bindings+&+(bindings-old bindings.server-state.ax)
           auth+&+authentication-state.server-state.ax
-          connections+&+connections.server-state.ax
+          connections+&+(connections-old connections.server-state.ax)
           channels+&+channel-state.server-state.ax
           axle+&+ax
       ==
@@ -2705,8 +2756,8 @@
   ?.  ?=(%$ ren)
     [~ ~]
   ?+  syd  [~ ~]
-    %bindings              ``noun+!>(bindings.server-state.ax)
-    %connections           ``noun+!>(connections.server-state.ax)
+    %bindings              ``noun+!>((bindings-old bindings.server-state.ax))
+    %connections           ``noun+!>((connections-old connections.server-state.ax))
     %authentication-state  ``noun+!>(authentication-state.server-state.ax)
     %channel-state         ``noun+!>(channel-state.server-state.ax)
   ::


### PR DESCRIPTION
The previous changes implementing the `/~/name` endpoint were breaking, since we changed the type of `$action:eyre`. This commit keeps the `/~/name` endpoint functional, but adds adapters to eyre scries that returns the old `$action:eyre` type. These adapters and their associated intermediate types can be removed the next time we burn a kelvin.

The associated issue is #6342, see also #5918 and #6324.