### PR TITLE
ted: add mark to use eval thread via khan

### DIFF
--- a/pkg/arvo/mar/ted/eval.hoon
+++ b/pkg/arvo/mar/ted/eval.hoon
@@ -1,0 +1,10 @@
+/-  eval=ted-eval
+|_  put=inpt:eval
+++  grab  |%
+          ++  noun  inpt:eval
+          --
+++  grow  |%
+          ++  noun  put
+          --
+++  grad  %noun
+--

--- a/pkg/arvo/sur/ted/eval.hoon
+++ b/pkg/arvo/sur/ted/eval.hoon
@@ -1,0 +1,5 @@
+^?
+|%
++$  deps  (list path)
++$  inpt  $@(cord (pair cord deps))
+--

--- a/pkg/arvo/ted/eval.hoon
+++ b/pkg/arvo/ted/eval.hoon
@@ -1,16 +1,11 @@
-/-  spider
+/-  spider, eval=ted-eval
 /+  strandio
 =,  strand=strand:spider
-=>
-|%
-+$  deps  (list path)
-+$  inpt  $@(cord (pair cord deps))
---
 ^-  thread:spider
 |=  raw=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg=(unit inpt) raw)
+=+  !<(arg=(unit inpt:eval) raw)
 ?~  arg
   (strand-fail:strand %no-input ~)
 ?@  u.arg

--- a/pkg/arvo/ted/khan-eval.hoon
+++ b/pkg/arvo/ted/khan-eval.hoon
@@ -1,16 +1,11 @@
-/-  spider
+/-  spider, eval=ted-eval
 /+  strandio
 =,  strand=strand:spider
-=>
-|%
-+$  deps  (list path)
-+$  inpt  $@(cord (pair cord deps))
---
 ^-  thread:spider
 |=  raw=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg=(unit inpt) raw)
+=+  !<(arg=(unit inpt:eval) raw)
 ?~  arg
   (strand-fail:strand %no-input ~)
 =/  com


### PR DESCRIPTION
Partially resolves [#197](https://github.com/urbit/vere/issues/197)

Add a mark to make it easier to use the `eval` and `khan-eval` threads via `conn.c` + Khan.