### PR TITLE
hoon: minor improvement to +mod and +dvr

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -50,12 +50,7 @@
   |:  [a=`@`1 b=`@`1]
   ::  quotient
   ^-  @
-  ~_  leaf+"divide-by-zero"
-  ?<  =(0 b)
-  =+  c=0
-  |-
-  ?:  (lth a b)  c
-  $(a (sub a b), c +(c))
+  -:(dvr a b)
 ::
 ++  dvr
   ~/  %dvr
@@ -63,11 +58,16 @@
   ::
   ::  a: dividend
   ::  b: divisor
-  |=  [a=@ b=@]
+  |:  [a=`@`1 b=`@`1]
   ::  p: quotient
   ::  q: remainder
   ^-  [p=@ q=@]
-  [(div a b) (mod a b)]
+  ~_  leaf+"divide-by-zero"
+  ?<  =(0 b)
+  =+  c=0
+  |-
+  ?:  (lth a b)  [c a]
+  $(a (sub a b), c +(c))
 ::
 ++  gte
   ~/  %gte
@@ -150,8 +150,7 @@
   |:  [a=`@`1 b=`@`1]
   ::  the remainder
   ^-  @
-  ?<  =(0 b)
-  (sub a (mul b (div a b)))
+  +:(dvr a b)
 ::
 ++  mul
   ~/  %mul


### PR DESCRIPTION
Unify logic for `div` and `mod` in `dvr`, instead of splitting the logic and repeating the same calculation twice on a `dvr` call.

Also add default sample to `dvr`, mirroring `div` and `mod`.

Tested changes successfully against latest code from `develop` (both `urbit/urbit` and `urbit/vere`).