### PR TITLE
ci: upgrade to `cachix/install-nix-action@v20`

### DIFF
--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -61,12 +61,12 @@ jobs:
       # for the docker build. We don't want in on Mac, where it isn't but
       # it breaks the nix install. The two `if` clauses should be mutually
       # exclusive
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
             system-features = nixos-test benchmark big-parallel kvm
         if: ${{ matrix.type == 'linux' }}
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v20
         if: ${{ matrix.os != 'ubuntu-latest' }}
 
       - uses: cachix/cachix-action@v10


### PR DESCRIPTION
[This issue](https://github.com/cachix/cachix-action/issues/144) in the `cachix/install-nix-action` repository provides the solution to our problem: simply upgrade the action.

The successful CI jobs associated with this PR/branch (see below) demonstrate the effectiveness of this solution.

Resolves #6367.