### PR TITLE
ci: use branch for `vere` version

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,34 @@
+name: Push to develop
+
+on:
+  push:
+    branches:
+      - 'develop'
+    paths:
+      - '.github/workflows/feature.yml'
+      - '.github/workflows/develop.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/master.yml'
+      - '.github/workflows/vere.yml'
+      - 'pkg/arvo/**'
+      - 'pkg/docker-image/**'
+      - 'pkg/ent/**'
+      - 'pkg/ge-additions/**'
+      - 'pkg/libaes_siv/**'
+      - 'pkg/urbit/**'
+      - 'pkg/urcrypt/**'
+      - 'tests/**'
+      - 'bin/**'
+      - 'nix/**'
+      - 'default.nix'
+
+jobs:
+  call-vere:
+    uses: ./.github/workflows/vere.yml
+    with:
+      pace: 'edge'
+      upload: >-
+        ${{
+        (github.ref_name == 'next/vere' && github.ref_type == 'branch')
+        }}
+    secrets: inherit

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -1,25 +1,12 @@
-name: build
+name: Feature pull request
 
 on:
-  push:
-    paths:
-      - '.github/workflows/build.yml'
-      - '.github/workflows/vere.yml'
-      - 'pkg/arvo/**'
-      - 'pkg/docker-image/**'
-      - 'pkg/ent/**'
-      - 'pkg/ge-additions/**'
-      - 'pkg/libaes_siv/**'
-      - 'pkg/urbit/**'
-      - 'pkg/urcrypt/**'
-      - 'tests/**'
-      - 'bin/**'
-      - 'nix/**'
-      - 'default.nix'
-      - 'vere-version'
   pull_request:
     paths:
-      - '.github/workflows/build.yml'
+      - '.github/workflows/feature.yml'
+      - '.github/workflows/develop.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/master.yml'
       - '.github/workflows/vere.yml'
       - 'pkg/arvo/**'
       - 'pkg/docker-image/**'
@@ -32,13 +19,12 @@ on:
       - 'bin/**'
       - 'nix/**'
       - 'default.nix'
-      - 'vere-version'
 
 jobs:
   call-vere:
     uses: ./.github/workflows/vere.yml
     with:
-      pace: 'edge' # XX s/b once?
+      pace: 'edge'
       upload: >-
         ${{
         (github.ref_name == 'next/vere' && github.ref_type == 'branch')

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,34 @@
+name: Push to master
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/feature.yml'
+      - '.github/workflows/develop.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/master.yml'
+      - '.github/workflows/vere.yml'
+      - 'pkg/arvo/**'
+      - 'pkg/docker-image/**'
+      - 'pkg/ent/**'
+      - 'pkg/ge-additions/**'
+      - 'pkg/libaes_siv/**'
+      - 'pkg/urbit/**'
+      - 'pkg/urcrypt/**'
+      - 'tests/**'
+      - 'bin/**'
+      - 'nix/**'
+      - 'default.nix'
+
+jobs:
+  call-vere:
+    uses: ./.github/workflows/vere.yml
+    with:
+      pace: 'edge'
+      upload: >-
+        ${{
+        (github.ref_name == 'next/vere' && github.ref_type == 'branch')
+        }}
+    secrets: inherit

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,7 @@ jobs:
   call-vere:
     uses: ./.github/workflows/vere.yml
     with:
-      pace: 'edge'
+      pace: 'live'
       upload: >-
         ${{
         (github.ref_name == 'next/vere' && github.ref_type == 'branch')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Push to release branch
+
+on:
+  push:
+    branches:
+      - 'next/*'
+    paths:
+      - '.github/workflows/feature.yml'
+      - '.github/workflows/develop.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/master.yml'
+      - '.github/workflows/vere.yml'
+      - 'pkg/arvo/**'
+      - 'pkg/docker-image/**'
+      - 'pkg/ent/**'
+      - 'pkg/ge-additions/**'
+      - 'pkg/libaes_siv/**'
+      - 'pkg/urbit/**'
+      - 'pkg/urcrypt/**'
+      - 'tests/**'
+      - 'bin/**'
+      - 'nix/**'
+      - 'default.nix'
+
+jobs:
+  call-vere:
+    uses: ./.github/workflows/vere.yml
+    with:
+      pace: 'soon'
+      upload: >-
+        ${{
+        (github.ref_name == 'next/vere' && github.ref_type == 'branch')
+        }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Push to release branch
 on:
   push:
     branches:
-      - 'next/*'
+      - 'release/*'
     paths:
       - '.github/workflows/feature.yml'
       - '.github/workflows/develop.yml'

--- a/.github/workflows/vere.yml
+++ b/.github/workflows/vere.yml
@@ -39,11 +39,6 @@ on:
         - soon
         - live
 
-env:
-  UPLOAD_BASE: bootstrap.urbit.org/vere
-  VERE_PACE: ${{ inputs.pace }}
-  VERSION_TYPE: ${{ (inputs.pace == 'soon' || inputs.pace == 'live') && 'real' || 'hash' }}
-
 jobs:
   urbit:
     strategy:
@@ -78,8 +73,10 @@ jobs:
         name: run urbit-tests
         run: |
           cp -RL tests pkg/arvo/tests
-          vere="$(cat ./vere-version | sed -e 's/\([^ ]*\) \([^ ]*\)/\1\/\2\/vere-\2/g' | tr -d '\n')"
-          url="$(echo https://bootstrap.urbit.org/vere/${vere}-linux-x86_64)"
+          vere=$(curl https://bootstrap.urbit.org/vere/${{ inputs.pace }}/last)
+          echo $vere
+          url="$(echo https://bootstrap.urbit.org/vere/${{ inputs.pace }}/v${vere}/vere-v${vere}-linux-x86_64)"
+          echo $url
           # put in .jam so it doesn't crash when it gets -A'd in
           curl -Lo pkg/arvo/vere.jam "$url"
           chmod +x pkg/arvo/vere.jam


### PR DESCRIPTION
Resolves #6370.

@jalehman Should we be using `next/*` for our "release branch" pattern? We could use `next/kelvin/*` or `next/release/*` as well. Thoughts appreciated. See `release.yml` for where we use it.

cc @philipcmonk @zalberico