### PR TITLE
hoon: in +ape:ag, make zero a plain atom

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5312,7 +5312,7 @@
   --
 ++  ag
   |%
-  ++  ape  |*(fel=rule ;~(pose (cold 0 (just '0')) fel))
+  ++  ape  |*(fel=rule ;~(pose (cold `@`0 (just '0')) fel))
   ++  bay  (ape (bass 16 ;~(plug qeb:ab (star ;~(pfix dog qib:ab)))))
   ++  bip  =+  tod=(ape qex:ab)
            (bass 0x1.0000 ;~(plug tod (stun [7 7] ;~(pfix dog tod))))


### PR DESCRIPTION
In the `+ape` parser constructor, we were providing `0` as the parsing result for the zero character. Hoon syntax dictates this is a `@ud` however, resulting in a parsing output type of `?(@ud etc)`. Since `+ape` is commonly used for parsing atoms of various kinds, one might end up with a result of `?(@ud @)`, which would fail to nest directly under, say, `@uv`, requiring parsers to add a casting step.

Here, we simply cast the zero result to `@` to make it perfectly generic. This should alleviate the need for a casting step in parsers that need to fit their output into a specific aura.

(The output type in the common case (ie, `+hex:ag`, `+viz:ag`) is now `?(@ @)`, which is still somewhat strange, but should have better ergonomics.)

Since `@` can be used in any place `@ud` is accepted, this is a non-breaking change.