### PR TITLE
Fix stuck %eth-watcher due to get-block-by-number zero-padded number RPC failure.

### DIFF
--- a/pkg/base-dev/lib/ethereum.hoon
+++ b/pkg/base-dev/lib/ethereum.hoon
@@ -946,8 +946,6 @@
   |=  n=@
   ^-  tape
   %-  prefix-hex
-  ?:  =(0 n)
-    "0"
   ((x-co:co 1) n)
 ::
 ++  address-to-hex

--- a/pkg/base-dev/lib/ethereum.hoon
+++ b/pkg/base-dev/lib/ethereum.hoon
@@ -733,7 +733,7 @@
     ::
         %eth-get-block-by-number
       :-  'eth_getBlockByNumber'
-      :~  (tape (num-to-hex bon.req))
+      :~  (tape (num-to-hex-minimal bon.req))
           b+txs.req
       ==
     ::
@@ -942,6 +942,15 @@
   %-  render-hex-bytes
   (as-octs:mimes:html n)
 ::
+++  num-to-hex-minimal
+  |=  n=@
+  ^-  tape
+  %-  prefix-hex
+  ?:  =(0 n)
+    "0"
+  %-  render-hex-bytes-minimal
+  (as-octs:mimes:html n)
+::
 ++  address-to-hex
   |=  a=address
   ^-  tape
@@ -979,6 +988,12 @@
   |=  a=octs
   ^-  tape
   ((x-co:co (mul 2 p.a)) q.a)
+::
+++  render-hex-bytes-minimal
+  :: atom to string of hex bytes without 0x prefix and dots, minimal representation (no padding).
+  |=  a=octs
+  ^-  tape
+  ((x-co:co 1) q.a)
 ::
 ++  pad-to-multiple
   |=  [wat=tape mof=@ud wer=?(%left %right)]

--- a/pkg/base-dev/lib/ethereum.hoon
+++ b/pkg/base-dev/lib/ethereum.hoon
@@ -948,8 +948,7 @@
   %-  prefix-hex
   ?:  =(0 n)
     "0"
-  %-  render-hex-bytes-minimal
-  (as-octs:mimes:html n)
+  ((x-co:co 1) n)
 ::
 ++  address-to-hex
   |=  a=address
@@ -988,12 +987,6 @@
   |=  a=octs
   ^-  tape
   ((x-co:co (mul 2 p.a)) q.a)
-::
-++  render-hex-bytes-minimal
-  :: atom to string of hex bytes without 0x prefix and dots, minimal representation (no padding).
-  |=  a=octs
-  ^-  tape
-  ((x-co:co 1) q.a)
 ::
 ++  pad-to-multiple
   |=  [wat=tape mof=@ud wer=?(%left %right)]


### PR DESCRIPTION
### Description

Resolves #6376.

Adds ethereum-types:render-hex-minimal and and ethereum-types:hex-bytes-minimal. Modifies RPC for get-block-by-number to render block number using these.

Fixes 16-bit alignment in ethereum block number serialisation which results in stuck eth-watcher on livenet.

### Commentary

I'm new to hoon so I'm sure there's a more elegant way to do this. However, this addressed the issue locally and on the test ships I have available. This is a minimal patch which should not impact other users of num-to-hex or render-hex-bytes until further discussion can be had.

Urbit ID: ~macpem-micsec