### PR TITLE
hoon: make sane memory-efficient for large atoms

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4066cd90ac7d33b3d96b1b4d611d846d941de6e538c8355047c7cafcadce0851
-size 6017832
+oid sha256:9d0ff563027d47436d12f00b7500352ec844a1db7d336b0e5b9cfd5c4c49c66c
+size 6017943

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4221,15 +4221,14 @@
   =+  cur=(cut 3 [inx 1] b)
   ?:  &((lth cur 32) !=(10 cur))  |
   =+  tef=(teff cur)
-  ?&  ?|
-          =(1 tef)
+  ?&  ?|  =(1 tef)
           =+  i=1
-        |-  ?|
-            =(i tef)
-            ?&  (gte (cut 3 [(add i inx) 1] b) 128)
-                $(i +(i))
-        ==  ==
-      ==
+          |-  ^-  ?
+          ?|
+              =(i tef)
+              ?&  (gte (cut 3 [(add i inx) 1] b) 128)
+                  $(i +(i))
+      ==  ==  ==
       $(inx +(inx))
   ==
 ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4217,12 +4217,21 @@
         $(inx +(inx))
     ==
   |-  ^-  ?
-  ?:  =(0 b)  &
-  =+  cur=(end 3 b)
+  ?:  =(inx len)  &
+  =+  cur=(cut 3 [inx 1] b)
   ?:  &((lth cur 32) !=(10 cur))  |
-  =+  len=(teff cur)
-  ?&  |(=(1 len) =+(i=1 |-(|(=(i len) &((gte (cut 3 [i 1] b) 128) $(i +(i)))))))
-      $(b (rsh [3 len] b))
+  =+  tef=(teff cur)
+  ::  ==
+  ?&  ?|
+          =(1 tef)
+          =+  i=1
+        |-  ?|
+            =(i tef)
+            ?&  (gte (cut 3 [(add i inx) 1] b) 128)
+                $(i +(i))
+        ==  ==
+      ==
+      $(inx +(inx))
   ==
 ::
 ++  ruth                                                ::  biblical sanity

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4221,7 +4221,6 @@
   =+  cur=(cut 3 [inx 1] b)
   ?:  &((lth cur 32) !=(10 cur))  |
   =+  tef=(teff cur)
-  ::  ==
   ?&  ?|
           =(1 tef)
           =+  i=1


### PR DESCRIPTION
### Description

Resolves #6380.

I updated the section of `sane` which checks for `%t` validity to iterate through bytes with an incrementing cursor. This greatly reduces memory load.