### PR TITLE
sss: Distinguish between an empty path and a wiped path

### DIFF
--- a/pkg/base-dev/lib/sss.hoon
+++ b/pkg/base-dev/lib/sss.hoon
@@ -201,7 +201,8 @@
     ?^  dat=(get:wav wav.tide u.when.req)
       :_  pub  :_  ~
       (send scry/wave/u.dat src.bowl [dude u.when path]:req)
-    ?.  (gth u.when.req key::(fall (ram:wav wav.tide) [key=+(u.when.req) **]))
+    ?.  %+  gth  u.when.req
+        key::(fall (ram:wav wav.tide) (pry:rok rok.tide) [=key val]:wav)
       :_  pub  :_  ~
       (send yore/~ src.bowl [dude u.when path]:req)
     :-  ~[(send nigh/~ src.bowl [dude u.when path]:req)]

--- a/pkg/base-dev/lib/sss.hoon
+++ b/pkg/base-dev/lib/sss.hoon
@@ -201,7 +201,7 @@
     ?^  dat=(get:wav wav.tide u.when.req)
       :_  pub  :_  ~
       (send scry/wave/u.dat src.bowl [dude u.when path]:req)
-    ?.  %+  gth  u.when.req
+    ?:  %+  lte  u.when.req
         key::(fall (ram:wav wav.tide) (pry:rok rok.tide) [=key val]:wav)
       :_  pub  :_  ~
       (send yore/~ src.bowl [dude u.when path]:req)


### PR DESCRIPTION
Closes #6397

Forgot a step in my `;:` chain, and had the wrong "base case". Also cleaned up the logic, `?:` seems clearer than `?.`.

The logic here is: When trying to serve a wave `w'` that doesn't exist, we only assume that it was deleted (i.e. send a `%yore`)
- if the last known wave `w` exists, then only if `w' < w`
- if the last known rock `r` exists, then only if `w' ≤ r`.

In all other cases, including when neither `w` nor `r` exist, the requested wave is in the future and should result in a `%nigh`.

Shout out to @rabsef-bicrym who discovered the mistake. :)

Side note: using the irregular forms of tisgal and miccol together seems to break Github's syntax highlighting. Do we know who is responsible for this?