### PR TITLE
sss: Unsubscribing and permissions

### DIFF
--- a/pkg/base-dev/lib/sss.hoon
+++ b/pkg/base-dev/lib/sss.hoon
@@ -260,23 +260,16 @@
   ++  block                                  ::  No-ops on public paths.
     |=  [who=(list ship) whence=(list paths)]
     ^-  pubs
-    %+  edit  whence
-    |=  =buoy
-    ?@  tid.buoy  buoy
-    ?~  alo.buoy  buoy
-    %=  buoy
-      alo      `(~(dif in u.alo.buoy) (sy who))
-      mem.tid  (~(dif by mem.tid.buoy) (malt (turn who (late ~))))
-    ==
+    %+  perm  whence
+    |=  old=(unit (set ship))
+    ?~  old  ~  `(~(dif in u.old) (sy who))
   ::                                         ::  Allow ships to paths.
   ++  allow                                  ::  Any public paths will no-op.
     |=  [who=(list ship) where=(list paths)]
     ^-  pubs
-    %+  edit  where
-    |=  =buoy
-    ?@  tid.buoy  buoy
-    ?~  alo.buoy  buoy
-    buoy(alo `(~(gas in u.alo.buoy) who))
+    %+  perm  where
+    |=  old=(unit (set ship))
+    ?~  old  ~  `(~(gas in u.old) who)
   ::                                         ::  Kill a list of paths, i.e. tell
   ++  kill                                   ::  subs to not expect updates.
     (curr edit |=(=buoy buoy(tid (latest tid.buoy))))

--- a/pkg/base-dev/lib/sss.hoon
+++ b/pkg/base-dev/lib/sss.hoon
@@ -40,75 +40,119 @@
   |*  [=(lake) paths=mold]
   =>
     |%
-    +$  flow  [=aeon fail=_| =rock:lake]
+    +$  from    (on-rock:poke lake paths)
+    +$  into    (response:poke lake paths)
+    +$  result  (request:poke paths)
+    +$  fail    [paths ship dude]
+    +$  flow    [=aeon stale=_| fail=_| =rock:lake]
+    +$  subs    [%0 (map [ship dude paths] (unit flow))]
     --
-  |_  [sub=(map [ship dude paths] flow) =bowl:gall result-type=type on-rock-type=type]
-  ++  surf  pine                             ::  Subscribe to [ship dude path].
+  |=  $:  sub=subs
+          =bowl:gall
+          result-type=type
+          on-rock-type=type
+          fail-type=type
+      ==
+  =>  .(sub +.sub)
+  |%
+  ++  surf                                   ::  Subscribe to [ship dude path].
+    |=  which=[ship dude paths]
+    ^-  (quip card:agent:gall subs)
+    ?+  flow=(~(get by sub) which)  `0/sub
+      ~                 [~[(pine which)] 0/(~(put by sub) which ~)]
+      [~ ~]             [~[(pine which)] 0/sub]
+      [~ ~ [* %& * *]]  [~[(scry `+(aeon.u.u.flow) which)] 0/sub]
+    ==
+  ++  quit  (corl (lead %0) ~(del by sub))   ::  Unsub from [ship dude path].
   ++  read                                   ::  See current subscribed states.
-    ^-  (map [ship dude paths] [fail=? rock:lake])
-    %-  ~(run by sub)
-    |=  =flow
-    [fail rock]:flow
-  ::                                         ::  Check poke-acks for errors.
+    ^-  (map [ship dude paths] [stale=? fail=? =rock:lake])
+    %-  malt  %+  murn  ~(tap by sub)
+    |=  [key=[ship dude paths] val=(unit flow)]
+    ?~  val  ~
+    `[key +.u.val]
+  ::                                         ::  Check poke-ack for errors.
   ::                                         ::  If an %sss-on-rock poke nacks,
   ++  chit                                   ::  that state is flagged as failed.
     |=  [[aeon=term ship=term dude=term path=paths] =sign:agent:gall]
-    ^+  sub
+    ^-  subs
+    :-  %0
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  sub
     %+  ~(jab by sub)  [(slav %p ship) dude path]
-    |=  =flow
+    |=  (unit flow)
+    =/  =flow  (need +<)
     ?>  =(aeon.flow (slav %ud aeon))
-    flow(fail &)
+    `flow(fail &)
+  ::                                         ::  Check poke-ack for errors.
+  ::                                         ::  If a scry request nacks,
+  ++  tell                                   ::  that state is flagged as stale.
+    |=  [[ship=term =dude aeon=term path=paths] =sign:agent:gall]
+    ^-  (quip card:agent:gall subs)
+    ?>  ?=(%poke-ack -.sign)
+    ?~  p.sign  `0/sub
+    =/  current  [ship=(slav %p ship) dude=dude path=path]
+    ?+    flow=(~(get by sub) current)  `0/sub
+        [~ ~ *]
+      =.  stale.u.u.flow  &
+      :_  0/(~(put by sub) current u.flow)
+      ~[(on-rock-poke current u.u.flow ~)]
+    ::
+        [~ ~]
+      :_  0/(~(del by sub) current)  :_  ~
+      :*  %pass   (zoom surf-fail/aeon/ship/dude/path)
+          %agent  [our dap]:bowl
+          %poke   %sss-surf-fail  fail-type  ^-  fail
+          [path ship dude]:current
+      ==
+    ==
   ::                                         ::  Check if we're still interested
   ::                                         ::  in a wave. If no, no-op.
   ::                                         ::  If yes, scry.
   ++  behn                                   ::  (See https://gist.github.com/belisarius222/7f8452bfea9b199c0ed717ab1778f35b)
     |=  [ship=term =dude aeon=term path=paths]
     ^-  (list card:agent:gall)
+    %-  fall  :_  ~  %-  mole  |.
     =/  ship  (slav %p ship)
     =/  aeon  (slav %ud aeon)
-    ?:  (lte aeon aeon:(~(got by sub) ship dude path))  ~
+    ?:  (lte aeon aeon:(fall (~(got by sub) ship dude path) *flow))  ~
     ~[(scry `aeon ship dude path)]
   ::
   ++  apply                                  ::  Handle response from publisher.
     |=  res=(response:poke lake paths)
-    ^-  (quip card:agent:gall _sub)
+    ^-  (quip card:agent:gall subs)
+    %-  fall  :_  `0/sub  %-  mole  |.
+    =*  current  [src.bowl dude.res path.res]
+    =/  old=flow  (fall (~(got by sub) current) *flow)
     ?-    type.res
+        %tomb
+      =/  =flow  old(stale &)
+      :_  0/(~(put by sub) current `flow)  :_  ~
+      (on-rock-poke current flow ~)
+    ::
         %yore
-      :_  sub  :_  ~
+      :_  0/sub  :_  ~
       (pine src.bowl dude.res path.res)
     ::
         %nigh
-      :_  sub  :_  ~
+      :_  0/sub  :_  ~
       (behn-s25 [dude aeon path]:res)
     ::
         %scry
-      =*  current  [src.bowl dude.res path.res]
       =/  [wave=(unit wave:lake) =flow]
-        =/  old=flow  (~(gut by sub) current *flow)
         ?-  what.res
           %rock  ?>  (gte aeon.res aeon.old)
-                 `[aeon.res | rock.res]
-          %wave  ~|  [%weird-wave res=res old=old]
-                 ?>  =(aeon.res +(aeon.old))
-                 [`wave.res [aeon.res | (wash:lake rock.old wave.res)]]
+                 [~ [aeon.res | | rock.res]]
+          %wave  ?>  =(aeon.res +(aeon.old))
+                 [`wave.res [aeon.res | | (wash:lake rock.old wave.res)]]
         ==
-      :_  (~(put by sub) current flow)
-      %-  flop
-      :~  (scry `+(aeon.res) src.bowl dude.res path.res)
-          :*  %pass   (zoom on-rock/(scot %ud aeon.flow)^(scot %p src.bowl)^dude.res^path.res)
-              %agent  [our dap]:bowl
-              %poke   %sss-on-rock  on-rock-type  ^-  from
-              [path.res src.bowl dude.res rock.flow wave]
-      ==  ==
+      :_  0/(~(put by sub) current `flow)
+      :~  (on-rock-poke current flow wave)
+          (scry `+(aeon.res) src.bowl dude.res path.res)
+      ==
     ==
   ::
   ::  Non-public facing arms below
   ::
-  +$  from    (on-rock:poke lake paths)
-  +$  into    (response:poke lake paths)
-  +$  result  (request:poke paths)
   ++  behn-s25
     |=  [=dude =aeon path=noun]
     ^-  card:agent:gall
@@ -119,71 +163,137 @@
   ++  scry
     |=  [when=(unit aeon) who=ship which=dude where=paths]
     ^-  card:agent:gall
-    =/  when  ?~  when  %~  (scot %ud u.when)
-    :*  %pass   (zoom request/scry/(scot %p who)^which^when^where)
+    =/  when  ?~  when  ~  (scot %ud u.when)
+    :*  %pass   (zoom scry-request/(scot %p who)^which^when^where)
         %agent  [who which]
         %poke   %sss-to-pub  :-  result-type  ^-  result
-        [where which ^when]
+        [where dap.bowl ^when]
+    ==
+  ++  on-rock-poke
+    |=  [[=ship =dude path=paths] flow wave=(unit wave:lake)]
+    ^-  card:agent:gall
+    :*  %pass   (zoom on-rock/(scot %ud aeon)^(scot %p ship)^dude^path)
+        %agent  [our dap]:bowl
+        %poke   %sss-on-rock  on-rock-type  ^-  from
+        [path ship dude stale fail rock wave]
     ==
   --
 ++  du                                       ::  Manage publications.
   |*  [=(lake) paths=mold]
   =>
     |%
-    +$  rule  [rocks=_1 waves=_5]            ::  Retention policy
+    +$  into    (request:poke paths)
+    +$  result  (response:poke lake paths)
+    +$  rule    [rocks=_1 waves=_5]          ::  Retention policy
     +$  tide
       $:  rok=((mop aeon rock:lake) gte)
           wav=((mop aeon wave:lake) lte)
           rul=rule
-          mem=(mip aeon [ship dude] @da)
+          mem=(mip ship dude @da)
       ==
+    +$  buoy
+      $:  tid=$~(*tide $@(aeon tide))
+          alo=(unit (set ship))
+      ==
+    +$  pubs  [%0 (map paths buoy)]
     --
-  |_  [pub=(map paths tide) =bowl:gall result-type=type]
-  +*  rok  ((on aeon rock:lake) gte)
-      wav  ((on aeon wave:lake) lte)
-  ::
+  |=  [pub=pubs =bowl:gall result-type=type]
+  =>  .(pub +.pub)
+  =*  rok  ((on aeon rock:lake) gte)
+  =*  wav  ((on aeon wave:lake) lte)
+  |%
   ++  rule                                   ::  Set new retention policy.
     |=  [path=paths =^rule]
-    ^+  pub
+    ^-  pubs
+    :-  %0
     %+  ~(jab by pub)  path
-    |=  =tide
-    (form tide(rul rule))
+    |=  =buoy
+    ?@  tid.buoy  buoy
+    buoy(tid (form tid.buoy(rul rule)))
   ::
   ++  wipe                                   ::  Create new rock and wipe rest.
     |=  path=paths
-    ^+  pub
+    ^-  pubs
+    :-  %0
     %+  ~(jab by pub)  path
-    |=  =tide
-    %*  .  (form tide(rul [0 1]))
-      rul  rul.tide
-      wav  ~
+    |=  =buoy
+    ?@  tid.buoy  buoy
+    %*  .  buoy(tid (form tid.buoy(rul [0 1])))
+      rul.tid  rul.tid.buoy
+      wav.tid  ~
     ==
   ++  give                                   ::  Give a wave on a path.
     |=  [path=paths =wave:lake]
-    ^-  (quip card:agent:gall _pub)
-    ?~  ;;((soft ^path) path)  ~|  %need-path  !!
-    =/  =tide  (~(gut by pub) path *tide)
-    =/  next=aeon
-      .+  %+  max
-        (fall (bind (pry:rok rok.tide) head) 0)
-      (fall (bind (ram:wav wav.tide) head) 0)
-    ::
-    :_  %+  ~(put by pub)  path
-        =/  last=[=aeon =rock:lake]  (fall (pry:rok rok.tide) *[key val]:rok)
-        =.  wav.tide  (put:wav wav.tide next wave)
-        =.  mem.tide  (~(del by mem.tide) next)
-        ?.  =(next (add aeon.last waves.rul.tide))  tide
-        (form tide)
-    ::
-    %+  murn  ~(tap by (~(gut by mem.tide) next ~))
-    |=  [[=ship =dude] =@da]
-    ?:  (lth da now.bowl)  ~
-    `(send scry/wave/wave ship dude next path)
+    ^-  (quip card:agent:gall pubs)
+    ?~  ((soft ^path) path)  ~|  %need-path  !!
+    =/  buoy  (~(gut by pub) path *buoy)
+    ?@  tide=tid.buoy  ~|  %dead-path  !!  ::TODO is this good behavior?
+    =/  next=aeon  +((latest tide))
+    :-  %+  murn  ~(tap bi mem.tide)
+        |=  [=ship =dude =@da]
+        ?:  (lth da now.bowl)  ~
+        `(send scry/wave/wave ship dude next path)
+    :-  %0
+    %+  ~(put by pub)  path
+    =/  last=[=aeon =rock:lake]  (fall (pry:rok rok.tide) *[key val]:rok)
+    =.  wav.tide  (put:wav wav.tide next wave)
+    =.  mem.tide  (~(del by mem.tide) next)
+    ?.  =(next (add aeon.last waves.rul.tide))  buoy
+    buoy(tid (form tide))
+  ::
+  ++  perm                                   ::  Change permissions with gate.
+    |=  [where=(list paths) diff=$-((unit (set ship)) (unit (set ship)))]
+    ^-  pubs
+    %+  edit  where
+    |=  =buoy
+    =/  new=_alo.buoy  (diff alo.buoy)
+    ?@  tid.buoy  buoy(alo new)
+    %=  buoy
+      alo      new
+      mem.tid  ?~  new  mem.tid.buoy
+               %.  mem.tid.buoy
+               ~(int by (malt (turn ~(tap in u.new) (late *(map @ @)))))
+    ==
+  ++  public  (curr perm _~)                 ::  Make list of paths public.
+  ++  secret  (curr perm _`~)                ::  Make list of paths secret.
+  ::                                         ::  Block ships from paths.
+  ++  block                                  ::  No-ops on public paths.
+    |=  [who=(list ship) whence=(list paths)]
+    ^-  pubs
+    %+  edit  whence
+    |=  =buoy
+    ?@  tid.buoy  buoy
+    ?~  alo.buoy  buoy
+    %=  buoy
+      alo      `(~(dif in u.alo.buoy) (sy who))
+      mem.tid  (~(dif by mem.tid.buoy) (malt (turn who (late ~))))
+    ==
+  ::                                         ::  Allow ships to paths.
+  ++  allow                                  ::  Any public paths will no-op.
+    |=  [who=(list ship) where=(list paths)]
+    ^-  pubs
+    %+  edit  where
+    |=  =buoy
+    ?@  tid.buoy  buoy
+    ?~  alo.buoy  buoy
+    buoy(alo `(~(gas in u.alo.buoy) who))
+  ::                                         ::  Kill a list of paths, i.e. tell
+  ++  kill                                   ::  subs to not expect updates.
+    (curr edit |=(=buoy buoy(tid (latest tid.buoy))))
+  ::                                         ::  Reopen list of killed paths.
+  ++  live                                   ::  No-ops on live paths.
+    %+  curr  edit
+    |=  =buoy
+    ?^  tid.buoy  buoy
+    %*(. buoy(tid *tide) rok.tid (put:rok ~ +(tid.buoy) *rock:lake))
+  ::
   ++  read                                   ::  See current published states.
-    ^-  (map paths rock:lake)
-    %-  ~(run by pub)
-    |=  =tide
-    =<  rock
+    ^-  (map paths [allowed=(unit (set ship)) =rock:lake])
+    %-  malt  %+  murn  ~(tap by pub)
+    |=  [path=paths =buoy]
+    ^-  (unit [paths (unit (set ship)) rock:lake])
+    ?@  tide=tid.buoy  ~
+    :^  ~  path  alo.buoy  =<  rock
     =/  snap=[=aeon =rock:lake]  (fall (pry:rok rok.tide) *[key val]:rok)
     %+  roll  (tap:wav (lot:wav wav.tide `aeon.snap ~))
     |=  [[=aeon =wave:lake] =_snap]
@@ -192,39 +302,58 @@
   ::
   ++  apply                                  ::  Handle request from subscriber.
     |=  req=(request:poke paths)
-    ^-  (quip card:agent:gall _pub)
-    =/  =tide  (~(gut by pub) path.req *tide)
+    ^-  (quip card:agent:gall pubs)
+    =/  =buoy  (~(gut by pub) path.req *buoy)
+    ?<  &(?=(^ alo.buoy) !(~(has in u.alo.buoy) src.bowl))
+    ?@  tid.buoy
+      :_  0/pub  :_  ~
+      (send tomb/~ src.bowl dude.req tid.buoy path.req)
     ?~  when.req
-      =/  last  (fall (pry:rok rok.tide) *[=key =val]:rok)
-      :_  pub  :_  ~
+      =/  last  (fall (pry:rok rok.tid.buoy) *[=key =val]:rok)
+      :_  0/pub  :_  ~
       (send scry/rock/val.last src.bowl dude.req key.last path.req)
-    ?^  dat=(get:wav wav.tide u.when.req)
-      :_  pub  :_  ~
+    ?^  dat=(get:wav wav.tid.buoy u.when.req)
+      :_  0/pub  :_  ~
       (send scry/wave/u.dat src.bowl [dude u.when path]:req)
     ?:  %+  lte  u.when.req
-        key::(fall (ram:wav wav.tide) (pry:rok rok.tide) [=key val]:wav)
-      :_  pub  :_  ~
+        key::(fall (ram:wav wav.tid.buoy) (pry:rok rok.tid.buoy) [=key val]:wav)
+      :_  0/pub  :_  ~
       (send yore/~ src.bowl [dude u.when path]:req)
+    ?>  =(u.when.req +((latest tid.buoy)))
     :-  ~[(send nigh/~ src.bowl [dude u.when path]:req)]
+    :-  %0
     %+  ~(put by pub)  path.req
-    %=  tide  mem
-      %^  ~(put bi mem.tide)  u.when.req  [src.bowl dude.req]
-      (add ~s25 now.bowl)
+    %=  buoy
+      mem.tid  (~(put bi mem.tid.buoy) src.bowl dude.req (add ~s25 now.bowl))
     ==
   ::
   ::  Non-public facing arms below
   ::
-  +$  into    (request:poke paths)
-  +$  result  (response:poke lake paths)
   ++  send
     |=  [payload=_|3:*(response:poke lake paths) =ship =dude =aeon path=paths]
     ^-  card:agent:gall
     =*  mark  (cat 3 %sss- name:lake)
-    :*  %pass   (zoom response/scry/(scot %p ship)^dude^(scot %ud aeon)^path)
+    :*  %pass   (zoom scry-response/(scot %p ship)^dude^(scot %ud aeon)^path)
         %agent  [ship dude]
         %poke   mark  result-type  ^-  (response:poke lake paths)
         [path dap.bowl aeon payload]
     ==
+  ++  latest
+    |=  =$@(aeon tide)
+    ^-  aeon
+    ?@  tide  tide
+    %+  max  (fall (bind (pry:rok rok.tide) head) 0)
+    (fall (bind (ram:wav wav.tide) head) 0)
+  ::
+  ++  edit
+    |=  [ps=(list paths) edit=$-(buoy buoy)]
+    ^-  pubs
+    :-  %0
+    %-  ~(rep in (sy ps))
+    |=  [path=paths =_pub]
+    %-  fall  :_  pub  %-  mole  |.
+    (~(jab by pub) path edit)
+  ::
   ++  form
     |=  =tide
     ^+  tide

--- a/pkg/base-dev/sur/sss.hoon
+++ b/pkg/base-dev/sur/sss.hoon
@@ -24,13 +24,20 @@
     $:  path=paths
         =dude
         =aeon
-        $%  [type=?(%nigh %yore) ~]
+        $%  [type=?(%nigh %yore %tomb) ~]
             $:  type=%scry
                 $%  [what=%rock =rock:lake]
                     [what=%wave =wave:lake]
     ==  ==  ==  ==
   ++  on-rock
     |*  [=(lake) paths=mold]
-    ,[path=paths src=ship from=dude =rock:lake wave=(unit wave:lake)]
+    $:  path=paths
+        src=ship
+        from=dude
+        stale=?
+        fail=?
+        =rock:lake
+        wave=(unit wave:lake)
+    ==
   --
 --


### PR DESCRIPTION
Closes #6409 

Turned into a fairly large rewrite. Still some rough edges in terms of architecture, but the interface should be stable and it works as intended (as far as I can tell after testing), and I wanted to get it released quickly to unblock hodzod and focus on remote scry instead.

Permissions are either set by using `+public:du`, `+secret:du`, `+allow:du` and `+block:du`, or manually by passing a gate to the `+perm:du` arm. Permissions are encoded as `(unit (set ship))`, with `~` indicating public data and `[~ ships]` indicating that only `ships` are allowed. So for example, to only grant access to `~sampel`, call `+perm:du` with `_[~ (silt ~sampel ~)]`. 

It’s also possible to kill a path using `+kill:du`. This deletes the state from the publisher and informs anyone who tries to access it that no more data will come. However, subscribers won’t automatically delete their copy of the state, that’s up to them.

More controversially, you can revive a killed path with `+live:du`. This will start over from the bunt (but at a new aeon, to maintain referential transparency). **Very open to a discussion about this!**

Permissions are maintained even for killed paths, to prevent metadata leaks. A blocked ship can’t tell whether the path is live or dead.

The calling convention changes in a few places. Usage of the new functionality and the new calling conventions are both demonstrated at [wicrum-wicrun/sss](https://github.com/wicrum-wicrun/sss/blob/master/urbit/app/simple.hoon) as before, though some of the cases still need to be properly documented. (All of the new user-facing arms in the library do have comments though.)

**Unfortunately this is not backwards compatible**, since I failed to tag my state in the previous version. State migration would've run a `;;` on the entire subscription/publication state *even when it was already up to date*, which seemed unacceptable. Given the relative novelty and experimental nature of this library, I figured that it's acceptable for things to break. Both @rabsef-bicrym and @dr-frmr have been informed, as they are the main developers using this afaik. Paging @litlep-nibbyt too. Sorry about that, I've made sure that if I change the state again this won't happen.