### PR TITLE
arvo: add more files to |new-desk generator

### DIFF
--- a/pkg/arvo/gen/hood/new-desk.hoon
+++ b/pkg/arvo/gen/hood/new-desk.hoon
@@ -5,7 +5,7 @@
 :-  %ask
 |=  $:  [now=@da eny=@uvJ bek=beak]
         [=desk ~]
-        [from=$~(%base desk) hard=_| minimal=_|]
+        [from=$~(%base desk) hard=_| gall=_|]
     ==
 ::
 =;  make-new-desk
@@ -34,7 +34,7 @@
         /mar/kelvin/hoon
         /sys/kelvin
       ==
-    =/  extra-files=(list path)  ?:  minimal  [~]
+    =/  extra-files=(list path)  ?.  gall  [~]
       :~
         /mar/bill/hoon
         /mar/mime/hoon

--- a/pkg/arvo/gen/hood/new-desk.hoon
+++ b/pkg/arvo/gen/hood/new-desk.hoon
@@ -5,7 +5,7 @@
 :-  %ask
 |=  $:  [now=@da eny=@uvJ bek=beak]
         [=desk ~]
-        [from=$~(%base desk) hard=_|]
+        [from=$~(%base desk) hard=_| minimal=_|]
     ==
 ::
 =;  make-new-desk
@@ -27,12 +27,23 @@
 %-  ~(gas by *(map path page:clay))
 |^  =-  (turn - mage)
     ^-  (list path)
-    :~  /mar/noun/hoon
+    =/  common-files=(list path)  :~
+        /mar/noun/hoon
         /mar/hoon/hoon
         /mar/txt/hoon
         /mar/kelvin/hoon
         /sys/kelvin
-    ==
+      ==
+    =/  extra-files=(list path)  ?:  minimal  [~]
+      :~
+        /mar/bill/hoon
+        /mar/mime/hoon
+        /mar/json/hoon
+        /lib/skeleton/hoon
+        /lib/default-agent/hoon
+        /lib/dbug/hoon
+      ==
+    (weld common-files extra-files)
 ::
 ++  mage
   |=  =path


### PR DESCRIPTION
Resolves #6426.

Add an optional argument "minimal" to `|new-desk` which preserves current behavior; otherwise, by default, include an additional list of files in the new desk that will help jump-start development of a Gall agent.