### PR TITLE
hotfix clay rebuild loop

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -583,15 +583,13 @@
     ..abet
   =/  kel  i.wic
   %-  emil
-  =/  cards
+  =/  desks=(list [=desk =zest])
     %+  murn  ~(tap by rock)
     |=  [=desk =zest wic=(set weft)]
     ?:  |(=(%base desk) !?=(%live zest) (~(has in wic) kel))
       ~
-    `u=[%pass /kiln/bump/[desk] %arvo %c %zest desk %held]
-  ?~  cards
-    [%pass /kiln/bump/wick %arvo %c %wick ~]~
-  cards
+    `u=[desk %held]
+  [%pass /kiln/bump/zeal %arvo %c %zeal desks]~
 ::
 ++  poke-cancel
   |=  a=@tas

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -801,6 +801,7 @@
         [%warp wer=ship rif=riff]                       ::  internal file req
         [%werp who=ship wer=ship rif=riff-any]          ::  external file req
         [%wick ~]                                       ::  try upgrade
+        [%zeal lit=(list [=desk =zest])]                ::  batch zest
         [%zest des=desk liv=zest]                       ::  live
         $>(%plea vane-task)                             ::  ames request
     ==                                                  ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5018,9 +5018,22 @@
   ::
       %wick
     =^  mos  ruf
-      =/  den  ((de now rof hen ruf) our %base)
-      abet:wick:den                                     ::  [wick]
+      abet:wick:((de now rof hen ruf) our %base)        ::  [wick]
     [mos ..^$]
+  ::
+      %zeal
+    =^  m1  ruf
+      =|  mos=(list move)
+      |-  ^+  [mos ruf]
+      ?~  lit.req
+        [mos ruf]
+      =/  den  ((de now rof hen ruf) our desk.i.lit.req)
+      =^  mos-new  ruf  abet:(set-zest:den zest.i.lit.req)
+      $(mos (weld mos mos-new), lit.req t.lit.req)
+    =^  m2  ruf
+      abet:wick:((de now rof hen ruf) our %base)
+    =^  m3  ruf  abet:goad:(lu now rof hen ruf)
+    [:(weld m1 m2 m3) ..^$]
   ::
       %zest
     =^  m1  ruf


### PR DESCRIPTION
We were retrying failed kelvin upgrades as many times as we had apps that needed to be suspended, because suspending an app triggers an attempt to run the next kelvin upgrade.  This suspends all those apps in one batch move, and then tries the next kelvin upgrade only once at the end.

Fixes #6407

Partially addresses #6285