### PR TITLE
hoon: fix @da parser (DO NOT MERGE)

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5798,7 +5798,7 @@
     ;~  plug
       %+  cook
         |=([a=@ b=?] [b a])
-      ;~(plug dim:ag ;~(pose (cold | hep) (easy &)))
+      ;~(plug dip:ag ;~(pose (cold | hep) (easy &)))
       ;~(pfix dot mot:ag)   ::  month
       ;~(pfix dot dip:ag)   ::  day
       ;~  pose


### PR DESCRIPTION
This turned out during my ongoing work on slaw, scot jets. There is a bug in @da parser. 

In Hoon, there is no year 0 (in the sense that no date atom will ever render to a date with year 0. See `++yore` for details). 
However, the parser admits a date such as `~0.1.1` as valid, while 
the printer will render the resulting date atom as `~1-.1.1'. 

There is also an associated bug: trying to type `~0-.1.1` (note the hep) will result in a decrement error and dojo crash.
This is because hep marks the year as BC, and there is an internal book-keeping calculation which will try to decrement the year (already 0). 

The fix is to disallow year 0 in the date parser.