### PR TITLE
ames: add last-contact scry endpoint

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3963,6 +3963,7 @@
   ::  /ax/protocol/version           @
   ::  /ax/peers                      (map ship ?(%alien %known))
   ::  /ax/peers/[ship]               ship-state
+  ::  /ax/peers/[ship]/last-contact  (unit @da)
   ::  /ax/peers/[ship]/forward-lane  (list lane)
   ::  /ax/bones/[ship]               [snd=(set bone) rcv=(set bone)]
   ::  /ax/snd-bones/[ship]/[bone]    vase

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3988,6 +3988,13 @@
         [~ ~]
       ``noun+!>(u.peer)
     ::
+        [%last-contact ~]
+      :^  ~  ~  %noun
+      !>  ^-  (unit @da)
+      ?.  ?=([~ %known *] peer)
+        ~
+      `last-contact.qos.u.peer
+    ::
         [%forward-lane ~]
       ::
       ::  this duplicates the routing hack from +send-blob:event-core


### PR DESCRIPTION
Resolves [#6442](https://github.com/urbit/urbit/issues/6442).
`.^((unit @da) %ax /=//=/peers/~zod/last-contact)` now returns a `(unit @da)` of the `last-contact`.