### PR TITLE
behn: propagate errors in deferred moves

### DIFF
--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -108,10 +108,9 @@
       [duct card]
     =/  =tang
       (weld u.error `tang`[leaf/"drip failed" ~])
-    ::  XX should be
-    ::  [duct %hurl fail/tang card]
+    ::  XX we don't know the mote due to the %wake pattern
     ::
-    [duct %pass /drip-slog %d %flog %crud %drip-fail tang]
+    [duct %hurl fail/tang card]
   ::
   +|  %tasks
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1384,7 +1384,7 @@
       `[[care.mood case.mood syd] path.mood cage]:[u.res syd=syd]
     ?~  ref
       [%give %writ riot]
-    [%slip %b %drip !>([%writ riot])]
+    [%pass /drip %b %drip !>([%writ riot])]
   ::
   ++  case-to-date
     |=  =case
@@ -3781,7 +3781,7 @@
             (~(run in moods) |=(m=mood [care.m path.m]))
           =/  gift  [%wris cas res]
           ?:  ?=(^ ref)
-            [%slip %b %drip !>(gift)]
+            [%pass /drip %b %drip !>(gift)]  :: XX s/b [%behn %wris ...] in $sign?
           [%give gift]
         ?>  ?=([* ~ ~] res)
         :_  ~
@@ -5753,7 +5753,25 @@
   |=  [tea=wire hen=duct dud=(unit goof) hin=sign]
   ^+  [*(list move) ..^$]
   ?^  dud
-    ~|(%clay-take-dud (mean tang.u.dud))
+    ?+    tea
+      ~|(%clay-take-dud (mean tang.u.dud))
+    ::
+        [%drip ~]
+      %.  [~ ..^$]
+      %-  slog
+      ^-  tang
+      :*  'clay: drip fail'
+          [%rose [": " "" ""] 'bail' mote.u.dud ~]
+          tang.u.dud
+      ==
+    ==
+  ::
+  ::  pseudo %slip on %drip
+  ::
+  ?:  ?=([%drip ~] tea)
+    ?>  ?=([?(%behn %clay) ?(%writ %wris) *] hin)
+    [[`move`[hen %give +.hin] ~] ..^$]
+  ::
   ?:  ?=([%lu %load *] tea)
     ?>  ?=(%unto +<.hin)
     ?>  ?=(%poke-ack -.p.hin)
@@ -5909,7 +5927,7 @@
       ~(tap in ducts)
     =/  cancel-moves=(list move)
       %+  turn  cancel-ducts
-      |=(=duct [duct %slip %b %drip !>([%writ ~])])
+      |=(=duct [duct %pass /drip %b %drip !>([%writ ~])])
     ::  delete local state of foreign desk
     ::
     =.  hoy.ruf  (~(del by hoy.ruf) who)


### PR DESCRIPTION
... and handle them correctly in the only remaining %drip-sites in %clay.

This has been tested and validated in various upgrade scenarios between local fake ships. It was motivated by a case of `.^` in `+on-load` rendering a ship effectively inoperable (`behn: queue blocked`).