### PR TITLE
dill: exclude wrapped-task from most +call traces

### DIFF
--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -250,8 +250,10 @@
           wrapped-task=(hobo task)
       ==
   ^+  [*(list move) ..^$]
-  ~|  wrapped-task
-  =/  task=task  ((harden task) wrapped-task)
+  =/  task=task
+    ~|  wrapped-task
+    ((harden task) wrapped-task)
+  ~|  -.task
   ::  unwrap session tasks, default to session %$
   ::
   =^  ses=@tas  task


### PR DESCRIPTION
Instead of including wrapped-task as-is in most call traces, we now only include it in traces for crashing (harden task) calls. For everything else, we include only the tag of the resulting $task.

Closes #6444. That issue doesn't specify under what conditions this was observed. I imagine in the crashing `harden` case we'll still want to be able to inspect the noun. I still include the tag of the resulting task in the general trace, for clarity.