### PR TITLE
[WIP] kiln: |wipe to uninstall, nuke, and clean a desk

### DIFF
--- a/pkg/arvo/gen/hood/wipe.hoon
+++ b/pkg/arvo/gen/hood/wipe.hoon
@@ -1,0 +1,5 @@
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [[=desk ~] ~]
+    ==
+[%kiln-wipe desk]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -556,6 +556,7 @@
     %kiln-uninstall          =;(f (f !<(_+<.f vase)) poke-uninstall)
     %kiln-unmount            =;(f (f !<(_+<.f vase)) poke-unmount)
     %kiln-unsync             =;(f (f !<(_+<.f vase)) poke-unsync)
+    %kiln-wipe               =;(f (f !<(_+<.f vase)) poke-wipe)
   ==
 ::
 ++  poke-autocommit
@@ -834,6 +835,22 @@
     abet:(spam (render "not syncing" [sud her syd ~]:hus) ~)
   =.  zyn  (~(del by zyn) hus)
   abet:(spam (render "cancelling sync" sud.hus her.hus syd.hus kid.u.got) ~)
+::
+++  poke-wipe
+  |=  loc=desk
+  ~>  %slog.(fmt "wiping {<loc>}")
+  ::  |uninstall %desk
+  %+  poke-uninstall loc
+  ::  |nuke %desk, =desk &
+  %+  poke-nuke loc
+  ::  |new-desk %desk
+  %^  new-desk:cloy loc ~ ~
+  ::  |norm our %the-desk / |
+  ::  TODO
+  ::  |pick
+  ::  TODO
+  ::  |norm our %the-desk / &
+  ::  TODO  
 ::  +peer: handle %watch
 ::
 ++  peer


### PR DESCRIPTION
`|wipe %desk` - results in a desk with no apps, no app state, bare minimum files and all past revision data wiped

Inspired by a comment by @tinnus-napbus in UC > Help:

![image](https://user-images.githubusercontent.com/16504501/230534576-993f56cd-ce92-4518-ad18-a5194272bb82.png)

chat reference:
```
/1/chan/chat/~dopzod/urbit-help/msg/~socsel-pacted/170.141.184.506.157.338.499.576.888.404.274.577.408
```