### PR TITLE
arvo: print module compilation times

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -773,6 +773,7 @@
       ::
       ~>  %slog.[0 leaf+"1-c (compiling compiler, wait a few minutes)"]
       =/  compiler-tool
+        ~>  %bout
         .*([compiler-gate noun/hoon.log] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  switch to the second-generation compiler.  we want to be
@@ -781,7 +782,7 @@
       ::  generate last-generation spans for `!>`, etc.
       ::
       ~>  %slog.[0 leaf+"1-d"]
-      =.  compiler-gate  .*(0 +.compiler-tool)
+      =.  compiler-gate  ~>(%bout .*(0 +.compiler-tool))
       ::
       ::  get the span (type) of the kernel core, which is the context
       ::  of the compiler gate.  we just compiled the compiler,
@@ -791,17 +792,20 @@
       ::
       ~>  %slog.[0 leaf+"1-e"]
       =/  kernel-span
+        ~>  %bout
         -:.*([compiler-gate -.compiler-tool '+>'] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  compile the arvo source against the kernel core.
       ::
       ~>  %slog.[0 leaf+"1-f"]
       =/  kernel-tool
+        ~>  %bout
         .*([compiler-gate kernel-span arvo.log] [%9 2 %10 [6 %0 3] %0 2])
       ::
       ::  create the arvo kernel, whose subject is the kernel core.
       ::
       ~>  %slog.[0 leaf+"1-g"]
+      ~>  %bout
       [.*(+>.compiler-gate +.kernel-tool) epic.log]
     --
   ::
@@ -1046,6 +1050,7 @@
           |=  [cap=tape sub=vase pax=path txt=@t]
           ^-  vase
           ~>  %slog.[0 leaf/"{cap}: {(scow p+(mug txt))}"]
+          ~>  %bout
           %-  road  |.
           ~_  leaf/"{cap}: build failed"
           (slap sub (rain pax txt))
@@ -1623,6 +1628,7 @@
   ?~  hun
     =/  gat
       ~>  %slog.[0 'arvo: compiling next arvo']
+      ~>  %bout
       %-  road  |.
       (slap !>(..ride) (rain /sys/arvo/hoon van))
     =/  lod
@@ -1640,6 +1646,7 @@
     ::
     =/  raw
       ~>  %slog.[0 'arvo: compiling hoon']
+      ~>  %bout
       (road |.((ride %noun u.hun)))
     ::  activate the new compiler gate, producing +ride
     ::
@@ -1665,6 +1672,7 @@
         [raw cop]
       =/  hot
         ~>  %slog.[0 leaf/"arvo: recompiling hoon %{(scow %ud nex)}"]
+        ~>  %bout
         (road |.((slum cop [%noun u.hun])))
       [hot .*(0 +.hot)]
     ::  extract the hoon core from the outer gate (+ride)
@@ -1680,6 +1688,7 @@
   ::
   =/  rav
     ~>  %slog.[0 'arvo: compiling next arvo']
+    ~>  %bout
     (road |.((slum cop [hyp van])))
   ::  activate arvo and extract the arvo core from the outer gate
   ::


### PR DESCRIPTION
This PR prints the time it takes to compile Hoon, Arvo, Lull, Zuse, and the vanes.  Compile times seem to have slowed down recently, so it would be good to know which modules are the bottlenecks.

Sample output (upgrading from an old Arvo that did not have these hints yet):

```
> |commit %base
>=
arvo: beginning upgrade
arvo: compiling next arvo
arvo: +load next
lull: ~hidtem-sardyn
took s/5.899.605
zuse: ~rindeg-bollyt
took s/8.318.232
vane: %ames: ~mormul-divnux
took s/3.766.802
vane: %behn: ~sogmut-tonmus
took ms/494.150
vane: %clay: ~fashus-ridwex
took s/16.344.822
vane: %dill: ~togmed-bondyl
took s/1.098.004
vane: %eyre: ~danfet-dosfyr
took s/3.579.556
vane: %gall: ~foddeb-nacsul
took s/2.876.367
vane: %iris: ~macryl-midnyl
took ms/404.828
vane: %jael: ~ravnex-fitref
took s/2.320.433
vane: %khan: ~tintux-halnux
took ms/237.406
clay: kernel updated
clay: rebuilding %base after kernel update

```