### PR TITLE
ted/test.hoon: repair vestigial select-by-prefix feature

### DIFF
--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -26,13 +26,6 @@
           &+[leaf+"OK      {name}"]~
         |+(flop `tang`[leaf+"FAILED  {name}" p.run])
   ==
-::  +filter-tests-by-prefix: TODO document
-::
-++  filter-tests-by-prefix
-  |=  [prefix=path tests=(list test)]
-  ^+  tests
-  =/  prefix-length=@ud  (lent prefix)
-  (skim tests |=([p=path *] =(prefix (scag prefix-length p))))
 ::  +resolve-test-paths: add test names to file paths to form full identifiers
 ::
 ++  resolve-test-paths
@@ -130,15 +123,11 @@
     gather-tests(fiz t.fiz, build-ok |)
   ~>  %slog.0^leaf+"built   {(spud s.beam.i.fiz)}"
   =/  arms=(list test-arm)  (get-test-arms u.cor)
-  ::
-  ::  XX this logic appears to be vestigial
-  ::
+  ::  if test path specified an arm prefix, filter arms to match
   =?  arms  ?=(^ test.i.fiz)
-    |-  ^+  arms
-    ?~  arms  ~|(no-test-arm+i.fiz !!)
-    ?:  =(name.i.arms u.test.i.fiz)
-      [i.arms]~
-    $(arms t.arms)
+    %+  skim  arms
+    |=  test-arm
+    =((end [3 (met 3 u.test.i.fiz)] name) u.test.i.fiz)
   =.  test-arms  (~(put by test-arms) (snip s.beam.i.fiz) arms)
   gather-tests(fiz t.fiz)
 %-  pure:m  !>  ^=  ok


### PR DESCRIPTION
I believe this is an old feature that has since stopped working. This change removes some old code marked as "vestigial" and replaces it with what seemed to be its intended function, which is to select test arms by matching the beginning of each arm name with the test name entered by the user. I wanted this functionality and it seems to work now, as I use this modified version of ted/test.hoon in my fakeship.