### PR TITLE
eyre: do not clear unacked events in +on-get-request

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1348,13 +1348,13 @@
       ::
       =/  heartbeat-time=@da  (add now ~s20)
       =/  heartbeat  (set-heartbeat-move channel-id heartbeat-time)
-      ::  clear the event queue, record the duct for future output and
+      ::  record the duct for future output and
       ::  record heartbeat-time for possible future cancel
       ::
       =.  session.channel-state.state
         %+  ~(jab by session.channel-state.state)  channel-id
         |=  =channel
-        channel(events ~, state [%| duct], heartbeat (some [heartbeat-time duct]))
+        channel(state [%| duct], heartbeat (some [heartbeat-time duct]))
       ::
       [[heartbeat :(weld http-moves cancel-moves moves)] state]
     ::  +acknowledge-events: removes events before :last-event-id on :channel-id


### PR DESCRIPTION
Eyre keeps a queue of unacked events, resending them to a frontend through a SSE stream until they are acked. This behavior is violated in `+on-get-request` where the events are cleared from the queue without waiting to hear the acknowledgement. This is incorrect.

This PR has bearing on #6311, but there are other problems as well. More fixes coming up later.