### PR TITLE
ames: properly migrate old %snub tasks

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1044,14 +1044,14 @@
               ==  ==
               $:  %9
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-11)
                       state=ames-state-9
                   ==
                   [%adult state=ames-state-9]
               ==  ==
               $:  %10
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-11)
                       state=ames-state-10
                   ==
                   [%adult state=ames-state-10]
@@ -1125,7 +1125,17 @@
       ::
           [%9 %larva *]
         ~>  %slog.0^leaf/"ames: larva: load"
-        =.  queued-events  events.old
+        =.  queued-events
+          ::  "+rep:in on a +qeu looks strange, but works fine."
+          ::
+          %-  ~(rep in events.old)
+          |=  [e=queued-event-11 q=(qeu queued-event)]
+          %-  ~(put to q)  ^-  queued-event
+          ?.  ?=(%call -.e)  e
+          =/  task=task-11  ((harden task-11) wrapped-task.e)
+          %=  e
+            wrapped-task  ?.(?=(%snub -.task) task [%snub %deny ships.task])
+          ==
         larval-gate
       ::
           [%10 %adult *]
@@ -1135,7 +1145,17 @@
       ::
           [%10 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
-        =.  queued-events  events.old
+        =.  queued-events
+          ::  "+rep:in on a +qeu looks strange, but works fine."
+          ::
+          %-  ~(rep in events.old)
+          |=  [e=queued-event-11 q=(qeu queued-event)]
+          %-  ~(put to q)  ^-  queued-event
+          ?.  ?=(%call -.e)  e
+          =/  task=task-11  ((harden task-11) wrapped-task.e)
+          %=  e
+            wrapped-task  ?.(?=(%snub -.task) task [%snub %deny ships.task])
+          ==
         larval-gate
       ::
           [%11 %adult *]


### PR DESCRIPTION
The `%snub` task was introduced in `urbit-os-v2.131`: https://github.com/urbit/urbit/blob/urbit-os-v2.131/pkg/arvo/sys/lull.hoon#L379

This corresponds to `%ames` state `%9`: https://github.com/urbit/urbit/blob/urbit-os-v2.131/pkg/arvo/sys/vane/ames.hoon#L863

It was later modified in in `urbit-os-v2.136`: https://github.com/urbit/urbit/blob/urbit-os-v2.136/pkg/arvo/sys/lull.hoon#L383

Corresponding `%ames` state is `%12`: https://github.com/urbit/urbit/blob/urbit-os-v2.136/pkg/arvo/sys/vane/ames.hoon#L884

The `+load` migration was correctly written from `%ames` state `%11` to `%12`, but given that the `queued-event` type is dependent on the type of `task:ames` in lull, versions `%9` and `%10` will miserably fail to migrate, printing out the type of ames state for hours.

TLDR it's currently impossible to update  your `urbit-os` from a few versions back, unless you know how to manually do it one version at a time. This PR fixes the problem.

I've tested this  on multiple livenet ships that experienced this problem. I've also tested it with all relevant `urbit-os` combinations using fakezods booted from old pills.