### PR TITLE
gall: task and scry provenance WIP

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -109,6 +109,7 @@
   |$  [a]
   $~  =>(~ |~(* ~))
   $-  $:  lyc=gang                                      ::  leakset
+          pov=path                                      ::  provenance
           vis=view                                      ::  perspective
           bem=beam                                      ::  path
       ==                                                ::
@@ -117,7 +118,7 @@
   (cask a)
 +$  roon                                                ::  partial namespace
   $~  =>(~ |~(* ~))
-  $-  [lyc=gang car=term bem=beam]
+  $-  [lyc=gang pov=path car=term bem=beam]
   (unit (unit cage))
 +$  root  $-(^ (unit (unit)))
 +$  view  $@(term [way=term car=term])
@@ -340,13 +341,13 @@
 ::
 ++  look
   ~/  %look
-  |=  [rof=roof lyc=gang]
+  |=  [rof=roof lyc=gang pov=path]
   ^-  root
   ~/  %in
   |=  [ref=* raw=*]
   ?~  pax=((soft path) raw)  ~
   ?~  mon=(de-omen u.pax)  ~
-  ?~  dat=(rof lyc u.mon)  ~
+  ?~  dat=(rof lyc pov u.mon)  ~
   ?~  u.dat  [~ ~]
   =*  vax  q.u.u.dat
   ?.  ?&  ?=(^ ref)
@@ -1092,7 +1093,7 @@
       ::
       ++  peek
         ^-  rook
-        |=  [lyc=gang vis=view bem=beam]
+        |=  [lyc=gang pov=path vis=view bem=beam]
         ^-  (unit (unit (cask meta)))
         ::  namespace reads receive no entropy
         ::
@@ -1104,7 +1105,7 @@
           ~>  %mean.'peek: pull failed'
           (~(slap wa sac) rig [%limb %scry])
         ::
-        =/  mas=[gang view beam]  [lyc vis bem]
+        =/  mas=[gang path view beam]  [lyc pov vis bem]
         ::
         =^  pro  sac
           ~>  %mean.'peek: call failed'
@@ -1364,7 +1365,7 @@
       |=  [nam=term =vane]
       =;  mas=(list mass)
         nam^|+(welp mas [dot+&+q.vase typ+&+p.vase sac+&+worm ~]:vane)
-      ?~  met=(peek [~ ~] nam bem)  ~
+      ?~  met=(peek [~ ~] / nam bem)  ~
       ?~  u.met  ~
       ~|  mass+nam
       ;;((list mass) q.q.u.u.met)
@@ -1372,7 +1373,7 @@
     ::
     ++  peek
       ^-  rook
-      |=  [lyc=gang vis=view bem=beam]
+      |=  [lyc=gang pov=path vis=view bem=beam]
       ^-  (unit (unit (cask meta)))
       ::  vane and care may be concatenated
       ::
@@ -1383,12 +1384,12 @@
         [(end 3 vis) (rsh 3 vis)]
       ::
       ?:  ?=(%$ way)
-        (peek:pith lyc car bem)
+        (peek:pith lyc pov car bem)
       ::
       =.  way  (grow way)
       ?~  van=(~(get by van.mod) way)
         ~
-      %.  [lyc car bem]
+      %.  [lyc pov car bem]
       peek:spin:(~(plow va [vil u.van]) now peek)
     ::  +call: advance to target
     ::
@@ -1543,7 +1544,7 @@
       ::
       ++  peek
         ^-  roon
-        |=  [lyc=gang car=term bem=beam]
+        |=  [lyc=gang pov=path car=term bem=beam]
         ^-  (unit (unit cage))
         ?.  ?|  =(our p.bem)
                 ?=(%$ q.bem)
@@ -1797,7 +1798,7 @@
     ==
   ::
   ?~  hap  ~
-  =/  pro  (~(peek le:part [pit vil] sol) lyc [vis bem]:u.hap)
+  =/  pro  (~(peek le:part [pit vil] sol) lyc / [vis bem]:u.hap)
   ?:  |(?=(~ pro) ?=(~ u.pro))  ~
   =/  dat=(cask)  [p q.q]:u.u.pro
   ?.  pat.u.hap  `dat

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -49,7 +49,7 @@
 +$  rift  @ud                                           ::  ship continuity
 +$  mime  (pair mite octs)                              ::  mimetyped data
 +$  octs  (pair @ud @)                                  ::  octet-stream
-+$  sock  (pair ship ship)                              ::  outgoing [our his]
++$  sock  (trel ship ship path)                         ::  out [our his from]
 +$  stub  (list (pair stye (list @c)))                  ::  styled unicode
 +$  stye  (pair (set deco) (pair tint tint))            ::  decos/bg/fg
 +$  styl  %+  pair  (unit deco)                         ::  cascading style
@@ -1883,6 +1883,7 @@
           $:  $:  our=ship                              ::  host
                   src=ship                              ::  guest
                   dap=term                              ::  agent
+                  pro=path                              ::  provenance
               ==                                        ::
               $:  wex=boat                              ::  outgoing subs
                   sup=bitt                              ::  incoming subs

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1404,7 +1404,7 @@
           =/  tim
             ;;  (list [@da ^duct])
             =<  q.q  %-  need  %-  need
-            (rof ~ %bx [[our %$ da+now] /debug/timers])
+            (rof ~ /ames %bx [[our %$ da+now] /debug/timers])
           (skim tim |=([@da hen=^duct] ?=([[%ames ?(%pump %recork) *] *] hen)))
         ::
         ::  set timers for flows that should have one set but don't
@@ -1975,7 +1975,7 @@
             =|  =point
             =.  life.point     life
             =.  keys.point     (my [life crypto-suite public-key]~)
-            =.  sponsor.point  `(^^sein:title rof our now ship)
+            =.  sponsor.point  `(^^sein:title rof /ames our now ship)
             ::
             (on-publ-full (my [ship point]~))
           ::
@@ -2103,7 +2103,7 @@
           =.  sponsor.peer-state
             ?^  sponsor.point
               u.sponsor.point
-            (^^sein:title rof our now ship)
+            (^^sein:title rof /ames our now ship)
           ::  automatically set galaxy route, since unix handles lookup
           ::
           =?  route.peer-state  ?=(%czar (clan:title ship))
@@ -2131,7 +2131,7 @@
         =/  turfs
           ;;  (list turf)
           =<  q.q  %-  need  %-  need
-          (rof ~ %j `beam`[[our %turf %da now] /])
+          (rof ~ /ames %j `beam`[[our %turf %da now] /])
         ::
         (emit unix-duct.ames-state %give %turf turfs)
       ::  +on-vega: handle kernel reload
@@ -3866,7 +3866,7 @@
       ?:  ?=(%pawn (clan:title ship))  0
       ;;  @ud
       =<  q.q  %-  need  %-  need
-      (rof ~ %j `beam`[[our %rift %da now] /(scot %p ship)])
+      (rof ~ /ames %j `beam`[[our %rift %da now] /(scot %p ship)])
     :-   -.ship-state
     :_  +.peer-state
     =,  -.peer-state
@@ -3940,7 +3940,7 @@
 ::
 ++  scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -236,7 +236,7 @@
 ::
 ++  scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5564,7 +5564,7 @@
 ++  scry                                              ::  inspect
   ~/  %clay-scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  scry-loop  $
   |^

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -104,7 +104,7 @@
         ::
             %seat
           %^  pass  /seat  %g
-          :+  %deal   [our our]
+          :+  %deal   [our our /dill]
           [%hood %poke %kiln-install !>([desk.kyz our desk.kyz])]
         ==
       ::
@@ -129,7 +129,7 @@
       ::
       ++  deal                                          ::  pass to %gall
         |=  [=wire =deal:gall]
-        (pass wire [%g %deal [our our] ram deal])
+        (pass wire [%g %deal [our our /dill] ram deal])
       ::
       ++  pass                                          ::  pass note
         |=  [=wire =note]
@@ -146,7 +146,7 @@
       ++  sponsor
         ^-  ship
         =/  dat=(unit (unit cage))
-          (rof `[our ~ ~] j/[[our sein/da/now] /(scot %p our)])
+          (rof `[our ~ ~] /jael j/[[our sein/da/now] /(scot %p our)])
         ;;(ship q.q:(need (need dat)))
       ::
       ++  init                                          ::  initialize
@@ -479,7 +479,7 @@
 ::
 ++  scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem
@@ -528,9 +528,9 @@
       ::  only the new-style subscription.
       ::
       =/  hey  (need hey.all.lax)
-      :*  [hey %pass / %g %deal [our our] %hood %leave ~]
-          [hey %pass [%peer %$ ~] %g %deal [our our] %hood %leave ~]
-          [hey %pass [%peer %$ ~] %g %deal [our our] %hood %watch [%dill %$ ~]]
+      :*  [hey %pass / %g %deal [our our /dill] %hood %leave ~]
+          [hey %pass /peer/$ %g %deal [our our /dill] %hood %leave ~]
+          [hey %pass /peer/$ %g %deal [our our /dill] %hood %watch /dill/$]
           moz
       ==
     =.  egg.all.lax  |

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -677,12 +677,12 @@
         %gen
       =/  bek=beak  [our desk.generator.action da+now]
       =/  sup=spur  path.generator.action
-      =/  ski       (rof ~ %ca bek sup)
+      =/  ski       (rof ~ /eyre %ca bek sup)
       =/  cag=cage  (need (need ski))
       ?>  =(%vase p.cag)
       =/  gat=vase  !<(vase q.cag)
       =/  res=toon
-        %-  mock  :_  (look rof ~)
+        %-  mock  :_  (look rof ~ /eyre)
         :_  [%9 2 %0 1]  |.
         %+  slam
           %+  slam  gat
@@ -824,7 +824,7 @@
     ++  do-scry
       |=  [care=term =desk =path]
       ^-  (unit (unit cage))
-      (rof ~ care [our desk da+now] path)
+      (rof ~ /eyre care [our desk da+now] path)
     ::
     ++  error-response
       |=  [status=@ud =tape]
@@ -838,12 +838,12 @@
     |=  [app=term =inbound-request:eyre]
     ^-  (list move)
     :~  :*  duct  %pass  /watch-response/[eyre-id]
-            %g  %deal  [our our]  app
+            %g  %deal  [our our /eyre]  app
             %watch  /http-response/[eyre-id]
         ==
       ::
         :*  duct  %pass  /run-app-request/[eyre-id]
-            %g  %deal  [our our]  app
+            %g  %deal  [our our /eyre]  app
             %poke  %handle-http-request
             !>(`[@ta inbound-request:eyre]`[eyre-id inbound-request])
         ==
@@ -867,7 +867,7 @@
       :_  ~
       %-  (trace 1 |.("leaving subscription to {<app.action.u.connection>}"))
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.u.connection
+          %g  %deal  [our our /eyre]  app.action.u.connection
           %leave  ~
       ==
     ::
@@ -1087,7 +1087,7 @@
     ++  code
       ^-  @ta
       =/  res=(unit (unit cage))
-        (rof ~ %j [our %code da+now] /(scot %p our))
+        (rof ~ /eyre %j [our %code da+now] /(scot %p our))
       (rsh 3 (scot %p ;;(@ q.q:(need (need res)))))
     ::  +session-cookie-string: compose session cookie
     ::
@@ -1448,7 +1448,7 @@
           ^-  move
           :^  duct  %pass  /channel/poke/[channel-id]/(scot %ud request-id.i.requests)
           =,  i.requests
-          :*  %g  %deal  `sock`[our ship]  app
+          :*  %g  %deal  `sock`[our ship /eyre]  app
               `task:agent:gall`[%poke-as mark %json !>(json)]
           ==
         ::
@@ -1464,7 +1464,7 @@
           :^  duct  %pass
             (subscription-wire channel-id request-id ship app)
           %-  (trace 1 |.("subscribing to {<app>} on {<path>}"))
-          :*  %g  %deal  [our ship]  app
+          :*  %g  %deal  [our ship /eyre]  app
               `task:agent:gall`[%watch path]
           ==
         ::
@@ -1501,7 +1501,7 @@
           :^  duc  %pass
             (subscription-wire channel-id subscription-id.i.requests ship app)
           %-  (trace 1 |.("leaving subscription to {<app>}"))
-          :*  %g  %deal  [our ship]  app
+          :*  %g  %deal  [our ship /eyre]  app
               `task:agent:gall`[%leave ~]
           ==
         ::
@@ -1550,7 +1550,7 @@
       ^-  move
       :^  duct  %pass
         (subscription-wire channel-id request-id ship app)
-      [%g %deal [our ship] app `task:agent:gall`[%leave ~]]
+      [%g %deal [our ship /eyre] app `task:agent:gall`[%leave ~]]
     ::  +emit-event: records an event occurred, possibly sending to client
     ::
     ::    When an event occurs, we need to record it, even if we immediately
@@ -1651,7 +1651,7 @@
         %-  (trace 1 |.("leaving subscription to {<app>}"))
         :^  duct  %pass
           (subscription-wire channel-id request-id ship app)
-        [%g %deal [our ship] app %leave ~]
+        [%g %deal [our ship /eyre] app %leave ~]
       ::  update channel state to reflect the %kick
       ::
       =?  u.channel  kicking
@@ -1700,7 +1700,7 @@
       ?~  sub
         ((trace 0 |.("no subscription for request-id {(trip request-id)}")) ~)
       =/  des=(unit (unit cage))
-        (rof ~ %gd [our app.u.sub da+now] ~)
+        (rof ~ /eyre %gd [our app.u.sub da+now] ~)
       ?.  ?=([~ ~ *] des)
         ((trace 0 |.("no desk for app {<app.u.sub>}")) ~)
       `!<(=desk q.u.u.des)
@@ -1717,7 +1717,7 @@
       ?~  des  ~
       =*  have=mark  mark.event
       =/  val=(unit (unit cage))
-        (rof ~ %cb [our u.des da+now] /[have])
+        (rof ~ /eyre %cb [our u.des da+now] /[have])
       ?.  ?=([~ ~ *] val)
         ((trace 0 |.("no mark {(trip have)}")) ~)
       =+  !<(=dais:clay q.u.u.val)
@@ -1744,7 +1744,7 @@
         =*  have=mark  p.cage.sign
         =/  convert=(unit vase)
           =/  cag=(unit (unit cage))
-            (rof ~ %cf [our u.des da+now] /[have]/json)
+            (rof ~ /eyre %cf [our u.des da+now] /[have]/json)
           ?.  ?=([~ ~ *] cag)  ~
           `q.u.u.cag
         ?~  convert
@@ -1866,7 +1866,7 @@
       %-  (trace 1 |.("{<channel-id>} leaving subscription to {<app>}"))
       :^  duc  %pass
         (subscription-wire channel-id request-id ship app)
-      [%g %deal [our ship] app %leave ~]
+      [%g %deal [our ship /eyre] app %leave ~]
     --
   ::  +handle-gall-error: a call to +poke-http-response resulted in a %coup
   ::
@@ -1881,7 +1881,7 @@
       :_  ~
       %-  (trace 1 |.("leaving subscription to {<app.action.connection>}"))
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.connection
+          %g  %deal  [our our /eyre]  app.action.connection
           %leave  ~
       ==
     ::
@@ -2028,7 +2028,7 @@
       %-  %+  trace  1
           |.("leaving subscription to {<app.action.u.connection-state>}")
       :*  duct  %pass  /watch-response/[eyre-id]
-          %g  %deal  [our our]  app.action.u.connection-state
+          %g  %deal  [our our /eyre]  app.action.u.connection-state
           %leave  ~
       ==
     --
@@ -2397,7 +2397,7 @@
       :_  http-server-gate
       =/  cmd
         [%acme %poke `cage`[%acme-order !>(mod)]]
-      [duct %pass /acme/order %g %deal [our our] cmd]~
+      [duct %pass /acme/order %g %deal [our our /eyre] cmd]~
     ==
   ::
       %request
@@ -2706,7 +2706,7 @@
 ++  scry
   ~/  %eyre-scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -42,9 +42,9 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
-::  $state-11: overall gall state, versioned
+::  $state-12: overall gall state, versioned
 ::
-+$  state-11  [%11 state]
++$  state-12  [%12 state]
 ::  $state: overall gall state
 ::
 ::    system-duct: TODO document
@@ -57,7 +57,7 @@
 +$  state
   $:  system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
-      contacts=(set ship)
+      contacts=(map ship contact-version)
       yokes=(map term yoke)
       blocked=(map term (qeu blocked-move))
       =bug
@@ -66,7 +66,7 @@
 ::
 +$  routes
   $:  disclosing=(unit (set ship))
-      attributing=ship
+      attributing=[=ship =path]
   ==
 ::  $yoke: agent runner state
 ::
@@ -98,6 +98,13 @@
 ::  $blocked-move: enqueued move to an agent
 ::
 +$  blocked-move  [=duct =routes move=(each deal unto)]
+::
+::  $contact-version: $ames-request version negotiation info
+::
++$  contact-version
+  $:  version=ames-request-version
+      asked=(unit [=time open=?])
+  ==
 ::  $stats: statistics
 ::
 ::    change: how many moves this agent has processed
@@ -121,10 +128,21 @@
 ::    %s: watch
 ::    %u: leave
 ::
++$  ames-request-version
+  $~  %0
+  ?(%0 %1)
+::
 +$  ames-request-all
-  $%  [%0 ames-request]
+  $%  [%1 ames-request]
+      [%0 ames-request-0]
   ==
 +$  ames-request
+  $%  [%m prov=path =mark noun=*]
+      [%l prov=path =mark =path]
+      [%s prov=path =path]
+      [%u prov=path ~]
+  ==
++$  ames-request-0
   $%  [%m =mark noun=*]
       [%l =mark =path]
       [%s =path]
@@ -149,10 +167,10 @@
 ::  $spore: structures for update, produced by +stay
 ::
 +$  spore
-  $:  %11
+  $:  %12
       system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
-      contacts=(set ship)
+      contacts=(map ship (unit ?(%0 %1)))
       eggs=(map term egg)
       blocked=(map term (qeu blocked-move))
       =bug
@@ -175,7 +193,7 @@
 --
 ::  adult gall vane interface, for type compatibility with pupa
 ::
-=|  state=state-11
+=|  state=state-12
 |=  [now=@da eny=@uvJ rof=roof]
 =*  gall-payload  .
 ~%  %gall-top  ..part  ~
@@ -232,26 +250,26 @@
   ::  +mo-doff: kill all outgoing subscriptions
   ::
   ++  mo-doff
-    |=  [dude=(unit dude) ship=(unit ship)]
+    |=  [[dude=(unit dude) ship=(unit ship)] prov=path]
     ^+  mo-core
     =/  apps=(list (pair term yoke))
       ?~  dude  ~(tap by yokes.state)
       (drop (bind (~(get by yokes.state) u.dude) (lead u.dude)))
     |-  ^+  mo-core
     ?~  apps  mo-core
-    =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
+    =/  ap-core  (ap-yoke:ap p.i.apps [~ our prov] q.i.apps)
     $(apps t.apps, mo-core ap-abet:(ap-doff:ap-core ship))
   ::  +mo-rake: send %cork's for old subscriptions if needed
   ::
   ++  mo-rake
-    |=  [dude=(unit dude) all=?]
+    |=  [[dude=(unit dude) all=?] prov=path]
     ^+  mo-core
     =/  apps=(list (pair term yoke))
       ?~  dude  ~(tap by yokes.state)
       (drop (bind (~(get by yokes.state) u.dude) (lead u.dude)))
     |-  ^+  mo-core
     ?~  apps  mo-core
-    =/  ap-core  (ap-yoke:ap p.i.apps [~ our] q.i.apps)
+    =/  ap-core  (ap-yoke:ap p.i.apps [~ our prov] q.i.apps)
     $(apps t.apps, mo-core ap-abet:(ap-rake:ap-core all))
   ::  +mo-receive-core: receives an app core built by %ford.
   ::
@@ -267,7 +285,7 @@
   ::
   ++  mo-receive-core
     ~/  %mo-receive-core
-    |=  [dap=term bek=beak =agent]
+    |=  [[dap=term bek=beak =agent] prov=path]
     ^+  mo-core
     ::
     =/  yak  (~(get by yokes.state) dap)
@@ -289,7 +307,7 @@
       ::
       =.  yokes.state
         (~(put by yokes.state) dap u.yak(beak bek, code agent))
-      =/  ap-core  (ap-abed:ap dap `our)
+      =/  ap-core  (ap-abed:ap dap [~ our prov])
       =.  ap-core  (ap-reinstall:ap-core agent)
       =.  mo-core  ap-abet:ap-core
       (mo-clear-queue dap)
@@ -306,7 +324,7 @@
     ::
     =/  old  mo-core
     =/  wag
-      =/  ap-core  (ap-abed:ap dap `our)
+      =/  ap-core  (ap-abed:ap dap [~ our prov])
       (ap-upgrade-state:ap-core ~)
     ::
     =/  maybe-tang  -.wag
@@ -323,18 +341,31 @@
   ::
   ++  mo-send-foreign-request
     ~/  %mo-send-foreign-request
-    |=  [=ship foreign-agent=term =deal]
+    |=  [=ship foreign-agent=term prov=path =deal]
     ^+  mo-core
     ::
     =.  mo-core  (mo-track-ship ship)
+    =^  ver=ames-request-version  mo-core  (mo-contact-version ship)
     ?<  ?=(?(%raw-poke %poke-as) -.deal)
     =/  =ames-request-all
-      :-  %0
-      ?-  -.deal
-        %poke      [%m p.cage.deal q.q.cage.deal]
-        %leave     [%u ~]
-        %watch-as  [%l [mark path]:deal]
-        %watch     [%s path.deal]
+      ?-    ver
+          %1
+        :-  %1
+        ?-  -.deal
+          %poke      [%m prov p.cage.deal q.q.cage.deal]
+          %leave     [%u prov ~]
+          %watch-as  [%l prov mark.deal path.deal]
+          %watch     [%s prov path.deal]
+        ==
+      ::
+          %0
+        :-  %0
+        ?-  -.deal
+          %poke      [%m p.cage.deal q.q.cage.deal]
+          %leave     [%u ~]
+          %watch-as  [%l mark.deal path.deal]
+          %watch     [%s path.deal]
+        ==
       ==
     ::
     =/  wire
@@ -353,6 +384,32 @@
     ?.  ?=(%leave -.deal)
       mo-core
     (mo-pass wire [%a [%cork ship]])
+  ::
+  ::
+  ++  mo-contact-version
+    |=   =ship
+    ^-  [ames-request-version _mo-core]
+    ?~  maybe-cv=(~(get by contacts.state) ship)
+      mo-core
+    =/  cv=contact-version  u.maybe-cv
+    ?-    version.cv
+        %1  [%1 mo-core]
+        %0
+      ?.  ?|  ?=(~ asked.cv)
+              ?&  !open.u.asked
+                  ?|  (gth time.u.asked now)
+                      (gte (sub now time.u.ask) ~d1)
+                  ==
+              ==
+          ==
+        [%0 mo-core]
+      =.  contacts.state  (~(put by contacts.state) ship [%0 ~ now &])
+      ::
+      =/  =wire       /sys/ver/(scot %p ship)
+      =/  =note-arvo  [%a %plea ship %g /ver [%0 %1 ~]]
+      ::
+      [%0 (mo-pass wire note-arvo)]
+    ==
   ::  +mo-track-ship: subscribe to ames and jael for notices about .ship
   ::
   ++  mo-track-ship
@@ -360,11 +417,11 @@
     ^+  mo-core
     ::  if already contacted, no-op
     ::
-    ?:  (~(has in contacts.state) ship)
+    ?:  (~(has by contacts.state) ship)
       mo-core
     ::  first contact; update state and subscribe to notifications
     ::
-    =.  contacts.state  (~(put in contacts.state) ship)
+    =.  contacts.state  (~(put by contacts.state) [ship ~])
     ::  ask ames to track .ship's connectivity
     ::
     =.  moves  [[system-duct.state %pass /sys/lag %a %heed ship] moves]
@@ -381,11 +438,11 @@
     ^+  mo-core
     ::  if already canceled, no-op
     ::
-    ?.  (~(has in contacts.state) ship)
+    ?.  (~(has by contacts.state) ship)
       mo-core
     ::  delete .ship from state and kill subscriptions
     ::
-    =.  contacts.state  (~(del in contacts.state) ship)
+    =.  contacts.state  (~(del by contacts.state) ship)
     ::
     =.  moves  [[system-duct.state %pass /sys/lag %a %jilt ship] moves]
     ::
@@ -411,7 +468,7 @@
     ?~  agents
       mo-core
     =.  mo-core
-      =/  =routes  [disclosing=~ attributing=ship]
+      =/  =routes  [disclosing=~ attributing=[our /jael]]
       =/  app  (ap-abed:ap name.i.agents routes)
       ap-abet:(ap-breach:app ship)
     $(agents t.agents)
@@ -430,6 +487,7 @@
       %era  (mo-handle-sys-era wire sign-arvo)
       %lag  (mo-handle-sys-lag wire sign-arvo)
       %req  (mo-handle-sys-req wire sign-arvo)
+      %ver  (mo-handle-sys-ver wire sign-arvo)
       %way  (mo-handle-sys-way wire sign-arvo)
     ==
   ::  +mo-handle-sys-era: receive update about contact
@@ -456,7 +514,7 @@
     ?~  agents  mo-core
     ::
     =.  mo-core
-      =/  app  (ap-abed:ap i.agents `our)
+      =/  app  (ap-abed:ap i.agents [~ our /ames])
       ap-abet:(ap-clog:app ship.sign-arvo)
     ::
     $(agents t.agents)
@@ -494,6 +552,24 @@
         ?~  p.unto  ~
         `[%watch-ack u.p.unto]
       (mo-give %done err)
+    ==
+  ::
+  ::
+  ++  mo-handle-sys-ver
+    |=  [=wire =sign-arvo]
+    ^+  mo-core
+    ::
+    ?>  ?=([%ver @ ~] wire)
+    =/  him  (slav %p i.t.wire)
+    ?+    sign-arvo  !!
+        [%ames %done *]
+      ?~  maybe-cv=(~(get by contacts.state) ship)
+        mo-core
+      ?^  error.tang
+    ::
+        [%ames %boon *]
+    ::
+        [%ames %lost *]
     ==
   ::  +mo-handle-sys-way: handle response to outgoing remote request
   ::
@@ -572,7 +648,8 @@
       ::
       ::  TODO: %drip %kick so app crash can't kill the remote %pull
       ::
-      =.  mo-core  (mo-send-foreign-request ship foreign-agent %leave ~)
+      =.  mo-core
+        (mo-send-foreign-request ship foreign-agent / %leave ~)
       =.  mo-core  (mo-give %unto %kick ~)
       mo-core
     ==
@@ -607,14 +684,15 @@
         mo-core
       =/  app
         =/  =ship  (slav %p i.t.t.wire)
-        =/  =routes  [disclosing=~ attributing=ship]
+        =/  =routes  [disclosing=~ attributing=[ship /[-.sign-arvo]]]
         (ap-abed:ap dap routes)
       ::
       =.  app  (ap-generic-take:app t.t.t.wire sign-arvo)
       ap-abet:app
     ?>  ?=([%out @ @ *] t.t.wire)
-    =/  =ship  (slav %p i.t.t.t.wire)
-    =/  =routes  [disclosing=~ attributing=ship]
+    =/  ship  (slav %p i.t.t.t.wire)
+    =/  other-agent  i.t.t.t.t.wire
+    =/  =routes  [disclosing=~ attributing=[ship /gall/[other-agent]]]
     =/  =unto  +>.sign-arvo
     ?:  ?=(%| -.agent.u.yoke)
       =/  blocked=(qeu blocked-move)
@@ -649,7 +727,7 @@
       ~(get to blocked)
     ?:  ?=(%| -.blocker)  $
     =/  =move
-      =/  =sock  [attributing.routes our]
+      =/  =sock  [ship.attributing.routes our /gall]
       =/  card   [%slip %g %deal sock dap p.blocker]
       [duct card]
     $(moves [move moves])
@@ -673,39 +751,39 @@
         new-agents  (~(put by new-agents) name.i.agents new-blocked)
       ==
     =^  mov=blocked-move  blocked.i.agents  ~(get to blocked.i.agents)
-    =?  new-blocked  !=(ship attributing.routes.mov)
+    =?  new-blocked  !=(ship ship.attributing.routes.mov)
       (~(put to new-blocked) mov)
     $
   ::  +mo-idle: put agent to sleep
   ::
   ++  mo-idle
-    |=  dap=dude
+    |=  [dap=dude prov=path]
     ^+  mo-core
     ?.  (~(has by yokes.state) dap)
       ~>  %slog.0^leaf/"gall: ignoring %idle for {<dap>}, not running"
       mo-core
-    ap-abet:ap-idle:(ap-abed:ap dap `our)
+    ap-abet:ap-idle:(ap-abed:ap dap [~ our prov])
   ::  +mo-nuke: delete agent completely
   ::
   ++  mo-nuke
-    |=  dap=dude
+    |=  [dap=dude prov=path]
     ^+  mo-core
     ?.  (~(has by yokes.state) dap)
       ~>  %slog.0^leaf/"gall: ignoring %nuke for {<dap>}, not running"
       mo-core
     ~>  %slog.0^leaf/"gall: nuking {<dap>}"
-    =.  mo-core  ap-abet:ap-nuke:(ap-abed:ap dap `our)
+    =.  mo-core  ap-abet:ap-nuke:(ap-abed:ap dap [~ our prov])
     mo-core(yokes.state (~(del by yokes.state) dap))
   ::  +mo-load: install agents
   ::
   ++  mo-load
-    |=  agents=(list [=dude =beak =agent])
+    |=  [agents=(list [=dude =beak =agent]) prov=path]
     =.  mo-core
       |-  ^+  mo-core
       ?~  agents  mo-core
       =/  [=dude =desk]  [dude q.beak]:i.agents
       ::  ~>  %slog.0^leaf/"gall: starting {<dude>} on {<desk>}"
-      $(agents t.agents, mo-core (mo-receive-core i.agents))
+      $(agents t.agents, mo-core (mo-receive-core i.agents prov))
     ::
     =/  kil
       =/  lol  (skim ~(tap by yokes.state) |=([term yoke] -.agent))
@@ -716,7 +794,7 @@
     |-  ^+  mo-core
     ?~  kil  mo-core
     ~>  %slog.0^leaf/"gall: stopping {<i.kil>}"
-    $(kil t.kil, mo-core (mo-idle i.kil))
+    $(kil t.kil, mo-core (mo-idle i.kil prov))
   ::  +mo-peek:  call to +ap-peek (which is not accessible outside of +mo).
   ::
   ++  mo-peek
@@ -737,7 +815,7 @@
         %raw-poke
       =/  =case:clay  da+now
       =/  =desk  q.beak:(~(got by yokes.state) dap)
-      =/  sky  (rof ~ %cb [our desk case] /[mark.deal])
+      =/  sky  (rof ~ /gall %cb [our desk case] /[mark.deal])
       ?-    sky
           ?(~ [~ ~])
         =/  ror  "gall: raw-poke fail :{(trip dap)} {<mark.deal>}"
@@ -760,7 +838,7 @@
       =/  =mars:clay  [p.cage mark]:deal
       =/  mars-path   /[a.mars]/[b.mars]
       =/  =desk  q.beak:(~(got by yokes.state) dap)
-      =/  sky  (rof ~ %cc [our desk case] mars-path)
+      =/  sky  (rof ~ /gall %cc [our desk case] mars-path)
       ?-    sky
           ?(~ [~ ~])
         =/  ror  "gall: poke cast fail :{(trip dap)} {<mars>}"
@@ -791,10 +869,10 @@
   ::    +deal.  Otherwise simply apply the action to the agent.
   ::
   ++  mo-handle-local
-    |=  [=ship agent=term =deal]
+    |=  [=ship agent=term prov=path =deal]
     ^+  mo-core
     ::
-    =/  =routes  [disclosing=~ attributing=ship]
+    =/  =routes  [disclosing=~ attributing=[ship prov]]
     =/  running  (~(get by yokes.state) agent)
     =/  is-running  ?~(running %| ?=(%& -.agent.u.running))
     =/  is-blocked  (~(has by blocked.state) agent)
@@ -813,6 +891,22 @@
     %_  mo-core
       blocked.state  (~(put by blocked.state) agent blocked)
     ==
+  ::  +mo-handle-ames-request-all: handle (maybe old) %ames request
+  ::
+  ++  mo-handle-ames-request-all
+    |=  [=ship agent-name=term =ames-request-all]
+    ^+  mo-core
+    =/  =ames-request
+      ?-  -.ames-request-all
+        %1  +.ames-request-all
+        %0  ?-  +<.ames-request-all
+              %m  [%m / mark noun]:ames-request-all
+              %l  [%l / mark path]:ames-request-all
+              %s  [%s / path]:ames-request-all
+              %u  [%u / ~]
+            ==
+      ==
+    (mo-handle-ames-request ship agent-name ames-request)
   ::  +mo-handle-ames-request: handle %ames request message.
   ::
   ++  mo-handle-ames-request
@@ -825,14 +919,15 @@
     ::
     =/  =wire  /sys/req/(scot %p ship)/[agent-name]
     ::
-    =/  =deal
+    ::
+    =/  [prov=path =deal]
       ?-  -.ames-request
-        %m  [%raw-poke [mark noun]:ames-request]
-        %l  [%watch-as [mark path]:ames-request]
-        %s  [%watch path.ames-request]
-        %u  [%leave ~]
+        %m  [prov %raw-poke mark noun]:ames-request
+        %l  [prov %watch-as mark path]:ames-request
+        %s  [prov %watch path]:ames-request
+        %u  [prov %leave ~]:ames-request
       ==
-    (mo-pass wire %g %deal [ship our] agent-name deal)
+    (mo-pass wire %g %deal [ship our prov] agent-name deal)
   ::  +mo-spew: handle request to set verbosity toggles on debug output
   ::
   ++  mo-spew
@@ -994,7 +1089,7 @@
         =/  =case:clay  da+now
         =/  bek=beak    [our q.beak.yoke case]
         =/  mars-path  /[a.mars]/[b.mars]
-        =/  sky  (rof ~ %cc bek mars-path)
+        =/  sky  (rof ~ /gall %cc bek mars-path)
         ?-    sky
             ?(~ [~ ~])
           %-  (slog leaf+"watch-as fact conversion find-fail" >sky< ~)
@@ -1028,14 +1123,15 @@
           ?-  -.neet
             %agent  [%out (scot %p ship.neet) name.neet wire]
             %huck   [%out (scot %p ship.neet) name.neet wire]
-            %arvo   [(scot %p attributing.agent-routes) wire]
+            %arvo   [(scot %p ship.attributing.agent-routes) wire]
           ==
         ::
+        =/  prov=path  /gall/[agent-name]
         =/  =note-arvo
           ?-  -.neet
             %arvo   note-arvo.neet
             %huck   note-arvo.neet
-            %agent  [%g %deal [our ship.neet] [name deal]:neet]
+            %agent  [%g %deal [our ship.neet prov] [name deal]:neet]
           ==
         [duct %pass wire note-arvo]~
       ==
@@ -1167,7 +1263,7 @@
       =/  tub=(unit tube:clay)
         ?:  =(have want)  `(bake same ^vase)
         =/  tuc=(unit (unit cage))
-          (rof ~ %cc [our q.beak.yoke da+now] /[have]/[want])
+          (rof ~ /gall %cc [our q.beak.yoke da+now] /[have]/[want])
         ?.  ?=([~ ~ *] tuc)  ~
         `!<(tube:clay q.u.u.tuc)
       ?~  tub
@@ -1196,8 +1292,10 @@
     ++  ap-construct-bowl
       ^-  bowl
       :*  :*  our                                     ::  host
-              attributing.agent-routes                ::  guest
+              ship.attributing.agent-routes           ::  guest
               agent-name                              ::  agent
+              path.attributing.agent-routes           ::  provenance
+
           ==                                          ::
           :*  wex=boat.yoke                           ::  outgoing
               sup=bitt.yoke                           ::  incoming
@@ -1235,7 +1333,7 @@
       ~/  %ap-subscribe
       |=  pax=path
       ^+  ap-core
-      =/  incoming   [attributing.agent-routes pax]
+      =/  incoming   [ship.attributing.agent-routes pax]
       =.  bitt.yoke  (~(put by bitt.yoke) agent-duct incoming)
       =^  maybe-tang  ap-core
         %+  ap-ingest  %watch-ack  |.
@@ -1295,7 +1393,7 @@
         ?:  ?=(%spider agent-name)
           :-  [%fact mark.unto !>(noun.unto)]
           ap-core
-        =/  sky  (rof ~ %cb [our q.beak.yoke case] /[mark.unto])
+        =/  sky  (rof ~ /gall %cb [our q.beak.yoke case] /[mark.unto])
         ?.  ?=([~ ~ *] sky)
           (mean leaf+"gall: ames mark fail {<mark.unto>}" ~)
         ::
@@ -1477,7 +1575,7 @@
       |=  =duct
       ^-  (list move)
       ::
-      :~  [duct %slip %g %deal [our our] agent-name %leave ~]
+      :~  [duct %slip %g %deal [our our /gall/[agent-name]] agent-name %leave ~]
           [duct %give %unto %kick ~]
       ==
     ::  +ap-kill-down: 2-sided kill from subscriber side
@@ -1549,7 +1647,7 @@
       ++  scry-peer-state
         |=  her=ship
         ~+  ^-  (unit peer-state:ames)
-        =/  sky  (rof [~ ~] %ax [our %$ da+now] /peers/(scot %p her))
+        =/  sky  (rof [~ ~] /gall %ax [our %$ da+now] /peers/(scot %p her))
         ?:  |(?=(~ sky) ?=(~ u.sky))
           ~
         =/  sat  !<(ship-state:ames q.u.u.sky)
@@ -1566,7 +1664,7 @@
     ++  ap-mule
       |=  run=_^?(|.(*step:agent))
       ^-  (each step:agent tang)
-      =/  res  (mock [run %9 2 %0 1] (look rof ~))
+      =/  res  (mock [run %9 2 %0 1] (look rof ~ /gall/[agent-name]))
       ?-  -.res
         %0  [%& !<(step:agent [-:!>(*step:agent) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -1577,7 +1675,7 @@
     ++  ap-mule-peek
       |=  run=_^?(|.(*(unit (unit cage))))
       ^-  (each (unit (unit cage)) tang)
-      =/  res  (mock [run %9 2 %0 1] (look rof ~))
+      =/  res  (mock [run %9 2 %0 1] (look rof ~ /gall/[agent-name]))
       ?-  -.res
         %0  [%& !<((unit (unit cage)) [-:!>(*(unit (unit cage))) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -1720,6 +1818,18 @@
   ::
   ~|  [%gall-call-failed duct hic]
   =/  =task  ((harden task) hic)
+  =/  prov=path
+    ?:  ?=(%deal -.task)
+      r.p.task
+    ?.  ?&  ?=([^ *] duct)
+            ?=  $?  %ames  %behn  %clay
+                    %dill  %eyre  %gall
+                    %iris  %jael  %khan
+                ==
+            i.i.duct
+        ==
+      *path
+    /[i.i.duct]
   ::
   =/  mo-core  (mo-abed:mo duct)
   ?-    -.task
@@ -1727,8 +1837,8 @@
     =/  [=sock =term =deal]  [p q r]:task
     ?.  =(q.sock our)
       ?>  =(p.sock our)
-      mo-abet:(mo-send-foreign-request:mo-core q.sock term deal)
-    mo-abet:(mo-handle-local:mo-core p.sock term deal)
+      mo-abet:(mo-send-foreign-request:mo-core q.sock term prov deal)
+    mo-abet:(mo-handle-local:mo-core p.sock term prov deal)
   ::
       %init  [~ gall-payload(system-duct.state duct)]
       %plea
@@ -1741,17 +1851,16 @@
     =/  agent-name  i.t.path
     ::
     =+  ;;(=ames-request-all noun)
-    ?>  ?=(%0 -.ames-request-all)
-    =>  (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
+    =>  (mo-handle-ames-request-all:mo-core ship agent-name ames-request-all)
     mo-abet
   ::
       %sear  mo-abet:(mo-filter-queue:mo-core ship.task)
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)
-      %idle  mo-abet:(mo-idle:mo-core dude.task)
-      %load  mo-abet:(mo-load:mo-core +.task)
-      %nuke  mo-abet:(mo-nuke:mo-core dude.task)
-      %doff  mo-abet:(mo-doff:mo-core +.task)
-      %rake  mo-abet:(mo-rake:mo-core +.task)
+      %idle  mo-abet:(mo-idle:mo-core dude.task prov)
+      %load  mo-abet:(mo-load:mo-core +.task prov)
+      %nuke  mo-abet:(mo-nuke:mo-core dude.task prov)
+      %doff  mo-abet:(mo-doff:mo-core +.task prov)
+      %rake  mo-abet:(mo-rake:mo-core +.task prov)
       %spew  mo-abet:(mo-spew:mo-core veb.task)
       %sift  mo-abet:(mo-sift:mo-core dudes.task)
       %trim  [~ gall-payload]
@@ -1765,17 +1874,29 @@
       =?  old  ?=(%8 -.old)  (spore-8-to-9 old)
       =?  old  ?=(%9 -.old)  (spore-9-to-10 old)
       =?  old  ?=(%10 -.old)  (spore-10-to-11 old)
-      ?>  ?=(%11 -.old)
+      =?  old  ?=(%11 -.old)  (spore-11-to-12 old)
+      ?>  ?=(%12 -.old)
       gall-payload(state old)
   ::
-  +$  spore-any  $%(spore spore-7 spore-8 spore-9 spore-10)
+  +$  spore-any  $%(spore spore-7 spore-8 spore-9 spore-10 spore-11)
+  +$  spore-11
+    $:  %11
+        system-duct=duct
+        outstanding=(map [wire duct] (qeu remote-request))
+        contacts=(set ship)
+        eggs=(map term egg)
+        blocked=(map term (qeu blocked-move-11))
+        =bug
+    ==
+  +$  blocked-move-11  [=duct routes=routes-11 move=(each deal unto)]
+  +$  routes-11  [disclosing=(unit (set ship)) attributing=ship]
   +$  spore-10
     $:  %10
         system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg-10)
-        blocked=(map term (qeu blocked-move))
+        blocked=(map term (qeu blocked-move-11))
         =bug
     ==
   +$  egg-10
@@ -1797,7 +1918,7 @@
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
         eggs=(map term egg-10)
-        blocked=(map term (qeu blocked-move))
+        blocked=(map term (qeu blocked-move-11))
         =bug
     ==
   ::
@@ -1809,7 +1930,7 @@
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
         eggs=(map term egg-8)
-        blocked=(map term (qeu blocked-move))
+        blocked=(map term (qeu blocked-move-11))
     ==
   +$  egg-8
     $:  control-duct=duct
@@ -1830,7 +1951,7 @@
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
         eggs=(map term egg-8)
-        blocked=(map term (qeu blocked-move))
+        blocked=(map term (qeu blocked-move-11))
     ==
   ::
   ++  spore-7-to-8
@@ -1884,7 +2005,7 @@
   ::
   ++  spore-10-to-11
     |=  old=spore-10
-    ^-  spore
+    ^-  spore-11
     %=    old
         -  %11
         eggs
@@ -1893,13 +2014,35 @@
       ^-  egg
       e(|3 |4.e(|4 `|8.e(old-state [%| p.old-state.e])))
     ==
+  ::
+  ::  added provenance path to attributing.routes
+  ::
+  ++  spore-11-to-12
+    |=  old=spore-11
+    ^-  spore
+    %=    old
+        -  %12
+        contacts
+      %-  ~(gas by *(map ship (unit ?(%0 %1))))
+      %+  turn  ~(tap in contacts.old)
+      |=(=ship [ship *contact-version])
+    ::
+        blocked
+      %-  ~(run by blocked.old)
+      |=  q=(qeu blocked-move-11)
+      %-  ~(gas to *(qeu blocked-move))
+      %+  turn  ~(tap to q)
+      |=  b=blocked-move-11
+      ^-  blocked-move
+      b(attributing.routes [attributing.routes.b /])
+    ==
   --
 ::  +scry: standard scry
 ::
 ++  scry
   ~/  %gall-scry
   ^-  roon
-  |=  [lyc=gang care=term bem=beam]
+  |=  [lyc=gang pov=path care=term bem=beam]
   ^-  (unit (unit cage))
   =/  =shop  &/p.bem
   =*  dap  q.bem
@@ -1919,7 +2062,7 @@
       |=  [dap=term =yoke]
       ^-  mass
       =/  met=(list mass)
-        =/  dat  (mo-peek:mo | dap [~ ship] %x /whey/mass)
+        =/  dat  (mo-peek:mo | dap [~ ship /] %x /whey/mass)
         ?:  ?=(?(~ [~ ~]) dat)  ~
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
       ?~  met
@@ -1997,7 +2140,7 @@
     [~ ~]
   ?.  ?=(^ path)
     ~
-  =/  =routes  [~ ship]
+  =/  =routes  [~ ship pov]
   (mo-peek:mo & dap routes care path)
 ::  +stay: save without cache; suspend non-%base agents
 ::

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -385,7 +385,7 @@
 ::
 ++  scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -199,7 +199,7 @@
         /[app]/poke
         %g
         %deal
-        [our our]
+        [our our /jael]
         app
         %poke
         %azimuth-poke
@@ -635,7 +635,7 @@
         [app path]
         %g
         %deal
-        [our our]
+        [our our /jael]
         app
         %watch
         path
@@ -1055,7 +1055,7 @@
 ::                                                      ::  ++scry
 ++  scry                                                ::  inspect
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   =*  ren  car
   =*  why=shop  &/p.bem

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -72,7 +72,7 @@
 ++  get-dais
   |=  [=beak =mark rof=roof]
   ^-  dais:clay
-  ?~  ret=(rof ~ %cb beak /[mark])
+  ?~  ret=(rof ~ /khan %cb beak /[mark])
     ~|(mark-unknown+mark !!)
   ?~  u.ret
     ~|(mark-invalid+mark !!)
@@ -82,7 +82,7 @@
 ++  get-tube
   |=  [=beak =mark =out=mark rof=roof]
   ^-  tube:clay
-  ?~  ret=(rof ~ %cc beak /[mark]/[out-mark])
+  ?~  ret=(rof ~ /khan %cc beak /[mark]/[out-mark])
     ~|(tube-unknown+[mark out-mark] !!)
   ?~  u.ret
     ~|(tube-invalid+[mark out-mark] !!)
@@ -105,12 +105,12 @@
 ++  poke-spider
   |=  [hen=duct =cage]
   ^-  move
-  [hen %pass //g %g %deal [our our] %spider %poke cage]
+  [hen %pass //g %g %deal [our our /khan] %spider %poke cage]
 ::
 ++  watch-spider
   |=  [hen=duct =path]
   ^-  move
-  [hen %pass //g %g %deal [our our] %spider %watch path]
+  [hen %pass //g %g %deal [our our /khan] %spider %watch path]
 --
 =|  khan-state
 =*  state  -
@@ -173,7 +173,7 @@
 ::
 ++  scry
   ^-  roon
-  |=  [lyc=gang car=term bem=beam]
+  |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   ~
 ++  stay  state

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5019,10 +5019,10 @@
   ::
   =>  |%
       ++  sein
-        |=  [rof=roof our=ship now=@da who=ship]
+        |=  [rof=roof pov=path our=ship now=@da who=ship]
         ;;  ship
         =<  q.q  %-  need  %-  need
-        (rof ~ %j `beam`[[our %sein %da now] /(scot %p who)])
+        (rof ~ pov %j `beam`[[our %sein %da now] /(scot %p who)])
       --
   ::  middle core: stateless queries for default numeric sponsorship
   ::


### PR DESCRIPTION
based off of https://github.com/urbit/urbit/pull/4095

this adds an extra `pro=path` field to an agent's `bowl`: the `path` denotes which vane the event came from and the agent if it came from gall. This is populated in all cases - scries/pokes/watches/signs, etc. For a gall agent the path is `/gall/[agent-name]`, for other vanes it's just `/[vane]`, if it's indeterminate it's just `/`. The provenance of events from the local ship can be trusted, the provenance of `deal`s over ames cannot be - it just says whatever the other ship claims.

This adds an additional `pov=path` arg after `lyc=gang` in arvo's `roof`/`room`/`roof`/`rook` scry types, `++look` and relevant machinery. The `++scry` vane arm also takes `pov`. Arvo's external `++peek` doesn't. At this stage, all vanes just use their own name eg `/eyre` except for gall which uses `/gall/[agent-name]` for scries coming from within its agents.

The version of `$ames-request` in gall is bumped to `%1` from its current `%0` version & a `prov` field is added to each case. Since current gall simply crashes without an error message on any `$ames-request-all` that's not `%0`, talking to old galls is tricky. Current approach is to change `contacts.state` from a simple `(set ship)` to a `map` containing info about which ames-request version to use, and versions will be negotiated. We ask the other ship what version(s) they support if we don't know, defaulting to sending %0 until we hear back from them, retrying at most once a day per ship until they're upgraded. If a %1 gall receives a %0 `$ames-request-all`, it just uses an empty `/` provenance`.