### PR TITLE
fine: next steps

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -15,7 +15,7 @@
       running=(axal thread-form)
       tid=(map tid yarn)
       serving=(map tid [(unit @ta) =mark =desk])
-      scries=(map tid [=ship =path])
+      scrying=(jug tid [=wire =ship =path])
   ==
 ::
 +$  clean-slate-any
@@ -25,16 +25,26 @@
       clean-slate-2
       clean-slate-3
       clean-slate-4
+      clean-slate-5
       clean-slate
   ==
 ::
 +$  clean-slate
+  $:  %6
+      starting=(map yarn [=trying =vase])
+      running=(list yarn)
+      tid=(map tid yarn)
+      serving=(map tid [(unit @ta) =mark =desk])
+      scrying=(jug tid [wire ship path])
+  ==
+::
++$  clean-slate-5
   $:  %5
       starting=(map yarn [=trying =vase])
       running=(list yarn)
       tid=(map tid yarn)
       serving=(map tid [(unit @ta) =mark =desk])
-      scries=(map tid [ship path])
+      scrying=(map tid [ship path])
   ==
 ::
 +$  clean-slate-4
@@ -110,17 +120,23 @@
     =.  any  (old-to-3 any)
     =.  any  (old-to-4 any)
     =.  any  (old-to-5 any)
-    ?>  ?=(%5 -.any)
+    =.  any  (old-to-6 any)
+    ?>  ?=(%6 -.any)
     ::
     =.  tid.state  tid.any
     =/  yarns=(list yarn)
       %+  welp  running.any
       ~(tap in ~(key by starting.any))
+    ~&  yarns+yarns
     |-  ^-  (quip card _this)
-    ?~  yarns
+     ?~  yarns
       [~[bind-eyre:sc] this]
     =^  cards-1  state
-      (handle-stop-thread:sc (yarn-to-tid i.yarns) |)
+      %.  [(yarn-to-tid i.yarns) nice=%.n]
+      ::  the |sc core needs to now about the previous
+      ::  scrying state in order to send $yawns to %ames
+      ::
+      %*(handle-stop-thread sc scrying.state scrying.any)
     =^  cards-2  this
       $(yarns t.yarns)
     [:(weld upgrade-cards cards-1 cards-2) this]
@@ -133,8 +149,8 @@
     ++  old-to-2
       |=  old=clean-slate-any
       ^-  (quip card clean-slate-any)
-      ?>  ?=(?(%1 %2 %3 %4 %5) -.old)
-      ?:  ?=(?(%2 %3 %4 %5) -.old)
+      ?>  ?=(?(%1 %2 %3 %4 %5 %6) -.old)
+      ?:  ?=(?(%2 %3 %4 %5 %6) -.old)
         `old
       :-  ~[bind-eyre:sc]
       :*  %2
@@ -147,8 +163,8 @@
     ++  old-to-3
       |=  old=clean-slate-any
       ^-  clean-slate-any
-      ?>  ?=(?(%2 %3 %4 %5) -.old)
-      ?:  ?=(?(%3 %4 %5) -.old)
+      ?>  ?=(?(%2 %3 %4 %5 %6) -.old)
+      ?:  ?=(?(%3 %4 %5 %6) -.old)
         old
       :*  %3
         starting.old
@@ -156,11 +172,12 @@
         tid.old
         (~(run by serving.old) |=([id=@ta =mark] [id mark q.byk.bowl]))
       ==
+    ::
     ++  old-to-4
       |=  old=clean-slate-any
       ^-  clean-slate-any
-      ?>  ?=(?(%3 %4 %5) -.old)
-      ?:  ?=(?(%4 %5) -.old)
+      ?>  ?=(?(%3 %4 %5 %6) -.old)
+      ?:  ?=(?(%4 %5 %6) -.old)
         old
       :*  %4
         starting.old
@@ -171,10 +188,27 @@
     ::
     ++  old-to-5
       |=  old=clean-slate-any
-      ^-  clean-slate
-      ?>  ?=(?(%4 %5) -.old)
-      ?:  ?=(%5 -.old)  old
+      ^-  clean-slate-any
+      ?>  ?=(?(%4 %5 %6) -.old)
+      ?:  ?=(?(%5 %6) -.old)  old
       [%5 +.old(serving [serving.old ~])]
+    ::
+    ++  old-to-6
+      |=  old=clean-slate-any
+      ^-  clean-slate
+      ?>  ?=(?(%5 %6) -.old)
+      ?:  ?=(%6 -.old)  old
+      :-  %6
+      %=    +.old
+          scrying
+        %-  ~(run by scrying.old)
+        |=  [=ship =path]
+        %-  ~(gas in *(set [wire ^ship ^path]))
+        ::  XX +keen:strandio used /keen as the default wire
+        ::  this assumes that any old thread used that as well
+        ::
+        [/keen ship path]~
+      ==
     --
   ::
   ++  on-poke
@@ -421,14 +455,13 @@
   ?:  (~(has of running.state) u.yarn)
       ?.  nice
         (thread-fail u.yarn %cancelled ~)
-      =^  cancel-cards  state  (cancel-scry tid &)
-      =^  done-cards    state  (thread-done u.yarn *vase)
-      [(weld cancel-cards done-cards) state]
+      =^  done-cards  state  (thread-done u.yarn *vase silent=%.n)
+      [done-cards state]
   ?:  (~(has by starting.state) u.yarn)
     (thread-fail-not-running tid %stopped-before-started ~)
   ~&  [%thread-not-started u.yarn]
   ?:  nice
-    (thread-done u.yarn *vase)
+    (thread-done u.yarn *vase silent=%.y)
   (thread-fail u.yarn %cancelled ~)
 ::
 ++  take-input
@@ -457,8 +490,8 @@
     ^-  [(list card) _state]
     %+  roll  cards.r
     |=  [=card cards=(list card) s=_state]
-    :_  =?  scries.s  ?=([%pass ^ %arvo %a %keen @ *] card)
-          (~(put by scries.s) tid &6.card +>+>+>.card)
+    :_  =?  scrying.s  ?=([%pass ^ %arvo %a %keen @ *] card)
+          (~(put ju scrying.s) tid [&2 &6 |6]:card)
         s
     :_  cards
     ^-  ^card
@@ -476,7 +509,7 @@
     ?-  -.eval-result.r
       %next  `state
       %fail  (thread-fail yarn err.eval-result.r)
-      %done  (thread-done yarn value.eval-result.r)
+      %done  (thread-done yarn value.eval-result.r silent=%.y)
     ==
   [(weld cards final-cards) state]
 ::
@@ -500,12 +533,15 @@
 ++  cancel-scry
   |=  [=tid silent=?]
   ^-  (quip card _state)
-  ?~  scry=(~(get by scries.state) tid)
+  ?~  scrying=(~(get ju scrying.state) tid)
     `state
-  :_  state(scries (~(del by scries.state) tid))
+  :_  state(scrying (~(del by scrying.state) tid))
   ?:  silent  ~
-  %-  (slog leaf+"cancelling {<tid>}: [{<[ship path]:u.scry>}]" ~)
-  [%pass /thread/[tid]/keen %arvo %a %yawn [ship path]:u.scry]~
+  %-  ~(rep in `(set [wire ship path])`scrying)
+  |=  [[=wire =ship =path] cards=(list card)]
+  %-  (slog leaf+"cancelling {<tid>}: [{<[wire ship path]>}]" ~)
+  :_  cards
+  [%pass (welp /thread/[tid] wire) %arvo %a %yawn ship path]
 ::
 ++  thread-http-fail
   |=  [=tid =term =tang]
@@ -535,9 +571,9 @@
   ::%-  (slog leaf+"strand {<yarn>} failed" leaf+<term> tang)
   =/  =tid  (yarn-to-tid yarn)
   =/  fail-cards  (thread-say-fail tid term tang)
-  =^  cards  state  (thread-clean yarn)
+  =^  cards       state  (thread-clean yarn)
   =^  http-cards  state  (thread-http-fail tid term tang)
-  =^  scry-card   state  (cancel-scry tid |)
+  =^  scry-card   state  (cancel-scry tid silent=%.n)
   :_  state
   :(weld fail-cards cards http-cards scry-card)
 ::
@@ -556,7 +592,7 @@
   (json-response:gen:server !<(json (tube vase)))
 ::
 ++  thread-done
-  |=  [=yarn =vase]
+  |=  [=yarn =vase silent=?]
   ^-  (quip card ^state)
   ::  %-  (slog leaf+"strand {<yarn>} finished" (sell vase) ~)
   =/  =tid  (yarn-to-tid yarn)
@@ -566,8 +602,8 @@
     ==
   =^  http-cards  state
     (thread-http-response tid vase)
-  =^  scry-card  state  (cancel-scry tid &)
-  =^  cards  state  (thread-clean yarn)
+  =^  scry-card  state  (cancel-scry tid silent)
+  =^  cards      state  (thread-clean yarn)
   [:(weld done-cards cards http-cards scry-card) state]
 ::
 ++  thread-clean
@@ -640,7 +676,7 @@
 ::
 ++  clean-state
   !>  ^-  clean-slate
-  5+state(running (turn ~(tap of running.state) head))
+  6+state(running (turn ~(tap of running.state) head))
 ::
 ++  convert-tube
   |=  [from=mark to=mark =desk =bowl:gall]

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -127,9 +127,8 @@
     =/  yarns=(list yarn)
       %+  welp  running.any
       ~(tap in ~(key by starting.any))
-    ~&  yarns+yarns
     |-  ^-  (quip card _this)
-     ?~  yarns
+    ?~  yarns
       [~[bind-eyre:sc] this]
     =^  cards-1  state
       %.  [(yarn-to-tid i.yarns) nice=%.n]

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2616,6 +2616,7 @@
             $=  sky                                     ::  scry bindings
             %+  map  path                               ::
             ((mop @ud (pair @da (each page @uvI))) lte) ::
+            ken=(jug spar:ames wire)                    ::  open keens
         ==                                              ::
         $:  act=@ud                                     ::  change number
             eny=@uvJ                                    ::  entropy

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2616,7 +2616,6 @@
             $=  sky                                     ::  scry bindings
             %+  map  path                               ::
             ((mop @ud (pair @da (each page @uvI))) lte) ::
-            ken=(jug spar:ames wire)                    ::  open keens
         ==                                              ::
         $:  act=@ud                                     ::  change number
             eny=@uvJ                                    ::  entropy

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1311,6 +1311,7 @@
           :*  wex=boat.yoke                           ::  outgoing
               sup=bitt.yoke                           ::  incoming
               sky=(~(run by sky.yoke) tail)           ::  bindings
+              ken=ken.yoke                            ::  requests
           ==                                          ::
           :*  act=change.stats.yoke                   ::  tick
               eny=eny.stats.yoke                      ::  nonce

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -958,8 +958,18 @@
         moves        moves
       ==
     ::
+    ++  ap-yawn-all
+      ^-  (list card:agent)
+      %-  zing
+      %+  turn  ~(tap by ken.yoke)
+      |=  [=spar:ames wyz=(set wire)]
+      %+  turn  ~(tap in wyz)
+      |=  =wire
+      [%pass wire %arvo %a %yawn spar]
+    ::
     ++  ap-idle
       ?:  ?=(%| -.agent.yoke)  ap-core
+      =>  (ap-ingest ~ |.([ap-yawn-all p.agent.yoke]))
       ap-core(agent.yoke |+on-save:ap-agent-core)
     ::
     ++  ap-nuke
@@ -979,12 +989,7 @@
           |=  [[=wire =dock] ? =path]
           [%pass wire %agent dock %leave ~]
         ::
-          %-  zing
-          %+  turn  ~(tap by ken.yoke)
-          |=  [=spar:ames wyz=(set wire)]
-          %+  turn  ~(tap in wyz)
-          |=  =wire
-          [%pass wire %arvo %a %yawn spar]
+          ap-yawn-all
         ==
       =^  maybe-tang  ap-core  (ap-ingest ~ |.([will *agent]))
       ap-core

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -968,9 +968,10 @@
       [%pass wire %arvo %a %yawn spar]
     ::
     ++  ap-idle
+      ^+  ap-core
       ?:  ?=(%| -.agent.yoke)  ap-core
-      =>  (ap-ingest ~ |.([ap-yawn-all p.agent.yoke]))
-      ap-core(agent.yoke |+on-save:ap-agent-core)
+      =>  [ken=ken.yoke (ap-ingest ~ |.([ap-yawn-all *agent]))]
+      ap-core(ken.yoke ken, agent.yoke |+on-save:ap-agent-core)
     ::
     ++  ap-nuke
       ^+  ap-core
@@ -1327,6 +1328,12 @@
         ?:  ?=(%& -.agent.yoke)
           on-save:ap-agent-core
         p.agent.yoke
+      =?  ap-core  &(?=(%| -.agent.yoke) ?=(^ ken.yoke))
+        =-  +:(ap-ingest ~ |.([+< agent]))
+        %-  zing
+        %+  turn  ~(tap by `(jug spar:ames wire)`ken.yoke)
+        |=  [=spar:ames wyz=(set wire)]
+        (turn ~(tap in wyz) |=(=wire [%pass wire %arvo %a %keen spar]))
       =^  error  ap-core
         (ap-install(agent.yoke &+agent) `old-state)
       ?~  error

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1311,7 +1311,6 @@
           :*  wex=boat.yoke                           ::  outgoing
               sup=bitt.yoke                           ::  incoming
               sky=(~(run by sky.yoke) tail)           ::  bindings
-              ken=ken.yoke                            ::  requests
           ==                                          ::
           :*  act=change.stats.yoke                   ::  tick
               eny=eny.stats.yoke                      ::  nonce

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -42,9 +42,9 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
-::  $state-12: overall gall state, versioned
+::  $state-13: overall gall state, versioned
 ::
-+$  state-12  [%12 state]
++$  state-13  [%13 state]
 ::  $state: overall gall state
 ::
 ::    system-duct: TODO document
@@ -82,6 +82,7 @@
 ::    beak: compilation source
 ::    marks: mark conversion requests
 ::    sky: scry bindings
+::    ken: open keen requests
 ::
 +$  yoke
   $%  [%nuke sky=(map spur @ud)]
@@ -98,6 +99,7 @@
           =beak
           marks=(map duct mark)
           sky=(map spur path-state)
+          ken=(jug spar:ames wire)
   ==  ==
 ::
 +$  path-state
@@ -160,7 +162,7 @@
 ::  $spore: structures for update, produced by +stay
 ::
 +$  spore
-  $:  %12
+  $:  %13
       system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
       contacts=(set ship)
@@ -185,11 +187,12 @@
           =beak
           marks=(map duct mark)
           sky=(map spur path-state)
+          ken=(jug spar:ames wire)
   ==  ==
 --
 ::  adult gall vane interface, for type compatibility with pupa
 ::
-=|  state=state-12
+=|  state=state-13
 |=  [now=@da eny=@uvJ rof=roof]
 =*  gall-payload  .
 ~%  %gall-top  ..part  ~
@@ -967,13 +970,22 @@
         |=  [=duct =ship =path]
         path
       =/  will=(list card:agent)
-        %+  welp
+        ;:  welp
           ?:  =(~ inbound-paths)
             ~
           [%give %kick ~(tap in inbound-paths) ~]~
-        %+  turn  ~(tap by boat.yoke)
-        |=  [[=wire =dock] ? =path]
-        [%pass wire %agent dock %leave ~]
+        ::
+          %+  turn  ~(tap by boat.yoke)
+          |=  [[=wire =dock] ? =path]
+          [%pass wire %agent dock %leave ~]
+        ::
+          %-  zing
+          %+  turn  ~(tap by ken.yoke)
+          |=  [=spar:ames wyz=(set wire)]
+          %+  turn  ~(tap in wyz)
+          |=  =wire
+          [%pass wire %arvo %a %yawn spar]
+        ==
       =^  maybe-tang  ap-core  (ap-ingest ~ |.([will *agent]))
       ap-core
     ::  +ap-grow: bind a path in the agent's scry namespace
@@ -1365,6 +1377,8 @@
       =^  maybe-tang  ap-core
         %+  ap-ingest  ~  |.
         (on-arvo:ap-agent-core wire sign-arvo)
+      =?  ken.yoke  ?=([%ames %tune spar=* *] sign-arvo)
+        (~(del ju ken.yoke) spar.sign-arvo wire)
       ?^  maybe-tang
         (ap-error %arvo-response u.maybe-tang)
       ap-core
@@ -1714,6 +1728,7 @@
       ::
       =.  agent.yoke  &++.p.result
       =^  fex  ap-core  (ap-handle-sky -.p.result)
+      =.  ken.yoke    (ap-handle-ken fex)
       =/  moves       (zing (turn fex ap-from-internal))
       =.  bitt.yoke   (ap-handle-kicks moves)
       (ap-handle-peers moves)
@@ -1731,6 +1746,17 @@
         [%pass * ?(%agent %arvo %pyre) *]  $(caz t.caz, fex [i.caz fex])
         [%give *]  $(caz t.caz, fex [i.caz fex])
         [%slip *]  !!
+      ==
+    ::  +ap-handle-ken
+    ::
+    ++  ap-handle-ken
+      |=  fex=(list carp)
+      ^+  ken.yoke
+      %+  roll  fex
+      |=  [=carp ken=_ken.yoke]
+      ?+  carp  ken
+        [%pass * %arvo %a %keen spar=*]  (~(put ju ken) [spar.q p]:carp)
+        [%pass * %arvo %a %yawn spar=*]  (~(del ju ken) [spar.q p]:carp)
       ==
     ::  +ap-handle-kicks: handle cancels of bitt.watches
     ::
@@ -1875,10 +1901,36 @@
       =?  old  ?=(%9 -.old)  (spore-9-to-10 old)
       =?  old  ?=(%10 -.old)  (spore-10-to-11 old)
       =?  old  ?=(%11 -.old)  (spore-11-to-12 old)
-      ?>  ?=(%12 -.old)
+      =?  old  ?=(%12 -.old)  (spore-12-to-13 old)
+      ?>  ?=(%13 -.old)
       gall-payload(state old)
   ::
-  +$  spore-any  $%(spore spore-7 spore-8 spore-9 spore-10 spore-11)
+  +$  spore-any  $%(spore spore-7 spore-8 spore-9 spore-10 spore-11 spore-12)
+  +$  spore-12
+    $:  %12
+        system-duct=duct
+        outstanding=(map [wire duct] (qeu remote-request))
+        contacts=(set ship)
+        eggs=(map term egg-12)
+        blocked=(map term (qeu blocked-move))
+        =bug
+    ==
+  +$  egg-12
+    $%  [%nuke sky=(map spur @ud)]
+        $:  %live
+            control-duct=duct
+            run-nonce=@t
+            sub-nonce=@
+            =stats
+            =bitt
+            =boat
+            =boar
+            code=~
+            old-state=[%| vase]
+            =beak
+            marks=(map duct mark)
+            sky=(map spur path-state)
+    ==  ==
   +$  spore-11
     $:  %11
         system-duct=duct
@@ -2010,20 +2062,6 @@
     %+  murn  ~(tap to q)
     |=(r=remote-request-9 ?:(?=(%cork r) ~ `r))
   ::
-  ::  added sky
-  ::
-  ++  spore-11-to-12
-    |=  old=spore-11
-    ^-  spore
-    %=    old
-        -  %12
-        eggs
-      %-  ~(urn by eggs.old)
-      |=  [a=term e=egg-11]
-      ^-  egg
-      live/e(marks [marks.e sky:*$>(%live egg)])
-    ==
-  ::
   ::  removed live
   ::  changed old-state from (each vase vase) to [%| vase]
   ::  added code
@@ -2038,6 +2076,35 @@
       |=  [a=term e=egg-10]
       ^-  egg-11
       e(|3 |4.e(|4 `|8.e(old-state [%| p.old-state.e])))
+    ==
+  ::
+  ::  added sky
+  ::
+  ++  spore-11-to-12
+    |=  old=spore-11
+    ^-  spore-12
+    %=    old
+        -  %12
+        eggs
+      %-  ~(urn by eggs.old)
+      |=  [a=term e=egg-11]
+      ^-  egg-12
+      live/e(marks [marks.e sky:*$>(%live egg)])
+    ==
+  ::
+  ::  added ken
+  ::
+  ++  spore-12-to-13
+    |=  old=spore-12
+    ^-  spore
+    %=    old
+        -  %13
+        eggs
+      %-  ~(urn by eggs.old)
+      |=  [a=term e=egg-12]
+      ^-  egg
+      ?:  ?=(%nuke -.e)  e
+      e(sky [sky.e ken:*$>(%live egg)])
     ==
   --
 ::  +scry: standard scry

--- a/pkg/arvo/ted/keen.hoon
+++ b/pkg/arvo/ted/keen.hoon
@@ -6,7 +6,10 @@
 =/  m  (strand ,vase)
 ^-  form:m
 =+  !<([~ =spar:ames] arg)
-;<  [* roar=(unit roar:ames)]  bind:m  (keen:strandio spar)
+;<  ~  bind:m
+  (keen:strandio /keen spar)
+;<  [* roar=(unit roar:ames)]  bind:m
+  (take-tune:strandio /keen)
 ?~  roar
   (pure:m !>(~))
 ?~  data=q.dat.u.roar

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -332,11 +332,10 @@
   (take-wake `until)
 ::
 ++  keen
-  |=  =spar:ames
-  =/  m  (strand ,[spar:ames (unit roar:ames)])
+  |=  [=wire =spar:ames]
+  =/  m  (strand ,~)
   ^-  form:m
-  ;<  ~  bind:m  (send-raw-card %pass /keen %arvo %a %keen spar)
-  (take-tune /keen)
+  (send-raw-card %pass wire %arvo %a %keen spar)
 ::
 ++  sleep
   |=  for=@dr


### PR DESCRIPTION
Closes #6504 

- [ ] aqua: test fine integration, run aqua tests
- [x] spider: improve incremental scry state lifecycle mgmt (WIP, pending review)
- [x] spider: use (and maybe fix) +take-tune in strandio
- [ ] deq: implement +apt
- [x] gall
  - [x] track %keen/%tune
  - [x] send %yawn on nuke
  - [x] send %yawn on uninstall
  - [ ] ~expose open %keens in the bowl~
- [ ] hoon: write thru keens alias should work (currently using keens.peer-state)
- [ ] clay: implement permissions checks in scry (move out of fine %hunk namespace)
- [ ] fine: %drip %tune
- [ ] have Fine perform peer discovery, possibly by having the publisher respond to the requester's galaxy