### PR TITLE
arvo: fix %gall meta-namespace reads (missed in merge)

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -437,7 +437,7 @@
   ::
   ++  running
     |=  app=term
-    (scry ? %gu app ~)
+    (scry ? %gu app /$)
   ::
   ++  dbugable
     |=  app=term

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -887,7 +887,7 @@
       ^-  (unit tube:clay)
       ?:  =(from to)  `(bake same vase)
       =/  des=(unit (unit cage))
-        (do-scry %gd dap ~)
+        (do-scry %gd dap /$)
       ?.  ?=([~ ~ *] des)  ~
       =+  !<(=desk q.u.u.des)
       =/  tub=(unit (unit cage))

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -225,7 +225,7 @@
   |=  [our=ship =desk now=@da]
   ^-  (list [=dude live=?])
   %~  tap  in
-  .^((set [=dude live=?]) ge+/(scot %p our)/[desk]/(scot %da now))
+  .^((set [=dude live=?]) ge+/(scot %p our)/[desk]/(scot %da now)/$)
 ::
 ++  mergebase-hashes
   |=  [our=@p syd=desk now=@da her=ship sud=desk]


### PR DESCRIPTION
This PR fixes some %gall meta-namespace reads that were missed in merging #6406 (revised there to account for #6388). Thanks to @arthyn for the bug reports.

It'd be great to trigger (more) of these codepaths in CI. Maybe loading parts of the debug dashboard over HTTP?