### PR TITLE
json: used optimized arm for mime -> json

### DIFF
--- a/pkg/base-dev/mar/json.hoon
+++ b/pkg/base-dev/mar/json.hoon
@@ -17,7 +17,7 @@
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=([p=mite q=octs] (fall (de:json:html (@t q.q)) *^json))
+  ++  mime  |=([p=mite q=octs] (fall (de:json (@t q.q)) *^json))
   ++  noun  ^json                                        ::  clam from %noun
   ++  numb  numb:enjs
   ++  time  time:enjs

--- a/pkg/base-dev/mar/json.hoon
+++ b/pkg/base-dev/mar/json.hoon
@@ -17,7 +17,7 @@
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=([p=mite q=octs] (fall (rush (@t q.q) apex:de:json) *^json))
+  ++  mime  |=([p=mite q=octs] (fall (de:json:html (@t q.q)) *^json))
   ++  noun  ^json                                        ::  clam from %noun
   ++  numb  numb:enjs
   ++  time  time:enjs


### PR DESCRIPTION
On the tin, this uses the more standard `de:json:html` instead of the internal parsing arm.