### PR TITLE
clay: Make commits fast again

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4558,7 +4558,8 @@
     |*  [her=ship syd=desk yon=(unit aeon) res=* =state:ford:fusion]
     =^  moves  ruf
       =/  den  ((de now rof hen ruf) her syd)
-      abet:+:(tako-flow:den ?~(yon let.dom:den u.yon) res cache.state &2.state)
+      =/  tak  (aeon-to-tako:ze:den ?~(yon let.dom:den u.yon))
+      abet:+:(tako-flow:den tak res cache.state &2.state)
     [res (emil moves)]
   ::
   ++  trace


### PR DESCRIPTION
Fixes an unreleased bug where commits are much slower than they should be.

I recorded this debugging session in an effort to demonstrate "absolute debugging", which is available [here](https://youtu.be/d1VZcaGWBRM).  If you're going to watch that, I recommend not looking at the diff here -- you want to actually wonder yourself.  If you just want to skip to an explanation of the bug, jump to [1:38:00](https://youtu.be/d1VZcaGWBRM?t=5880), or the eureka moment at [1:32:29](https://youtu.be/d1VZcaGWBRM?t=5549).  The commit message here reflects that as well.