### PR TITLE
aqua: fix ph tests for %413

### DIFF
--- a/pkg/arvo/ted/aqua/ames.hoon
+++ b/pkg/arvo/ted/aqua/ames.hoon
@@ -26,9 +26,10 @@
   ^-  (list card:agent:gall)
   =/  rcvr=ship  (lane-to-ship lan)
   =/  hear-lane  (ship-to-lane sndr)
-  =/  [ames=? =packet]  (decode-packet pac)
-  ?:  &(!ames !resp==(& (cut 0 [2 1] pac)))
-    =/  [=peep =purr]  (decode-request-info `@ux`(rsh 3^64 content.packet))
+  =/  =shot  (sift-shot pac)
+  ?:  &(!sam.shot req.shot)  :: is fine request
+    =/  [=peep =meow]    (sift-purr `@ux`content.shot)
+    ~&  fine-request+peep
     %+  emit-aqua-events  our
     [%read [rcvr path.peep] [hear-lane num.peep]]~
   %+  emit-aqua-events  our

--- a/pkg/arvo/ted/aqua/dill.hoon
+++ b/pkg/arvo/ted/aqua/dill.hoon
@@ -14,20 +14,24 @@
   |=  [who=@p way=wire %blit blits=(list blit:dill)]
   ^-  (list card:agent:gall)
   =/  last-line
-    %+  roll  blits
-    |=  [b=blit:dill line=tape]
-    ?-    -.b
-        %put  (tape p.b)
-        %klr  (tape (zing (turn p.b tail)))
-        %nel  ~&  "{<who>}: {line}"  ""
-        %hop  line
-        %bel  line
-        %clr  ""
-        %sag  ~&  [%save-jamfile-to p.b]  line
-        %sav  ~&  [%save-file-to p.b]  line
-        %url  ~&  [%activate-url p.b]  line
-        %wyp  ""
-    ==
+    |^  (roll blits ha-blit)
+    ::
+    ++  ha-blit
+      |=  [b=blit:dill line=tape]
+      ?-    -.b
+          %put  (tape p.b)
+          %klr  (tape (zing (turn p.b tail)))
+          %mor  `tape`(roll p.b ha-blit)
+          %nel  ~&  "{<who>}: {line}"  ""
+          %hop  line
+          %bel  line
+          %clr  ""
+          %sag  ~&  [%save-jamfile-to p.b]  line
+          %sav  ~&  [%save-file-to p.b]  line
+          %url  ~&  [%activate-url p.b]  line
+          %wyp  ""
+      ==
+    --
   ~?  !=(~ last-line)  last-line
   ~
 --

--- a/pkg/arvo/ted/ph/keen.hoon
+++ b/pkg/arvo/ted/ph/keen.hoon
@@ -7,7 +7,7 @@
 ;<  ~  bind:m  start-simple
 ;<  ~  bind:m  (init-ship ~bud &)
 ;<  ~  bind:m  (init-ship ~dev &)
-;<  ~  bind:m  (dojo ~bud "-keen /cx/~dev/kids/1/desk/bill")
-;<  ~  bind:m  (wait-for-output ~bud "[ ~")
+;<  ~  bind:m  (dojo ~bud "-keen ~dev /c/x/1/kids/sys/kelvin")
+;<  ~  bind:m  (wait-for-output ~bud "kal=[lal=%zuse num={(scow %ud zuse)}]")
 ;<  ~  bind:m  end
 (pure:m *vase)

--- a/pkg/base-dev/lib/ph/util.hoon
+++ b/pkg/base-dev/lib/ph/util.hoon
@@ -62,15 +62,26 @@
 ::TODO  should be rename -dill-output
 ++  is-dojo-output
   |=  [who=ship her=ship uf=unix-effect what=tape]
+  |^
   ?&  =(who her)
       ?=(%blit -.q.uf)
-    ::
-      %+  lien  p.q.uf
-      |=  =blit:dill
-      ?.  ?=(%put -.blit)
-        |
-      !=(~ (find what p.blit))
+       (lien p.q.uf handle-blit)
   ==
+  ::
+  ++  handle-blit
+    |=  =blit:dill
+    ^-  ?
+    ?:  ?=(%mor -.blit)
+      (lien p.blit handle-blit)
+    ?+  -.blit  |
+      %put  !=(~ (find what p.blit))
+    ::
+        %klr
+      %+  lien  p.blit
+      |=  [* q=(list @c)]
+      !=(~ (find what q))
+    ==
+  --
 ::
 ::  Test is successful if +is-dojo-output
 ::

--- a/pkg/base-dev/sur/aquarium.hoon
+++ b/pkg/base-dev/sur/aquarium.hoon
@@ -82,5 +82,10 @@
       [%kill ~]
       [%init ~]
       [%request id=@ud request=request:http]
+      [%turf p=(list turf)]
+      ::  XX effects seen after running :aqua [%swap-files ~]
+      [%vega ~]
+      [%set-config =http-config:eyre]
+      [%sessions p=(set @t)]
   ==
 --


### PR DESCRIPTION
WIP

This fixes the issues that disallowed running any tests, but the ones involving %clay are very slow, or just «behn» (also running with https://github.com/urbit/urbit/pull/6524). I remember %aqua tests being very slow during the remote scry work so that issue still seems to be present here.