### PR TITLE
+vats: sort %base and %kids (sometimes)

### DIFF
--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -1,21 +1,23 @@
-::  Print diagnostic information about desks. 
+::  Print diagnostic information about desks.
 ::
-::  Accepts an optional argument of a list of one or more desks, returns info  
+::  Accepts an optional argument of a list of one or more desks, returns info
 ::  on all desks if no desks are specified.
 ::
-::  Keyword arguments include =filt and =verb. =filt takes one of %running, 
+::  Keyword arguments include =filt and =verb. =filt takes one of %running,
 ::  %suspended, %exists, %exists-not, or %blocking; =verb takes either & or |
-:: 
+::
 ::  If both a list of desks and a filter are provided, the output will include
-::  the desks from the list that match the filter, with the exception of the 
+::  the desks from the list that match the filter, with the exception of the
 ::  %blocking filter which always returns all desks that match.
 ::
 /-  *hood
 :-  %say
 |=  [[now=@da * bec=beak] deks=$@(~ (list desk)) filt=@tas verb=_|]
-?:  &(=(~ deks) =(%$ filt))  
-  :-  %tang 
-  %+  turn  
-    ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now))) 
+?:  &(=(~ deks) =(%$ filt))
+  :-  %tang
+  %+  turn
+    %+  sort
+      ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now)))
+    |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
   |=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))
-[%tang (report-vats p.bec now deks filt verb)] 
+[%tang (report-vats p.bec now deks filt verb)]

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -41,53 +41,55 @@
   |=  [our=@p now=@da desks=(list desk) filt=@tas verb=?]
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
-  =/  prep  (report-prep our now) 
+  =/  prep  (report-prep our now)
   ?~  filt
     %+  turn  (flop desks)
     |=(syd=@tas (report-vat prep our now syd verb))
-  =/  deks  
-    ?~  desks  ~(tap in -.prep)
-    %+  skip  ~(tap in -.prep)                                      
+  =/  deks
+    ?~  desks
+      %+  sort  ~(tap in -.prep)
+      |=([[a=desk *] [b=desk *]] ?|(=(a %kids) =(b %base)))
+    %+  skip  ~(tap in -.prep)
     |=([syd=@tas *] =(~ (find ~[syd] desks)))
-  ?:  =(filt %blocking)  
+  ?:  =(filt %blocking)
     =/  base-wic
       %+  sort  ~(tap by wic:(~(got by -.prep) %base))
-      |=([[* a=@ud] [* b=@ud]] (gth a b))  
-    ?~  base-wic  ~[leaf+"%base already up-to-date"]  
+      |=([[* a=@ud] [* b=@ud]] (gth a b))
+    ?~  base-wic  ~[leaf+"%base already up-to-date"]
     =/  blockers=(list desk)
       %+  turn
         %+  skip  ~(tap in -.prep)
-        |=  [* [zest=@tas wic=(set weft)]]  
-        ?.  =(zest %live)  & 
-        (~(has in wic) i.base-wic)    
-      |=([syd=desk *] syd)  
+        |=  [* [zest=@tas wic=(set weft)]]
+        ?.  =(zest %live)  &
+        (~(has in wic) i.base-wic)
+      |=([syd=desk *] syd)
     ?~  blockers  ~[leaf+"No desks blocking upgrade, run |bump to apply"]
     :-  [%rose [" %" "To unblock upgrade run |suspend %" ""] blockers]
     %+  turn  (flop blockers)
-    |=(syd=desk (report-vat prep our now syd verb)) 
+    |=(syd=desk (report-vat prep our now syd verb))
   %+  turn
-    ?+    filt  !!    
-    ::  
-          %exists      
-        %+  skip  deks
-        |=([syd=desk *] =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0))
-    ::  
-        %running       
-      %+  skim  deks  
+    ?+    filt  !!
+    ::
+        %exists
+      %+  skip  deks
+      |=([syd=desk *] =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0))
+    ::
+        %running
+      %+  skim  deks
       |=([* [zest=@tas *]] =(zest %live))
-    ::  
-        %suspended       
-      %+  skip  deks  
-      |=  [syd=@tas [zest=@tas *]] 
-      ?|  =(syd %kids) 
+    ::
+        %suspended
+      %+  skip  deks
+      |=  [syd=@tas [zest=@tas *]]
+      ?|  =(syd %kids)
           =(zest %live)
           =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0)
-      ==    
-    ::  
-        %exists-not      
+      ==
+    ::
+        %exists-not
       %+  skim  deks
       |=([syd=desk *] =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0))
-    ==                                  
+    ==
   |=([syd=desk *] (report-vat prep our now syd verb))
 ::  +report-vat: report on a single desk installation
 ::
@@ -155,7 +157,7 @@
         leaf/"%cz hash ends in:      {(truncate-hash hash)}"
         leaf/"app status:            {sat}"
         leaf/"pending updates:       {<`(list [@tas @ud])`~(tap in wic.dek)>}"
-    ==  
+    ==
   :~  leaf/"/sys/kelvin:     {kul}"
       leaf/"base hash:        {?.(=(1 (lent meb)) <meb> <(head meb)>)}"
       leaf/"%cz hash:         {<hash>}"


### PR DESCRIPTION
_(plus trailing whitespace cleanups)_

Display `%base` first and `%kids` last if you don't specify a list of desks (`+vats` or `+vats, =filt %exists`).

before
```
> +vats
%bitcoin
  <snip>
::
%base
  <snip>
::
%kids %cz hash:     0v1f.ga4df.4tv9m.tbrep.209ub.kngeg.tlfqm.7ct9l.srvaf.6apg6.j43l7
%talk
  <snip>
::
```
after
```
> +vats
%base
  <snip>
::
%bitcoin
  <snip>
::
%talk
  <snip>
::
%kids %cz hash:     0v1f.ga4df.4tv9m.tbrep.209ub.kngeg.tlfqm.7ct9l.srvaf.6apg6.j43l7
```

The `+sort` moves `%kids` to the head of the list and `%base` to the rear.  A downstream `+flop` displays the desks in the desired order.

The `+sort` is in two places because `+vats` and `+vats, =filt %exists` are different code paths.

If you specify a list of desks no sorting occurs.
```
> +vats %bitcoin %kids %talk %base
%bitcoin
  <snip>
::
%kids %cz hash:     0v1f.ga4df.4tv9m.tbrep.209ub.kngeg.tlfqm.7ct9l.srvaf.6apg6.j43l7
%talk
  <snip>
::
%base
  <snip>
::
```
