### PR TITLE
vats: force multiline rendering, improve performance

### DIFF
--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -12,13 +12,16 @@
 ::
 /-  *hood
 :-  %say
-|=  [[now=@da * bec=beak] deks=$@(~ (list desk)) filt=@tas verb=_|]
-?:  &(=(~ deks) =(%$ filt))
-  :-  %tang
-  %-  zing
-  %+  turn
-    %+  sort
-      ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now)))
-    |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
-  |=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))
-[%tang (report-vats p.bec now deks filt verb)]
+|=  $:  [now=@da * bec=beak]
+        deks=(list desk)
+        [filt=@tas verb=_|]
+    ==
+:-  %tang  ^-  tang
+?.  &(=(~ deks) =(%$ filt))
+  (report-vats p.bec now deks filt verb)
+%-  zing
+%+  turn
+  %+  sort
+    ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now)))
+  |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
+|=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))

--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -15,6 +15,7 @@
 |=  [[now=@da * bec=beak] deks=$@(~ (list desk)) filt=@tas verb=_|]
 ?:  &(=(~ deks) =(%$ filt))
   :-  %tang
+  %-  zing
   %+  turn
     %+  sort
       ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now)))

--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -22,6 +22,7 @@
 %-  zing
 %+  turn
   %+  sort
-    ~(tap in .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now)))
+    =/  sed  .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now))
+    (sort ~(tap in sed) |=([a=@ b=@] !(aor a b)))
   |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
 |=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -40,10 +40,12 @@
 ::
 ++  report-vats
   |=  [our=@p now=@da desks=(list desk) filt=@tas verb=?]
+  ^-  tang
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
   =/  prep  (report-prep our now)
   ?~  filt
+    %-  zing
     %+  turn  (flop desks)
     |=(syd=@tas (report-vat prep our now syd verb))
   =/  deks
@@ -66,8 +68,11 @@
       |=([syd=desk *] syd)
     ?~  blockers  ~[leaf+"No desks blocking upgrade, run |bump to apply"]
     :-  [%rose [" %" "To unblock upgrade run |suspend %" ""] blockers]
+    %-  zing
     %+  turn  (flop blockers)
     |=(syd=desk (report-vat prep our now syd verb))
+  ::
+  %-  zing
   %+  turn
     ?+    filt  !!
     ::
@@ -100,6 +105,15 @@
           ==
           our=ship  now=@da  syd=desk  verb=?
       ==
+  ^-  tang
+  =-  ::  hack to force wrapped rendering
+      ::
+      ::    edg=6 empirically prevents dedent
+      ::
+      %+  roll
+        (~(win re -) [0 6])
+      |=([a=tape b=(list @t)] [(crip a) b])
+  ::
   ^-  tank
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -142,9 +142,6 @@
     ?~  sink  [hash]~
     (mergebase-hashes our syd now her.u.sink sud.u.sink)
   =/  dek  (~(got by tyr) syd)
-  =/  =dome  (~(got by cone) our syd)
-  =/  [on=(list [@tas ?]) of=(list [@tas ?])]
-    (skid ~(tap by ren.dome) |=([* ?] +<+))
   =/  sat
     ?-  zest.dek
       %live  "running"
@@ -174,13 +171,17 @@
         leaf/"app status:            {sat}"
         leaf/"pending updates:       {<`(list [@tas @ud])`~(tap in wic.dek)>}"
     ==
+  ::
+  =/  [on=(list [@tas ?]) of=(list [@tas ?])]
+    =/  =dome  (~(got by cone) our syd)
+    (skid ~(tap by ren.dome) |=([* ?] +<+))
   :~  leaf/"/sys/kelvin:     {kul}"
       leaf/"base hash:        {?.(=(1 (lent meb)) <meb> <(head meb)>)}"
       leaf/"%cz hash:         {<hash>}"
       ::
       leaf/"app status:       {sat}"
-      leaf/"force on:         {?:(=(~ on) "~" <on>)}"
-      leaf/"force off:        {?:(=(~ of) "~" <of>)}"
+      leaf/"force on:         {<(sort (turn on head) aor)>}"
+      leaf/"force off:        {<(sort (turn of head) aor)>}"
       ::
       leaf/"publishing ship:  {?~(sink <~> <(get-publisher our syd now)>)}"
       leaf/"updates:          {?~(sink "local" "remote")}"

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -50,8 +50,9 @@
     |=(syd=@tas (report-vat prep our now syd verb))
   =/  deks
     ?~  desks
-      %+  sort  ~(tap in -.prep)
-      |=([[a=desk *] [b=desk *]] ?|(=(a %kids) =(b %base)))
+      %+  sort
+        (sort ~(tap in -.prep) |=([[a=@ *] b=@ *] !(aor a b)))
+      |=([[a=@ *] [b=@ *]] ?|(=(a %kids) =(b %base)))
     %+  skip  ~(tap in -.prep)
     |=([syd=@tas *] =(~ (find ~[syd] desks)))
   ?:  =(filt %blocking)

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -1,3 +1,4 @@
+/%  kelvin  %kelvin
 =,  clay
 =*  dude  dude:gall
 |%


### PR DESCRIPTION
This PR pre-renders the tanks in `+vats` to ensure that they're always wrapped across multiple lines (this is an expedient hack to avoid more custom rendering logic). It also imports the kelvin mark in `sur/hood` to ensure that it's not being built inside scrys, where it can't be cached. And it sorts desks and force on/off lists alphabetically.

/cc @jfranklin9000 