### PR TITLE
landscape: actual 413 compat

### DIFF
--- a/pkg/landscape/app/dm-hook.hoon
+++ b/pkg/landscape/app/dm-hook.hoon
@@ -41,7 +41,7 @@
   :_  this
   :_  ~
   =/  dms=(list resource)
-    ?.  .^(? %gu (scry:io %graph-store $ ~))
+    ?.  .^(? %gu (scry:io %graph-store /$))
       ~
     %+  skim  ~(tap in get-keys:gra)
     |=([ship name=term] ?=(^ (rush name ;~(pfix (jest 'dm--') fed:ag))))


### PR DESCRIPTION
This fixes incorrect call to `scry:io` in dm-hook.