### PR TITLE
vats: fixes +vat

### DIFF
--- a/pkg/arvo/gen/vat.hoon
+++ b/pkg/arvo/gen/vat.hoon
@@ -1,7 +1,7 @@
 /-  *hood
 :-  %say
 |=  [[now=@da eny=@uvJ bec=beak] [syd=desk ~] verb=_&]
-:~  %tang
+:*  %tang
     leaf+"Notice: +vat is deprecated as +vats now takes lists of one or more desks"
     (report-vat (report-prep p.bec now) p.bec now syd verb)
 ==


### PR DESCRIPTION
In #6532 I changed `+report-vat` to produce a `tang` instead of a `tank`, but I forgot that `+vat` still existed.