### PR TITLE
clay: fix read-s subs for 413

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4243,7 +4243,7 @@
     ::  +read-s: produce miscellaneous
     ::
     ++  read-s
-      |=  [tak=tako pax=path]
+      |=  [tak=tako pax=path =case]
       ^-  (unit (unit cage))
       ?:  ?=([%subs ~] pax)
         ?.  =([%da now] case)  ~
@@ -4514,7 +4514,7 @@
           %f  (read-f tak path.mun)
           %p  [(read-p path.mun) ..park]
           %r  (read-r tak path.mun)
-          %s  [(read-s tak path.mun) ..park]
+          %s  [(read-s tak path.mun case.mun) ..park]
           %t  [(read-t tak path.mun) ..park]
           %u  [(read-u tak path.mun) ..park]
           %v  [(read-v tak path.mun) ..park]


### PR DESCRIPTION
`=case` was added as an argument to read-s to support %cs subs. It was accidentally removed as an argument during a merge, breaking %cs subs by causing it to always crash in a comparison between `case` and `[%da now]`, because `case` resolved to the mold rather than a value. This commit restores intended functionality.