### PR TITLE
hoon: support configurable doccords parsing

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -118,7 +118,7 @@
   |=  [our=ship dir=beam]
   |%
   ++  default-app         %hood
-  ++  hoon-parser         (vang | (en-beam dir) &)
+  ++  hoon-parser         (vang | (en-beam dir))
   ++  our                 p.dir
   ::
   ++  parse-command-line  ;~(sfix parse-command (star ace) (just '\0a'))
@@ -309,7 +309,7 @@
   ++  parse-rood
     ::  XX should this use +hoon-parser instead to normalize the case?
     ::
-    =>  (vang | (en-beam dir) &)
+    =>  (vang | (en-beam dir))
     ;~  pose
       rood
     ::
@@ -1225,7 +1225,7 @@
           :+  %clhp
             [%rock %tas %cx]
           %+  rash  pax.source.com
-          rood:(vang | /(scot %p our.hid)/base/(scot %da now.hid) &)
+          rood:(vang | /(scot %p our.hid)/base/(scot %da now.hid))
         ::
             %url         [%ur (crip (en-purl:html url.source.com))]
             %api         !!
@@ -1256,7 +1256,7 @@
             %hoon
           :*  %do
               %+  rash  code.source.com
-              tall:(vang | /(scot %p our.hid)/base/(scot %da now.hid) &)
+              tall:(vang | /(scot %p our.hid)/base/(scot %da now.hid))
               $(num +(num), source.com next.source.com)
           ==
         ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11422,14 +11422,9 @@
 ::    5d: parser
 +|  %parser
 ::
-::  +vang: set +vast params
-::
-::    bug: debug mode
-::    wer: where we are
-::    doc: doccord parsing
-++  vang
-  |=  [bug=? wer=path doc=?]
-  %*(. vast bug bug, wer wer, doc doc)
+++  vang                                                ::  set ++vast params
+  |=  [bug=? wer=path]                                  ::  bug: debug mode
+  %*(. vast bug bug, wer wer)                           ::  wer: where we are
 ::
 ++  vast                                                ::  main parsing core
   =+  [bug=`?`| wer=*path doc=`?`&]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11422,9 +11422,15 @@
 ::    5d: parser
 +|  %parser
 ::
-++  vang                                                ::  set ++vast params
-  |=  [bug=? wer=path]                                  ::  bug: debug mode
-  %*(. vast bug bug, wer wer)                           ::  wer: where we are
+::  +vang: set +vast params
+::
+::    bug: debug mode
+::    doc: doccord parsing
+::    wer: where we are
+::
+++  vang
+  |=  [f=$@(? [bug=? doc=?]) wer=path]
+  %*(. vast bug ?@(f f bug.f), doc ?@(f & doc.f), wer wer)
 ::
 ++  vast                                                ::  main parsing core
   =+  [bug=`?`| wer=*path doc=`?`&]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -969,7 +969,7 @@
         ==
       ::
         %+  stag  %tssg
-        (most gap tall:(vang & pax &))
+        (most gap tall:(vang & pax))
       ==
       ::
       ++  pant

--- a/pkg/base-dev/lib/language-server/parser.hoon
+++ b/pkg/base-dev/lib/language-server/parser.hoon
@@ -44,7 +44,7 @@
     ==
   ::
     %+  stag  %tssg
-    (most gap tall:(vang & pax &))
+    (most gap tall:(vang & pax))
   ==
   ::
   ++  pant

--- a/pkg/landscape/app/chat-cli.hoon
+++ b/pkg/landscape/app/chat-cli.hoon
@@ -683,7 +683,7 @@
       |=  tub=nail
       %.  tub
       %+  stag  (crip q.tub)
-      wide:(vang & [&1:% &2:% (scot %da now.bowl) |3:%] &)
+      wide:(vang & [&1:% &2:% (scot %da now.bowl) |3:%])
     --
   ::  +tab-list: command descriptions
   ::


### PR DESCRIPTION
.. with backwards-compatible `+vang` interface. This PR targets #6509. (The combined diff looks like https://github.com/urbit/urbit/compare/develop...jb/vang-compat.)