### PR TITLE
clay: virtualize parsing to workaround runaway memoization

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -925,7 +925,9 @@
       ~/  %parse-pile
       |=  [pax=path tex=tape]
       ^-  pile
-      =/  [=hair res=(unit [=pile =nail])]  ((pile-rule pax) [1 1] tex)
+      =/  [=hair res=(unit [=pile =nail])]
+        %-  road  |.
+        ((pile-rule pax) [1 1] tex)
       ?^  res  pile.u.res
       %-  mean  %-  flop
       =/  lyn  p.hair


### PR DESCRIPTION
This significantly reduces memory usage during userspace rebuilds. It's not exactly clear why; there's some kind of effective space leak in memoization while parsing. This is an easy, low-risk, stop-gap.