### PR TITLE
clay: on update, remove all previous pending updates

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1818,7 +1818,11 @@
       =?  ..park  !?=(%base syd)  wick                  ::  [wick]
       %-  (slog leaf+"clay: wait-for-kelvin, {<[need=zuse/zuse have=kel]>}" ~)
       tare                                              ::  [tare] >
-    =.  wic.dom  (~(del by wic.dom) zuse+zuse)
+    =.  wic.dom
+      %-  ~(gas by *(map weft ^yoki))
+      %+  skip  ~(tap by wic.dom)
+      |=  [w=weft ^yoki]
+      (gte num.w zuse)
     ::
     =/  old-yaki
       ?:  =(0 let.dom)


### PR DESCRIPTION
Fixes #6537, see discussion there for alternatives.

Tested on a fakezod by reproducing that bug, then applying this fix and attempting to reproduce again.

For existing ships that have past pending updates, this will clear those old updates as soon as they get another kelvin update, so I wouldn't do anything more specific.  Although it shouldn't be necessary, if someone wants to clear their state ahead of time, they can use the debug command `|pass [%c %stir %stay %desk ~]` where `%desk` is the desk to clear all pending updates on.