### PR TITLE
eyre: handle agent errors safely

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -656,7 +656,8 @@
     =/  connection=outstanding-connection
       [action [authenticated secure address request] ~ 0]
     =.  connections.state
-      :: XX pretty sure this is superfluous - done in +handle-response
+      ::  NB: required by +handle-response. XX optimize
+      ::
       (~(put by connections.state) duct connection)
     ::  redirect to https if insecure, redirects enabled
     ::  and secure port live

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2058,8 +2058,8 @@
               (session-cookie-string u.session-id &)
             headers.response-header.http-event
           ::
-          =/  connection=outstanding-connection
-            (~(got by connections.state) duct)
+          =*  connection  u.connection-state
+          ::
           ::  if the request was a simple cors request from an approved origin
           ::  append the necessary cors headers to the response
           ::
@@ -2078,7 +2078,7 @@
           =.  connections.state
             %-  (trace 2 |.("{<duct>} start"))
             %+  ~(put by connections.state)  duct
-            %_  connection
+            %=  connection
               response-header  `response-header
               bytes-sent  ?~(data.http-event 0 p.u.data.http-event)
             ==

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1986,7 +1986,10 @@
     |=  =tang
     ^-  [(list move) server-state]
     ::
-    =+  connection=(~(got by connections.state) duct)
+    ?~  connection-state=(~(get by connections.state) duct)
+      %.  `state
+      (trace 0 |.("{<duct>} error on invalid outstanding connection"))
+    =*  connection  u.connection-state
     =/  moves-1=(list move)
       ?.  ?=(%app -.action.connection)
         ~


### PR DESCRIPTION
... and responses more efficiently.

The `+got:by` in `+handle-gall-error` was not correct -- pokes to suspended agents can be deferred arbitrarily, and there's no guarantee that we still have the connection. (@finned-palmer encountered this with a suspended %garden).

The `+got:by` in `+handle-response` was redundant, the connection is already in scope. There also redundant connection-state updates, or patterns of update followed immediately by delete.