### PR TITLE
eyre: when a %request causes a crud, serve 500

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2358,12 +2358,24 @@
   ::
   =/  task=task  ((harden task) wrapped-task)
   ::
-  ::  XX handle error notifications
+  ::  XX handle more error notifications
   ::
   ?^  dud
-    =/  moves=(list move)
-      [[duct %slip %d %flog %crud [-.task tang.u.dud]] ~]
-    [moves http-server-gate]
+    :_  http-server-gate
+    ::  always print the error trace
+    ::
+    :-  [duct %slip %d %flog %crud [-.task tang.u.dud]]
+    ^-  (list move)
+    ::  if a request caused the crash, respond with a 500
+    ::
+    ?.  ?=(?(%request %request-local) -.task)  ~
+    ^~
+    =/  data  (as-octs:mimes:html 'crud!')
+    =/  head
+      :~  ['content-type' 'text/html']
+          ['content-length' (crip (a-co:co p.data))]
+      ==
+    [duct %give %response %start 500^head `data &]~
   ::  %init: tells us what our ship name is
   ::
   ?:  ?=(%init -.task)


### PR DESCRIPTION
Previously, if an incoming request caused a crash, we would just drop it on the floor. We should at least have the decency to serve the client a quick 500 and let them get on with their day.

We make sure not to touch state here. The connection is guaranteed-fresh because of the task's semantics, and we're handling it in-line in one go.

Notably we only give a simple "crud!" for the body, instead of the full error trace. We don't know whether the request is authenticated or not (and who knows if checking was the cause of the crash!), and the crud might leak sensitive details about the ship it occurred on. For the owner, the trace still gets printed into the terminal.