### PR TITLE
ames: ship-state scry returns a unit

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4759,7 +4759,7 @@
   ::  /ax//whey                      (list mass)
   ::  /ax/protocol/version           @
   ::  /ax/peers                      (map ship ?(%alien %known))
-  ::  /ax/peers/[ship]               ship-state
+  ::  /ax/peers/[ship]               (unit ship-state)
   ::  /ax/peers/[ship]/last-contact  (unit @da)
   ::  /ax/peers/[ship]/forward-lane  (list lane)
   ::  /ax/bones/[ship]               [snd=(set bone) rcv=(set bone)]
@@ -4793,9 +4793,7 @@
     =/  peer  (~(get by peers.ames-state) u.who)
     ?+    req.tyl  [~ ~]
         ~
-      ?~  peer
-        [~ ~]
-      ``noun+!>(u.peer)
+      ``noun+!>(peer)
     ::
         [%last-contact ~]
       :^  ~  ~  %noun


### PR DESCRIPTION
Resolves [#6552](https://github.com/urbit/urbit/issues/6552).
no longer crash if scrying for a ship that's not in peers.