### PR TITLE
gall: don't try to notify nuked agents about breaches

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -423,7 +423,8 @@
     ^+  mo-core
     =.  mo-core  (mo-untrack-ship ship)
     =.  mo-core  (mo-filter-queue ship)
-    =/  agents=(list [name=term =yoke])  ~(tap by yokes.state)
+    =/  agents=(list [name=term =yoke])
+      (skim ~(tap by yokes.state) |=([* =yoke] =(%live -.yoke)))
     =.  outstanding.state
       %-  malt
       %+  skip  ~(tap by outstanding.state)


### PR DESCRIPTION
Since we added the new `%nuke` fork to `$yoke` for 413k, we need to check this before trying to instantiate `+ap` with an agent tat might be nuked. This showed up on @mopfel-winrux's ship, causing him to not handle breaches correctly. 