### PR TITLE
gall: always check that an agent isn't nuked before initializing `+ap`

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -433,7 +433,7 @@
     |-  ^+  mo-core
     ?~  agents
       mo-core
-    =?  mo-core  ?=(%live -.i.agents)
+    =?  mo-core  ?=(%live -.yoke.i.agents)
       =/  =routes  [disclosing=~ attributing=ship]
       =/  app  (ap-abed:ap name.i.agents routes)
       ap-abet:(ap-breach:app ship)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -915,7 +915,6 @@
       ^+  wire
       =/  nonce=@  (~(got by boar.yoke) wire dock)
       ?:  =(0 nonce)  wire
-      ~&  %hello
       [(scot %ud nonce) wire]
     ::
     ++  ap-core  .

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -757,6 +757,7 @@
     |=  [veb=? dap=term =routes care=term =path]
     ^-  (unit (unit cage))
     ::
+    ?.  ?=([~ %live *] (~(get by yokes.state) dap))  [~ ~]
     =/  app  (ap-abed:ap dap routes)
     (ap-peek:app veb care path)
   ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -423,8 +423,7 @@
     ^+  mo-core
     =.  mo-core  (mo-untrack-ship ship)
     =.  mo-core  (mo-filter-queue ship)
-    =/  agents=(list [name=term =yoke])
-      (skim ~(tap by yokes.state) |=([* =yoke] =(%live -.yoke)))
+    =/  agents=(list [name=term =yoke])  ~(tap by yokes.state)
     =.  outstanding.state
       %-  malt
       %+  skip  ~(tap by outstanding.state)
@@ -434,7 +433,7 @@
     |-  ^+  mo-core
     ?~  agents
       mo-core
-    =.  mo-core
+    =?  mo-core  ?=(%live -.i.agents)
       =/  =routes  [disclosing=~ attributing=ship]
       =/  app  (ap-abed:ap name.i.agents routes)
       ap-abet:(ap-breach:app ship)
@@ -475,12 +474,12 @@
     ?>  ?=([%lag ~] wire)
     ?>  ?=([%ames %clog *] sign-arvo)
     ::
-    =/  agents=(list term)  ~(tap in ~(key by yokes.state))
+    =/  agents=(list [=dude =yoke])  ~(tap by yokes.state)
     |-  ^+  mo-core
     ?~  agents  mo-core
     ::
-    =.  mo-core
-      =/  app  (ap-abed:ap i.agents `our)
+    =?  mo-core  ?=(%live -.yoke.i.agents)
+      =/  app  (ap-abed:ap dude.i.agents `our)
       ap-abet:(ap-clog:app ship.sign-arvo)
     ::
     $(agents t.agents)
@@ -705,7 +704,8 @@
   ++  mo-idle
     |=  dap=dude
     ^+  mo-core
-    ?.  (~(has by yokes.state) dap)
+    =/  yoke=(unit yoke)  (~(get by yokes.state) dap)
+    ?:  |(?=(~ yoke) ?=(%nuke -.u.yoke))
       ~>  %slog.0^leaf/"gall: ignoring %idle for {<dap>}, not running"
       mo-core
     ap-abet:ap-idle:(ap-abed:ap dap `our)
@@ -714,14 +714,15 @@
   ++  mo-nuke
     |=  dap=dude
     ^+  mo-core
-    ?.  (~(has by yokes.state) dap)
+    =/  yoke=(unit yoke)  (~(get by yokes.state) dap)
+    ?:  |(?=(~ yoke) ?=(%nuke -.u.yoke))
       ~>  %slog.0^leaf/"gall: ignoring %nuke for {<dap>}, not running"
       mo-core
     ~>  %slog.0^leaf/"gall: nuking {<dap>}"
     =.  mo-core  ap-abet:ap-nuke:(ap-abed:ap dap `our)
     =-  mo-core(yokes.state -)
     %+  ~(jab by yokes.state)  dap
-    |=  =yoke
+    |=  =^yoke
     ?:  ?=(%nuke -.yoke)  yoke
     :-  %nuke
     %-  ~(run by sky.yoke)
@@ -914,6 +915,7 @@
       ^+  wire
       =/  nonce=@  (~(got by boar.yoke) wire dock)
       ?:  =(0 nonce)  wire
+      ~&  %hello
       [(scot %ud nonce) wire]
     ::
     ++  ap-core  .


### PR DESCRIPTION
Same as #6565 but everywhere.