### PR TITLE
clay: the commit must actually be known

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4492,14 +4492,13 @@
     ++  read-at-tako                                    ::    read-at-tako:ze
       |=  [for=(unit ship) tak=tako mun=mood]           ::  seek and read
       ^-  [(unit (unit cage)) _..park]
-      ?.  |(?=(~ for) (may-read u.for care.mun tak path.mun))
-        [~ ..park]
       ::  the commit must be known, and reachable from within this desk
       ::
-      ?.  ?|  =(0v0 tak)
-          ?&  (~(has by hut.ran) tak)
+      ?.  ?&  !=(0v0 tak)
+              (~(has by hut.ran) tak)
               (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
-          ==  ==
+              |(?=(~ for) (may-read u.for care.mun tak path.mun))
+          ==
         [~ ..park]
       ::  virtualize to catch and produce deterministic failures
       ::


### PR DESCRIPTION
+read-at-tako was checking for the zero tako, but had the conditional inverted. Here, we correct the conditional, and fold the +may-read check into the whole.