### PR TITLE
clay: allow reads at the null tako

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4492,13 +4492,13 @@
     ++  read-at-tako                                    ::    read-at-tako:ze
       |=  [for=(unit ship) tak=tako mun=mood]           ::  seek and read
       ^-  [(unit (unit cage)) _..park]
-      ::  the commit must be known, and reachable from within this desk
+      ::  non-zero commits must be known, and reachable from within this desk
       ::
-      ?.  ?&  !=(0v0 tak)
-              (~(has by hut.ran) tak)
+      ?.  ?|  =(0v0 tak)
+          ?&  (~(has by hut.ran) tak)
               (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
               |(?=(~ for) (may-read u.for care.mun tak path.mun))
-          ==
+          ==  ==
         [~ ..park]
       ::  virtualize to catch and produce deterministic failures
       ::


### PR DESCRIPTION
This PR relaxes a constraint introduced in #6568, which is too restrictive for existing use cases.