### PR TITLE
Clay/gall: make pings fast

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4496,7 +4496,9 @@
       ::
       ?.  ?|  =(0v0 tak)
           ?&  (~(has by hut.ran) tak)
-              (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
+              ?|  (~(any by hit.dom) |=(=tako =(tak tako)))  ::  fast-path
+                  (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
+              ==
               |(?=(~ for) (may-read u.for care.mun tak path.mun))
           ==  ==
         [~ ..park]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -769,6 +769,10 @@
       (mo-apply-sure dap routes deal)
     ::
         %raw-poke
+      ::  don't validate %noun pokes, for performance
+      ::
+      ?:  =(%noun mark.deal)
+        (mo-apply-sure dap routes [%poke %noun %noun noun.deal])
       =/  =case  da+now
       =/  yok  (~(got by yokes.state) dap)
       =/  =desk  q.beak:?>(?=(%live -.yok) yok)  ::TODO acceptable assertion?


### PR DESCRIPTION
Meta: this is hotpatched directly onto ~dem.  Nothing should be released before this, or if it is, then this should be re-hotpatched onto ~dem.

Galaxies process a lot of pings, and in 413K, the time required to process pings regressed by roughly 10x, to around 30-40ms each.  In the 413K refactoring around requests for remote scry, we started checking whether a requested hash was in the "reachable takos" of a desk before we could approve the request.  Unfortunately, for many live ships, this process takes more than 10ms.

There are several possible mitigations, two of which are implemented here.

- First, the ping requests use the `%noun` mark, and Gall dutifully tries to build the `%noun` mark in order to validate that the untyped noun it received is in fact an untyped noun.  There's no point to that, so this PR short-circuits in that case.
- Second, the check for reachable takos computes all the reachable takos before checking against any of them.  Most of the time, we'll be requesting something from a numbered commit, and those are the easy to check, so this PR adds a short-circuit check for those.  This reduces the overall runtime of most Clay cache hits by around 30x on ~dem.
- Third, reachable takos is a pretty common operation, and it would probably be worth maintaining an index or cache of that request.
- Fourth, pings should be almost always handled in the runtime, only going into arvo when the lane changes.  This will add several orders of magnitude to our ping handling capacity.

My tests indicate that the changes in this PR reduce ~dem's ping processing times from about 45ms to 4-5ms.

Separately, I would expect anything that makes a lot of Clay requests, even if they're mostly cache hits, to be significantly sped up by this PR.