### PR TITLE
clarify +vats usage in +vat deprecation msg

### DIFF
--- a/pkg/arvo/gen/vat.hoon
+++ b/pkg/arvo/gen/vat.hoon
@@ -2,6 +2,6 @@
 :-  %say
 |=  [[now=@da eny=@uvJ bec=beak] [syd=desk ~] verb=_&]
 :*  %tang
-    leaf+"Notice: +vat is deprecated as +vats now takes lists of one or more desks"
+    leaf+"Notice: +vat is deprecated. use +vats which now takes one or more desks as arguments. e.g. '+vats %base %garden'"
     (report-vat (report-prep p.bec now) p.bec now syd verb)
 ==


### PR DESCRIPTION
**Describe the bug**
+vat has been deprecated. when you run it it gives the message "Notice: +vat is deprecated as +vats now takes lists of one or more desks"

this prompted me to try ```+vats ~[%base %garden]``` which fails. I assert that this is the correct interpretation of the message above.

I propose to change the message to: "Notice: +vat is deprecated as +vats now takes one or more desks as arguments. e.g. '+vats %base %garden'"

**Additional context**
This is a simple one-liner that may prevent frustration in others as well. Especially until the docs are updated.

**Notify maintainers**
@joemfb 

tested on local planet by copying over new vat.hoon and running ```|commit %base```.

output:
```
> +vat %base
%base
  /sys/kelvin:      [%zuse 413]
  base hash:        0v19.lu2ua.0tfl3.v6nek.5oog0.9obm0.3fsdl.8gj4d.rrkg0.ur2ts.f0rjg
  %cz hash:         0v1e.lal9a.kaklo.2ibft.64kec.eokma.57q3u.fu40r.2ijkq.2n8gp.4c0q5
  app status:       running
  force on:         ~[%eth-watcher]
  force off:        ~
  publishing ship:  ~
  updates:          remote
  source ship:      ~darlur
  source desk:      %kids
  source aeon:      134
  kids desk:        %kids
  pending updates:  ~
::
Notice: +vat is deprecated. use +vats which now takes one or more desks as arguments. e.g. '+vats %base %garden'
```