### PR TITLE
ames: packet retry tweaks

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2886,6 +2886,10 @@
           ::  expire direct route if the peer is not responding
           ::
           =.  peer-state  (update-peer-route her peer-state)
+          ::  required so that the following +send-blob's (including
+          ::  inside +call:mu), access up-to-date peer state
+          ::
+          =.  event-core  abet
           ::  resend comet attestation packet if first message times out
           ::
           ::    The attestation packet doesn't get acked, so if we tried to
@@ -4449,7 +4453,7 @@
             ::  if this was a re-send, don't adjust rtt or downstream state
             ::
             ?:  (gth tries.packet-state 1)
-              metrics
+              metrics(rto (clamp-rto (add rtt (mul 4 rttvar))))
             ::  rtt-datum: new rtt measurement based on packet roundtrip
             ::
             =/  rtt-datum=@dr  (sub-safe now last-sent.packet-state)


### PR DESCRIPTION
First, I noticed that when we time out a route, we aren't immediately sending to the galaxy.  This turned out to be due to a state mismanagement bug, where we updated our local copy of `peer-state`, but `+send-blob` used the global copy of it.  I fix this by saving our local copy manually, and I confirmed this fixed the issue, but I wouldn't be surprised if we have similar bugs elsewhere.

Second, we have a rule that we don't update congestion control stats when a response is returned to a packet that we've been retrying.  This is because packets that we've had to retry are often outliers, so we don't want that to infect our stats.  However, I believe we should reset `rto` here, because `+on-timeout` may have inflated it a lot, and in some circumstances that can cause frustrating increases in latency.  With this change, as soon as you re-establish contact, your `rto` returns to a normal value, instead of a requiring a second packet.