### PR TITLE
ames: more bugfixes after #6593

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1819,7 +1819,7 @@
         =/  ship-state  (~(get by peers.ames-state) ship)
         ?:  ?=([~ %known *] ship-state)
           abet:on-heed:(abed-peer:pe ship +.u.ship-state)
-        %+  enqueue-alien-todo  ship
+        %^  enqueue-alien-todo  ship  ship-state
         |=  todos=alien-agenda
         todos(heeds (~(put in heeds.todos) duct))
       ::  +on-jilt: handle request to stop tracking .ship's responsiveness
@@ -1830,7 +1830,7 @@
         =/  ship-state  (~(get by peers.ames-state) ship)
         ?:  ?=([~ %known *] ship-state)
           abet:on-jilt:(abed-peer:pe ship +.u.ship-state)
-        %+  enqueue-alien-todo  ship
+        %^  enqueue-alien-todo  ship  ship-state
         |=  todos=alien-agenda
         todos(heeds (~(del in heeds.todos) duct))
       ::  +on-hear: handle raw packet receipt
@@ -1971,7 +1971,7 @@
         ::  will be resent.
         ::
         ?.  ?=([~ %known *] sndr-state)
-          (enqueue-alien-todo sndr.shot |=(alien-agenda +<))
+          (enqueue-alien-todo sndr.shot sndr-state |=(alien-agenda +<))
         ::  decrypt packet contents using symmetric-key.channel
         ::
         ::    If we know them, we have a $channel with them, which we've
@@ -2062,7 +2062,7 @@
         =/  ship-state  (~(get by peers.ames-state) ship)
         ::
         ?.  ?=([~ %known *] ship-state)
-          %+  enqueue-alien-todo  ship
+          %^  enqueue-alien-todo  ship  ship-state
           |=  todos=alien-agenda
           todos(messages [[duct plea] messages.todos])
         ::
@@ -2084,7 +2084,7 @@
         =/  =plea       [%$ /flow [%cork ~]]
         =/  ship-state  (~(get by peers.ames-state) ship)
         ?.  ?=([~ %known *] ship-state)
-          %+  enqueue-alien-todo  ship
+          %^  enqueue-alien-todo  ship  ship-state
           |=  todos=alien-agenda
           todos(messages [[duct plea] messages.todos])
         =/  =peer-state  +.u.ship-state
@@ -2578,7 +2578,7 @@
         =/  ship-state  (~(get by peers.ames-state) ship)
         ?:  ?=([~ %known *] ship-state)
           abet:(on-keen:(abed-peer:pe ship +.u.ship-state) path duct)
-        %+  enqueue-alien-todo  ship
+        %^  enqueue-alien-todo  ship  ship-state
         |=  todos=alien-agenda
         todos(keens (~(put ju keens.todos) path duct))
       ::
@@ -2604,10 +2604,11 @@
       ::    If talking to a comet, requests attestation packet.
       ::
       ++  enqueue-alien-todo
-        |=  [=ship mutate=$-(alien-agenda alien-agenda)]
+        |=  $:  =ship
+                ship-state=(unit ship-state)
+                mutate=$-(alien-agenda alien-agenda)
+            ==
         ^+  event-core
-        ::
-        =/  ship-state  (~(get by peers.ames-state) ship)
         ::  create a default $alien-agenda on first contact
         ::
         =+  ^-  [already-pending=? todos=alien-agenda]
@@ -2659,7 +2660,7 @@
             ?.  ?=([~ %known *] ship-state)
               ?:  ?=(%pawn (clan:title ship))
                 (try-next-sponsor (^sein:title ship))
-              %+  enqueue-alien-todo  ship
+              %^  enqueue-alien-todo  ship  ship-state
               |=  todos=alien-agenda
               todos(packets (~(put in packets.todos) blob))
             ::
@@ -2708,7 +2709,7 @@
           ::
           ?:  =(ship sponsor)
             event-core
-          ^$(ship sponsor)
+          ^$(ship sponsor, ship-state (~(get by peers.ames-state) sponsor))
         --
       ::  +attestation-packet: generate signed self-attestation for .her
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4373,6 +4373,10 @@
                 last-sent.u.want  now
               ==
             =.  wan.keen  (put:fi-mop wan.keen [fra .]:u.want)
+            ::  required so that the following +send-blob in
+            ::  +fi-send access up-to-date peer state
+            ::
+            =.  event-core  abet
             (fi-send `@ux`hoot.u.want)
           --
         ::  +ga: constructor for |pump-gauge congestion control core


### PR DESCRIPTION
Continuation of https://github.com/urbit/urbit/pull/6593. I found another instance of the bug fixed in that PR, in the `|fine` core. 

I don't think that we should use the "early `+abet`" pattern in general—to me that points to doing something in two different contexts. Open to other suggestions but I think that it's best to, if we have updated a piece of state that code declared outside of the current core uses, pass that directly. In this case it means to extract the retrieval of the peer-state outside of `+send-blob`. I've done that for all the call sites where we use that arm. I'm opening this for review to get feedback (but will test this on a live ship to confirm that nothing is obviously wrong with the change)