### PR TITLE
ames: correctly %lose a %boon we crashed on

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4018,15 +4018,13 @@
                   ::
                   =/  dat  [her bone=bone message-num=message-num]
                   ?:(ok "sink boon {<dat>}" "crashed on sink boon {<dat>}")
-              =?  moves  !ok
-                ::  we previously crashed on this message; notify client vane
-                ::
-                %+  turn  moves
-                |=  =move
-                ?.  ?=([* %give %boon *] move)  move
-                [duct.move %give %lost ~]
+              ::  if we previously crashed on this message;
+              ::  notify client vane instead of making it try again
               ::
-              =.  peer-core  (pe-emit (got-duct bone) %give %boon message)
+              =.  peer-core
+                %+  pe-emit  (got-duct bone)
+                ?.  ok  [%give %lost ~]
+                [%give %boon message]
               ::  send ack unconditionally
               ::
               (call %done ok=%.y)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4018,13 +4018,14 @@
                   ::
                   =/  dat  [her bone=bone message-num=message-num]
                   ?:(ok "sink boon {<dat>}" "crashed on sink boon {<dat>}")
-              ::  if we previously crashed on this message;
-              ::  notify client vane instead of making it try again
-              ::
-              =.  peer-core
-                %+  pe-emit  (got-duct bone)
-                ?.  ok  [%give %lost ~]
-                [%give %boon message]
+              =.  peer-core  (pe-emit (got-duct bone) %give %boon message)
+              =?  moves  !ok
+                ::  we previously crashed on this message; notify client vane
+                ::
+                %+  turn  moves
+                |=  =move
+                ?.  ?=([* %give %boon *] move)  move
+                [duct.move %give %lost ~]
               ::  send ack unconditionally
               ::
               (call %done ok=%.y)

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -503,6 +503,25 @@
     !>  [~[/g/talk] %give %done `error]
     !>  (snag 0 `(list move:ames)`moves5)
 ::
+++  test-boon-lost  ^-  tang
+  ::  ~nec -> %plea -> ~bud
+  ::
+  =^  moves1  nec  (call nec ~[/g/talk] %plea ~bud %g /talk [%get %post])
+  =^  moves2  bud  (call bud ~[//unix] %hear (snag-packet 0 moves1))
+  ::  ~bud -> %done -> ~nec
+  ::
+  =^  moves3  bud  (take bud /bone/~nec/0/1 ~[//unix] %g %done ~)
+  =^  moves4  nec  (call nec ~[//unix] %hear (snag-packet 0 moves3))
+  ::  ~bud -> %boon -> ~nec, but we tell ~nec it crashed during the handling
+  ::
+  =^  moves5  bud  (take bud /bone/~nec/0/1 ~[//unix] %g %boon [%post 'first1'])
+  =^  moves6  nec
+    =/  vane-core  (nec(now `@da`(add ~s1 now.nec)))
+    (call:vane-core ~[//unix] `[%test-error ~] %hear (snag-packet 0 moves5))
+  %+  expect-eq
+    !>  [~[/g/talk] %give %lost ~]
+    !>  (snag 0 `(list move:ames)`moves6)
+::
 ++  test-fine-request
   ^-  tang
   =/  want=path  /c/z/1/kids/sys


### PR DESCRIPTION
Previously, if we noticed `%boon` handling had caused a crash, we would transform any existing `%boon`s into `%lost`s, but still emit a new `%boon` for the message we crashed on.

Now, we make sure to just directly send a `%lost` if sending the `%boon` caused a crash. We drop the existing-moves transformation entirely, assuming it to vestigial from a brief glance at the blame/history. Reviewers, please confirm whether this is correct or not. (It must be, the tests still pass after all. (; )

Fixes #6611 (see there for more deets) and adds a test to make sure it doesn't occur again.