### PR TITLE
ames: skip corks if pending acks for naxplanations

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3774,7 +3774,7 @@
               %drop  sink(nax.state (~(del in nax.state) message-num.task))
               %done  (done ok.task)
             ::
-                %hear
+                 %hear
               |^  ?:  ?|  corked
                       ?&  %*(corked sink bone (mix 0b10 bone))
                           =(%nack (received bone))
@@ -3783,9 +3783,9 @@
               ::
               ?>  ?=(%& -.meat.shut-packet.task)
               =+  [num-fragments fragment-num fragment]=+.meat.shut-packet.task
-              ?.  &(=(num-fragments 1) =(fragment-num 0))
-                (hear [lane shut-packet ok]:task)
-              (check-pending-acks fragment-num num-fragments fragment)
+              ?:  &(=(num-fragments 1) =(fragment-num 0))
+                (check-pending-acks fragment)
+              (hear [lane shut-packet ok]:task)
               ::
               ++  ack-on-corked-bone
                 ::  if we %hear a fragment on a corked bone, always ack
@@ -3798,22 +3798,16 @@
                 |.("hear {<(received bone)>} on corked bone={<bone>}")
               ::
               ++  check-pending-acks
-                ::  if this is a %cork %plea and are still waiting to
-                ::  hear %acks for previous naxplanation we sent, no-op
+                ::  if this is a %cork %plea and we are still waiting to
+                ::  hear %acks for previous naxplanations we sent, no-op
                 ::
-                |=  [num=@ud frags=@ud frag=@uw]
+                |=  frag=@uw
                 ^+  sink
-                =/  message-blob=*
-                  %+  assemble-fragments  frags
-                  (~(gas by *(map fragment-num fragment)) [num frag]~)
-                =/  cork-plea=?
-                  ?=(^ ;;((soft [%$ path %cork ~]) message-blob))
-                =/  pending-ack=?
-                  =/  nax-bone=^bone  (mix 0b10 bone)
-                  =/  live-packets=@ud
-                   ~(wyt by live.packet-pump-state.state:(abed:mu nax-bone))
-                  (gth live-packets 0)
-                ?.  &(cork-plea pending-ack)
+                =/  blob=*  (cue (rep packet-size [frag]~))
+                =+  pump=(abed:mu (mix 0b10 bone))
+                ?.  ?&  ?=(^ ;;((soft [%$ path %cork ~]) blob))
+                        ?=(^ live.packet-pump-state.state.pump)
+                    ==
                   (hear [lane shut-packet ok]:task)
                 %.  sink
                 %+  pe-trace  odd.veb


### PR DESCRIPTION
Fixes #6608 by implementing the solution proposed [here](https://github.com/urbit/urbit/issues/6608#issuecomment-1559498863): 

> to check if we, as a server ames (the one not sending the %cork), are waiting for acks on messages we have sent, don't process the %cork, and wait for the client to send another one.

Testing the error found in https://github.com/urbit/urbit/pull/6598, it removes the flow on both sides, but waiting to hear from @Fang- to confirm that there are no other issues.