### PR TITLE
mar: add vere mark

### DIFF
--- a/pkg/arvo/mar/vere.hoon
+++ b/pkg/arvo/mar/vere.hoon
@@ -1,0 +1,1 @@
+../../base-dev/mar/vere.hoon

--- a/pkg/base-dev/mar/vere.hoon
+++ b/pkg/base-dev/mar/vere.hoon
@@ -1,0 +1,17 @@
+|_  v=vere
+++  grab
+  |%
+  ++  noun  vere
+  --
+++  grow
+  |%
+  ++  json
+    %-  pairs:enjs:format
+    :-  [%non s+non.v]
+    :-  [%rev (path:enjs:format rev.v)]
+    %+  turn  kel.v
+    |=  w=weft
+    [lal.w (numb:enjs:format num.w)]
+  --
+++  grad  %noun
+--


### PR DESCRIPTION
Useful for frontends that want to check whether vere is up to date.

Format is 
`{"zuse":413,"arvo":238,"non":"0ve.kp3qf","nock":4,"rev":"/vere/~.2.6","lull":324,"hoon":139}`