### PR TITLE
fine: handle misordered responses

### DIFF
--- a/pkg/arvo/lib/test/ames-gall.hoon
+++ b/pkg/arvo/lib/test/ames-gall.hoon
@@ -188,7 +188,7 @@
     %-  need  %-  need
     (scry:(ames-gate now eny roof) ~ %x beam)
   ::
-  =/   paz=(list have:ames)
+  =/  paz=(list have:ames)
     %+  spun  meows
     |=  [blob=@ux num=_1]
     ^-  [have:ames _num]
@@ -196,9 +196,10 @@
     [num (sift-meow:ames blob)]
   ::
   :-  sig:(sift-roar:ames-raw (lent paz) (flop paz))
-  %+  turn  meows
-  |=  meow=@ux
-  (can 3 4^lop 2^wid wid^`@`pat (met 3 meow)^meow ~)
+  %+  spun  meows
+  |=  [meow=@ux num=_1]
+  :_  +(num)
+  (can 3 4^num 2^wid wid^`@`pat (met 3 meow)^meow ~)
 :: ::
 ++  ames-scry-peer
   |=  $:  =ames-gate

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -288,7 +288,9 @@
   ^-  [sig=@ux dat=$@(~ (cask))]
   =/  mes=@
     %+  rep  response-size
-    (roll hav |=([=have dat=(list @ux)] [dat.have dat]))
+    %+  turn
+      (sort hav |=([a=have b=have] (lth fra.a fra.b)))
+    |=(=have dat.have)
   =+  sig=(end 9 mes)
   :-  sig
   =+  dat=(rsh 9 mes)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -293,8 +293,9 @@
   :-  sig
   =+  dat=(rsh 9 mes)
   ?~  dat  ~
+  =/  non  ~|(%fine-cue (cue dat))
   ~|  [%fine %response-not-cask]
-  ;;((cask) (cue dat))
+  ;;((cask) non)
 ::  +etch-hunk: helper core to serialize a $hunk
 ::
 ++  etch-hunk
@@ -4312,12 +4313,12 @@
           ::
           ++  fi-sift-full
             =,  keen
-            ~|  %frag-mismatch
-            ~|  have/num-received
-            ~|  need/num-fragments
-            ~|  path/path
-            ?>  =(num-fragments num-received)
-            ?>  =((lent hav) num-received)
+            ?.  ?&  =(num-fragments num-received)
+                    =((lent hav) num-received)
+                ==
+              ~|  :-  %frag-mismatch
+                  [have/num-received need/num-fragments path/path]
+              !!
             (sift-roar num-fragments hav)
           ::
           ++  fi-fast-retransmit

--- a/tests/sys/fine.hoon
+++ b/tests/sys/fine.hoon
@@ -18,6 +18,15 @@
           %cx  ``hoon+!>(kelvin)
       ==
     ::
+    ++  bex-roof
+      ^-  roof
+      |=  [lyc=gang vis=view bem=beam]
+      ^-  (unit (unit cage))
+      ?>  =(s.bem //some/data/atom)
+      ?+  vis  ~
+        %gx  ``atom+!>((bex (bex 14)))
+      ==
+    ::
     ++  etch-request-content
       |=  [our=@p =path num=@ud]
       ^-  @
@@ -192,4 +201,111 @@
     listeners:u.keen
   ~&  >  'checks no more listeners'
   (expect-eq !>(~) !>(listeners))
+::
+++  test-fine-misordered
+  %-  run-chain
+  |.  :-  %|
+  =+  (nec-bud:v life=[nec=1 bud=1] rift=[nec=1 bud=1])
+  ::  uncomment to turn on verbose debug output
+  ::=^  *  ames.nec
+  ::  (ames-call:v ames.nec ~[/none] [%spew ~[%msg %snd %rcv %odd]] *roof)
+  ::=^  *  ames.bud
+  ::  (ames-call:v ames.bud ~[/none] [%spew ~[%msg %snd %rcv %odd]] *roof)
+  =/  scry-path=path       /g/x/0/dap//some/data/atom
+  =/  fine-behn-wire=wire  (weld /fine/behn/wake/~bud scry-path)
+  =/  =task:ames           [%keen ~bud scry-path]
+  ::
+  =/  requests=(list shot:ames)
+    %+  turn  (gulf 1 3)
+    |=  frag=@ud
+    ^-  shot:ames
+    :*  [sndr=~nec rcvr=~bud]
+        req=&  sam=|
+        sndr-tick=0b1
+        rcvr-tick=0b1
+        origin=~
+        content=(etch-request-content ~nec (weld /~bud/1/1 scry-path) frag)
+    ==
+  =+  ^=  [req1 req2 req3]
+    ?>  ?=([^ ^ ^ *] requests)
+    [i i.t i.t.t]:requests
+  ~&  >  'poke requester %ames with a %keen task'
+  =^  t1  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef *roof]
+      [~[/keen-duct-1] task]
+      :~  [~[//unix] [%give %send [%& ~bud] (etch-shot:ames req1)]]
+          [~[//unix] %pass fine-behn-wire %b %wait ~1111.1.1..00.00.01]
+      ==
+    ==
+  ::
+  =/  [sig=@ux meows=(list @ux)]
+    %:  ames-scry-hunk:v  ames.bud
+      [~1111.1.1 0xbeef.dead bex-roof]
+      ~bud
+      [1 16.384 (weld /~bud/1/1 scry-path)]
+    ==
+  =/  responses=(list shot:ames)
+    %+  turn  meows
+    |=  m=@ux
+    ^-  shot:ames
+    :*  [sndr=~bud rcvr=~nec]
+        req=|  sam=|
+        sndr-tick=0b1
+        rcvr-tick=0b1
+        origin=~
+        content=m
+    ==
+  =+  ^=  [resp1 resp2 resp3]
+    ?>  ?=([^ ^ ^ *] responses)
+    [i i.t i.t.t]:responses
+  ::
+  =/  roar=(unit roar:ames)
+    :+  ~  [(weld /~bud/1/1 scry-path) `atom+(bex (bex 14))]
+    [[~bud [1 sig]] ~ ~]
+  ::
+  :-  t1  |.  :-  %|
+  ~&  >  'hear first response fragment'
+  =^  t2  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.2 0xbeef.dead *roof]
+      :-  ~[//fine]
+      :*  %hear  [%& ~bud]
+          (etch-shot:ames resp1)
+      ==
+      :~  [~[//fine] %pass /qos %d %flog %text "; ~bud is your neighbor"]
+          [~[//unix] [%give %send [%& ~bud] (etch-shot:ames req2)]]
+          [~[//unix] [%give %send [%& ~bud] (etch-shot:ames req3)]]
+          [~[//unix] %pass fine-behn-wire %b %rest ~1111.1.1..00.00.01]
+          [~[//unix] %pass fine-behn-wire %b %wait ~1111.1.2..00.02.00]
+      ==
+    ==
+  ::
+  :-  t2  |.  :-  %|
+  ~&  >  'hear third response fragment'
+  =^  t3  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.2 0xbeef.dead *roof]
+      :-  ~[//fine]
+      :*  %hear  [%& ~bud]
+          (etch-shot:ames resp3)
+      ==
+    ::
+      ~
+    ==
+  :-  t3  |.  :-  %&
+  ~&  >  'hear second response fragment'
+  =^  t4  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.3 0xbeef.dead *roof]
+      :-  ~[//fine]
+      :*  %hear  [%& ~bud]
+          (etch-shot:ames resp2)
+      ==
+      :~  [~[/keen-duct-1] %give %tune [~bud scry-path] roar]
+          [~[//unix] %pass fine-behn-wire %b %rest ~1111.1.2..00.02.00]
+      ==
+    ==
+  ::
+  t4
 --

--- a/tests/sys/fine.hoon
+++ b/tests/sys/fine.hoon
@@ -3,40 +3,17 @@
 /+  *test, v=test-ames-gall
 /*  kelvin  %hoon  /sys/kelvin
 =>  |%
-    ++  crypto-core
-      |%  ++  nec  (pit:nu:crub:crypto 512 (shaz 'nec'))
-          ++  bud  (pit:nu:crub:crypto 512 (shaz 'bud'))
-          ++  sign
-            |=  [=ship data=@ux]
-            %.  data
-            ?:(=(ship ~nec) sigh:as:nec sigh:as:bud)
-      --
-    ::
-    ++  n-frags
-      |=  n=@
-      ^-  @ux
-      ::  6 chosen randomly to get some trailing zeros
-      ::
-      %+  rsh  10
-      %+  rep  13
-      %+  turn  (gulf 1 n)
-      |=(x=@ (fil 3 1.024 (dis 0xff x)))
-    ::
-    ++  custom-roof
+    ++  kelvin-roof
       ^-  roof
       ::
       |=  [lyc=gang vis=view bem=beam]
       ^-  (unit (unit cage))
+      ?>  =(s.bem /sys/kelvin)
       ?+  vis  ~
           %cp
         =/  black=dict:clay
           %*(. *dict:clay mod.rul %black)
         ``noun+!>([black black])
-      ::
-          %cz
-        ?+  -.r.bem  !!
-          %ud  ``noun+!>((n-frags p.r.bem))
-        ==
       ::
           %cx  ``hoon+!>(kelvin)
       ==
@@ -77,7 +54,7 @@
         sndr-tick=0b1
         rcvr-tick=0b1
         origin=~
-        content=(etch-request-content ~nec /~bud/1/1/c/x/1/kids/sys/kelvin 1)
+        content=(etch-request-content ~nec (weld /~bud/1/1 scry-path) 1)
     ==
   ~&  >  'poke requester %ames with a %keen task'
   =^  t1  ames.nec
@@ -116,9 +93,9 @@
   ~&  >  'gives a remote scry response to listeners'
   =/  [sig=@ux meows=(list @ux)]
     %:  ames-scry-hunk:v  ames.bud
-      [~1111.1.2 0xbeef.dead custom-roof]
+      [~1111.1.2 0xbeef.dead kelvin-roof]
       ~bud
-      [1 16.384 /~bud/1/1/c/x/1/kids/sys/kelvin]
+      [1 16.384 (weld /~bud/1/1 scry-path)]
     ==
   =/  response=shot:ames
     :*  [sndr=~bud rcvr=~nec]
@@ -132,7 +109,7 @@
     ==
   ::
   =/  roar=(unit roar:ames)
-    :+  ~  [/~bud/1/1/c/x/1/kids/sys/kelvin `hoon+kelvin]
+    :+  ~  [(weld /~bud/1/1 scry-path) `hoon+kelvin]
     [[~bud [1 sig]] ~ ~]
   =^  t4  ames.nec
     %:  ames-check-call:v  ames.nec
@@ -155,7 +132,7 @@
         sndr-tick=0b1
         rcvr-tick=0b1
         origin=~
-        content=(etch-request-content ~nec /~bud/1/1/c/x/5/kids/sys/kelvin 1)
+        content=(etch-request-content ~nec (weld /~bud/1/1 future-path) 1)
     ==
   ~&  >  'poke requester %ames with a %keen task for a future case'
   =^  t5  ames.nec
@@ -201,8 +178,8 @@
     %:  ames-check-call:v  ames.nec
       [~1111.1.1 0xdead.beef *roof]
       [~[/wham-duct] %wham ~bud future-path]
-      :~  [~[/keen-duct-4] [%give %tune [~bud /c/x/5/kids/sys/kelvin] ~]]
-          [~[/keen-duct-5] [%give %tune [~bud /c/x/5/kids/sys/kelvin] ~]]
+      :~  [~[/keen-duct-4] [%give %tune [~bud future-path] ~]]
+          [~[/keen-duct-5] [%give %tune [~bud future-path] ~]]
           [~[//unix] %pass future-behn %b %rest ~1111.1.1..00.00.01]
       ==
     ==


### PR DESCRIPTION
Unbelievably, *fine* has been implicitly depending on hearing response fragments in the correct order. This PR fixes that by sorting them before deserialization, with a test case to prove it. It also limits fine response error messages to the appropriate scope, and refactors the existing fine tests.