### PR TITLE
hoon: jib and jub wip

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1540,6 +1540,34 @@
     ::
     a(r $(a r.a))
   ::
+  ++  jub                                               ::  add or modify
+    ~/  %jub
+    |*  [key=_?>(?=(^ a) p.n.a) fun=$-((unit _?>(?=(^ a) q.n.a)) _?>(?=(^ a) q.n.a))]
+    ^+  a
+    ::
+    ?~  a  [key (fun ~) ~ ~]
+    ::
+    ?:  =(key p.n.a)
+      a(q.n (fun `q.n.a))
+    ::
+    ?:  (gor key p.n.a)
+      a(l $(a l.a))
+    a(r $(a r.a))
+  ::                                                    :: bunt or modify
+  ++  jib  
+    ~/  %jib
+    |*  [key=_?>(?=(^ a) p.n.a) fun=$-(_?>(?=(^ a) q.n.a) _?>(?=(^ a) q.n.a))]
+    ^+  a
+    ::
+    ?~  a  [key (fun) ~ ~]
+    ::
+    ?:  =(key p.n.a)
+      a(q.n (fun q.n.a))
+    ::
+    ?:  (gor key p.n.a)
+      a(l $(a l.a))
+    a(r $(a r.a))
+  ::
   ++  mar                                               ::  add with validation
     |*  [b=* c=(unit *)]
     ?~  c


### PR DESCRIPTION
Adds +jib (like jab, but call the gate with its bunt if the key is missing) and jub (like jab, but call the gate with `~` if the key is missing and `[~ q.n.a]` if present) to the stdlib 

NOT YET TESTED