### PR TITLE
solid: preserve structural sharing in arvo

### DIFF
--- a/pkg/base-dev/lib/pill.hoon
+++ b/pkg/base-dev/lib/pill.hoon
@@ -206,19 +206,24 @@
     |=  [ovo=ovum ken=*]
     [~ (slum ken [now ovo])]
   ::
-  ::  boot-two: startup formula
+  ::  kernel-formula
   ::
   ::    We evaluate :arvo-formula (for jet registration),
   ::    then ignore the result and produce .installed
   ::
+  =/  kernel-formula
+    [%7 arvo-formula %1 installed]
+  ::
+  ::  boot-two: startup formula
+  ::
   =/  boot-two
-    =>  *[arvo-formula=^ installed=^ tale=*]
-    !=  =+(.*(0 arvo-formula) [installed tale])
+    =>  *[kernel-formula=^ tale=*]
+    !=  [.*(0 kernel-formula) tale]
   ::
   ::  boot-ova
   ::
   =/  boot-ova=(list)
-    [aeon:eden:part boot-two arvo-formula installed ~]
+    [aeon:eden:part boot-two kernel-formula ~]
   ::
   ::  a pill is a 3-tuple of event-lists: [boot kernel userspace]
   ::


### PR DESCRIPTION
This PR fixes a problem I introduced in #5989. Splitting the raw `arvo-formula` and pre-processed arvo kernel (`installed`) across separate events in the solid pill breaks structural sharing between them. If it's not recovered through some other means (such as IPC event batching), this can create massive performance problems matching jets. See urbit/vere#420 for how this came up and the current workaround -- this PR will fix solid pills going forward, but existing piers must (always) be accounted for regardless.