### PR TITLE
spider: provide a tang http response when a thread called via http crashes

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -557,7 +557,8 @@
   ?.  ?=(http-error:spider term)
     %-  (slog tang)
     =/  tube  (convert-tube %tang %json desk bowl)
-    %-  json-response:gen:server
+    :-  [500 [['content-type' 'application/json'] ~]]
+    =-  `(as-octt:mimes:html (en-json:html -))
     o/(malt `(list [key=@t json])`[term+s/term tang+!<(json (tube !>(tang))) ~])
   :_  ~  :_  ~
   ?-  term

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -558,7 +558,7 @@
     %-  (slog tang)
     =/  tube  (convert-tube %tang %json desk bowl)
     :-  [500 [['content-type' 'application/json'] ~]]
-    =-  `(as-octt:mimes:html (en-json:html -))
+    =-  `(as-octs:mimes:html (en:json:html -))
     o/(malt `(list [key=@t json])`[term+s/term tang+!<(json (tube !>(tang))) ~])
   :_  ~  :_  ~
   ?-  term


### PR DESCRIPTION
(1) In +thread-fail, +thread-clean is called before +thread-http-fail and +cancel-scry meaning neither of the latter two actually run in any meaningful way. `serving` has been replaced with `(~(del by serving.state) tid)` and `scrying` has been replaced with `(~(del by scrying.state) tid)` in the state and therefore we cannot `(~(get by serving.state) tid)` in +thread-http-fail or `(~(get by scrying.state) tid)` in +cancel-scry.

(2) In +thread-http-fail return an informative tang as json instead of an empty 500 http response when the failure results from an internal crash.
