### PR TITLE
dojo: gen tab complete for non-base desks

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1466,9 +1466,10 @@
           (cat 3 '|' gen)
         :((cury cat 3) ':' app '|' gen)
       =+  [our=(scot %p our.hid) now=(scot %da now.hid)]
-      ?.  .^(? %gu /[our]/[app]/[now]/$)
-        ~
-      =+  .^(=desk %gd /[our]/[app]/[now]/$)
+      =/  =desk
+        ?.  .^(? %gu /[our]/[app]/[now]/$)
+          q:he-beam
+        .^(desk %gd /[our]/[app]/[now]/$)
       =/  pfix=path  /[our]/[desk]/[now]/gen/[app]
       ::
       %^  tab-generators:auto  pfix  `app

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1466,6 +1466,8 @@
           (cat 3 '|' gen)
         :((cury cat 3) ':' app '|' gen)
       =+  [our=(scot %p our.hid) now=(scot %da now.hid)]
+      ?.  .^(? %gu /[our]/[app]/[now]/$)
+        ~
       =+  .^(=desk %gd /[our]/[app]/[now]/$)
       =/  pfix=path  /[our]/[desk]/[now]/gen/[app]
       ::

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1465,8 +1465,9 @@
         ?:  =(%hood app)
           (cat 3 '|' gen)
         :((cury cat 3) ':' app '|' gen)
-      =/  pfix=path
-        /(scot %p our.hid)/[q:he-beam]/(scot %da now.hid)/gen/[app]
+      =+  [our=(scot %p our.hid) now=(scot %da now.hid)]
+      =+  .^(=desk %gd /[our]/[app]/[now]/$)
+      =/  pfix=path  /[our]/[desk]/[now]/gen/[app]
       ::
       %^  tab-generators:auto  pfix  `app
       %+  murn


### PR DESCRIPTION
`+complete-gen-poke-to-app` now works for desks other than `%base`.

`:dojo|<tab>`
```
:dojo|allow-remote-login   ::  allow-remote-login: allow a ship to link to dojo
:dojo|wipe                 ::  wipe: poke dojo to wipe its state
:dojo|acl                  ::  acl: list the ships that are allowed to link to dojo
:dojo|revoke-remote-login  ::  revoke-remote-login: revoke a ship's right to link to dojo,
```

`:treaty|<tab>`
```
:treaty|remove-desk  ::  :treaty|remove-desk: Stop republishing remote desk
:treaty|unpublish    ::  :treaty|unpublish: Stop publishing local desk
:treaty|add-desk     ::  :treaty|add-desk: Republish remote desk
:treaty|unally       ::  :treaty|unally: Stop syncing treaty data from ship
:treaty|publish      ::  :treaty|publish: Publish local desk
:treaty|ally         ::  :treaty|ally: Sync treaty data from ship
```