### PR TITLE
%perk task added to clay : flue injection for quick desk builds in %pyro

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1491,6 +1491,7 @@
         [%dirk pot=term]                                ::  mark mount dirty
         [%ogre pot=$@(term beam)]                       ::  delete mount point
         [%park des=desk yok=yoki ran=rang]              ::  synchronous commit
+        [%perk des=desk yok=yoki ran=rang sip=sprig]    ::  fast commit
         [%perm des=desk pax=path rit=rite]              ::  change permissions
         [%pork ~]                                       ::  resume commit
         [%prep lat=(map lobe page)]                     ::  prime clay store
@@ -1833,7 +1834,10 @@
   ::    Sprig is a fast-lookup index over the global ford cache.  The only
   ::    goal is to make cache hits fast.
   ::
-  +$  flue  [spill=(set leak) sprig=(map mist [=leak =soak])]
+  +$  flue  [spill=(set leak) =sprig]
+  ::
+  +$  sprig  (map mist [=leak =soak])
+  ::
   ::
   ::  Ford build without content.
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1899,10 +1899,22 @@
       (promote-ford fod.dom invalid)
     =.  fad
       (lose-leaks:fusion veb.bug fad (~(dif in spill.old-fod) spill.fod.dom))
-    ::  TODO ingest the sprig
-    ::    create spill for a complete flue
-    ::    add those leaks to the flow
-    ::    inject it into fod.dom
+    ::  create spill for a complete flue
+    =/  new-spill=(map leak soak)
+      ?~  sip  ~
+      %-  ~(gas by *(map leak soak))
+      %+  turn  ~(tap by u.sip)
+      |=([* =leak =soak] [leak soak])
+    ::  add those leaks to the flow
+    =.  fad
+      %-  ~(urn by fad)
+      |=  [=leak refs=@ud =soak]
+      ?.  (~(has by new-spill) leak)  [refs soak]
+      [+(refs) (~(got by new-spill) leak)] :: TODO is this correct ref counting?
+    ::  inject it into fod.dom
+    =?  fod.dom  ?=(^ sip)
+      [~(key by new-spill) u.sip]
+    ::
     =?  changes  updated  (changes-for-upgrade q.old-yaki deletes changes)
     ::
     =/  files
@@ -2472,7 +2484,7 @@
       ?~  mr
         (done %& ~)
       =.  ..merge  (done %& conflicts.u.mr)
-      (park | & new.u.mr ~ lat.u.mr ~)
+      (park | & new.u.mr [~ lat.u.mr] ~)
     ==
   ::
   +$  merge-result  [conflicts=(set path) new=yoki lat=(map lobe page)]
@@ -4988,7 +5000,7 @@
       ~|([%park-bad-desk des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
-      abet:(park:den | & [yok ran]:req ~)
+      abet:(park:den | & [yok ran ~]:req)
     [mos ..^$]
   ::
       %perk
@@ -4996,7 +5008,7 @@
       ~|([%park-bad-desk des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
-      abet:(park:den | & [yok ran sip]:req)
+      abet:(park:den | & [yok ran `sip]:req)
     [mos ..^$]
   ::
       %pork

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4838,7 +4838,10 @@
       ==
   ^-  [(list move) _..^$]
   ::
-  =/  req=task  ((harden task) wrapped-task)
+  =/  req=task
+    ?:  ?=([%soft %perk *] wrapped-task)
+      !<(task [-:!>(*task) +.wrapped-task])
+    ((harden task) wrapped-task)
   ::
   ::  TODO handle error notifications
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1727,7 +1727,7 @@
       ?>  ?=(~ deletes)
       =/  data=(map path (each page lobe))
         (~(run by changes) |=(=cage &+[p q.q]:cage))
-      (park | & &+[~ data] *rang)
+      (park | & &+[~ data] *rang ~)
     ::
     =/  parent-tako=tako  (aeon-to-tako:ze let.dom)
     =/  data=(map path (each page lobe))
@@ -1742,7 +1742,7 @@
       (~(run by changes) |=(=cage &+[p q.q]:cage))
     ::
     =/  =yuki  [~[parent-tako] data]
-    (park | & &+yuki *rang)
+    (park | & &+yuki *rang ~)
   ::
   ::  Unix commit
   ::
@@ -1787,7 +1787,7 @@
   ++  park
     =/  check-sane  |
     |^
-    |=  [updated=? goat=? =yoki =rang]
+    |=  [updated=? goat=? =yoki =rang sip=(unit sprig)]
     ^+  ..park
     =:  hut.ran  (~(uni by hut.rang) hut.ran)
         lat.ran  (~(uni by lat.rang) lat.ran)
@@ -1895,9 +1895,14 @@
     =/  old-fod  fod.dom
     =.  fod.dom
       ?:  updated  [~ ~]
+      ?^  sip      [~ ~]  :: if you supplied a cache, throw everything away
       (promote-ford fod.dom invalid)
     =.  fad
       (lose-leaks:fusion veb.bug fad (~(dif in spill.old-fod) spill.fod.dom))
+    ::  TODO ingest the sprig
+    ::    create spill for a complete flue
+    ::    add those leaks to the flow
+    ::    inject it into fod.dom
     =?  changes  updated  (changes-for-upgrade q.old-yaki deletes changes)
     ::
     =/  files
@@ -1975,7 +1980,7 @@
       ::  [goad] < call without goading so that we apply all the commits
       ::  before trying to compile all desks to send to gall.
       ::
-      =^  moves-3  ruf  abet:(park:den | | u.wat *^rang)
+      =^  moves-3  ruf  abet:(park:den | | u.wat *^rang ~)
       =.  moves-2  (weld moves-2 moves-3)
       $(desks t.desks)
     ::  tell gall to try to run agents if %held
@@ -2386,7 +2391,7 @@
     ^+  ..take-fuse
     ?~  merges
       =.  ..take-fuse  (done-fuse clean-state %& ~)
-      (park | & [%| next-yaki(p (flop parents))] rag)
+      (park | & [%| next-yaki(p (flop parents))] rag ~)
     =/  [bec=beak g=germ]  i.merges
     =/  ali-dom=domo  (need (~(got by sto.fiz) bec))
     =/  result  (merge-helper p.bec q.bec g ali-dom `next-yaki)
@@ -2467,7 +2472,7 @@
       ?~  mr
         (done %& ~)
       =.  ..merge  (done %& conflicts.u.mr)
-      (park | & new.u.mr ~ lat.u.mr)
+      (park | & new.u.mr ~ lat.u.mr ~)
     ==
   ::
   +$  merge-result  [conflicts=(set path) new=yoki lat=(map lobe page)]
@@ -3217,7 +3222,7 @@
     =.  wis  (skip wis |=([[* a=@ud] *] (gte a zuse)))
     ?~  wis  ::  Every commit bottoms out here ?
       ..park
-    (park | & yoki.i.wis *rang)
+    (park | & yoki.i.wis *rang ~)
   ::
   ::  Cancel a request.
   ::
@@ -4983,7 +4988,15 @@
       ~|([%park-bad-desk des.req] !!)
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our des.req)
-      abet:(park:den | & [yok ran]:req)
+      abet:(park:den | & [yok ran]:req ~)
+    [mos ..^$]
+  ::
+      %perk
+    ?.  ((sane %tas) des.req)
+      ~|([%park-bad-desk des.req] !!)
+    =^  mos  ruf
+      =/  den  ((de now rof hen ruf) our des.req)
+      abet:(park:den | & [yok ran sip]:req)
     [mos ..^$]
   ::
       %pork
@@ -4991,7 +5004,7 @@
     =.  pud.ruf  ~
     =^  mos  ruf
       =/  den  ((de now rof hen ruf) our syd)
-      abet:(park:den & & yoki *rang)
+      abet:(park:den & & yoki *rang ~)
     [mos ..^$]
   ::
       %prep

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1895,7 +1895,7 @@
     =/  old-fod  fod.dom
     =.  fod.dom
       ?:  updated  [~ ~]
-      ?^  sip      [~ ~]  :: if you supplied a cache, throw everything away
+      ?^  sip   ~&  >  "cell"   [~ ~]  :: if you supplied a cache, throw everything away
       (promote-ford fod.dom invalid)
     =.  fad
       (lose-leaks:fusion veb.bug fad (~(dif in spill.old-fod) spill.fod.dom))
@@ -1907,10 +1907,13 @@
       |=([* =leak =soak] [leak soak])
     ::  add those leaks to the flow
     =.  fad
-      %-  ~(urn by fad)
-      |=  [=leak refs=@ud =soak]
-      ?.  (~(has by new-spill) leak)  [refs soak]
-      [+(refs) (~(got by new-spill) leak)] :: TODO is this correct ref counting?
+      ^-  (map leak [@ud soak])
+      %-  ~(gas by fad)
+      %+  turn  ~(tap by new-spill)
+      |=  [=leak =soak]
+      ?:  (~(has by fad) leak)
+        [leak +(refs:(~(got by fad) leak)) soak]
+      [leak 1 soak]
     ::  inject it into fod.dom
     =?  fod.dom  ?=(^ sip)
       [~(key by new-spill) u.sip]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1895,7 +1895,7 @@
     =/  old-fod  fod.dom
     =.  fod.dom
       ?:  updated  [~ ~]
-      ?^  sip   ~&  >  "cell"   [~ ~]  :: if you supplied a cache, throw everything away
+      ?^  sip      [~ ~]  :: if you supplied a cache, throw everything away
       (promote-ford fod.dom invalid)
     =.  fad
       (lose-leaks:fusion veb.bug fad (~(dif in spill.old-fod) spill.fod.dom))
@@ -1907,13 +1907,27 @@
       |=([* =leak =soak] [leak soak])
     ::  add those leaks to the flow
     =.  fad
-      ^-  (map leak [@ud soak])
-      %-  ~(gas by fad)
-      %+  turn  ~(tap by new-spill)
-      |=  [=leak =soak]
+      ^+  fad
+      =/  spills=(list [=leak =soak])  ~(tap by new-spill)
+      |-
+      ?~  spills  fad
+      =,  i.spills
       ?:  (~(has by fad) leak)
-        [leak +(refs:(~(got by fad) leak)) soak]
-      [leak 1 soak]
+        =.  fad  (~(put by fad) leak +(refs:(~(got by fad) leak)) soak)
+        $(spills t.spills)
+      ::  If we're creating a cache entry, add refs to our dependencies
+      ::
+      =/  deps=(list ^leak)  ~(tap in deps.leak)
+      |-
+      ?~  deps
+        =.  fad  (~(put by fad) leak 1 soak)
+        ^$(spills t.spills)
+      =.  fad
+        %+  ~(put by fad)  i.deps
+        ?~  got=(~(get by fad) i.deps)
+          [1 (~(got by new-spill) i.deps)]
+        [+(refs) soak]:u.got
+      $(deps t.deps)
     ::  inject it into fod.dom
     =?  fod.dom  ?=(^ sip)
       [~(key by new-spill) u.sip]


### PR DESCRIPTION
Right now, it is quite easy to inject a `$flow` cache into clay from pyro. While this speeds things up quite a bit, it could be much faster if we also injected the local cahce (`$flue`). Currently there is no easy way to do this from pyro becasue cache injection has to happen midway through `+park`. By adding a new `%perk` task to clay, and editing some of the `+park` internals, we can achieve `$flue` injection