### PR TITLE
hoon, lull: add some type name

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -2043,6 +2043,7 @@
 +$  tang  (list tank)                                   ::  bottom-first error
 ::                                                      ::
 +$  iota                                                ::  typed path segment
+  $+  iota
   $~  [%n ~]
   $@  @tas
   $%  [%ub @ub]  [%uc @uc]  [%ud @ud]  [%ui @ui]
@@ -2067,6 +2068,7 @@
 ::           flat-mid, open, close
 ::
 +$  tank
+  $+  tank
   $~  leaf/~
   $@  cord
   $%  [%leaf p=tape]
@@ -6382,6 +6384,7 @@
       ==
   --                                                    ::
 +$  hoon                                                ::  hoon AST
+  $+  hoon                                              ::
   $~  [%zpzp ~]                                         ::
   $^  [p=hoon q=hoon]                                   ::
   $%                                                    ::
@@ -6535,7 +6538,8 @@
               [%know p=stud]                            ::  global standard
               [%made p=term q=(unit (list wing))]       ::  structure
           ==                                            ::
-+$  type  $~  %noun                                     ::
++$  type  $+  type                                      ::
+          $~  %noun                                     ::
           $@  $?  %noun                                 ::  any nouns
                   %void                                 ::  no noun
               ==                                        ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2592,6 +2592,7 @@
   +$  boat  (map [=wire =ship =term] [acked=? =path])   ::  outgoing subs
   +$  boar  (map [=wire =ship =term] nonce=@)           ::  and their nonces
   +$  bowl                                              ::  standard app state
+    $+  gall-agent-bowl                                 ::
     $:  $:  our=ship                                    ::  host
             src=ship                                    ::  guest
             dap=term                                    ::  agent
@@ -2635,7 +2636,7 @@
     =<  form
     |%
     +$  step  (quip card form)
-    +$  card  (wind note gift)
+    +$  card  $+(gall-agent-card (wind note gift))
     +$  note
       $%  [%agent [=ship name=term] =task]
           [%arvo note-arvo]
@@ -2646,6 +2647,7 @@
           [%cull =case =spur]
       ==
     +$  task
+      $+  gall-agent-task
       $%  [%watch =path]
           [%watch-as =mark =path]
           [%leave ~]
@@ -2653,12 +2655,14 @@
           [%poke-as =mark =cage]
       ==
     +$  gift
+      $+  gall-agent-gift
       $%  [%fact paths=(list path) =cage]
           [%kick paths=(list path) ship=(unit ship)]
           [%watch-ack p=(unit tang)]
           [%poke-ack p=(unit tang)]
       ==
     +$  sign
+      $+  gall-agent-sign
       $%  [%poke-ack p=(unit tang)]
           [%watch-ack p=(unit tang)]
           [%fact =cage]


### PR DESCRIPTION
I've named the following types using `$+` in Arvo according to this issue #6494 by @belisarius222.

I'd be happy to add more names elsewhere, please leave comments with suggestions. Note: these are generally helpful in reducing the size of error prints in the case of type mismatches, but the full unnamed type definition is still shown if one is casting directly to a named type. This is still annoying -- it would be nice to show just the name if I try to cast some code to the type `hoon` and it fails, and I'm wondering if there's a good way to do that.

hoon.hoon
  - hoon: “hoon”
  - type: “type”
  - iota: “iota”
  - tank: “tank”

lull.hoon
- gall
    - bowl: “gall-bowl”
    - card: “gall-agent-card”
    - task: “gall-agent-task”
    - gift: “gall-agent-gift”
    - sign: “gall-agent-sign”