### PR TITLE
dojo: sort complete options aor

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1532,7 +1532,9 @@
       ::  Else, print results
       ::
       %+  he-diff  %tab
-      options
+      %+  sort  options
+      |=  [[a=term *] [b=term *]]
+      (aor a b)
     --
   ::
   ++  he-type                                           ::  apply input


### PR DESCRIPTION
dojo `+complete` options are now sorted alphabetically.

before:
`:a<tab>`
```
:aqua
:acme
:azimuth-tracker
:azimuth
:azimuth-rpc
```

after:
`:a<tab>`
```
:acme
:aqua
:azimuth
:azimuth-rpc
:azimuth-tracker
```