### PR TITLE
hoon: add rune ?_, equality test w type refinement

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6499,6 +6499,7 @@
     [%wtpt p=wing q=hoon r=hoon]                        ::  ?@  if p is atom
     [%wtsg p=wing q=hoon r=hoon]                        ::  ?~  if p is null
     [%wthx p=skin q=wing]                               ::  ?#  if q matches p
+    [%wtcb p=hoon q=wing]                               ::  ?_  if q equals p
     [%wtts p=spec q=wing]                               ::  ?=  if q matches p
     [%wtzp p=hoon]                                      ::  ?!  loobean not
   ::                                            ::::::  special
@@ -7497,6 +7498,7 @@
   ++  wtsg  |=([sic=hoon non=hoon] (gray [%wtsg puce (blue sic) (blue non)]))
   ++  wthx  |=(syn=skin (gray [%wthx (tele syn) puce]))
   ++  wtts  |=(mod=spec (gray [%wtts (teal mod) puce]))
+  ++  wtcb  |=(sic=hoon (gray [%wtcb (blue sic) puce]))
   --
 ::
 ++  ax
@@ -8670,6 +8672,7 @@
         [%wtpt *]   [%wtcl [%wtts [%base %atom %$] p.gen] q.gen r.gen]
         [%wtsg *]   [%wtcl [%wtts [%base %null] p.gen] q.gen r.gen]
         [%wtts *]   [%fits ~(example ax p.gen) q.gen]
+        [%wtcb *]   [%dtts p.gen [%wing q.gen]]
         [%wtzp *]   [%wtcl p.gen [%rock %f 1] [%rock %f 0]]
         [%zpgr *]
       [%cncl [%limb %onan] [%zpmc [%kttr [%bcmc %limb %abel]] p.gen] ~]
@@ -9689,6 +9692,8 @@
     |=  [how=? gen=hoon]  ^-  type
     ?:  ?=([%wtts *] gen)
       (cool how q.gen (play ~(example ax p.gen)))
+    ?:  ?=([%wtcb *] gen)
+      (cool how q.gen (play p.gen))
     ?:  ?=([%wthx *] gen)
       =+  (play %wing q.gen)
       ~>  %slog.[0 [%leaf "chipping"]]
@@ -13333,6 +13338,7 @@
                   ['.' (rune dot %wtdt expc)]
                   ['<' (rune gal %wtgl expb)]
                   ['>' (rune gar %wtgr expb)]
+                  ['_' ;~(pfix cab (toad txcb))]
                   ['-' ;~(pfix hep (toad txhp))]
                   ['^' ;~(pfix ket (toad tkkt))]
                   ['=' ;~(pfix tis (toad txts))]
@@ -13640,6 +13646,7 @@
     ++  expx  |.(;~(goop ropa loaf loaf))               ::  wings and two hoons
     ++  expy  |.(loaf(bug &))                           ::  hoon with tracing
     ++  expz  |.(;~(goop loan loaf loaf loaf))          ::  spec and three hoons
+    ++  exp0  |.(;~(goop loaf rope))                    ::  hoon, wing
     ::  spec contents
     ::
     ++  exqa  |.(loan)                                  ::  one spec
@@ -13677,6 +13684,9 @@
     ++  txts  |.  %+  cook  |=  [a=spec b=tiki]
                             (~(wtts ah b) a)
                   ;~(gunk loan teak)
+    ++  txcb  |.  %+  cook  |=  [a=hoon b=tiki]
+                            (~(wtcb ah b) a)
+                  ;~(gunk loaf teak)
     ++  txhx  |.  %+  cook  |=  [a=skin b=tiki]
                             (~(wthx ah b) a)
                   ;~(gunk lore teak)


### PR DESCRIPTION
This PR introduces a new rune ?_(a=hoon b=wing), subject to renaming, whose compiled nock is equivalent to .=, but refines the type of b to that of a on equality. Most notably, this introduces new types of polymorphism with wet gates, particularly, I have managed to make work a dependently typed map, which could *perhaps* even be used for dependently typed axals later on.

I haven't included any changes to e.g. +by to fully exploit this yet, though I have tested this out on my own by replacing put and get by:
```hoon
++  put                                               ::  adds key-value pair
  ~/  %put
  |*  [b=* c=*]
  |-  ^+  a
  ?~  a
    [[b c] ~ ~]
  ?:  ?_(b p.n.a)
    ?:  =(c q.n.a)
      a
    a(n [b c])
  ?:  (gor b p.n.a)
    =+  d=$(a l.a)
    ?>  ?=(^ d)
    ?:  (mor p.n.a p.n.d)
      a(l d)
    d(r a(l r.d))
  =+  d=$(a r.a)
  ?>  ?=(^ d)
  ?:  (mor p.n.a p.n.d)
    a(r d)
  d(l a(r l.d))
::
++  get                                               ::  grab value by key
  ~/  %get
  |*  b=*
  |-  ^-  (unit _?>(&(?=(^ a) ?_(b p.n.a)) q.n.a))
  ?~  a
    ~
  ?:  ?_(b p.n.a)
    (some q.n.a)
  ?:  (gor b p.n.a)
    $(a l.a)
  $(a r.a)
```