### PR TITLE
hoon: fix gate currying

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1905,17 +1905,17 @@
 ++  corl                                                ::  compose backwards
   |*  [a=$-(* *) b=$-(* *)]
   =<  +:|.((a (b)))      ::  type check
-  |*  c=_+<.b
+  |*  c=_,.+<.b
   (a (b c))
 ::
 ++  cury                                                ::  curry left
   |*  [a=$-(^ *) b=*]
-  |*  c=_+<+.a
+  |*  c=_,.+<+.a
   (a b c)
 ::
 ++  curr                                                ::  curry right
   |*  [a=$-(^ *) c=*]
-  |*  b=_+<-.a
+  |*  b=_,.+<-.a
   (a b c)
 ::
 ++  fore  |*(a=$-(* *) |*(b=$-(* *) (pair a b)))        ::  pair before

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1915,7 +1915,7 @@
 ::
 ++  curr                                                ::  curry right
   |*  [a=$-(^ *) c=*]
-  |*  b=_+<+.a
+  |*  b=_+<-.a
   (a b c)
 ::
 ++  fore  |*(a=$-(* *) |*(b=$-(* *) (pair a b)))        ::  pair before

--- a/tests/sys/hoon/func.hoon
+++ b/tests/sys/hoon/func.hoon
@@ -1,0 +1,23 @@
+::  Tests for currying gates and ++corl
+::
+/+  *test
+|%
+++  test-func
+  ;:  weld
+    %+  expect-eq
+      !>  `(list)`~[0 1 2]
+      !>  ((curr oust `(list)`~[0 1 2]))
+    %+  expect-eq
+      !>  `@`6
+      !>  ((curr roll add) (gulf 1 3))
+    %+  expect-eq
+      !>  `@`6
+      !>  ((cury roll (gulf 1 3)) add)
+    ::  check that ++corl strips face from b's subject
+    ::
+    %+  expect-eq
+      !>  `@`15
+      !>  ((corl same (cury roll (gulf 1 5))) add)
+  ==
+::
+--


### PR DESCRIPTION
### Description

Resolves #6655.

Fixes the sample of the wet gate produced by `++curr`.
Prior to the fix, `++curr` used the same expression for the sample of the returned wet gate as in `++cury`, minus the different face. This is incorrect: `++curr` binds the tail of `a`'s sample, so `b` should use the head of `a`'s sample instead of its tail.

The fix was successfully tested on a fakezod, although I only tested it on the version %139.