### PR TITLE
dojo: complete teds in dirs

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1510,35 +1510,24 @@
     ::
     ++  complete-naked-ted
       |=  ted=term
-      |^
       =/  pfix=path
         /(scot %p our.hid)/[q:he-beam]/(scot %da now.hid)/ted
       =+  .^(paths=(list path) %ct pfix)
       %+  complete  (cat 3 '-' ted)
       %+  murn  paths
-      |=  =path
+      |=  pax=path
       ^-  (unit [term tank])
-      ?~  path
+      ?~  pax
         ~
-      ?~  t.path
+      ?~  t.pax
         ~
-      ?.  =(%hoon (rear t.path))
+      ?.  =(%hoon (rear t.pax))
         ~
       =/  =cord
-        %-  crip
-        (path-heps (snip `^path`t.path))
+        (reel (join '-' (snip `path`t.pax)) (cury cat 3))
       ?.  =(ted (end [3 (met 3 ted)] cord))
         ~
       `[(cat 3 '-' cord) *tank]
-      ::
-      ++  path-heps
-        |=  a=path  ^-  tape
-        ?~  a  ""
-        |-  ^-  tape
-        %+  welp  (trip i.a)
-        ?~  t.a  ""
-        ['-' $(a t.a)]
-      --
     ::
     ++  complete
       |=  [completing=term options=(list [term tank])]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1510,17 +1510,35 @@
     ::
     ++  complete-naked-ted
       |=  ted=term
-      =/  pax=path
+      |^
+      =/  pfix=path
         /(scot %p our.hid)/[q:he-beam]/(scot %da now.hid)/ted
+      =+  .^(paths=(list path) %ct pfix)
       %+  complete  (cat 3 '-' ted)
-      %+  murn  ~(tap by dir:.^(arch %cy pax))
-      |=  [=term ~]
-      ^-  (unit [^term tank])
-      ?.  =(ted (end [3 (met 3 ted)] term))
+      %+  murn  paths
+      |=  =path
+      ^-  (unit [term tank])
+      ?~  path
         ~
-      ?~  =<(fil .^(arch %cy (weld pax ~[term %hoon])))
+      ?~  t.path
         ~
-      `[(cat 3 '-' term) *tank]
+      ?.  =(%hoon (rear t.path))
+        ~
+      =/  =cord
+        %-  crip
+        (path-heps (snip `^path`t.path))
+      ?.  =(ted (end [3 (met 3 ted)] cord))
+        ~
+      `[(cat 3 '-' cord) *tank]
+      ::
+      ++  path-heps
+        |=  a=path  ^-  tape
+        ?~  a  ""
+        |-  ^-  tape
+        %+  welp  (trip i.a)
+        ?~  t.a  ""
+        ['-' $(a t.a)]
+      --
     ::
     ++  complete
       |=  [completing=term options=(list [term tank])]


### PR DESCRIPTION
dojo thread completion now works for subdirectories. e.g. `/ted/azimuth/load/hoon`
`-az<tab>`
```
-azimuth-load
-azimuth-snap-logs
-azimuth-snap-state
```