### PR TITLE
clay: add debug command to retry remote scry

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5055,6 +5055,11 @@
           ==
         ==
       [~ ..^$]
+    ::
+        [%fine ~]
+      ~&  "clay: resetting fine state.  old:"
+      ~&  sad.ruf
+      `..^$(sad.ruf ~)
     ==
   ::
       %tire


### PR DESCRIPTION
This just clears `sad`, so that as soon as we try the next lobe, we'll try remote scry again.

This was very useful to help identify the bugs in #6661.