### PR TITLE
arvo: print vane hashes as hashes, not `@p`s

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1052,7 +1052,7 @@
         ++  smit
           |=  [cap=tape sub=vase pax=path txt=@t]
           ^-  vase
-          ~>  %slog.[0 leaf/"{cap}: {(scow p+(mug txt))}"]
+          ~>  %slog.[0 leaf/"{cap}: {(scow ux+(mug txt))}"]
           ~>  %bout
           %-  road  |.
           ~_  leaf/"{cap}: build failed"

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1879,7 +1879,7 @@
           ++  smit
             |=  [cap=tape sub=(trap vase) pax=path txt=@t]
             ^-  (trap vase)
-            ~>  %slog.[0 leaf/"{cap}: {(scow p+(mug txt))}"]
+            ~>  %slog.[0 leaf/"{cap}: {(scow ux+(mug txt))}"]
             %-  road  |.
             ~_  leaf/"{cap}: build failed"
             (swat sub (rain pax txt))

--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1052,7 +1052,7 @@
         ++  smit
           |=  [cap=tape sub=vase pax=path txt=@t]
           ^-  vase
-          ~>  %slog.[0 leaf/"{cap}: {(scow ux+(mug txt))}"]
+          ~>  %slog.[0 leaf/"{cap}: {(scow uv+(mug txt))}"]
           ~>  %bout
           %-  road  |.
           ~_  leaf/"{cap}: build failed"
@@ -1879,7 +1879,7 @@
           ++  smit
             |=  [cap=tape sub=(trap vase) pax=path txt=@t]
             ^-  (trap vase)
-            ~>  %slog.[0 leaf/"{cap}: {(scow ux+(mug txt))}"]
+            ~>  %slog.[0 leaf/"{cap}: {(scow uv+(mug txt))}"]
             %-  road  |.
             ~_  leaf/"{cap}: build failed"
             (swat sub (rain pax txt))


### PR DESCRIPTION
This has bothered me for a while now: when compiling vanes, arvo prints the mug hashes of the vane source as a ship name.
<img width="301" alt="Screenshot 2023-06-12 at 3 26 17 PM" src="https://github.com/urbit/urbit/assets/93405247/b795d80c-e8cb-49e6-a96b-461faa692a7f">

This is confusing; it is not immediately clear what these `@p`s mean in this context. The first several times I saw these prints, first getting into Urbit, I assumed these were the source ship for code I was downloading, or something like that. Printing the hashes as `@uv`, in line with how desk source hashes are printed, will make their true nature clearer.