### PR TITLE
fine: Various fixes

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1365,7 +1365,9 @@
     =+  len=(cut 3 [4 2] hoot)
     =+  pat=(cut 3 [6 len] hoot)
     ~|  pat=pat
-    [(add 6 len) [(stab pat) num]]
+    :-  (add 6 len)
+    :_  num
+    (rash pat ;~(pfix fas (most fas (cook crip (star ;~(less fas prn))))))
   ::
   ++  sift-meow
     |=  =yowl

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -1518,7 +1518,10 @@
         file-path=term                                  ::
     ==                                                  ::
   +$  care                                              ::  clay submode
-    ?(%a %b %c %d %e %f %p %r %s %t %u %v %w %x %y %z)  ::
+    $?  %a  %b  %c  %d  %e  %f                          ::
+        %p  %q  %r  %s  %t  %u                          ::
+        %v  %w  %x  %y  %z                              ::
+    ==                                                  ::
   +$  cash                                              ::  case or tako
     $%  [%tako p=tako]                                  ::
         case                                            ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4297,37 +4297,29 @@
           ++  fi-on-ack
             =|  marked=(list want)
             |=  fra=@ud
-            |-  ^-  [found=? cor=_fine]
-            ?:  =(~ wan.keen)
-              [| fine]
-            ::
-            =/  old-wan  ?>(?=(^ wan.keen) wan.keen)
-            =^  found-left  fine  $(wan.keen ?>(?=(^ wan.keen) l.wan.keen))
-            =.  wan.keen  old-wan(l wan.keen)
-            ?:  found-left
-              [& fine]
-            ::
-            =^  found-node=?  fine
-              ?>  ?=(^ wan.keen)
-              ?:  =(fra fra.val.n.wan.keen)
-                =.  metrics.keen  (on-ack:fi-gauge +>.val.n.wan.keen)
-                [& fine(wan.keen +:(del:fi-mop wan.keen fra))]
-              =.  skips.val.n.wan.keen  +(skips.val.n.wan.keen)
+            ^-  [found=? cor=_fine]
+            =.  fine
+              =/  first  (pry:fi-mop wan.keen)
+              ?~  first
+                fine
+              ?:  =(fra fra.val.u.first)
+                fine
               =^  resend=?  metrics.keen
-                (on-skipped-packet:fi-gauge +>.val.n.wan.keen)
+                (on-skipped-packet:fi-gauge +>.val.u.first)
               ?:  !resend
-                [| fine]
-              =.  tries.val.n.wan.keen  +(tries.val.n.wan.keen)
-              =.  last-sent.val.n.wan.keen  now
-              =.  fine  =>((fi-send `@ux`hoot.val.n.wan.keen) ?>(?=(^ wan.keen) .))
-              [| fine]
-            ?:  found-node
-              [& fine]
+                fine
+              =.  tries.val.u.first  +(tries.val.u.first)
+              =.  last-sent.val.u.first  now
+              =.  wan.keen  (put:fi-mop wan.keen u.first)
+              =.  fine  (fi-send `@ux`hoot.val.u.first)
+              fine
             ::
-            =/  old-wan  ?>(?=(^ wan.keen) wan.keen)
-            =^  found-rite  fine  $(wan.keen ?>(?=(^ wan.keen) r.wan.keen))
-            =.  wan.keen  old-wan(r wan.keen)
-            [found-rite fine]
+            =/  found  (get:fi-mop wan.keen fra)
+            ?~  found
+              [| fine]
+            =.  metrics.keen  (on-ack:fi-gauge +>.u.found)
+            =.  wan.keen  +:(del:fi-mop wan.keen fra)
+            [& fine]
           ::
           ++  fi-done
             |=  [sig=@ data=$@(~ (cask))]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4297,28 +4297,37 @@
           ++  fi-on-ack
             =|  marked=(list want)
             |=  fra=@ud
-            ^-  [? _fine]
-            =;  [[found=? cor=_fine] wan=_wan.keen]
-              :-  found
-              ?.(found fine cor(wan.keen wan))
-            %^  (dip:fi-mop ,[found=? cor=_fine])  wan.keen
+            |-  ^-  [found=? cor=_fine]
+            ?:  =(~ wan.keen)
               [| fine]
-            |=  [[found=? cor=_fine] @ud =want]
-            ^-  [(unit _want) stop=? [found=? cor=_fine]]
-            =.  fine  cor
-            ?:  =(fra fra.want)
-              =.  metrics.keen
-                (on-ack:fi-gauge +>.want)
-              [~ %.y %.y fine]
-            =.  skips.want  +(skips.want)
-            =^  resend=?  metrics.keen
-              (on-skipped-packet:fi-gauge +>.want)
-            ?.  resend
-              [`want %.n found fine]
-            =.  tries.want  +(tries.want)
-            =.  last-sent.want  now
-            =.  fine  (fi-send `@ux`hoot.want)
-            [`want %.n found fine]
+            ::
+            =/  old-wan  ?>(?=(^ wan.keen) wan.keen)
+            =^  found-left  fine  $(wan.keen ?>(?=(^ wan.keen) l.wan.keen))
+            =.  wan.keen  old-wan(l wan.keen)
+            ?:  found-left
+              [& fine]
+            ::
+            =^  found-node=?  fine
+              ?>  ?=(^ wan.keen)
+              ?:  =(fra fra.val.n.wan.keen)
+                =.  metrics.keen  (on-ack:fi-gauge +>.val.n.wan.keen)
+                [& fine(wan.keen +:(del:fi-mop wan.keen fra))]
+              =.  skips.val.n.wan.keen  +(skips.val.n.wan.keen)
+              =^  resend=?  metrics.keen
+                (on-skipped-packet:fi-gauge +>.val.n.wan.keen)
+              ?:  !resend
+                [| fine]
+              =.  tries.val.n.wan.keen  +(tries.val.n.wan.keen)
+              =.  last-sent.val.n.wan.keen  now
+              =.  fine  =>((fi-send `@ux`hoot.val.n.wan.keen) ?>(?=(^ wan.keen) .))
+              [| fine]
+            ?:  found-node
+              [& fine]
+            ::
+            =/  old-wan  ?>(?=(^ wan.keen) wan.keen)
+            =^  found-rite  fine  $(wan.keen ?>(?=(^ wan.keen) r.wan.keen))
+            =.  wan.keen  old-wan(r wan.keen)
+            [found-rite fine]
           ::
           ++  fi-done
             |=  [sig=@ data=$@(~ (cask))]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1,5 +1,5 @@
 ::  clay (4c), revision control
-::
+!:
 ::  The way to understand Clay is to take it section-by-section:
 ::
 ::  - Data structures.  You *must* start here; make sure you understand
@@ -159,6 +159,8 @@
   $%  [%0 =desk =lobe]
       [%1 =desk =lobe]
   ==
+::
+::  All except %1 are deprecated
 ::
 +$  fell
   $%  [%direct p=lobe q=page]
@@ -1544,7 +1546,7 @@
     ::
     ++  good-care
       |=  =care
-      (~(has in ^~((silt `(list ^care)`~[%u %w %x %y %z]))) care)
+      (~(has in ^~((silt `(list ^care)`~[%q %u %w %x %y %z]))) care)
     --
   ::
   ::  Build and send agents to gall
@@ -3362,6 +3364,7 @@
           %s  ~|  %please-dont-get-your-takos-over-a-network  !!
           %t  ~|  %requesting-foreign-directory-is-vaporware  !!
           %v  ~|  %weird-shouldnt-get-v-request-from-network  !!
+          %q  `[p %noun q]:r.rand
           %u  `(validate-u r.rand)
           %w  `(validate-w r.rand)
           %x  (validate-x [p.p q.p q r]:rand)
@@ -3566,7 +3569,7 @@
             ==  ==
           ::  make the request over remote scry
           ::
-          =/  =mood  [%x uv+tako path]:i.need.sat
+          =/  =mood  [%q uv+tako path]:i.need.sat
           =<  [`[%back-index -] +]
           (send-over-scry %back-index hen her inx syd mood)
         ::  otherwise, request over ames
@@ -4255,6 +4258,27 @@
         ^-  (list (pair path lobe))
         [[~ ?~(us *lobe u.us)] descendants]
       |=([[path lobe] @uvI] (shax (jam +<)))
+    ::  +read-q: typeless %x
+    ::
+    ::  useful if the marks can't be built (eg for old marks built
+    ::  against an incompatible standard library).  also useful if you
+    ::  don't need the type (eg for remote scry) because it's faster.
+    ::
+    ++  read-q
+      |=  [tak=tako pax=path]
+      ^-  (unit (unit cage))
+      ?:  =(0v0 tak)
+        [~ ~]
+      =+  yak=(tako-to-yaki tak)
+      =+  lob=(~(get by q.yak) pax)
+      ?~  lob
+        [~ ~]
+      =/  peg=(unit page)  (~(get by lat.ran) u.lob)
+      ::  if tombstoned, nothing to return
+      ::
+      ?~  peg
+        ~
+      ``[p.u.peg %noun q.u.peg]
     ::  +read-r: %x wrapped in a vase
     ::
     ++  read-r
@@ -4449,23 +4473,15 @@
     ++  read-x
       |=  [tak=tako pax=path]
       ^-  [(unit (unit cage)) _..park]
-      ?:  =(0v0 tak)
-        [[~ ~] ..park]
-      =+  yak=(tako-to-yaki tak)
-      =+  lob=(~(get by q.yak) pax)
-      ?~  lob
-        [[~ ~] ..park]
-      =/  peg=(unit page)  (~(get by lat.ran) u.lob)
-      ::  if tombstoned, nothing to return
-      ::
-      ?~  peg
-        [~ ..park]
+      =/  q  (read-q tak pax)
+      ?~  q    `..park
+      ?~  u.q  `..park
       ::  should convert any lobe to cage
       ::
       =^  =cage  ..park
         %+  tako-flow  tak
         %-  wrap:fusion
-        (page-to-cage:(tako-ford tak) u.peg)
+        (page-to-cage:(tako-ford tak) p.u.u.q q.q.u.u.q)
       [``cage ..park]
     ::
     ::  Gets an arch (directory listing) at a node.
@@ -4539,6 +4555,7 @@
           %e  (read-e tak path.mun)
           %f  (read-f tak path.mun)
           %p  [(read-p path.mun) ..park]
+          %q  [(read-q tak path.mun) ..park]
           %r  (read-r tak path.mun)
           %s  [(read-s tak path.mun case.mun) ..park]
           %t  [(read-t tak path.mun) ..park]
@@ -6200,20 +6217,22 @@
       =/  =desk      (slav %tas i.t.t.tea)
       =/  index=@ud  (slav %ud i.t.t.t.tea)
       ::
-      =/  fell=(unit fell)
-        ?:  ?=(%boon +<.hin)  `;;(fell payload.hin)
+      =/  =fell
+        ?:  ?=(%boon +<.hin)  ;;(fell payload.hin)
+        :-  %1
+        ^-  (unit page)
+        ::  if we can't get the answer, we assume it's been tombstoned
+        ::  and move on
+        ::
         ?~  roar.hin  ~
         ?~  q.dat.u.roar.hin  ~
-        =*  pag  u.q.dat.u.roar.hin
-        `[%direct (page-to-lobe pag) pag]
+        `u.q.dat.u.roar.hin
       ::
       =^  mos  ruf
         =/  den  ((de now rof hen ruf) her desk)
-        ?~  fell
-          abet:(retry-with-ames:den %back-index index)
         =?  den  ?=(%tune +<.hin)
           (cancel-scry-timeout:den index)
-        abet:abet:(take-backfill:(foreign-update:den index) u.fell)
+        abet:abet:(take-backfill:(foreign-update:den index) fell)
       [mos ..^$]
     ::
          %wake

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -3569,7 +3569,15 @@
             ==  ==
           ::  make the request over remote scry
           ::
-          =/  =mood  [%q uv+tako path]:i.need.sat
+          ::  TODO: switch %x -> %q as soon as practical to improve
+          ::  performance and stop tombstoning some past files.  we
+          ::  can't do it immediately because if you request %q from
+          ::  someone who doesn't understand it, they'll return null and
+          ::  we'll interpret that as a tombstoned file.  once most
+          ::  sponsors and app distributors have updated, we can change
+          ::  this to %q.
+          ::
+          =/  =mood  [%x uv+tako path]:i.need.sat
           =<  [`[%back-index -] +]
           (send-over-scry %back-index hen her inx syd mood)
         ::  otherwise, request over ames

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1,5 +1,5 @@
 ::  clay (4c), revision control
-!:
+::
 ::  The way to understand Clay is to take it section-by-section:
 ::
 ::  - Data structures.  You *must* start here; make sure you understand


### PR DESCRIPTION
This is a draft because I want to rerun all my tests from scratch against it.

Remote scry is used in Clay to download OTAs.  The largest OTA we ever deal with is the first one you get after boot, because it downloads the entire history of OTAs (separately: it probably shouldn't do that).  Making this initial OTA happen entirely over remote scry is both a good test of remote scry and a very practical thing: if you want to bring up many ships at the same time, they all need to download this initial OTA which is tens of MBs.

This PR is narrowly focused on making that initial download work entirely over remote scry.  This entails several fixes:

- Handle tombstoned files correctly, instead of falling back to ames.

- If we receive a null back from remote scry, that means they know how to speak remote scry, so don't retry with ames.  Instead, treat it like a tombstoned file.

- Permit scry paths with uppercase letters.  Clay grudgingly supports paths with capital letters, so there are files in its history with them.  We used to drop those packets, causing us to fall back to ames.  With these changes (and the accompanying vere changes), we accept those paths.

- Don't try to build types for files on the publisher side.  This is slow if it works and crashes if it doesn't.  The crash turns into a null, which in the past would have fallen back to ames and now would be interpreted as a tombstoned file.

To do this last one, we introduce a new care `%q`, which is like `%x` except it produces a noun instead of a well-typed value.  This resolves the longstanding issue that you can't always access old files, even locally, if their mark doesn't compile with the current kernel.  Secondarily, it's much faster for large files.

This completes the trio of "read a file" scries:
- `%q` produces a file as a noun
- `%x` produces a file as a well-typed value
- `%r` produces a file as a vase of a well-typed value

Finally, we modify the misordered ack handling to avoid pathological cases when the congestion window is large.  We had two issues here.  First, the congestion window wasn't getting correctly modified, probably due to incorrect state handling.

Second, the whole +dip flow is suspect, and I remove it here.  Suppose you drop a single packet while 1000 packets are outstanding.  Then, in the old +dip flow, for each of the 999 acks you receive, you would iterate through that many outstanding packets and do the misordered ack handling for each one.  This is n^2, and that handling sometimes sends additional packets as well, which can't help.

Here, I remove that entire iteration and make the rule very simple:
- if the ack is not for the first packet, handle the first packet as a misordered ack
- then go find the packet that actually got acked and delete that from the outstanding list

In theory you should be able to do better than this.  In practice, it doesn't have the pathological case the previous system did, so I think it's good enough for now.  The same issues that used to take >30 minutes now take around 30 seconds to resolve.

I believe Ames should receive the same treatment, and the only reason we haven't noticed it is that Ames never gets very large congestion windows because it's slow.  However, I think it would be a bad idea to make that change at the same time as we change Fine, because Ames is a critical fallback in case Fine fails to make progress.