### PR TITLE
vats: add source ship, remove base hash from default output

### DIFF
--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -22,7 +22,7 @@
 %-  zing
 %+  turn
   %+  sort
-    =/  sed  .^((set desk) %cd /(scot %p p.bec)/base/(scot %da now))
+    =/  sed  .^((set desk) %cd /(scot %p p.bec)//(scot %da now))
     (sort ~(tap in sed) |=([a=@ b=@] !(aor a b)))
   |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
 |=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -159,16 +159,10 @@
     |=  [=weft =tape]
     (welp " {<[lal num]:weft>}" tape)
   ?.  verb
-    =/  cut=(list tape)  (turn meb truncate-hash)
-    =/  len  (lent cut)
-    =/  base-hash
-      ?:  =(0 len)  "~"
-      ?:  =(1 len)  (head cut)
-        "~[{`tape`(zing (join " " `(list tape)`cut))}]"
     :~  leaf/"/sys/kelvin:          {kul}"
-        leaf/"base hash ends in:     {base-hash}"
         leaf/"%cz hash ends in:      {(truncate-hash hash)}"
         leaf/"app status:            {sat}"
+        leaf/"source ship:           {?~(sink <~> <her.u.sink>)}"
         leaf/"pending updates:       {<`(list [@tas @ud])`~(tap in wic.dek)>}"
     ==
   ::


### PR DESCRIPTION
The absence of the source ship in the default output is a common source of complaints. And the %cz hash is much more useful than the base hash these days.

Bikeshedding welcome.