### PR TITLE
dojo: preserve input history after crash

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1060,13 +1060,6 @@
   ++  he-abet                                           ::  resolve
     [(flop moz) %_(state hoc (~(put by hoc) id +<+>+))]
   ::
-  ++  he-slip                                           ::  to self
-    |=  txt=tape
-    ^+  +>
-    =/  =cage  [%self !>([txt id moz])]
-    =.  moz  ~
-    (he-card %pass /self %agent [our.hid %dojo] %poke cage)
-  ::
   ++  he-card                                           ::  emit gift
     |=  =card:agent:gall
     ^+  +>
@@ -1583,9 +1576,12 @@
       he-pine:(~(dy-type dy u.poy) act)
     ?-  -.dat.act
       %det  (he-stir +.dat.act)
-      %ret  (he-slip (tufa buf.say))
       %clr  he-pine(buf "")
       %tab  (he-tab +.dat.act)
+    ::
+        %ret  
+      %-  he-card 
+      [%pass /self %agent [our.hid %dojo] %poke %self !>([id (tufa buf.say)])]
     ==
   ::
   ++  he-lame                                           ::  handle error
@@ -1705,11 +1701,10 @@
     ^-  (quip card:agent:gall house)
     ?+  mark  ~|([%dojo-poke-bad-mark mark] !!)
         %self
-      =+  !<(old=[txt=tape =id moz=(list card:agent:gall)] vase)
+      =+  !<(old=[=id txt=tape] vase)
       =/  =session  (~(got by hoc) id.old)
-      =/  he-old  ~(. he hid id.old moz.old session)
-      =<  he-abet
-      (he-done:he-old txt.old)
+      =/  he-old  ~(. he hid id.old ~ session)
+      he-abet:(he-done:he-old txt.old)
     ::
         %sole-action
       =/  act  !<(sole-action vase)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1586,7 +1586,7 @@
       he-pine:(~(dy-type dy u.poy) act)
     ?-  -.dat.act
       %det  (he-stir +.dat.act)
-      %ret  (he-card %pass /self %agent [our.hid %dojo] %poke %self !>(id))
+      %ret  (he-card %pass /self %agent [our.hid %dojo] %poke %done !>(id))
       %clr  he-pine(buf "")
       %tab  (he-tab +.dat.act)
     ==
@@ -1707,10 +1707,6 @@
   =^  moves  state
     ^-  (quip card:agent:gall house)
     ?+  mark  ~|([%dojo-poke-bad-mark mark] !!)
-        %self
-      =+  !<(=id vase)
-      =/  =session  (~(got by hoc) id)
-      he-abet:(~(he-done he hid id ~ session) (tufa buf.say.session))
     ::
         %sole-action
       =/  act  !<(sole-action vase)
@@ -1720,6 +1716,11 @@
       =+  !<([ses=@ta =command:lens] vase)
       =/  =id  [our.hid ses]
       he-abet:(~(he-lens he hid id ~ (~(got by hoc) id)) command)
+    ::
+        %done
+      =+  !<(=id vase)
+      =/  ses=session  (~(got by hoc) id)
+      he-abet:(~(he-done he hid id ~ ses) (tufa buf.say.ses))
     ::
         %allow-remote-login
       =/  who  !<(@p vase)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1326,10 +1326,6 @@
           [%txt "> "]
           [%nex ~]
       ==
-    (he-slip txt)
-  ::
-  ++  he-self
-    |=  txt=tape
     =+  doy=(he-duke txt)
     ?-    -.doy
         %|  (he-errd ~ p.doy)
@@ -1587,7 +1583,7 @@
       he-pine:(~(dy-type dy u.poy) act)
     ?-  -.dat.act
       %det  (he-stir +.dat.act)
-      %ret  (he-done (tufa buf.say))
+      %ret  (he-slip (tufa buf.say))
       %clr  he-pine(buf "")
       %tab  (he-tab +.dat.act)
     ==
@@ -1713,7 +1709,7 @@
       =/  =session  (~(got by hoc) id.old)
       =/  he-old  ~(. he hid id.old moz.old session)
       =<  he-abet
-      (he-self:he-old txt.old)
+      (he-done:he-old txt.old)
     ::
         %sole-action
       =/  act  !<(sole-action vase)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1174,12 +1174,12 @@
     ==
   ::
   ++  he-self
-    |=  [way=wire cit=sign:agent:gall]
+    |=  [way=wire =sign:agent:gall]
     ^+  +>
-    ?.  ?=(%poke-ack -.cit)
-      ~&  [%strange-self cit]
+    ?.  ?=(%poke-ack -.sign)
+      ~&  [%strange-self sign]
       +>
-    ?~  p.cit
+    ?~  p.sign
       +>
     (he-diff %tan leaf+"dojo: failed to process input" ~)
   ::  +he-http-response: result from http-client

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1576,12 +1576,9 @@
       he-pine:(~(dy-type dy u.poy) act)
     ?-  -.dat.act
       %det  (he-stir +.dat.act)
+      %ret  (he-card %pass /self %agent [our.hid %dojo] %poke %self !>(id))
       %clr  he-pine(buf "")
       %tab  (he-tab +.dat.act)
-    ::
-        %ret  
-      %-  he-card 
-      [%pass /self %agent [our.hid %dojo] %poke %self !>([id (tufa buf.say)])]
     ==
   ::
   ++  he-lame                                           ::  handle error
@@ -1701,10 +1698,9 @@
     ^-  (quip card:agent:gall house)
     ?+  mark  ~|([%dojo-poke-bad-mark mark] !!)
         %self
-      =+  !<(old=[=id txt=tape] vase)
-      =/  =session  (~(got by hoc) id.old)
-      =/  he-old  ~(. he hid id.old ~ session)
-      he-abet:(he-done:he-old txt.old)
+      =+  !<(=id vase)
+      =/  =session  (~(got by hoc) id)
+      he-abet:(~(he-done he hid id ~ session) (tufa buf.say.session))
     ::
         %sole-action
       =/  act  !<(sole-action vase)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1060,6 +1060,13 @@
   ++  he-abet                                           ::  resolve
     [(flop moz) %_(state hoc (~(put by hoc) id +<+>+))]
   ::
+  ++  he-slip                                           ::  to self
+    |=  txt=tape
+    ^+  +>
+    =/  =cage  [%self !>([txt id moz])]
+    =.  moz  ~
+    (he-card %pass /self %agent [our.hid %dojo] %poke cage)
+  ::
   ++  he-card                                           ::  emit gift
     |=  =card:agent:gall
     ^+  +>
@@ -1319,6 +1326,10 @@
           [%txt "> "]
           [%nex ~]
       ==
+    (he-slip txt)
+  ::
+  ++  he-self
+    |=  txt=tape
     =+  doy=(he-duke txt)
     ?-    -.doy
         %|  (he-errd ~ p.doy)
@@ -1697,6 +1708,12 @@
   =^  moves  state
     ^-  (quip card:agent:gall house)
     ?+  mark  ~|([%dojo-poke-bad-mark mark] !!)
+        %self
+      =+  !<(old=[txt=tape =id moz=(list card:agent:gall)] vase)
+      =/  =session  (~(got by hoc) id.old)
+      =/  he-old  ~(. he hid id.old moz.old session)
+      =<  he-abet
+      (he-self:he-old txt.old)
     ::
         %sole-action
       =/  act  !<(sole-action vase)
@@ -1765,6 +1782,8 @@
   |=  [=wire =sign:agent:gall]
   ^-  (quip card:agent:gall _..on-init)
   ?>  ?=([@ @ @ *] wire)
+  ?:  =(%self i.t.t.wire)
+    `..on-init
   =/  =id  [(slav %p i.wire) i.t.wire]
   =/  =session  (~(got by hoc) id)
   =/  he-full  ~(. he hid id ~ session)

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1172,6 +1172,16 @@
     ::
         %kick  +>.$
     ==
+  ::
+  ++  he-self
+    |=  [way=wire cit=sign:agent:gall]
+    ^+  +>
+    ?.  ?=(%poke-ack -.cit)
+      ~&  [%strange-self cit]
+      +>
+    ?~  p.cit
+      +>
+    (he-diff %tan leaf+"dojo: failed to process input" ~)
   ::  +he-http-response: result from http-client
   ::
   ++  he-http-response
@@ -1769,8 +1779,6 @@
   |=  [=wire =sign:agent:gall]
   ^-  (quip card:agent:gall _..on-init)
   ?>  ?=([@ @ @ *] wire)
-  ?:  =(%self i.t.t.wire)
-    `..on-init
   =/  =id  [(slav %p i.wire) i.t.wire]
   =/  =session  (~(got by hoc) id)
   =/  he-full  ~(. he hid id ~ session)
@@ -1780,6 +1788,7 @@
     ?+  i.t.t.wire  ~|([%dojo-bad-on-agent wire -.sign] !!)
       %poke  (he-unto:he-full t.wire sign)
       %wool  (he-wool:he-full t.wire sign)
+      %self  (he-self:he-full t.wire sign)
     ==
   [moves ..on-init]
 ::


### PR DESCRIPTION
This should probably be tested thoroughly.

`%dojo` now preserves input history after crashing.

This is an implementation of `~sarpen-laplux`'s idea of having `%dojo` poke itself to avoid crashing in `%drum`.

https://github.com/urbit/urbit/pull/6068#issuecomment-1317261818