### PR TITLE
add:by, upd:by

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1376,6 +1376,12 @@
   ~/  %by
   =|  a=(tree (pair))  ::  (map)
   |@
+  ++  add                                               ::  crash if key exists or add key-value pair
+    |*  [b=* c=*]
+    ^+  a
+    ?:  (has b)
+      !!
+    (put b c)
   ++  all                                               ::  logical AND
     ~/  %all
     |*  b=$-(* ?)
@@ -1645,6 +1651,12 @@
       $(l.b $(b l.b, r.a ~), a r.a)
     $(r.b $(b r.b, l.a ~), a l.a)
   ::
+  ++  upd                                               ::  update key-value pair, crash if key doesn't exist
+    |*  [b=* c=*]
+    ^+  a
+    ?.  (has b)
+      !!
+    (put b c)
   ++  urn                                               ::  apply gate to nodes
     ~/  %urn
     |*  b=$-([* *] *)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1376,11 +1376,10 @@
   ~/  %by
   =|  a=(tree (pair))  ::  (map)
   |@
-  ++  add                                               ::  crash if key exists or add key-value pair
+  ++  add                                               ::  assert new key, add key-value pair
     |*  [b=* c=*]
     ^+  a
-    ?:  (has b)
-      !!
+    ?<  (has b)
     (put b c)
   ++  all                                               ::  logical AND
     ~/  %all
@@ -1651,11 +1650,10 @@
       $(l.b $(b l.b, r.a ~), a r.a)
     $(r.b $(b r.b, l.a ~), a l.a)
   ::
-  ++  upd                                               ::  update key-value pair, crash if key doesn't exist
+  ++  upd                                               ::  update key-value pair
     |*  [b=* c=*]
     ^+  a
-    ?.  (has b)
-      !!
+    ?>  (has b)
     (put b c)
   ++  urn                                               ::  apply gate to nodes
     ~/  %urn


### PR DESCRIPTION
Addes arms to `by` core requested in #6668 

I wonder if jets are even needed since `has:by` and `put:by` are already jetted and the added arms just call those. But that would be a nice exercise for me to try anyway if no one else will do it.

_(Also, `has:by` calls jetted `get:by` and checks if the result is not null, yet `has` is still jetted. So I might be missing something.)_