### PR TITLE
dojo: don't +complete-gen-poke-to-app for dead dudes

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1470,17 +1470,16 @@
     ::
     ++  complete-gen-poke-to-app
       |=  [app=term gen=term]
-      =.  app
-        ?:(?=(%$ app) %hood app)
+      =?  app  =(%$ app)
+        %hood
       %+  complete
         ?:  =(%hood app)
           (cat 3 '|' gen)
         :((cury cat 3) ':' app '|' gen)
       =+  [our=(scot %p our.hid) now=(scot %da now.hid)]
-      =/  =desk
-        ?.  .^(? %gu /[our]/[app]/[now]/$)
-          q:he-beam
-        .^(desk %gd /[our]/[app]/[now]/$)
+      ?.  .^(? %gu /[our]/[app]/[now]/$)
+        ~
+      =+  .^(=desk %gd /[our]/[app]/[now]/$)
       =/  pfix=path  /[our]/[desk]/[now]/gen/[app]
       ::
       %^  tab-generators:auto  pfix  `app


### PR DESCRIPTION
To [avoid false positives](https://github.com/urbit/urbit/pull/6652#pullrequestreview-1473439945), `+complete-gen-poke-to-app` now works for live dudes only.
Also, switch `=.` to `=?` for clarity.