### PR TITLE
gall: fix typo in +ap-peek causing redundant mark conversion

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1274,7 +1274,7 @@
       ::
       ?.  ?&  ?=(%x care)
               ?=([~ ~ *] p.peek-result)
-              !=(mark p.u.u.p.peek-result)
+              !=(want p.u.u.p.peek-result)
           ==
         p.peek-result
       ::  for %x scries, attempt to convert to the requested mark if needed


### PR DESCRIPTION
this fixes a typo in +ap-peek causing %x scries to always run the mark conversion logic even if the mark you want is the same as what the endpoint produced