### PR TITLE
gall, eyre: more tube caching for eyre scries

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1262,10 +1262,14 @@
         ?.  ?=(%x care)  [%$ tyl]
         =.  tyl  (flop tyl)
         [(head tyl) (flop (tail tyl))]
+      ::  %r scries are %x without mark conversion
+      ::
+      =/  show-care
+        ?:  ?=(%r care)  %x  care
       ::  call the app's +on-peek, producing [~ ~] if it crashes
       ::
       =/  peek-result=(each (unit (unit cage)) tang)
-        (ap-mule-peek |.((on-peek:ap-agent-core [care tyl])))
+        (ap-mule-peek |.((on-peek:ap-agent-core [show-care tyl])))
       ?:  ?=(%| -.peek-result)
         ?.  veb  [~ ~]
         ((slog leaf+"peek bad result" p.peek-result) [~ ~])
@@ -1274,7 +1278,7 @@
       ::
       ?.  ?&  ?=(%x care)
               ?=([~ ~ *] p.peek-result)
-              !=(mark p.u.u.p.peek-result)
+              !=(want p.u.u.p.peek-result)
           ==
         p.peek-result
       ::  for %x scries, attempt to convert to the requested mark if needed


### PR DESCRIPTION
Eyre currently caches tubes for scries through its external scry interface. The problem is that two mark conversions are actually done:

(mark produced by agent) -> (mark specified by extension in URL path) -> %mime

Eyre can't cache the tube for the first conversion because it's done internally by gall. Gall can't cache it either because the request is coming through its +scry arm.

This PR does two things:

- adds %r care to gall that presents to the agent as %x but doesn't require the trailing mark and doesn't perform mark conversion

- changes eyre to use %r care for gall agent scries and perform the triple conversion of (endpoint mark -> requested mark -> mime) itself, so it can cache both tubes.

Open questions as to whether:

- it's appropriate to add an obscure care to Gall for this particular purpose. It might not have much utility outside of this
- it's ok to lie to the agent about an %r care being an %x care