### PR TITLE
clay: fix syntax error pointer

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -948,6 +948,7 @@
       %-  mean  %-  flop
       =/  lyn  p.hair
       =/  col  q.hair
+      %-  flop
       ^-  (list tank)
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
         ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -945,10 +945,9 @@
         %-  road  |.
         ((pile-rule pax) [1 1] tex)
       ?^  res  pile.u.res
-      %-  mean  %-  flop
+      %-  mean
       =/  lyn  p.hair
       =/  col  q.hair
-      %-  flop
       ^-  (list tank)
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
         ::


### PR DESCRIPTION
The syntax error pointer now points to the correct location.

before:
```
[%error-building /app/acme/hoon]
-------------^
    =/  (~foo)
syntax error at [349 14] in /app/acme/hoon
```

```
[%error-building /app/acme/hoon]
^
<<end of file>>
syntax error at [1.416 1] in /app/acme/hoon
```

after:
```
[%error-building /app/acme/hoon]
syntax error at [349 14] in /app/acme/hoon
    =/  (~foo)
-------------^
```

```
[%error-building /app/acme/hoon]
syntax error at [1.416 1] in /app/acme/hoon
<<end of file>>
^
```
