### PR TITLE
dojo: better generator errors

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -846,7 +846,6 @@
       ::  kev: key-value named arguments
       ::  kuv: default keyword arguments
       ::  sam: fully populated sample
-      ::  rog: default gat sample
       ::
       |.  ^-  vase
       =/  gat=vase  (slot 3 q.cay)
@@ -883,10 +882,12 @@
       ::
       =/  sam=vase  :(slop ven poz kev)
       ?.  (~(nest ut p.som) | p.sam)
+        =/  ned=vase  (slot 3 som)
+        =/  hav=vase  (slot 3 sam)
         ~>  %slog.1^leaf+"dojo: nest-need"
-        ~>  %slog.0^(skol p.som)
+        ~>  %slog.0^(skol p.ned)
         ~>  %slog.1^leaf+"dojo: nest-have"
-        ~>  %slog.0^(skol p.sam)
+        ~>  %slog.0^(skol p.hav)
         !!
       (slam gat sam)
     ::


### PR DESCRIPTION
`%say` and `%ask` generators now skip printing `[now eny beak]` in error messages, making them more legible.

For context see:
[Separate type-checks for head and tail of generator arguments](https://github.com/urbit/arvo/issues/65)
[Generator build failures](https://github.com/urbit/urbit/issues/6459)

`|new-desk` with no arguments is used as an example.

before:
```
>   dojo: nest-need
[ [ now=@da
    eny=@uvJ
      bek
    [ p=@p
      q=@tas
      r=?([%da p=@da] [%tas p=@tas] [%ud p=@ud] [%uv p=@uv])
    ]
  ]
  [desk=@tas %~]
  from=@tas
  hard=?(%.y %.n)
  gall=?(%.y %.n)
]
>   dojo: nest-have
[ [ now=@da
    eny=@uvJ
      bec
    [ p=@p
      q=@tas
      r=?([%da p=@da] [%tas p=@tas] [%ud p=@ud] [%uv p=@uv])
    ]
  ]
  %~
  from=@tas
  hard=?(%.y %.n)
  gall=?(%.y %.n)
]
> |new-desk
dojo: generator failure
```

after:
```
>   dojo: nest-need
[[desk=@tas %~] from=@tas hard=?(%.y %.n) gall=?(%.y %.n)]
>   dojo: nest-have
[%~ from=@tas hard=?(%.y %.n) gall=?(%.y %.n)]
> |new-desk
dojo: generator failure
```