### PR TITLE
ames: Don't check for lane staleness

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2758,10 +2758,6 @@
               ?:  for
                 event-core
               (try-next-sponsor sponsor.peer-state)
-            ::  if forwarding, route must not be stale
-            ::
-            ?:  &(for (lth last-contact.qos.peer-state (sub now ~h1)))
-              (try-next-sponsor sponsor.peer-state)
             ::
             ?~  route=route.peer-state
               %-  (ev-trace rot.veb final-ship |.("no route to:  {<ship>}"))
@@ -4977,8 +4973,6 @@
           ~
         [%& gal]~
       =;  zar=(trap (list lane))
-        ?:  (lth last-contact.qos.u.peer (sub now ~h1))
-          $:zar
         ?~  route.u.peer  $:zar
         =*  rot  u.route.u.peer
         ?:(direct.rot [lane.rot ~] [lane.rot $:zar])


### PR DESCRIPTION
When forwarding packets, we check that we've heard a message along that lane in the last hour, and if we haven't, then we don't use that lane.  This does not work if you enable `%no-nat`, because you'll only receive very occasional pings.  As a result, galaxies will stop forwarding for `%no-nat` ships after one hour.

Those checks were added because we knew that all our children would ping us every 25 seconds, so no messages for one hour was a sure-fire indicator that they weren't online.  This is no longer the case, and the short-circuit is only an optimization anyway.  This PR removes those checks.

If we wanted to re-enable this kind of behavior, we could add a once-a-day ping even when your lane hasn't changed in `%no-nat` mode, and then declare a lane stale if we haven't heard anything in two days.  However, I don't believe this behavior is important.

Tlon has deployed this fix to ~dem and ~fen, which are the two galaxies we host ships under.  Since likely all ships that have enabled `%no-nat` are under these two galaxies, I don't believe this is super urgent to be deployed more broadly -- although if ~zod in particular were affected, we could deploy it there as well.  We should, however, recommend that `%no-nat` not be used until it's deployed.

Re: testing, as mentioned, this is deployed to ~dem and ~fen already, and it resolved the connectivity issues we saw.  It also caused `.^(* %ax /=//=/peers/~ship-name/forward-lane)` to produce a lane instead of `0`, which is what the runtime needs to forward packets.