### PR TITLE
zuse: fix to-wain jet mismatch

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -3319,6 +3319,7 @@
     ~%  %leer  ..part  ~
     |=  txt=cord
     ^-  wain
+    ?~  txt  ~
     =/  len=@  (met 3 txt)
     =/  cut  =+(cut -(a 3, c 1, d txt))
     =/  sub  sub


### PR DESCRIPTION
As discovered by @joemfb https://github.com/urbit/vere/pull/480#issuecomment-1615162411

``` hoon
> `*`=+(to-wain:format .*(-(+6 '') -<))
[0 0]
> `*`(to-wain:format '')
0
```

Fixing the hoon instead of the jet unlike the vere PR above.