### PR TITLE
base: fix /ted/hi, /ted/code and /ted/read output formatting

### DIFF
--- a/pkg/arvo/ted/code.hoon
+++ b/pkg/arvo/ted/code.hoon
@@ -7,7 +7,4 @@
 ^-  form:m
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ;<  code=@p  bind:m  (scry:strandio @p /j/code/(scot %p our.bowl))
-%-  pure:m
-!>  ^-  tape
-%+  slag  1
-(scow %p code)
+(pure:m !>(code))

--- a/pkg/arvo/ted/hi.hoon
+++ b/pkg/arvo/ted/hi.hoon
@@ -9,4 +9,4 @@
 =/  [who=ship message=@t]
   ?@(arg [who.arg ''] [who.arg (crip mez.arg)])
 ;<  ~  bind:m  (poke:strandio [who %hood] %helm-hi !>(message))
-(pure:m !>("hi {<who>} successful"))
+(pure:m !>((crip "hi {<who>} successful")))

--- a/pkg/arvo/ted/read.hoon
+++ b/pkg/arvo/ted/read.hoon
@@ -14,5 +14,5 @@
 ;<  =riot:clay  bind:m
   (warp:strandio ship desk ~ %sing care case target-path)
 ?~  riot
-  (pure:m !>("nothing"))
+  (pure:m !>('nothing'))
 (pure:m q.r.u.riot)


### PR DESCRIPTION
Before:
```
> -hi ~zod
l
u
f
s
s
e
c
c
u
s
 
d
o
z
~
 
i
h
```

After:
```
> -hi ~zod
'hi ~zod successful'
```

Same problem for `-code` and `-read`.