### PR TITLE
lull: add %'PATCH' to $method:http

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -585,6 +585,7 @@
         %'GET'
         %'HEAD'
         %'OPTIONS'
+        %'PATCH'
         %'POST'
         %'PUT'
         %'TRACE'


### PR DESCRIPTION
As of [RFC 5789](https://www.rfc-editor.org/rfc/rfc5789), PATCH is a valid HTTP request method. The `$method:http` type, however, did not include it, preventing us from making requests with this method.

Here, we add it to the `$method:http` type, so that it now includes all nine standard HTTP methods.

It doesn't look like we `?-` over the request method anywhere in base, and vere simply treats the method as a cord. Still, since user code could be `?-`ing on this (or similar), this is a breaking change. Targeting the 412 branch as such.