### PR TITLE
kiln: have +poke-uninstall unsync desks with %dead zest 

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -795,7 +795,7 @@
   %+  turn
     %+  skim  desks
     |=  dek=desk
-    ?:  (~(has in .^((set desk) %cd /(scot %p our)/base/(scot %da now))) dek)
+    ?:  (~(has in .^((set desk) %cd /(scot %p our)//(scot %da now))) dek)
       &  
     ~>  %slog.(fmt "desk does not yet exist: {<dek>}")  |   
   |=(=desk [%pass /kiln/suspend %arvo %c %zest desk %dead])

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -821,10 +821,9 @@
   =+  .^(=rock:tire %cx /(scot %p our)//(scot %da now)/tire)
   ?~  got=(~(get by rock) loc)
     abet:(spam leaf+"desk does not exist: {<loc>}" ~)
-  ?:  =(+<:got %dead)
-    abet:(spam leaf+"desk not installed: {<loc>}" ~)
   ~>  %slog.(fmt "uninstalling {<loc>}")
-  =.  ..on-init  (emit %pass /kiln/uninstall %arvo %c %zest loc %dead)
+  =?  ..on-init  !=(+<:got %dead)  
+    (emit %pass /kiln/uninstall %arvo %c %zest loc %dead)
   ?~  sync=(~(get by sources) loc)
     abet
   (poke-unsync loc u.sync)


### PR DESCRIPTION
If `|uninstall` is run on a desk with a `zest` of `%dead` (e.g. a desk that has been `|suspend`ed), `+poke-uninstall` will no-op and fail to cancel the desk's syncs if it has any. This PR rewrites `+poke-uninstall` such that it will cancel a desk's syncs irrespective of its `zest`, which was the behavior of `|uninstall` prior to #6382 . I suspect that #6720 is related, but even if not I believe that this change reflects the desired behavior of `|uninstall`. Also fixes a deprecated `%cd` scry in `+poke-suspend`.