### PR TITLE
kiln: avoid downloading updates for uninstalled desks

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -1127,6 +1127,12 @@
     =/  m  (strand:rand ,vase)
     ;<  =riot:clay  bind:m  (warp:strandio her sud ~ %sing %w ud+let /)
     ?>  ?=(^ riot)
+    ::  The syncs may have changed, so get the latest
+    ::
+    ;<  zyx=(map kiln-sync sync-state)  bind:m
+      (scry:strandio (map kiln-sync sync-state) /gx/hood/kiln/syncs/noun)
+    ?.  (~(has by zyx) syd her sud)
+      (pure:m !>(%done))
     ~>  %slog.(fmt "downloading update for {here}")
     ;<  =riot:clay  bind:m  (warp:strandio her sud ~ %sing %v ud+let /)
     ?>  ?=(^ riot)


### PR DESCRIPTION
Resolves the `uninstall` case in #6720

Currently, if a foreign desk is uninstalled, the first update that the publisher commits will produce the following output in dojo (this happens because we asked the other ship to notify us when an update happens before uninstalling the desk, so the data will eventually come):
``` 
kiln: downloading update for %desk from ~publisher/%desk
 ```
However, the update eventually no-ops, and the desk remains unchanged.

This PR solves the problem by checking if the desk is still installed before downloading it.