### PR TITLE
ames: consolidate dead flows to a single behn timer

### DIFF
--- a/bin/solid.pill
+++ b/bin/solid.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fbab4ec845202c742a2ab029b485e0449febc96a4c8877ec88d10684aba09b0
-size 6709899
+oid sha256:feaae0eece54db3e92122263706c283674af581d14ffde8a29fb24e1873a35b1
+size 6453015

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2406,15 +2406,15 @@
             =.  dead.ames-state.cor  `[~[/ames] /dead-flow `@da`(add now ~m2)]
             (emit:cor duct %pass /dead-flow %b %wait `@da`(add now ~m2))
           %-  ~(rep by peers.ames-state)
-            |=  [[=ship =ship-state] core=_event-core]
-            ^+  event-core
-            =/  peer-state=(unit peer-state)  (get-peer-state:core ship)
-            ?~  peer-state  core
-            %-  ~(rep by snd.u.peer-state)
-            |=  [[=bone =message-pump-state] cor=_core]
-              ?.  =(~m2 rto.metrics.packet-pump-state.message-pump-state)
-                cor
-              abet:(on-wake:(abed-peer:pe:cor ship u.peer-state) bone error)
+          |=  [[=ship =ship-state] core=_event-core]
+          ^+  event-core
+          =/  peer-state=(unit peer-state)  (get-peer-state:core ship)
+          ?~  peer-state  core
+          %-  ~(rep by snd.u.peer-state)
+          |=  [[=bone =message-pump-state] cor=_core]
+          ?.  =(~m2 rto.metrics.packet-pump-state.message-pump-state)
+            cor
+          abet:(on-wake:(abed-peer:pe:cor ship u.peer-state) bone error)
         ::
         ?.  ?=([%recork ~] wire)
           =/  res=(unit ?([%fine her=ship =^wire] [%pump her=ship =bone]))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1756,7 +1756,10 @@
         14+(state-13-to-14:load:adult-core +.u.cached-state)
       =?  u.cached-state  ?=(%14 -.u.cached-state)
         15+(state-14-to-15:load:adult-core +.u.cached-state)
-      =?  u.cached-state  ?=(%15 -.u.cached-state)
+      =^  moz  u.cached-state
+        ?.  ?=(%15 -.u.cached-state)  [~ u.cached-state]
+        ~>  %slog.0^leaf/"ames: init dead flow consolidation timer"
+        :-  [[/ames]~ %pass /dead-flow %b %wait `@da`(add now ~m2)]~
         16+(state-15-to-16:load:adult-core +.u.cached-state)
       ?>  ?=(%16 -.u.cached-state)
       =.  ames-state.adult-gate  +.u.cached-state
@@ -2395,6 +2398,20 @@
           ?:  ?=([~ %known *] ship-state)
             event-core
           (request-attestation u.ship)
+        ::
+        ?:  ?=([%dead-flow ~] wire)
+          =;  cor=event-core
+            (emit:cor duct %pass /dead-flow %b %wait `@da`(add now ~m2))
+          %-  ~(rep by peers.ames-state)
+            |=  [[=ship =ship-state] core=_event-core]
+            ^+  event-core
+            =/  peer-state=(unit peer-state)  (get-peer-state:core ship)
+            ?~  peer-state  core
+            %-  ~(rep by snd.u.peer-state)
+            |=  [[=bone =message-pump-state] cor=_core]
+              ?.  =(~m2 rto.metrics.packet-pump-state.message-pump-state)
+                cor
+              abet:(on-wake:(abed-peer:pe:cor ship u.peer-state) bone error)
         ::
         ?.  ?=([%recork ~] wire)
           =/  res=(unit ?([%fine her=ship =^wire] [%pump her=ship =bone]))
@@ -3976,9 +3993,11 @@
               ::
               =?  peer-core  !=(~ next-wake.state)
                 (pu-emit %b %rest (need next-wake.state))
-              ::  set new timer if non-null
+              ::  set new timer if non-null and not at max-backoff
               ::
               =?  peer-core  ?=(^ new-wake)
+                ?:  =(~m2 rto.metrics.state)
+                  peer-core
                 (pu-emit %b %wait u.new-wake)
               ::
               =?  next-wake.state  !=(~ next-wake.state)   ~  ::  unset

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4006,7 +4006,11 @@
               ::
               =?  peer-core  !=(~ next-wake.state)
                 (pu-emit %b %rest (need next-wake.state))
-              ::  set new timer if non-null and not at max-backoff
+              ::  set new timer if non-null and not at at max-backoff
+              ::
+              ::  we are using the ~m2 literal instead of max-backoff:gauge
+              ::  because /app/ping has a special cased maximum backoff of ~s25
+              ::  and we don't want to consolidate that
               ::
               =?  peer-core  ?=(^ new-wake)
                 ?:  =(~m2 rto.metrics.state)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -556,6 +556,7 @@
 ::    bug:         debug printing configuration
 ::    snub:        blocklist for incoming packets
 ::    cong:        parameters for marking a flow as clogged
+::    dead:        dead flow consolidation timer, if set
 ::
 +$  ames-state
   $+  ames-state
@@ -567,6 +568,7 @@
       =bug
       snub=[form=?(%allow %deny) ships=(set ship)]
       cong=[msg=@ud mem=@ud]
+      dead=(unit [=duct =wire date=@da])
   ==
 ::
 +$  azimuth-state    [=symmetric-key =life =rift =public-key sponsor=ship]
@@ -2401,6 +2403,7 @@
         ::
         ?:  ?=([%dead-flow ~] wire)
           =;  cor=event-core
+            =.  dead.ames-state.cor  `[~[/ames] /dead-flow `@da`(add now ~m2)]
             (emit:cor duct %pass /dead-flow %b %wait `@da`(add now ~m2))
           %-  ~(rep by peers.ames-state)
             |=  [[=ship =ship-state] core=_event-core]
@@ -2777,7 +2780,17 @@
           (rof ~ /ames %j `beam`[[our %turf %da now] /])
         ::
         =*  duct  unix-duct.ames-state
+        ::
+        =/  dead-moves=(list move)
+          ?:  ?=(^ dead.ames-state)  ~
+          [~[/ames] %pass /dead-flow %b %wait `@da`(add now ~m2)]~
+        =?  dead.ames-state  ?=(~ dead.ames-state)
+          `[~[/ames] /dead-flow `@da`(add now ~m2)]
+        ::
         %-  emil
+        %+  weld
+          dead-moves
+        ^-  (list move)
         :~  [duct %give %turf turfs]
             [duct %pass /ping %g %deal [our our /ames] %ping %poke %noun !>(%kick)]
         ==
@@ -5093,6 +5106,8 @@
     |=  old=ames-state-15
     ^-  ^ames-state
     %=    old
+      cong  [cong.old `[~[/ames] /dead-flow `@da`(add now ~m2)]]
+      ::
         peers
       %-  ~(run by peers.old)
       |=  ship-state=ship-state-15

--- a/tests/sys/grq.hoon
+++ b/tests/sys/grq.hoon
@@ -306,7 +306,6 @@
               0xb.130c.ab37.ca24.49cd.aecb.23ba.70f1.6f1c.4d00.124e.c9a5.
               3413.3843.d81c.47c4.7040.6e62.3700.0200.0132.e1ab.9000
           ==
-          :-  ~[/ames]  [%pass /pump/~bud/0 %b %wait ~1111.1.5..00.02.00]
       ==
     ==
   ::  publisher ames hears %kick ack


### PR DESCRIPTION
As discussed with @yosoyubik and @joemfb out of band.

I tested this with 50 000 dead flows. Without consolidation these flows resulted in a constant 30 % cpu usage. Consolidating the timers led to a CPU usage of almost 0 with a 100 % spike for a few seconds every two minutes.

The retry interval is the normal ~m2, we can make it configurable later.