### PR TITLE
lull, ames: add %tame task to delete a route for a ship

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -767,6 +767,7 @@
   ::    %heed: track peer's responsiveness; gives %clog if slow
   ::    %jilt: stop tracking peer's responsiveness
   ::    %cork: request to delete message flow
+  ::    %tame: request to delete route for ship
   ::    %kroc: request to delete specific message flows, from their bones
   ::    %plea: request to send message
   ::    %deep: deferred calls to %ames, from itself
@@ -796,6 +797,7 @@
         [%heed =ship]
         [%jilt =ship]
         [%cork =ship]
+        [%tame =ship]
         [%kroc bones=(list [ship bone])]
         $>(%plea vane-task)
         [%deep =deep]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2303,6 +2303,21 @@
             =/  rcvr  [ship her-life.channel.peer-core]
             "plea {<sndr rcvr bone=bone vane.plea path.plea>}"
         abet:(on-memo:peer-core bone plea %plea)
+      ::  +on-tame: handle request to delete a route
+      ::
+      ++  on-tame
+        |=  =ship
+        ^+  event-core
+        ?:  =(%czar (clan:title ship))
+          %-  %+  slog
+            leaf+"ames: bad idea to %tame galaxy {(scow %p ship)}, ignoring"
+          ~
+          event-core
+        =/  peer-state=(unit peer-state)  (get-peer-state ship)
+        ?~  peer-state
+          %-  (slog leaf+"ames: no peer-state for {(scow %p ship)}, ignoring" ~)
+          event-core
+        abet:on-tame:(abed-peer:pe ship u.peer-state)
       ::  +on-cork: handle request to kill a flow
       ::
       ++  on-cork
@@ -3218,6 +3233,10 @@
             fi-abet:(fi-sub:(abed:fi path) duct)
           =.  keens  (~(put by keens) path *keen-state)
           fi-abet:(fi-start:(abed:fi path) duct)
+        ::
+        ++  on-tame
+          ^+  peer-core
+          peer-core(route.peer-state ~)
         ::  +on-cork-flow: mark .bone as closing
         ::
         ++  on-cork-flow
@@ -4889,6 +4908,7 @@
       %vega  on-vega:event-core
       %plea  (on-plea:event-core [ship plea]:task)
       %cork  (on-cork:event-core ship.task)
+      %tame  (on-tame:event-core ship.task)
       %kroc  (on-kroc:event-core bones.task)
       %deep  (on-deep:event-core deep.task)
     ::


### PR DESCRIPTION
I decided to make a new task instead of using `%stir` as suggested by @philipcmonk here: https://github.com/urbit/urbit/pull/6700#issuecomment-1648475369. We need to pass a ship argument (`%stir` takes just a `@tas`) and unbelievable nonsense can erupt in `+load` when you change a type of a task so I think this is better.