### PR TITLE
Add a list repeater gate.

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -679,6 +679,13 @@
   ?:  =(~ t.a)  ~
   [i.a $(a t.a)]
 ::
+++  snog                                                ::  glue together a copies of list
+    |*  [a=@ b=(list *)]
+    =/  c  *_b
+    |-  ^+  b
+    ?~  a  ~
+    (weld b $(a (dec a)))
+::
 ++  sort  !.                                            ::  quicksort
   ~/  %sort
   |*  [a=(list) b=$-([* *] ?)]


### PR DESCRIPTION
A version of `++reap` appropriate for lists that wish to remain flat lists (rather than a list of lists).