### PR TITLE
clay: propagate [~ ~] properly from read-x

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4475,7 +4475,7 @@
       ^-  [(unit (unit cage)) _..park]
       =/  q  (read-q tak pax)
       ?~  q    `..park
-      ?~  u.q  `..park
+      ?~  u.q  [[~ ~] ..park]
       ::  should convert any lobe to cage
       ::
       =^  =cage  ..park


### PR DESCRIPTION
Looks like the introduction of `+read-q` led to a bug where a `[~ ~]` from `+read-q` was not propagated correctly from `+read-x`, instead becoming `~`. This results in stuff like `-read %x our %base da+now /i-dont-exist/txt` blocking forever even though we know the file does not exist.