### PR TITLE
eyre: serve 503 if bound agent is not running

### DIFF
--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -375,6 +375,7 @@
   |=  [gang pov=path =view =beam]
   ^-  (unit (unit cage))
   ?:  =(%gd view)  ``noun+!>(%base)
+  ?:  =(%gu view)  ``noun+!>(=(%app1 q.beam))
   ?:  &(=(%ca view) =(/gen/handler/hoon s.beam))
     :+  ~  ~
     vase+!>(!>(|=(* |=(* [[%404 ~] ~]))))
@@ -553,6 +554,21 @@
     (take /watch-response/[eyre-id] ~[/http-blah] sign)
   =/  headers  ['content-type' 'text/html']~
   (expect-moves mos (ex-continue-response `[3 'ya!'] %.n) ~)
+::
+++  test-dead-app-request
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  ~  bind:m  perform-init-wo-timer
+  ;<  ~  bind:m  (wait ~d1)
+  ::  dead-app binds successfully
+  ::
+  ;<  ~  bind:m  (connect %dead-app /)
+  ;<  ~  bind:m  (wait ~d1)
+  ::  outside requests a path that dead-app has bound to
+  ::
+  ;<  mos=(list move)  bind:m  (get '/' ~)
+  =/  body  `(error-page:eyre-gate 503 %.n '/' "%dead-app not running")
+  (expect-moves mos (ex-response 503 ['content-type' 'text/html']~ body) ~)
 ::  tests an app redirecting to the login handler, which then receives a post
 ::  and redirects back to app
 ::


### PR DESCRIPTION
Was reminded of this by today's core architecture meeting. Figured this eyre-side fix was small enough to just implement on the spot.

Previously, for endpoints bound to agents, we would pass the request onto the agent even if the agents wasn't currently running.

Here, we make eyre check to see if the agent is actually running, before passing the request on. If the bound agent is not running, eyre serves a 503 synchronously instead.

This way, we avoid cluttering up the gall queue for the bound agent. It also improves the UX for this case, giving an immediate response instead of appearing to hang during page-load.

(Targeting the 412 branch to avoid conflicts with the significant eyre changes that live there.)