### PR TITLE
ames: fix bug in dead flow consolidation

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2427,7 +2427,9 @@
           ?~  peer-state  core
           %-  ~(rep by snd.u.peer-state)
           |=  [[=bone =message-pump-state] cor=_core]
-          ?.  =(~m2 rto.metrics.packet-pump-state.message-pump-state)
+          ?.  ?&  =(~m2 rto.metrics.packet-pump-state.message-pump-state)
+                  ?=(^ next-wake.packet-pump-state.message-pump-state)
+              ==
             cor
           abet:(on-wake:(abed-peer:pe:cor ship u.peer-state) bone error)
         ::


### PR DESCRIPTION
When implementing #6738 I assumed that all flows with an `rto` of `~m2` would be dead. My thinking was that any acked/nacked packets would reset the `rto` to a smaller value, but that is evidently not the case. There are flows with no unsent fragments in in the `packet-queue` but with an rto stuck at `~m2`:

<img width="1225" alt="image" src="https://github.com/urbit/urbit/assets/14286382/c5b60a88-2368-4b0d-b453-48c6ad6da589">

I am unsure whether this indicates a deeper bug with the way `rto` is adjusted in %ames but fixing dead flow consolidation to account for this is very simple: just check if `rto` is `~m2` and that `next-wake` is not null.

@arthyn ran into this issue when migrating Tlons stuff to 412k-rc0. 