### PR TITLE
eyre: handle old wires correctly in +on-gall-response

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2518,13 +2518,18 @@
       :_  state
       :_  ~
       ^-  move
-      =/  as=^ship
+      =/  [as=@p old=?]
         ?+  t.t.extra  ~|([%strange-wire extra] !!)
-          ~      our  ::  old-style wire
-          [@ ~]  (slav %p i.t.t.extra)
+          ~      [our &]
+          [@ ~]  [(slav %p i.t.t.extra) |]
         ==
+      =/  =wire  (subscription-wire channel-id request-id as ship app)
       %+  deal-as
-        (subscription-wire channel-id request-id as ship app)
+        ::NOTE  we previously used a wire format that had the local identity
+        ::      implicit, instead of explicit at the end of the wire. if we
+        ::      detect we used the old wire here, we must re-use that format
+        ::      (without id in the wire) for sending the %leave.
+        ?:(old (snip wire) wire)
       [as ship app %leave ~]
     ::  +emit-event: records an event occurred, possibly sending to client
     ::


### PR DESCRIPTION
I decided to run the upcoming 412k release on `~dinleb-rambep`. Something that immediately started occurring on every page refresh was seeing stuff like this in the dojo:
```
eyre: removing watch for non-existent channel 1692289927-d5b4c7 chat
```

It turns out the issue was that the wires being sent to Gall are formatted slightly differently after the 412k eyre changes.
```
:: old format
/channel/subscription/1692289927-d5b4c7/52/~dinleb-rambep/chat
:: new format 
/channel/subscription/1692289927-d5b4c7/52/~dinleb-rambep/chat/~dinleb-rambep
```
This resulted in old subscriptions never being cleaned up and getting some annoying eyre messages on every page refresh. This PR fixes the issue.