### PR TITLE
arvo: persistently cache scry type checks

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -352,7 +352,9 @@
   ?~  dat=(rof lyc pov u.mon)  ~
   ?~  u.dat  [~ ~]
   =*  vax  q.u.u.dat
-  ?.  ?&  ?=(^ ref)
+  ?.  =>  [ref=ref vax=p=p.vax hoon-version=hoon-version wa=wa worm=worm]
+      ~>  %memo./arvo/look                  ::  with memoization
+      ?&  ?=(^ ref)
           =(hoon-version -.ref)
           -:(~(nets wa *worm) +.ref p.vax)
       ==


### PR DESCRIPTION
Depends on urbit/vere#496.