### PR TITLE
arvo: add provenance when casting forward move

### DIFF
--- a/pkg/arvo/sys/arvo.hoon
+++ b/pkg/arvo/sys/arvo.hoon
@@ -1294,7 +1294,7 @@
           :^  %pass  [vane.gem vane]
             ?:  ?=(?(%deal %deal-gall) +>-.task)
               :-  :-  +>-.task
-                  ;;([[ship ship] term term] [+>+< +>+>- +>+>+<]:task)
+                  ;;([[ship ship path] term term] [+>+< +>+>- +>+>+<]:task)
               wire
             [(symp +>-.task) wire]
           duct


### PR DESCRIPTION
`|verb` is broken on 412k prerelease because we were casting to old-style `[ship ship]` here instead of the correct `[ship ship path]` with provenance included.

Thanks goes to @midden-fabler for the bug report and @joemfb for the fix.