### PR TITLE
x/jub: add jub:by

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1564,6 +1564,29 @@
     ::
     a(r $(a r.a))
   ::
+  ++  jub
+    ~/  %jub
+    |*  [b=* fun=$-((unit _?>(?=(^ a) q.n.a)) (unit _?>(?=(^ a) q.n.a)))]
+    =>  .(b ^+(?>(?=(^ a) p.n.a) b))
+    |-  ^-  (tree _?>(?=(^ a) n.a))
+    ?~  a
+      ?~(c=(fun ~) ~ [[b u.c] ~ ~])
+    ?:  =(b p.n.a)
+      ?~  c=(fun `q.n.a)  (del(a ^+($ a)) b)
+      ?:  =(q.n.a u.c)  a
+      a(n [b u.c])
+    ?:  (gor b p.n.a)
+      =+  d=$(a l.a)
+      ?~  d  (put(a r.a) n.a)
+      ?:  (mor p.n.a p.n.d)
+        a(l d)
+      d(r a(l r.d))
+    =+  d=$(a r.a)
+    ?~  d  (put(a l.a) n.a)
+    ?:  (mor p.n.a p.n.d)
+      a(r d)
+    d(l a(r l.d))
+  ::
   ++  mar                                               ::  add with validation
     |*  [b=* c=(unit *)]
     ?~  c


### PR DESCRIPTION
jub:by is a variant of jab:by, which applies a gate to a value at a certain key. It crashes if it's not there, and also does not allow it to be deleted. This variant allows a create, update, or delete operation with one gate call and one tree traversal. The gate passed to jub takes a unit and returns a unit. The unit it is passed is ~ if the kv pair does not exist, and `val if it does. The unit returned causes a deletion if it is ~, and inserts otherwise.

Would replace https://github.com/urbit/urbit/pull/6621.

Do we want to add the jib mentioned there? See my last comment if so if we want to also add the same deletion semantics.

https://github.com/urbit/vere/pull/510 is the corresponding vere PR.