### PR TITLE
lick: initialize unix-duct before %born

### DIFF
--- a/pkg/arvo/sys/vane/lick.hoon
+++ b/pkg/arvo/sys/vane/lick.hoon
@@ -11,7 +11,7 @@
     ::
     +$  lick-state
       $:  %0
-          unix-duct=duct
+          unix-duct=_`duct`[//lick ~]
           owners=(map name duct)
       ==
     ::


### PR DESCRIPTION
Without this people have to restart vere after upgrading to 412 to enable lick.