### PR TITLE
roller-rpc: do not assert team:title for http-requests

### DIFF
--- a/pkg/arvo/app/roller-rpc.hoon
+++ b/pkg/arvo/app/roller-rpc.hoon
@@ -45,7 +45,6 @@
     |=  [=mark =vase]
     ^-  (quip card _this)
     |^
-    ?>  (team:title our.bowl src.bowl)
     ?+  mark  (on-poke:def mark vase)
         %handle-http-request
       =+  !<([id=@ta req=inbound-request:eyre] vase)
@@ -53,6 +52,7 @@
       (handle-http-request id req)
     ::
         %azimuth-action
+      ?>  (team:title our.bowl src.bowl)
       =+  !<([%disconnect bind=binding:eyre] vase)
       ~&  >>>  "disconnecting at {<bind>}"
       :_  this


### PR DESCRIPTION
One of these was still left in %base, can't do this anymore because of comet identities.