### PR TITLE
eyre: more permissive channel creation

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2372,11 +2372,6 @@
       ?:  ?=(%| -.maybe-requests)
         %^  return-static-data-on-duct  400  'text/html'
         (error-page 400 & url.request (trip p.maybe-requests))
-      ::  while weird, the request list could be empty
-      ::
-      ?:  =(~ p.maybe-requests)
-        %^  return-static-data-on-duct  400  'text/html'
-        (error-page 400 %.y url.request "empty list of actions")
       ::  check for the existence of the channel-id
       ::
       ::    if we have no session, create a new one set to expire in

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -757,6 +757,18 @@
   =/  mov-2  (ex-channel-response ~)
   (expect-moves mos mov-1 mov-2 ~)
 ::
+++  test-channel-put-zero-requests
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  ~  bind:m  perform-init-start-channel-2
+  ;<  ~  bind:m  (wait ~m1)
+  ;<  mos=(list move)  bind:m
+    (put '/~/channel/0123456789abcdef' cookie '[]')
+  =/  mov-1  ex-204
+  =/  mov-2  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
+  =/  mov-3  (ex-wait /channel/timeout/'0123456789abcdef' ~1111.1.2..12.01.00)
+  (expect-moves mos mov-1 mov-2 mov-3 ~)
+::
 ++  test-channel-results-before-open
   %-  eval-mare
   =/  m  (mare ,~)

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -262,7 +262,7 @@
   ==
 ::
 ++  ex-channel-response
-  |=  body=@t
+  |=  body=(unit @t)
   |=  mov=move
   ^-  tang
   ?.  ?=([[[%http-blah ~] ~] %give %response %start * * %.n] mov)
@@ -273,7 +273,7 @@
         ['connection' 'keep-alive']
         ['set-cookie' cookie-string]
     ==
-  =/  body  `(as-octs:mimes:html body)
+  =/  body  (bind body as-octs:mimes:html)
   ;:  weld
     (expect-eq !>(200) !>(status-code.response-header.http-event.p.card.mov))
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
@@ -743,6 +743,20 @@
   =/  wire  /channel/subscription/'0123456789abcdef'/1/~nul/two/~nul
   (expect-moves mos (ex-gall-deal wire ~nul %two %leave ~) ~)
 ::
+++  test-channel-open-with-get
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  ~  bind:m  perform-init-wo-timer
+  ;<  ~  bind:m  perform-born
+  ;<  ~  bind:m  (wait ~d1)
+  ;<  ~  bind:m  perform-authentication-2
+  ;<  mos=(list move)  bind:m
+    (get '/~/channel/0123456789abcdef' cookie)
+  ;<  now=@da  bind:m  get-now
+  =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' (add now ~s20))
+  =/  mov-2  (ex-channel-response ~)
+  (expect-moves mos mov-1 mov-2 ~)
+::
 ++  test-channel-results-before-open
   %-  eval-mare
   =/  m  (mare ,~)
@@ -776,7 +790,7 @@
   ;<  now=@da  bind:m  get-now
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' (add now ~s20))
   =/  mov-2
-    %-  ex-channel-response
+    %+  ex-channel-response  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -920,7 +934,7 @@
   ;<  now=@da  bind:m  get-now
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' (add now ~s20))
   =/  mov-2
-    %-  ex-channel-response
+    %+  ex-channel-response  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -1022,7 +1036,7 @@
   =/  heartbeat  (add now ~s20)
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' heartbeat)
   =/  mov-2
-    %-  ex-channel-response
+    %+  ex-channel-response  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -1092,7 +1106,7 @@
   =/  heartbeat  (add now ~s20)
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' heartbeat)
   =/  mov-2
-    %-  ex-channel-response
+    %+  ex-channel-response  ~
     '''
     id: 2
     data: {"json":[1],"id":1,"response":"diff"}


### PR DESCRIPTION
Been doing light work on [urbit/js-http-api](https://github.com/urbit/js-http-api/) as of late, and Eyre's behavior forces it to do some sub-optimal things during initial setup. Here, we update Eyre to have a slightly simpler channel creation API.

Previously, a channel could only be created by sending a PUT request,
and a GET request to receive the channel's stream would only succeed
after channel creation had happened that way. This forces client
libraries, that generally have an explicit "set up" step before allowing
normal operation, to do strange things, [like sending faux pokes
(commonly hi-ing oneself)](https://github.com/urbit/js-http-api/blob/3e17850bbed0f9a4718a5058d911acbb892da489/src/Urbit.ts#L281-L287) before connecting to the channel's stream as
normal. This was especially egregious considering that PUT requests containing the empty list of channel-requests would get rejected, making it impossible to do channel creation "silently".

Here, we update the GET request handling for channels to allow requests
for non-existent channels. When this happens, the channel will be
created, and eyre tracks the request as normal. We also update PUT request handling to accept the empty list of channel-requests as valid.

We do some... gentle restructuring... of +on-get-request:by-channel to
let the new creation case share code with the "already exists" codepath.
In the process, we find that duct-to-key was never getting updated in
the case where we replace the original channel request/connection with
the new incoming one. We fix this, it's trivial. We also identify two
other areas with vaguely-incorrect behavior, but consider them less
important and out of scope.

Lastly, we add tests for both changes.

Client libraries written prior to this change remain compatible and need not change their behavior. However, once this is live, it would be good for them to stop doing poke/PUT-powered channel creation, and simply GET without preparation instead.