### PR TITLE
dojo: reject pasted bad code

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1134,8 +1134,14 @@
   ++  he-errd                                           ::  reject update
     |=  [rev=(unit sole-edit) err=@u]  ^+  +>
     =+  red=(fall rev [%nop ~])       ::  required for error location sync
+    =?  red  =(%mor -:red)
+      =/  rel  ;;((list sole-edit) +:red)
+      =/  idx  (find `(list sole-edit)`[%del `@ud`err]~ rel)
+      ?.  ?=(^ idx)
+        red
+      [%mor (oust [+:idx (lent rel)] rel)]
     =^  lic  say  (~(transmit sole say) red)
-    (he-diff %mor [%det lic] [%err err] ~)
+    (he-diff %mor [%det lic] [%err (lent buf.say)] ~)
   ::
   ++  he-pone                                           ::  clear prompt
     ^+  .
@@ -1348,8 +1354,14 @@
     ::  ~&  [%his-clock ler.cal]
     ::  ~&  [%our-clock ven.say]
     =^  dat  say  (~(transceive sole say) cal)
-    ?.  ?&  ?=(%del -.dat)
-            =(+(p.dat) (lent buf.say))
+    =/  len  (lent buf.say)
+    ?.  ?|  ?&  ?=(%del -.dat)
+                =(+(p.dat) len)
+            ==
+            ?&  ?=([%mor ^] dat)
+                =(%del +<-:dat)
+                =(+(;;(@ud +<+:dat)) len)
+            ==
         ==
       +>.$
     =+  foy=(he-dope (tufa buf.say))


### PR DESCRIPTION
pasting `(add  2 2)`  (double whitespace after 'add')

before:
```
~sampel-palnet:dojo> (add  2 2)
```
now:
```
~sampel-palnet:dojo> (add  
```
%dojo will reject the code from the errored character onwards, and the errored character will be displayed. This is different from the behavior when typing single characters one at a time (the errored character doesn't go through), but I don't see a better solution.