### PR TITLE
clay: iterate over all aeons in +read-at-tako

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4533,7 +4533,12 @@
       ?.  ?|  =(0v0 tak)
           ?&  (~(has by hut.ran) tak)
               ?|  (~(any by hit.dom) |=(=tako =(tak tako)))  ::  fast-path
-                  (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
+                  |-  ^-  ?
+                  ?:  (lte let.dom 1)
+                    %.n
+                  ?|  (~(has in (reachable-takos (aeon-to-tako:ze let.dom))) tak)
+                      $(let.dom (dec let.dom))
+                  ==
               ==
               |(?=(~ for) (may-read u.for care.mun tak path.mun))
           ==  ==


### PR DESCRIPTION
Many users have reported issues installing new desks, sometimes having them take hours. Today me and a crew consisting of @yosoyubik @joemfb @Fang- and especially @philipcmonk figured out the reason why.

When a ship does `|install` to install a new desk it fetches not only the latest version but the entire history of the desk. Many histories contain commits that do not have a direct parent. This situation messes up our conditional in `+read-at-tako` since we only analyse the reachable commits (takos) from the latest commit. The fix is to iterate over all aeons to determine whether a tako is reachable.

It is unclear why these commits are so prevalent, but older desks in the wild seem to all have them. My guess is that all desks that have been created with `|merge` from `%base` as opposed to `|new-desk` suffer from this problem. 
