### PR TITLE
clay: return all takos in /cs/bloc scry

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4315,8 +4315,12 @@
         :-  -:!>(*(map lobe page))
         ^-  (map lobe page)
         %-  %~  rep  in
-            %-  reachable-takos
-            (~(got by hit.dom) let.dom)
+            |-  ^-  (set tako)
+            =/  ts=(set tako)
+              %-  reachable-takos
+              (~(got by hit.dom) let.dom)
+            ?:  (lte let.dom 1)  ts
+            (~(uni in ts) $(let.dom (dec let.dom)))
         |=  [t=tako o=(map lobe page)]
         %-  ~(gas by o)
         %+  turn


### PR DESCRIPTION
This has the exact same problem as #6807, where the result of the `%bloc` scry excludes takos that are not reachable from the latest aeon.

The `%bloc` scry is only used by `/lib/pill` to pre-populate the clay blob store. The current urbit-v2.12 bootstrap pill is already built with this fix.