### PR TITLE
runtime-version: parse current version properly

### DIFF
--- a/pkg/arvo/ted/runtime-version.hoon
+++ b/pkg/arvo/ted/runtime-version.hoon
@@ -12,7 +12,7 @@
 ++  parse-current-version
   |=  current=vere
   ^-  @t
-  (rear rev.current)
+  (slav %ta (rear rev.current))
 ::
 ++  is-equal-version
   |=  [latest=@t current=vere]


### PR DESCRIPTION
Looks like I missed that the `slav %ta` was dropped in #6729. The `-runtime-version` thread will always indicate that the runtime is out of date until this fix is applied.