### PR TITLE
hoon: fix +crip to properly convert tapes containing \00 bytes

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4179,7 +4179,7 @@
   ^-  tape
   (turn vib |=(a=@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32))))
 ::
-++  crip  |=(a=tape `@t`(rap 3 a))                      ::  tape to cord
+++  crip  |=(a=tape `@t`(rep 3 a))                      ::  tape to cord
 ::
 ++  mesc                                                ::  ctrl code escape
   |=  vib=tape


### PR DESCRIPTION
The issue is described here: https://github.com/urbit/urbit/issues/6817. This PR is a straightforward 
solution to allow `+crip` to correctly handle (non-trailing) `\00` bytes in tapes. 