### PR TITLE
Revert "hoon: add pin and awl arms to test and trim subaxes"

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -226,34 +226,6 @@
     *   (add (mod b 2) (mul $(b (div b 2)) 2))
   ==
 ::
-++  pin
-  ~/  %pin
-  ::    sub axis test
-  ::
-  ::  checks whether {b} addresses a subtree of the tree addressed by {a}.
-  |=  [a=@ b=@]
-  ?<  =(0 a)
-  ?<  =(0 b)
-  |-  ^-  ?
-  ?:  =(a 1)  &
-  ?:  =(b 1)  |
-  ?.  =((cap a) (cap b))  |
-  $(a (mas a), b (mas b))
-::
-++  hub
-  ~/  %hub
-  ::    axis after axis
-  ::
-  ::  computes the remainder of axis {b} when navigating to {a}.
-  ::  (crashes if not `(pin a b)`)
-  |=  [a=@ b=@]
-  ?<  =(0 a)
-  ?<  =(0 b)
-  |-  ^-  @
-  ?:  =(a 1)  b
-  ?>  =((cap a) (cap b))
-  $(a (mas a), b (mas b))
-::
 ::  #  %containers
 ::
 ::    the most basic of data types


### PR DESCRIPTION
These new APIs are unused, and I believe there are no plans to use them. They can always be added back if we need them.