### PR TITLE
fix: change `en-json` to `en:json` and `as-octt` to `as-octs`

### DIFF
--- a/pkg/yard/lib/etch.hoon
+++ b/pkg/yard/lib/etch.hoon
@@ -7,7 +7,7 @@
 ::
 ++  show-json
   |=  =vase
-  (en-json:html (en-vase vase))
+  (en:json:html (en-vase vase))
 ::
 ++  en-vase
   |=  [typ=type arg=*]

--- a/pkg/yard/lib/rudder.hoon
+++ b/pkg/yard/lib/rudder.hoon
@@ -272,7 +272,7 @@
   (fall (rush url ;~(plug apat:de-purl:html yque:de-purl:html)) [[~ ~] ~])
 ::
 ++  press  ::  manx to octs
-  (cork en-xml:html as-octt:mimes:html)
+  (cork en-xml:html as-octs:mimes:html)
 ::
 ++  spout  ::  build full response cards
   |=  [eyre-id=@ta simple-payload:http]

--- a/pkg/yard/lib/schooner.hoon
+++ b/pkg/yard/lib/schooner.hoon
@@ -73,27 +73,27 @@
   ?-  -.resource
     ::
       %application-javascript
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'application/javascript']~)
     ::
       %application-json
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'application/json']~)
     ::
       %application-pdf
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'application/pdf']~)
     ::
       %application-rtf
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'application/rtf']~)
     ::
       %application-xml
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'application/xml']~)
     ::
@@ -196,15 +196,15 @@
     :-  :-  http-status
         %+  weld  headers
         ['content-type'^'application/json']~
-    `(as-octt:mimes:html (en-json:html j.resource))
+    `(as-octs:mimes:html (en-json:html j.resource))
     ::
       %manx
     :-  :-  http-status
       (weld headers ['content-type'^'text/html']~)
-    `(as-octt:mimes:html (en-xml:html m.resource))
+    `(as-octs:mimes:html (en-xml:html m.resource))
     ::
       %plain
-    :_  `(as-octt:mimes:html p.resource)
+    :_  `(as-octs:mimes:html p.resource)
     :-  http-status
     (weld headers ['content-type'^'text/plain']~)
     ::
@@ -288,7 +288,7 @@
   %+  give-simple-payload:app:server
     eyre-id
   ^-  simple-payload:http
-  :_  `(as-octt:mimes:html p.resource)
+  :_  `(as-octs:mimes:html p.resource)
   :-  http-status
   =/  a  (trip -.resource)
   =/  b  (find "-" a)
@@ -302,7 +302,7 @@
   (weld headers ['content-type'^'text/html']~)
   :-  ~
   =+  (title-content code)
-  %-  as-octt:mimes:html
+  %-  as-octs:mimes:html
     %-  en-xml:html
   ;html
     ;head

--- a/pkg/yard/lib/schooner.hoon
+++ b/pkg/yard/lib/schooner.hoon
@@ -196,7 +196,7 @@
     :-  :-  http-status
         %+  weld  headers
         ['content-type'^'application/json']~
-    `(as-octs:mimes:html (en-json:html j.resource))
+    `(as-octs:mimes:html (en:json:html j.resource))
     ::
       %manx
     :-  :-  http-status


### PR DESCRIPTION
### Description

Update occurrences of `en-json` (deprecated) to `en:json` and `as-octt` to `as-octs` in developer desk `yard`.