### PR TITLE
vats: handle insane desk names

### DIFF
--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -51,10 +51,11 @@
   =/  deks
     ?~  desks
       %+  sort
-        (sort ~(tap in -.prep) |=([[a=@ *] b=@ *] !(aor a b)))
+        (sort ~(tap by -.prep) |=([[a=@ *] b=@ *] !(aor a b)))
       |=([[a=@ *] [b=@ *]] ?|(=(a %kids) =(b %base)))
-    %+  skip  ~(tap in -.prep)
+    %+  skip  ~(tap by -.prep)
     |=([syd=@tas *] =(~ (find ~[syd] desks)))
+  =.  deks  (skim deks |=([=desk *] ((sane %tas) desk)))
   ?:  =(filt %blocking)
     =/  base-wic
       %+  sort  ~(tap by wic:(~(got by -.prep) %base))
@@ -118,6 +119,8 @@
   ^-  tank
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
+  ?.  ((sane %tas) syd)
+    leaf+"insane desk: {<syd>}"
   =+  .^(=cass %cw /[ego]/[syd]/[wen])
   ?:  =(ud.cass 0)
     leaf+"desk does not yet exist: {<syd>}"


### PR DESCRIPTION
less-than-ideal fix for #6768 

This makes +vats check desk sanity before trying to scry that desk

Somebody has presumably made an error in their app where they pass Clay a task with the ship name in the desk field. Clay doesn't sanity-check desks in all its tasks eg `%zest` which can result in an insane desk nominally existing in Clay's state. The problem afaics is that arvo's ++de-beam implicitly sanity-checks desks with `(slaw %tas` which means scries fail for insane desks.

Presumably Clay should be updated to sanity-check desks for all tasks but idk how you fix the existing insane entries. Either you need to update clay to expunge insane desks or ++de-beam should stop sanity-checking the desk maybe

Thoughts on proper solution @philipcmonk ?