### PR TITLE
zuse: fix +de:base64:mimes:html

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4298,8 +4298,11 @@
             ~&(%base-64-padding-err-two ~)
           =/  len  (sub (mul 3 (div (add lat dif) 4)) dif)
           :+  ~  len
-          %+  swp  3
-          (rep [0 6] (flop (weld dat (reap dif 0))))
+          =/  res  (rsh [1 dif] (rep [0 6] (flop dat)))
+          =/  amt  (met 3 res)
+          ::  left shift trailing zeroes in after byte swap
+          =/  trl  ?:  (lth len amt)  0  (sub len amt)
+          (lsh [3 trl] (swp 3 res))
         --
       --
     ::


### PR DESCRIPTION
`+de:base64:mimes:html` is misbehaving in two scenarios.

1. We do a byte swap on the result at the end of decoding. This means that any leading zeroes that should become trailing zeroes get dropped. An example input for this problem is `(de:base64:mimes:html 'AAD+wg==')`.
2. We pad zeroes at the end for every `=` padding character. This is incorrect behavior, we should instead drop two bits from the end for every padding character. An example input for this problem is `(de:base64:mimes:html '/si=')`.

This PR fixes these issues. Thanks to `~litlep-nibbyt` for discovering the problem and helping with the solution.