### PR TITLE
lull, ames: do not store jammed messages in unsent-messages

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -774,6 +774,7 @@
         ::
           :-  'unsent-messages'  ::  as byte sizes
           (set-array unsent-messages (cork (cury met 3) numb))
+          (set-array unsent-messages (cork jam (cork (cury met 3) numb)))
         ::
           'unsent-fragments'^(numb (lent unsent-fragments))  ::  as lent
         ::

--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -773,7 +773,6 @@
           'next'^(numb next)
         ::
           :-  'unsent-messages'  ::  as byte sizes
-          (set-array unsent-messages (cork (cury met 3) numb))
           (set-array unsent-messages (cork jam (cork (cury met 3) numb)))
         ::
           'unsent-fragments'^(numb (lent unsent-fragments))  ::  as lent

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -904,6 +904,12 @@
   ::    payload: semantic message contents
   ::
   +$  plea  [vane=@tas =path payload=*]
+  ::
+  +$  message
+    $%  [%plea plea]
+        [%boon payload=*]
+        [%naxplanation =message-num =error]
+    ==
   ::  $spar:  pair of $ship and $path
   ::
   ::    Instead of fully qualifying a scry path, ames infers rift and
@@ -913,7 +919,7 @@
   ::  $deep: deferred %ames call, from self, to keep +abet cores pure
   ::
   +$  deep
-    $%  [%nack =ship =nack=bone =message-blob]
+    $%  [%nack =ship =nack=bone =message]
         [%sink =ship =target=bone naxplanation=[=message-num =error]]
         [%drop =ship =nack=bone =message-num]
         [%cork =ship =bone]
@@ -1157,7 +1163,7 @@
     $+  message-pump-state
     $:  current=_`message-num`1
         next=_`message-num`1
-        unsent-messages=(qeu message-blob)
+        unsent-messages=(qeu message)
         unsent-fragments=(list static-fragment)
         queued-message-acks=(map message-num ack)
         =packet-pump-state

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2471,7 +2471,7 @@
           %-  %^  ev-trace  odd.veb  her
               |.("parsing old wire: {(spud wire)}")
           peer-core
-        abet:(on-memo:peer-core bone [%boon payload] %boon)
+        abet:(on-memo:peer-core bone [%boon payload])
       ::  +on-plea: handle request to send message
       ::
       ++  on-plea
@@ -2493,7 +2493,7 @@
             =/  sndr  [our our-life.channel.peer-core]
             =/  rcvr  [ship her-life.channel.peer-core]
             "plea {<sndr rcvr bone=bone vane.plea path.plea>}"
-        abet:(on-memo:peer-core bone [%plea plea] %plea)
+        abet:(on-memo:peer-core bone [%plea plea])
       ::  +on-tame: handle request to delete a route
       ::
       ++  on-tame
@@ -2536,7 +2536,7 @@
             =/  sndr  [our our-life.channel.peer-core]
             =/  rcvr  [ship her-life.channel.peer-core]
             "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
-        abet:(on-memo:(on-cork-flow:peer-core bone) bone [%plea plea] %plea)
+        abet:(on-memo:(on-cork-flow:peer-core bone) bone [%plea plea])
       ::  +on-kroc: cork all stale flows from failed subscriptions
       ::
       ++  on-kroc
@@ -3341,10 +3341,10 @@
         ::  +on-memo: handle request to send message
         ::
         ++  on-memo
-          |=  [=bone payload=* valence=?(%plea %boon)]
+          |=  [=bone =message]
           ^+  peer-core
           ?:  ?&  (~(has in closing.peer-state) bone)
-                  !=(payload [%$ /flow %cork ~])
+                  !=(message [%plea %$ /flow %cork ~])
               ==
             ~>  %slog.0^leaf/"ames: ignoring message on closing bone {<bone>}"
             peer-core
@@ -3352,10 +3352,9 @@
             ~>  %slog.0^leaf/"ames: ignoring message on corked bone {<bone>}"
             peer-core
           ::
-          =/  =message   ;;(message payload)
           =.  peer-core  abet:(call:(abed:mu bone) %memo message)
           ::
-          ?:  ?&  =(%boon valence)
+          ?:  ?&  ?=(%boon -.message)
                   (gte now (add ~s30 last-contact.qos.peer-state))
               ==
             check-clog
@@ -3576,7 +3575,7 @@
           ~>  %slog.0^leaf/"ames: recork {<her i.boz>}"
           =/  =plea     [%$ /flow [%cork ~]]
           =/  =message  [%plea plea]
-          (on-memo i.boz message %plea)
+          (on-memo i.boz message)
         ::  +handle-cork: handle flow kill after server ames has taken %done
         ::
         ++  handle-cork

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1091,6 +1091,55 @@
     --
   --
 ::
+
++$  ames-state-17
+  $+  ames-state-17
+  $:  peers=(map ship ship-state-17)
+      =unix=duct
+      =life
+      =rift
+      crypto-core=acru:ames
+      =bug
+      snub=[form=?(%allow %deny) ships=(set ship)]
+      cong=[msg=_5 mem=_100.000]
+    ::
+      $=  dead
+      $:  flow=[%flow (unit dead-timer)]
+          cork=[%cork (unit dead-timer)]
+  ==  ==
++$  ship-state-17
+  $+  ship-state-17
+  $%  [%alien alien-agenda]
+      [%known peer-state-17]
+  ==
++$  peer-state-17
+  $+  peer-state-17
+  $:  $:  =symmetric-key
+          =life
+          =rift
+          =public-key
+          sponsor=ship
+      ==
+      route=(unit [direct=? =lane])
+      =qos
+      =ossuary
+      snd=(map bone message-pump-state-17)
+      rcv=(map bone message-sink-state)
+      nax=(set [=bone =message-num])
+      heeds=(set duct)
+      closing=(set bone)
+      corked=(set bone)
+      keens=(map path keen-state)
+  ==
++$  message-pump-state-17
+  $+  message-pump-state-17
+  $:  current=_`message-num`1
+      next=_`message-num`1
+      unsent-messages=(qeu message-blob)
+      unsent-fragments=(list static-fragment)
+      queued-message-acks=(map message-num ack)
+      =packet-pump-state
+  ==
 +$  ames-state-14  ames-state-16
 +$  ames-state-15  ames-state-16
 +$  ames-state-16
@@ -1176,7 +1225,26 @@
   $+  task-11-and-16
   $%  [%kroc dry=?]
       [%snub ships=(list ship)]
-      $<(?(%snub %kroc) task)
+      $<(?(%snub %kroc) task-17)
+  ==
+::
++$  task-17
+  $+  task-17
+  $%  $<(%deep task)
+      $:  %deep 
+        $%  [%nack =ship =nack=bone =message-blob]
+            [%sink =ship =target=bone naxplanation=[=message-num =error]]
+            [%drop =ship =nack=bone =message-num]
+            [%cork =ship =bone]
+            [%kill =ship =bone]
+        ==
+      ==
+  ==
+::
++$  queued-event-17
+  $+  queued-event-17
+  $%  [%call =duct wrapped-task=(hobo task-17)]
+      [%take =wire =duct =sign]
   ==
 ::
 +$  queued-event-16
@@ -1188,7 +1256,7 @@
 +$  task-16
   $+  task-16
   $%  [%kroc dry=?]
-      $<(%kroc task)
+      $<(%kroc task-17)
   ==
 ::  $bug: debug printing configuration
 ::
@@ -1281,7 +1349,7 @@
 ::    %wake: handle timer firing
 ::
 +$  message-pump-task
-  $%  [%memo =message-blob]
+  $%  [%memo =message]
       [%hear =message-num =ack-meat]
       [%near =naxplanation]
       [%prod ~]
@@ -1337,7 +1405,8 @@
             [%14 ames-state-14]
             [%15 ames-state-15]
             [%16 ames-state-16]
-            [%17 ^ames-state]
+            [%17 ames-state-17]
+            [%18 ^ames-state]
         ==
     ::
     |=  [now=@da eny=@ rof=roof]
@@ -1460,7 +1529,7 @@
     ::  lifecycle arms; mostly pass-throughs to the contained adult ames
     ::
     ++  scry  scry:adult-core
-    ++  stay  [%17 %larva queued-events ames-state.adult-gate]
+    ++  stay  [%18 %larva queued-events ames-state.adult-gate]
     ++  load
       |=  $=  old
           $%  $:  %4
@@ -1556,6 +1625,13 @@
               ==  ==
               $:  %17
               $%  $:  %larva
+                      events=(qeu queued-event-17)
+                      state=ames-state-17
+                  ==
+                  [%adult state=ames-state-17]
+              ==  ==
+              $:  %18
+              $%  $:  %larva
                       events=(qeu queued-event)
                       state=_ames-state.adult-gate
                   ==
@@ -1632,7 +1708,7 @@
           [%10 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%10 state.old]
-        =.  queued-events  (event-11-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-11-to-17 events.old))
         larval-gate
       ::
           [%11 %adult *]
@@ -1643,7 +1719,7 @@
           [%11 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%11 state.old]
-        =.  queued-events  (event-11-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-11-to-17 events.old))
         larval-gate
       ::
           [%12 %adult *]
@@ -1654,7 +1730,7 @@
           [%12 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%12 state.old]
-        =.  queued-events  (event-16-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-16-to-17 events.old))
         larval-gate
       ::
           [%13 %adult *]
@@ -1665,7 +1741,7 @@
           [%13 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%13 state.old]
-        =.  queued-events  (event-16-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-16-to-17 events.old))
         larval-gate
       ::
           [%14 %adult *]
@@ -1676,7 +1752,7 @@
           [%14 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%14 state.old]
-        =.  queued-events  (event-16-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-16-to-17 events.old))
         larval-gate
       ::
           [%15 %adult *]
@@ -1687,7 +1763,7 @@
           [%15 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%15 state.old]
-        =.  queued-events  (event-16-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-16-to-17 events.old))
         larval-gate
       ::
           [%16 %adult *]
@@ -1698,15 +1774,27 @@
           [%16 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
         =.  cached-state  `[%16 state.old]
-        =.  queued-events  (event-16-to-17 events.old)
+        =.  queued-events  (event-17-to-18 (event-16-to-17 events.old))
         larval-gate
       ::
-          [%17 %adult *]  (load:adult-core %17 state.old)
+          [%17 %adult *]
+        =.  cached-state  `[%17 state.old]
+        ~>  %slog.0^leaf/"ames: larva reload"
+        larval-gate
       ::
           [%17 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
+        =.  cached-state  `[%17 state.old]
+        =.  queued-events  (event-17-to-18 events.old)
+        larval-gate
+
+      ::
+          [%18 %adult *]  (load:adult-core %18 state.old)
+      ::
+          [%18 %larva *]
+        ~>  %slog.1^leaf/"ames: larva: load"
         =.  queued-events  events.old
-        =.  adult-gate     (load:adult-core %17 state.old)
+        =.  adult-gate     (load:adult-core %18 state.old)
         larval-gate
       ==
       ::
@@ -1726,10 +1814,10 @@
       ::
       ++  event-11-to-17
         |=  events=(qeu queued-event-11-and-16)
-        ^-  (qeu queued-event)
+        ^-  (qeu queued-event-17)
         %-  ~(rep in events)
-        |=  [e=queued-event-11-and-16 q=(qeu queued-event)]
-        %-  ~(put to q)  ^-  queued-event
+        |=  [e=queued-event-11-and-16 q=(qeu queued-event-17)]
+        %-  ~(put to q)  ^-  queued-event-17
         ?.  ?=(%call -.e)  e
         =/  task=task-11-and-16  ((harden task-11-and-16) wrapped-task.e)
         %=    e
@@ -1742,14 +1830,32 @@
       ::
       ++  event-16-to-17
         |=  events=(qeu queued-event-16)
-        ^-  (qeu queued-event)
+        ^-  (qeu queued-event-17)
         %-  ~(rep in events)
-        |=  [e=queued-event-16 q=(qeu queued-event)]
-        %-  ~(put to q)  ^-  queued-event
+        |=  [e=queued-event-16 q=(qeu queued-event-17)]
+        %-  ~(put to q)  ^-  queued-event-17
         ?.  ?=(%call -.e)  e
         =/  task=task-16  ((harden task-16) wrapped-task.e)
         %=  e
           wrapped-task  ?.(?=(%kroc -.task) task [%kroc ~])
+        ==
+      ++  event-17-to-18
+        |=  events=(qeu queued-event-17)
+        ^-  (qeu queued-event)
+        %-  ~(rep in events)
+        |=  [e=queued-event-17 q=(qeu queued-event)]
+        %-  ~(put to q)  ^-  queued-event
+        ?.  ?=(%call -.e)  e
+        =/  task=task-17  ((harden task-17) wrapped-task.e)
+        %=  e
+          wrapped-task
+          ?.  ?=([%deep %nack *] task)  task
+          =/  msg  (cue message-blob.task)
+          =/  hed
+            ?:  =(1 (end 0 nack-bone.task))          %plea
+            ?:  =(0 (end 0 (rsh 0 nack-bone.task)))  %boon
+            %nack
+          [%deep %nack ship.task nack-bone.task ;;(message [hed msg])]
         ==
       --
     ::  +molt: re-evolve to adult-ames
@@ -1797,7 +1903,9 @@
           (rof ~ /ames %bx [[our %$ da+now] /debug/timers])
         |=([@da =duct] ?=([[%ames %recork *] *] duct))
       ::
-      ?>  ?=(%17 -.u.cached-state)
+      =?  u.cached-state  ?=(%17 -.u.cached-state)
+        18+(state-17-to-18:load:adult-core +.u.cached-state)
+      ?>  ?=(%18 -.u.cached-state)
       =.  ames-state.adult-gate  +.u.cached-state
       [moz larval-core(cached-state ~)]
     --
@@ -1932,12 +2040,11 @@
           ::
           =/  failed=message-num
             last-acked:(~(got by rcv.peer-state.peer-core) bone)
-          =/  =naxplanation  [failed error]
-          =/  =message-blob  (jam naxplanation)
+          =/  =message  [%naxplanation failed error]
           ::  send nack-trace message on associated .nack-bone
           ::
           =/  nack-bone=^bone  (mix 0b10 bone)
-          abet:(call:(abed:mu:peer-core nack-bone) %memo message-blob)
+          abet:(call:(abed:mu:peer-core nack-bone) %memo message)
         --
       ::  +on-sift: handle request to filter debug output by ship
       ::
@@ -2364,7 +2471,7 @@
           %-  %^  ev-trace  odd.veb  her
               |.("parsing old wire: {(spud wire)}")
           peer-core
-        abet:(on-memo:peer-core bone payload %boon)
+        abet:(on-memo:peer-core bone [%boon payload] %boon)
       ::  +on-plea: handle request to send message
       ::
       ++  on-plea
@@ -2386,7 +2493,7 @@
             =/  sndr  [our our-life.channel.peer-core]
             =/  rcvr  [ship her-life.channel.peer-core]
             "plea {<sndr rcvr bone=bone vane.plea path.plea>}"
-        abet:(on-memo:peer-core bone plea %plea)
+        abet:(on-memo:peer-core bone [%plea plea] %plea)
       ::  +on-tame: handle request to delete a route
       ::
       ++  on-tame
@@ -2429,7 +2536,7 @@
             =/  sndr  [our our-life.channel.peer-core]
             =/  rcvr  [ship her-life.channel.peer-core]
             "cork plea {<sndr rcvr bone=bone vane.plea path.plea>}"
-        abet:(on-memo:(on-cork-flow:peer-core bone) bone plea %plea)
+        abet:(on-memo:(on-cork-flow:peer-core bone) bone [%plea plea] %plea)
       ::  +on-kroc: cork all stale flows from failed subscriptions
       ::
       ++  on-kroc
@@ -2451,7 +2558,7 @@
         ?>  ?=([~ %known *] ship-state)
         =+  peer-core=(abed-peer:pe ship.deep +.u.ship-state)
         |^  ?-  -.deep
-          %nack  abet:(send-nack-trace [nack-bone message-blob]:deep)
+          %nack  abet:(send-nack-trace [nack-bone message]:deep)
           %sink  abet:(sink-naxplanation [target-bone naxplanation]:deep)
           %drop  abet:(clear-nack [nack-bone message-num]:deep)
           %cork  =~((cork-bone bone.deep) (emit duct %give %done ~))
@@ -2459,8 +2566,8 @@
         ==
         ::
         ++  send-nack-trace
-          |=  [=nack=bone =message-blob]
-          abet:(call:(abed:mu:peer-core nack-bone) %memo message-blob)
+          |=  [=nack=bone =message]
+          abet:(call:(abed:mu:peer-core nack-bone) %memo message)
         ::
         ++  sink-naxplanation
           |=  [=target=bone =naxplanation]
@@ -3245,8 +3352,8 @@
             ~>  %slog.0^leaf/"ames: ignoring message on corked bone {<bone>}"
             peer-core
           ::
-          =/  =message-blob  (jim payload)
-          =.  peer-core      abet:(call:(abed:mu bone) %memo message-blob)
+          =/  =message   ;;(message payload)
+          =.  peer-core  abet:(call:(abed:mu bone) %memo message)
           ::
           ?:  ?&  =(%boon valence)
                   (gte now (add ~s30 last-contact.qos.peer-state))
@@ -3414,7 +3521,7 @@
             =.  mem
               %+  add
                 %-  ~(rep in unsent-messages.i.pumps)
-                |=([a=@ b=_mem] (add b (met 3 a)))
+                |=([m=message b=_mem] (add b (met 3 (jim m))))
               ?~  unsent-fragments.i.pumps  0
               (met 3 fragment.i.unsent-fragments.i.pumps)
             ?:  (gte mem mem.cong.ames-state)
@@ -3467,8 +3574,9 @@
           ::
           ::  TODO use +trace
           ~>  %slog.0^leaf/"ames: recork {<her i.boz>}"
-          =/  =plea  [%$ /flow [%cork ~]]
-          (on-memo i.boz plea %plea)
+          =/  =plea     [%$ /flow [%cork ~]]
+          =/  =message  [%plea plea]
+          (on-memo i.boz message %plea)
         ::  +handle-cork: handle flow kill after server ames has taken %done
         ::
         ++  handle-cork
@@ -3566,7 +3674,7 @@
             ^+  pump
             ::
             ?-  -.task
-              %memo  (on-memo message-blob.task)
+              %memo  (on-memo message.task)
               %prod  abet:(call:packet-pump %prod ~)
               %wake  abet:(call:packet-pump %wake current.state)
               %near  %-  on-done
@@ -3601,8 +3709,8 @@
           ::  +on-memo: handle request to send a message
           ::
           ++  on-memo
-            |=  blob=message-blob
-            pump(unsent-messages.state (~(put to unsent-messages.state) blob))
+            |=  =message
+            pump(unsent-messages.state (~(put to unsent-messages.state) message))
           ::  +on-hear: handle packet acknowledgment
           ::
           ++  on-hear
@@ -3727,11 +3835,11 @@
               ?~(unsent feed-packets pump)
             ::  .unsent-messages is nonempty; pop a message off and feed it
             ::
-            =^  =message-blob  unsent-messages.state
+            =^  =message  unsent-messages.state
               ~(get to unsent-messages.state)
             ::  break .message into .chunks and set as .unsent-fragments
             ::
-            =.  unsent-fragments.state  (split-message next.state message-blob)
+            =.  unsent-fragments.state  (split-message next.state (jim +.message))
             ::  try to feed packets from the next message
             ::
             =.  next.state  +(next.state)
@@ -4380,13 +4488,13 @@
                   |.("sink plea {<dat>}")
               ?.  ok
                 =/  nack-bone=^bone  (mix 0b10 bone)
-                =/  =message-blob    (jam [message-num *error])
+                =/  =^message        [%naxplanation message-num *error]
                 =/  =wire  (make-bone-wire her her-rift.channel nack-bone)
                 ::  send nack-trace with blank .error for security
                 ::
                 =.  peer-core
                   %+  pe-emit  duct
-                  [%pass wire %a %deep %nack her nack-bone message-blob]
+                  [%pass wire %a %deep %nack her nack-bone message]
                 ::
                 (done ok=%.n)
               ::
@@ -5022,15 +5130,15 @@
   [moves ames-gate]
 ::  +stay: extract state before reload
 ::
-++  stay  [%17 %adult ames-state]
+++  stay  [%18 %adult ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load
   =<  |=  $=  old-state
-          $%  [%17 ^ames-state]
+          $%  [%18 ^ames-state]
           ==
       ^+  ames-gate
-      ?>  ?=(%17 -.old-state)
+      ?>  ?=(%18 -.old-state)
       ames-gate(ames-state +.old-state)
   ::  all state transitions are called from larval ames
   ::
@@ -5203,7 +5311,7 @@
   ::
   ++  state-16-to-17
     |=  old=ames-state-16
-    ^-  ^ames-state
+    ^-  ames-state-17
     %=    old
         cong
       :+  cong.old
@@ -5213,7 +5321,7 @@
         peers
       %-  ~(run by peers.old)
       |=  ship-state=ship-state-16
-      ^-  ^ship-state
+      ^-  ship-state-17
       ?.  ?=(%known -.ship-state)
         ship-state
       |^
@@ -5225,7 +5333,7 @@
       ::
       ++  message-pump-16-to-17
         |=  pump=message-pump-state-16
-        ^-  message-pump-state
+        ^-  message-pump-state-17
         %=    pump
             metrics.packet-pump-state
           [rto rtt rttvar ssthresh cwnd counter]:metrics.packet-pump-state.pump
@@ -5261,6 +5369,34 @@
         ==
       --
     ==
+  ++  state-17-to-18
+    |=  old=ames-state-17
+    ^-  ^ames-state
+    %=  old
+      peers
+    %-  ~(run by peers.old)
+    |=  s=ship-state-17
+    ?:  ?=(%alien -.s)  s
+    %=  s
+      snd.+
+    %-  malt
+    %+  turn
+      ~(tap by snd.+.s)
+    |=  [=bone m=message-pump-state-17]
+    :-  bone
+    %=  m
+      unsent-messages
+    %-  ~(gas to *(qeu message))
+    %+  turn
+      ~(tap to unsent-messages.m)
+    |=  b=message-blob
+    ^-  message
+     =/  hed
+       ?:  =(1 (end 0 bone))          %plea
+       ?:  =(0 (end 0 (rsh 0 bone)))  %boon
+       %nack
+    ;;(message [hed (cue b)])
+    ==  ==  ==
   --
 ::  +scry: dereference namespace
 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1854,7 +1854,7 @@
           =/  hed
             ?:  =(1 (end 0 nack-bone.task))          %plea
             ?:  =(0 (end 0 (rsh 0 nack-bone.task)))  %boon
-            %nack
+            %naxplanation
           [%deep %nack ship.task nack-bone.task ;;(message [hed msg])]
         ==
       --
@@ -5393,7 +5393,7 @@
      =/  hed
        ?:  =(1 (end 0 bone))          %plea
        ?:  =(0 (end 0 (rsh 0 bone)))  %boon
-       %nack
+       %naxplanation
     ;;(message [hed (cue b)])
     ==  ==  ==
   --


### PR DESCRIPTION
The upcoming introduction of persistent nock caching allows us to get rid of the insane `+dedup-message` arm in ames. This wonky function existed to ensure reasonable memory usage in scenarios such as when a busy publisher is sending the exact same `%fact` to many ships. 

Pruning the persistent nock cache with `+dedup-message` removed presents a risk of losing structural sharing in ames `unsent-messages`. This PR refactors `unsent-messages` to store the messages as nouns instead of jammed atoms to fix the problem.