### PR TITLE
ames: do not ignore our peer-state

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -559,7 +559,7 @@
 ::    dead:        dead flow consolidation timer and recork timer, if set
 ::
 +$  ames-state
-  $+  ames-state
+  $+  ames-state-17
   $:  peers=(map ship ship-state)
       =unix=duct
       =life
@@ -1338,6 +1338,7 @@
             [%15 ames-state-15]
             [%16 ames-state-16]
             [%17 ^ames-state]
+            [%18 ^ames-state]
         ==
     ::
     |=  [now=@da eny=@ rof=roof]
@@ -1560,6 +1561,13 @@
                       state=_ames-state.adult-gate
                   ==
                   [%adult state=_ames-state.adult-gate]
+              ==  ==
+              $:  %18
+              $%  $:  %larva
+                      events=(qeu queued-event)
+                      state=_ames-state.adult-gate
+                  ==
+                  [%adult state=_ames-state.adult-gate]
           ==  ==  ==
       |^  ?-  old
           [%4 %adult *]
@@ -1701,12 +1709,23 @@
         =.  queued-events  (event-16-to-17 events.old)
         larval-gate
       ::
-          [%17 %adult *]  (load:adult-core %17 state.old)
+          [%17 %adult *]
+        =.  cached-state  `[%17 state.old]
+        ~>  %slog.0^leaf/"ames: larva reload"
+        larval-gate
       ::
           [%17 %larva *]
         ~>  %slog.1^leaf/"ames: larva: load"
+        =.  cached-state  `[%17 state.old]
         =.  queued-events  events.old
-        =.  adult-gate     (load:adult-core %17 state.old)
+        larval-gate
+      ::
+          [%18 %adult *]  (load:adult-core %18 state.old)
+      ::
+          [%18 %larva *]
+        ~>  %slog.1^leaf/"ames: larva: load"
+        =.  queued-events  events.old
+        =.  adult-gate     (load:adult-core %18 state.old)
         larval-gate
       ==
       ::
@@ -1797,7 +1816,14 @@
           (rof ~ /ames %bx [[our %$ da+now] /debug/timers])
         |=([@da =duct] ?=([[%ames %recork *] *] duct))
       ::
-      ?>  ?=(%17 -.u.cached-state)
+      =^  moz  u.cached-state
+        ?.  ?=(%17 -.u.cached-state)  [~ u.cached-state]
+        :_  [%18 +.u.cached-state]
+        ~>  %slog.0^leaf/"ames: fetching our public keys"
+        ^-  (list move)
+        [[[/ames]~ %pass /public-keys %j %public-keys [n=our ~ ~]] moz]
+      ::
+      ?>  ?=(%18 -.u.cached-state)
       =.  ames-state.adult-gate  +.u.cached-state
       [moz larval-core(cached-state ~)]
     --
@@ -2716,10 +2742,6 @@
         ++  on-publ-sponsor
           |=  [=ship sponsor=(unit ship)]
           ^+  event-core
-          ::
-          ?:  =(our ship)
-            event-core
-          ::
           ?~  sponsor
             %-  (slog leaf+"ames: {(scow %p ship)} lost sponsor, ignoring" ~)
             event-core
@@ -2743,9 +2765,8 @@
               ::
               =+  ^-  [=ship =point]  i.points
               ::
-              ?:  =(our ship)
-                =.  rift.ames-state  rift.point
-                $(points t.points)
+              =?  rift.ames-state  =(our ship)
+                rift.point
               ::
               ?.  (~(has by keys.point) life.point)
                 $(points t.points)
@@ -2811,9 +2832,8 @@
         ++  on-publ-rift
           |=  [=ship =rift]
           ^+  event-core
-          ?:  =(our ship)
-            =.  rift.ames-state  rift
-            event-core
+          =?  rift.ames-state  =(our ship)
+            rift
           ?~  ship-state=(~(get by peers.ames-state) ship)
             ::  print error here? %rift was probably called before %keys
             ::
@@ -5027,15 +5047,15 @@
   [moves ames-gate]
 ::  +stay: extract state before reload
 ::
-++  stay  [%17 %adult ames-state]
+++  stay  [%18 %adult ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load
   =<  |=  $=  old-state
-          $%  [%17 ^ames-state]
+          $%  [%18 ^ames-state]
           ==
       ^+  ames-gate
-      ?>  ?=(%17 -.old-state)
+      ?>  ?=(%18 -.old-state)
       ames-gate(ames-state +.old-state)
   ::  all state transitions are called from larval ames
   ::


### PR DESCRIPTION
Consider the following scenario:

`~sampel-palnet` is behind a NAT. `/app/ping` will try to ping its sponsor `~sampel` every 25 seconds. `~sampel-palnet` just booted and has no route to `~sampel` so he will try to contact `~sampel` through the galaxy `~pel`.

`~sampel` received the ping. It will respond directly to `~sampel-palnet`, but knowing that the ping came through an indirect route the star will also send the ack through `~sampel-palnet`s sponsorship chain. This is where things go wrong.

`~sampel` will enter `+send-blob`, send the direct ack, but when it enters `+try-next-sponsor` it will encounter a missing peer-state for the sponsor. This sponsor is of course `~sampel` itself. Now `~sampel` will enter this code path : https://github.com/urbit/urbit/blob/10db04b944c6cdb7ed0d4ef3a17c63dc7bf769fa/pkg/arvo/sys/vane/ames.hoon#L3005-L3010

calling `+enqueue-alien-todo` for himself! This is very bad and results in `~sampel-palnet` never being able to receive the ack from `~sampel`. Looks like this bug has been present since 238a36de1de1f2419e005f85c9dab0a4a99b463f.

There are multiple possible approaches to fix this, but I think this one is the simplest. We create a dummy state migration that asks jael for our %public-keys, triggering `+on-publ-full` and eventually `+meet-alien`, clearing all garbage in `packets.todos`.

Thanks to `~sibnes` for reporting this bug.