### PR TITLE
Allow multiple declarations on in de-xml:html

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -4780,7 +4780,7 @@
       =+  spa=;~(pose comt whit)
       %+  knee  *manx  |.  ~+
       %+  ifix
-        [;~(plug (punt decl) (star spa)) (star spa)]
+        [;~(plug (more spa decl) (star spa)) (star spa)]
       ;~  pose
         %+  sear  |=([a=marx b=marl c=mane] ?.(=(c n.a) ~ (some [a b])))
           ;~(plug head many tail)


### PR DESCRIPTION
It is common for RSS feeds to have a `<?xml-stylesheet ... ?>` tag beneath the initial `<?xml ... ?>` tag.

Example: https://feeds.transistor.fm/other-life (go into dev tools and look at the xml file)

These tags are called [Processing Instructions](https://en.wikipedia.org/wiki/Processing_Instruction)
This PR allows multiple processing instructions to exist at the top of an XML file. Such as:

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheet href="https://feeds.transistor.fm/stylesheet.xsl" type="text/xsl"?>
<rss>
  ...
</rss>
```

... however, it also allows a technically incorrect XML file to get parsed:
```
<?xml version="1.0" encoding="UTF-8"?>
<?xml version="1.0" encoding="UTF-8"?> <!-- this is invalid -->
<rss>
  ...
</rss>
```

I think that this is not that big of a deal because `decl` is only used in the part of `ifix` that gets thrown away.
If this is a problem, lmk and I can add an arm for matching non-declaration processing instructions.