### PR TITLE
eyre: simplify the login page ux a little bit

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -459,8 +459,6 @@
                 name.focus();
               }
               function doEauth() {
-                console.log('mb get value from event', event);
-                console.log('compare', name.value, our);
                 if (name.value == our) {
                   event.preventDefault();
                   goLocal();
@@ -471,10 +469,6 @@
     ;body
       =class   "{?:(=(`& eauth) "eauth" "local")}"
       =onload  "setup({?:(=(`& eauth) "true" "false")})"
-      ;nav
-        ;div.local(onclick "goLocal()"):"Local"
-        ;div.eauth(onclick "goEauth()"):"EAuth"
-      ==
       ;div#local
         ;p:"Urbit ID"
         ;input(value "{(scow %p our)}", disabled "true", class "mono");
@@ -528,16 +522,11 @@
         ==
       ==
       ;*  ?:  ?=(%ours -.identity)  ~
-          =+  id=(trim 29 (scow %p who.identity))
           =+  as="proceed as{?:(?=(%fake -.identity) " guest" "")}"
           ;+  ;span.guest.mono
-                ; Or
+                ; Or try to
                 ;a/"{(trip (fall redirect-url '/'))}":"{as}"
-                ; :
-                ;br;
-                ; {p.id}
-                ;br;
-                ; {q.id}
+                ; .
               ==
     ==
     ;script:'''


### PR DESCRIPTION
We remove the local<->eauth switching tabs entirely. The only way to see the eauth login page is if the url contains an "eauth" query parameter. (Entering the local ship name into the eauth form still brings you to the normal login screen.)
The "proceed as guest" blurp no longer shows the guest identity, and we clarify the language to indicate that it is not guaranteed to result in access to content.

Both of those changes help simplify the look and feel of the login page. Various users had complained that it was confusing, given that logging into your own ship is still the common case, and not everyone knows what "euauth" is.

For applications redirecting to the login page, it is still recommended to add the ?eauth GET parameter if non-local sessions are supported. For applications that don't it should now be more obvious that logging in through eauth won't do anything (since it's not presented as an option).

We also remove some debugging prints that somehow remained in the javascript.

Screenshot of the page on the eauth screen:

<img width="373" alt="image" src="https://github.com/urbit/urbit/assets/3829764/347b1a1a-ca83-492d-aa7b-7cff53bd5113">

Screenshot of the page on the local login screen:

<img width="370" alt="image" src="https://github.com/urbit/urbit/assets/3829764/02d3d865-f2d4-4b09-a267-4b052d307439">