### PR TITLE
gall: fix remote scry bug

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1021,7 +1021,7 @@
       =/  ski  (~(gut by sky.yoke) spur *path-state)
       =-  ski(fan (put:on-path fan.ski -< -> &/page))
       ?~  las=(ram:on-path fan.ski)
-        [(fall bob.ski 0) now]
+        [?~(bob.ski 0 +(u.bob.ski)) now]
       :_  (max now +(p.val.u.las))
       ?~(bob.ski +(key.u.las) +((max key.u.las u.bob.ski)))
     ::  +ap-tomb: tombstone -- replace bound value with hash
@@ -1066,8 +1066,21 @@
         %.  sky.yoke
         %+  trace  odd.veb.bug.state
         [leaf+"gall: {<agent-name>}: cull {<[case spur]>} no-op"]~
+      ?~  las=(ram:on-path fan.u.old)
+        %.  sky.yoke
+        %+  trace  &
+        [leaf+"gall: {<agent-name>}: cull {<[case spur]>} no paths"]~
+      =/  fis  (need (pry:on-path fan.u.old))
+      ?.  &((gth yon key.fis) (lte yon key.u.las))
+        %.  sky.yoke
+        %+  trace  &
+        :_  ~
+        :-  %leaf
+        %+  weld
+          "gall: {<agent-name>}: cull {<[case spur]>} out of range,"
+        "min: {<key.fis>}, max: {<key.u.las>}"
       %+  ~(put by sky.yoke)  spur  ::  delete all older paths
-      [`yon (lot:on-path fan.u.old `+(yon) ~)]
+      [`yon (lot:on-path fan.u.old `yon ~)]
     ::  +ap-from-internal: internal move to move.
     ::
     ::    We convert from cards to duct-indexed moves when resolving

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1077,7 +1077,7 @@
         :_  ~
         :-  %leaf
         %+  weld
-          "gall: {<agent-name>}: cull {<[case spur]>} out of range,"
+          "gall: {<agent-name>}: cull {<[case spur]>} out of range, "
         "min: {<key.fis>}, max: {<key.u.las>}"
       %+  ~(put by sky.yoke)  spur  ::  delete all older paths
       [`yon (lot:on-path fan.u.old `yon ~)]


### PR DESCRIPTION
As reported by @rivmud-fabwen in `~dister-dozzod-lapdeg/battery-payload`.

Consider the case where you `%grow` a path `/foo` 3 times from a gall agent. After this you decide to `%cull` the same path with the case of `[%ud 2]`, removing the cases `[%ud 0]`, `[%ud 1]` and `[%ud 2]`. Everything works as expected so far, however! The next `%grow` that happens for the path `/foo` gets written to case `[%ud 2]`, completely breaking referential transparency. This happens because of a off-by-one error in `+ap-grow`.

That's not all folks. In the previous case if you decide to `%cull` with a case of `[%ud 1]` you also cull the case `[%ud 2]` because of another off-by-one error in `+ap-cull`.

This PR fixes both of the aforementioned issues. I also decided to enforce culling cases to be between the first and last cases that are currently bound, so culling with `[%ud 1.000.000]` with only cases 0, 1 and 2 existing will no-op and print the message: `gall: %your-agent: cull [[%ud p=1.000.000] /foo] out of range, min: 0, max: 2`

Thanks to @yosoyubik for figuring this out with me.
