### PR TITLE
eyre: append set-cookie header rather than clobbering

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2915,6 +2915,7 @@
             =*  session-id  session-id.u.connection-state
             =*  sessions    sessions.auth.state
             =*  inbound     inbound-request.u.connection-state
+            =*  headers     headers.response-header.http-event
             ::
             ?.  (~(has by sessions) session-id)
               ::  if the session has expired since the request was opened,
@@ -2925,9 +2926,14 @@
                 |=  =session
                 session(expiry-time (add now session-timeout))
             =-  response-header.http-event(headers -)
-            %+  snoc
-              headers.response-header.http-event
-            ['set-cookie' (session-cookie-string session-id &)]
+            =/  cookie=(pair @t @t)
+              ['set-cookie' (session-cookie-string session-id &)]
+            |-
+            ?~  headers
+              [cookie ~]
+            ?:  &(=(key.i.headers p.cookie) =(value.i.headers q.cookie))
+              headers
+            [i.headers $(headers t.headers)]
           ::
           =*  connection  u.connection-state
           ::

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2925,9 +2925,9 @@
                 |=  =session
                 session(expiry-time (add now session-timeout))
             =-  response-header.http-event(headers -)
-            %^  set-header:http  'set-cookie'
-              (session-cookie-string session-id &)
-            headers.response-header.http-event
+            %+  snoc
+              headers.response-header.http-event
+            ['set-cookie' (session-cookie-string session-id &)]
           ::
           =*  connection  u.connection-state
           ::


### PR DESCRIPTION
Apps can set-cookies in http responses, but eyre overwrites them. This PR makes eyre append its cookies instead.