### PR TITLE
gall: migrate sky to versioned path

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2762,7 +2762,7 @@
             sky=(map spur path-state)
             ken=(jug spar:ames wire)
     ==  ==
-  +$  egg-any  $%([%15 egg])
+  +$  egg-any  $%([%15 egg %16 egg])
   +$  bowl                                              ::  standard app state
     $:  $:  our=ship                                    ::  host
             src=ship                                    ::  guest

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -42,9 +42,9 @@
 ::  $move: Arvo-level move
 ::
 +$  move  [=duct move=(wind note-arvo gift-arvo)]
-::  $state-15: overall gall state, versioned
+::  $state-16: overall gall state, versioned
 ::
-+$  state-15  [%15 state]
++$  state-16  [%16 state]
 ::  $state: overall gall state
 ::
 ::    system-duct: TODO document
@@ -150,8 +150,7 @@
 ::  remember to duplicate version tag changes here to $egg-any:gall in lull
 ::
 +$  spore
-  $:  %15
-      system-duct=duct
+  $:  system-duct=duct
       outstanding=(map [wire duct] (qeu remote-request))
       contacts=(set ship)
       eggs=(map term egg)
@@ -159,10 +158,11 @@
       =bug
       leaves=(unit [=duct =wire date=@da])
   ==
++$  spore-16  [%16 spore]
 --
 ::  adult gall vane interface, for type compatibility with pupa
 ::
-=|  state=state-15
+=|  state=state-16
 |=  [now=@da eny=@uvJ rof=roof]
 =*  gall-payload  .
 ~%  %gall-top  ..part  ~
@@ -1062,7 +1062,7 @@
         %+  trace  &
         [leaf+"gall: {<agent-name>}: cull {<[case spur]>} no paths"]~
       =/  fis  (need (pry:on-path fan.u.old))
-      ?.  &((gth yon key.fis) (lte yon key.u.las))
+      ?.  &((gte yon key.fis) (lte yon key.u.las))
         %.  sky.yoke
         %+  trace  &
         :_  ~
@@ -1791,12 +1791,16 @@
       ^+  [fex ap-core]
       ?~  caz  [(flop fex) ap-core]
       ?-  i.caz
-        [%pass * %grow *]  $(caz t.caz, ap-core (ap-grow +.q.i.caz))
-        [%pass * %tomb *]  $(caz t.caz, ap-core (ap-tomb +.q.i.caz))
-        [%pass * %cull *]  $(caz t.caz, ap-core (ap-cull +.q.i.caz))
         [%pass * ?(%agent %arvo %pyre) *]  $(caz t.caz, fex [i.caz fex])
         [%give *]  $(caz t.caz, fex [i.caz fex])
         [%slip *]  !!
+        ::
+          [%pass * %grow *]
+        $(caz t.caz, ap-core (ap-grow ['1' +<.q.i.caz] +>.q.i.caz))
+          [%pass * %tomb *]
+        $(caz t.caz, ap-core (ap-tomb +<.q.i.caz ['1' +>.q.i.caz]))
+          [%pass * %cull *]
+        $(caz t.caz, ap-core (ap-cull +<.q.i.caz ['1' +>.q.i.caz]))
       ==
     ::  +ap-handle-ken
     ::
@@ -1959,31 +1963,33 @@
 ::
 ++  load
   |^  |=  old=spore-any
-      =?  old  ?=(%7 -.old)   (spore-7-to-8 old)
-      =?  old  ?=(%8 -.old)   (spore-8-to-9 old)
-      =?  old  ?=(%9 -.old)   (spore-9-to-10 old)
-      =?  old  ?=(%10 -.old)  (spore-10-to-11 old)
-      =?  old  ?=(%11 -.old)  (spore-11-to-12 old)
-      =?  old  ?=(%12 -.old)  (spore-12-to-13 old)
-      =?  old  ?=(%13 -.old)  (spore-13-to-14 old)
-      =?  old  ?=(%14 -.old)  (spore-14-to-15 old)
-      ?>  ?=(%15 -.old)
+      =?  old  ?=(%7 -.old)   (spore-7-to-8 +.old)
+      =?  old  ?=(%8 -.old)   (spore-8-to-9 +.old)
+      =?  old  ?=(%9 -.old)   (spore-9-to-10 +.old)
+      =?  old  ?=(%10 -.old)  (spore-10-to-11 +.old)
+      =?  old  ?=(%11 -.old)  (spore-11-to-12 +.old)
+      =?  old  ?=(%12 -.old)  (spore-12-to-13 +.old)
+      =?  old  ?=(%13 -.old)  (spore-13-to-14 +.old)
+      =?  old  ?=(%14 -.old)  (spore-14-to-15 +.old)
+      =?  old  ?=(%15 -.old)  (spore-15-to-16 +.old)
+      ?>  ?=(%16 -.old)
       gall-payload(state old)
   ::
   +$  spore-any
-    $%  spore
-        spore-7
-        spore-8
-        spore-9
-        spore-10
-        spore-11
-        spore-12
-        spore-13
-        spore-14
+    $%  [%16 spore]
+        [%7 spore-7]
+        [%8 spore-8]
+        [%9 spore-9]
+        [%10 spore-10]
+        [%11 spore-11]
+        [%12 spore-12]
+        [%13 spore-13]
+        [%14 spore-14]
+        [%15 spore-15]
     ==
+  +$  spore-15  spore
   +$  spore-14
-    $:  %14
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg)
@@ -1991,8 +1997,7 @@
         =bug
     ==
   +$  spore-13
-    $:  %13
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg)
@@ -2005,8 +2010,7 @@
         attributing=ship
     ==
   +$  spore-12
-    $:  %12
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg-12)
@@ -2030,8 +2034,7 @@
             sky=(map spur path-state)
     ==  ==
   +$  spore-11
-    $:  %11
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg-11)
@@ -2052,8 +2055,7 @@
         marks=(map duct mark)
     ==
   +$  spore-10
-    $:  %10
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request))
         contacts=(set ship)
         eggs=(map term egg-10)
@@ -2074,8 +2076,7 @@
         marks=(map duct mark)
     ==
   +$  spore-9
-    $:  %9
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
         eggs=(map term egg-10)
@@ -2086,8 +2087,7 @@
   +$  remote-request-9  ?(remote-request %cork)
   ::
   +$  spore-8
-    $:  %8
-        system-duct=duct
+    $:  system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
         eggs=(map term egg-8)
@@ -2106,8 +2106,7 @@
   +$  watches-8  [inbound=bitt outbound=boat-8]
   +$  boat-8  (map [wire ship term] [acked=? =path])
   +$  spore-7
-    $:  %7
-        wipe-eyre-subs=_|  ::NOTE  band-aid for #3196
+    $:  wipe-eyre-subs=_|  ::NOTE  band-aid for #3196
         system-duct=duct
         outstanding=(map [wire duct] (qeu remote-request-9))
         contacts=(set ship)
@@ -2117,20 +2116,22 @@
   ::
   ++  spore-7-to-8
     |=  old=spore-7
-    ^-  spore-8
+    ^-  spore-any
     :-  %8
+    ^-  spore-8
     =.  eggs.old
       %-  ~(urn by eggs.old)
       |=  [a=term e=egg-8]
       ::  kiln will kick off appropriate app revival
       ::
       e(old-state [%| p.old-state.e])
-    +>.old
+    +.old
   ::
   ++  spore-8-to-9
     |=  old=spore-8
+    :-  %9
     ^-  spore-9
-    =-  old(- %9, eggs -, blocked [blocked.old *bug])
+    =-  old(eggs -, blocked [blocked.old *bug])
     %-  ~(run by eggs.old)
     |=  =egg-8
     ^-  egg-10
@@ -2153,7 +2154,9 @@
   ::
   ++  spore-9-to-10
     |=  old=spore-9
-    =-  old(- %10, outstanding -)
+    :-  %10
+    ^-  spore-10
+    =-  old(outstanding -)
     %-  ~(run by outstanding.old)
     |=  q=(qeu remote-request-9)
     %-  ~(gas to *(qeu remote-request))
@@ -2166,9 +2169,9 @@
   ::
   ++  spore-10-to-11
     |=  old=spore-10
+    :-  %11
     ^-  spore-11
     %=    old
-        -  %11
         eggs
       %-  ~(urn by eggs.old)
       |=  [a=term e=egg-10]
@@ -2180,9 +2183,9 @@
   ::
   ++  spore-11-to-12
     |=  old=spore-11
+    :-  %12
     ^-  spore-12
     %=    old
-        -  %12
         eggs
       %-  ~(urn by eggs.old)
       |=  [a=term e=egg-11]
@@ -2194,9 +2197,9 @@
   ::
   ++  spore-12-to-13
     |=  old=spore-12
+    :-  %13
     ^-  spore-13
     %=    old
-        -  %13
         eggs
       %-  ~(urn by eggs.old)
       |=  [a=term e=egg-12]
@@ -2208,10 +2211,9 @@
   ::
   ++  spore-13-to-14
     |=  old=spore-13
+    :-  %14
     ^-  spore-14
     %=    old
-        -  %14
-      ::
         blocked
       ^-  (map term (qeu blocked-move))
       %-  ~(run by blocked.old)
@@ -2228,8 +2230,35 @@
   ::
   ++  spore-14-to-15
     |=  old=spore-14
-    ^-  spore
-    old(- %15, bug [bug.old ~])
+    :-  %15
+    ^-  spore-15
+    old(bug [bug.old ~])
+  ::  convert to versioned sky
+  ::
+  ++  spore-15-to-16
+    |=  old=spore-15
+    ^-  spore-16
+    :-  %16
+    %=    old
+        eggs
+      %-  ~(urn by eggs.old)
+      |=  [=term e=egg]
+      ^-  egg
+      ?:  ?=(%nuke -.e)  e(sky *(map spur @ud))
+      %=  e
+          sky
+        %-  molt
+        %+  turn  ~(tap by sky.e)
+        |=  [=spur p=path-state]
+        :-  ['1' spur]
+        :-  ~
+        =/  m  ~(val by fan.p)
+        %+  gas:on-path  *_fan.p
+        %+  turn  (gulf 1 ~(wyt by fan.p))
+        |=  a=@ud
+        [a (snag (dec a) m)]
+      ==
+    ==
   --
 ::  +scry: standard scry
 ::
@@ -2432,7 +2461,7 @@
 ::    TODO: superfluous? see +molt
 ::
 ++  stay
-  ^-  spore
+  ^-  spore-16
   =;  eggs=(map term egg)  state(yokes eggs)
   %-  ~(run by yokes.state)
   |=  =yoke


### PR DESCRIPTION
Since we noticed %gall breaking referential transparency in #6847 we have decided to change the interface to incorporate a version tag in the path. This allows us easier migrations if the namespace ever changes in the future.

This means that a path with the format `/~zod/test-agent/2//foo` becomes a path with the format `/~zod/test-agent/2//1/foo`. We will migrate all data from the old unversioned paths to the new versioned paths automatically. Note that since referential transparency is lost we will recover whatever we can from the old `sky` and start the aeons in the path from 1. This means that if you had culled all older revisions and had data at the paths `/~zod/test-agent/10//foo`  `/~zod/test-agent/11//foo` and  `/~zod/test-agent/12//foo`, this data will be migrated to live at  `/~zod/test-agent/1//1/foo`  `/~zod/test-agent/2//1/foo` and  `/~zod/test-agent/3//1/foo` respectively.

Queries against the old unversioned path scheme will block forever once kelvin 411 ships.

This PR also contains some housekeeping so I could do `+$  spore-15  spore`

A few questions. Did I put the version tag in the right place in the namespace hierarchy? Should the version tag itself be something else than just 1?