### PR TITLE
gall: add egg-any cast to %gv scry

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2336,7 +2336,7 @@
           p.agent.u.yok
         on-save:p.agent.u.yok
       ==
-    ``noun+!>([-:*spore egg])
+    ``noun+!>(`egg-any`[-:*spore egg])
   ::
   ?:  ?&  =(%w care)
           =([%$ %da now] coin)


### PR DESCRIPTION
Adds `egg-any` cast to `%gv` scry.
This should help keep changes to `$spore` in sync with `$egg-any`.