### PR TITLE
hoon: more vase mode arms for (trap vase)

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11457,6 +11457,25 @@
     %-  ~(play ut p.vax)
     [%wtgr [%wtts [%leaf %tas -.q.vax] [%& 2]~] [%$ 1]]
   (~(fuse ut p.vax) [%cell %noun %noun])
+::  +shot: deferred +slam
+::
+++  shot
+  |=  [gat=(trap vase) sam=(trap vase)]
+  ^-  (trap vase)
+  =+  :-  ^=  typ  ^-  type
+          [%cell p:$:gat p:$:sam]
+      ^=  gen  ^-  hoon
+      [%cnsg [%$ ~] [%$ 2] [%$ 3] ~]
+  =+  gun=(~(mint ut typ) %noun gen)
+  |.  ~+
+  [p.gun (slum q:$:gat q:$:sam)]
+::  +slew: deferred +slop
+::
+++  slew
+  |=  [hed=(trap vase) tal=(trap vase)]
+  ^-  (trap vase)
+  |.  ~+
+  [[%cell p:$:hed p:$:tal] [q:$:hed q:$:tal]]
 ::  +swat: deferred +slap
 ::
 ++  swat
@@ -11465,6 +11484,16 @@
   =/  gun  (~(mint ut p:$:tap) %noun gen)
   |.  ~+
   [p.gun .*(q:$:tap q.gun)]
+::  +swel: +swat but with +slop
+::
+++  swel
+  |=  [tap=(trap vase) gen=hoon]
+  ^-  (trap vase)
+  =/  gun  (~(mint ut p:$:tap) %noun gen)
+  =>  [tap=tap gun=gun]
+  |.  ~+
+  =/  pro  q:$:tap
+  [[%cell p.gun p:$:tap] [.*(pro q.gun) pro]]
 ::
 ::    5d: parser
 +|  %parser

--- a/pkg/base-dev/lib/pill.hoon
+++ b/pkg/base-dev/lib/pill.hoon
@@ -340,17 +340,6 @@
       %+  ifix  [fas (just `@`10)]
       (star ;~(less (just `@`10) next))
     ==
-  ::  +swel: +swat but with +slop
-  ::
-  ++  swel
-    |=  [tap=(trap vase) gen=hoon]
-    ^-  (trap vase)
-    =/  gun  (~(mint ut p:$:tap) %noun gen)
-    =>  [tap=tap gun=gun]
-    |.  ~+
-    =/  pro  q:$:tap
-    [[%cell p.gun p:$:tap] [.*(pro q.gun) pro]]
-  --
 ::
 ++  events
   |%


### PR DESCRIPTION
Added a few gates for working with `(trap vase)`s. One of them, `+swel`, was in `lib/pill.hoon` so I removed it from there and put it into hoon.hoon. We also now have a deferred `+slam` and deferred `+slop`.

These are just the ones I personally needed - are there any other `vase` operations I should make `(trap vase)` versions of while I'm at it?