### PR TITLE
Add ;. micdot rune for reversed association of ;: miccol.

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6466,7 +6466,8 @@
     [%sgzp p=hoon q=hoon]                               ::  ~!  type on trace
   ::                                            ::::::  miscellaneous
     [%mcts p=marl:hoot]                                 ::  ;=  list templating
-    [%mccl p=hoon q=(list hoon)]                        ::  ;:  binary to nary
+    [%mccl p=hoon q=(list hoon)]                        ::  ;:  binary to nary, right
+    [%mcdt p=hoon q=(list hoon)]                        ::  ;.  binary to nary, left
     [%mcfs p=hoon]                                      ::  ;/  [%$ [%$ p ~] ~]
     [%mcgl p=spec q=hoon r=hoon s=hoon]                 ::  ;<  bind
     [%mcsg p=hoon q=(list hoon)]                        ::  ;~  kleisli arrow
@@ -8551,6 +8552,22 @@
         :+  %tsls
           p.gen
         =+  yex=`(list hoon)`q.gen
+        |-  ^-  hoon
+        ?-  yex
+          [* ~]  [%tsgr [%$ 3] i.yex]
+          [* ^]   [%cncl [%$ 2] [%tsgr [%$ 3] i.yex] $(yex t.yex) ~]
+          ~      !!
+        ==
+      ==
+    ::
+        [%mcdt *]
+      ?-    q.gen
+          ~      [%zpzp ~]
+          [* ~]  i.q.gen
+          ^
+        :+  %tsls
+          p.gen
+        =+  yex=(flop `(list hoon)`q.gen)
         |-  ^-  hoon
         ?-  yex
           [* ~]  [%tsgr [%$ 3] i.yex]
@@ -12951,6 +12968,13 @@
             ;~(pfix fas (stag %mcfs wide))
           ==
         ==
+      :-  '.'
+        ;~  pfix  col
+          ;~  pose
+            (stag %mcdt (ifix [pal par] (most ace wide)))
+            ;~(pfix fas (stag %mcfs wide))
+          ==
+        ==
       :-  '='
         ;~  pfix  tis
           ;~  pose
@@ -13298,6 +13322,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
+                  ['.' (rune col %mcdt expi)]
                   ['/' (rune fas %mcfs expa)]
                   ['<' (rune gal %mcgl expz)]
                   ['~' (rune sig %mcsg expi)]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12968,10 +12968,6 @@
             ;~(pfix fas (stag %mcfs wide))
           ==
         ==
-      :-  '.'
-        ;~  pfix  dot
-          (stag %mcdt (ifix [pal par] (most ace wide)))
-        ==
       :-  '='
         ;~  pfix  tis
           ;~  pose

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8555,7 +8555,7 @@
         |-  ^-  hoon
         ?-  yex
           [* ~]  [%tsgr [%$ 3] i.yex]
-          [* ^]   [%cncl [%$ 2] [%tsgr [%$ 3] i.yex] $(yex t.yex) ~]
+          [* ^]  [%cncl [%$ 2] [%tsgr [%$ 3] i.yex] $(yex t.yex) ~]
           ~      !!
         ==
       ==
@@ -8571,7 +8571,7 @@
         |-  ^-  hoon
         ?-  yex
           [* ~]  [%tsgr [%$ 3] i.yex]
-          [* ^]   [%cncl [%$ 2] [%tsgr [%$ 3] i.yex] $(yex t.yex) ~]
+          [* ^]  [%cncl [%$ 2] $(yex t.yex) [%tsgr [%$ 3] i.yex] ~]
           ~      !!
         ==
       ==

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13315,7 +13315,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
-                  ['.' (rune col %mcdt expi)]
+                  ['.' (rune dot %mcdt expi)]
                   ['/' (rune fas %mcfs expa)]
                   ['<' (rune gal %mcgl expz)]
                   ['~' (rune sig %mcsg expi)]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -12969,11 +12969,8 @@
           ==
         ==
       :-  '.'
-        ;~  pfix  col
-          ;~  pose
-            (stag %mcdt (ifix [pal par] (most ace wide)))
-            ;~(pfix fas (stag %mcfs wide))
-          ==
+        ;~  pfix  dot
+          (stag %mcdt (ifix [pal par] (most ace wide)))
         ==
       :-  '='
         ;~  pfix  tis


### PR DESCRIPTION
`;:` miccol can be counterintuitive for developers, since its order of evaluation is `5 4 3 2 1`.

`;.` micdot reverses the order by flopping it for `1 2 3 4 5`.