### PR TITLE
lib/dprint: fix crashes with recursive types and =,

### DIFF
--- a/pkg/arvo/lib/dprint.hoon
+++ b/pkg/arvo/lib/dprint.hoon
@@ -255,7 +255,8 @@
     ^-  (unit item)
     ?>  ?=([%face *] sut)
     ::  TODO: handle tune case
-    ?>  ?=(term p.sut)
+    ?.  ?=(term p.sut)
+      return-item:this(sut q.sut)
     =*  compiled-against  return-item:this(sut q.sut)
     `[%face (trip p.sut) *what compiled-against]
   ::
@@ -318,7 +319,14 @@
         [%face *]  return-face
         [%fork *]  return-fork
         [%hint *]  return-hint
-        [%hold *]  return-item:this(sut (~(play ut p.sut) q.sut))
+        [%hold *]
+      ?:  (~(has in gil) sut)
+        ~
+      =<  return-item
+      %=  this
+        gil  (~(put in gil) sut)
+        sut  (~(play ut p.sut) q.sut)
+      ==  
     ==
   ::
   ++  return-hint-core

--- a/pkg/arvo/lib/dprint.hoon
+++ b/pkg/arvo/lib/dprint.hoon
@@ -77,6 +77,7 @@
 ::  +hunt: door used for refining the type while searching for doccords
 ::
 ++  hunt
+  =|  gil=(set type)
   |_  [topics=(lest term) sut=type]
   +*  this  .
   ::


### PR DESCRIPTION
Addresses two bugs in `lib/dprint`

The first bug originates from the handling of `%hold`s in `+return-item`, which could lead to an infinite loop with some recursive types. The fix was to introduce a check for duplicate types in the `%hold` case in `+return-item`.

To reproduce:

1. `=c -build-file %/gen/cat/hoon`
2. `# c`
3. Observe hang

The second bug was linked to the handling of the `$tune` case in `+return-face`. Previously, the function would crash if `p.type` was not a term, which lead to crashes with built files that contained `=,` expressions. This fix skips the `%face` instead of crashing when `p.type` is not a term.

To reproduce:

1. `=n -build-file %/gen/norms/hoon`
2. `# n`
3. Observe crash

Resolves #6255 