### PR TITLE
clay: print download progress for desk updates

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -770,7 +770,7 @@
       (clap a b furl)
   |-  ^-  (list (unit toro))
   =+  b=.^(arch %cy a)
-  ?:  ?=([^ ~] b)  (snoc c `(fray a))  
+  ?:  ?=([^ ~] b)  (snoc c `(fray a))
   =?  c  ?=(^ fil.b)  (snoc c `(fray a))
   %-  zing
   %+  turn  ~(tap by dir.b)
@@ -796,8 +796,8 @@
     %+  skim  desks
     |=  dek=desk
     ?:  (~(has in .^((set desk) %cd /(scot %p our)//(scot %da now))) dek)
-      &  
-    ~>  %slog.(fmt "desk does not yet exist: {<dek>}")  |   
+      &
+    ~>  %slog.(fmt "desk does not yet exist: {<dek>}")  |
   |=(=desk [%pass /kiln/suspend %arvo %c %zest desk %dead])
 ::
 ++  poke-sync
@@ -822,7 +822,7 @@
   ?~  got=(~(get by rock) loc)
     abet:(spam leaf+"desk does not exist: {<loc>}" ~)
   ~>  %slog.(fmt "uninstalling {<loc>}")
-  =?  ..on-init  !=(+<:got %dead)  
+  =?  ..on-init  !=(+<:got %dead)
     (emit %pass /kiln/uninstall %arvo %c %zest loc %dead)
   ?~  sync=(~(get by sources) loc)
     abet
@@ -1134,7 +1134,7 @@
     ?.  (~(has by zyx) syd her sud)
       (pure:m !>(%done))
     ~>  %slog.(fmt "downloading update for {here}")
-    ;<  =riot:clay  bind:m  (warp:strandio her sud ~ %sing %v ud+let /)
+    ;<  =riot:clay  bind:m  (rate:strandio her sud ~ %sing %v ud+let /)
     ?>  ?=(^ riot)
     (pure:m !>(%done))
   ::

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -845,6 +845,7 @@
         [%send =lane =blob]
     ::
         [%tune spar roar=(unit roar)]
+        [%rate spar fragment=@ud num-fragments=@ud]
     ::
         [%turf turfs=(list turf)]
     ==
@@ -1485,6 +1486,7 @@
         [%hill p=(list @tas)]                           ::  mount points
         [%done error=(unit error:ames)]                 ::  ames message (n)ack
         [%mere p=(each (set path) (pair term tang))]    ::  merge result
+        :: [%rate ]
         [%ogre p=@tas]                                  ::  delete mount point
         [%rule red=dict wit=dict]                       ::  node r+w permissions
         [%tire p=(each rock:tire wave:tire)]            ::  app state

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -845,7 +845,7 @@
         [%send =lane =blob]
     ::
         [%tune spar roar=(unit roar)]
-        [%rate spar fragment=@ud num-fragments=@ud]
+        [%rate =spar fragment=@ud num-fragments=@ud]
     ::
         [%turf turfs=(list turf)]
     ==
@@ -1486,7 +1486,7 @@
         [%hill p=(list @tas)]                           ::  mount points
         [%done error=(unit error:ames)]                 ::  ames message (n)ack
         [%mere p=(each (set path) (pair term tang))]    ::  merge result
-        :: [%rate ]
+        $>(%rate gift:ames)                             ::  XX  $keen progress
         [%ogre p=@tas]                                  ::  delete mount point
         [%rule red=dict wit=dict]                       ::  node r+w permissions
         [%tire p=(each rock:tire wave:tire)]            ::  app state

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3571,6 +3571,7 @@
           ++  abed
             |=  b=^bone
             pump(bone b, state (~(gut by snd.peer-state) b *message-pump-state))
+          ::
           ++  abet
             ::  if the bone was corked, it's been removed from the state,
             ::  so we avoid adding it again.
@@ -4318,6 +4319,8 @@
                         num-fragments=num-fragments  closing=closing
                     ==
                   "send ack-1 {<data>}"
+              ::  XX notify %clay about %rate?
+              ::
               sink
             ::  last-heard<seq<10+last-heard; this is a packet in a live message
             ::
@@ -4365,6 +4368,8 @@
                   =/  data
                     [seq=seq fragment-num=fragment-num fragments=num-fragments]
                   "send ack-2 {<data>}"
+              ::  XX notify %clay about %rate?
+              ::
               (send-shut-packet bone seq %| %& fragment-num)
             ::  enqueue all completed messages starting at +(last-heard.state)
             ::
@@ -4634,6 +4639,10 @@
             |=  dat=(unit roar)
             |=([=^duct =_fine] (fi-emit:fine duct %give %tune [her path] dat))
           ::
+          ++  fi-give-rate
+            |=  [frag=@ud num=@ud]
+            |=([=^duct =_fine] (fi-emit:fine duct %give %rate [her path] frag^num))
+          ::
           +|  %entry-points
           ::
           ++  fi-start
@@ -4776,10 +4785,13 @@
             ?:  |(=(~ nex.keen) =(inx max))
               fine
             =^  =want  nex.keen  nex.keen
-            =.  last-sent.want   now
-            =.      tries.want   +(tries.want)
-            =.        wan.keen   (put:fi-mop wan.keen [fra .]:want)
-            =.            fine   (fi-send `@ux`hoot.want)
+            =.   last-sent.want  now
+            =.       tries.want  +(tries.want)
+            =.         wan.keen  (put:fi-mop wan.keen [fra .]:want)
+            =.             fine  (fi-send `@ux`hoot.want)
+            =.  fine
+              %-  ~(rep in listeners.keen)
+              (fi-give-rate fra.want num-fragments.keen)
             $(inx +(inx))
           ::
           ++  fi-sift-full

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4789,7 +4789,7 @@
             =.       tries.want  +(tries.want)
             =.         wan.keen  (put:fi-mop wan.keen [fra .]:want)
             =.             fine  (fi-send `@ux`hoot.want)
-            =.  fine
+            =?  fine  =(0 (mod fra.want 100))
               %-  ~(rep in listeners.keen)
               (fi-give-rate fra.want num-fragments.keen)
             $(inx +(inx))
@@ -5358,6 +5358,7 @@
   ::  /ax/snubbed                    (?(%allow %deny) (list ship))
   ::  /ax/fine/hunk/[path/...]       (list @ux) scry response fragments
   ::  /ax/fine/ducts/[path/]         (list duct)
+  ::  /ax/fine/rate/[path/]          [num-received=@ud num-fragments=@ud]
   ::  /ax/rift                        @
   ::  /ax/corked/[ship]              (set bone)
   ::  /ax/closing/[ship]             (set bone)
@@ -5530,6 +5531,18 @@
     ?~  keen=(~(get by keens.u.peer) path)
       [~ ~]
     ``noun+!>(listeners:u.keen)
+  ::
+      [%fine %rate her=@ pax=^]
+    ?~  who=(slaw %p her.tyl)  [~ ~]
+    ?~  peer=(~(get by peers.ames-state) u.who)
+      [~ ~]
+    ?.  ?=([~ %known *] peer)
+      [~ ~]  :: TODO handle aliens
+    :^  ~  ~  %noun
+    !>  ^-  (unit [@ud @ud])
+    ?~  keen=(~(get by keens.u.peer) pax.tyl)
+      ~
+    `[num-received num-fragments]:u.keen
   ::
       [%rift ~]
     ``noun+!>(rift.ames-state)

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -363,6 +363,7 @@
                   %done                                 ::  (n)ack
                   %lost                                 ::  lost boon
                   %tune                                 ::  scry response
+                  %rate                                 ::  scry progress
               ==                                        ::
           gift:ames                                     ::
       ==                                                ::
@@ -6221,19 +6222,23 @@
       %-  (slog leaf+"clay: lost backfill from {<tea>}" ~)
       [~ ..^$]
     ::
-        ?(%boon %tune)
+        ?(%boon %tune %rate)
       =/  her=ship   (slav %p i.t.tea)
       =/  =desk      (slav %tas i.t.t.tea)
       =/  index=@ud  (slav %ud i.t.t.t.tea)
       ::
       =/  fell=(unit fell)
         ?:  ?=(%boon +<.hin)  `;;(fell payload.hin)
+        ?.  ?=(%tune +<.hin)  ~
         ?~  roar.hin  ~
         ?~  q.dat.u.roar.hin  ~
         `[%1 `u.q.dat.u.roar.hin]
       ::
       =^  mos  ruf
         =/  den  ((de now rof hen ruf) her desk)
+        ?:  ?=(%rate +<.hin)
+          ~&  >  rate/[fragment num-fragments]:hin
+          `ruf
         ?~  fell
           ::  We shouldn't get back null on any of the fine requests we
           ::  make unless they're out of date
@@ -6347,6 +6352,7 @@
       ::
       %boon  !!
       %tune  !!
+      %rate  !!
       %lost  !!
       %unto  !!
       %wris  ~&  %strange-wris  !!

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -375,6 +375,7 @@
           $>  $?  %mere                                 ::
                   %writ                                 ::
                   %wris                                 ::
+                  %rate                                 ::
               ==                                        ::
           gift                                          ::
       ==                                                ::
@@ -6237,8 +6238,10 @@
       =^  mos  ruf
         =/  den  ((de now rof hen ruf) her desk)
         ?:  ?=(%rate +<.hin)
-          ~&  >  rate/[fragment num-fragments]:hin
-          `ruf
+          :_  ruf
+          ?~  ref.den  ~
+          =/  sat=update-state  (~(got by bom.u.ref.den) index)
+          [duct.sat %give %rate [spar fragment num-fragments]:hin]~
         ?~  fell
           ::  We shouldn't get back null on any of the fine requests we
           ::  make unless they're out of date

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -569,6 +569,49 @@
   ;<  ~  bind:m  (send-raw-card %pass /warp %arvo %c %warp ship riff)
   (take-writ /warp)
 ::
+++  take-rate
+  |=  =wire
+  =/  m  (strand ,vase)
+  ^-  form:m
+  |=  tin=strand-input:strand
+  ?+  in.tin  `[%skip ~]
+      ~  `[%wait ~]
+    ::
+      [~ %sign * %clay %rate *]
+    ?.  =(wire wire.u.in.tin)
+      `[%skip ~]
+    :+  ~  %done
+    !>(rate/[path.spar fragment num-fragments]:+>.sign-arvo.u.in.tin)
+    ::
+      [~ %sign * ?(%behn %clay) %writ *]
+    ?.  =(wire wire.u.in.tin)
+      `[%skip ~]
+    `[%done !>(writ/+>.sign-arvo.u.in.tin)]
+  ==
+::
+++  rate
+  |=  [=ship =riff:clay]
+  =/  m  (strand ,riot:clay)
+  =|  =riot:clay
+  =/  rate=[frag=@ud num=@ud]  [frag=0 num=1]
+  ;<  ~  bind:m  (send-raw-card %pass /rate %arvo %c %warp ship riff)
+  |-  ^-  form:m
+  ?:  ?=(^ riot)
+    (pure:m riot)
+  ;<  =vase  bind:m  (take-rate /rate)
+  ?:  ?=(%rate -.q.vase)
+    =+  !<([%rate rat=[loc=path =_rate]] vase)
+    =/  progress  =,  rat
+      (mul:rs (div:rs (sun:rs frag.rate) (sun:rs num.rate)) (sun:rs 100))
+    =>  .(loc.rat `(pole knot)`loc.rat)
+    ?>  ?=([van=@t car=@t cas=@t file-path=*] loc.rat)
+    ~&  >>  [progress `path`file-path.loc.rat]
+    $(rate rate.rat)
+  ?>  ?=(%writ -.q.vase)
+  ~&  >  .100
+  =+  !<([%writ maybe=riot:clay] vase)
+  $(riot maybe)
+::
 ++  read-file
   |=  [[=ship =desk =case] =spur]
   =*  arg  +<


### PR DESCRIPTION
WIP 
![rate](https://github.com/urbit/urbit/assets/1033194/49c224ed-68b0-4439-9fc5-9073c8e4c91a)

(Note: possible alternative version of https://github.com/urbit/urbit/pull/6867; instead of scrying the rate out of `%ames` we rely on `%ames` notifying any subscribers for a `%keen`—In this case `%clay` while just send the `%rate` `%gift` to `%kiln`. Leaving as a draft so we can compare what approach is more ergonomic) 