### PR TITLE
all: enforce the gang when scrying

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2006,7 +2006,7 @@
         %+  skim
           ;;  (list [@da duct])
           =<  q.q  %-  need  %-  need
-          (rof ~ /ames %bx [[our %$ da+now] /debug/timers])
+          (rof [~ ~] /ames %bx [[our %$ da+now] /debug/timers])
         |=([@da =duct] ?=([[%ames %recork *] *] duct))
       ::
       =^  moz  u.cached-state
@@ -2078,7 +2078,7 @@
       ++  get-sponsors
         ;;  (list ship)
         =<  q.q  %-  need  %-  need
-        (rof ~ /ames %j `beam`[[our %saxo %da now] /(scot %p our)])
+        (rof [~ ~] /ames %j `beam`[[our %saxo %da now] /(scot %p our)])
       ::
       +|  %tasks
       ::  +on-take-flub: vane not ready to process message, pretend it
@@ -2273,7 +2273,7 @@
         ++  do-rift
           =/  =rift
             =-  ~|(%no-rift (,@ q.q:(need (need -))))
-            (rof ~ /ames %j `beam`[[our %rift %da now] /(scot %p our)])
+            (rof [~ ~] /ames %j `beam`[[our %rift %da now] /(scot %p our)])
           ?:  =(rift rift.ames-state)
             event-core
           ~&  "ames: fixing rift from {<rift.ames-state>} to {<rift>}"
@@ -2298,7 +2298,7 @@
             =/  tim
               ;;  (list [@da ^duct])
               =<  q.q  %-  need  %-  need
-              (rof ~ /ames %bx [[our %$ da+now] /debug/timers])
+              (rof [~ ~] /ames %bx [[our %$ da+now] /debug/timers])
             (skim tim |=([@da hen=^duct] ?=([[%ames ?(%pump %recork) *] *] hen)))
           ::
           ::  set timers for flows that should have one set but don't
@@ -3208,7 +3208,7 @@
         =/  turfs
           ;;  (list turf)
           =<  q.q  %-  need  %-  need
-          (rof ~ /ames %j `beam`[[our %turf %da now] /])
+          (rof [~ ~] /ames %j `beam`[[our %turf %da now] /])
         ::
         =*  duct  unix-duct.ames-state
         ::
@@ -5443,7 +5443,7 @@
       ?:  ?=(%pawn (clan:title ship))  0
       ;;  @ud
       =<  q.q  %-  need  %-  need
-      (rof ~ /ames %j `beam`[[our %rift %da now] /(scot %p ship)])
+      (rof [~ ~] /ames %j `beam`[[our %rift %da now] /(scot %p ship)])
     :-   -.ship-state
     :_  +.peer-state
     =,  -.peer-state
@@ -5524,7 +5524,7 @@
   ++  state-12-to-13
     |=  old=ames-state-12
     ^-  ames-state-13
-    =+  !<(=rift q:(need (need (rof ~ /ames %j our-beam))))
+    =+  !<(=rift q:(need (need (rof [~ ~] /ames %j our-beam))))
     =+  pk=sec:ex:crypto-core.old
     :*  peers=(~(run by peers.old) ship-state-12-to-13)
         unix-duct.old
@@ -5566,7 +5566,7 @@
   ++  state-14-to-15
     |=  old=ames-state-14
     ^-  ames-state-15
-    old(rift !<(=rift q:(need (need (rof ~ /ames %j our-beam)))))
+    old(rift !<(=rift q:(need (need (rof [~ ~] /ames %j our-beam)))))
   ::
   ++  state-15-to-16
     |=  old=ames-state-15
@@ -5771,107 +5771,136 @@
   ::
   ?.  ?=(%x ren)  ~
   =>  .(tyl `(pole knot)`tyl)
-  ?+    tyl  ~
-      [%$ %whey ~]
-    =/  maz=(list mass)
-      =+  [known alien]=(skid ~(val by peers.ames-state) |=(^ =(%known +<-)))
-      :~  peers-known+&+known
-          peers-alien+&+alien
-      ==
-    ``mass+!>(maz)
-  ::
-      [%protocol %version ~]
-    ``noun+!>(protocol-version)
-  ::
-      [%chain %latest ~]
-    ?:  ?=(?(~ [~ ~]) lyc)
-      [~ ~]
-    ``noun+!>(`[idx=@ key=@ =path]`(need (ram:on:chain chain.ames-state)))
-  ::
-      [%chain idx=@ ~]
-    ?:  ?=(?(~ [~ ~]) lyc)
-      [~ ~]
-    ?~  idx=(slaw %ud idx.tyl)
-      [~ ~]
-    ?~  key=(get:on:chain chain.ames-state u.idx)
-      [~ ~]
-    ``noun+!>(`[idx=@ key=@]`[u.idx key.u.key])
-  ::
-      [%peers ~]
-    :^  ~  ~  %noun
-    !>  ^-  (map ship ?(%alien %known))
-    (~(run by peers.ames-state) head)
-  ::
-      [%peers her=@ req=*]
-    =/  who  (slaw %p her.tyl)
-    ?~  who  [~ ~]
-    =/  peer  (~(get by peers.ames-state) u.who)
-    ?+    req.tyl  [~ ~]
-        ~
-      ?~  peer
+  ?:  =([~ ~] lyc)
+    ?+    tyl  ~
+        [%$ %whey ~]
+      =/  maz=(list mass)
+        =+  [known alien]=(skid ~(val by peers.ames-state) |=(^ =(%known +<-)))
+        :~  peers-known+&+known
+            peers-alien+&+alien
+        ==
+      ``mass+!>(maz)
+     ::
+        [%chain %latest ~]
+      ``noun+!>(`[idx=@ key=@ =path]`(need (ram:on:chain chain.ames-state)))
+     ::
+        [%chain idx=@ ~]
+      ?~  idx=(slaw %ud idx.tyl)
         [~ ~]
-      ``noun+!>(u.peer)
-    ::
-        [%last-contact ~]
+      ?~  key=(get:on:chain chain.ames-state u.idx)
+        [~ ~]
+      ``noun+!>(`[idx=@ key=@]`[u.idx key.u.key])
+     ::
+        [%peers ~]
       :^  ~  ~  %noun
-      !>  ^-  (unit @da)
+      !>  ^-  (map ship ?(%alien %known))
+      (~(run by peers.ames-state) head)
+    ::
+        [%peers her=@ req=*]
+      =/  who  (slaw %p her.tyl)
+      ?~  who  [~ ~]
+      =/  peer  (~(get by peers.ames-state) u.who)
+      ?+    req.tyl  [~ ~]
+          ~
+        ?~  peer
+          [~ ~]
+        ``noun+!>(u.peer)
+      ::
+          [%last-contact ~]
+        :^  ~  ~  %noun
+        !>  ^-  (unit @da)
+        ?.  ?=([~ %known *] peer)
+          ~
+        `last-contact.qos.u.peer
+      ::
+          [%forward-lane ~]
+        ::
+        ::  this duplicates the routing hack from +send-blob:event-core
+        ::  so long as neither the peer nor the peer's sponsoring galaxy is us,
+        ::  and the peer has been reached recently:
+        ::
+        ::    - no route to the peer, or peer has not been contacted recently:
+        ::      send to the peer's sponsoring galaxy
+        ::    - direct route to the peer: use that
+        ::    - indirect route to the peer: send to both that route and the
+        ::      the peer's sponsoring galaxy
+        ::
+        :^  ~  ~  %noun
+        !>  ^-  (list lane)
+        ?:  =(our u.who)
+          ~
+        ?:  ?=([~ %known *] peer)
+          (get-forward-lanes our +.u.peer peers.ames-state)
+        =/  sax  (rof ~ /ames %j `beam`[[our %saxo %da now] /(scot %p u.who)])
+        ?.  ?=([~ ~ *] sax)
+          ~
+        =/  gal  (rear ;;((list ship) q.q.u.u.sax))
+        ?:  =(our gal)
+          ~
+        [%& gal]~
+      ==
+    ::
+        [%bones her=@ ~]
+      =/  who  (slaw %p her.tyl)
+      ?~  who  [~ ~]
+      =/  per  (~(get by peers.ames-state) u.who)
+      ?.  ?=([~ %known *] per)  [~ ~]
+      =/  res
+        =,  u.per
+        [snd=~(key by snd) rcv=~(key by rcv)]
+      ``noun+!>(res)
+    ::
+        [%snd-bones her=@ bon=@ ~]
+      =/  who  (slaw %p her.tyl)
+      ?~  who  [~ ~]
+      =/  ost  (slaw %ud bon.tyl)
+      ?~  ost  [~ ~]
+      =/  per  (~(get by peers.ames-state) u.who)
+      ?.  ?=([~ %known *] per)  [~ ~]
+      =/  mps  (~(get by snd.u.per) u.ost)
+      ?~  mps  [~ ~]
+      =/  res
+        u.mps
+      ``noun+!>(!>(res))
+    ::
+        [%snubbed ~]
+      ``noun+!>([form.snub.ames-state ~(tap in ships.snub.ames-state)])
+    ::
+        [%fine %ducts pax=^]
+      ?~  bulk=(de-path-soft:balk pax.tyl)  ~
+      ?~  peer=(~(get by peers.ames-state) her.u.bulk)
+        [~ ~]
       ?.  ?=([~ %known *] peer)
-        ~
-      `last-contact.qos.u.peer
+        [~ ~]  :: TODO handle aliens
+      ?~  spr.u.bulk  [~ ~]
+      =/  =path  =,(u.bulk [van car (scot cas) spr])
+      ?~  keen=(~(get by keens.u.peer) path)
+        [~ ~]
+      ``noun+!>(listeners:u.keen)
     ::
-        [%forward-lane ~]
-      ::
-      ::  this duplicates the routing hack from +send-blob:event-core
-      ::  so long as neither the peer nor the peer's sponsoring galaxy is us,
-      ::  and the peer has been reached recently:
-      ::
-      ::    - no route to the peer, or peer has not been contacted recently:
-      ::      send to the peer's sponsoring galaxy
-      ::    - direct route to the peer: use that
-      ::    - indirect route to the peer: send to both that route and the
-      ::      the peer's sponsoring galaxy
-      ::
-      :^  ~  ~  %noun
-      !>  ^-  (list lane)
-      ?:  =(our u.who)
-        ~
-      ?:  ?=([~ %known *] peer)
-        (get-forward-lanes our +.u.peer peers.ames-state)
-      =/  sax  (rof ~ /ames %j `beam`[[our %saxo %da now] /(scot %p u.who)])
-      ?.  ?=([~ ~ *] sax)
-        ~
-      =/  gal  (rear ;;((list ship) q.q.u.u.sax))
-      ?:  =(our gal)
-        ~
-      [%& gal]~
+        [%rift ~]
+      ``noun+!>(rift.ames-state)
+    ::
+        [%corked her=@ ~]
+      =/  who  (slaw %p her.tyl)
+      ?~  who  [~ ~]
+      =/  per  (~(get by peers.ames-state) u.who)
+      ?.  ?=([~ %known *] per)  [~ ~]
+      ``noun+!>(corked.u.per)
+    ::
+        [%closing her=@ ~]
+      =/  who  (slaw %p her.tyl)
+      ?~  who  [~ ~]
+      =/  per  (~(get by peers.ames-state) u.who)
+      ?.  ?=([~ %known *] per)  [~ ~]
+      ``noun+!>(closing.u.per)
+    ::
+        [%protocol %version ~]
+      ``noun+!>(protocol-version)
+    ::
     ==
-  ::
-      [%bones her=@ ~]
-    =/  who  (slaw %p her.tyl)
-    ?~  who  [~ ~]
-    =/  per  (~(get by peers.ames-state) u.who)
-    ?.  ?=([~ %known *] per)  [~ ~]
-    =/  res
-      =,  u.per
-      [snd=~(key by snd) rcv=~(key by rcv)]
-    ``noun+!>(res)
-  ::
-      [%snd-bones her=@ bon=@ ~]
-    =/  who  (slaw %p her.tyl)
-    ?~  who  [~ ~]
-    =/  ost  (slaw %ud bon.tyl)
-    ?~  ost  [~ ~]
-    =/  per  (~(get by peers.ames-state) u.who)
-    ?.  ?=([~ %known *] per)  [~ ~]
-    =/  mps  (~(get by snd.u.per) u.ost)
-    ?~  mps  [~ ~]
-    =/  res
-      u.mps
-    ``noun+!>(!>(res))
-  ::
-      [%snubbed ~]
-    ``noun+!>([form.snub.ames-state ~(tap in ships.snub.ames-state)])
-  ::
+
+    ?+    tyl  ~
       [%fine %hunk lop=@t len=@t pax=^]
     ::TODO  separate endpoint for the full message (instead of packet list)
     ::  .pax is expected to be a scry path of the shape /vc/desk/rev/etc,
@@ -5886,33 +5915,15 @@
     |^
     =/  van  ?@(vis.nom (end 3 vis.nom) way.vis.nom)
     =/  kyr  ?@(vis.nom (rsh 3 vis.nom) car.vis.nom)
-    ?+    van  ~
-        %a
-      ?+  kyr  ~
-        %x  (en-hunk (rof lyc /ames nom))
-      ==
-    ::
-        %c
-      =+  pem=(rof lyc /ames nom(vis %cp))
-      ?.  ?=(^ pem)    ~
-      ?.  ?=(^ u.pem)  ~
-      ~|  u.u.pem
-      =+  per=!<([r=dict:clay w=dict:clay] q.u.u.pem)
-      ?.  =([%black ~ ~] rul.r.per)  ~
+    ?.  =(%c van)
       (en-hunk (rof ~ /ames nom))
-    ::
-        %e
-      %-  en-hunk
-      ?+  kyr  ~
-        %x  (rof ~ /ames nom)
-      ==
-    ::
-        %g
-      %-  en-hunk
-      ?+  kyr  ~
-        %x  (rof ~ /ames nom)
-      ==
-    ==
+    =+  pem=(rof [~ ~] /ames nom(vis %cp))
+    ?.  ?=(^ pem)    ~
+    ?.  ?=(^ u.pem)  ~
+    ~|  u.u.pem
+    =+  per=!<([r=dict:clay w=dict:clay] q.u.u.pem)
+    ?.  =([%black ~ ~] rul.r.per)  ~
+    (en-hunk (rof [~ ~] /ames nom))
     ::
     ++  en-hunk
       |=  res=(unit (unit cage))
@@ -5926,34 +5937,7 @@
         [~ ~ *]  ``noun+!>((etch-open:hu-co pax.tyl hunk [p q.q]:u.u.res))
       ==
     --
+    ==
   ::
-      [%fine %ducts pax=^]
-    ?~  bulk=(de-path-soft:balk pax.tyl)  ~
-    ?~  peer=(~(get by peers.ames-state) her.u.bulk)
-      [~ ~]
-    ?.  ?=([~ %known *] peer)
-      [~ ~]  :: TODO handle aliens
-    ?~  spr.u.bulk  [~ ~]
-    =/  =path  =,(u.bulk [van car (scot cas) spr])
-    ?~  keen=(~(get by keens.u.peer) path)
-      [~ ~]
-    ``noun+!>(listeners:u.keen)
-  ::
-      [%rift ~]
-    ``noun+!>(rift.ames-state)
-  ::
-      [%corked her=@ ~]
-    =/  who  (slaw %p her.tyl)
-    ?~  who  [~ ~]
-    =/  per  (~(get by peers.ames-state) u.who)
-    ?.  ?=([~ %known *] per)  [~ ~]
-    ``noun+!>(corked.u.per)
-  ::
-      [%closing her=@ ~]
-    =/  who  (slaw %p her.tyl)
-    ?~  who  [~ ~]
-    =/  per  (~(get by peers.ames-state) u.who)
-    ?.  ?=([~ %known *] per)  [~ ~]
-    ``noun+!>(closing.u.per)
-  ==
+
 --

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -243,11 +243,12 @@
   =*  lot=coin  $/r.bem
   =*  tyl  s.bem
   ::
-  ::  only respond for the local identity, %$ desk, current timestamp
+  ::  only respond for the local identity, %$ desk, current timestamp, root gang
   ::
   ?.  ?&  =(&+our why)
           =([%$ %da now] lot)
           =(%$ syd)
+          =([~ ~] lyc)
       ==
     ~
   ::  /bx//whey         (list mass)        memory usage labels

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5934,6 +5934,7 @@
   ::
   =/  for=(unit ship)  ?~(lyc ~ ?~(u.lyc ~ `n.u.lyc))
   ?:  &(=(our his) ?=(?(%d %x) ren) =(%$ syd) =([%da now] u.luk))
+    ?.  =([~ ~] lyc)  ~
     ?-  ren
       %d  (read-buc-d tyl)
       %x  (read-buc-x tyl)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -490,11 +490,12 @@
   ?.  ?=(%& -.why)  ~
   =*  his  p.why
   ::
-  ::  only respond for the local identity, %$ desk, current timestamp
+  ::  only respond for the local identity, %$ desk, current timestamp, root gang
   ::
   ?.  ?&  =(&+our why)
           =([%$ %da now] lot)
           =(%$ syd)
+          =(~ lyc)
       ==
     ~
   ::  /%x//whey           (list mass)   memory usage labels

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -917,12 +917,12 @@
         %gen
       =/  bek=beak  [our desk.generator.action da+now]
       =/  sup=spur  path.generator.action
-      =/  ski       (rof ~ /eyre %ca bek sup)
+      =/  ski       (rof [~ ~] /eyre %ca bek sup)
       =/  cag=cage  (need (need ski))
       ?>  =(%vase p.cag)
       =/  gat=vase  !<(vase q.cag)
       =/  res=toon
-        %-  mock  :_  (look rof ~ /eyre)
+        %-  mock  :_  (look rof ?.(authenticated ~ [~ ~]) /eyre)
         :_  [%9 2 %0 1]  |.
         %+  slam
           %+  slam  gat
@@ -1137,7 +1137,7 @@
     ++  do-scry
       |=  [care=term =desk =path]
       ^-  (unit (unit cage))
-      (rof ~ /eyre care [our desk da+now] path)
+      (rof [~ ~] /eyre care [our desk da+now] path)
     ::
     ++  error-response
       |=  [status=@ud =tape]
@@ -1152,7 +1152,7 @@
     ^-  (quip move server-state)
     ::  if the agent isn't running, we synchronously serve a 503
     ::
-    ?.  !<(? q:(need (need (rof ~ /eyre %gu [our app da+now] /$))))
+    ?.  !<(? q:(need (need (rof [~ ~] /eyre %gu [our app da+now] /$))))
       %^  return-static-data-on-duct  503  'text/html'
       %:  error-page
         503
@@ -1545,7 +1545,7 @@
     ++  code
       ^-  @ta
       =/  res=(unit (unit cage))
-        (rof ~ /eyre %j [our %code da+now] /(scot %p our))
+        (rof [~ ~] /eyre %j [our %code da+now] /(scot %p our))
       (rsh 3 (scot %p ;;(@ q.q:(need (need res)))))
     ::  +session-cookie-string: compose session cookie
     ::
@@ -2746,7 +2746,7 @@
       ?~  sub
         ((trace 0 |.("no subscription for request-id {(scow %ud request-id)}")) ~)
       =/  des=(unit (unit cage))
-        (rof ~ /eyre %gd [our app.u.sub da+now] /$)
+        (rof [~ ~] /eyre %gd [our app.u.sub da+now] /$)
       ?.  ?=([~ ~ *] des)
         ((trace 0 |.("no desk for app {<app.u.sub>}")) ~)
       `!<(=desk q.u.u.des)
@@ -2782,7 +2782,7 @@
         =*  have=mark  mark.event
         =/  convert=(unit vase)
           =/  cag=(unit (unit cage))
-            (rof ~ /eyre %cf [our desk.event da+now] /[have]/json)
+            (rof [~ ~] /eyre %cf [our desk.event da+now] /[have]/json)
           ?.  ?=([~ ~ *] cag)  ~
           `q.u.u.cag
         ?~  convert
@@ -3302,7 +3302,7 @@
   ?~  u  [%| "invalid scry path"]
   ::  perform scry
   ::
-  ?~  res=(rof ~ /eyre u.u)  [%| "failed scry"]
+  ?~  res=(rof [~ ~] /eyre u.u)  [%| "failed scry"]
   ?~  u.res                  [%| "no scry result"]
   =*  mark   p.u.u.res
   =*  vase   q.u.u.res
@@ -3331,7 +3331,7 @@
         %c
       [%& q.beam]
         %g
-      =/  res  (rof ~ /eyre %gd [our q.beam da+now] /$)
+      =/  res  (rof [~ ~] /eyre %gd [our q.beam da+now] /$)
       ?.  ?=([~ ~ *] res)
         [%| "no desk for app {<q.beam>}"]
       [%& !<(=desk q.u.u.res)]
@@ -3341,7 +3341,7 @@
     |=  [=vase from=mark to=mark =desk]
     ^-  (each ^vase tape)
     ?:  =(from to)  [%& vase]
-    =/  tub  (rof ~ /eyre %cc [our desk da+now] /[from]/[to])
+    =/  tub  (rof [~ ~] /eyre %cc [our desk da+now] /[from]/[to])
     ?.  ?=([~ ~ %tube *] tub)
       [%| "no tube from {(trip from)} to {(trip to)}"]
     =/  tube  !<(tube:clay q.u.u.tub)
@@ -4116,97 +4116,104 @@
     [~ ~]
   ?.  =(our who)
     ?.  =([%da now] p.lot)
-      [~ ~]
+      ~
     ~&  [%r %scry-foreign-host who]
     ~
-  ?:  &(?=(%x ren) ?=(%$ syd))
-    =,  server-state.ax
-    ?+  tyl  [~ ~]
-      [%$ %whey ~]         =-  ``mass+!>(`(list mass)`-)
-                           :~  bindings+&+bindings.server-state.ax
-                               auth+&+auth.server-state.ax
-                               connections+&+connections.server-state.ax
-                               channels+&+channel-state.server-state.ax
-                               axle+&+ax
-                           ==
-    ::
-      [%cors ~]            ``noun+!>(cors-registry)
-      [%cors %requests ~]  ``noun+!>(requests.cors-registry)
-      [%cors %approved ~]  ``noun+!>(approved.cors-registry)
-      [%cors %rejected ~]  ``noun+!>(rejected.cors-registry)
-    ::
-        [%cors ?(%approved %rejected) @ ~]
-      =*  kind  i.t.tyl
-      =*  orig  i.t.t.tyl
-      ?~  origin=(slaw %t orig)  [~ ~]
-      ?-  kind
-        %approved  ``noun+!>((~(has in approved.cors-registry) u.origin))
-        %rejected  ``noun+!>((~(has in rejected.cors-registry) u.origin))
-      ==
-    ::
-        [%eauth %url ~]
-      =*  endpoint  endpoint.auth.server-state.ax
-      ?.  ?=(%da -.p.lot)  [~ ~]
-      ::  we cannot answer for something prior to the last set time,
-      ::  or something beyond the present moment.
+  :: private endpoints
+  ?:  ?=([~ ~] lyc)
+    ?:  &(?=(%x ren) ?=(%$ syd))
+      =,  server-state.ax
+      ?+  tyl  ~
+        [%$ %whey ~]         =-  ``mass+!>(`(list mass)`-)
+                             :~  bindings+&+bindings.server-state.ax
+                                 auth+&+auth.server-state.ax
+                                 connections+&+connections.server-state.ax
+                                 channels+&+channel-state.server-state.ax
+                                 axle+&+ax
+                             ==
       ::
-      ?:  ?|  (lth q.p.lot time.endpoint)
-              (gth q.p.lot now)
-          ==
-        ~
-      :^  ~  ~  %noun
-      !>  ^-  (unit @t)
-      =<  eauth-url:eauth:authentication
-      (per-server-event [eny *duct now rof] server-state.ax)
-    ::
-        [%authenticated %cookie @ ~]
-      ?~  cookies=(slaw %t i.t.t.tyl)  [~ ~]
-      :^  ~  ~  %noun
-      !>  ^-  ?
-      %-  =<  request-is-authenticated:authentication
-          (per-server-event [eny *duct now rof] server-state.ax)
-      %*(. *request:http header-list ['cookie' u.cookies]~)
-    ::
-        [%cache @ @ ~]
-      ?~  aeon=(slaw %ud i.t.tyl)        [~ ~]
-      ?~  url=(slaw %t i.t.t.tyl)        [~ ~]
-      ?~  entry=(~(get by cache) u.url)  [~ ~]
-      ?.  =(u.aeon aeon.u.entry)         [~ ~]
-      ?~  val=val.u.entry                [~ ~]
-      ``noun+!>(u.val)
-    ::
-        [%'_~_' *]
-      =/  mym  (scry-mime now rof (deft:de-purl:html tyl))
-      ?:  ?=(%| -.mym)  [~ ~]
-      ``noun+!>(p.mym)
+        [%cors ~]            ``noun+!>(cors-registry)
+        [%cors %requests ~]  ``noun+!>(requests.cors-registry)
+        [%cors %approved ~]  ``noun+!>(approved.cors-registry)
+        [%cors %rejected ~]  ``noun+!>(rejected.cors-registry)
+      ::
+          [%cors ?(%approved %rejected) @ ~]
+        =*  kind  i.t.tyl
+        =*  orig  i.t.t.tyl
+        ?~  origin=(slaw %t orig)  [~ ~]
+        ?-  kind
+          %approved  ``noun+!>((~(has in approved.cors-registry) u.origin))
+          %rejected  ``noun+!>((~(has in rejected.cors-registry) u.origin))
+        ==
+      ::
+          [%authenticated %cookie @ ~]
+        ?~  cookies=(slaw %t i.t.t.tyl)  [~ ~]
+        :^  ~  ~  %noun
+        !>  ^-  ?
+        %-  =<  request-is-authenticated:authentication
+            (per-server-event [eny *duct now rof] server-state.ax)
+        %*(. *request:http header-list ['cookie' u.cookies]~)
+      ::
+          [%'_~_' *]
+        =/  mym  (scry-mime now rof (deft:de-purl:html tyl))
+        ?:  ?=(%| -.mym)  [~ ~]
+        ``noun+!>(p.mym)
+      ==
+    ?.  ?=(%$ ren)  ~
+    ?+  syd  ~
+      %bindings              ``noun+!>(bindings.server-state.ax)
+      %connections           ``noun+!>(connections.server-state.ax)
+      %authentication-state  ``noun+!>(auth.server-state.ax)
+      %channel-state         ``noun+!>(channel-state.server-state.ax)
+      ::
+        %host
+      %-  (lift (lift |=(a=hart:eyre [%hart !>(a)])))
+      ^-  (unit (unit hart:eyre))
+      =.  p.lot  ?.(=([%da now] p.lot) p.lot [%tas %real])
+      ?+  p.lot
+        [~ ~]
+      ::
+          [%tas %fake]
+        ``[& [~ 8.443] %& /localhost]
+      ::
+          [%tas %real]
+        =*  domains  domains.server-state.ax
+        =*  ports  ports.server-state.ax
+        =/  =host:eyre  [%& ?^(domains n.domains /localhost)]
+        =/  port=(unit @ud)
+          ?.  ?=(^ secure.ports)
+            ?:(=(80 insecure.ports) ~ `insecure.ports)
+          ?:(=(443 u.secure.ports) ~ secure.ports)
+        ``[?=(^ secure.ports) port host]
+      ==
     ==
-  ?.  ?=(%$ ren)
-    [~ ~]
-  ?+  syd  [~ ~]
-    %bindings              ``noun+!>(bindings.server-state.ax)
-    %connections           ``noun+!>(connections.server-state.ax)
-    %authentication-state  ``noun+!>(auth.server-state.ax)
-    %channel-state         ``noun+!>(channel-state.server-state.ax)
-  ::
-      %host
-    %-  (lift (lift |=(a=hart:eyre [%hart !>(a)])))
-    ^-  (unit (unit hart:eyre))
-    =.  p.lot  ?.(=([%da now] p.lot) p.lot [%tas %real])
-    ?+  p.lot
-      [~ ~]
+  :: public endpoints
+  ?+  tyl  ~
+      [%eauth %url ~]
+    =*  endpoint  endpoint.auth.server-state.ax
+    ?.  ?=(%da -.p.lot)  [~ ~]
+    ::  we cannot answer for something prior to the last set time,
+    ::  or something beyond the present moment.
     ::
-        [%tas %fake]
-      ``[& [~ 8.443] %& /localhost]
+    ?:  ?|  (lth q.p.lot time.endpoint)
+            (gth q.p.lot now)
+        ==
+      ~
+    :^  ~  ~  %noun
+    !>  ^-  (unit @t)
+    =<  eauth-url:eauth:authentication
+    (per-server-event [eny *duct now rof] server-state.ax)
+ ::
+      [%cache @ @ ~]
+    =,  server-state.ax
+    ?~  aeon=(slaw %ud i.t.tyl)        [~ ~]
+    ?~  url=(slaw %t i.t.t.tyl)        [~ ~]
+    ?~  entry=(~(get by cache) u.url)  [~ ~]
+    ?.  =(u.aeon aeon.u.entry)         [~ ~]
+    ?~  val=val.u.entry                [~ ~]
+    ?:  &(auth.u.val !=([~ ~] lyc))    ~ 
+    ``noun+!>(u.val)
     ::
-        [%tas %real]
-      =*  domains  domains.server-state.ax
-      =*  ports  ports.server-state.ax
-      =/  =host:eyre  [%& ?^(domains n.domains /localhost)]
-      =/  port=(unit @ud)
-        ?.  ?=(^ secure.ports)
-          ?:(=(80 insecure.ports) ~ `insecure.ports)
-        ?:(=(443 u.secure.ports) ~ secure.ports)
-      ``[?=(^ secure.ports) port host]
-    ==
   ==
+
 --

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -126,9 +126,12 @@
 ++  of-farm
   |_  =farm
   ++  key-coops
-    =|  pos=path
-    %-  ~(gas in *(set coop))
-    |-  ^-  (list coop)
+    |=  pos=path
+    ^-  (list coop)
+    =/  frm  (get-farm pos)
+    ?~  frm  ~
+    =.  farm  u.frm
+    |- 
     ?:  ?=(%coop -.farm)
       ~[pos]
     %-  zing
@@ -156,6 +159,7 @@
     ?~  nex=(~(get by q.farm) i.path)
       ~
     $(wer [i.path wer], path t.path, farm u.nex)
+  ::
   ++  put
     |=  [=path =plot]
     ^-  (unit _farm)
@@ -247,6 +251,18 @@
       `p.farm
     ?:  ?=(%coop -.farm)
       ~
+    ?~  nex=(~(get by q.farm) i.path)
+      ~
+    $(path t.path, farm u.nex)
+  ::
+  ++  get-farm
+    |=  =path
+    ^-  (unit ^farm)
+    ?:  ?=(%coop -.farm)
+      ?~  (~(get by q.farm) path)
+        ~
+      `farm
+    ?~  path  ~
     ?~  nex=(~(get by q.farm) i.path)
       ~
     $(path t.path, farm u.nex)
@@ -982,6 +998,29 @@
     ?~  kil  mo-core
     ~>  %slog.0^leaf/"gall: stopping {<i.kil>}"
     $(kil t.kil, mo-core (mo-idle prov i.kil))
+  ::
+  ++  mo-authorized-coop
+    |=  [lyc=(set ship) =farm dap=term =path =coop]
+    %-  ~(all in lyc)
+    |=  =ship
+    =/  cag  (mo-peek | dap [~ ship path] %c (snoc coop (scot %p ship)))
+    ?.  ?=([~ ~ ^] cag)
+      %.n
+    ?~  res=((soft ,?) q.q.u.u.cag)
+      %.n
+    u.res
+  ::
+  ++  mo-authorized
+    |=  [lyc=gang =farm dap=term =path]
+    ^-  ?
+    ?:  =([~ ~] lyc)
+      %.y
+    ?~  (~(get-hutch of-farm farm) path)
+      %.y
+    ?~  coop=(~(match-coop of-farm farm) path)
+      %.n
+    ?<  ?=(~ lyc)
+    (mo-authorized-coop u.lyc farm dap path u.coop)
   ::  +mo-peek:  call to +ap-peek (which is not accessible outside of +mo).
   ::
   ++  mo-peek
@@ -1008,7 +1047,7 @@
       =/  =case  da+now
       =/  yok  (~(got by yokes.state) dap)
       =/  =desk  q.beak:?>(?=(%live -.yok) yok)  ::TODO acceptable assertion?
-      =/  sky  (rof ~ /gall %cb [our desk case] /[mark.deal])
+      =/  sky  (rof [~ ~] /gall %cb [our desk case] /[mark.deal])
       ?-    sky
           ?(~ [~ ~])
         =/  ror  "gall: raw-poke fail :{(trip dap)} {<mark.deal>}"
@@ -1032,7 +1071,7 @@
       =/  mars-path   /[a.mars]/[b.mars]
       =/  yok  (~(got by yokes.state) dap)
       =/  =desk  q.beak:?>(?=(%live -.yok) yok)  ::TODO acceptable assertion?
-      =/  sky  (rof ~ /gall %cc [our desk case] mars-path)
+      =/  sky  (rof [~ ~] /gall %cc [our desk case] mars-path)
       ?-    sky
           ?(~ [~ ~])
         =/  ror  "gall: poke cast fail :{(trip dap)} {<mars>}"
@@ -1528,7 +1567,7 @@
         =/  =case       da+now
         =/  bek=beak    [our q.beak.yoke case]
         =/  mars-path  /[a.mars]/[b.mars]
-        =/  sky  (rof ~ /gall %cc bek mars-path)
+        =/  sky  (rof [~ ~] /gall %cc bek mars-path)
         ?-    sky
             ?(~ [~ ~])
           %-  (slog leaf+"watch-as fact conversion find-fail" >sky< ~)
@@ -1708,7 +1747,7 @@
       =/  tub=(unit tube:clay)
         ?:  =(have want)  `(bake same ^vase)
         =/  tuc=(unit (unit cage))
-          (rof ~ /gall %cc [our q.beak.yoke da+now] /[have]/[want])
+          (rof [~ ~] /gall %cc [our q.beak.yoke da+now] /[have]/[want])
         ?.  ?=([~ ~ *] tuc)  ~
         `!<(tube:clay q.u.u.tuc)
       ?~  tub
@@ -1857,7 +1896,7 @@
         ?:  ?=(%spider agent-name)
           :-  [%fact mark.unto !>(noun.unto)]
           ap-core
-        =/  sky  (rof ~ /gall %cb [our q.beak.yoke case] /[mark.unto])
+        =/  sky  (rof [~ ~] /gall %cb [our q.beak.yoke case] /[mark.unto])
         ?.  ?=([~ ~ *] sky)
           (mean leaf+"gall: ames mark fail {<mark.unto>}" ~)
         ::
@@ -2129,7 +2168,7 @@
     ++  ap-mule
       |=  run=_^?(|.(*step:agent))
       ^-  (each step:agent tang)
-      =/  res  (mock [run %9 2 %0 1] (look rof ~ /gall/[agent-name]))
+      =/  res  (mock [run %9 2 %0 1] (look rof [~ ~] /gall/[agent-name]))
       ?-  -.res
         %0  [%& !<(step:agent [-:!>(*step:agent) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -2140,7 +2179,7 @@
     ++  ap-mule-peek
       |=  run=_^?(|.(*(unit (unit cage))))
       ^-  (each (unit (unit cage)) tang)
-      =/  res  (mock [run %9 2 %0 1] (look rof ~ /gall/[agent-name]))
+      =/  res  (mock [run %9 2 %0 1] (look rof [~ ~] /gall/[agent-name]))
       ?-  -.res
         %0  [%& !<((unit (unit cage)) [-:!>(*(unit (unit cage))) p.res])]
         %1  [%| (smyt ;;(path p.res)) ~]
@@ -2708,6 +2747,7 @@
   ?.  ?=([%$ *] path)  ::  [%$ *] is for the vane, all else is for the agent
     ?.  ?&  =(our ship)
             =([%$ %da now] coin)
+            =([~ ~] lyc)
         ==                           ~
     ?.  (~(has by yokes.state) dap)  [~ ~]
     ?.  ?=(^ path)                   ~
@@ -2720,6 +2760,7 @@
           =(~ path)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     =;  hav=?
       [~ ~ noun+!>(hav)]
@@ -2730,6 +2771,7 @@
           =(~ path)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     =/  yok=(unit yoke)  (~(get by yokes.state) dap)
     ?.  ?=([~ %live *] yok)
@@ -2740,6 +2782,7 @@
           =(~ path)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     :+  ~  ~
     :-  %apps  !>  ^-  (set [=dude live=?])
@@ -2756,6 +2799,7 @@
           =(~ path)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     :+  ~  ~
     :-  %nonces  !>  ^-  (map dude @)
@@ -2767,6 +2811,7 @@
           ?=([@ @ ^] path)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     =/  yok  (~(get by yokes.state) dap)
     ?.  ?=([~ %live *] yok)
@@ -2780,6 +2825,7 @@
   ?:  ?&  =(%v care)
           =([%$ %da now] coin)
           =(our ship)
+          =([~ ~] lyc)
       ==
     =/  yok  (~(get by yokes.state) dap)
     ?.  ?=([~ %live *] yok)
@@ -2805,6 +2851,8 @@
     ?.  ?=([~ %live *] yok)             [~ ~]
     ?~  ski=(~(get of-farm sky.u.yok) path)  [~ ~]
     ?~  las=(ram:on-path fan.u.ski)     [~ ~]
+    ?.  (mo-authorized:mo lyc sky.u.yok q.bem path)
+      ~
     ``case/!>(ud/key.u.las)
   ::
   ?:  &(?=(%x care) ?=([%'1' *] path))
@@ -2814,6 +2862,7 @@
     ?:  ?=(%$ q.bem)  :: app %$ reserved
       ?+    path  ~
           [%whey ~]
+        ?.  ?=([~ ~] lyc)  ~
         =/  blocked
           =/  queued  (~(run by blocked.state) |=((qeu blocked-move) [%.y +<]))
           (sort ~(tap by queued) aor)
@@ -2842,6 +2891,8 @@
     ?:  ?=(%nuke -.u.yok)  ~
     ?~  ski=(~(get of-farm sky.u.yok) path)
       ~
+    ?.  (mo-authorized:mo lyc sky.u.yok q.bem path)
+      ~
     =/  res=(unit (each page @uvI))
       ?+    -.r.bem  ~
           %ud  (bind (get:on-path fan.u.ski p.r.bem) tail)
@@ -2866,6 +2917,16 @@
     =>  .(path t.path)
     =/  yok  (~(get by yokes.state) q.bem)
     ?.  ?=([~ %live *] yok)  ~
+    =/  keys=(list coop)  (~(key-coops of-farm sky.u.yok) path)
+    =/  authorized=?
+      ?:  =([~ ~] lyc)  %.y
+      |-
+      ?~  keys  %.y
+      ?<  ?=(~ lyc)
+      ?.  (mo-authorized-coop:mo u.lyc sky.u.yok q.bem path i.keys)
+        %.n
+      $(keys t.keys)
+    ?.  authorized  ~
     :^  ~  ~  %file-list  !>  ^-  (list ^path)
     %+  skim  (turn ~(tap-plot of-farm sky.u.yok) head)
     |=  =spur
@@ -2881,6 +2942,8 @@
     =/  yok  (~(get by yokes.state) q.bem)
     ?.  ?=([~ %live *] yok)             ~
     ?~  ski=(~(get of-farm sky.u.yok) path)  ~
+    ?.  (mo-authorized:mo lyc sky.u.yok q.bem path)
+      ~
     =/  res=(unit (pair @da (each noun @uvI)))
       ?+  -.r.bem  ~
         %ud  (get:on-path fan.u.ski p.r.bem)

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -395,7 +395,7 @@
   ::
   ?.  ?=(%& -.why)  ~
   =*  his  p.why
-  ?:  &(?=(%x ren) =(tyl //whey))
+  ?:  &(?=(%x ren) =(tyl //whey) =([~ ~] lyc))
     =/  maz=(list mass)
       :~  nex+&+next-id.state.ax
           outbound+&+outbound-duct.state.ax

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -1065,7 +1065,7 @@
   ::
   ::  XX review for security, stability, cases other than now
   ::
-  ?.  =(lot [%$ %da now])  ~
+  ?.  &(=(lot [%$ %da now]) =([~ ~] lyc))  ~
   ::
   ?:  &(?=(%x ren) =(tyl //whey))
     =/  maz=(list mass)

--- a/pkg/arvo/sys/vane/khan.hoon
+++ b/pkg/arvo/sys/vane/khan.hoon
@@ -72,7 +72,7 @@
 ++  get-dais
   |=  [=beak =mark rof=roof]
   ^-  dais:clay
-  ?~  ret=(rof ~ /khan %cb beak /[mark])
+  ?~  ret=(rof [~ ~] /khan %cb beak /[mark])
     ~|(mark-unknown+mark !!)
   ?~  u.ret
     ~|(mark-invalid+mark !!)
@@ -82,7 +82,7 @@
 ++  get-tube
   |=  [=beak =mark =out=mark rof=roof]
   ^-  tube:clay
-  ?~  ret=(rof ~ /khan %cc beak /[mark]/[out-mark])
+  ?~  ret=(rof [~ ~] /khan %cc beak /[mark]/[out-mark])
     ~|(tube-unknown+[mark out-mark] !!)
   ?~  u.ret
     ~|(tube-invalid+[mark out-mark] !!)

--- a/pkg/arvo/sys/vane/lick.hoon
+++ b/pkg/arvo/sys/vane/lick.hoon
@@ -88,11 +88,12 @@
   |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   |^
-  ::  only respond for the local identity, current timestamp
+  ::  only respond for the local identity, current timestamp, root gang
   ::
   ?.  ?&  =(our p.bem)
           =(%$ q.bem) 
           =([%da now] r.bem)
+          =([~ ~] lyc)
       ==
     ~
   ?+  car  ~

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -5256,7 +5256,7 @@
         |=  [rof=roof pov=path our=ship now=@da who=ship]
         ;;  ship
         =<  q.q  %-  need  %-  need
-        (rof ~ pov %j `beam`[[our %sein %da now] /(scot %p who)])
+        (rof [~ ~] pov %j `beam`[[our %sein %da now] /(scot %p who)])
       --
   ::  middle core: stateless queries for default numeric sponsorship
   ::


### PR DESCRIPTION
We've had the gang system for quite a while to set privilege levels when scrying. A gang of `[~ ~]` indicates that you are "root" and vanes should never hide data from you. A gang of `~` indicates that anybody could be asking, vanes should block requests for private data. The gang can also be a set of ships, in which case the permissions have to be checked for each one. The interface has existed for a while but the gang system had been unimplemented until now. This PR goes through every scry callsite and arm in every vane and enforces the gang. Some scry callsites are in vere, see urbit/vere#569.

This fixes a security hole with #6790 where you could use unencrypted remote scry to fetch encrypted private data.

Compiles but as of yet untested.