### PR TITLE
ames: produce correct larval state tag

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1461,7 +1461,7 @@
     ::  lifecycle arms; mostly pass-throughs to the contained adult ames
     ::
     ++  scry  scry:adult-core
-    ++  stay  [%17 %larva queued-events ames-state.adult-gate]
+    ++  stay  [%18 %larva queued-events ames-state.adult-gate]
     ++  load
       |=  $=  old
           $%  $:  %4


### PR DESCRIPTION
Producing the wrong tag for the larval state could cause problems when updating ames.hoon because we would be regressing back to a previous state that doesn't nest in our latest. Luckily, ames-states 17 and 18 are identical, so we are only going to retrieve (again) our public keys in +molt and then evolve to adult ames, with the latest tag.

(note: still untested on live ships)