### PR TITLE
kiln: check for desk.bill in +poke-rein

### DIFF
--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -755,7 +755,10 @@
 ::
 ++  poke-rein
   |=  [=desk =rein]
-  abet:(emit %pass /kiln/rein %arvo %c %rein desk rein)
+  ?:  .^(? %cu /(scot %p our)/[desk]/(scot %da now)/desk/bill)
+    abet:(emit %pass /kiln/rein %arvo %c %rein desk rein)
+  =<  abet  %-  spam
+  ~[leaf+"kiln: rein not updated due to missing desk.bill on {<desk>}"]
 ::
 ++  poke-revive
   |=  =desk


### PR DESCRIPTION
Currently, the `|rein` generator's behavior can cause confusion when it's used to start agents on desks without a `desk.bill` file. Although it will apparently succeed and the desk's `rein` will be updated (as reflected in the `force on:` field in the `+vats` output for the desk), the specified agent won't actually be started because `+goad` skips desks that don't include a `desk.bill` without providing any indication that it has done so. This adds a check for a `desk.bill` on the desk passed to `+poke-rein`, and if there isn't one, `+poke-rein` will no-op and produce an error message.

Resolves #6527