### PR TITLE
restore rut:by as an alias of urn:by

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1588,6 +1588,8 @@
     ?~  a  a
     [n=[p=p.n.a q=(b q.n.a)] l=$(a l.a) r=$(a r.a)]
   ::
+  ++  rut  urn                                          :: ~2023.12.30: deprecated; use urn instead
+  ::
   ++  tap                                               ::  listify pairs
     =<  $
     ~/  %tap


### PR DESCRIPTION
## Context

https://github.com/urbit/urbit/pull/6640 removed `rut:by` because it was a duplicate of `urn:by`. 

## Motivation

I think we should break our habit of breaking public interfaces whenever possible. We don't know that there isn't software out there that depends on `rut:by`, and by removing it we force some developer to go and update all their code for no real reason.

This PR makes `rut:by` into an alias of `urn:by`. That means we don't have more surface area to introduce bugs (the reason deleting code is considered "good"), and no one's interface breaks. I've marked it as deprecated in a comment — further in the future we can remove it after giving anyone that relies on this ample time to migrate away from it.