### PR TITLE
hoon: generalize +trim

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -4266,9 +4266,9 @@
   ::  ?.  ((sane a) b)  !!
   b
 ::
-++  trim                                                ::  tape split
-  |=  [a=@ b=tape]
-  ^-  [p=tape q=tape]
+++  trim                                                ::  list split
+  |*  [a=@ b=(list)]
+  ^+  [p=b q=b]
   ?~  b
     [~ ~]
   ?:  =(0 a)


### PR DESCRIPTION
It was written for tapes, but can operate on arbitrary lists just fine.

We update it in-place here, for the smallest/clearest diff, but can move it into the lists section of the library as desired.