### PR TITLE
drum: prevent Dojo crash with M-c on certain characters

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -1070,8 +1070,9 @@
   ++  wrd                                             ::  next or current word
     |=  a=(list @)
     =|  i=@ud
+    ?~  a  i
     |-  ^-  @ud
-    ?:  |(?=(~ a) (alnm i.a))  i
+    ?:  |(?=(~ t.a) (alnm i.a))  i
     $(i +(i), a t.a)
   --
 --


### PR DESCRIPTION
This PR addresses an off-by-one error in `wrd:offset`. Previously, if M-c were used on a non-alphanumeric character and there were no alphanumeric characters between the position of the cursor and the end of the buffer, `wrd:offset` would increment its counter to a value one greater than the remaining length of the buffer. As a result, this `+snag` call in `/lib/sole` would fail due to its using an out-of-bounds index, causing Dojo to crash and unlink: https://github.com/urbit/urbit/blob/4576213e53e186083d67fd65497c031b6886b8d0/pkg/base-dev/lib/sole.hoon#L86
 

This fix corrects the issue by modifying `wrd` to check if the next character is null (i.e. the end of the buffer) and if so to return the current value of the counter rather than incrementing, preventing the off-by-one error and resultant crash.

Resolves #6864 