### PR TITLE
gall: separate put:of-grow to put-tend and put-grow

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2758,9 +2758,10 @@
   +$  boat  (map [=wire =ship =term] [acked=? =path])   ::  outgoing subs
   +$  boar  (map [=wire =ship =term] nonce=@)           ::  and their nonces
   ::
+  +$  fans  ((mop @ud (pair @da (each page @uvI))) lte)
   +$  plot
     $:  bob=(unit @ud)
-        fan=((mop @ud (pair @da (each page @uvI))) lte)
+        fan=fans
     ==
   +$  stats                                             ::  statistics
     $:  change=@ud                                      ::  processed move count
@@ -2776,7 +2777,6 @@
         [%plot p=(unit plot) q=(map @ta farm)]
     ==
   ::
-
   +$  egg                                               ::  migratory agent state
     $%  [%nuke sky=(map spur @ud) cop=(map coop hutch)] ::  see /sys/gall $yoke
         $:  %live
@@ -2823,9 +2823,7 @@
         ==                                              ::
         $:  wex=boat                                    ::  outgoing subs
             sup=bitt                                    ::  incoming subs
-            $=  sky                                     ::  scry bindings
-            %+  map  path                               ::
-            ((mop @ud (pair @da (each page @uvI))) lte) ::
+            sky=(map path fans)                         ::  scry bindings
         ==                                              ::
         $:  act=@ud                                     ::  change number
             eny=@uvJ                                    ::  entropy

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -146,7 +146,7 @@
     |=  [=path =plot]
     ^-  (unit _farm)
     ?:  ?=(%coop -.farm)
-      `farm(q (~(put by q.farm) path plot))
+      ~
     ?~  path
       `farm(p `plot)
     =/  nex  (~(get by q.farm) i.path)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -108,11 +108,6 @@
           gem=(jug coop [path page])
   ==  ==
 ::
-+$  plot
-  $:  bob=(unit @ud)
-      fan=((mop @ud (pair @da (each page @uvI))) lte)
-  ==
-::
 ++  of-farm
   |_  =farm
   ++  key-coops

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -181,7 +181,7 @@
     %+  put  spur
     =-  ski(fan (put:on-path fan.ski -< -> &/page))
     ?~  las=(ram:on-path fan.ski)
-      [(fall bob.ski 1) now]
+      [?~(bob.ski 1 +(u.bob.ski)) now]
     :_  (max now +(p.val.u.las))
     ?~(bob.ski +(key.u.las) +((max key.u.las u.bob.ski)))
   ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -130,14 +130,6 @@
     ^-  (list coop)
     ^$(pos (snoc pos seg), farm f)
   ::
-  ++  migrate
-    |=  from=(map spur plot)
-    =/  from  ~(tap by from)
-    |-  ^+  farm
-    ?~  from  farm
-    =.  farm  (need (put i.from))
-    $(from t.from)
-  ::
   ++  match-coop
     =|  wer=path
     |=  =path

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -142,7 +142,7 @@
       ~
     $(wer [i.path wer], path t.path, farm u.nex)
   ::
-  ++  put
+  ++  put-grow
     |=  [=path =plot]
     ^-  (unit _farm)
     ?:  ?=(%coop -.farm)
@@ -155,10 +155,24 @@
     ?~  res  ~
     `farm(q (~(put by q.farm) i.path u.res))
   ::
+  ++  put-tend
+    |=  [=path =plot]
+    ^-  (unit _farm)
+    ?:  ?=(%coop -.farm)
+      `farm(q (~(put by q.farm) path plot))
+    ?~  path
+      `farm(p `plot)
+    ?~  nex=(~(get by q.farm) i.path)
+      ~
+    =/  res
+      $(path t.path, farm u.nex)
+    ?~  res  ~
+    `farm(q (~(put by q.farm) i.path u.res))
+  ::
   ++  grow
     |=  [=spur now=@da =page]
     =/  ski  (gut spur)
-    %+  put  spur
+    %+  put-grow  spur
     =-  ski(fan (put:on-path fan.ski -< -> &/page))
     ?~  las=(ram:on-path fan.ski)
       [(fall bob.ski 1) now]
@@ -258,6 +272,7 @@
     ?~  nex=(~(get by q.farm) i.path)
       ~
     $(path t.path, farm u.nex)
+  ::
   ++  tap-plot
     =|  wer=path
     |-  ^-  (list [path plot])
@@ -512,7 +527,7 @@
         =/  sky=(list [=spur bob=@ud])  ~(tap by sky.u.yak)
         |-
         ?~  sky  farm
-        =.  farm  (need (~(put of-farm farm) spur.i.sky [`bob.i.sky ~]))
+        =.  farm  (need (~(put-tend of-farm farm) spur.i.sky [`bob.i.sky ~]))
         $(sky t.sky)
       == 
     ::
@@ -1424,7 +1439,7 @@
       |=  [=spur =page]
       ^+  ap-core
       :: check here, and no-op, so that +need below does not crash
-      ?:  =(~ (ap-match-coop spur))
+      ?:  =(^ (ap-match-coop spur))
         %.  ap-core
         %+  trace  &
         [leaf+"gall: {<agent-name>}: grow {<spur>} has coop, dropping"]~
@@ -1455,7 +1470,7 @@
       ::
           %&  ::  replace with hash
         %-  need
-        %+  ~(put of-farm sky.yoke)  spur
+        %+  ~(put-grow of-farm sky.yoke)  spur
         u.old(fan (put:on-path fan.u.old yon u.val(q |/(shax (jam p.q.u.val)))))
       ==
     ::  +ap-cull: delete all bindings up to and including .case
@@ -1491,7 +1506,7 @@
         %.  sky.yoke
         %+  trace  &
         [leaf+"gall: {<agent-name>}: cull {<[case spur]>} invalid path structure"]~
-      %+  ~(put of-farm sky.yoke)  spur  ::  delete all older paths
+      %+  ~(put-grow of-farm sky.yoke)  spur  ::  delete all older paths
       [`yon (lot:on-path fan.u.old `yon ~)]
     ::  +ap-from-internal: internal move to move.
     ::
@@ -2692,7 +2707,7 @@
           farm
         =/  [=spur p=plot]  i.ski
         =;  new
-          ?~  nex=(~(put of-farm farm) spur new)
+          ?~  nex=(~(put-tend of-farm farm) spur new)
             ~&  %weird
             !!  :: shouldn't continue else loss of ref integrity
             :: $(ski t.ski)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -142,6 +142,17 @@
       ~
     $(wer [i.path wer], path t.path, farm u.nex)
   ::
+  ++  put
+    |=  [=path =plot]
+    ^-  _farm
+    ?:  ?=(%coop -.farm)
+      farm(q (~(put by q.farm) path plot))
+    ?~  path
+      farm(p `plot)
+    =/  nex  (~(get by q.farm) i.path)
+    =/  res  $(path t.path, farm ?~(nex *^farm u.nex))
+    farm(q (~(put by q.farm) i.path res))
+  ::
   ++  put-grow
     |=  [=path =plot]
     ^-  (unit _farm)
@@ -172,7 +183,7 @@
   ++  grow
     |=  [=spur now=@da =page]
     =/  ski  (gut spur)
-    %+  put-grow  spur
+    %+  put  spur
     =-  ski(fan (put:on-path fan.ski -< -> &/page))
     ?~  las=(ram:on-path fan.ski)
       [(fall bob.ski 1) now]
@@ -527,7 +538,7 @@
         =/  sky=(list [=spur bob=@ud])  ~(tap by sky.u.yak)
         |-
         ?~  sky  farm
-        =.  farm  (need (~(put-tend of-farm farm) spur.i.sky [`bob.i.sky ~]))
+        =.  farm  (need (~(put-grow of-farm farm) spur.i.sky [`bob.i.sky ~]))
         $(sky t.sky)
       == 
     ::
@@ -1397,10 +1408,10 @@
         ?.  (~(has by gem.yoke) coop)
           %.  ap-core
           %+  trace  &
-          [leaf+"gall: {<agent-name>} no such coop {<coop>}, dropping %grow at {<path>}"]~
+          [leaf+"gall: {<agent-name>} no such coop {<coop>}, dropping %tend at {<path>}"]~
         =.  gem.yoke  (~(put ju gem.yoke) coop path page)
         ap-core
-      =.  sky.yoke  (need (~(grow of-farm sky.yoke) (welp coop path) now page))
+      =.  sky.yoke  (~(grow of-farm sky.yoke) (welp coop path) now page)
       ap-core
     ::
     ++  ap-germ
@@ -1439,12 +1450,12 @@
       |=  [=spur =page]
       ^+  ap-core
       :: check here, and no-op, so that +need below does not crash
-      ?:  =(^ (ap-match-coop spur))
+      ?:  ?=(^ (ap-match-coop spur))
         %.  ap-core
         %+  trace  &
         [leaf+"gall: {<agent-name>}: grow {<spur>} has coop, dropping"]~
       =-  ap-core(sky.yoke -)
-      (need (~(grow of-farm sky.yoke) spur now page))
+      (~(grow of-farm sky.yoke) spur now page)
     ::  +ap-tomb: tombstone -- replace bound value with hash
     ::
     ++  ap-tomb
@@ -1469,8 +1480,7 @@
         [leaf+"gall: {<agent-name>}: tomb {<[case spur]>} no-op"]~
       ::
           %&  ::  replace with hash
-        %-  need
-        %+  ~(put-grow of-farm sky.yoke)  spur
+        %+  ~(put of-farm sky.yoke)  spur
         u.old(fan (put:on-path fan.u.old yon u.val(q |/(shax (jam p.q.u.val)))))
       ==
     ::  +ap-cull: delete all bindings up to and including .case
@@ -1501,12 +1511,7 @@
         %+  weld
           "gall: {<agent-name>}: cull {<[case spur]>} out of range, "
         "min: {<key.fis>}, max: {<key.u.las>}"
-      =;  nex=(unit farm)
-        ?^  nex  u.nex
-        %.  sky.yoke
-        %+  trace  &
-        [leaf+"gall: {<agent-name>}: cull {<[case spur]>} invalid path structure"]~
-      %+  ~(put-grow of-farm sky.yoke)  spur  ::  delete all older paths
+      %+  ~(put of-farm sky.yoke)  spur  ::  delete all older paths
       [`yon (lot:on-path fan.u.old `yon ~)]
     ::  +ap-from-internal: internal move to move.
     ::
@@ -2707,7 +2712,7 @@
           farm
         =/  [=spur p=plot]  i.ski
         =;  new
-          ?~  nex=(~(put-tend of-farm farm) spur new)
+          ?~  nex=(~(put-grow of-farm farm) spur new)
             ~&  %weird
             !!  :: shouldn't continue else loss of ref integrity
             :: $(ski t.ski)


### PR DESCRIPTION
Also fixes a check in `+ap-grow` that was the wrong way around. This resulted in `%grow` being broken on 411-rc0.