### PR TITLE
test thread: now prints errors/failures in red instead of gray

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4552,7 +4552,7 @@
       |^  =/  res  (mule |.(read))
           ?:  ?=(%& -.res)  p.res
           %.  [[~ ~] ..park]
-          (slog leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
+          (%*(. slog1 pri 3) leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
       ::
       ++  read
         ^-  [(unit (unit cage)) _..park]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4552,7 +4552,7 @@
       |^  =/  res  (mule |.(read))
           ?:  ?=(%& -.res)  p.res
           %.  [[~ ~] ..park]
-          (%*(. slog1 pri 3) leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
+          (%*(. slog pri 3) leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
       ::
       ++  read
         ^-  [(unit (unit cage)) _..park]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4552,7 +4552,7 @@
       |^  =/  res  (mule |.(read))
           ?:  ?=(%& -.res)  p.res
           %.  [[~ ~] ..park]
-          (%*(. slog pri 3) leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
+          (slog leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
       ::
       ++  read
         ^-  [(unit (unit cage)) _..park]

--- a/pkg/arvo/ted/test.hoon
+++ b/pkg/arvo/ted/test.hoon
@@ -17,14 +17,14 @@
 ::
 ++  run-test
   |=  [pax=path test=test-func]
-  ^-  [ok=? =tang]
+  ^-  [ok=? output=tang result=tang]
   =+  name=(spud pax)
   =+  run=(mule test)
   ?-  -.run
-    %|  |+(welp p.run leaf+"CRASHED {name}" ~)
+    %|  |+[p.run [leaf+"CRASHED {name}" ~]]
     %&  ?:  =(~ p.run)
-          &+[leaf+"OK      {name}"]~
-        |+(flop `tang`[leaf+"FAILED  {name}" p.run])
+          &+[p.run [leaf+"OK      {name}" ~]]
+        |+[p.run [leaf+"FAILED  {name}" ~]]
   ==
 ::  +resolve-test-paths: add test names to file paths to form full identifiers
 ::
@@ -119,7 +119,7 @@
 ?^  fiz
   ;<  cor=(unit vase)  bind:m  (build-file:strandio beam.i.fiz)
   ?~  cor
-    ~>  %slog.0^leaf+"FAILED  {(spud s.beam.i.fiz)} (build)"
+    ~>  %slog.3^leaf+"FAILED  {(spud s.beam.i.fiz)} (build)"
     gather-tests(fiz t.fiz, build-ok |)
   ~>  %slog.0^leaf+"built   {(spud s.beam.i.fiz)}"
   =/  arms=(list test-arm)  (get-test-arms u.cor)
@@ -135,5 +135,6 @@
 |=  [[=path =test-func] ok=_build-ok]
 ^+  ok
 =/  res  (run-test path test-func)
-%-  (slog (flop tang.res))
+%-  (%*(. slog pri ?:(ok.res 0 3)) output.res)
+%-  (%*(. slog pri ?:(ok.res 0 3)) result.res)
 &(ok ok.res)


### PR DESCRIPTION
When something goes wrong it should print in red.  It looks better and adds visual contrast (drawing your eye to the important bit).

Before vs after (test assertion failed):
![image](https://github.com/urbit/urbit/assets/152581965/42a2ff23-11b8-4144-9bb9-3906dded56e6)
![image](https://github.com/urbit/urbit/assets/152581965/42609bdd-ef14-4948-bc30-4ee56d4d218a)

Before vs after (build failure):
![image](https://github.com/urbit/urbit/assets/152581965/1c6e1d32-af5e-461d-aa29-ce1689993024)
![image](https://github.com/urbit/urbit/assets/152581965/b49df403-3823-42be-a0ee-9d8f7e67c452)
