### PR TITLE
clay: do not return false conversion gate from build-cast

### DIFF
--- a/pkg/arvo/app/herm.hoon
+++ b/pkg/arvo/app/herm.hoon
@@ -5,7 +5,6 @@
 ::  keep relevant mark conversions in cache for performance
 ::
 /$  blit-to-json  %blit  %json
-/$  json-to-blit  %json  %blit
 /$  json-to-task  %json  %herm-task
 ::
 =,  jael

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -729,11 +729,7 @@
       ::
       %-  (trace 1 |.("make cast {<a>} -> {<b>}"))
       =^  old=vase  nub  (build-fit %mar a)
-      ?:  =/  ram  (mule |.((slap old !,(*hoon grow))))
-          ?:  ?=(%| -.ram)  %.n
-          =/  lab  (mule |.((slob b p.p.ram)))
-          ?:  ?=(%| -.lab)  %.n
-          p.lab
+      ?:  (has-arm %grow b old)
         ::  +grow core has .b arm; use that
         ::
         %+  gain-leak  cast+a^b
@@ -749,12 +745,7 @@
       ::  try direct +grab
       ::
       =^  new=vase  nub  (build-fit %mar b)
-      =/  rib  (mule |.((slap new !,(*hoon grab))))
-      =/  arm=?
-        ?:  ?=(%| -.rib)  %.n
-        =/  lab  (mule |.((slob a p.p.rib)))
-        ?:  ?=(%| -.lab)  %.n
-        p.lab
+      =/  arm=?  (has-arm %grab a new)
       =/  rab  (mule |.((slap new tsgl/[limb/a limb/%grab])))
       ?:  &(arm ?=(%& -.rab) ?=(^ q.p.rab))
         %+  gain-leak  cast+a^b
@@ -762,6 +753,17 @@
         %-  (trace 4 |.("{<a>} -> {<b>}: +{(trip a)}:grab:{(trip b)}"))
         =.  nub  nob
         :_(nub vase+p.rab)
+      ::  try +jump
+      ::
+      =/  jum  (mule |.((slap old tsgl/[limb/b limb/%jump])))
+      ?:  &((has-arm %jump a old) ?=(%& -.jum))
+        =/  via  !<(mark p.jum)
+        %-  (trace 4 |.("{<a>} -> {<b>}: via {<via>} per +jump:{(trip a)}"))
+        (compose-casts a via b)
+      ?:  &(arm ?=(%& -.rab))
+        =/  via  !<(mark p.rab)
+        %-  (trace 4 |.("{<a>} -> {<b>}: via {<via>} per +grab:{(trip b)}"))
+        (compose-casts a via b)
       ?:  ?=(%noun b)
         %+  gain-leak  cast+a^b
         |=  nob=state
@@ -769,6 +771,28 @@
         =.  nub  nob
         :_(nub vase+same.bud)
       ~|(no-cast-from+[a b] !!)
+    ::
+    ++  compose-casts
+      |=  [x=mark y=mark z=mark]
+      ^-  [soak state]
+      =^  uno=vase  nub  (build-cast x y)
+      =^  dos=vase  nub  (build-cast y z)
+      %+  gain-leak  cast+x^z
+      |=  nob=state
+      =.  nub  nob
+      :_  nub  :-  %vase
+      %+  slap
+        (with-faces uno+uno dos+dos ~)
+      !,(*hoon |=(_+<.uno (dos (uno +<))))
+    ::
+    ++  has-arm
+      |=  [arm=@tas =mark core=vase]
+      ^-  ?
+      =/  rib  (mule |.((slap core [%wing ~[arm]])))
+      ?:  ?=(%| -.rib)  %.n
+      =/  lab  (mule |.((slob mark p.p.rib)))
+      ?:  ?=(%| -.lab)  %.n
+      p.lab
     ::  +build-tube: produce a $tube mark conversion gate from .a to .b
     ::
     ++  build-tube

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -749,24 +749,19 @@
       ::  try direct +grab
       ::
       =^  new=vase  nub  (build-fit %mar b)
+      =/  rib  (mule |.((slap new !,(*hoon grab))))
+      =/  arm=?
+        ?:  ?=(%| -.rib)  %.n
+        =/  lab  (mule |.((slob a p.p.rib)))
+        ?:  ?=(%| -.lab)  %.n
+        p.lab
       =/  rab  (mule |.((slap new tsgl/[limb/a limb/%grab])))
-      ?:  &(?=(%& -.rab) ?=(^ q.p.rab))
+      ?:  &(arm ?=(%& -.rab) ?=(^ q.p.rab))
         %+  gain-leak  cast+a^b
         |=  nob=state
         %-  (trace 4 |.("{<a>} -> {<b>}: +{(trip a)}:grab:{(trip b)}"))
         =.  nub  nob
         :_(nub vase+p.rab)
-      ::  try +jump
-      ::
-      =/  jum  (mule |.((slap old tsgl/[limb/b limb/%jump])))
-      ?:  ?=(%& -.jum)
-        =/  via  !<(mark p.jum)
-        %-  (trace 4 |.("{<a>} -> {<b>}: via {<via>} per +jump:{(trip a)}"))
-        (compose-casts a via b)
-      ?:  ?=(%& -.rab)
-        =/  via  !<(mark p.rab)
-        %-  (trace 4 |.("{<a>} -> {<b>}: via {<via>} per +grab:{(trip b)}"))
-        (compose-casts a via b)
       ?:  ?=(%noun b)
         %+  gain-leak  cast+a^b
         |=  nob=state
@@ -774,19 +769,6 @@
         =.  nub  nob
         :_(nub vase+same.bud)
       ~|(no-cast-from+[a b] !!)
-    ::
-    ++  compose-casts
-      |=  [x=mark y=mark z=mark]
-      ^-  [soak state]
-      =^  uno=vase  nub  (build-cast x y)
-      =^  dos=vase  nub  (build-cast y z)
-      %+  gain-leak  cast+x^z
-      |=  nob=state
-      =.  nub  nob
-      :_  nub  :-  %vase
-      %+  slap
-        (with-faces uno+uno dos+dos ~)
-      !,(*hoon |=(_+<.uno (dos (uno +<))))
     ::  +build-tube: produce a $tube mark conversion gate from .a to .b
     ::
     ++  build-tube


### PR DESCRIPTION
@Fang- noticed today that sometimes the clay `%cf` scry returns a mark conversion gate that's complete nonsense:

```hoon
=x .^($-(* *) %cf /=base=/hoon/json)
(x *hoon)
[1.887.072.378 0]
```

`/mar/json` or `/mar/hoon` do not contain the proper arms, yet this scry still works. The gate we get returns the bunt of `hoon` in this case (which is definitely not `json`).

The reason why this happens can be gleaned from the following snippet:

```hoon
=c |%  ++  grab  |%  ++  hello  1  --  --
hoon:grab:c
<1.fji [* <236.trs 51.enr 139.uat 33.rnj 1.pnw %139>]>
```

When trying the `+grab` arm in the mark we don't use `slob` to check whether the arm actually exists, we just trust the tisgal to get us what we want. This PR fixes the bug.

I also decided to remove some unused `+jump` mark stuff I've never seen before.