### PR TITLE
gall: fix migration when sky contains empty mop

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2715,7 +2715,11 @@
         :-  ~
         =/  m  ~(val by fan.p)
         %+  gas:on-path  *_fan.p
-        %+  turn  (gulf 1 ~(wyt by fan.p))
+        %+  turn  
+          ^-  (list @)                                                           
+          =/  wit  ~(wyt by fan.p)                                               
+          ?:  =(0 wit)  ~                                                        
+          (gulf 1 wit)
         |=  a=@ud
         [a (snag (dec a) m)]
       ==


### PR DESCRIPTION
@midden-fabler ran into an issue with this migration when testing the 411k pre-release. When `fan.p` is the empty `mop` the `gulf` call here will crash.