### PR TITLE
dojo: allow assignation of faces prefixed with 'dir'

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -168,7 +168,7 @@
     ::
       ;~  pfix  tis
         ;~  pose
-          (parse-variable (jest %dir) ;~(pfix ace :(stag 0 %ex parse-rood)))
+          (parse-variable (cold %dir (jest 'dir ')) :(stag 0 %ex parse-rood))
           (parse-variable sym ;~(pfix ace parse-source))
         ==
       ==


### PR DESCRIPTION
Fixes the handling of faces that begin with `dir` (e.g. `=directories`) in `+parse-command:parser-at`. Resolves #5911 