### PR TITLE
Replace %garden with %landscape within `+vat` hint

### DIFF
--- a/pkg/arvo/gen/vat.hoon
+++ b/pkg/arvo/gen/vat.hoon
@@ -2,6 +2,6 @@
 :-  %say
 |=  [[now=@da eny=@uvJ bec=beak] [syd=desk ~] verb=_&]
 :*  %tang
-    leaf+"Notice: +vat is deprecated. use +vats which now takes one or more desks as arguments. e.g. '+vats %base %garden'"
+    leaf+"Notice: +vat is deprecated. use +vats which now takes one or more desks as arguments. e.g. '+vats %base %landscape'"
     (report-vat (report-prep p.bec now) p.bec now syd verb)
 ==


### PR DESCRIPTION
A fresh fake ship no longer comes with the `%garden` desk installed, this is a confusing message for new developers to encounter.