### PR TITLE
Add error message testing arm

### DIFF
--- a/pkg/base-dev/lib/test.hoon
+++ b/pkg/base-dev/lib/test.hoon
@@ -50,6 +50,27 @@
     %&  ~
     %|  ['expected success - failed' p.b]
   ==
+::
+::  +expect-fail-message: kicks a trap, expecting crash, compares the resulting error message
+++  expect-fail-message
+  |=  [msg=@t a=(trap)]
+  ^-  tang
+  =/  b  (mule a)
+  ?-  -.b
+    %|  |^
+        =/  =tang  (flatten +.b)
+        ?:  ?=(^ (find (trip msg) tang))
+          ~
+        ['expected error message - not found' ~]
+        ++  flatten
+          |=  tang=(list tank)
+          =|  res=tape
+          |-  ^-  tape
+          ?~  tang  res
+          $(tang t.tang, res (weld ~(ram re i.tang) res))
+        --
+    %&  ['expected failure - succeeded' ~]
+  ==
 ::  $a-test-chain: a sequence of tests to be run
 ::
 ::  NB: arms shouldn't start with `test-` so that `-test % ~` runs


### PR DESCRIPTION
Target tested code:

```hoon
++  fail
  |=  *
  ~|(%an-error-message !!)
```

Usage in a test thread:

```hoon
++  test-failure
    %+  expect-fail-message
      %an-error-message                                                         
    |.  (fail:main ~)
```

A recursive `+find` could make this less cumbersome.