### PR TITLE
gall: respond to /whey scries (for |mass)

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -2854,6 +2854,7 @@
       ~
     ``case/!>(ud/key.u.las)
   ::
+  =?  path  =(/whey path)  /1/whey
   ?:  &(?=(%x care) ?=([%'1' *] path))
     =>  .(path t.path)
     ?.  =(p.bem our)  ~


### PR DESCRIPTION
The restructuring in #6852 put everything under versioned scry paths. Arvo remains none the wiser and still happily scries for /whey, without a leading version number, resulting in loss of detail for gall's section in |mass output.

Here, we simply slap the current version number in front of the /whey scry path, to get it to resolve.