### PR TITLE
eyre: respect host from Forwarded header, if set

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -798,14 +798,15 @@
     =*  headers  header-list.request
     ::  for requests from localhost, respect the "forwarded" header
     ::
-    =/  [secure=? =^address]
-      =*  same  [secure address]
+    =/  [secure=? host=(unit @t) =^address]
+      =/  host=(unit @t)  (get-header:http 'host' headers)
+      =*  same  [secure host address]
       ?.  =([%ipv4 .127.0.0.1] address)        same
       ?~  forwards=(forwarded-params headers)  same
-      :-  (fall (forwarded-secure u.forwards) secure)
+      :+  (fall (forwarded-secure u.forwards) secure)
+        (clap (forwarded-host u.forwards) host head)
       (fall (forwarded-for u.forwards) address)
     ::
-    =/  host  (get-header:http 'host' headers)
     =/  [=action suburl=@t]
       (get-action-for-binding host url.request)
     ::
@@ -3240,6 +3241,12 @@
     %http   `|
     %https  `&
   ==
+::
+++  forwarded-host
+  |=  forwards=(list (map @t @t))
+  ^-  (unit @t)
+  ?.  ?=(^ forwards)  ~
+  (~(get by i.forwards) 'host')
 ::
 ++  parse-request-line
   |=  url=@t


### PR DESCRIPTION
Eyre already looks at the `Forwarded` header for the original requester's IP address, and the security level of the connection. Some proxies may modify the original `Host` header, but still provide the original in the `Forwarded` header. So, if present, we now respect that.

(For the record, for those using nginx, the full `Forwarded` header is constructed as such:

```nginx
proxy_set_header Forwarded 'proto=https;host=$host;for=$remote_addr';
```

Without this change, to get eyre to read the correct/origin `Host` header, you'll need to explicitly un-rewrite it:

```nginx
proxy_set_header Host $host;
```
)