### PR TITLE
eyre: update eauth endpoint timestamp less eagerly

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1307,9 +1307,15 @@
       ::
       =?  endpoint.auth.state  ?=(^ host)
         %-  (trace 2 |.("eauth: storing endpoint at {(trip u.host)}"))
-        :+  user.endpoint.auth.state
+        =/  new-auth=(unit @t)
           `(cat 3 ?:(secure 'https://' 'http://') u.host)
-        now
+        =,  endpoint.auth.state
+        :+  user  new-auth
+        ::  only update the timestamp if the derived endpoint visibly changed.
+        ::  that is, it's not hidden behind a user-provided hardcoded url,
+        ::  and the new value is different from the old.)
+        ::
+        ?:(|(?=(^ user) =(new-auth auth)) time now)
       ::
       =;  out=[moves=(list move) server-state]
         out(moves [give-session-tokens :(weld moz moves.fex moves.out)])
@@ -3506,6 +3512,8 @@
     $(moves [mov moves], siz t.siz)
   ::
   ?:  ?=(%eauth-host -.task)
+    ?:  =(user.endpoint.auth.server-state.ax host.task)
+      [~ http-server-gate]
     =.  user.endpoint.auth.server-state.ax  host.task
     =.  time.endpoint.auth.server-state.ax  now
     [~ http-server-gate]


### PR DESCRIPTION
We always update the eauth endpoint based on new logins from the local identity. We also let the user configure a hardcoded endpoint url. In both cases, we update a recency timestamp for the endpoint, to help us keep our scry namespace responses immutable.

However, we even updated this timestamp if the visible endpoint didn't change. That is, if the new value was identical, or if the auto-detected endpoint changed, but it was actively being overridden by a user-configured url.

Here, we update the stored timestamp only if the visible url actually changed. This should help us respond to (remote) scry requests more consistently.

(See also the note in +send-keen:)

https://github.com/urbit/urbit/blob/19f9441ce1edc794c13010c8f21c2580d390db23/pkg/arvo/sys/vane/eyre.hoon#L1751-L1757