### PR TITLE
eyre: do not store localhost as eauth-url

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1306,8 +1306,13 @@
         o(session-id session.fex)
       ::  store the hostname used for this login, later reuse it for eauth
       ::
-      =?  endpoint.auth.state  
-        &(?=(^ host) !=('localhost' (fall (rush u.host host-sans-port) '')))
+      =?  endpoint.auth.state
+          ::  avoid overwriting public domains with localhost
+          ::
+          ?&  ?=(^ host)
+          ?|  ?=(~ auth.endpoint.auth.state)
+              !=('localhost' (fall (rush u.host host-sans-port) '')))
+          ==  ==
         %-  (trace 2 |.("eauth: storing endpoint at {(trip u.host)}"))
         =/  new-auth=(unit @t)
           `(cat 3 ?:(secure 'https://' 'http://') u.host)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1306,7 +1306,8 @@
         o(session-id session.fex)
       ::  store the hostname used for this login, later reuse it for eauth
       ::
-      =?  endpoint.auth.state  ?=(^ host)
+      =?  endpoint.auth.state  
+        &(?=(^ host) !=('localhost' (fall (rush u.host host-sans-port) '')))
         %-  (trace 2 |.("eauth: storing endpoint at {(trip u.host)}"))
         =/  new-auth=(unit @t)
           `(cat 3 ?:(secure 'https://' 'http://') u.host)


### PR DESCRIPTION
Tlon hosting has a login health check that regularly logs into the ship using the `+code`. This login happens from a sidecar and therefore thrashes the eauth-url with localhost constantly. This causes ships on Tlon hosting to have unreliable eauth currently.

Disallowing localhost as the eauth-url seems like the simplest solution to me.