### PR TITLE
clay: respect %rein for desks without a bill

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4648,10 +4648,12 @@
         $(desks t.desks)
       =^  res  den  (aver:den ~ %x da+now /desk/bill)
       =.  ruf  +:abet:den
-      ?.  ?=([~ ~ *] res)
+      =/  bill
+        ?.  ?=([~ ~ *] res)  *bill
+        ~|([%building-bill i.desks] !<(bill q.u.u.res))
+      ?~  rid=(override bill ren.dom.den)
+        %-  (trace 2 |.("{<i.desks>} has no dudes"))
         $(desks t.desks)
-      =/  bill  ~|  [%building-bill i.desks]  !<(bill q.u.u.res)
-      =/  rid  (override bill ren.dom.den)
       %-  %+  trace  2  |.
           "{<i.desks>} has bill {<bill>} and rein {<ren.dom.den>}, so {<rid>}"
       =^  sats  ..abet  $(desks t.desks)
@@ -4674,22 +4676,9 @@
   ::  +override: apply rein to bill
   ::
   ++  override
-    |=  [duz=bill ren=(map dude:gall ?)]
-    ^-  bill
-    =.  duz
-      %+  skip  duz
-      |=  =dude:gall
-      =(`| (~(get by ren) dude))
-    ::
-    =/  dus  (sy duz)
-    =.  duz
-      %+  weld  duz
-      %+  murn  ~(tap by ren)
-      |=  [=dude:gall on=?]
-      ?:  &(?=(%& on) !(~(has in dus) dude))
-        `u=dude
-      ~
-    duz
+    |=  [duz=bill ren=(map dude:gall ?)]  ^-  bill
+    =/  out=bill  (skip duz ~(has by ren))
+    (~(rep by ren) |=([[d=dude:gall r=?] =_out] ?.(r out [d out])))
   ::  +apply-precedence: resolve conflicts between $bill's
   ::
   ::    policy is to crash if multiple desks are trying to run the same


### PR DESCRIPTION
This PR is a fix for #6527, as an alternative to #6879. With these changes:

```
merged with strategy %init
> |merge %tmp our %base
>=
kiln: desk not live
> |start %tmp %test
>=
removed: /~zod/tmp/~2024.3.13..18.00.47..1f25/desk/bill
> |rm /=tmp=/desk/bill
>=
- /~zod/tmp/2/desk/bill
kiln: desk not live
> |start %tmp %test
>=
gall: installing %test
> |install our %tmp
>=
gall: booted %test
built   /app/acme
built   /app/aqua
....
```

It's possible that `|start` or `|rein` should also set the desk to `%live`, so as to not need the explicit `|install`.