### PR TITLE
ping: only ping galaxy

### DIFF
--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -22,18 +22,6 @@
 ::
 +$  card  card:agent:gall
 ::
-+$  state-2
-  $:  %2
-      ships=(set ship)
-      nonce=@ud
-      $=  plan
-      $~  [%nat ~]
-      $%  [%nat ~]
-          [%pub ip=(unit @t)]
-          [%off ~]
-          [%one ~]
-      ==
-  ==
 +$  state-3
   $:  %3
      mode=?(%formal %informal)
@@ -66,7 +54,7 @@
     ?:  &(!force (gth pokes.state 0) =(ship galaxy.state))
       [~ state]
     :_  state(pokes +(pokes.state), galaxy ship)
-    [%pass /ping/(scot %p ship) %agent [ship %ping] %poke %noun !>(~)]~
+    [%pass /ping %agent [ship %ping] %poke %noun !>(~)]~
 --
 %+  verb  |
 ^-  agent:gall
@@ -111,6 +99,18 @@
         $%  [%nat ~]
             [%pub ip=(unit @t)]
     ==  ==
+  +$  state-2
+    $:  %2
+        ships=(set ship)
+        nonce=@ud
+        $=  plan
+        $~  [%nat ~]
+        $%  [%nat ~]
+            [%pub ip=(unit @t)]
+            [%off ~]
+            [%one ~]
+        ==
+    ==
   ::
   ++  state-0-to-1
     |=  old=state-0
@@ -125,7 +125,14 @@
   ++  state-2-to-3
     |=  old=state-2
     ^-  state-3
-    [%3 %formal 0 ~ (galaxy-for our.bowl bowl)]
+    :*  %3  %formal  0  ~
+    =/  galaxy=(list @p)
+      %+  skim  ~(tap in ships.old)
+      |=(p=@p ?=(%czar (clan:title p)))
+    ?:  =(1 (lent galaxy))
+      -.galaxy
+    (head (flop (^saxo:title our.bowl)))
+    ==
   --
 ::  +on-poke: positively acknowledge pokes
 ::
@@ -155,19 +162,17 @@
 ++  on-agent
   |=  [=wire =sign:agent:gall]
   ^-  [(list card) _this]
-  ?.  ?=([%ping s=@ *] wire)
-    `this
-  ?.  =(galaxy.state (slav %p i.t.wire))
+  ?.  ?=([%ping *] wire)
     `this
   ?.  ?=(%poke-ack -.sign)
     `this
   =.  pokes.state  (dec pokes.state)
-  ?.  |(?=(%formal mode.state) ?=(^ p.sign))
-    `this
   ?.  =(pokes.state 0)
     `this
+  ?.  |(?=(%formal mode.state) ?=(^ p.sign))
+    `this
   =/  wir  /wait
-  =.  timer.state  `[wire now.bowl]
+  =.  timer.state  `[wir now.bowl]
   [[(wait-card wir now.bowl)]~ this]
 ::  +on-arvo: handle timer firing
 ::

--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -49,7 +49,7 @@
   ++  galaxy-for
     |=  [=ship =bowl:gall]
     ^-  @p
-    =/  next  (sein:title [our now our]:bowl)
+    =/  next  (sein:title our.bowl now.bowl ship)
     ?:  ?=(%czar (clan:title next))
       next
     $(ship next)


### PR DESCRIPTION
`/app/ping` has a few problems. One of them is that we created a state machine hole with the informal pinging changes in the upcoming 411k release. This is a serious, luckily unreleased bug that would make the galaxies lose track of their planets if the planets were restarted more than once after upgrading to 411.

The other one is that the state transitions were triggered for any poke-ack even though we really only care about the galaxy.

This is my attempt at making `/app/ping` only ping the galaxy. In addition, we rip out all of the jael stuff and just scry every time since most people will be informally pinging anyways. `/app/ping` used to have more responsibilities wrt subscribing to our own keys but they should be addressed by #6838.

We also rip out the hacky `%no-nat` stuff that was being used as a workaround in times before informal pings.