### PR TITLE
ames: emit %saxo on ++molt

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -894,7 +894,7 @@
   +$  address  @uxaddress
   ::  $verb: verbosity flag for ames
   ::
-  +$  verb  ?(%snd %rcv %odd %msg %ges %for %rot %kay %fin)
+  +$  verb  ?(%snd %rcv %odd %msg %ges %for %rot %kay %fin %sun)
   ::  $blob: raw atom to or from unix, representing a packet
   ::
   +$  blob  @uxblob

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2046,7 +2046,7 @@
         ::  start sending informal pings to the sponsorship chain
         ::
         ?~  unix-duct.+.u.cached-state
-          ~
+          moz
         ~>  %slog.0^leaf/"ames: retrieving sponsorship chain"
         ^-  (list move)
         :_  moz

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -101,6 +101,7 @@
       rot=`?`%.n  ::  routing attempts
       kay=`?`%.n  ::  is ok/not responding
       fin=`?`%.n  ::  remote-scry
+      sun=`?`%.n  ::  STUN
   ==
 =/  packet-size  13
 =>
@@ -850,7 +851,7 @@
       =life
       =rift
       crypto-core=acru:ames
-      =bug
+      bug=bug-19
       snub=[form=?(%allow %deny) ships=(set ship)]
       cong=[msg=@ud mem=@ud]
   ==
@@ -1150,7 +1151,7 @@
       =life
       =rift
       crypto-core=acru:ames
-      =bug
+      bug=bug-19
       snub=[form=?(%allow %deny) ships=(set ship)]
       cong=[msg=_5 mem=_100.000]
     ::
@@ -1204,7 +1205,7 @@
       =life
       =rift
       crypto-core=acru:ames
-      =bug
+      bug=bug-19
       snub=[form=?(%allow %deny) ships=(set ship)]
       cong=[msg=@ud mem=@ud]
   ==
@@ -1328,7 +1329,28 @@
       $<(?(%keen %deep) task)
   ==
 ::
-+$  ames-state-19  ames-state
++$  bug-19
+  $:  veb=_[`?`%.n `?`%.n `?`%.n `?`%.n `?`%.n `?`%.n `?`%.n `?`%.n `?`%.n]
+      ships=(set ship)
+  ==
+::
++$  ames-state-19
+  $+  ames-state-19
+  $:  peers=(map ship ship-state)
+      =unix=duct
+      =life
+      =rift
+      crypto-core=acru:ames
+      bug=bug-19
+      snub=[form=?(%allow %deny) ships=(set ship)]
+      cong=[msg=@ud mem=@ud]
+      $=  dead
+      $:  flow=[%flow (unit dead-timer)]
+          cork=[%cork (unit dead-timer)]
+      ==
+    ::
+      =chain
+  ==
 ::  $bug: debug printing configuration
 ::
 ::    veb: verbosity toggles
@@ -2040,7 +2062,7 @@
         19+(state-18-to-19:load:adult-core +.u.cached-state)
       =^  moz  u.cached-state
         ?.  ?=(%19 -.u.cached-state)  [~ u.cached-state]
-        :_  [%20 +.u.cached-state]
+        :_  20+(state-19-to-20:load:adult-core +.u.cached-state)
         ::  if we didn't have a unix-duct, the larval stage will be expecting
         ::  a %born task from unix, which will in turn emit the %saxo that will
         ::  start sending informal pings to the sponsorship chain
@@ -2234,6 +2256,7 @@
             %rot  acc(rot %.y)
             %kay  acc(kay %.y)
             %fin  acc(fin %.y)
+            %sun  acc(sun %.y)
           ==
         event-core
       ::  +on-prod: re-send a packet per flow to each of .ships
@@ -2803,6 +2826,19 @@
       ++  on-stun
         |=  =stun
         ^+  event-core
+        %-  %^  ev-trace  sun.veb  ship.stun
+            =/  lane=tape
+              ?:  &
+                ::  turn off until correct parsing ip/port in ames.c
+                ::  (see https://github.com/urbit/vere/pull/623)
+                ""
+              ?:  ?=(%& -.lane.stun)
+                "from {<p.lane.stun>}"
+              =,  lane.stun
+              =/  ip=@if  (end [0 32] p)
+              =/  pt=@ud  (cut 0 [32 16] p)
+              "lane {(scow %if ip)}:{((d-co:co 1) pt)} ({(scow %ux p)})"
+            |.("inject %stun {<-.stun>} {lane}")
         %-  emit
         %^  poke-ping-app  unix-duct.ames-state  our
         ?.  ?=(%fail -.stun)  -.stun
@@ -5670,7 +5706,7 @@
   ::
   ++  state-18-to-19
     |=  old=ames-state-18
-    ^-  ^ames-state
+    ^-  ames-state-19
     %=    old
     ::
         dead  [dead.old ~]
@@ -5707,6 +5743,13 @@
           ~+  ;;(message [hed (cue arg)])
         ==
       ==
+    ==
+  ::
+  ++  state-19-to-20
+    |=  old=ames-state-19
+    ^-  ^ames-state
+    %=  old
+      veb.bug  [&1 &2 &3 &4 &5 &6 &7 &8 |8 %.n]:veb.bug.old
     ==
   --
 ::  +scry: dereference namespace

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -619,7 +619,7 @@
 ::    dead:        dead flow consolidation timer and recork timer, if set
 ::
 +$  ames-state
-  $+  ames-state-19
+  $+  ames-state-20
   $:  peers=(map ship ship-state)
       =unix=duct
       =life
@@ -1327,6 +1327,8 @@
       deep-task-14                  ::  introduced in state %14, modified in %19
       $<(?(%keen %deep) task)
   ==
+::
++$  ames-state-19  ames-state
 ::  $bug: debug printing configuration
 ::
 ::    veb: verbosity toggles
@@ -1479,7 +1481,8 @@
             [%16 ames-state-16]
             [%17 ames-state-17]
             [%18 ames-state-17]
-            [%19 ^ames-state]
+            [%19 ames-state-19]
+            [%20 ^ames-state]
         ==
     ::
     |=  [now=@da eny=@ rof=roof]
@@ -1602,7 +1605,7 @@
     ::  lifecycle arms; mostly pass-throughs to the contained adult ames
     ::
     ++  scry  scry:adult-core
-    ++  stay  [%19 %larva queued-events ames-state.adult-gate]
+    ++  stay  [%20 %larva queued-events ames-state.adult-gate]
     ++  load
       |=  $=  old
           $%  $:  %4
@@ -1711,6 +1714,13 @@
                   [%adult state=ames-state-18]
               ==  ==
               $:  %19                                 :: %keen & %deep modified
+              $%  $:  %larva
+                      events=(qeu queued-event)
+                      state=ames-state-19
+                  ==
+                  [%adult state=ames-state-19]
+              ==  ==
+              $:  %20                                 :: start informal %ping
               $%  $:  %larva
                       events=(qeu queued-event)
                       state=_ames-state.adult-gate
@@ -1899,12 +1909,23 @@
         =.  queued-events  (event-17-and-18-to-last events.old)
         larval-gate
       ::
-          [%19 %adult *]  (load:adult-core %19 state.old)
+          [%19 %adult *]
+        =.  cached-state  `[%19 state.old]
+        ~>  %slog.0^leaf/"ames: larva %19 reload"
+        larval-gate
       ::
           [%19 %larva *]
         ~>  %slog.1^leaf/"ames: larva %19 load"
+        =.  cached-state  `[%19 state.old]
         =.  queued-events  events.old
-        =.  adult-gate     (load:adult-core %19 state.old)
+        larval-gate
+      ::
+          [%20 %adult *]  (load:adult-core %20 state.old)
+      ::
+          [%20 %larva *]
+        ~>  %slog.1^leaf/"ames: larva %20 load"
+        =.  queued-events  events.old
+        =.  adult-gate     (load:adult-core %20 state.old)
         larval-gate
       ==
       ::
@@ -2017,7 +2038,22 @@
       ::
       =?  u.cached-state  ?=(%18 -.u.cached-state)
         19+(state-18-to-19:load:adult-core +.u.cached-state)
-      ?>  ?=(%19 -.u.cached-state)
+      =^  moz  u.cached-state
+        ?.  ?=(%19 -.u.cached-state)  [~ u.cached-state]
+        :_  [%20 +.u.cached-state]
+        ::  if we didn't have a unix-duct, the larval stage will be expecting
+        ::  a %born task from unix, which will in turn emit the %saxo that will
+        ::  start sending informal pings to the sponsorship chain
+        ::
+        ?~  unix-duct.+.u.cached-state
+          ~
+        ~>  %slog.0^leaf/"ames: retrieving sponsorship chain"
+        ^-  (list move)
+        :_  moz
+        =+  ev-core=(ev [now eny rof] [/saxo]~ ames-state.adult-gate)
+        [unix-duct.+.u.cached-state %give %saxo get-sponsors:ev-core]
+      ::
+      ?>  ?=(%20 -.u.cached-state)
       =.  ames-state.adult-gate  +.u.cached-state
       [moz larval-core(cached-state ~)]
     --
@@ -5392,15 +5428,15 @@
   [moves ames-gate]
 ::  +stay: extract state before reload
 ::
-++  stay  [%19 %adult ames-state]
+++  stay  [%20 %adult ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load
   =<  |=  $=  old-state
-          $%  [%19 ^ames-state]
+          $%  [%20 ^ames-state]
           ==
       ^+  ames-gate
-      ?>  ?=(%19 -.old-state)
+      ?>  ?=(%20 -.old-state)
       ames-gate(ames-state +.old-state)
   ::  all state transitions are called from larval ames
   ::


### PR DESCRIPTION
Before this, ships wouldn't start sending informal pings unless the driver was restarted. Now, as soon as we get the 411 OTA, we introduce a dummy state migration that will emit the %saxo gift to unix (same behavior that happens on-born).

(We are only doing this if we did have a unix-duct, if we don't, we skip that since the larval stage will be expecting a %born task from unix anyway, and that code path—`++on-born:ev:adult-core`—is what always sends the sponsorship chain to the driver)

Note: tested on a live ship that applies the state migration; that and booting from a pill will need to be tested once https://github.com/urbit/urbit/pull/6936 is ready.