### PR TITLE
vats: fix vats and make faster

### DIFF
--- a/pkg/arvo/gen/vats.hoon
+++ b/pkg/arvo/gen/vats.hoon
@@ -17,12 +17,4 @@
         [filt=@tas verb=_|]
     ==
 :-  %tang  ^-  tang
-?.  &(=(~ deks) =(%$ filt))
-  (report-vats p.bec now deks filt verb)
-%-  zing
-%+  turn
-  %+  sort
-    =/  sed  .^((set desk) %cd /(scot %p p.bec)//(scot %da now))
-    (sort ~(tap in sed) |=([a=@ b=@] !(aor a b)))
-  |=([a=desk b=desk] ?|(=(a %kids) =(b %base)))
-|=(syd=desk (report-vat (report-prep p.bec now) p.bec now syd verb))
+(report-vats p.bec now deks filt verb)

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -251,13 +251,11 @@
     ^-  @t
     ?:  =(~ wefts)
       '~'
-    %+  rap  3
-    %+  join  ' '
-    %+  turn
-      (sort ~(tap in wefts) aor)
-    |=  =weft
-    ^-  @t
-    (rap 3 '[%' lal.weft ' ' (scot %ud num.weft) ']' ~)
+    %+  roll  (sort ~(tap in wefts) aor)
+    |=  [=weft out=@t]
+    ?:  =('' out)
+      (rap 3 '[%' lal.weft ' ' (scot %ud num.weft) ']' ~)
+    (rap 3 out ' [%' lal.weft ' ' (scot %ud num.weft) ']' ~)
   ::
   ++  print-shorthash
     |=  hash=@uv

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -59,7 +59,7 @@
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
   :*  .^(rock:tire %cx /[ego]//[wen]/tire)
-      .^(=cone %cx /[ego]//[wen]/domes)
+      .^(cone %cx /[ego]//[wen]/domes)
       .^((map desk [ship desk]) %gx /[ego]/hood/[wen]/kiln/sources/noun)
       .^  (map [desk ship desk] sync-state)  %gx
           /[ego]/hood/[wen]/kiln/syncs/noun
@@ -72,44 +72,73 @@
   ^-  tang
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
-  =/  prep  (report-prep our now)
-  ?~  filt
+  =+  prep=[tyr cone sor zyn]=(report-prep our now)
+  ?:  =(%$ filt)
     %-  zing
-    %+  turn  (flop desks)
+    %+  turn
+      ?^  desks
+        `(list desk)`desks
+      %+  sort  ~(tap in ~(key by tyr.prep))
+      |=  [a=desk b=desk]
+      ?:  |(=(a %kids) =(b %base))  &
+      ?:  |(=(a %base) =(b %kids))  |
+      (aor b a)
     |=(syd=@tas (report-vat prep our now syd verb))
-  =/  deks
+  =/  deks=(list [=desk =zest wic=(set weft)])
     ?~  desks
-      %+  sort
-        (sort ~(tap by -.prep) |=([[a=@ *] b=@ *] !(aor a b)))
-      |=([[a=@ *] [b=@ *]] ?|(=(a %kids) =(b %base)))
-    %+  skip  ~(tap by -.prep)
-    |=([syd=@tas *] =(~ (find ~[syd] desks)))
-  =.  deks  (skim deks |=([=desk *] ((sane %tas) desk)))
+      %+  sort  ~(tap by tyr.prep)
+      |=  [[a=desk *] [b=desk *]]
+      ?:  |(=(a %kids) =(b %base))  &
+      ?:  |(=(a %base) =(b %kids))  |
+      (aor b a)
+    %+  murn  `(list desk)`desks
+    |=  des=desk
+    ^-  (unit [=desk =zest wic=(set weft)])
+    ?~  got=(~(get by tyr.prep) des)
+      ~
+    `[des u.got]
   ?:  =(filt %blocking)
-    =/  base-wic
-      %+  sort  ~(tap by wic:(~(got by -.prep) %base))
-      |=([[* a=@ud] [* b=@ud]] (gth a b))
-    ?~  base-wic  ~[leaf+"%base already up-to-date"]
+    =/  base-weft=(unit weft)
+      %-  ~(rep in wic:(~(got by tyr.prep) %base))
+      |=  [=weft out=(unit weft)]
+      ?~  out
+        `weft
+      ?:  (lth num.weft num.u.out)
+        out
+      `weft
+    ?~  base-weft  ~['%base already up-to-date']
     =/  blockers=(list desk)
-      %+  turn
-        %+  skip  ~(tap in -.prep)
-        |=  [* [zest=@tas wic=(set weft)]]
-        ?.  =(zest %live)  &
-        (~(has in wic) i.base-wic)
-      |=([syd=desk *] syd)
-    ?~  blockers  ~[leaf+"No desks blocking upgrade, run |bump to apply"]
-    :-  [%rose [" %" "To unblock upgrade run |suspend %" ""] blockers]
+      %+  sort
+        ^-  (list desk)
+        %+  murn  deks
+        |=  [=desk =zest wic=(set weft)]
+        ^-  (unit ^desk)
+        ?.  =(%live zest)
+          ~
+        ?:  (~(has in wic) u.base-weft)
+          ~
+        `desk
+      aor
+    ?~  blockers  ~['No desks blocking upgrade']
     %-  zing
-    %+  turn  (flop blockers)
+    ^-  (list tang)
+    :-  :~  %+  rap  3
+            :~  'These desks are blocking upgrade to [%zuse '
+                (scot %ud num.u.base-weft)
+                ']:'
+        ==  ==
+    %+  turn  blockers
     |=(syd=desk (report-vat prep our now syd verb))
   ::
   %-  zing
   %+  turn
     ?+    filt  !!
-    ::
         %exists
       %+  skip  deks
-      |=([syd=desk *] =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0))
+      |=  [syd=desk *]
+      ?~  got=(~(get by cone.prep) our syd)
+        &
+      =(0 let.u.got)
     ::
         %running
       %+  skim  deks
@@ -120,12 +149,17 @@
       |=  [syd=@tas [zest=@tas *]]
       ?|  =(syd %kids)
           =(zest %live)
-          =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0)
+          ?~  got=(~(get by cone.prep) our syd)
+            &
+          =(0 let.u.got)
       ==
     ::
         %exists-not
       %+  skim  deks
-      |=([syd=desk *] =(ud:.^(cass %cw /[ego]/[syd]/[wen]) 0))
+      |=  [syd=desk *]
+      ?~  got=(~(get by cone.prep) our syd)
+        |
+      =(0 let.u.got)
     ==
   |=([syd=desk *] (report-vat prep our now syd verb))
 ::  +report-vat: report on a single desk installation
@@ -136,34 +170,21 @@
           ==
           our=ship  now=@da  syd=desk  verb=?
       ==
-  ^-  tang
-  =-  ::  hack to force wrapped rendering
-      ::
-      ::    edg=6 empirically prevents dedent
-      ::
-      %+  roll
-        (~(win re -) [0 6])
-      |=([a=tape b=(list @t)] [(crip a) b])
-  ::
-  ^-  tank
+  |^  ^-  tang
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
   ?.  ((sane %tas) syd)
-    leaf+"insane desk: {<syd>}"
-  =+  .^(=cass %cw /[ego]/[syd]/[wen])
-  ?:  =(ud.cass 0)
-    leaf+"desk does not yet exist: {<syd>}"
-  ?:  =(%kids syd)
-    =+  .^(hash=@uv %cz /[ego]/[syd]/[wen])
-    leaf+"%kids %cz hash:     {<hash>}"
-  =/  kel-path
-    /[ego]/[syd]/[wen]/sys/kelvin
-  ?.  .^(? %cu kel-path)
-    leaf+"bad desk: {<syd>}"
-  =+  .^(=waft %cx kel-path)
-  :+  %rose  ["" "{<syd>}" "::"]
-  ^-  tang
+    ~[(cat 3 'insane desk: %' syd)]
+  ?.  (~(has by cone) our syd)
+    ~[(cat 3 'desk does not yet exist: %' syd)]
   =/  hash  .^(@uv %cz /[ego]/[syd]/[wen])
+  ?:  =(%kids syd)
+    ~[(cat 3 '%kids %cz hash:     ' (scot %uv hash))]
+  =/  kel-path  /[ego]/[syd]/[wen]/sys/kelvin
+  ?.  .^(? %cu kel-path)
+    ~[(cat 3 'bad desk: %' syd)]
+  =+  .^(=waft %cx kel-path)
+  ^-  tang
   =/  =sink
     ?~  s=(~(get by sor) syd)
       ~
@@ -171,52 +192,102 @@
       ~
     `[p.u.s q.u.s [kid let]:u.z]
   =/  meb=(list @uv)
-    ?~  sink  [hash]~
-    (mergebase-hashes our syd now her.u.sink sud.u.sink)
+    ?~  sink  ~[hash]
+    %+  turn
+      .^  (list tako)  %cs
+        /[ego]/[syd]/[wen]/base/(scot %p her.u.sink)/[sud.u.sink]
+      ==
+    |=(=tako .^(@uv %cs /[ego]/[syd]/[wen]/hash/(scot %uv tako)))
   =/  dek  (~(got by tyr) syd)
   =/  sat
     ?-  zest.dek
-      %live  "running"
-      %dead  "suspended"
-      %held  "suspended until next update"
+      %live  'running'
+      %dead  'suspended'
+      %held  'suspended until next update'
     ==
-  =/  kul=tape
-    %+  roll
-      %+  sort
-        ~(tap in (waft-to-wefts:clay waft))
-      |=  [a=weft b=weft]
-      ?:  =(lal.a lal.b)
-        (lte num.a num.b)
-      (lte lal.a lal.b)
-    |=  [=weft =tape]
-    (welp " {<[lal num]:weft>}" tape)
+  =/  kul=cord  (print-wefts (waft-to-wefts waft))
   ?.  verb
-    :~  leaf/"/sys/kelvin:          {kul}"
-        leaf/"%cz hash ends in:      {(truncate-hash hash)}"
-        leaf/"app status:            {sat}"
-        leaf/"source ship:           {?~(sink <~> <her.u.sink>)}"
-        leaf/"pending updates:       {<`(list [@tas @ud])`~(tap in wic.dek)>}"
+    :~  '::'
+        (cat 3 '  pending updates:       ' (print-wefts wic.dek))
+        (cat 3 '  source ship:           ' ?~(sink '~' (scot %p her.u.sink)))
+        (cat 3 '  app status:            ' sat)
+        (cat 3 '  %cz hash ends in:      ' (print-shorthash hash))
+        (cat 3 '  /sys/kelvin:           ' (print-wefts (waft-to-wefts waft)))
+        (cat 3 '%' syd)
     ==
   ::
-  =/  [on=(list [@tas ?]) of=(list [@tas ?])]
-    =/  =dome  (~(got by cone) our syd)
-    (skid ~(tap by ren.dome) |=([* ?] +<+))
-  :~  leaf/"/sys/kelvin:     {kul}"
-      leaf/"base hash:        {?.(=(1 (lent meb)) <meb> <(head meb)>)}"
-      leaf/"%cz hash:         {<hash>}"
-      ::
-      leaf/"app status:       {sat}"
-      leaf/"force on:         {<(sort (turn on head) aor)>}"
-      leaf/"force off:        {<(sort (turn of head) aor)>}"
-      ::
-      leaf/"publishing ship:  {?~(sink <~> <(get-publisher our syd now)>)}"
-      leaf/"updates:          {?~(sink "local" "remote")}"
-      leaf/"source ship:      {?~(sink <~> <her.u.sink>)}"
-      leaf/"source desk:      {?~(sink <~> <sud.u.sink>)}"
-      leaf/"source aeon:      {?~(sink <~> <let.u.sink>)}"
-      leaf/"kids desk:        {?~(sink <~> ?~(kid.u.sink <~> <u.kid.u.sink>))}"
-      leaf/"pending updates:  {<`(list [@tas @ud])`~(tap in wic.dek)>}"
+  =/  [on=(list @tas) of=(list @tas)]
+    =/  [on=(list @tas) of=(list @tas)]
+      %-  ~(rep by ren:(~(got by cone) our syd))
+      |=  [[=dude:gall is-on=?] on=(list @tas) of=(list @tas)]
+      ?:  is-on
+        [[dude on] of]
+      [on [dude of]]
+    [(sort on aor) (sort of aor)]
+  :~  '::'
+      (cat 3 '  pending updates:  ' (print-wefts wic.dek))
+      %^  cat  3  '  kids desk:        '  ?~  sink  '~'
+                                          ?~  kid.u.sink  '~'
+                                          (cat 3 '%' u.kid.u.sink)
+      (cat 3 '  source aeon:      ' ?~(sink '~' (scot %ud let.u.sink)))
+      (cat 3 '  source desk:      ' ?~(sink '~' (cat 3 '%' sud.u.sink)))
+      (cat 3 '  source ship:      ' ?~(sink '~' (scot %p her.u.sink)))
+      (cat 3 '  updates:          ' ?~(sink 'local' 'remote'))
+      %^  cat  3  '  publishing ship:  '  ?~  got=(get-publisher our syd now)
+                                            '~'
+                                          (scot %p u.got)
+  ::
+      (cat 3 '  force off:        ' (print-agents of))
+      (cat 3 '  force on:         ' (print-agents on))
+      (cat 3 '  app status:       ' sat)
+  ::
+      (cat 3 '  %cz hash:         ' (scot %uv hash))
+      (cat 3 '  base hash:        ' (print-mergebases meb))
+      (cat 3 '  /sys/kelvin:      ' (print-wefts (waft-to-wefts waft)))
+      (cat 3 '%' syd)
   ==
+  ++  print-wefts
+    |=  wefts=(set weft)
+    ^-  @t
+    ?:  =(~ wefts)
+      '~'
+    %+  rap  3
+    %+  join  ' '
+    %+  turn
+      (sort ~(tap in wefts) aor)
+    |=  =weft
+    ^-  @t
+    (rap 3 '[%' lal.weft ' ' (scot %ud num.weft) ']' ~)
+  ::
+  ++  print-shorthash
+    |=  hash=@uv
+    ^-  @t
+    (crip ((v-co:co 5) (end [0 25] hash)))
+  ::
+  ++  print-mergebases
+    |=  hashes=(list @uv)
+    ^-  @t
+    ?~  hashes
+      '~'
+    ?~  t.hashes
+      (scot %uv i.hashes)
+    %+  roll  `(list @uv)`hashes
+    |=  [hash=@uv out=@t]
+    ?:  =('' out)
+      (print-shorthash hash)
+    (rap 3 out ' ' (print-shorthash hash) ~)
+  ::
+  ++  print-agents
+    |=  agents=(list @tas)
+    ^-  @t
+    ?~  agents
+      '~'
+    %+  roll  `(list @tas)`agents
+    |=  [agent=@tas out=@tas]
+    ?:  =('' out)
+      (cat 3 '%' agent)
+    (rap 3 out ' %' agent ~)
+  --
 ::  +report-kids: non-vat cz hash report for kids desk
 ::
 ++  report-kids
@@ -226,9 +297,9 @@
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
   ?.  (~(has in .^((set desk) %cd /[ego]//[wen])) syd)
-    leaf/"no %kids desk"
+    'no %kids desk'
   =+  .^(hash=@uv %cz /[ego]/[syd]/[wen])
-  leaf/"%kids %cz hash:     {<hash>}"
+  (cat 3 '%kids %cz hash:     ' (scot %uv hash))
 ::  +read-bill-foreign: read /desk/bill from a foreign desk
 ::
 ++  read-bill-foreign
@@ -288,8 +359,8 @@
   =/  her  (scot %p her)
   =/  ego  (scot %p our)
   =/  wen  (scot %da now)
-  %+  turn  .^((list tako) %cs ~[ego syd wen %base her sud])
-  |=(=tako .^(@uv %cs ~[ego syd wen %hash (scot %uv tako)]))
+  %+  turn  .^((list tako) %cs /[ego]/[syd]/[wen]/base/[her]/[sud])
+  |=(=tako .^(@uv %cs /[ego]/[syd]/[wen]/hash/(scot %uv tako)))
 ::
 ++  enjs
   =,  enjs:format


### PR DESCRIPTION
`+vats` is agonisingly slow on my ship. This speeds it up by replacing tape interpolation & pretty-printer usage with explicit printing functions and cord concatenation. It also optimised a bunch of the code & reduces excessive scrying. Additionally, it fixes the %blocking filter to correctly print only the desks that are blocking the oldest pending kernel update.

before: `took s/107.362.567` 
after: `took s/31.124.617`
