### PR TITLE
spider: support speaking raw nouns

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -357,7 +357,7 @@
     ::
         %noun
       =/  tube  (convert-tube %noun input-mark desk bowl)
-      =/  body=noun  (cue (slav %uw q.u.body.request.inbound-request))
+      =/  body=noun  (cue q.u.body.request.inbound-request)
       (tube !>(body))
     ==
   =/  boc  bec
@@ -609,7 +609,7 @@
     ::
         %noun
       :-  [500 [['content-type' 'application/x-urb-jam'] ~]]
-      `(as-octs:mimes:html (scot %uw (jam [term tang])))
+      `(as-octs:mimes:html (jam [term tang]))
     ==
   :_  ~  :_  ~
   ?-  term
@@ -651,7 +651,7 @@
     :_  state(serving (~(del by serving.state) tid))
     %+  give-simple-payload:app:server  rid.u.request
     :-  [200 ['content-type' 'application/x-urb-jam']~]
-    `(as-octs:mimes:html (scot %uw (jam q.vase)))
+    `(as-octs:mimes:html (jam q.vase))
   ==
 ::
 ++  thread-done

--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -14,7 +14,7 @@
   $:  starting=(map yarn [=trying =vase])
       running=(axal thread-form)
       tid=(map tid yarn)
-      serving=(map tid [(unit @ta) =mark =desk])
+      serving=(map tid [(unit [rid=@ta take=?(%json %noun)]) =mark =desk])
       scrying=(jug tid [=wire =ship =path])
   ==
 ::
@@ -26,10 +26,20 @@
       clean-slate-3
       clean-slate-4
       clean-slate-5
+      clean-slate-6
       clean-slate
   ==
 ::
 +$  clean-slate
+  $:  %7
+      starting=(map yarn [=trying =vase])
+      running=(list yarn)
+      tid=(map tid yarn)
+      serving=(map tid [(unit [rid=@ta take=?(%json %noun)]) =mark =desk])
+      scrying=(jug tid [wire ship path])
+  ==
+::
++$  clean-slate-6
   $:  %6
       starting=(map yarn [=trying =vase])
       running=(list yarn)
@@ -121,7 +131,8 @@
     =.  any  (old-to-4 any)
     =.  any  (old-to-5 any)
     =.  any  (old-to-6 any)
-    ?>  ?=(%6 -.any)
+    =.  any  (old-to-7 any)
+    ?>  ?=(%7 -.any)
     ::
     =.  tid.state  tid.any
     =/  yarns=(list yarn)
@@ -148,8 +159,8 @@
     ++  old-to-2
       |=  old=clean-slate-any
       ^-  (quip card clean-slate-any)
-      ?>  ?=(?(%1 %2 %3 %4 %5 %6) -.old)
-      ?:  ?=(?(%2 %3 %4 %5 %6) -.old)
+      ?>  ?=(?(%1 %2 %3 %4 %5 %6 %7) -.old)
+      ?:  ?=(?(%2 %3 %4 %5 %6 %7) -.old)
         `old
       :-  ~[bind-eyre:sc]
       :*  %2
@@ -162,8 +173,8 @@
     ++  old-to-3
       |=  old=clean-slate-any
       ^-  clean-slate-any
-      ?>  ?=(?(%2 %3 %4 %5 %6) -.old)
-      ?:  ?=(?(%3 %4 %5 %6) -.old)
+      ?>  ?=(?(%2 %3 %4 %5 %6 %7) -.old)
+      ?:  ?=(?(%3 %4 %5 %6 %7) -.old)
         old
       :*  %3
         starting.old
@@ -175,8 +186,8 @@
     ++  old-to-4
       |=  old=clean-slate-any
       ^-  clean-slate-any
-      ?>  ?=(?(%3 %4 %5 %6) -.old)
-      ?:  ?=(?(%4 %5 %6) -.old)
+      ?>  ?=(?(%3 %4 %5 %6 %7) -.old)
+      ?:  ?=(?(%4 %5 %6 %7) -.old)
         old
       :*  %4
         starting.old
@@ -188,15 +199,15 @@
     ++  old-to-5
       |=  old=clean-slate-any
       ^-  clean-slate-any
-      ?>  ?=(?(%4 %5 %6) -.old)
-      ?:  ?=(?(%5 %6) -.old)  old
+      ?>  ?=(?(%4 %5 %6 %7) -.old)
+      ?:  ?=(?(%5 %6 %7) -.old)  old
       [%5 +.old(serving [serving.old ~])]
     ::
     ++  old-to-6
       |=  old=clean-slate-any
-      ^-  clean-slate
-      ?>  ?=(?(%5 %6) -.old)
-      ?:  ?=(%6 -.old)  old
+      ^-  clean-slate-any
+      ?>  ?=(?(%5 %6 %7) -.old)
+      ?:  ?=(?(%6 %7) -.old)  old
       :-  %6
       %=    +.old
           scrying
@@ -208,6 +219,16 @@
         ::
         [/keen ship path]~
       ==
+    ::
+    ++  old-to-7
+      |=  old=clean-slate-any
+      ^-  clean-slate-any
+      ?>  ?=(?(%6 %7) -.old)
+      ?:  ?=(%7 -.old)  old
+      =-  old(- %7, serving -)
+      %-  ~(run by serving.old)
+      |=  [request=(unit @ta) =mark =desk]
+      [(bind request (late %json)) mark desk]
     --
   ::
   ++  on-poke
@@ -309,15 +330,36 @@
   =*  input-mark   i.t.t.site.url
   =*  thread       i.t.t.t.site.url
   =*  output-mark  i.t.t.t.t.site.url
-  =/  =tid         (new-thread-id thread)
-  =.  serving.state
-    (~(put by serving.state) tid [`eyre-id output-mark desk])
   ::  TODO: speed this up somehow. we spend about 15ms in this arm alone
   ::
-  =/  tube  (convert-tube %json input-mark desk bowl)
   ?>  ?=(^ body.request.inbound-request)
-  =/  body=json  (need (de:json:html q.u.body.request.inbound-request))
-  =/  input=vase  (slop !>(~) (tube !>(body)))
+  =/  test=$-(@t ?(%json %noun))
+    |=  head=@t
+    =;  type=(unit @t)
+      ?:(=(`'application/x-urb-jam' type) %noun %json)
+    %+  bind
+      (get-header:http head header-list.request.inbound-request)
+    :(cork trip cass crip)
+  =/  give  (test 'content-type')
+  =/  take  (test 'accept')
+  ::
+  =/  =tid  (new-thread-id thread)
+  =.  serving.state
+    (~(put by serving.state) tid [`[eyre-id take] output-mark desk])
+  ::
+  =/  input=vase
+    %+  slop  !>(~)
+    ?-  give
+        %json
+      =/  tube  (convert-tube %json input-mark desk bowl)
+      =/  body=json  (need (de:json:html q.u.body.request.inbound-request))
+      (tube !>(body))
+    ::
+        %noun
+      =/  tube  (convert-tube %noun input-mark desk bowl)
+      =/  body=noun  (cue (slav %uw q.u.body.request.inbound-request))
+      (tube !>(body))
+    ==
   =/  boc  bec
   =/  =start-args:spider  [~ `tid boc(q desk, r da+now.bowl) thread input]
   (handle-start-thread start-args)
@@ -550,18 +592,25 @@
   =-  (fall - `state)
   %+  bind
     (~(get by serving.state) tid)
-  |=  [eyre-id=(unit @ta) output=mark =desk]
+  |=  [request=(unit [rid=@ta take=?(%json %noun)]) output=mark =desk]
   :_  state(serving (~(del by serving.state) tid))
-  ?~  eyre-id
+  ?~  request
     ~
-  %+  give-simple-payload:app:server  u.eyre-id
+  %+  give-simple-payload:app:server  rid.u.request
   ^-  simple-payload:http
   ?.  ?=(http-error:spider term)
     %-  (slog tang)
-    =/  tube  (convert-tube %tang %json desk bowl)
-    :-  [500 [['content-type' 'application/json'] ~]]
-    =-  `(as-octs:mimes:html (en:json:html -))
-    o/(malt `(list [key=@t json])`[term+s/term tang+!<(json (tube !>(tang))) ~])
+    ?-  take.u.request
+        %json
+      =/  tube  (convert-tube %tang %json desk bowl)
+      :-  [500 [['content-type' 'application/json'] ~]]
+      =-  `(as-octs:mimes:html (en:json:html -))
+      o/(malt `(list [key=@t json])`[term+s/term tang+!<(json (tube !>(tang))) ~])
+    ::
+        %noun
+      :-  [500 [['content-type' 'application/x-urb-jam'] ~]]
+      `(as-octs:mimes:html (scot %uw (jam [term tang])))
+    ==
   :_  ~  :_  ~
   ?-  term
     %bad-request  400
@@ -588,13 +637,22 @@
   =-  (fall - `state)
   %+  bind
     (~(get by serving.state) tid)
-  |=  [eyre-id=(unit @ta) output=mark =desk]
-  ?~  eyre-id
+  |=  [request=(unit [rid=@ta take=?(%json %noun)]) output=mark =desk]
+  ?~  request
     `state
-  =/  tube  (convert-tube output %json desk bowl)
-  :_  state(serving (~(del by serving.state) tid))
-  %+  give-simple-payload:app:server  u.eyre-id
-  (json-response:gen:server !<(json (tube vase)))
+  ?-  take.u.request
+      %json
+    =/  tube  (convert-tube output %json desk bowl)
+    :_  state(serving (~(del by serving.state) tid))
+    %+  give-simple-payload:app:server  rid.u.request
+    (json-response:gen:server !<(json (tube vase)))
+  ::
+      %noun
+    :_  state(serving (~(del by serving.state) tid))
+    %+  give-simple-payload:app:server  rid.u.request
+    :-  [200 ['content-type' 'application/x-urb-jam']~]
+    `(as-octs:mimes:html (scot %uw (jam q.vase)))
+  ==
 ::
 ++  thread-done
   |=  [=yarn =vase silent=?]
@@ -681,7 +739,7 @@
 ::
 ++  clean-state
   !>  ^-  clean-slate
-  6+state(running (turn ~(tap of running.state) head))
+  7+state(running (turn ~(tap of running.state) head))
 ::
 ++  convert-tube
   |=  [from=mark to=mark =desk =bowl:gall]


### PR DESCRIPTION
in the thread-calling http interface.

Specifying a `content-type` header of `application/x-urb-jam` will make the request body be interpreted as a `@uw`-encoded jammed noun, rather than json.

Specifying an `accept` header of `application/x-urb-jam` will make the thread result in the response body be rendered as ~~a `@uw`-encoded~~ jammed noun bytes, rather than json.

For the latter, the output mark becomes unused, since we can just "render" the resulting noun directly, without needing to explicitly convert it. (This assumes that converting any mark to %noun will always result in the same noun, which isn't guaranteed in theory, but is always the case in practice.)

This ~~maps closely to~~ is adjacent to Eyre's "noun channels" support, and prepares spider for use in a nouns-based version of the js-http-api.

Example:

```bash
$ curl --silent -X POST --data \x02 --header 'content-type: application/x-urb-jam' --header "cookie: urbauth-~zod=0v4.8lljk.ujoa5.t05b7.iako9.npqet" --header 'accept: application/x-urb-jam' http://localhost/spider/base/ship/hi/noun | xxd -p
003ed0d240fcf4dec840e6eac6c6cae6e6ccead8
```

```hoon
> `@uw`(jam ~zod)
0w2
> ;;(@t (cue 0xd8ea.cce6.e6ca.c6c6.eae6.40c8.def4.fc40.d2d0.3e00))
'hi ~zod successful'
```