### PR TITLE
ames: fix chain mop order

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3306,7 +3306,7 @@
         ^+  event-core
         =/  key=@  (shaz eny) :: TODO: check key width
         =/  num=@ud
-          ?~  latest=(pry:on:chain chain.ames-state)
+          ?~  latest=(ram:on:chain chain.ames-state)
             1
           .+(key.u.latest)
         =.  chain.ames-state


### PR DESCRIPTION
The `chain` in ames ordered the wrong way around. This problem shows up on line 3335 here: https://github.com/urbit/urbit/blob/49975d9821e775241069ad6e2584a76ee5c84a44/pkg/arvo/sys/vane/ames.hoon#L3330-L3340

`num` there is always either 1 or 2. This causes the key `2` to be overwritten all the time which is obviously not good.

@yosoyubik noticed this when working on new ames, but this is wrong in 411 too.

```hoon
> =mymop ((on ,@ ,[key=@ =path]) lte)
> (pry:mymop (gas:mymop *((mop ,@ ,[key=@ =path]) lte) [2 [0x1 /hello]] [1 [0x1 /hello-2]] ~))
[~ [key=1 val=[key=1 path=/hello-2]]]
```