### PR TITLE
eyre: scry with root gang in http generators

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -922,7 +922,7 @@
       ?>  =(%vase p.cag)
       =/  gat=vase  !<(vase q.cag)
       =/  res=toon
-        %-  mock  :_  (look rof ?.(authenticated ~ [~ ~]) /eyre)
+        %-  mock  :_  (look rof [~ ~] /eyre)
         :_  [%9 2 %0 1]  |.
         %+  slam
           %+  slam  gat


### PR DESCRIPTION
#6876 started enforcing the gang system when scrying. Eyre has the capability to register generators to provide responses for http requests. These would now scry with the unauthenticated `~` gang if the http request is unauthenticated, and the root gang `[~ ~]` when authenticated. This broke `/app/acme` letsencrypt certificate renewal that was relying on making `%gx` scries for unauthenticated requests from `/gen/acme/domain-validation`.

This PR allows http generators to scry with the root `[~ ~]` gang. This should be fine since the interface for the generators accepts the `authenticated=?` flag and can use it do whatever dispatch it wants.