### PR TITLE
gall: don't ack %leave for non-running agents

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4585,10 +4585,12 @@
                 %drop  sink(nax.state (~(del in nax.state) message-num.task))
                 %done  (done ok.task)
                 %flub
-              %=  sink
-                last-heard.state        (dec last-heard.state)
-                pending-vane-ack.state  ~(nap to pending-vane-ack.state)
-              ==
+              =?  pending-vane-ack.state  ?=(^ pending-vane-ack.state)
+                ::  a %leave gets acked in %gall before sending the %flub,
+                ::  so %ames has already removed the pending ack from its queue
+                ::
+                ~(nap to pending-vane-ack.state)
+              sink(last-heard.state (dec last-heard.state))
             ::
                 %hear
               |^  ?:  ?|  corked

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4585,12 +4585,10 @@
                 %drop  sink(nax.state (~(del in nax.state) message-num.task))
                 %done  (done ok.task)
                 %flub
-              =?  pending-vane-ack.state  ?=(^ pending-vane-ack.state)
-                ::  a %leave gets acked in %gall before sending the %flub,
-                ::  so %ames has already removed the pending ack from its queue
-                ::
-                ~(nap to pending-vane-ack.state)
-              sink(last-heard.state (dec last-heard.state))
+              %=  sink
+                last-heard.state        (dec last-heard.state)
+                pending-vane-ack.state  ~(nap to pending-vane-ack.state)
+              ==
             ::
                 %hear
               |^  ?:  ?|  corked

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1147,10 +1147,8 @@
   ++  mo-handle-ames-request
     |=  [=ship agent-name=term =ames-request]
     ^+  mo-core
-    ::  %u/%leave gets automatically acked
     ::
     =.  mo-core  (mo-track-ship ship)
-    =?  mo-core  ?=(%u -.ames-request)  (mo-give %done ~)
     ::
     =/  yok=(unit yoke)  (~(get by yokes.state) agent-name)
     ?~  yok
@@ -1160,6 +1158,10 @@
     ?:  ?=(%.n -.agent.u.yok)
       (mo-give %flub ~)
   ::
+    ::  %u/%leave gets automatically acked
+    ::
+    =?  mo-core  ?=(%u -.ames-request)
+      (mo-give %done ~)
     =/  =wire  /sys/req/(scot %p ship)/[agent-name]
     ::
     =/  =deal


### PR DESCRIPTION
In %gall, %pokes to a non-running agent are dropped, and a `%flub` task is sent to %ames to "forget" about the message that has been sent by decreasing the heard (but not acked) sequence number, and removing the pending-ack from its queue.

If the %poke is a `%leave`(s), %gall automatically %acks it (giving a %done to %ames) before sending the %flub, which means that %ames has already remove the pending-ack, and we are going to crash on the %leave, and send a %nack, making the subscriber to retry the %leave forever, every ~m2.

The fix: ~~we just check that the queue is not empty.~~ don't ack %leave for non-running agents