### PR TITLE
gen: prevent re-creating existing moons in |moon

### DIFF
--- a/pkg/arvo/gen/hood/moon.hoon
+++ b/pkg/arvo/gen/hood/moon.hoon
@@ -24,6 +24,14 @@
   ?^  arg
     mon.arg
   (add our (lsh 5 (end 5 (shaz eny))))
+=/  ryf=(unit rift)
+  .^((unit rift) %j /(scot %p p.bec)/ryft/(scot %da now)/(scot %p mon))
+?^  ryf
+  %.  ~
+  %-  slog
+  :~  leaf+"can't create {(scow %p mon)}, it already exists."
+      'use |moon-breach and/or |moon-cycle-keys instead.'
+  ==
 =/  seg=ship  (sein:title our now mon)
 ?.  =(our seg)
   %-  %-  slog  :_  ~


### PR DESCRIPTION
I got bitten by this today. @pkova said he had gotten bit by this some time ago. Maybe this isn't the full, 100%, ideal & accurate fix, but it should prevent you from getting into a confusing bad state.

Apparently the operation triggered by this generator may cause the rift for the specified moon to be inaccurate if |moon-breach was run previously.

Here, detect if the moon has been created before, and recommend the other generators if that is the case.