### PR TITLE
base: %test arg -> test or [desk test]

### DIFF
--- a/nix/test-fake-ship.nix
+++ b/nix/test-fake-ship.nix
@@ -102,7 +102,7 @@ in pkgs.stdenvNoCC.mkDerivation {
   '';
 
   checkPhase = ''
-    if egrep "((FAILED|CRASHED|Failed|[0 %avow 0 %noun 1])|warn:)" $out >/dev/null; then
+    if egrep "((FAILED|CRASHED|Failed|\[0 %avow 0 %noun 1\])|warn:)" $out >/dev/null; then
       exit 1
     fi
   '';

--- a/pkg/arvo/app/test.hoon
+++ b/pkg/arvo/app/test.hoon
@@ -2,7 +2,7 @@
 !:
 |%
 +$  card  card:agent:gall
-+$  command  [=desk =test]
++$  command  $@(=test [=desk =test])
 +$  test  ?(%agents %marks %generators %threads)
 +$  state
   $:  app=(set path)
@@ -29,6 +29,9 @@
   ^-  [(list card) _this]
   ?>  (team:title [our src]:bowl)
   =+  !<(cmd=command vase)
+  =?  cmd  ?=(@ cmd)
+    [q.byk.bowl test.cmd]
+  ?>  ?=(^ cmd)
   |^
   ?-  test.cmd
     %marks       test-marks


### PR DESCRIPTION
addresses @joemfb 's comment:

> I think this would be better if `$command` where `$@(test [desk test])`. Easy to default to `%base` and keep compatibility in this interface (so old CI scripts still run, &c).
https://github.com/urbit/urbit/pull/6955#issuecomment-2052925280