### PR TITLE
ci: catch khan errors in ci

### DIFF
--- a/nix/test-fake-ship.nix
+++ b/nix/test-fake-ship.nix
@@ -102,7 +102,7 @@ in pkgs.stdenvNoCC.mkDerivation {
   '';
 
   checkPhase = ''
-    if egrep "((FAILED|CRASHED|Failed)|warn:)" $out >/dev/null; then
+    if egrep "((FAILED|CRASHED|Failed|[0 %avow 0 %noun 1])|warn:)" $out >/dev/null; then
       exit 1
     fi
   '';


### PR DESCRIPTION
https://github.com/urbit/urbit/pull/6955 broke CI by modifying `/app/test`, but CI still passed. This happened because we are running out tests via khan (click) and we were not catching khan errors, just errors inside the agents and threads.