### PR TITLE
ames: fix spurious %10 in ++stay

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1691,7 +1691,7 @@
     ::  lifecycle arms; mostly pass-throughs to the contained adult ames
     ::
     ++  scry  scry:adult-core
-    ++  stay  [%10 %larva queued-events ames-state.adult-gate]
+    ++  stay  [%21 %larva queued-events ames-state.adult-gate]
     ++  load
       |=  $=  old
           $%  $:  %4


### PR DESCRIPTION
I messed up this one too in #6970. I also did some surgery on `~binnec-dozzod-marzod` to fix everybody that was affected and waited for their clay subscriptions to be filled.