### PR TITLE
ames: do not got:by in +check-clog

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3730,8 +3730,9 @@
         ++  check-clog
           |=  [=bone id=*]
           ^+  peer-core
-          =/  =message-pump-state  (~(got by snd.peer-state) bone)
-          ?:  (gth ~(wyt in unsent-messages.message-pump-state) msg.cong.ames-state)
+          =/  m=(unit message-pump-state)  (~(get by snd.peer-state) bone)
+          ?~  m  peer-core
+          ?:  (gth ~(wyt in unsent-messages.u.m) msg.cong.ames-state)
             (pe-emit [/ames]~ %pass /clog %g %clog id)
           peer-core
         ::  +on-memo: handle request to send message


### PR DESCRIPTION
Migrating `~halbex-palheb` to the new `%clog` stuff was unsuccessful since it seems like `+check-clog` sometimes gets called with a bone that doesn't exist in `snd`. This happens when we are trying to send something on a corked bone, so we need to handle this case in `+check-clog` also.