### PR TITLE
ames: fix old state migrations

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1275,6 +1275,17 @@
       counter=@ud
   ==
 ::
++$  task-4-til-8
+  $+  task-4-til-8
+  $%  [?(%heed %jilt) =ship]              ::  introduced in state %4, removed in %21
+      $<(?(%snub %kroc %deep %keen) task) ::  tasks introduced later
+  ==
++$  queued-event-4-til-8
+  $+  queued-event-4-til-8
+  $%  [%call =duct wrapped-task=(hobo task-4-til-8)]
+      [%take =wire =duct =sign]
+  ==
+::
 +$  queued-event-9-til-11
   $+  queued-event-9-til-11
   $%  [%call =duct wrapped-task=(hobo task-9-til-11)]
@@ -1285,6 +1296,7 @@
   $+  task-9-til-11
   $%  [%kroc dry=?]                 ::  introduced in state %10, modified in %17
       [%snub ships=(list ship)]     ::  introduced in state %9,  modified in %11
+      [?(%heed %jilt) =ship]        ::  introduced in state %4, removed in %21
       $<(?(%snub %kroc %deep %keen) task) ::  %deep/%keen introduced later
   ==
 ::
@@ -1299,6 +1311,7 @@
   $%  [%kroc dry=?]                 ::  introduced in state %10, modified in %17
       [%keen spar]                  ::  introduced in state %13, modified in %19
       deep-task-14                  ::  introduced in state %14, modified in %19
+      [?(%heed %jilt) =ship]        ::  introduced in state %4, removed in %21
       $<(?(%kroc %keen %deep) task)
   ==
 ::
@@ -1321,6 +1334,7 @@
   $+  task-16-and-18
   $%  [%keen spar]                  ::  introduced in state %13, modified in %19
       deep-task-14                  ::  introduced in state %14, modified in %19
+      [?(%heed %jilt) =ship]        ::  introduced in state %4, removed in %21
       $<(?(%keen %deep) task)
   ==
 ::
@@ -1347,16 +1361,15 @@
       =chain
   ==
 ::
-+$  task-20
-  $+  task-20
-  $%  task
-      [%heed =ship]
-      [%jilt =ship]
++$  task-19-and-20
+  $+  task-19-and-20
+  $%  [?(%heed %jilt) =ship]       ::  introduced in state %4, removed in %21
+      task
   ==
 ::
-+$  queued-event-20
-  $+  queued-event-20
-  $%  [%call =duct wrapped-task=(hobo task-20)]
++$  queued-event-19-and-20
+  $+  queued-event-19-and-20
+  $%  [%call =duct wrapped-task=(hobo task-19-and-20)]
       [%take =wire =duct =sign]
   ==
 ::
@@ -1696,47 +1709,47 @@
       |=  $=  old
           $%  $:  %4
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-4-til-8)
                       state=ames-state-4
                   ==
                   [%adult state=ames-state-4]
               ==  ==
               $:  %5
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-4-til-8)
                       state=ames-state-5
                   ==
                   [%adult state=ames-state-5]
               ==  ==
               $:  %6
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-4-til-8)
                       state=ames-state-6
                   ==
                   [%adult state=ames-state-6]
               ==  ==
               $:  %7
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-4-til-8)
                       state=ames-state-7
                   ==
                   [%adult state=ames-state-7]
               ==  ==
               $:  %8
               $%  $:  %larva
-                      events=(qeu queued-event)
+                      events=(qeu queued-event-4-til-8)
                       state=ames-state-8
                   ==
                   [%adult state=ames-state-8]
               ==  ==
-              $:  %9                                  :: %snub introduced
+              $:  %9                             :: %snub introduced
               $%  $:  %larva
                       events=(qeu queued-event-9-til-11)
                       state=ames-state-9
                   ==
                   [%adult state=ames-state-9]
               ==  ==
-              $:  %10                                 :: %kroc introduced
+              $:  %10                            :: %kroc introduced
               $%  $:  %larva
                       events=(qeu queued-event-9-til-11)
                       state=ames-state-10
@@ -1750,21 +1763,21 @@
                   ==
                   [%adult state=ames-state-11]
               ==  ==
-              $:  %12                                 :: %snub modified
+              $:  %12                            :: %snub modified
               $%  $:  %larva
                       events=(qeu queued-event-12-til-16)
                       state=ames-state-12
                   ==
                   [%adult state=ames-state-12]
               ==  ==
-              $:  %13
-              $%  $:  %larva                          :: %keen introduced
+              $:  %13                            :: %keen introduced
+              $%  $:  %larva
                       events=(qeu queued-event-12-til-16)
                       state=ames-state-13
                   ==
                   [%adult state=ames-state-13]
               ==  ==
-              $:  %14                                 :: %deep introduced
+              $:  %14                            :: %deep introduced
               $%  $:  %larva
                       events=(qeu queued-event-12-til-16)
                       state=ames-state-14
@@ -1785,7 +1798,7 @@
                   ==
                   [%adult state=ames-state-16]
               ==  ==
-              $:  %17                                 :: %kroc modified
+              $:  %17                            :: %kroc modified
               $%  $:  %larva
                       events=(qeu queued-event-17-and-18)
                       state=ames-state-17
@@ -1799,21 +1812,21 @@
                   ==
                   [%adult state=ames-state-18]
               ==  ==
-              $:  %19                                 :: %keen & %deep modified
+              $:  %19                            :: %keen & %deep modified
               $%  $:  %larva
-                      events=(qeu queued-event-20)
+                      events=(qeu queued-event-19-and-20)
                       state=ames-state-19
                   ==
                   [%adult state=ames-state-19]
               ==  ==
-              $:  %20                                 :: start informal %ping
+              $:  %20                            :: start informal %ping
               $%  $:  %larva
-                      events=(qeu queued-event-20)
+                      events=(qeu queued-event-19-and-20)
                       state=ames-state-20
                   ==
                   [%adult state=ames-state-20]
               ==  ==
-              $:  %21                                 :: remove %heed and %jilt
+              $:  %21                            :: remove %heed and %jilt
               $%  $:  %larva
                       events=(qeu queued-event)
                       state=_ames-state.adult-gate
@@ -1837,7 +1850,11 @@
           [%5 %larva *]
         ~>  %slog.0^leaf/"ames: larva %5 load"
         =.  cached-state  `[%5 state.old]
-        =.  queued-events  events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%6 %adult *]
@@ -1848,7 +1865,11 @@
           [%6 %larva *]
         ~>  %slog.0^leaf/"ames: larva %6 load"
         =.  cached-state  `[%6 state.old]
-        =.  queued-events  events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%7 %adult *]
@@ -1858,8 +1879,12 @@
       ::
           [%7 %larva *]
         ~>  %slog.0^leaf/"ames: larva %7 load"
-        =.  queued-events  events.old
         =.  cached-state  `[%7 state.old]
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%8 %adult *]
@@ -1870,7 +1895,11 @@
           [%8 %larva *]
         ~>  %slog.0^leaf/"ames: larva %8 load"
         =.  cached-state  `[%8 state.old]
-        =.  queued-events  events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%9 %adult *]
@@ -1881,11 +1910,11 @@
           [%9 %larva *]
         ~>  %slog.0^leaf/"ames: larva %9 load"
         =.  cached-state  `[%9 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           %-  event-9-til-11-to-12
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%10 %adult *]
@@ -1896,11 +1925,11 @@
           [%10 %larva *]
         ~>  %slog.1^leaf/"ames: larva %10 load"
         =.  cached-state  `[%10 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           %-  event-9-til-11-to-12
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%11 %adult *]
@@ -1911,11 +1940,11 @@
           [%11 %larva *]
         ~>  %slog.1^leaf/"ames: larva %11 load"
         =.  cached-state  `[%11 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           %-  event-9-til-11-to-12
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            %-  event-9-til-11-to-12
+                            events.old
         larval-gate
       ::
           [%12 %adult *]
@@ -1926,10 +1955,10 @@
           [%12 %larva *]
         ~>  %slog.1^leaf/"ames: larva %12 load"
         =.  cached-state  `[%12 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            events.old
         larval-gate
       ::
           [%13 %adult *]
@@ -1940,10 +1969,10 @@
           [%13 %larva *]
         ~>  %slog.1^leaf/"ames: larva %13 load"
         =.  cached-state  `[%13 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            events.old
         larval-gate
       ::
           [%14 %adult *]
@@ -1954,10 +1983,10 @@
           [%14 %larva *]
         ~>  %slog.1^leaf/"ames: larva %14 load"
         =.  cached-state  `[%14 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            events.old
         larval-gate
       ::
           [%15 %adult *]
@@ -1968,10 +1997,10 @@
           [%15 %larva *]
         ~>  %slog.1^leaf/"ames: larva %15 load"
         =.  cached-state  `[%15 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            events.old
         larval-gate
       ::
           [%16 %adult *]
@@ -1982,10 +2011,10 @@
           [%16 %larva *]
         ~>  %slog.1^leaf/"ames: larva %16 load"
         =.  cached-state  `[%16 state.old]
-        =.  queued-events  %-  event-20-to-21
-                           %-  event-17-and-18-to-last
-                           %-  event-12-til-16-to-17
-                           events.old
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            %-  event-12-til-16-to-17
+                            events.old
         larval-gate
       ::
           [%17 %adult *]
@@ -1996,7 +2025,9 @@
           [%17 %larva *]
         ~>  %slog.1^leaf/"ames: larva %17 load"
         =.  cached-state  `[%17 state.old]
-        =.  queued-events  (event-20-to-21 (event-17-and-18-to-last events.old))
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            events.old
         larval-gate
       ::
           [%18 %adult *]
@@ -2007,7 +2038,9 @@
           [%18 %larva *]
         ~>  %slog.1^leaf/"ames: larva %18 load"
         =.  cached-state  `[%18 state.old]
-        =.  queued-events  (event-20-to-21 (event-17-and-18-to-last events.old))
+        =.  queued-events   %-  event-20-to-21
+                            %-  event-17-and-18-to-20
+                            events.old
         larval-gate
       ::
           [%19 %adult *]
@@ -2072,17 +2105,17 @@
           [%kroc ~]
         ==
       ::
-      ++  event-17-and-18-to-last
+      ++  event-17-and-18-to-20
         |=  events=(qeu queued-event-17-and-18)
-        ^-  (qeu queued-event)
+        ^-  (qeu queued-event-19-and-20)
         %-  ~(rep in events)
-        |=  [e=queued-event-17-and-18 q=(qeu queued-event)]
-        %-  ~(put to q)  ^-  queued-event
+        |=  [e=queued-event-17-and-18 q=(qeu queued-event-19-and-20)]
+        %-  ~(put to q)  ^-  queued-event-19-and-20
         ?.  ?=(%call -.e)  e
         =/  task=task-16-and-18  ((harden task-16-and-18) wrapped-task.e)
         %=    e
             wrapped-task
-          ^-  ^task
+          ^-  task-19-and-20
           ?:  ?=(%keen -.task)
             [%keen ~ +.task]
           ?.  ?=([%deep %nack *] task)  task
@@ -2095,15 +2128,17 @@
             %naxplanation
           [%deep %nack ship.task nack-bone.task ;;(message [hed msg])]
         ==
+      ::
       ++  event-20-to-21
-        |=  events=(qeu queued-event-20)
+        |=  events=(qeu queued-event-19-and-20)
         ^-  (qeu queued-event)
         %-  ~(rep in events)
-        |=  [e=queued-event-20 q=(qeu queued-event)]
+        |=  [e=queued-event-19-and-20 q=(qeu queued-event)]
         ?.  ?=(%call -.e)  (~(put to q) e)
-        =/  task=task-20  ((harden task-20) wrapped-task.e)
+        =/  task=task-19-and-20  ((harden task-19-and-20) wrapped-task.e)
         ?:  ?=(?(%heed %jilt) -.task)  q
         (~(put to q) e(wrapped-task task))
+      ::
       --
     ::  +molt: re-evolve to adult-ames
     ::


### PR DESCRIPTION
PS: draft until I can test *some* old migrations

PPS: i might refactor +load to make it call itself recursively instead of migrating queued events at one, but that means removing +molt so will see, since hopefully we won't have any more +larval migrations.