### PR TITLE
gen: add +commit-event

### DIFF
--- a/pkg/arvo/gen/commit-event.hoon
+++ b/pkg/arvo/gen/commit-event.hoon
@@ -4,6 +4,8 @@
 ::    to be used with ./urbit-binary -I event.jam pier
 ::
 ::    XX expand with arbitrary user-defined events?
+::    XX only supports files in which +noun:grab in the mark file returns a @t
+::       (e.g. hoon files)
 ::
 :-  %say
 |=  [[now=@da eny=@uvJ bec=beak] [=path ~] ~]
@@ -12,4 +14,4 @@
   ~|(%path-not-beam !!)
 =+  .^(file=@t %cx path)
 =+  .^(=tube:clay %cc /(scot %p p.bec)/[q.bec]/(scot %da now)/txt/mime)
-[/c/sync %into %base | [s.u.beam [~ !<(mime (tube !>(~[file])))]]~]
+[/c/sync %into desk=q.u.beam | [s.u.beam [~ !<(mime (tube !>(~[file])))]]~]

--- a/pkg/arvo/gen/commit-event.hoon
+++ b/pkg/arvo/gen/commit-event.hoon
@@ -1,0 +1,15 @@
+::  make a unix commit event
+::
+::    call as > .event/jam +commit-event /path/to/file
+::    to be used with ./urbit-binary -I event.jam pier
+::
+::    XX expand with arbitrary user-defined events?
+::
+:-  %say
+|=  [[now=@da eny=@uvJ bec=beak] [=path ~] ~]
+:-  %noun
+?~  beam=(de-beam path)
+  ~|(%path-not-beam !!)
+=+  .^(file=@t %cx path)
+=+  .^(=tube:clay %cc /(scot %p p.bec)/[q.bec]/(scot %da now)/txt/mime)
+[/c/sync %into %base | [s.u.beam [~ !<(mime (tube !>(~[file])))]]~]


### PR DESCRIPTION
Produces a unix commit event from the provided path. This is useful in situations where a pier is running a buggy version of a hoon file that we cannot recover from.

By making a jammed event of the commit, we can inject into the affected pier (using the "-I event.jam" flag) a restored version of the file that fixes the issue.