### PR TITLE
jael: notify gall the vane before notifying gall agents

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -670,7 +670,9 @@
     $(yez t.yez)
     ::
     ::  We want to notify Ames, then Clay, then Gall.  This happens to
-    ::  be alphabetical, but this is mostly a coincidence.
+    ::  be alphabetical, but this is mostly a coincidence. We also have
+    ::  to notify Gall the vane before we notify any Gall agents, so we
+    ::  can kiss the coincidence goodbye.
     ::
     ++  sorter
       |=  [a=duct b=duct]
@@ -678,6 +680,8 @@
         |
       ?.  ?=([[@ *] *] b)
         &
+      ?:  &(?=([[%gall *] *] a) ?=([[%gall *] *] b))
+        ?=([%gall %sys *] i.a)
       (lth (end 3 i.i.a) (end 3 i.i.b))
     --
   ::


### PR DESCRIPTION
When testing `%phoenix` we discovered that a poke that the app sends when hearing about a breach was always dropped with a `gall: missing` message. This is because jael delivers breach notifications to gall the vane and gall agents in an undefined order.

Old behavior:
```hoon
(sort `(list duct)`[[i=/gall/use/ping/0w3.psfYX/~dinleb-rambep/jael t=[i=/dill t=~[//term/1]]] [i=/gall/sys/era t=[i=/dill t=~[//term/1]]] ~] sorter)
~[[i=/gall/use/ping/0w3.psfYX/~dinleb-rambep/jael t=[i=/dill t=~[//term/1]]] [i=/gall/sys/era t=[i=/dill t=~[//term/1]]]]
```

New behavior:

```hoon
(sort `(list duct)`[[i=/gall/use/ping/0w3.psfYX/~dinleb-rambep/jael t=[i=/dill t=~[//term/1]]] [i=/gall/sys/era t=[i=/dill t=~[//term/1]]] ~] sorter)
~[[i=/gall/sys/era t=[i=/dill t=~[//term/1]]] [i=/gall/use/ping/0w3.psfYX/~dinleb-rambep/jael t=[i=/dill t=~[//term/1]]]]
```

Here we fix jael to always notify the vane before notifying any agents by special casing the `/sys` wire.