### PR TITLE
hoon: expand =| through ^* to enable constant-folding

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8602,7 +8602,7 @@
       [%cnhp ~(factory ax p.gen) q.gen]
     ::
         [%tsbr *]
-      [%tsls ~(example ax p.gen) q.gen]
+      [%tsls [%kttr p.gen] q.gen]
     ::
         [%tstr *]
       :+  %tsgl


### PR DESCRIPTION
I discovered this while helping debug ares-codegen, and was surprised to the current macro-expansion. I can't think of any reason not to make this change. It will help cut down on the overhead of calls into manually deconstructed cores (like `+in`, `+by`, `+nest:ut`, &c).