### PR TITLE
hoon: retain face on type in +lose:ar (for ?#)

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8988,7 +8988,7 @@
                        ?.  =(%noun ^skin.skin)
                          (cell - ^$(skin ^skin.skin, ref %noun))
                        [%core - q.ref]
-            [%face *]  $(ref q.ref)
+            [%face *]  (face p.ref $(ref q.ref))
             [%fork *]  (fork (turn ~(tap in p.ref) |=(=type ^$(ref type))))
             [%hint *]  (hint p.ref $(ref q.ref))
             [%hold *]  ?:  (~(has in gil) ref)  %void


### PR DESCRIPTION
`?#` wuthax was stripping faces in some type subtraction scenarios, which is unexpected and undesirable.

Excluding `.skin` doesn't necessarily mean we lose any of `.ref`'s faces. The `%base` and `%leaf` cases were already retaining them, we now do so for the `%cell` case too.

Previously:

```hoon
> =+  l=(gulf 0 5)
> ?<  ?#([one=@ two=@ rest=~] l)  l
[i=0 [i=1 t=[i=2 t=~[3 4 5]]]]
```

Now:

```hoon
> =+  l=(gulf 0 5)
> ?<  ?#([one=@ two=@ rest=~] l)  l
[i=0 t=[i=1 t=[i=2 t=~[3 4 5]]]]
```