### PR TITLE
ames: ignore message-num.task for %drop tasks

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4643,7 +4643,29 @@
             |=  task=message-sink-task
             ^+  sink
             ?-    -.task
-                %drop  sink(nax.state (~(del in nax.state) message-num.task))
+                %drop
+              ::  ignore message-num.task; it refers to a message in the
+              ::  naxplanation flow associated with the reference bone
+              ::
+              %_   sink
+                  nax.state
+                %-  ~(rep in nax.state)
+                |=  [=message-num nax=_nax.state]
+                ::  XX  nax.peer-state was never used after %alef became %ames
+                ::  track nacks in here, but keep e.g. only the last 10?
+                ::
+                :: =?  nax.peer-state  (lte message-num last-acked.state)
+                ::   (~(put in nax.peer-state) bone message-num)
+                ::
+                ::  we can safely assume that any messages less or equal than
+                ::  last acked have been already processed, independent or what
+                ::  naxplanation ack triggered the %drop task.
+                ::
+                =?  nax  (lte message-num last-acked.state)
+                  (~(del in nax) message-num)
+                nax
+              ==
+            ::
                 %done  (done ok.task)
                 %flub
               %=  sink


### PR DESCRIPTION
tl;dr: not working, but wanted to get some eyes on it first since this behavior has been in place since the %alef rewrite.

When a message is nacked (e.g. seq=25), we add it to nax.sink and create a %naxplanation message (e.g. seq=1; first ever naxplanation sent) that contains the nacked sequence number (25), and send it to the original sender on the naxplanation flow.

When the ack for the naxplanation (seq=1) comes back, we know that this was an ack for a naxplanation bone and then drop the sequence number of [_this_ naxplanation message](https://github.com/urbit/urbit/blob/develop/pkg/arvo/sys/vane/ames.hoon#L4257) (seq=1) instead of the original message (seq=25) that was nacked.

This causes a range of messages in nax.sink that will remain there until naxplanations catch up with the actual message numbers from the reference flow.

We are removing messages that might not have been nacked, but that seems ok since the message won't be there anyway. But this could mean that there are gaps in the sequence of messages that we have nacked so the fact that there are messages in nax.sink doesn't mean that we can say: "if a sequence number higher than what's in the queue is not in nax.sink, we can we assume that it has not been nacked?".

In any case, it looks like this behavior has not caused any (known?) issues, and as of this commit, this change introduced some problems (re: looking into it right now) so as it stands I wouldn't say that we should fix this before Directed Messaging is released since we could introduce other problems, but wanted to have some eyes on it since it looks like some of this was a part of the %alef rewrite (e.g. [nax.peer-state](https://github.com/urbit/urbit/pull/1996/files#diff-170aa64feef9c085358aed454b0f366f7654d665439d028585e299c693d5d0a2L1552) which was never used, only nax.sink in the .message-sink) but got dropped when it got merged into %ames.

(PS: wip, currently does not work)

(PPS: [a space-leak fix](https://github.com/urbit/urbit/pull/6642/files#diff-2cea4c07b4facff63d912c6b2d14b2b6cc83b356e6d8b7ea74f205c5ae364d08R5088-R5091) targeted these nacked messages directly and removed anything that had already been acked)