### PR TITLE
ames: assume ok when handling next pending-vane-ack

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4854,7 +4854,10 @@
             =.  peer-core
               (send-shut-packet bone message-num %| %| ok lag=`@dr`0)
             ?~  next=~(top to pending-vane-ack.state)  sink
-            (handle-sink message-num.u.next message.u.next ok)
+            ::  u.next has not been sent to the vane so we assume ok=%.y;
+            ::  +done will be called again in the case of error
+            ::
+            (handle-sink message-num.u.next message.u.next ok=%.y)
           ::
           +|  %implementation
           ::  +handle-sink: dispatch message


### PR DESCRIPTION
See this https://github.com/urbit/urbit/pull/6996#issuecomment-2126190938 for context.

When processing pending-vane-acks, if there are any in the queue (i.e. that we have not delivered it to the vane; seq=10) we were wrongly passing the `ok=?(%.n %.y)` of the previous message—this happens in scenarios where things come out of order (seq=10 comes before seq=9, so we enqueue 10, and when 9 is processed we dequeue it right away).

If that had been a %nack (seq=9), we wouldn't be delivering the pending-ack to the vane, and just send a naxplanation directly in `+ha-plea`, and then increasing last-acked (9 -> 10). When the vane gives the %done back to %ames (and it was an error, seq=9), we are going to send a naxplanation, but because we reference `last-acked` (10) which has already been increased, when are not going to use seq=9.

The original sender of the %pokes that got nacked is going to receive two naxplanations, both referencing the same message (10), and will never receive a naxplanation of the previous one that is in range (9). Both naxplanations refer to future acks, so we are going to drop them and never give anything to the vane.

This seems to be a weird situation since it doesn't look like we have seen this in the live network, probably because of latency, but when testing this locally, the pokes come fast enough that %gall is nos giving the done to %ames before the next poke comes in.

In any case this looks like a serious bug, I'm going to test this on a moon and see that this doesn't introduce any unexpected new bugs.