### PR TITLE
gen: commit %info instead of %into

### DIFF
--- a/pkg/arvo/gen/commit-event.hoon
+++ b/pkg/arvo/gen/commit-event.hoon
@@ -13,5 +13,4 @@
 ?~  beam=(de-beam path)
   ~|(%path-not-beam !!)
 =+  .^(file=@t %cx path)
-=+  .^(=tube:clay %cc /(scot %p p.bec)/[q.bec]/(scot %da now)/txt/mime)
-[/c/sync %into desk=q.u.beam | [s.u.beam [~ !<(mime (tube !>(~[file])))]]~]
+[/c/sync %info desk=q.u.beam | [s.u.beam %ins %mime !>([/ (as-octs:mimes:html file)])]~]

--- a/pkg/arvo/gen/commit-event.hoon
+++ b/pkg/arvo/gen/commit-event.hoon
@@ -13,4 +13,4 @@
 ?~  beam=(de-beam path)
   ~|(%path-not-beam !!)
 =+  .^(file=@t %cx path)
-[/c/sync %info desk=q.u.beam | [s.u.beam %ins %mime !>([/ (as-octs:mimes:html file)])]~]
+[/c/sync %info desk=q.u.beam & [s.u.beam %ins %mime !>([/ (as-octs:mimes:html file)])]~]


### PR DESCRIPTION
This works even if the desk is not mounted which is important in some recovery scenarios.