### PR TITLE
ping: do not ping if we are a galaxy

### DIFF
--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -141,6 +141,9 @@
   ?.  =(our src):bowl    :: don't crash, this is where pings are handled
     `this
   ::
+  ?:  ?=(%czar (clan:title our.bowl))
+    `this
+  ::
   =^  cards  state
     ?:  ?=([%kick ?] q.vase)
       =?  mode.state  =(+.q.vase %.y)
@@ -182,6 +185,8 @@
   =^  cards  state
     ?+    wire  `state
         [%wait *]
+      ?:  ?=(%czar (clan:title our.bowl))
+        `state
       ?.  ?=(%formal mode.state)  `state
       ?>  ?=(%wake +<.sign-arvo)
       ?^  error.sign-arvo


### PR DESCRIPTION
I saw nine /ping timers on ~zod, this is because we never start attempt to start stunning if we are a galaxy. This makes galaxies no-op if they poke their own ping app or get a behn ping timer.