### PR TITLE
eyre: tweak time-related eauth numbers

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -126,6 +126,9 @@
 ::  session-timeout: the delay before an idle session expires
 ::
 ++  session-timeout  ~d7
+::  eauth-timeout: max time we wait for remote scry response before serving 504
+::
+++  eauth-timeout         ~s50
 --
 ::  utilities
 ::
@@ -2077,7 +2080,7 @@
       ++  start-timeout
         |=  =path
         ^-  move
-        [duct %pass [%eauth %expire path] %b %wait (add now ~m5)]
+        [duct %pass [%eauth %expire path] %b %wait (add now eauth-timeout)]
       --
     --
   ::  +channel: per-event handling of requests to the channel system

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -127,8 +127,10 @@
 ::
 ++  session-timeout  ~d7
 ::  eauth-timeout: max time we wait for remote scry response before serving 504
+::  eauth-cache-rounding: scry case rounding for cache hits & clock skew aid
 ::
 ++  eauth-timeout         ~s50
+++  eauth-cache-rounding  ~m5
 --
 ::  utilities
 ::
@@ -1766,10 +1768,10 @@
           %-  (trace 2 |.("eauth: %{(trip kind)} into {(scow %p ship)}"))
           ::  we round down the time to make it more likely to hit cache,
           ::  at the expense of not working if the endpoint changed within
-          ::  the last hour.
+          ::  the last +eauth-cache-rounding.
           ::
           =/  =wire       /eauth/keen/(scot %p ship)/(scot %uv nonce)
-          =.   time       (sub time (mod time ~h1))
+          =.   time       (sub time (mod time eauth-cache-rounding))
           =/  =spar:ames  [ship /e/x/(scot %da time)//eauth/url]
           [duct %pass wire %a ?-(kind %keen keen+[~ spar], %yawn yawn+spar)]
         ::

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -1312,7 +1312,8 @@
     ++  ex-keen
       |=  =time
       %+  ex  ~[/http-blah]
-      =.  time  (sub time (mod time ~h1))
+      ::TODO  want to access eauth-cache-rounding:eyre-gate here but can't..?
+      =.  time  (sub time (mod time ~m5))
       [%pass wire %a %keen ~ ~sampel /e/x/(scot %da time)//eauth/url]
     ::
     ++  ex-yawn
@@ -1367,7 +1368,7 @@
   ;<  ~  bind:m
     %+  expect-moves  mos
     :~  (ex-keen now)
-        (ex-wait /eauth/expire/visitors/(scot %uv nonce) (add now ~m5))
+        (ex-wait /eauth/expire/visitors/(scot %uv nonce) (add now eauth-timeout:eyre-gate))
     ==
   ::  ~sampel gets back to us with a url, we redirect the requester
   ::
@@ -1428,7 +1429,7 @@
   ;<  =time  bind:m  get-now
   ::  expiry timer fires, we serve a response and delete the attempt
   ::
-  ;<  ~  bind:m  (wait ~m5)
+  ;<  ~  bind:m  (wait eauth-timeout:eyre-gate)
   ;<  mos=(list move)  bind:m
     =/  =^wire  /eauth/expire/visitors/(scot %uv nonce)
     (take wire ~[/http-blah] %behn %wake ~)
@@ -1518,7 +1519,7 @@
   ;<  ~  bind:m
     %+  expect-moves  mos
     :~  (ex-plea ~hoster %0 %open 0vnonce `0v4.qkgot.d07e3.pi1qd.m1bhj.ti8bo)
-        (ex-wait /eauth/expire/visiting/~hoster/0vnonce (add now ~m5))
+        (ex-wait /eauth/expire/visiting/~hoster/0vnonce (add now eauth-timeout:eyre-gate))
     ==
   ::  upon receiving an %okay from ~hoster, redirect the user
   ::


### PR DESCRIPTION
We make two changes in the hopes of improving the UX of eauth, especially around its failure cases.

1. Lower the eauth timeout from 5 minutes to 50 seconds.
  - This way we serve the user a formal error page much more eagerly. In practice, most commonly, remote scry for the eauth url either gets a response reasonably fast, or not at all.
  - Nginx, popularly used as a proxy server in front of urbit, times out connections after a minute unless configured otherwise. Setting the timeout to be slightly below that ensures eyre gets to serve an error page itself in those common setups.
2. Lower the eauth url scry's case rounding from 1 hour down to 5 minutes.
  - The high value was interfering with UX around updated public urls. The strong rounding is supposed to give us more frequent scry cache hits, but highly questionable whether that actually matters in practice.
  - 5 minutes should still be plenty to avoid scry breakage due to clock skew in almost all cases (right?). "Wait up to five minutes for it to work" still isn't great, but it's much better than "up to an hour".
  - The most-correct answer here is scry-at-latest, and we should switch to using that whenever it arrives.