### PR TITLE
ames: really scry jael for sponsors when peer is alien

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -6025,7 +6025,7 @@
           ~
         ?:  ?=([~ %known *] peer)
           (get-forward-lanes our +.u.peer peers.ames-state)
-        =/  sax  (rof ~ /ames %j `beam`[[our %saxo %da now] /(scot %p u.who)])
+        =/  sax  (rof [~ ~] /ames %j `beam`[[our %saxo %da now] /(scot %p u.who)])
         ?.  ?=([~ ~ *] sax)
           ~
         =/  gal  (rear ;;((list ship) q.q.u.u.sax))


### PR DESCRIPTION
Consider the following piece of code in the Ames scry for the `%forward-lane`:
https://github.com/urbit/urbit/blob/5e7359fbb5546de171954f6092d483946c79d93e/pkg/arvo/sys/vane/ames.hoon#L6026-L6030

This piece of code is scrying jael for the sponsoring galaxy if the peer in question is `%alien`, ie we've never communicated via Ames before. Unfortunately this is always going to respond with `~` because the gang in the `rof` call is incorrectly `~` instead of `[~ ~]`. This problem has been around since #6876.

Notably this issue never matters unless somebody is making a fine request to a ship without ever having communicated with that ship before. All other codepaths end up injecting packets into Ames that eventually lead to the peer state becoming `%known`.

This problem right here is the reason eAuth has been flaky.