### PR TITLE
dill: implement %mass & %meme memory reports

### DIFF
--- a/pkg/arvo/app/ping.hoon
+++ b/pkg/arvo/app/ping.hoon
@@ -159,6 +159,7 @@
 ++  on-peek
   |=  =path
   ^-  (unit (unit cage))
+  ?<  ?=([%x %whey ~] path)
   ``noun+!>(state)
 ::  +on-agent: handle ames ack
 ::

--- a/pkg/arvo/mar/mass.hoon
+++ b/pkg/arvo/mar/mass.hoon
@@ -1,0 +1,1 @@
+../../base-dev/mar/mass.hoon

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2011,7 +2011,8 @@
     ==                                                  ::
   +$  task                                              ::  in request ->$
     $~  [%vega ~]                                       ::
-    $%  [%boot lit=? p=*]                               ::  weird %dill boot
+    $%  $>(%born vane-task)                             ::  new unix process
+        [%boot lit=? p=*]                               ::  weird %dill boot
         [%crop p=@ud]                                   ::  trim kernel state
         [%flog p=flog]                                  ::  wrapped error
         [%heft ~]                                       ::  memory report

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2006,6 +2006,8 @@
         [%pack ~]                                       ::  compact memory
         [%trim p=@ud]                                   ::  trim kernel state
         [%logs =told]                                   ::  system output
+        [%meme p=(list quac)]                           ::  memory report
+        [%quac ~]                                       ::  memory runtime
     ==                                                  ::
   +$  task                                              ::  in request ->$
     $~  [%vega ~]                                       ::
@@ -2015,6 +2017,8 @@
         [%heft ~]                                       ::  memory report
         $>(%init vane-task)                             ::  after gall ready
         [%logs p=(unit ~)]                              ::  watch system output
+        [%mass ~]                                       ::  run memory report
+        [%quac p=(list quac)]                           ::  memory runtime
         [%meld ~]                                       ::  unify memory
         [%pack ~]                                       ::  compact memory
         [%seat =desk]                                   ::  install desk
@@ -2098,6 +2102,9 @@
     $:  ses=@tas                                        ::  target session
         dill-belt                                       ::  input
     ==                                                  ::
+  +$  quac                                              ::  memory report
+    $~  ['' 0 ~]
+    [name=@t size=@ud quacs=(list quac)]
   --  ::dill
 ::                                                      ::::
 ::::                    ++eyre                            ::  (1e) http-server

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -266,6 +266,13 @@
     ?<  ?=(%crud -.task)
     [%crud -.task tang.u.dud]
   ::
+  ::
+  ?:  ?=(%born -.task)
+    ?~  hey.all
+      [~ ..^$]
+    ?:  ?=(~ mem.all)
+      [~ ..^$]
+    [[u.hey.all %give %quac ~]~ ..^$]
   ::  the boot event passes thru %dill for initial duct distribution
   ::
   ?:  ?=(%boot -.task)
@@ -373,8 +380,11 @@
   ::
   ?:  ?=(%mass -.task)
     ?>  ?=(^ hey.all)
+    ?:  =(~ mem.all)
+      =.  mem.all  (~(put in mem.all) hen)
+      [[u.hey.all %give %quac ~]~ ..^$]
     =.  mem.all  (~(put in mem.all) hen)
-    [[u.hey.all %give %quac ~]~ ..^$]
+    [~ ..^$]
   ::  %quac is a memory report from the runtime
   ::
   ?:  ?=(%quac -.task)

--- a/pkg/arvo/sys/vane/dill.hoon
+++ b/pkg/arvo/sys/vane/dill.hoon
@@ -8,11 +8,12 @@
 --                                                      ::
 =>  |%                                                  ::  console protocol
 +$  axle                                                ::
-  $:  %7                                                ::
+  $:  %8                                                ::
       hey=(unit duct)                                   ::  default duct
       dug=(map @tas axon)                               ::  conversations
       eye=(jug @tas duct)                               ::  outside observers
       ear=(set duct)                                    ::  syslog listeners
+      mem=(set duct)                                    ::  memory requests
       lit=?                                             ::  boot in lite mode
       egg=_|                                            ::  see +take, removeme
   ==                                                    ::
@@ -368,6 +369,19 @@
       ?~  p.task  (~(del in ear.all) hen)
       (~(put in ear.all) hen)
     [~ ..^$]
+  ::  %mass runs a memory report
+  ::
+  ?:  ?=(%mass -.task)
+    ?>  ?=(^ hey.all)
+    =.  mem.all  (~(put in mem.all) hen)
+    [[u.hey.all %give %quac ~]~ ..^$]
+  ::  %quac is a memory report from the runtime
+  ::
+  ?:  ?=(%quac -.task)
+    =/  moz=(list move)
+      (turn ~(tap in mem.all) (late %give %meme p.task))
+    =.  mem.all  ~
+    [moz ..^$]
   ::  if we were $told something, give %logs to all interested parties
   ::
   ?:  ?=(?(%crud %talk %text) -.task)
@@ -389,13 +403,29 @@
 ++  load                                                ::  import old state
   =<  |=  old=any-axle
       ?-  -.old
-        %7  ..^$(all old)
+        %8  ..^$(all old)
+        %7  $(old (axle-7-to-8 old))
         %6  $(old (axle-6-to-7 old))
         %5  $(old (axle-5-to-6 old))
         %4  $(old (axle-4-to-5 old))
       ==
   |%
-  +$  any-axle  $%(axle axle-6 axle-5 axle-4)
+  +$  any-axle  $%(axle axle-7 axle-6 axle-5 axle-4)
+  ::
+  +$  axle-7
+    $:  %7
+        hey=(unit duct)
+        dug=(map @tas axon)
+        eye=(jug @tas duct)
+        ear=(set duct)
+        lit=?
+        egg=_|
+    ==
+  ::
+  ++  axle-7-to-8
+    |=  a=axle-7
+    ^-  axle
+    [%8 hey dug eye ear ~ lit egg]:a
   ::
   +$  axle-6
     $:  %6
@@ -409,7 +439,7 @@
   ::
   ++  axle-6-to-7
     |=  a=axle-6
-    ^-  axle
+    ^-  axle-7
     [%7 hey dug eye ~ lit egg]:a
   ::
   +$  axle-5

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1735,11 +1735,15 @@
         ?.  ?=([~ ~ *] tuc)  ~
         `!<(tube:clay q.u.u.tuc)
       ?~  tub
-        ((slog leaf+"peek no tube from {(trip have)} to {(trip want)}" ~) ~)
+        =/  msg  "%{(trip agent-name)}: ".
+                 "peek no tube from {(trip have)} to {(trip want)}"
+        ((slog leaf+msg ~) ~)
       =/  res  (mule |.((u.tub vase)))
       ?:  ?=(%& -.res)
         ``want^p.res
-      ((slog leaf+"peek failed tube from {(trip have)} to {(trip want)}" ~) ~)
+      =/  msg  "%{(trip agent-name)}: ".
+               "peek failed tube from {(trip have)} to {(trip want)}"
+      ((slog leaf+msg ~) ~)
     ::  +ap-move: send move
     ::
     ++  ap-move

--- a/pkg/arvo/ted/mass.hoon
+++ b/pkg/arvo/ted/mass.hoon
@@ -1,0 +1,56 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+=>
+|%
+++  print-quacs
+  |=  quz=(list quac:dill)
+  ^-  (list tank)
+  (zing (turn quz print-quac))
+::
+++  print-quac
+  |=  qua=quac:dill
+  ^-  (list tank)
+  =|  den=@ud
+  |-  ^-  (list tank)
+  ?:  =(~ quacs.qua)
+    ~[(rap 3 (fil 3 den ' ') name.qua ': ' (print-size size.qua) ~)]
+  :-  (rap 3 (fil 3 den ' ') name.qua ':' ~)
+  %+  weld
+    ^-  (list tank)
+    (zing (turn quacs.qua |=(q=quac:dill ^$(qua q, den (add den 2)))))
+  ^-  (list tank)
+  ~[(rap 3 (fil 3 den ' ') '--' (print-size size.qua) ~)]
+::
+++  print-size
+  |=  size=@ud
+  |^  ^-  @t
+  ?:  (lte size 1.024)
+    (crip "{(a-co:co size)} B")
+  ?:  (lte size (pow 1.024 2))
+    =+  (dvr size 1.024)
+    (crip "{(a-co:co p)}.{(y-co:co (round q))} KiB")
+  ?:  (lte size (pow 1.024 3))
+    =+  (dvr size (pow 1.024 2))
+    (crip "{(a-co:co p)}.{(y-co:co (round q))} MiB")
+  =+  (dvr size (pow 1.024 3))
+  (crip "{(a-co:co p)}.{(y-co:co (round q))} GiB")
+  ++  round
+    |=  n=@
+    ?:  (lth n 100)
+      n
+    =+  (dvr n 10)
+    ?:  (lth q 5)
+      $(n p)
+    $(n +(p))
+  --
+--
+::
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+;<  quz=(list quac:dill)  bind:m  mass:strandio
+%-  (slog (print-quacs quz))
+(pure:m !>(~))
+

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -345,6 +345,24 @@
   ;<  ~  bind:m  (send-wait until)
   (take-wake `until)
 ::
+++  mass
+  =/  m  (strand ,(list quac:dill))
+  ^-  form:m
+  =/  =card:agent:gall  [%pass /mass %arvo %d %mass ~]
+  ;<  ~  bind:m  (send-raw-card card)
+  ;<  quz=(list quac:dill)  bind:m  take-meme
+  (pure:m quz)
+::
+++  take-meme
+  =/  m  (strand ,(list quac:dill))
+  ^-  form:m
+  |=  tin=strand-input:strand
+  ?+  in.tin  `[%skip ~]
+    ~  `[%wait ~]
+      [~ %sign [%mass ~] %dill %meme *]
+    `[%done p.sign-arvo.u.in.tin]
+  ==
+::
 ++  keen
   |=  [=wire =spar:ames]
   =/  m  (strand ,~)

--- a/pkg/base-dev/mar/mass.hoon
+++ b/pkg/base-dev/mar/mass.hoon
@@ -1,0 +1,14 @@
+::
+::::  /hoon/mass/mar
+  ::
+|_  mas=mass
+++  grab
+  |%
+  ++  noun  mass
+  --
+++  grow
+  |%
+  ++  noun  mas
+  --
+++  grad  %noun
+--


### PR DESCRIPTION
- add -mass thread to print them
- add +mass & +take-meme to strandio
- include agent name in gall tube failure message
- add mass mark

this works in conjunction with https://github.com/urbit/vere/pull/675