### PR TITLE
clay: respect the gang system

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5942,15 +5942,7 @@
     |^
     =/  van  ?@(vis.nom (end 3 vis.nom) way.vis.nom)
     =/  kyr  ?@(vis.nom (rsh 3 vis.nom) car.vis.nom)
-    ?.  =(%c van)
-      (en-hunk (rof ~ /ames nom))
-    =+  pem=(rof [~ ~] /ames nom(vis %cp))
-    ?.  ?=(^ pem)    ~
-    ?.  ?=(^ u.pem)  ~
-    ~|  u.u.pem
-    =+  per=!<([r=dict:clay w=dict:clay] q.u.u.pem)
-    ?.  =([%black ~ ~] rul.r.per)  ~
-    (en-hunk (rof [~ ~] /ames nom))
+    (en-hunk (rof ~ /ames nom))
     ::
     ++  en-hunk
       |=  res=(unit (unit cage))

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -5927,13 +5927,23 @@
   ?~  run  [~ ~]
   ::TODO  if it ever gets filled properly, pass in the full fur.
   ::
-  =/  for=(unit ship)  ?~(lyc ~ ?~(u.lyc ~ `n.u.lyc))
   ?:  &(=(our his) ?=(?(%d %x) ren) =(%$ syd) =([%da now] u.luk))
     ?.  =([~ ~] lyc)  ~
     ?-  ren
       %d  (read-buc-d tyl)
       %x  (read-buc-x tyl)
     ==
+  =/  aut=?
+    ?^  lyc
+      %.y
+    =+  pem=(rof [~ ~] /clay %cp bem)
+    ?.  ?=(^ pem)    %.n
+    ?.  ?=(^ u.pem)  %.n
+    ~|  u.u.pem
+    =+  per=!<([r=dict:clay w=dict:clay] q.u.u.pem)
+    =([%black ~ ~] rul.r.per)
+  ?.  aut  ~
+  =/  for=(unit ship)  ?~(lyc ~ ?~(u.lyc ~ `n.u.lyc))
   =/  den  ((de now rof [/scryduct ~] ruf) his syd)
   =/  result  (mule |.(-:(aver:den for u.run u.luk tyl)))
   ?:  ?=(%| -.result)


### PR DESCRIPTION
All vanes except clay respect the gang system since #6876. The gang is of type `(unit (set ship))` and gets passed as an argument to the scry handler of every vane. A gang of `~` means "my identity is anybody, serve me only public data", a gang of `[~ ~]` means "I am root, give me all data", and a gang with a set of ships means that these ships are asking for the data. In other words the gang represents who is making the scry.

This PR implements the gang system for clay. As with the other vanes the multiple scryers case is not implemented, but with this change `~`, `[~ ~]` and `[~dinleb-rambep ~ ~]` work fine.

I decided to make an extra permissions check if the gang is `~` and otherwise leverage the existing clay permissions machinery. An alternative to having clay scry itself for permissions would be to change the type and semantics of the     
`for=(unit ship)` argument in `+aver` and elsewhere. Note that in the clay world a `for` of `~` means root user, a mismatch with the gang semantics.

Thanks to @midden-fabler for noticing this when working on #7033.