### PR TITLE
hoon: various ?= codepath fixes and improvements

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8325,10 +8325,10 @@
       (bind $(gen q.gen) |=(=skin [%help p.p.gen skin]))
     ::
         [%wing *]
-      ?:  ?=([@ ~] p.gen)
-        `i.p.gen
       =/  depth  0
       |-  ^-  (unit skin)
+      ?:  ?=([@ ~] p.gen)
+        `i.p.gen
       ?~  p.gen  `[%wash depth]
       ?.  =([%| 0 ~] i.p.gen)  ~
       $(p.gen t.p.gen)
@@ -9116,8 +9116,13 @@
           [%cell *]
         ?+  ref      sint
           [%atom *]  sut
-          [%cell *]  ?.  (nest(sut p.ref) | p.sut)  sut
-                     (cell p.sut dext(sut q.sut, ref q.ref))
+          [%cell *]  =/  lef  dext(sut p.sut, ref p.ref)
+                     =/  ryt  dext(sut q.sut, ref q.ref)
+                     %-  fork
+                     :~  (cell lef q.sut)
+                         (cell p.sut ryt)
+                         (cell lef ryt)
+                     ==
         ==
       ::
           [%core *]  ?:(?=(?([%atom *] [%cell *]) ref) sut sint)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9613,7 +9613,9 @@
       ==
         [%cell *]
       ?-  ref
-        [%cell *]   (cell $(sut p.sut, ref p.ref) $(sut q.sut, ref q.ref))
+        [%cell *]   =+  hed=$(sut p.sut, ref p.ref)
+                    ?:  ?=(%void hed)  %void
+                    (cell hed $(sut q.sut, ref q.ref))
         *           $(sut ref, ref sut)
       ==
     ::

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9594,13 +9594,16 @@
     ~/  %fuse
     |=  ref=type
     =+  bix=*(set [type type])
+    =+  rev=|
     |-  ^-  type
     ?:  ?|(=(sut ref) =(%noun ref))
       sut
     ?-    sut
         [%atom *]
       ?-    ref
-          [%atom *]   =+  foc=?:((fitz p.ref p.sut) p.sut p.ref)
+          [%atom *]   =/  foc
+                        =+  fit=(fitz ?:(rev [p.sut p.ref] [p.ref p.sut]))
+                        ?:(fit p.sut p.ref)
                       ?^  q.sut
                         ?^  q.ref
                           ?:  =(q.sut q.ref)
@@ -9609,14 +9612,14 @@
                         [%atom foc q.sut]
                       [%atom foc q.ref]
           [%cell *]   %void
-          *           $(sut ref, ref sut)
+          *           $(sut ref, ref sut, rev !rev)
       ==
         [%cell *]
       ?-  ref
         [%cell *]   =+  hed=$(sut p.sut, ref p.ref)
                     ?:  ?=(%void hed)  %void
                     (cell hed $(sut q.sut, ref q.ref))
-        *           $(sut ref, ref sut)
+        *           $(sut ref, ref sut, rev !rev)
       ==
     ::
         [%core *]  $(sut repo)

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9134,12 +9134,12 @@
       ^-  type
       ?+    ref    !!
         [%core *]  sut
-        [%face *]  dext(ref repo(sut ref))
+        [%face *]  dext(ref q.ref)
         [%fork *]  =+  yed=~(tap in p.ref)
                    |-  ^-  type
                    ?~  yed  sut
                    $(yed t.yed, sut dext(ref i.yed))
-        [%hint *]  dext(ref repo(sut ref))
+        [%hint *]  dext(ref q.ref)
         [%hold *]  dext(ref repo(sut ref))
       ==
     --

--- a/pkg/arvo/sys/vane/behn.hoon
+++ b/pkg/arvo/sys/vane/behn.hoon
@@ -62,7 +62,7 @@
     =?    ..this
         ?~  unix-duct.state  |
         =/  dif=[old=(unit @da) new=(unit @da)]  [next-wake.state new]
-        ?+  dif  ~|([%unpossible dif] !!)
+        ?-  dif
           [~ ~]  |                        :: no-op
           [~ ^]  &                        :: set
           [^ ~]  &                        :: clear


### PR DESCRIPTION
Collection of bugfixes and small improvements @joemfb and I have made to code in the `?=` codepath.

42a9700 and 3199204 are small correctness changes. 16c21d0 is a simple short-circuiting performance optimization.

fea003b is a proper breaking change, see also the change we needed to make to behn. Shouldn't impact too much, but I know for a fact there is code affected by it out there in the wild.