### PR TITLE
`-new-app` branch and directory

### DIFF
--- a/pkg/arvo/ted/new-app.hoon
+++ b/pkg/arvo/ted/new-app.hoon
@@ -9,9 +9,19 @@
 =/  m  (strand ,vase)
 ^-  form:m
 ;<  =bowl:spider  bind:m  get-bowl:strandio
-=/  desk  ;;(term +<.q.arg)
+=/  desk-branch-dir  +<.q.arg
 =/  repo  ;;(path +>.q.arg)
-=/  branch=cord  'master'
+=/  [desk=term branch=cord dir=cord]
+  ?+    desk-branch-dir  ~|(%weird-input !!)
+      term
+    [desk-branch-dir 'master' 'desk']
+  ::
+      [desk=term branch=cord]
+    [desk branch 'desk']:desk-branch-dir
+  ::
+      [desk=term branch=cord dir=cord]
+    [desk branch dir]:desk-branch-dir
+  ==
 ~&  >  "Building desk {<desk>} from https://github.com{<repo>}:{(trip branch)}."
 =/  tid  `cord`(cat 3 'strand_' (scot %uv (sham %retrieve-gh eny.bowl)))
 ;<  ~       bind:m  %-  watch-our:strandio
@@ -26,7 +36,7 @@
                                 `tid
                                 byk.bowl(r da+now.bowl)
                                 %retrieve-gh
-                                !>(`[repo branch])
+                                !>(`[repo branch dir])
                     ==      ==
 ;<  =cage   bind:m  (take-fact:strandio /awaiting/[tid])
 ;<  ~       bind:m  (take-kick:strandio /awaiting/[tid])
@@ -34,7 +44,7 @@
   (strand-fail:strandio !<([term tang] q.cage))
 ?>  ?=(%thread-done p.cage)
 ?~  q.q.cage
-  ~&  >>>  "No files found at /desk in repo."
+  ~&  >>>  "No files found at /{(trip dir)} in repo."
   (strand-fail:strand %no-desk-in-repo ~)
 ~&  >  "Successfully retrieved files."
 =/  fil  ;;((list (pair path (pair @ud @))) q.q.cage)

--- a/pkg/arvo/ted/retrieve-gh.hoon
+++ b/pkg/arvo/ted/retrieve-gh.hoon
@@ -1,4 +1,4 @@
-::  Retrieve the contents of a /desk folder in a GitHub repository
+::  Retrieve the contents of a folder in a GitHub repository
 ::  Derived from pkova/deployer/ted/sync.hoon
 ::
 /-  spider
@@ -46,7 +46,8 @@
 ^-  form:m
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 =/  repo=path    ;;(path +<.q.arg)
-=/  branch=cord  ;;(cord +>.q.arg)
+=/  branch=cord  ;;(cord +>-.q.arg)
+=/  dir=cord     ;;(cord +>+.q.arg)
 ~&  >  "Retrieving latest commit from https://github.com{<repo>}."
 =/  tid  `cord`(cat 3 'strand_' (scot %uv (sham %retrieve-latest-commit eny.bowl)))
 ;<  ~       bind:m  %-  watch-our:strandio
@@ -70,7 +71,7 @@
 ?>  ?=(%thread-done p.cage)
 =/  commit  ;;(cord q.q.cage)
 ::
-~&  >  "Retrieving file list in /desk."
+~&  >  "Retrieving file list in /{(trip dir)}."
 ;<  ~  bind:m  (send-raw-card:strandio (build-tree-request repo commit))
 ;<  res=(pair wire sign-arvo)  bind:m  take-sign-arvo:strandio
 ?.  ?=([%iris %http-response %finished *] q.res)
@@ -84,13 +85,13 @@
   %+  skim
     res
   |=  g=github
-  ?&  =('blob' type.g)                  :: only files, not trees
-      !=('120000' mode.g)               :: do not resolve symlinks
-      =('desk/' (cut 3 [0 5] path.g))   :: only grab from /desk
+  ?&  =('blob' type.g)                                       :: only files, not trees
+      !=('120000' mode.g)                                    :: do not resolve symlinks
+      =((cat 3 dir '/') (cut 3 [0 +((met 3 dir))] path.g))   :: only grab from /{<dir>}
       !=('.' (cut 3 [0 1] (rear (stab (crip (cass (trip (cat 3 '/' path.g))))))))
   ==
 ::
-~&  >  "Retrieving file URLs in /desk."
+~&  >  "Retrieving file URLs in /{(trip dir)}."
 =/  sob=(list (pair path (pair @ud @)))  ~
 |-
 ?~  res  (pure:m !>(`(list (pair path (pair @ud @)))`sob))

--- a/pkg/arvo/ted/retrieve-gh.hoon
+++ b/pkg/arvo/ted/retrieve-gh.hoon
@@ -48,6 +48,12 @@
 =/  repo=path    ;;(path +<.q.arg)
 =/  branch=cord  ;;(cord +>-.q.arg)
 =/  dir=cord     ;;(cord +>+.q.arg)
+?<  |(=(0 dir) =('/' dir))                               ::  sanitize dir
+=/  dir-len=@  (met 3 dir)
+=?  .  =('/' (cut 3 [0 1] dir))                          ::  /dir -> dir
+  .(dir (cut 3 [1 dir-len] dir), dir-len (dec dir-len))
+=?  dir  =('/' (cut 3 [(dec dir-len) 1] dir))            ::  dir/ -> dir
+  (cut 3 [0 (dec dir-len)] dir)
 ~&  >  "Retrieving latest commit from https://github.com{<repo>}."
 =/  tid  `cord`(cat 3 'strand_' (scot %uv (sham %retrieve-latest-commit eny.bowl)))
 ;<  ~       bind:m  %-  watch-our:strandio
@@ -93,6 +99,7 @@
 ::
 ~&  >  "Retrieving file URLs in /{(trip dir)}."
 =/  sob=(list (pair path (pair @ud @)))  ~
+=/  path-dir=path  (stab (add '/' (lsh [3 1] dir)))
 |-
 ?~  res  (pure:m !>(`(list (pair path (pair @ud @)))`sob))
 ~&  >>  path.i.res
@@ -104,6 +111,11 @@
   (strand-fail:strand %no-body ~)
 =/  t  (trip (cat 3 '/' path.i.res))
 =/  i  (need (find "." t))
-=/  p  (oust [0 1] (stab (crip (cass (snap t i '/')))))
+=/  p
+  =/  p-prefixed  (stab (crip (cass (snap t i '/'))))
+  |-  ^-  path
+  ?~  path-dir  p-prefixed
+  ?>  =(i.path-dir -.p-prefixed)
+  $(path-dir t.path-dir, p-prefixed +.p-prefixed)
 =/  s  [p data.u.full-file.client-response.q.new]
 $(sob [s sob], res t.res)


### PR DESCRIPTION
Adds input fields to `-new-app`. The first input is either of three:
  - just `desk=term`,
  - `[desk=term branch=cord]`,
  - `[desk=term branch=cord dir=cord]`,

with `branch='master'` and `dir='desk'` as default values.

Examples of input:
```
-new-app %dawn /sigilante/sunrise
```

```
-new-app [%wasm 'lia-jet'] /quodss/urwasm
```

```
-new-app [%blog 'main' 'src/backend'] /quodss/blog
```