### PR TITLE
clay: fix error flopping

### DIFF
--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -396,7 +396,7 @@
            =?  +>.$  !=(%hush lev)
              (se-text "crud: %{(trip p.told)} event failed")
            ?.  =(%loud lev)  +>.$
-           (se-dump q.told)
+           (se-dump (flop q.told))
     %talk  (se-dump (flop p.told))  ::NOTE  +se-dump flops internally
     %text  (se-text p.told)
   ==

--- a/pkg/arvo/lib/hood/drum.hoon
+++ b/pkg/arvo/lib/hood/drum.hoon
@@ -396,7 +396,7 @@
            =?  +>.$  !=(%hush lev)
              (se-text "crud: %{(trip p.told)} event failed")
            ?.  =(%loud lev)  +>.$
-           (se-dump (flop q.told))
+           (se-dump q.told)
     %talk  (se-dump (flop p.told))  ::NOTE  +se-dump flops internally
     %text  (se-text p.told)
   ==

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -954,7 +954,6 @@
       %-  mean
       =/  lyn  p.hair
       =/  col  q.hair
-      %-  flop
       ^-  (list tank)
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
         ::
@@ -4559,7 +4558,7 @@
       |^  =/  res  (mule |.(read))
           ?:  ?=(%& -.res)  p.res
           %.  [[~ ~] ..park]
-          (slog leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" p.res)
+          (slog leaf+"clay: read-at-tako fail {<[desk=syd mun]>}" (flop p.res))
       ::
       ++  read
         ^-  [(unit (unit cage)) _..park]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -954,6 +954,7 @@
       %-  mean
       =/  lyn  p.hair
       =/  col  q.hair
+      %-  flop
       ^-  (list tank)
       :~  leaf+"syntax error at [{<lyn>} {<col>}] in {<pax>}"
         ::


### PR DESCRIPTION
resolves #6539 

syntax errors are displayed in the correct orientation.

```
> |commit %base
>=
: /~fed/base/57/gen/help/hoon
clay: read-at-tako fail [desk=%base care=%a case=[%da p=~2024.8.7..14.09.48..4c0b] path=/gen/help/hoon]
syntax error at [12 4] in /gen/help/hoon
++ path2tape
---^
[%error-building /gen/help/hoon]
clay: %a build failed [%base 0v1p.0u5vt.s5n34.vc4u5.dbocr.fmh65.vlkji.cfh3a.6ul1m.ufoep.jfnil /gen/help/hoon]
dojo: %writ fail [i=%~.hand t=/gen/help]
> +help
/gen/help/hoon
%generator-build-fail
```
```
> |commit %base
>=
crud: %into event failed
syntax error at [5 4] in /sur/hood/hoon
+$ pike
---^
[%error-building /sur/hood/hoon]
[%error-building /app/azimuth/hoon]
[from=57 deletes={} changes={[i=~.gen t=/hood/clay/merge/help/txt] [i=~.gen t=/hood/clay/fuse/help/txt] [i=~.sur t=/hood/hoon]}]
call: failed
bar-stack=[i=[i=//sync/0v1.btuim t=~] t=~]
[%poke %into]
```