### PR TITLE
eyre: use a-co:co not +format-ud-as-integer

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -675,8 +675,6 @@
 ++  error-page
   |=  [code=@ud authorized=? url=@t t=tape]
   ^-  octs
-  ::
-  =/  code-as-tape=tape  (format-ud-as-integer code)
   =/  message=tape
     ?+  code  "{(scow %ud code)} Error"
       %400  "Bad Request"
@@ -691,7 +689,7 @@
   %-  en-xml:html
   ;html
     ;head
-      ;title:"{code-as-tape} {message}"
+      ;title:"{(a-co:co code)} {message}"
     ==
     ;body
       ;h1:"{message}"
@@ -703,15 +701,6 @@
           ~
     ==
   ==
-::  +format-ud-as-integer: prints a number for consumption outside urbit
-::
-++  format-ud-as-integer
-  |=  a=@ud
-  ^-  tape
-  ?:  =(0 a)  ['0' ~]
-  %-  flop
-  |-  ^-  tape
-  ?:(=(0 a) ~ [(add '0' (mod a 10)) $(a (div a 10))])
 ::  +host-matches: %.y if the site :binding should be used to handle :host
 ::
 ++  host-matches
@@ -967,7 +956,7 @@
           (delete-header:http 'content-length' headers.response-header.result)
         ::
         %^  set-header:http  'content-length'
-          (crip (format-ud-as-integer p.u.data.result))
+          (crip (a-co:co p.u.data.result))
         headers.response-header.result
       ::
       %-  handle-response
@@ -1037,7 +1026,7 @@
         :-  status-code=200
         ^=  headers
           :~  ['content-type' (rsh 3 (spat p.mime))]
-              ['content-length' (crip (format-ud-as-integer p.q.mime))]
+              ['content-length' (crip (a-co:co p.q.mime))]
               ['cache-control' ?:(fqp 'max-age=31536000' 'no-cache')]
           ==
         data=[~ q.mime]
@@ -1222,7 +1211,7 @@
         :-  status-code=code
         ^=  headers
           :~  ['content-type' content-type]
-              ['content-length' (crip (format-ud-as-integer p.data))]
+              ['content-length' (crip (a-co:co p.data))]
           ==
         data=[~ data]
         complete=%.y
@@ -1572,7 +1561,7 @@
       %-  crip
       =;  max-age=tape
         "urbauth-{(scow %p our)}={(scow %uv session)}; Path=/; Max-Age={max-age}"
-      %-  format-ud-as-integer
+      %-  a-co:co
       ?.  extend  0
       (div (msec:milly session-timeout) 1.000)
     ::
@@ -2852,7 +2841,7 @@
       ~%  %eyre-tape-to-wall  ..part  ~
       |=  [event-id=@ud =tape]
       ^-  wall
-      :~  (weld "id: " (format-ud-as-integer event-id))
+      :~  (weld "id: " (a-co:co event-id))
           (weld "data: " tape)
           ""
       ==


### PR DESCRIPTION
replace `+format-ud-as-integer` with `a-co:co` 

```
> =format-ud-as-integer |=  a=@ud
    ^-  tape
    ?:  =(0 a)  ['0' ~]
    %-  flop
    |-  ^-  tape
    ?:(=(0 a) ~ [(add '0' (mod a 10)) $(a (div a 10))])
> =((a-co:co `@ud`eny) (format-ud-as-integer `@ud`eny))
%.y
```