### PR TITLE
dbug: fix debug authentication redirect for comet identities

### DIFF
--- a/pkg/arvo/app/dbug.hoon
+++ b/pkg/arvo/app/dbug.hoon
@@ -42,8 +42,8 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
-    ?>  =(our src):bowl
     ?:  ?=(%noun mark)
+      ?>  =(our src):bowl
       =/  code  !<((unit @t) vase)
       =/  msg=tape
         ?~  code
@@ -56,6 +56,7 @@
       %-  (slog leaf+msg ~)
       [~ this(passcode code)]
     ?:  ?=(%json mark)
+      ?>  =(our src):bowl
       =/  jon=json  !<(json vase)
       =,  dejs:format
       =/  cmd


### PR DESCRIPTION
The debug dashboard that's found at `/~debug` has had broken authentication behavior since comet identities were released. `/app/dbug` uses `+require-authorization:app:server` from `/lib/server` to perform a redirect to the login page if needed, but this code has been unreachable for comet identities because of the `?>  =(our src):bowl`. In practice the fact that login redirects from `/~debug` don't work but return a 500 instead wouldn't be such a problem, however...

https://github.com/urbit/urbit/blob/effa0ba3d12e41e495c53e5dd14ce9977a8e9272/pkg/arvo/app/acme.hoon#L591-L593

`/app/acme` uses the `/~debug` endpoint to verify the dns domain the ship is running on! This relic of the pre software distribution era causes `/app/acme` to be unable to verify the domain, which means new ships are unable to order ssl certificates.