### PR TITLE
gall: delete agent blocked moves on |nuke

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -957,6 +957,10 @@
   ++  mo-nuke
     |=  [prov=path dap=dude]
     ^+  mo-core
+    =?  mo-core  (~(has by blocked.state) dap)
+      =/  num-movs=@  ~(wyt by (~(got by blocked.state) dap))
+      ~>  %slog.0^leaf/"gall: deleted {<num-movs>} blocked moves for {<dap>}"
+      mo-core(blocked.state (~(del by blocked.state) dap))
     =/  yoke=(unit yoke)  (~(get by yokes.state) dap)
     ?:  |(?=(~ yoke) ?=(%nuke -.u.yoke))
       ~>  %slog.0^leaf/"gall: ignoring %nuke for {<dap>}, not running"


### PR DESCRIPTION
I was investigating #6794 by running a local copy of `~finned-palmer`, manually breaching by doing `|pass [%j %ruin [~dinleb-rambep ~ ~]]` and observing the ship hang for a very long time. When I interrupted the ship by doing ctrl+c, the problem became quite evident.

`~finned-palmer` was spending all its' time in `+mo-filter-queue`. Specifically, it was iterating over 450 000 blocked moves to an agent called `%push-notify` trying to find any moves from the ship that just breached. This is an agent from the long defunct `%escape`.

This PR enables us to recover from scenarios where userspace programs do crazy stuff like this. It does potentially break some invariants, but I believe this to be worth it because this is a manual intervention.

@belisarius222 @joemfb 