### PR TITLE
clay: don't set zest %live unless zuse compat

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1426,6 +1426,46 @@
     ?~  ref
       [%give %writ riot]
     [%pass /drip %b %drip !>([%writ riot])]
+
+  ::
+  ::  +get-kelvin: read the desk's kernel version from /sys/kelvin
+  ::
+  ++  get-kelvin
+    |=  =yoki
+    ^-  waft
+    |^  ?-    -.yoki
+            %|
+          %-  lobe-to-waft
+          ~>  %mean.(cat 3 'clay: missing /sys/kelvin on ' syd)
+          ~|  ~(key by q.p.yoki)
+          (~(got by q.p.yoki) /sys/kelvin)
+        ::
+            %&
+          =/  fil=(each page lobe)
+            ~>  %mean.(cat 3 'clay: missing /sys/kelvin on ' syd)
+            ~|  ~(key by q.p.yoki)
+            (~(got by q.p.yoki) /sys/kelvin)
+          ?-    -.fil
+              %&  (page-to-waft p.fil)
+              %|  (lobe-to-waft p.fil)
+          ==
+        ==
+    ::
+    ++  lobe-to-waft
+      |=  =lobe
+      ^-  waft
+      =/  peg=(unit page)  (~(get by lat.ran) lobe)
+      ?~  peg  ~|([%sys-kelvin-tombstoned syd] !!)
+      (page-to-waft u.peg)
+    ::
+    ++  page-to-waft
+      |=  =page
+      ^-  waft
+      ?+    p.page  ~|(clay-bad-kelvin-mark/p.page !!)
+          %kelvin  ;;(waft q.page)
+          %mime    (cord-to-waft q.q:;;(mime q.page))
+      ==
+    --
   ::
   ++  case-to-date
     |=  =case
@@ -2013,45 +2053,6 @@
         |
       %-  ~(any in invalid)
       |=(p=path &((is-kernel-path p) !?=([%sys %vane *] p)))
-    ::
-    ::  +get-kelvin: read the desk's kernel version from /sys/kelvin
-    ::
-    ++  get-kelvin
-      |=  =yoki
-      ^-  waft
-      |^  ?-    -.yoki
-              %|
-            %-  lobe-to-waft
-            ~>  %mean.(cat 3 'clay: missing /sys/kelvin on ' syd)
-            ~|  ~(key by q.p.yoki)
-            (~(got by q.p.yoki) /sys/kelvin)
-          ::
-              %&
-            =/  fil=(each page lobe)
-              ~>  %mean.(cat 3 'clay: missing /sys/kelvin on ' syd)
-              ~|  ~(key by q.p.yoki)
-              (~(got by q.p.yoki) /sys/kelvin)
-            ?-    -.fil
-                %&  (page-to-waft p.fil)
-                %|  (lobe-to-waft p.fil)
-            ==
-          ==
-      ::
-      ++  lobe-to-waft
-        |=  =lobe
-        ^-  waft
-        =/  peg=(unit page)  (~(get by lat.ran) lobe)
-        ?~  peg  ~|([%sys-kelvin-tombstoned syd] !!)
-        (page-to-waft u.peg)
-      ::
-      ++  page-to-waft
-        |=  =page
-        ^-  waft
-        ?+    p.page  ~|(clay-bad-kelvin-mark/p.page !!)
-            %kelvin  ;;(waft q.page)
-            %mime    (cord-to-waft q.q:;;(mime q.page))
-        ==
-      --
     ::
     ::  Find which files changed or were deleted
     ::
@@ -3180,7 +3181,18 @@
   ::
   ++  set-zest                                          ::  [goad] <
     |=  liv=zest
-    =?  liv  =(%base syd)  %live
+    ?:  =(%base syd)
+      ..park(liv.dom %live)
+    ?.  ?=(%live liv)
+      ..park(liv.dom liv)
+    =/  kel=(set weft)
+      %-  waft-to-wefts
+      %+  fall
+        (mole |.((get-kelvin %| (aeon-to-yaki:ze let.dom))))
+      [[%1 ~] ~]
+    ?.  (~(has in kel) zuse+zuse)
+      =/  msg  "clay: can't set {<syd>} live, it doesn't support zuse {<zuse>}"
+      ((slog leaf+msg ~) ..park)
     ..park(liv.dom liv)
   ::
   ++  rise                                              ::  [goad] <


### PR DESCRIPTION
This makes ++set-zest check whether the desk is zuse-compatible before setting it `%live`. Currently you can turn on desks that aren't compatible and potentially cause problems.