### PR TITLE
eyre: don't %grow if duct not initialized yet

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -3079,6 +3079,11 @@
     =/  aeon  ?^(prev=(~(get by cache.state) url) +(aeon.u.prev) 1)
     =.  cache.state  (~(put by cache.state) url [aeon entry])
     :_  state
+    ::NOTE  during boot, userspace might've sent us this before we received
+    ::      our first %born, with which we initialize the outgoing-duct.
+    ::      it's fine to hold off on the %grow here, we'll re-send them
+    ::      whenever we finally receive the %born.
+    ?:  =(~ outgoing-duct.state)  ~
     [outgoing-duct.state %give %grow /cache/(scot %ud aeon)/(scot %t url)]~
   ::  +add-binding: conditionally add a pairing between binding and action
   ::


### PR DESCRIPTION
During boot, userspace might send `%set-response` tasks before eyre has received its first `%born` event. In that case, the `outgoing-duct` in state will be the bunted duct, `%give`-ing on which will result in an arvo crash that kills the boot.

Here, for safety, we simply don't emit a %grow if the duct is empty. The entry got stored in state and will be sent to the runtime as soon as we receive the `%born`.