### PR TITLE
eyre: ensure initial channel response has a body

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2328,7 +2328,14 @@
                 ['cache-control' 'no-cache']
                 ['connection' 'keep-alive']
             ==
-            (wall-to-octs wall)
+          ::
+            ::  if we wouldn't otherwise send any data, send an early heartbeat
+            ::  instead. some clients won't consider the connection established
+            ::  until they've heard some bytes come over the wire.
+            ::
+            ?.  =(~ wall)  (wall-to-octs wall)
+            (some (as-octs:mimes:html ':\0a'))
+          ::
             complete=%.n
         ==
       ::  associate this duct with this session key


### PR DESCRIPTION
Some clients will not consider the connection as being established until they've received some body bytes from it. If the client has logic that awaits the connection, this will result in a mandatory 20 second wait (until the first heartbeat fires).

Here, if we detect that we're not sending any event backlog, we simply send a heartbeat (empty sse comment) instead.