### PR TITLE
eyre: improve test ergonomics slightly

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -828,10 +828,14 @@
         [action [| secure address request] [invalid %fake *@p] ~ 0]
       ::  their cookie was invalid, make sure they expire it
       ::
+      =/  bod=octs  (as-octs:mimes:html 'bad session auth')
       %-  handle-response
       :*  %start
-          [401 ['set-cookie' (session-cookie-string:authentication invalid |)]~]
-          `(as-octs:mimes:html 'bad session auth')
+          :-  401
+          :~  ['set-cookie' (session-cookie-string:authentication invalid |)]
+              ['content-length' (crip (a-co:co p.bod))]
+          ==
+          `bod
           complete=%.y
       ==
     =;  [moz=(list move) sat=server-state]

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -78,6 +78,17 @@
     (pure:m ~)
   (fail tang)
 ::
+::  stupid way to normalize header order while maintaining ordering for
+::  headers whose field-name occurs multiple times
+++  header-sort
+  |=  heads=header-list:http
+  %+  roll  heads
+  |=  [head=[k=@t v=@t] heads=header-list:http]
+  ?~  heads  [head]~
+  ?:  =(k.head key.i.heads)     [i.heads $(heads t.heads)]
+  ?.  (aor k.head key.i.heads)  [i.heads $(heads t.heads)]
+  [head heads]
+::
 ++  call
   |=  [=duct wrapped-task=(hobo task:eyre-gate)]
   =/  m  (mare ,(list move))
@@ -220,7 +231,9 @@
   ;:  weld
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
-    (expect-eq !>(headers) !>(headers.response-header.http-event.p.card.mov))
+  ::
+    %+  expect-eq  !>((header-sort headers))
+    !>((header-sort headers.response-header.http-event.p.card.mov))
   ==
 ++  ex-start-response
   |=  [status=@ud headers=header-list:http body=(unit octs)]
@@ -232,7 +245,9 @@
   ;:  weld
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
-    (expect-eq !>(headers) !>(headers.response-header.http-event.p.card.mov))
+  ::
+    %+  expect-eq  !>((header-sort headers))
+    !>((header-sort headers.response-header.http-event.p.card.mov))
   ==
 ::
 ++  ex-continue-response

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -748,6 +748,20 @@
     [%app1 %poke %handle-http-request response]
   (expect-moves mos mov-1 mov-2 ~)
 ::
+++  test-bad-auth-401
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  ~  bind:m  perform-init-wo-timer
+  ::  request made with unrecognized session should 401 & redirect
+  ::
+  ;<  ~  bind:m  |=(=state [%& ~ state(sesh `'urbauth-~nul=0v0')])
+  ;<  mos=(list move)  bind:m  (get '/' ~)
+  ;<  ex-rs=$-(move tang)  bind:m
+    %^  make-ex-resp  401
+      ['set-cookie' 'urbauth-~nul=0v0; Path=/; Max-Age=0']~
+    `(as-octs:mimes:html 'bad session auth')
+  (expect-moves mos ex-rs ~)
+::
 ++  test-generator
   %-  eval-mare
   =/  m  (mare ,~)
@@ -1698,7 +1712,7 @@
   ;<  ~  bind:m  (setup-for-eauth 'http://client.com')
   ::  visitor attempts to approve an eauth attempt without being authenticated
   ::
-  ;<  ~  bind:m  |=(=state [%& ~ state(sesh `'urbauth-~nul=0v0')])
+  ;<  ~  bind:m  |=(=state [%& ~ state(sesh ~)])
   ;<  mos=(list move)  bind:m
     =/  body  'server=~hoster&nonce=0vnonce'
     (post '/~/eauth' ~ body)

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -1,6 +1,45 @@
 /+  *test
 /=  eyre-raw  /sys/vane/eyre
 ::
+::NOTE  some points about the testing style/structure here
+::
+::  the tests are written in monadic continuation-passing style with the help
+::  of the ;< rune. this tests file is the first place to use that pattern for
+::  tests, and it has grown/evolved organically since then. please forgive the
+::  rough edges.
+::
+::  in addition to tracking the time and full state of the eyre core, we also
+::  track the active cookie string (sesh.state). +call and +take put their
+::  resulting moves through +read-moves in order to figure out if/how to update
+::  the sesh. we try to roughly mimick the browser behavior, where a cookie
+::  either gets set, or is made to expire. (we don't pro-actively expire the
+::  sesh value based on +wait calls.)
+::
+::  both simulated requests, and tests for responses are augmented based on the
+::  sesh. if we have it, we'll inject it as a 'cookie' header into simulated
+::  requests, and expect it to be re-set in a 'set-cookie' header for the
+::  responses that we test. (if you manually provide 'cookie' or 'set-cookie'
+::  headers, the utilities will respect those instead.)
+::  (for response testers, this architecture unfortunately means we need to
+::  construct them inside ;< blocks, because we need to grab the sesh value
+::  from the continuation. less ergonomic than desired, to be improved...)
+::
+::  note that we only ever track one active cookie at a time, because we assume
+::  the tests only ever interact with the one eyre as its one client. for
+::  complicated multi-party tests, you would have to manually juggle the
+::  cookies, or further complicate the mechanism here.
+::
+::  when invoking +make-ex- arms, we do so _before_ running the call that will
+::  produce the moves you want to test. otherwise, the +make-ex- arm may
+::  construct the test based on the information it learned from the moves
+::  emitted by the call, leading to always-passing tests.
+::
+::  because we have a fair amount of things about test details that change only
+::  very rarely, we use the "optional args in the gate context" pattern in a
+::  number of places. (see, for example, +ex-start-response.)
+::  unfortunately, for indirect calls/constructors, this means we have to take
+::  care to thread even the optional args all the way through.
+::
 !:
 =/  eyre-gate  (eyre-raw ~nul)
 =/  eyre-id  '~.eyre_0v4.elsnk.20412.0h04v.50lom.5lq0o'
@@ -16,6 +55,7 @@
 ++  state
   $:  gate=_eyre-gate
       now=@da
+      sesh=(unit @t)  ::  last-heard cookie string, as 'urbauth-~xxx=0vyyy'
   ==
 ::
 ++  output-raw
@@ -27,6 +67,11 @@
   |%
   ++  ouptut  (output-raw a)
   ++  form  (form-raw a)
+  ++  easy
+    |=  g=$-(state a)
+    ^-  form
+    |=  =state
+    [%& (g state) state]
   ++  pure
     |=  arg=a
     ^-  form
@@ -89,6 +134,54 @@
   ?.  (aor k.head key.i.heads)  [i.heads $(heads t.heads)]
   [head heads]
 ::
+++  get-token
+  %-  easy:(mare ,@t)
+  |=  =state
+  (rsh 3^13 (need sesh.state))
+::
+++  get-cookie
+  %-  easy:(mare ,@t)
+  |=  =state
+  (need sesh.state)
+::
+++  expected-cookie
+  =/  next=@t  g-cook
+  |=  live=?
+  %-  easy:(mare ,@t)
+  |=  =state
+  %+  rap  3
+  :~  (fall sesh.state next)
+      '; Path=/; Max-Age='
+      ?:(live '604800' '0')
+  ==
+::
+++  read-moves
+  |=  [moves=(list move) =state]
+  ^+  state
+  =-  state(sesh -)
+  %+  roll  moves
+  |=  [=move =_sesh.state]
+  ?.  ?=([* %give %response %start *] move)
+    sesh
+  =/  soot=(unit @t)
+    %+  get-header:http  'set-cookie'
+    headers.response-header.http-event.p.card.move
+  ?~  soot  sesh
+  =;  [who=@p ses=@uv end=?]
+    ?:  end  ~
+    `(rap 3 'urbauth-' (scot %p who) '=' (scot %uv ses) ~)
+  %+  rash  u.soot
+  ;~  plug
+    ;~(pfix (jest 'urbauth-~') fed:ag)
+    ;~(pfix (jest '=0v') viz:ag)
+    ;~  pfix  (jest '; Path=/; Max-Age=')
+      ;~  pose
+        (cold & (just '0'))
+        (cold | dum:ag)
+      ==
+    ==
+  ==
+::
 ++  call
   |=  [=duct wrapped-task=(hobo task:eyre-gate)]
   =/  m  (mare ,(list move))
@@ -102,7 +195,7 @@
     ==
   =^  moves  gate.state
     (call:eyre-core duct ~ wrapped-task)
-  [%& moves state]
+  [%& moves (read-moves moves state)]
 ::
 ++  take
   |=  [=wire =duct =sign:eyre-gate]
@@ -117,39 +210,54 @@
     ==
   =^  moves  gate.state
     (take:eyre-core wire duct ~ sign)
-  [%& moves state]
+  [%& moves (read-moves moves state)]
+::
+++  call-request
+  |=  [=duct =method:http url=@t =header-list:http body=(unit @t)]
+  =/  m  (mare ,(list move))
+  ^-  form:m
+  |=  =state
+  %.  state
+  ::  if there is no cookie in the request, but we have one in state,
+  ::  inject it.
+  ::
+  =?  header-list
+      ?&  ?=(^ sesh.state)
+          ?=(~ (get-header:http 'cookie' header-list))
+      ==
+    [['cookie' u.sesh.state] header-list]
+  =/  body  (bind body as-octs:mimes:html)
+  %+  call  duct
+  [%request %.n [%ipv4 .192.168.1.1] [method url header-list body]]
 ::
 ++  get
   |=  [url=@t =header-list:http]
   =/  m  (mare ,(list move))
   ^-  form:m
-  %+  call  ~[/http-blah]
-  [%request %.n [%ipv4 .192.168.1.1] [%'GET' url header-list ~]]
+  %+  call-request  ~[/http-blah]
+  [%'GET' url header-list ~]
 ::
 ++  post
   |=  [url=@t =header-list:http body=@t]
   =/  m  (mare ,(list move))
   ^-  form:m
-  =/  body  (as-octs:mimes:html body)
-  %+  call  ~[/http-blah]
-  [%request %.n [%ipv4 .192.168.1.1] [%'POST' url header-list `body]]
+  %+  call-request  ~[/http-blah]
+  [%'POST' url header-list `body]
 ::
 ++  put
   |=  [url=@t =header-list:http body=@t]
   =/  m  (mare ,(list move))
   ^-  form:m
-  =/  body  (as-octs:mimes:html body)
-  %+  call  ~[/http-blah]
-  [%request %.n [%ipv4 .192.168.1.1] [%'PUT' url header-list `body]]
+  %+  call-request  ~[/http-blah]
+  [%'PUT' url header-list `body]
 ::  use different wire
 ::
 ++  put-2
   |=  [url=@t =header-list:http body=@t]
   =/  m  (mare ,(list move))
   ^-  form:m
-  =/  body  (as-octs:mimes:html body)
-  %+  call  ~[/http-put-request]
-  [%request %.n [%ipv4 .192.168.1.1] [%'PUT' url header-list `body]]
+  %+  call-request  ~[/http-put-request]
+  [%'PUT' url header-list `body]
 ::
 ++  connect
   |=  [app=@t pax=path]
@@ -217,6 +325,16 @@
   ^-  tang
   (expect-eq !>([duct=~[/unix] %give %sessions tokens]) !>(mov))
 ::
+++  make-ex-resp  ::  auto-fill 'set-cookie' header from observed value
+  =/  =duct  [/http-blah ~]
+  |=  [status=@ud headers=header-list:http body=(unit octs)]
+  %-  easy:(mare ,$-(move tang))
+  |=  =state
+  =?  headers  ?=(~ (get-header:http 'set-cookie' headers))
+    :_  headers
+    ['set-cookie' =<(?>(?=(%& -) out.p) ((expected-cookie &) state))]
+  (%*(. ex-response duct duct) status headers body)
+::
 ++  ex-response
   =/  =duct  [/http-blah ~]
   |=  [status=@ud headers=header-list:http body=(unit octs)]
@@ -224,11 +342,9 @@
   ^-  tang
   ?.  ?=([* %give %response %start * * %.y] mov)
     [leaf+"expected %response, got: {<mov>}" ~]
-  =?  headers  ?=(^ body)
-    %+  weld  headers
-    :~  ['content-length' (crip ((d-co:co 1) p.u.body))]
-        ['set-cookie' g-sook]
-    ==
+  =?  headers  &(?=(^ body) ?=(~ (get-header:http 'content-length' headers)))
+    :_  headers
+    ['content-length' (crip ((d-co:co 1) p.u.body))]
   ;:  weld
     (expect-eq !>(duct) !>(duct.mov))
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
@@ -237,14 +353,32 @@
     %+  expect-eq  !>((header-sort headers))
     !>((header-sort headers.response-header.http-event.p.card.mov))
   ==
+::
+++  make-ex-start-resp  ::  auto-fill 'set-cookie' header from observed value
+  =/  next=@t  g-cook
+  =/  auto-cl=?  &
+  |=  [status=@ud headers=header-list:http body=(unit octs)]
+  %-  easy:(mare ,$-(move tang))
+  |=  =state
+  =.  headers
+    :_  headers
+    ['set-cookie' =<(?>(?=(%& -) out.p) ((expected-cookie &) state))]
+  (%*(. ex-start-response auto-cl auto-cl) status headers body)
+::
 ++  ex-start-response
   =/  =duct  [/http-blah ~]
+  =/  auto-cl=?  &
   |=  [status=@ud headers=header-list:http body=(unit octs)]
   |=  mov=move
   ^-  tang
   ?.  ?=([* %give %response %start * * %.n] mov)
     [leaf+"expected start %response, got: {<mov>}" ~]
-  =.  headers  (weld headers ~[g-head])
+  =?  headers
+      ?&  auto-cl
+          ?=(^ body)
+          ?=(~ (get-header:http 'content-length' headers))
+      ==
+    [['content-length' (crip ((d-co:co 1) p.u.body))] headers]
   ;:  weld
     (expect-eq !>(duct) !>(duct.mov))
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
@@ -264,40 +398,17 @@
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
     (expect-eq !>(complete) !>(complete.http-event.p.card.mov))
   ==
-::  produce the 204 response to a put request
 ::
-++  ex-204
-  (ex-response 204 ['set-cookie' cookie-string]~ ~)
-::
-++  ex-204-2
-  |=  mov=move
-  ?.  ?=([[[%http-put-request ~] ~] %give %response %start * * %.y] mov)
-    [leaf+"expected %response, got: {<mov>}" ~]
-  =/  headers  ['set-cookie' cookie-string]~
-  ;:  weld
-    (expect-eq !>(204) !>(status-code.response-header.http-event.p.card.mov))
-    (expect-eq !>(~) !>(data.http-event.p.card.mov))
-    (expect-eq !>(headers) !>(headers.response-header.http-event.p.card.mov))
-  ==
-::
-++  ex-channel-response
+++  make-ex-channel-resp
   |=  body=(unit @t)
-  |=  mov=move
-  ^-  tang
-  ?.  ?=([[[%http-blah ~] ~] %give %response %start * * %.n] mov)
-    [leaf+"expected start %response, got: {<mov>}" ~]
+  =/  m  (mare ,$-(move tang))
+  ^-  form:m
   =/  headers
     :~  ['content-type' 'text/event-stream']
         ['cache-control' 'no-cache']
         ['connection' 'keep-alive']
-        ['set-cookie' cookie-string]
     ==
-  =/  body  (bind body as-octs:mimes:html)
-  ;:  weld
-    (expect-eq !>(200) !>(status-code.response-header.http-event.p.card.mov))
-    (expect-eq !>(body) !>(data.http-event.p.card.mov))
-    (expect-eq !>(headers) !>(headers.response-header.http-event.p.card.mov))
-  ==
+  (%*(. make-ex-start-resp auto-cl |) 200 headers (bind body as-octs:mimes:html))
 ::
 ++  ex-gall-deal
   |=  [=wire our=@p app=term =deal:gall]
@@ -384,7 +495,7 @@
   =/  m  (mare ,~)
   |=  computation=form:m
   ^-  tang
-  =/  res  (computation eyre-gate ~1111.1.1)
+  =/  res  (computation eyre-gate ~1111.1.1 ~)
   ?-  -.res
     %&  ~
     %|  p.res
@@ -419,20 +530,13 @@
   ::
   [~ ~ %noun !>(.~lidlut-tabwed-savheb-loslux)]
 ::
-++  cookie-value
-  'urbauth-~nul=0v2.v5g1m.rr6kg.bjj3k.59t1m.qp48h'
-::
-++  cookie-string
-  %^  cat  3  cookie-value
+++  bake-cookie
+  |=  sesh=@t
+  %^  cat  3  sesh
   '; Path=/; Max-Age=604800'
 ::
-++  cookie  ['cookie' cookie-value]~
-::
 ++  g-name  ~fitbur-togtep-ladnup-ronbus--tanmer-sibsyn-lavryg-ramnul
-++  g-auth  ['cookie' g-cook]
 ++  g-cook  'urbauth-~nul=0v5.gbhev.sbeh0.3rov1.o6ibh.a3t9r'
-++  g-sook  (cat 3 g-cook '; Path=/; Max-Age=604800')
-++  g-head  ['set-cookie' g-sook]
 --
 ::  Tests
 ::
@@ -488,10 +592,12 @@
   %-  eval-mare
   =/  m  (mare ,~)
   ;<  ~  bind:m  perform-init-wo-timer
+  ;<  ex-rs=$-(move tang)  bind:m
+    =/  headers  ['content-type' 'text/html']~
+    =/  body  `(error-page:eyre-gate 404 %.n '/' ~)
+    (make-ex-resp 404 headers body)
   ;<  mos=(list move)  bind:m  (get '/' ~)
-  =/  headers  ['content-type' 'text/html']~
-  =/  body  `(error-page:eyre-gate 404 %.n '/' ~)
-  (expect-moves mos (ex-response 404 headers body) ~)
+  (expect-moves mos ex-rs ~)
 ::
 ++  test-basic-app-request
   %-  eval-mare
@@ -508,13 +614,15 @@
   ;<  ~  bind:m  (wait ~d1)
   ::  theoretical outside response
   ::
+  ;<  ex-sr=$-(move tang)  bind:m
+    =/  headers  ['content-type' 'text/html']~
+    (make-ex-start-resp 200 headers ~)
   ;<  mos=(list move)  bind:m
     =/  response  !>([200 ['content-type' 'text/html']~])
     =/  sign=sign:eyre-gate
       [%gall %unto %fact %http-response-header response]
     (take /watch-response/[eyre-id] ~[/http-blah] sign)
-  =/  headers  ['content-type' 'text/html']~
-  (expect-moves mos (ex-start-response 200 headers ~) ~)
+  (expect-moves mos ex-sr ~)
 ::
 ++  test-app-error
   %-  eval-mare
@@ -531,13 +639,14 @@
   ;<  ~  bind:m  (wait ~d1)
   ::  the poke fails. we should relay this to the client
   ::
+  ;<  mov-2=$-(move tang)  bind:m
+    =/  response  `(internal-server-error:eyre-gate %.n '/' ~)
+    (make-ex-resp 500 ['content-type' 'text/html']~ response)
   ;<  mos=(list move)  bind:m
     =/  sign=sign:eyre-gate
       [%gall %unto %poke-ack ~ [%leaf "/~zod/...../app1:<[1 1].[1 20]>"]~]
     (take /run-app-request/[eyre-id] ~[/http-blah] sign)
   =/  mov-1  (ex-gall-deal /watch-response/[eyre-id] g-name %app1 [%leave ~])
-  =/  response  `(internal-server-error:eyre-gate %.n '/' ~)
-  =/  mov-2  (ex-response 500 ['content-type' 'text/html']~ response)
   (expect-moves mos mov-1 mov-2 ~)
 ::
 ++  test-multipart-app-request
@@ -555,14 +664,16 @@
   ;<  ~  bind:m  (wait ~d1)
   ::  theoretical outside response
   ::
+  ;<  ex-sr=$-(move tang)  bind:m
+    =/  headers  ['content-type' 'text/html']~
+    (make-ex-start-resp 200 headers ~)
   ;<  mos=(list move)  bind:m
     =/  response  !>([200 ['content-type' 'text/html']~])
     =/  sign=sign:eyre-gate
       [%gall %unto %fact %http-response-header response]
     (take /watch-response/[eyre-id] ~[/http-blah] sign)
   ;<  ~  bind:m
-    =/  headers  ['content-type' 'text/html']~
-    (expect-moves mos (ex-start-response 200 headers ~) ~)
+    (expect-moves mos ex-sr ~)
   ;<  ~  bind:m  (wait ~s1)
   ::  2nd response
   ::
@@ -585,9 +696,11 @@
   ;<  ~  bind:m  (wait ~d1)
   ::  outside requests a path that dead-app has bound to
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    =/  body  `(error-page:eyre-gate 503 %.n '/' "%dead-app not running")
+    (make-ex-resp 503 ['content-type' 'text/html']~ body)
   ;<  mos=(list move)  bind:m  (get '/' ~)
-  =/  body  `(error-page:eyre-gate 503 %.n '/' "%dead-app not running")
-  (expect-moves mos (ex-response 503 ['content-type' 'text/html']~ body) ~)
+  (expect-moves mos ex-rs ~)
 ::  tests an app redirecting to the login handler, which then receives a post
 ::  and redirects back to app
 ::
@@ -605,14 +718,16 @@
   ::
   ;<  ~  bind:m  (request %app1 /'~landscape')
   ;<  ~  bind:m  (wait ~d1)
-  ::  app then gives a redirect to Eyre
+  ::  app then gives a redirect to Eyre, which then includes a tmp guest cookie
   ::
   =/  headers  ['location' '/~/login?redirect=/~landscape/inner-path']~
+  ;<  ex-sr=$-(move tang)  bind:m
+    (make-ex-start-resp 303 headers ~)
   ;<  mos=(list move)  bind:m
     =/  sign=sign:eyre-gate
       [%gall %unto %fact %http-response-header !>([303 headers])]
     (take /watch-response/[eyre-id] ~[/http-blah] sign)
-  ;<  ~  bind:m  (expect-moves mos (ex-start-response 303 headers ~) ~)
+  ;<  ~  bind:m  (expect-moves mos ex-sr ~)
   ;<  ~  bind:m  (wait ~d1)
   ::  the browser then fetches the login page
   ::
@@ -620,13 +735,14 @@
   ;<  ~  bind:m  (wait ~h1)
   ::  going back to the original url will acknowledge the authentication cookie
   ::
+  ;<  c=@t  bind:m  get-cookie
   ;<  mos=(list move)  bind:m
-    (get '/~landscape/inner-path' ['cookie' cookie-value]~)
+    (get '/~landscape/inner-path' ~)
   =/  mov-1
     %^  ex-gall-deal  /watch-response/[eyre-id]  ~nul
     [%app1 %watch /http-response/[eyre-id]]
   =/  mov-2
-    =/  request  [%'GET' '/~landscape/inner-path' ['cookie' cookie-value]~ ~]
+    =/  request  [%'GET' '/~landscape/inner-path' ['cookie' c]~ ~]
     =/  response  !>([eyre-id %.y %.n [%ipv4 .192.168.1.1] request])
     %^  ex-gall-deal  /run-app-request/[eyre-id]  ~nul
     [%app1 %poke %handle-http-request response]
@@ -645,8 +761,9 @@
   ;<  ~  bind:m  (wait ~d1)
   ::  outside requests a path that app1 has bound to
   ::
+  ;<  ex-rs=$-(move tang)  bind:m  (make-ex-resp 404 ~ ~)
   ;<  mos=(list move)  bind:m  (get '/' ~)
-  (expect-moves mos (ex-response 404 [g-head]~ ~) ~)
+  (expect-moves mos ex-rs ~)
 ::
 ++  test-simplified-url-parser
   ;:  weld
@@ -768,12 +885,14 @@
   ;<  ~  bind:m  perform-init-wo-timer
   ;<  ~  bind:m  perform-born
   ;<  ~  bind:m  (wait ~d1)
+  ;<  ex-rs=$-(move tang)  bind:m
+    =/  headers  ['content-type' 'text/html']~
+    =/  body  `(error-page:eyre-gate 404 %.n '/~/channel/0123456789abcdef' ~)
+    (make-ex-resp 404 headers body)
   ;<  mos=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
+    (get '/~/channel/0123456789abcdef' ~)
   ;<  now=@da  bind:m  get-now
-  =/  headers  ['content-type' 'text/html']~
-  =/  body  `(error-page:eyre-gate 404 %.n '/~/channel/0123456789abcdef' ~)
-  (expect-moves mos (ex-response 404 headers body) ~)
+  (expect-moves mos ex-rs ~)
 ::
 ++  test-channel-put-zero-requests
   %-  eval-mare
@@ -781,8 +900,8 @@
   ;<  ~  bind:m  perform-init-start-channel-2
   ;<  ~  bind:m  (wait ~m1)
   ;<  mos=(list move)  bind:m
-    (put '/~/channel/0123456789abcdef' cookie '[]')
-  =/  mov-1  ex-204
+    (put '/~/channel/0123456789abcdef' ~ '[]')
+  ;<  mov-1=$-(move tang)  bind:m  (make-ex-resp 204 ~ ~)
   =/  mov-2  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
   =/  mov-3  (ex-wait /channel/timeout/'0123456789abcdef' ~1111.1.2..12.01.00)
   (expect-moves mos mov-1 mov-2 mov-3 ~)
@@ -815,12 +934,10 @@
   ::  send the channel a poke and a subscription request
   ::
   ;<  ~  bind:m  (wait ~m1)
-  ;<  mos=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
   ;<  now=@da  bind:m  get-now
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' (add now ~s20))
-  =/  mov-2
-    %+  ex-channel-response  ~
+  ;<  mov-2=$-(move tang)  bind:m
+    %+  make-ex-channel-resp  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -836,6 +953,8 @@
   ::  opening the channel cancels the timeout timer
   ::
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
+  ;<  mos=(list move)  bind:m
+    (get '/~/channel/0123456789abcdef' ~)
   ;<  ~  bind:m  (expect-moves mos mov-1 mov-2 mov-3 ~)
   ::  we get a cancel when we notice the client has disconnected
   ::
@@ -858,7 +977,7 @@
   ::    and a new one should be set.
   ::
   ;<  mos=(list move)  bind:m
-    %^  put  '/~/channel/0123456789abcdef'  cookie
+    %^  put  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "poke",
       "id": 2,
@@ -869,7 +988,7 @@
     '''
   =/  wire  /channel/poke/'0123456789abcdef'/'2'
   =/  mov-1  (ex-gall-deal wire ~nul %eight %poke-as %a %json !>([%n '9']))
-  =/  mov-2  ex-204
+  ;<  mov-2=$-(move tang)  bind:m  (make-ex-resp 204 ~ ~)
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
   =/  mov-4  (ex-wait /channel/timeout/'0123456789abcdef' ~1111.1.2..12.01.00)
   (expect-moves mos mov-1 mov-2 mov-3 mov-4 ~)
@@ -895,7 +1014,7 @@
   ::  sending an unsubscribe sends an unsubscribe to gall
   ::
   ;<  mos=(list move)  bind:m
-    %^  put  '/~/channel/0123456789abcdef'  cookie
+    %^  put  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "unsubscribe",
       "id": 2,
@@ -904,7 +1023,7 @@
     '''
   =/  wire  /channel/subscription/'0123456789abcdef'/'1'/~nul/two/~nul
   =/  mov-1  (ex-gall-deal wire ~nul %two %leave ~)
-  =/  mov-2  ex-204
+  ;<  mov-2=$-(move tang)  bind:m  (make-ex-resp 204 ~ ~)
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
   =/  mov-4  (ex-wait /channel/timeout/'0123456789abcdef' ~1111.1.2..12.03.00)
   (expect-moves mos mov-1 mov-2 mov-3 mov-4 ~)
@@ -930,7 +1049,7 @@
   ::  now make a second subscription from the client on the same path
   ::
   ;<  mos=(list move)  bind:m
-    %^  put  '/~/channel/0123456789abcdef'  cookie
+    %^  put  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "subscribe",
       "id": 2,
@@ -941,7 +1060,7 @@
     '''
   =/  wire  /channel/subscription/'0123456789abcdef'/'2'/~nul/two/~nul
   =/  mov-1  (ex-gall-deal wire ~nul %two %watch /one/two/three)
-  =/  mov-2  ex-204
+  ;<  mov-2=$-(move tang)  bind:m  (make-ex-resp 204 ~ ~)
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
   =/  mov-4  (ex-wait /channel/timeout/'0123456789abcdef' ~1111.1.2..12.03.00)
   ::  subscription gets 2 results
@@ -959,12 +1078,10 @@
   ;<  ~  bind:m  (expect-moves mos ~)
   ::  open up the channel
   ::
-  ;<  mos=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
   ;<  now=@da  bind:m  get-now
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' (add now ~s20))
-  =/  mov-2
-    %+  ex-channel-response  ~
+  ;<  mov-2=$-(move tang)  bind:m
+    %+  make-ex-channel-resp  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -983,11 +1100,13 @@
   ::  opening the channel cancels the timeout timer
   ::
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.03.00)
+  ;<  mos=(list move)  bind:m
+    (get '/~/channel/0123456789abcdef' ~)
   ;<  ~  bind:m  (expect-moves mos mov-1 mov-2 mov-3 ~)
   ::  we can close the first channel without closing the second
   ::
   ;<  mos=(list move)  bind:m
-    %^  put  '/~/channel/0123456789abcdef'  cookie
+    %^  put  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "unsubscribe",
       "id": 3,
@@ -996,7 +1115,7 @@
     '''
   =/  wire  /channel/subscription/'0123456789abcdef'/'1'/~nul/two/~nul
   =/  mov-1  (ex-gall-deal wire ~nul %two %leave ~)
-  =/  mov-2  ex-204
+  ;<  mov-2=$-(move tang)  bind:m  (make-ex-resp 204 ~ ~)
   ;<  ~  bind:m  (expect-moves mos mov-1 mov-2 ~)
   ::  gall responds on the second subscription.
   ::
@@ -1060,13 +1179,11 @@
   ::  open the http channel
   ::
   ;<  ~  bind:m  (wait ~m2)
-  ;<  mos=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
   ;<  now=@da  bind:m  get-now
   =/  heartbeat  (add now ~s20)
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' heartbeat)
-  =/  mov-2
-    %+  ex-channel-response  ~
+  ;<  mov-2=$-(move tang)  bind:m
+    %+  make-ex-channel-resp  ~
     '''
     id: 0
     data: {"ok":"ok","id":0,"response":"poke"}
@@ -1079,6 +1196,8 @@
   ::  opening the channel cancels the timeout timer
   ::
   =/  mov-3  (ex-rest /channel/timeout/'0123456789abcdef' ~1111.1.2..12.00.00)
+  ;<  mos=(list move)  bind:m
+    (get '/~/channel/0123456789abcdef' ~)
   ;<  ~  bind:m  (expect-moves mos mov-1 mov-2 mov-3 ~)
   ;<  ~  bind:m  (wait ~m1)
   ::  first subscription result gets sent to the user
@@ -1101,13 +1220,14 @@
   ::  the client now acknowledges up to event 1
   ::
   ;<  mos=(list move)  bind:m
-    %^  put-2  '/~/channel/0123456789abcdef'  cookie
+    %^  put-2  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "ack",
       "event-id": 1}
     ]
     '''
-  ;<  ~  bind:m  (expect-moves mos ex-204-2 ~)
+  ;<  ex-rs=$-(move tang)  bind:m  (%*(. make-ex-resp duct [/http-put-request]~) 204 ~ ~)
+  ;<  ~  bind:m  (expect-moves mos ex-rs ~)
   ;<  ~  bind:m  (wait ~m1)
   ::  the client connection is detected to be broken
   ::
@@ -1130,13 +1250,11 @@
   ::    Because the client has acknowledged up to event 1, we should start the connection by
   ::    resending events 2 and 3.
   ::
-  ;<  mos=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
   ;<  now=@da  bind:m  get-now
   =/  heartbeat  (add now ~s20)
   =/  mov-1  (ex-wait /channel/heartbeat/'0123456789abcdef' heartbeat)
-  =/  mov-2
-    %+  ex-channel-response  ~
+  ;<  mov-2=$-(move tang)  bind:m
+    %+  make-ex-channel-resp  ~
     '''
     id: 2
     data: {"json":[1],"id":1,"response":"diff"}
@@ -1148,12 +1266,16 @@
     '''
   =/  mov-3
     (ex-rest /channel/timeout/'0123456789abcdef' :(add ~1111.1.2 ~m6 ~h12))
+  ;<  mos=(list move)  bind:m
+    (get '/~/channel/0123456789abcdef' ~)
   (expect-moves mos mov-1 mov-2 mov-3 ~)
 ::
 ++  test-channel-subscription-clogged
   %-  eval-mare
   =/  m  (mare ,~)
   ;<  ~  bind:m  perform-init-start-channel-2
+  ::TODO  also test that if we get a bunch within +clog-timeout, it doesn't
+  ::      clog the channel yet
   ;<  ~  bind:m  (wait (add ~s1 clog-timeout:eyre-gate))
   ::  subscription gets a success message
   ::
@@ -1164,7 +1286,7 @@
   ::  opens the http channel
   ::
   ;<  tested-elsewhere=(list move)  bind:m
-    (get '/~/channel/0123456789abcdef' cookie)
+    (get '/~/channel/0123456789abcdef' ~)
   ::  user gets sent multiple subscription results
   ::
   =/  max=@ud  clog-threshold:eyre-gate
@@ -1276,30 +1398,51 @@
   ;<  mos=(list move)  bind:m  (call ~[/unix] [%born ~])
   (expect-moves mos (ex-set-config *http-config:eyre) (ex-sessions ~) ~)
 ::
+++  request-name
+  =/  m  (mare ,@p)
+  ^-  form:m
+  ;<  mos=(list move)  bind:m  (get '/~/name' ~)
+  ?>  ?=([[* %give %response %start * * %.y] ~] mos)
+  (pure:m (slav %p q:(need data.http-event.p.card.i.mos)))
+::
 ++  test-perform-authentication
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  perform-init-wo-timer
   ;<  ~  bind:m  perform-born
-  perform-authentication-2
+  ;<  name=@p  bind:m  request-name
+  ;<  ~  bind:m  (try (expect-eq !>(g-name) !>(name)))
+  ::
+  ;<  ~  bind:m  perform-authentication-2
+  ;<  name=@p  bind:m  request-name
+  (try (expect-eq !>(~nul) !>(name)))
 ::  +perform-authentication: goes through the authentication flow
 ::
 ++  perform-authentication-2
   =/  m  (mare ,~)
   ^-  form:m
-  ;<  mos=(list move)  bind:m
-    (get '/~/login?redirect=/~landscape/inner-path' g-auth ~)
-  ;<  ~  bind:m
+  ;<  ex-rs=$-(move tang)  bind:m
     =/  headers  ['content-type' 'text/html']~
     =/  body  `(login-page:eyre-gate `'/~landscape/inner-path' ~nul fake+g-name ~ %.n)
-    (expect-moves mos (ex-response 200 headers body) ~)
+    (make-ex-resp 200 headers body)
+  ;<  mos=(list move)  bind:m
+    (get '/~/login?redirect=/~landscape/inner-path' ~)
+  ;<  ~  bind:m
+    (expect-moves mos ex-rs ~)
+  ::
   ;<  mos=(list move)  bind:m
     =/  body  'password=lidlut-tabwed-pillex-ridrup&redirect=/~landscape'
     (post '/~/login' ~ body)
   ;<  ~  bind:m
-    =/  headers  ~[['location' '/~landscape'] ['set-cookie' cookie-string]]
-    =/  token  '0v2.v5g1m.rr6kg.bjj3k.59t1m.qp48h'
+    ::NOTE  post-hoc token rationalization, but this tests the mechanism used
+    ::      in these tests for capturing it from moves coming out of eyre.
+    ;<  t=@t  bind:m  get-token
+    =/  headers
+      :~  ['location' '/~landscape']
+          ['set-cookie' (bake-cookie (cat 3 'urbauth-~nul=' t))]
+      ==
+    =/  token  t
     (expect-moves mos (ex-sessions token ~ ~) (ex-response 303 headers ~) ~)
   (pure:m ~)
 ::
@@ -1312,7 +1455,7 @@
     ::
     ++  start
       =/  body  'eauth&name=~sampel&redirect=/final'
-      (post '/~/login' [g-auth]~ body)
+      (post '/~/login' ~ body)
     ::
     ++  tune
       %^  take  /eauth/keen/(scot %p ~sampel)/(scot %uv nonce)
@@ -1325,7 +1468,7 @@
       [%plea ~sampel %e /eauth/0 `eauth-plea:eyre`[%0 %open nonce `0vtoken]]
     ::
     ++  final
-      =;  url=@t  (get url [g-auth]~)
+      =;  url=@t  (get url ~)
       (cat 3 '/~/eauth?token=0vtoken&nonce=' (scot %uv nonce))
     ::
     ++  ex-keen
@@ -1356,7 +1499,7 @@
     ::
     ++  grant
       =/  body  'server=~hoster&nonce=0vnonce&grant=grant'
-      (post '/~/eauth' cookie body)
+      (post '/~/eauth' ~ body)
     ::
     ++  okay
       ::NOTE  eyre doesn't do anything with the %done ack,
@@ -1391,15 +1534,15 @@
     ==
   ::  ~sampel gets back to us with a url, we redirect the requester
   ::
-  ;<  mos=(list move)  bind:m  tune
-  ;<  ~  bind:m
-    %+  expect-moves  mos
+  ;<  ex-rs=$-(move tang)  bind:m
     =/  loc=@t
       %^  cat  3
         'http://sampel.com/~/eauth?server=~nul&nonce='
       (scot %uv nonce)
-    :~  (ex-response 303 ~['location'^loc g-head] ~)
-    ==
+    (make-ex-resp 303 ['location' loc]~ ~)
+  ;<  mos=(list move)  bind:m  tune
+  ;<  ~  bind:m
+    (expect-moves mos ex-rs ~)
   ::  requester approves, we get an %open plea, must give an %okay boon
   ::
   ;<  mos=(list move)  bind:m  grant
@@ -1410,11 +1553,11 @@
     ==
   ::  requester returns for the final request
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    (make-ex-resp 303 ['location' '/final']~ ~)
   ;<  mos=(list move)  bind:m  final
   ;<  ~  bind:m
-    %+  expect-moves  mos
-    :~  (ex-response 303 ~['location'^'/final' g-head] ~)
-    ==
+    (expect-moves mos ex-rs ~)
   (pure:m ~)
 ::
 ++  test-eauth-incoming-bad-token
@@ -1428,14 +1571,14 @@
   ;<  *  bind:m  grant
   ::  requester GETs a url with a non-matching token
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    =/  body  `(eauth-error-page:eyre-gate %server '/final')
+    (make-ex-resp 400 ['content-type' 'text/html']~ body)
   ;<  mos=(list move)  bind:m
-    =;  url=@t  (get url [g-auth]~)
+    =;  url=@t  (get url ~)
     (cat 3 '/~/eauth?token=0vbad&nonce=' (scot %uv nonce))
   ;<  ~  bind:m
-    %+  expect-moves  mos
-    =/  body  `(eauth-error-page:eyre-gate %server '/final')
-    :~  (ex-response 400 ['content-type' 'text/html']~ body)
-    ==
+    (expect-moves mos ex-rs ~)
   (pure:m ~)
 ::
 ++  test-eauth-incoming-expired
@@ -1449,15 +1592,14 @@
   ::  expiry timer fires, we serve a response and delete the attempt
   ::
   ;<  ~  bind:m  (wait eauth-timeout:eyre-gate)
+  ;<  ex-rs=$-(move tang)  bind:m
+    =/  body  `(eauth-error-page:eyre-gate %server '/final')
+    (make-ex-resp 503 ['content-type' 'text/html']~ body)
   ;<  mos=(list move)  bind:m
     =/  =^wire  /eauth/expire/visitors/(scot %uv nonce)
     (take wire ~[/http-blah] %behn %wake ~)
   ;<  ~  bind:m
-    %+  expect-moves  mos
-    =/  body  `(eauth-error-page:eyre-gate %server '/final')
-    :~  (ex-yawn time)
-        (ex-response 503 ['content-type' 'text/html']~ body)
-    ==
+    (expect-moves mos (ex-yawn time) ex-rs ~)
   (pure:m ~)
 ::
 ++  test-eauth-incoming-aborted
@@ -1470,14 +1612,13 @@
   ;<  *  bind:m  tune
   ::  visitor returns, saying the attempt was aborted. we delete it
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    (make-ex-resp 303 ['location' '/~/login?eauth&redirect=%2Ffinal']~ ~)
   ;<  mos=(list move)  bind:m
-    =;  url=@t  (get url [g-auth]~)
+    =;  url=@t  (get url ~)
     (cat 3 '/~/eauth?abort&nonce=' (scot %uv nonce))
   ;<  ~  bind:m
-    %+  expect-moves  mos
-    =/  loc  '/~/login?eauth&redirect=%2Ffinal'
-    :~  (ex-response 303 ~['location'^loc g-head] ~)
-    ==
+    (expect-moves mos ex-rs ~)
   (pure:m ~)
 ::
 ++  test-eauth-incoming-aborted-with-duct
@@ -1491,15 +1632,13 @@
   ;<  *  bind:m  grant
   ::  visitor returns, saying the attempt was aborted. we delete it
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    (make-ex-resp 303 ['location' '/~/login?eauth&redirect=%2Ffinal']~ ~)
   ;<  mos=(list move)  bind:m
-    =;  url=@t  (get url [g-auth]~)
+    =;  url=@t  (get url ~)
     (cat 3 '/~/eauth?abort&nonce=' (scot %uv nonce))
   ;<  ~  bind:m
-    %+  expect-moves  mos
-    =/  loc  '/~/login?eauth&redirect=%2Ffinal'
-    :~  (ex-response 303 ~['location'^loc g-head] ~)
-        (ex-boon %0 %shut nonce)
-    ==
+    (expect-moves mos ex-rs (ex-boon %0 %shut nonce) ~)
   (pure:m ~)
 ::
 ++  test-eauth-incoming-delete
@@ -1542,13 +1681,13 @@
     ==
   ::  upon receiving an %okay from ~hoster, redirect the user
   ::
-  ;<  mos=(list move)  bind:m  okay
-  ;<  ~  bind:m
-    %+  expect-moves  mos
+  ;<  ex-rs=$-(move tang)  bind:m
     =/  loc=@t
       'http://hoster.com/~/eauth?nonce=0vnonce&token=0v4.qkgot.d07e3.pi1qd.m1bhj.ti8bo'
-    :~  (ex-response 303 ~['location'^loc 'set-cookie'^cookie-string] ~)
-    ==
+    (make-ex-resp 303 ['location' loc]~ ~)
+  ;<  mos=(list move)  bind:m  okay
+  ;<  ~  bind:m
+    (expect-moves mos ex-rs ~)
   (pure:m ~)
 ::
 ++  test-eauth-unauthenticated-approval
@@ -1559,14 +1698,17 @@
   ;<  ~  bind:m  (setup-for-eauth 'http://client.com')
   ::  visitor attempts to approve an eauth attempt without being authenticated
   ::
+  ;<  ~  bind:m  |=(=state [%& ~ state(sesh `'urbauth-~nul=0v0')])
   ;<  mos=(list move)  bind:m
     =/  body  'server=~hoster&nonce=0vnonce'
-    (post '/~/eauth' [g-auth]~ body)
+    (post '/~/eauth' ~ body)
   ::  eyre must not comply, instead redirect to login page
   ::
+  ;<  ex-rs=$-(move tang)  bind:m
+    (make-ex-resp 303 ~['location'^'/~/login?redirect=%2F~%2Feauth'] ~)
   ;<  ~  bind:m
     %+  expect-moves  mos
-    :~  (ex-response 303 ~['location'^'/~/login?redirect=%2F~%2Feauth' g-head] ~)
+    :~  ex-rs
     ==
   (pure:m ~)
 ::
@@ -1584,7 +1726,7 @@
   ::  send the channel a poke and a subscription request
   ::
   ;<  mos=(list move)  bind:m
-    %^  put  '/~/channel/0123456789abcdef'  cookie
+    %^  put  '/~/channel/0123456789abcdef'  ~
     '''
     [{"action": "poke",
       "id": 0,
@@ -1607,7 +1749,8 @@
     %^  ex-gall-deal  /channel/subscription/'0123456789abcdef'/'1'/~nul/two/~nul
       ~nul
     [%two %watch /one/two/three]
-  =/  mov-3  (ex-response 204 ['set-cookie' cookie-string]~ ~)
+  ;<  mov-3=$-(move tang)  bind:m
+    (make-ex-resp 204 ~ ~)
   =/  mov-4
     %+  ex  ~[/http-blah]
     [%pass /channel/timeout/'0123456789abcdef' %b %wait (add now ~h12)]

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -218,10 +218,11 @@
   (expect-eq !>([duct=~[/unix] %give %sessions tokens]) !>(mov))
 ::
 ++  ex-response
+  =/  =duct  [/http-blah ~]
   |=  [status=@ud headers=header-list:http body=(unit octs)]
   |=  mov=move
   ^-  tang
-  ?.  ?=([[[%http-blah ~] ~] %give %response %start * * %.y] mov)
+  ?.  ?=([* %give %response %start * * %.y] mov)
     [leaf+"expected %response, got: {<mov>}" ~]
   =?  headers  ?=(^ body)
     %+  weld  headers
@@ -229,6 +230,7 @@
         ['set-cookie' g-sook]
     ==
   ;:  weld
+    (expect-eq !>(duct) !>(duct.mov))
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
   ::
@@ -236,13 +238,15 @@
     !>((header-sort headers.response-header.http-event.p.card.mov))
   ==
 ++  ex-start-response
+  =/  =duct  [/http-blah ~]
   |=  [status=@ud headers=header-list:http body=(unit octs)]
   |=  mov=move
   ^-  tang
-  ?.  ?=([[[%http-blah ~] ~] %give %response %start * * %.n] mov)
+  ?.  ?=([* %give %response %start * * %.n] mov)
     [leaf+"expected start %response, got: {<mov>}" ~]
   =.  headers  (weld headers ~[g-head])
   ;:  weld
+    (expect-eq !>(duct) !>(duct.mov))
     (expect-eq !>(status) !>(status-code.response-header.http-event.p.card.mov))
     (expect-eq !>(body) !>(data.http-event.p.card.mov))
   ::


### PR DESCRIPTION
Cookies have been the bane of eyre tests for a while. We had resorted to
hard-coding the couple of expected cookie values and being careful about
passing them in the right place, right time. This was very finicky.

Here, we update the state that's passed continuously to include a value
for the "live" cookie. The rest of the testing code and helpers are
updated to keep this value updated according to the responses emitted by
eyre, and to inject the cookie into requests we simulate. This way, we
get the desired behavior of remembering the cookie like a browser would.

We get to remove the hard-coded cookie values from most tests. In the
process, we clean up the helpers a little bit, but unfortunately also
have to add more complex helpers for pulling the cookie from state.

All in all, tests should be more robust/flexible, at a small complexity
cost. The pattern here (moving over operations, updating & accumulating
state, occasional temporary config changes) might be better implemented as the state machine core (aka abet)
pattern, but that would be a bigger rewrite.

Includes an additional test for #7076, which prompted these changes, and which this PR targets for that reason. Submitting this as a separate PR because it's otherwise unrelated, and should be reviewed in isolation.