### PR TITLE
eyre: do not %grow cache when outgoing-duct is empty

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -3090,6 +3090,7 @@
     =/  aeon  ?^(prev=(~(get by cache.state) url) +(aeon.u.prev) 1)
     =.  cache.state  (~(put by cache.state) url [aeon entry])
     :_  state
+    ?~  outgoing-duct.state  ~
     [outgoing-duct.state %give %grow /cache/(scot %ud aeon)/(scot %t url)]~
   ::  +add-binding: conditionally add a pairing between binding and action
   ::


### PR DESCRIPTION
When creating a pill for the currently live 411k-4 release I encountered a problem where the pill was unable to be booted and errored out with `give-no-duct` in arvo. The root cause of this is that `%groups` includes an agent that primes the eyre cache with `%set-response` in `+on-init`. This happens before we ever get the `%born` in gall which means that we blast out the gift to the empty wire.

Note that it's okay to skip giving the `%grow` to the runtime here because when we later get the `%born` we do this: https://github.com/urbit/urbit/blob/199f0848c8bd6e90d329ae495a201663195ec04d/pkg/arvo/sys/vane/eyre.hoon#L3494-L3499