### PR TITLE
Revert "eyre: do not %grow cache when outgoing-duct is empty"

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -3090,7 +3090,6 @@
     =/  aeon  ?^(prev=(~(get by cache.state) url) +(aeon.u.prev) 1)
     =.  cache.state  (~(put by cache.state) url [aeon entry])
     :_  state
-    ?~  outgoing-duct.state  ~
     [outgoing-duct.state %give %grow /cache/(scot %ud aeon)/(scot %t url)]~
   ::  +add-binding: conditionally add a pairing between binding and action
   ::


### PR DESCRIPTION
Reverts urbit/urbit#7087

I somehow managed to miss #7078 when making my PR. This problem has already been fixed, just unreleased on master.