### PR TITLE
411k-5

### DIFF
--- a/pkg/arvo/mar/egg-any.hoon
+++ b/pkg/arvo/mar/egg-any.hoon
@@ -1,0 +1,1 @@
+../../base-dev/mar/egg-any.hoon

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3060,10 +3060,9 @@
         =^  total-dead  event-core
           %-  ~(rep by peers.ames-state:event-core)
           |=  [[=ship =ship-state] n=@ core=_event-core]
-          ?~  peer-state=(get-peer-state:core ship)
+          ?.  ?=(%known -.ship-state)
             [n core]
-          ::
-          =*  peer     u.peer-state
+          =*  peer     +.ship-state
           =/  old-qos  -.qos.peer
           =/  old-rot  route.peer
           =.  peer     (update-peer-route ship peer)
@@ -3074,10 +3073,12 @@
                 ?=(%dead -.qos.peer)      ::
             ==
           ::
-          :-  ?:(expired +(n) n)
+          ?.  expired
+            [n core]
+          :-  +(n)
           ::
           %-  (ev-trace:core &(expired kay.veb) ship |.("route has expired"))
-          =?  core  expired
+          =.  core
             %-  emit:core
             :*  unix-duct.ames-state  %give  %nail  ship
                 (get-forward-lanes our peer peers.ames-state)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -6159,10 +6159,6 @@
           ::
           ?:(=(our u.gal) ~ [%& u.gal]~)
         =/  ev-core  (ev [now eny rof] [//scry]~ ames-state)
-        ?:  (is-route-dead:ev-core u.who +.u.peer)
-          ::  if the route is %dead, send to the sponsor galaxy
-          ::
-          ?~(gal ~ [%& u.gal]~)
         (get-forward-lanes our +.u.peer peers.ames-state)
       ==
     ::

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -3090,6 +3090,11 @@
     =/  aeon  ?^(prev=(~(get by cache.state) url) +(aeon.u.prev) 1)
     =.  cache.state  (~(put by cache.state) url [aeon entry])
     :_  state
+    ::NOTE  during boot, userspace might've sent us this before we received
+    ::      our first %born, with which we initialize the outgoing-duct.
+    ::      it's fine to hold off on the %grow here, we'll re-send them
+    ::      whenever we finally receive the %born.
+    ?:  =(~ outgoing-duct.state)  ~
     [outgoing-duct.state %give %grow /cache/(scot %ud aeon)/(scot %t url)]~
   ::  +add-binding: conditionally add a pairing between binding and action
   ::

--- a/pkg/base-dev/mar/egg-any.hoon
+++ b/pkg/base-dev/mar/egg-any.hoon
@@ -1,0 +1,11 @@
+|_  =egg-any:gall
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  egg-any
+  --
+++  grab
+  |%
+  ++  noun  egg-any:gall
+  --
+--


### PR DESCRIPTION
The route caching (eauth) fix from #7082 turned out to be way too heavy due to `+abet` in the peer core reallocating the entire peers map. This was causing my ship with around 5000 peers to spend around 25 seconds every two minutes behning.

I'll release a few other fixes as well:

1. The egg-any mark was requested by native planet.
2. Incorrect unix-duct handling in Gall was causing problems creating a pill for 411k-4.