### PR TITLE
fix shar:ed jet mismatch, add luck:ed, scad:ed, scap:ed, scas:ed, sign-raw:ed, sign-octs-raw:ed

### DIFF
--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1090,7 +1090,7 @@
       ::                                                ::  ++deco:ed:crypto
       ++  deco                                          ::  decode point
         |=  s=@  ^-  (unit [@ @])
-        ?>  (lte (met 3 s) cb)
+        ?.  (lte (met 3 s) cb)  ~
         =+  y=(cut 0 [0 (dec b)] s)
         =+  si=(cut 0 [(dec b) 1] s)
         =+  x=(xrec y)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1245,8 +1245,7 @@
       ~/  %sign-octs-raw
       |=  [m=octs pub=@udpoint sek=@udscalar]  ^-  @
       ?>  (lte (met 3 pub) cb)
-      ?>  (lte (met 3 sek) cb)
-      ?>  (lte (met 3 q.m) p.m)
+      ?>  (lte (met 3 sek) (mul 2 cb))
       =+  a=(cut 0 [0 b] sek)
       =+  ^=  r
           =+  hm=(cut 0 [b b] sek)

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1270,7 +1270,6 @@
       %-  mole  |.  ^-  ?
       ?:  (gth (met 3 s) (div b 4))  |
       ?:  (gth (met 3 pub) (div b 8))  |
-      ?:  (gth (met 3 q.m) p.m)  |
       =+  rr=(cut 0 [0 b] s)
       =+  ss=(cut 0 [b b] s)
       =+  ha=(can 3 ~[[cb rr] [cb pub] m])

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1106,6 +1106,16 @@
     ~%  %ed  +  ~
     |%
     ::
+    ++  recs
+      ~/  %recs
+      |=  a=@udscalar
+      (~(sit fo l) a)
+    ::
+    ++  smac
+      ~/  %smac
+      |=  [a=@udscalar b=@udscalar c=@udscalar]
+      (recs (add (mul a b) c))
+    ::
     ++  point-neg
       ~/  %point-neg
       |=  [a-point=@udpoint]
@@ -1122,6 +1132,7 @@
       ~/  %scalarmult
       |=  [a=@udscalar a-point=@udpoint]
       ^-  @udpoint
+      =.  a  (recs a)
       ::
       =/  a-point-decoded=[@ @]  (need (deco a-point))
       ::
@@ -1166,7 +1177,7 @@
       =/  n  (dis sca (con (lsh [3 (dec cb)] 0x7f) (fil 3 (dec cb) 0xff)))
       =/  s0  (cut 0 [0 b] sek)
       =/  s1  (cut 0 [b b] sek)
-      =/  ns0  (~(sit fo l) (add s0 n))
+      =/  ns0  (recs (add s0 n))
       =/  ns1  (shal (mul 2 cb) (can 0 ~[[b s1] [b sca]]))
       (can 0 ~[[b ns0] [b ns1]])
     ::                                                  ::  ++scap:ed:crypto
@@ -1230,10 +1241,11 @@
           =+  hm=(cut 0 [b b] sek)
           =+  i=(can 3 [cb hm] m ~)
           (shal (add cb p.m) i)
-      =+  rr=(scalarmult-base (~(sit fo l) r))
+      =+  rr=(scalarmult-base r)
       =+  ^=  ss
           =+  ha=(can 3 [cb rr] [cb pub] m ~)
-          (~(sit fo l) (add r (mul (shal (add (mul cb 2) p.m) ha) a)))
+          (smac (shal (add (mul cb 2) p.m) ha) a r)
+          ::(~(sit fo l) (add r (mul (shal (add (mul cb 2) p.m) ha) a)))
       (can 0 ~[[b rr] [b ss]])
     ::                                                  ::  ++veri:ed:crypto
     ++  veri                                            ::  validate
@@ -1251,7 +1263,7 @@
       =+  rr=(cut 0 [0 b] s)
       =+  ss=(cut 0 [b b] s)
       =+  ha=(can 3 ~[[cb rr] [cb pk] m])
-      =+  h=(~(sit fo l) (shal (add (mul 2 cb) p.m) ha))
+      =+  h=(shal (add (mul 2 cb) p.m) ha)
       =(rr (add-scalarmult-scalarmult-base h (point-neg pk) ss))
     --  ::ed
   ::                                                    ::

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1132,12 +1132,11 @@
       ~/  %scalarmult
       |=  [a=@udscalar a-point=@udpoint]
       ^-  @udpoint
-      =.  a  (recs a)
       ::
       =/  a-point-decoded=[@ @]  (need (deco a-point))
       ::
       %-  etch
-      (scam a-point-decoded a)
+      (scam a-point-decoded (recs a))
     ::
     ++  scalarmult-base
       ~/  %scalarmult-base
@@ -1217,6 +1216,16 @@
       =.  pub  +:(need (deco pub))
       =+  crv=(fra.fq (sum.fq 1 pub) (dif.fq 1 pub))
       (curt prv crv)
+    ::                                                  ::  ++slar:ed:crypto
+    ++  slar                                            ::  curve25519 secret
+      ~/  %slar
+      |=  [pub=@ sek=@]
+      ^-  @ux
+      =>  .(pub `@udpoint`pub)
+      =+  prv=(end [0 b] sek)
+      =.  pub  +:(need (deco pub))
+      =+  crv=(fra.fq (sum.fq 1 pub) (dif.fq 1 pub))
+      (curt prv crv)
     ::                                                  ::  ++sign:ed:crypto
     ++  sign                                            ::  certify
       ~/  %sign
@@ -1245,26 +1254,26 @@
       =+  ^=  ss
           =+  ha=(can 3 [cb rr] [cb pub] m ~)
           (smac (shal (add (mul cb 2) p.m) ha) a r)
-          ::(~(sit fo l) (add r (mul (shal (add (mul cb 2) p.m) ha) a)))
       (can 0 ~[[b rr] [b ss]])
     ::                                                  ::  ++veri:ed:crypto
     ++  veri                                            ::  validate
       ~/  %veri
-      |=  [s=@ m=@ pk=@]  ^-  ?
-      (veri-octs s (met 3 m)^m pk)
+      |=  [s=@ m=@ pub=@]  ^-  ?
+      (veri-octs s (met 3 m)^m pub)
     ::                                                  ::  ++veri-octs:ed:crypto
     ++  veri-octs                                       ::  validate octs
       ~/  %veri-octs
-      |=  [s=@ m=octs pk=@]  ^-  ?
+      |=  [s=@ m=octs pub=@]  ^-  ?
       =-  (fall - |)
       %-  mole  |.  ^-  ?
       ?:  (gth (met 3 s) (div b 4))  |
-      ?:  (gth (met 3 pk) (div b 8))  |
+      ?:  (gth (met 3 pub) (div b 8))  |
+      ?:  (gth (met 3 q.m) p.m)  |
       =+  rr=(cut 0 [0 b] s)
       =+  ss=(cut 0 [b b] s)
-      =+  ha=(can 3 ~[[cb rr] [cb pk] m])
+      =+  ha=(can 3 ~[[cb rr] [cb pub] m])
       =+  h=(shal (add (mul 2 cb) p.m) ha)
-      =(rr (add-scalarmult-scalarmult-base h (point-neg pk) ss))
+      =(rr (add-scalarmult-scalarmult-base h (point-neg pub) ss))
     --  ::ed
   ::                                                    ::
   ::::                    ++scr:crypto                  ::  (2b3) scrypt

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1090,6 +1090,7 @@
       ::                                                ::  ++deco:ed:crypto
       ++  deco                                          ::  decode point
         |=  s=@  ^-  (unit [@ @])
+        ?>  (lte (met 3 s) cb)
         =+  y=(cut 0 [0 (dec b)] s)
         =+  si=(cut 0 [(dec b) 1] s)
         =+  x=(xrec y)
@@ -1198,7 +1199,7 @@
       ~/  %luck
       |=  sed=@I
       ^-  [pub=@udpoint sek=@udscalar]
-      ?>  (lte (met 0 sed) b)
+      ?>  (lte (met 3 sed) cb)
       =+  h=(shal (rsh [0 3] b) sed)
       =+  ^=  a
           %+  add
@@ -1211,16 +1212,14 @@
       ~/  %shar
       |=  [pub=@ sed=@]
       ^-  @ux
-      =>  .(pub `@udpoint`pub)
-      =+  prv=(end [0 b] sek:(luck sed))
-      =.  pub  +:(need (deco pub))
-      =+  crv=(fra.fq (sum.fq 1 pub) (dif.fq 1 pub))
-      (curt prv crv)
+      (slar pub sek:(luck sed))
     ::                                                  ::  ++slar:ed:crypto
     ++  slar                                            ::  curve25519 secret
       ~/  %slar
       |=  [pub=@ sek=@]
       ^-  @ux
+      ?>  (lte (met 3 pub) cb)
+      ?>  (lte (met 3 sek) (mul 2 cb))
       =>  .(pub `@udpoint`pub)
       =+  prv=(end [0 b] sek)
       =.  pub  +:(need (deco pub))
@@ -1245,6 +1244,9 @@
     ++  sign-octs-raw                                   ::  certify octs
       ~/  %sign-octs-raw
       |=  [m=octs pub=@udpoint sek=@udscalar]  ^-  @
+      ?>  (lte (met 3 pub) cb)
+      ?>  (lte (met 3 sek) cb)
+      ?>  (lte (met 3 q.m) p.m)
       =+  a=(cut 0 [0 b] sek)
       =+  ^=  r
           =+  hm=(cut 0 [b b] sek)

--- a/tests/sys/zuse/crypto/ed25519.hoon
+++ b/tests/sys/zuse/crypto/ed25519.hoon
@@ -13,19 +13,19 @@
 ++  test-vectors
   ^-  tang
   |^  ;:  weld
-        %+  category  "puck"
-        (zing (turn vectors check-puck))
+        %+  category  "luck"
+        (zing (turn vectors check-luck))
         %+  category  "sign"
         (zing (turn vectors check-sign))
         %+  category  "veri"
         (zing (turn vectors check-veri))
       ==
   ::
-  ++  check-puck
+  ++  check-luck
     |=  vector
     %+  expect-eq
       !>  pk
-      !>  `@ux`(puck seed)
+      !>  `@ux`pub:(luck seed)
   ::
   ++  check-sign
     |=  vector

--- a/tests/sys/zuse/crypto/ed25519.hoon
+++ b/tests/sys/zuse/crypto/ed25519.hoon
@@ -1,7 +1,7 @@
 ::  tests for the ed25519 signature algorithm
 ::
 /+  *test
-=,  ed:crypto:z
+=,  ed:crypto
 |%
 ::
 ::  Test vectors from Section 7.1 of RFC 8032:

--- a/tests/sys/zuse/crypto/ed25519.hoon
+++ b/tests/sys/zuse/crypto/ed25519.hoon
@@ -1,8 +1,7 @@
 ::  tests for the ed25519 signature algorithm
 ::
 /+  *test
-=,  ed:crypto
-::
+=,  ed:crypto:z
 |%
 ::
 ::  Test vectors from Section 7.1 of RFC 8032:
@@ -15,10 +14,22 @@
   |^  ;:  weld
         %+  category  "luck"
         (zing (turn vectors check-luck))
+        %+  category  "puck"
+        (zing (turn vectors check-puck))
         %+  category  "sign"
         (zing (turn vectors check-sign))
+        %+  category  "sign-raw"
+        (zing (turn vectors check-sign-raw))
+        %+  category  "sign-raw-octs"
+        (zing (turn vectors check-sign-octs-raw))
+        %+  category  "sign-octs"
+        (zing (turn vectors check-sign-octs))
+        %+  category  "scad"
+        (zing (turn vectors check-scad))
         %+  category  "veri"
         (zing (turn vectors check-veri))
+        %+  category  "veri-octs"
+        (zing (turn vectors check-veri-octs))
       ==
   ::
   ++  check-luck
@@ -27,25 +38,62 @@
       !>  pk
       !>  `@ux`pub:(luck seed)
   ::
+  ++  check-puck
+    |=  vector
+    %+  expect-eq
+      !>  pk
+      !>  `@ux`(puck seed)
+  ::
   ++  check-sign
     |=  vector
     %+  expect-eq
       !>  sig
       !>  `@ux`(sign msg seed)
   ::
+  ++  check-sign-raw
+    |=  vector
+    %+  expect-eq
+      !>  sig
+      !>  `@ux`(sign-raw msg (luck seed))
+  ::
+  ++  check-sign-octs
+    |=  vector
+    %+  expect-eq
+      !>  sig
+      !>  `@ux`(sign-octs (met 3 msg)^msg seed)
+  ::
+  ++  check-sign-octs-raw
+    |=  vector
+    %+  expect-eq
+      !>  sig
+      !>  `@ux`(sign-octs-raw (met 3 msg)^msg (luck seed))
+  ::
+  ++  check-scad
+    |=  vector
+    =+  (luck seed)
+    =+  sca=(shax 'foo')
+    %+  expect-eq
+      !>  (scad pub sek sca)
+      !>  [(scap pub sca) (scas sek sca)]
+  ::
   ++  check-veri
     |=  vector
     %-  expect
       !>  (veri sig msg pk)
   ::
+  ++  check-veri-octs
+    |=  vector
+    %-  expect
+      !>  (veri-octs sig (met 3 msg)^msg pk)
+  ::
   ++  vectors
     ^~  (turn vectors-raw swp-vec)
   ++  swp-vec
     |=  vector
-    :^  (swp 3 seed)
-        (swp 3 pk)
-        (swp 3 msg)
-        (swp 3 sig)
+    :^  (rev 3 32 seed)
+        (rev 3 32 pk)
+        (rev 3 (met 3 msg) msg)
+        (rev 3 64 sig)
   ++  vectors-raw
     :~
       :^    0x9d61.b19d.effd.5a60.ba84.4af4.92ec.2cc4.

--- a/tests/sys/zuse/crypto/ed25519.hoon
+++ b/tests/sys/zuse/crypto/ed25519.hoon
@@ -9,6 +9,11 @@
 ::
 +$  vector  [seed=@ux pk=@ux msg=@ux sig=@ux]
 ::
+++  test-shar
+  %+  expect-eq
+    !>  (shar (puck (shax 'foo')) (shax 'bar'))
+    !>  (slar (puck (shax 'foo')) sek:(luck (shax 'bar')))
+::
 ++  test-vectors
   ^-  tang
   |^  ;:  weld


### PR DESCRIPTION
- luck:ed and sign-(octs-)raw go together
  - luck:ed generates a public private keypair where the private keypair is generated from SHA512(seed) and the usual EdDSA clamping procedure is done on the first 32 bytes.
  - sign-(octs-)raw allows one to sign from a keypair generated with luck (or, from sca(d/s))

- scad, scas, scap allows one to 'tweak' a public/private keypair with a scalar
  - scad tweaks public and private
  - scas tweaks private
  - scap tweaks public

this also fixes the jet mismatch mentioned in #7072, and potentially other jet mismatches due to sign:ed taking the bit rather than the byte length, whereas the jet uses u3r_bytes_fit to obtain the length to sign (the urcrypt library, moreover, doesn't allow signing at bit-level lengths). it also removes code deduplication generating pub/priv keys via use of luck:ed, and ensures that various length calculuations are derived from the parameters of the EdDSA curve.

a further change is recommended, as our curve parameters are merely in the subject, as opposed to arms, so theoretically, one could obtain a jet mismatch via manipulating the parameters which are hard coded to Ed25519 to some other curve, however that is out of the scope of this PR