### PR TITLE
eyre: separate session timeout for guest and auth

### DIFF
--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -405,7 +405,7 @@
 ::
 ++  cookie-string
   %^  cat  3  cookie-value
-  '; Path=/; Max-Age=604800'
+  '; Path=/; Max-Age=2592000'
 ::
 ++  cookie  ['cookie' cookie-value]~
 ::
@@ -1393,8 +1393,15 @@
   ::
   ;<  mos=(list move)  bind:m  final
   ;<  ~  bind:m
+    =/  nook
+      ::  a new cookie gets generated with the proper expiry time.
+      ::  the fact that the token here matches the +g-cook one is a side-effect
+      ::  of eyre killing the old session first, and the tests passing a static
+      ::  entropy value.
+      ::
+      'urbauth-~nul=0v5.gbhev.sbeh0.3rov1.o6ibh.a3t9r; Path=/; Max-Age=2592000'
     %+  expect-moves  mos
-    :~  (ex-response 303 ~['location'^'/final' g-head] ~)
+    :~  (ex-response 303 ~['location'^'/final' 'set-cookie'^nook] ~)
     ==
   (pure:m ~)
 ::


### PR DESCRIPTION
Presently, eyre creates a new guest session for every unauthenticated request it gets. For ships accessible from the clearweb, crawlers and other bots cause this to happen often. Sessions time out and get cleared up by eyre after some period of inactivity. As such, the amount of stored (guest) sessions is soft-bounded at "the amount of unauthenticated requests received within [session timeout time]".

To keep normal users from having to log in after a short time away from the keyboard, we want to increase the session timeout time. But this would loosen the bound described above.

Here, we separate the timeout times for guest sessions and "real", authenticated sessions. This lets us tweak their timeouts independently. We immediately use this to increase the time for real sessions to 30 days, but leave guest sessions untouched for now.

(Eyre doesn't strictly need to create a whole guest session if the incoming request wouldn't hit userspace. `+request` already has a TODO for a refactoring that would unlock that efficiency. But we punt on it for now. The change here gets us 80% of the desired effect, anyway.)

My reasoning for keeping guest sessions at `~d7` is that they don't presently give too much trouble (aside from the large nr of superfluous sessions showing up in debug dashboard), and that one can imagine legitimate guest usage where users want to retain their guest id for a weekend activity or w/e. iow a week seems like a human-reasonable cutoff.

The whole session extending logic could stand to be refactored lightly, but I considered that out of scope for now.

This closes TLON-2865. cc @jamesacklin for review on the new user-facing timeout (30 days).