### PR TITLE
ames: fix ping-bone detection in %boot scry

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7186,7 +7186,7 @@
                   %+  skim
                     ~(tap in ~(key by by-duct.ossuary))
                   |=  =duct
-                  =(-.duct /gall/sys/way/(scot %p who)/ping)
+                  ?=([* [%gall %use %ping @ %out @ %ping %ping] *] duct)
                 ?~  ducs  ``noun+!>(~)
                 =/  ping-bone
                   (~(got by by-duct.ossuary) -.ducs)
@@ -7203,7 +7203,7 @@
                 %+  skim
                   ~(tap in ~(key by by-duct.ossuary))
                 |=  =duct
-                =(-.duct /gall/sys/way/(scot %p who)/ping)
+                ?=([* [%gall %use %ping @ %out @ %ping %ping] *] duct)
               ?~  ducs  ``noun+!>(~)
               =/  ping-bone
                 (~(got by by-duct.ossuary) -.ducs)


### PR DESCRIPTION
The `%ping` app has a long and unfortunate history. A part of this history is the various different wires the ping app uses to poke the galaxy sponsor. This wire is a part of the duct that gets used by double boot protection to check whether a booting ship is actually the latest version of said ship. The previous logic for finding the correct flow was flawed because it would find stale ping flows on ships that are old enough to have been running the previous versions of `%ping`.

An example of an old-style duct:
```
~[/gall/sys/way/~zod/ping /gall/use/ping/0w3.psfYX/out/~zod/ping/nat/0ws/ping/~zod /dill //term/1]
```

An example of the newest version of the duct:
```
~[/gall/sys/way/~zod/ping /gall/use/ping/0w3.psfYX/out/~zod/ping/ping /dill //term/1]
```