### PR TITLE
clay: handle desks with no /sys/kelvin

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -1851,7 +1851,11 @@
         *yaki
       (aeon-to-yaki:ze let.dom)
     =/  old-kel=(set weft)
-      ?:  =(0 let.dom)
+      ?:  ?|  =(0 let.dom)
+              =-  ~?  -  "clay: missing /sys/kelvin on {<syd>}"
+                  -
+              !(~(has by q.old-yaki) /sys/kelvin)
+          ==
         [zuse+zuse ~ ~]
       (waft-to-wefts (get-kelvin %| old-yaki))
     =/  [deletes=(set path) changes=(map path (each page lobe))]


### PR DESCRIPTION
cc @pkova 

Ships that run into this issue can boot with the following jammed event (from `https://yosoyubik.fra1.digitaloceanspaces.com/clay-fix.jam`) that contains a commit with the updated clay.

The command:

```
urbit -I clay-fix.jam the-pier-folder
```

