### PR TITLE
eyre: respond to bad methods on channels endpoint

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -2291,7 +2291,9 @@
         ::  POST methods are used solely for deleting channels
         (on-put-request channel-id identity request)
       ::
-      ((trace 0 |.("session not a put")) `state)
+      %-  (trace 0 |.("session not a put"))
+      %^  return-static-data-on-duct  405  'text/html'
+      (error-page 405 & url.request "bad method for session endpoint")
     ::  +on-cancel-request: cancels an ongoing subscription
     ::
     ::    One of our long lived sessions just got closed. We put the associated


### PR DESCRIPTION
Instead of dropping the connection on the floor, we should give a response that tells a client they made a request with an unsupported method.

(OPTIONS requests also end up here if the origin domain has not been approved, but in that case the 405 is accurate enough.)