### PR TITLE
mesa: moar misc fixes

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3990,6 +3990,12 @@
         ++  on-kroc
           |=  bones=(list [ship bone])
           ^+  event-core
+          ?:  =(~ bones)  :: XX TMI
+            %-  ~(rep by peers.ames-state)
+            |=  [[her=ship per=ship-state] core=_event-core]
+            ?.  ?=(%known -.per)
+              core
+            abet:recork-one:(abed-peer:pe:core her +.per)
           ?:  &
             %-  (slog 'ames: %kroc task not allowed; TBD in |mesa' ~)
             event-core
@@ -4237,13 +4243,11 @@
             event-core
           ::  recork up to one bone per peer
           ::
-          =/  pez  ~(tap by peers.ames-state)
-          |-  ^+  event-core
-          ?~  pez  event-core
-          =+  [her sat]=i.pez
-          ?.  ?=(%known -.sat)
-            $(pez t.pez)
-          $(pez t.pez, event-core abet:recork-one:(abed-peer:pe her +.sat))
+          %-  ~(rep by peers.ames-state)
+          |=  [[her=ship per=ship-state] core=_event-core]
+          ?.  ?=(%known -.per)
+            core
+          abet:recork-one:(abed-peer:pe:core her +.per)
         ::  +on-trim: handle request to free memory
         ::
         ::    (%ruin comets not seen for six months)
@@ -4899,10 +4903,10 @@
           ++  on-kill-flow
             |=  b=bone
             ^+  peer-core
-            ?:  (~(has in corked.peer-state) b)
-              ~>  %slog.0^leaf/"ames: {<her>} ignore %kill on corked bone {<b>}"
-              peer-core
-            =.  peer-state
+            =+  ?.  (~(has in corked.peer-state) b)  ~
+                ~>  %slog.0^leaf/"ames: {<her>} ignore %kill; corked bone {<b>}"
+                ~
+            =?  peer-state  !(~(has in corked.peer-state) b)
               =,  peer-state
               %_  peer-state
                 ::  if the publisher was behind, preemptively remove any nacks

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -1903,7 +1903,6 @@
     ++  migration-test
       |=  [=ship ames=ship-state back=ship-state]
       ^-  ?
-      =-  ~?  >>>  !-  ship-failed/ship  -
       ?>  =(-.ames -.back)     :: both %known or %alien
       ?:  ?=(%alien -.ames)
         =(ames back)
@@ -2010,8 +2009,10 @@
         =(mesa back)
       ::
       ?&  ?=(%known -.back)
-          %+  print-check  %keys     =(+<.mesa +<.back)
-          %+  print-check  %lane    ?|  ?&  ?=(~ lane.mesa)
+          %+  print-check  %keys    =(+<.mesa +<.back)
+          %+  print-check  %lane    =-  ~?  !-  [back=lane.back mesa=lane.mesa]
+                                        -
+                                    ?|  ?&  ?=(~ lane.mesa)
                                              =(lane.mesa lane.back)
                                          ==
                                          ?&  ?=(^ lane.mesa)  ?=(^ lane.back)
@@ -3251,7 +3252,6 @@
             |=  [=duct dud=(unit goof) wrapped-task=(hobo task)]
             ^-  [(list move) _vane-gate]
             ::
-            ~|  wrapped-task
             =/  =task       ((harden task) wrapped-task)
             =/  event-core  (ev now^eny^rof duct ames-state)
             ::
@@ -3283,13 +3283,16 @@
               ::
                 %mate  ?.  dry.task  (on-mate:event-core +.task)
                        ?^  +<.task
-                         ~|  %dry-migration-failed
+                         ~|  %dry-migration-failed^u.+<.task
                          ?>  (on-mate-test:event-core u.+<.task)
-                         ~&  >  %dry-migration-worked
+                         ~&  >  %dry-migration-worked^u.+<.task
                          event-core
+                       ~&  >>
+                        "test migration of {<~(wyt by peers.ames-state)>} peers"
                        =/  test=?
                          %-  ~(rep by peers.ames-state)
-                         |=  [[=ship *] test=?]
+                         |=  [[=ship =ship-state] test=?]
+                         ?:  ?=(%alien -.ship-state)  test
                          =/  works=?  (on-mate-test:event-core ship)
                          ~?  >     works  mate-worked/ship
                          ~?  >>   !works  mate-failed/ship
@@ -4393,7 +4396,7 @@
           |=  =ship
           ^-  ?
           =/  ship-state  (~(get by peers.ames-state) ship)
-          ?>  ?=([~ %known *] ship-state)
+          ?.  ?=([~ %known *] ship-state)  %.n
           =+  peer-core=(abed-peer:pe ship +.u.ship-state)
           =/  ahoy-state=axle
             ~|(%migrate-crashed ames-state:on-migrate:peer-core)
@@ -7463,6 +7466,7 @@
                 ?>  (regression-test u.+<.task)
                 ~&  >  %dry-regression-worked
                 `ames-state
+              ~&  >>  "test regression of {<~(wyt by chums.ames-state)>} chums"
               =/  test=?
                 %-  ~(rep by chums.ames-state)
                 |=  [[=ship *] test=?]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3290,6 +3290,7 @@
                        ~&  >>
                         "test migration of {<~(wyt by peers.ames-state)>} peers"
                        =/  test=?
+                         ~>  %bout.[1 %make-mass-mate]
                          %-  ~(rep by peers.ames-state)
                          |=  [[=ship =ship-state] test=?]
                          ?:  ?=(%alien -.ship-state)  test
@@ -5136,6 +5137,13 @@
                   |=  $:  [=message-num =message-blob]
                           blobs=(list [message-num message])
                       ==
+                  ?:  ?&  ?=(^ blobs)
+                          ?=(%plea +<.i.blobs)
+                          =([0 117 0] payload.i.blobs)  ::  leave=[%0 %u ~]
+                      ==
+                    ::  filter any duplicate leaves
+                    ::
+                    blobs
                   :_  blobs
                   :-  message-num
                   ;;  message  :_  (cue message-blob)
@@ -5151,6 +5159,13 @@
                     =<  msgs
                     %-  ~(rep by unsent-messages.pump)
                     |=  [=message num=_next.pump msgs=(list [@ud message])]
+                    ?:  ?&  ?=(^ msgs)
+                            ?=(%plea +<.i.msgs)
+                            =([0 117 0] payload.i.msgs)  ::  leave=[%0 %u ~]
+                        ==
+                      ::  filter any duplicate leaves
+                      ::
+                      num^msgs
                     :-  +(num)
                     [num^message msgs]
                   %+  roll  (weld live unsent)
@@ -7468,6 +7483,7 @@
                 `ames-state
               ~&  >>  "test regression of {<~(wyt by chums.ames-state)>} chums"
               =/  test=?
+                ~>  %bout.[1 %make-mass-rege]
                 %-  ~(rep by chums.ames-state)
                 |=  [[=ship *] test=?]
                 =/  works=?  (regression-test ship)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11686,6 +11686,12 @@
   =/  ship-state  (pe-find-peer her.u.parsed-wire)
   %.  sample
   ?:  ?=(%ames -.ship-state)
+    ?:  ?=(%jael -.sign)
+      ::  any %jael gifts are captured in the |sy:mesa core. the case for this
+      ::  shows up as planets (that have not been migrated) giving the keys for
+      ::  their moons
+      ::
+      take:me-core
     take:am-core
   take:me-core
 ::  +stay: extract state before reload

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3291,8 +3291,8 @@
                          %-  ~(rep by peers.ames-state)
                          |=  [[=ship *] test=?]
                          =/  works=?  (on-mate-test:event-core ship)
-                         ~?  >     test  mate-worked/ship
-                         ~?  >>   !test  mate-failed/ship
+                         ~?  >     works  mate-worked/ship
+                         ~?  >>   !works  mate-failed/ship
                          &(test works)
                        ~?  >     test  %mass-mate-worked
                        ~?  >>>  !test  %mass-mate-failed
@@ -7463,8 +7463,8 @@
                 %-  ~(rep by chums.ames-state)
                 |=  [[=ship *] test=?]
                 =/  works=?  (regression-test ship)
-                ~?  >     test  rege-worked/ship
-                ~?  >>   !test  rege-failed/ship
+                ~?  >     works  rege-worked/ship
+                ~?  >>   !works  rege-failed/ship
                 &(test works)
               ~?  >     test  %mass-rege-worked
               ~?  >>>  !test  %mass-rege-failed

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5261,6 +5261,7 @@
                   |=  [[=message-num =message] core=_fo-core]
                   ?.  ?=(%naxplanation -.message)
                     =?  core  ?=([%plea %$ [%flow ~] %cork ~] message)
+                      ?>  (~(has in closing.peer-state) original-bone)
                       ::  if we are sending a %cork, we don't know if the other
                       ::  side has corked the flow after receiving it, and the
                       ::  %ack got lost, so we could still be trying to send the

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -507,11 +507,11 @@
       ::      use case for this is comets, about who nobody cares.
       =/  dus  (~(uni in nel.zim.pki) ~(key by yen.zim.pki))
       =/  sus  ~(. su hen now pki etn)
-      =/  sis  ~(tap in ships.tac)
-      |-
-      ?~  sis  (curd abet:sus)
-      =.  sus  (exec:sus dus %give %public-keys %breach i.sis)
-      $(sis t.sis)
+      =;  core=_sus
+        (curd abet:core)
+      %-  ~(rep in ships.tac)
+      |=  [=ship s=_sus]
+      (exec:s dus %give %public-keys %breach ship)
     ==
   ::
   ++  take
@@ -623,10 +623,10 @@
   ::
   ++  exec                                              ::  mass gift
     |=  [yen=(set duct) cad=card]
-    =/  noy  ~(tap in yen)
-    |-  ^+  this-su
-    ?~  noy  this-su
-    $(noy t.noy, moz [[i.noy cad] moz])
+    ^+  this-su
+    %-  ~(rep in yen)
+    |=  [=duct su=_this-su]
+    su(moz [[duct cad] moz])
   ::
   ++  emit-peer
     |=  [app=term =path]

--- a/pkg/base-dev/sur/hood.hoon
+++ b/pkg/base-dev/sur/hood.hoon
@@ -11,7 +11,7 @@
 ::
 +$  pikes  (map desk pike)
 ::  $jump: changes to update source change requests
-::      
+::
 +$  jump
   $%  [%all all=(map dock dock)]        :: pending requests
       [%add old=dock new=dock]          :: new request
@@ -211,13 +211,16 @@
   =/  pax=path  /(scot %p our)/[syd]/(scot %da now)
   ?.  verb
     :~  '::'
-        (cat 3 '  /desk/bill:            ' (crip "{<.^((list dude:gall) cx+(weld pax /desk/bill))>}"))
-        (cat 3 '  pending updates:       ' (print-wefts wic.dek))
-        (cat 3 '  source ship:           ' ?~(sink '~' (scot %p her.u.sink)))
-        (cat 3 '  app status:            ' sat)
-        (cat 3 '  essential desk:        ' ese)
-        (cat 3 '  %cz hash ends in:      ' (print-shorthash hash))
-        (cat 3 '  /sys/kelvin:           ' (print-wefts (waft-to-wefts waft)))
+        =+  .^(exist=? cu+(weld pax /desk/bill))
+        ?.  exist  '  /desk/bill:             missing'
+        =+  .^(dudes=(list dude:gall) cx+(weld pax /desk/bill))
+        (cat 3 '  /desk/bill:             ' (crip "{<dudes>}"))
+        (cat 3 '  pending updates:        ' (print-wefts wic.dek))
+        (cat 3 '  source ship:            ' ?~(sink '~' (scot %p her.u.sink)))
+        (cat 3 '  app status:             ' sat)
+        (cat 3 '  essential desk:         ' ese)
+        (cat 3 '  %cz hash ends in:       ' (print-shorthash hash))
+        (cat 3 '  /sys/kelvin:            ' (print-wefts (waft-to-wefts waft)))
         (cat 3 '%' syd)
     ==
   ::


### PR DESCRIPTION
- The current version of the test migration is more aggressive than it should be for certain cases of unsent/live message/fragments—fix for this incoming
  - This aggressive test discovered a bug where unsent messages were not added to the new payload ordered map _in its actual arrival order from gall_ 
- ~~There are certain flows with tens of thousands of duplicated messages (most of them %leaves=[%0 %u ~]) that make these migrations slow. Here we start a partial flow amnesty that filters these duplicated messages~~removed. diuplicate %leaves will remain in the queue due to the complexity of special casing them in the test, to check that we are not introducing any bugs in the filtering logic
- Subscriptions to %jael keys for moons was broken since we were only handling keys for planets and comets—public key udpates has been centralized into the |mesa core and only the /public-keys wire was matched.
- %jael was allocating all known ducts when ruining ships, causing a bail:meme, here we don't do that and just traverse the set in place.  
- TBA