### PR TITLE
math: better +sqt with newton's method

### DIFF
--- a/pkg/arvo/lib/math.hoon
+++ b/pkg/arvo/lib/math.hoon
@@ -699,7 +699,7 @@
     |=  x=@rs  ^-  @rs
     ?>  (sgn x)
     ?:  =(.0 x)  .0
-    =/  g=@rs  .2
+    =/  g=@rs  (div x .2)
     |-
     =/  n=@rs  (mul .0.5 (add g (div x g)))
     ?.  (gth (abs (sub g n)) rtol)
@@ -1486,7 +1486,7 @@
     |=  x=@rd  ^-  @rd
     ?>  (sgn x)
     ?:  =(.~0 x)  .~0
-    =/  g=@rd  .~2
+    =/  g=@rd  (div x .~2)
     |-
     =/  n=@rd  (mul .~0.5 (add g (div x g)))
     ?.  (gth (abs (sub g n)) rtol)
@@ -2255,7 +2255,7 @@
     |=  x=@rh  ^-  @rh
     ?>  (sgn x)
     ?:  =(.~~0 x)  .~~0
-    =/  g=@rh  .~~2
+    =/  g=@rh  (div x .~~2)
     |-
     =/  n=@rh  (mul .~~0.5 (add g (div x g)))
     ?.  (gth (abs (sub g n)) rtol)
@@ -2959,7 +2959,7 @@
     |=  x=@rq  ^-  @rq
     ?>  (sgn x)
     ?:  =(.~~~0 x)  .~~~0
-    =/  g=@rq  .~~~2
+    =/  g=@rq  (div x .~~~2)
     |-
     =/  n=@rq  (mul .~~~0.5 (add g (div x g)))
     ?.  (gth (abs (sub g n)) rtol)

--- a/pkg/arvo/lib/math.hoon
+++ b/pkg/arvo/lib/math.hoon
@@ -691,14 +691,20 @@
   ::      > (sqt .1)
   ::      .1
   ::      > (sqt .2)
-  ::      .1.4142128
-  ::      > (~(sqt rs [%z .1e-8]) .2)
-  ::      .1.414213
+  ::      .1.4142135
+  ::      > (sqt .1e5)
+  ::      .316.22775
   ::  Source
   ++  sqt
     |=  x=@rs  ^-  @rs
     ?>  (sgn x)
-    (pow x .0.5)
+    ?:  =(.0 x)  .0
+    =/  g=@rs  .2
+    |-
+    =/  n=@rs  (mul .0.5 (add g (div x g)))
+    ?.  (gth (abs (sub g n)) rtol)
+      n
+    $(g n)
   ::    +cbrt:  @rs -> @rs
   ::
   ::  Returns the cube root of a floating-point atom.
@@ -1472,14 +1478,20 @@
   ::      > (sqt .~1)
   ::      .~1
   ::      > (sqt .~2)
-  ::      .~1.4142135623721421
-  ::      > (~(sqt rd [%z .~1e-15]) .~2)
-  ::      .~1.4142135623730923
+  ::      .~1.414213562373095
+  ::      > (sqt 1e5)
+  ::      .~316.2277660168379
   ::  Source
   ++  sqt
     |=  x=@rd  ^-  @rd
     ?>  (sgn x)
-    (pow x .~0.5)
+    ?:  =(.~0 x)  .~0
+    =/  g=@rd  .~2
+    |-
+    =/  n=@rd  (mul .~0.5 (add g (div x g)))
+    ?.  (gth (abs (sub g n)) rtol)
+      n
+    $(g n)
   ::    +cbrt:  @rd -> @rd
   ::
   ::  Returns the cube root of a floating-point atom.
@@ -2235,14 +2247,20 @@
   ::      > (sqt .~~1)
   ::      .~~1
   ::      > (sqt .~~2)
-  ::      .~~1.412
-  ::      > (~(sqt rh [%z .~~1e-1]) .~~2)
-  ::      .~~1.404
+  ::      .~~1.414
+  ::      > (sqt .~~1e3)
+  ::      .~~31.61
   ::  Source
   ++  sqt
     |=  x=@rh  ^-  @rh
     ?>  (sgn x)
-    (pow x .~~0.5)
+    ?:  =(.~~0 x)  .~~0
+    =/  g=@rh  .~~2
+    |-
+    =/  n=@rh  (mul .~~0.5 (add g (div x g)))
+    ?.  (gth (abs (sub g n)) rtol)
+      n
+    $(g n)
   ::    +cbrt:  @rh -> @rh
   ::
   ::  Returns the cube root of a floating-point atom.
@@ -2933,14 +2951,20 @@
   ::      > (sqt .~~~1)
   ::      .~~~1
   ::      > (sqt .~~~2)
-  ::      .~~~1.4142135623730950488015335862957159
-  ::      > (~(sqt rq:math [%z .~~~1e-10]) .~~~2)
-  ::      .~~~1.4142135623721439870165294373250435
+  ::      .~~~1.414213562373095048801688724209698
+  ::      > (sqt .~~~1e5)
+  ::      .~~~316.2277660168379331998893544432718
   ::  Source
   ++  sqt
     |=  x=@rq  ^-  @rq
     ?>  (sgn x)
-    (pow x .~~~0.5)
+    ?:  =(.~~~0 x)  .~~~0
+    =/  g=@rq  .~~~2
+    |-
+    =/  n=@rq  (mul .~~~0.5 (add g (div x g)))
+    ?.  (gth (abs (sub g n)) rtol)
+      n
+    $(g n)
   ::    +cbrt:  @rq -> @rq
   ::
   ::  Returns the cube root of a floating-point atom.


### PR DESCRIPTION
`+pow` performance degrades rapidly as the exponent grows. Here we replace the `+sqt` implementation that calls `+pow` with one that uses the Newton-Raphson method. This gives way better performance, and more accurate results to boot.

Before:

```hoon
> ~>  %bout  (sqt:rd:lm .~1e-2)
.~0.10000000022017597   ::  took ms/181.095
> ~>  %bout  (sqt:rd:lm .~1e-3)
.~0.03162277732556293   ::  took s/10.576.252
> ~>  %bout  (sqt:rd:lm .~1e-4)
.~0.010000002308497298  ::  took s/743.265.918
> ~>  %bout  (sqt:rd:lm .~1e2)
.~9.999999977324386     ::  took ms/181.242
> ~>  %bout  (sqt:rd:lm .~1e3)
.~31.622775866034136    ::  took s/10.573.055
```

After:

```hoon
> ~>  %bout  (sqt:rd:lm .~1e-2)
.~0.09999999999999999   ::  took µs/80
> ~>  %bout  (sqt:rd:lm .~1e-3)
.~0.03162277660168379   ::  took µs/78
> ~>  %bout  (sqt:rd:lm .~1e-4)
.~0.01                  ::  took µs/105
> ~>  %bout  (sqt:rd:lm .~1e2)
.~10                    ::  took µs/114
> ~>  %bout  (sqt:rd:lm .~1e3)
.~31.622776601683793    ::  took µs/73
```