### PR TITLE
eth-watcher: rewind last block

### DIFF
--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -8,7 +8,7 @@
 =>  |%
     +$  card  card:agent:gall
     +$  app-state
-      $:  %6
+      $:  %7
           dogs=(map path watchdog)
       ==
     ::
@@ -182,11 +182,43 @@
       ==
     ==
   ::
-  [cards-1 this(state ?>(?=(%6 -.old-state) old-state))]
+  =^  cards-2=(list card)  old-state
+    ?.  ?=(%6 -.old-state)
+      `old-state
+    =.  dogs.old-state
+      %-   ~(run by dogs.old-state)
+      |=  dog=watchdog
+      =/  [old-b=@ud last-b=@ud]
+        ?~  history.dog         number.dog^number.dog
+        ?~  head=i.history.dog  number.dog^number.dog
+        ?~  mined=mined.i.head  number.dog^number.dog
+        number.dog^block-number.u.mined
+      ?:  =(old-b last-b)
+        dog
+      %-  (slog leaf+"rewinding eth-watcher from {<old-b>} to {<last-b>}" ~)
+      dog(number last-b)
+    ::
+    :_  old-state(- %7)
+    %+  turn  ~(tap by dogs.old-state)
+    |=  [=path dog=watchdog]
+    (wait-shortcut path now.bowl)
+  [(weld cards-1 cards-2) this(state ?>(?=(%7 -.old-state) old-state))]
   ::
   +$  app-states
-    $%(app-state-0 app-state-1 app-state-2 app-state-3 app-state-4 app-state-5 app-state)
+    $%  app-state-0
+        app-state-1
+        app-state-2
+        app-state-3
+        app-state-4
+        app-state-5
+        app-state-6
+        app-state
+    ==
   ::
+  +$  app-state-6
+    $:  %6
+        dogs=(map path watchdog)
+    ==
   +$  app-state-5
     $:  %5
         dogs=(map path watchdog-5)

--- a/pkg/arvo/app/eth-watcher.hoon
+++ b/pkg/arvo/app/eth-watcher.hoon
@@ -163,7 +163,6 @@
     ==
   ::
   =?  old-state  ?=(%5 -.old-state)
-    ^-  app-state
     %=    old-state
         -  %6
         dogs


### PR DESCRIPTION
Context: 
```
> -diagnose!azimuth
last downloaded %azimuth block: #31.996.103 on unknown
last processed %azimuth block: #21.991.360 on unknown
installed %eth-watcher? %.y
running %eth-watcher? %.y
installed %azimuth? %.y
has %eth-watcher an %azimuth subscription? %.y
has %eth-watcher a %behn timer? %.y
is %azimuth subscribed to %eth-watcher? %.y
...
(wait 5s. to run the thread again)
```

eth-watcher started downloading blocks up to a number way in the future—possible culprit `(get-latest-block:ethio url.pup)`?—making etch-watcher stuck on that block until logs show up within blocks of that range. /app/azimuth had the latest block processed correctly when the incident happened. for ~norsyr-torryn, this was around 03/07, and @pkova found out that coincidentally, that same day there was an incident where requests to Infura for ethereum mainnet were [routed to Optimism mainnet](https://status.infura.io/incidents/g9vzrcm5cv20). If true, this information should be in the event log of the affected ships.