### PR TITLE
ames, mesa: rederive keen paths with new public/private keys

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7794,7 +7794,16 @@
             =/  her=@p  ?:(=(u.her our) ship u.her) :: %poke payloads are for us
             =+  sat=(got-per her)        :: XX get-per
             :: ?>  ?=(%known -.per)  :: XX wat if %alien?
-            :: ?.  =(u.hyf life.per)   !!  :: XX handle?
+            ?:  ?&  =(u.^her our)  ::  for acks (on in general peeks)
+                    ?|  !=(u.hyf life.ames-state)
+                        !=(u.lyf life.per)
+                ==  ==
+              [*space ~ ~]
+            ?:  ?&  =(u.^her ship)  ::  for poke payloads
+                    ?|  !=(u.hyf life.per)
+                        !=(u.lyf life.ames-state)
+                ==  ==
+              [*space ~ ~]
             =*  key  `@uxI`symmetric-key.sat
             =/  =space  [%chum server=life.ames-state client=her life.sat key]
             [space cyf (open-path:crypt key u.cyf)]
@@ -7920,6 +7929,12 @@
             =/  [=space cyf=(unit @) =inner-poke=path]
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (ev-decrypt-path [pat her]:pok.pact)
+            ::
+            ?:  ?=(%none -.space)
+              %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
+                  |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
+                      " ack={<pat.ack.pact>}; skip"
+              ev-core
             ::
             =/  [pok=(pole iota) ack=(pole iota)]
               ::  path validation/decryption
@@ -10135,10 +10150,15 @@
               c
             =/  [=space pax=^path]
               [space inner]:(ev-decrypt-path:ev path her)
-            ?-  -.space
-              ?(%none %publ)  (on-keen:c(duct hen) ~ her pax)
-                       %chum  (on-chum:c(duct hen) her pax)
-                       %shut  (on-keen:c(duct hen) `[kid key]:space her pax)
+            =+  ?.  ?=(%none -.space)
+                ~
+                %-  %+  %*(ev-tace ev her her)  odd.veb.bug.ames-state
+                    |.("weird poke life={<life.fren>} path={<path>}; skip")
+                ~
+            ?+  -.space  !!
+              %publ  (on-keen:c(duct hen) ~ her pax)
+              %chum  (on-chum:c(duct hen) her pax)
+              %shut  (on-keen:c(duct hen) `[kid key]:space her pax)
             ==
           ::
           ++  get-route
@@ -11728,6 +11748,10 @@
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (ev-decrypt-path:ev-core [pat her]:pok.pact)
             ::
+            ?:  ?=(%none -.space)
+              %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
+                  |.("weird poke life={<life.per>} ack={<pat.ack.pact>}; skip")
+              `ames-state
             =/  [pok=(pole iota) ack=(pole iota)]
               ::  path validation/decryption
               ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7691,7 +7691,7 @@
               ==
             [moves vane-gate]
           ::
-          ++  scry  peek
+          ++  scry  peek:na
           ::
           --
       ::
@@ -8006,7 +8006,7 @@
                 |.("hear peek packet")
             ::
             =/  res=(unit (unit cage))
-              (peek ~ /ames %x (name-to-beam name))
+              (peek:na ~ /ames %x (name-to-beam name))
             ?.  ?=([~ ~ ^] res)
               ev-core
             ?.  ?=([%atom *] u.u.res)
@@ -10563,7 +10563,7 @@
           |=  =name:pact
           ^-  (unit data:pact)
           =/  res=(unit (unit cage))
-            (peek ~ /ames-get-page %x (name-to-beam name))  :: XX
+            (peek:na ~ /ames-get-page %x (name-to-beam name))  :: XX
           ?.  ?=([~ ~ %atom *] res)
             ~
           =;  page=pact:pact
@@ -10576,551 +10576,567 @@
         --
       ::
       +|  %namespaces
-      ::  publisher-side, message-level (public namespace)
       ::
-      ++  peek-publ
-        |=  [bem=beam tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%publ lyf=@ pat=*] tyl)
-          ~
-        =/  lyf  (slaw %ud lyf.tyl)
-        ?~  lyf  [~ ~]
-        ?.  =(u.lyf life.ames-state)
-          ~
-        ?~  inn=(inner-path-to-beam our pat.tyl)
-          [~ ~]
-        =/  view  ?@(vew.u.inn vew.u.inn (cat 3 [way car]:vew.u.inn))
-        ?~  res=(rof ~ /ames/publ view bem.u.inn)
-          ~
-        ?~  u.res
-          [~ ~]
-        =/  priv=@uxI  (end 8 (rsh 3 priv.ames-state))  :: extract ed25519 key
-        ::  XX  rift.ames-state
-        =>  [bem=bem res=res priv=priv ..crypt]
-        :: ~>  %memo./ames/publ
-        =/  gag  [p q.q]:u.u.res  :: XX how does receiver distinguish these?
-        =/  ful  (en-beam bem)
-        =/  ser  (jam gag)  :: unencrypted
-        =/  sig  (sign:crypt priv ful (root:lss (met 3 ser)^ser))
-        :^  ~  ~  %message
-        !>([%sign sig ser])
-      ::  publisher-side, message-level (two-party encrypted namespace)
-      ::
-      ++  peek-chum
-        |=  [bem=beam tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%chum lyf=@ her=@ hyf=@ cyf=@ ~] tyl)
-          ~
-        =/  lyf  (slaw %ud lyf.tyl)
-        =/  her  (slaw %p her.tyl)
-        =/  hyf  (slaw %ud hyf.tyl)
-        =/  cyf  (slaw %uv cyf.tyl)
-        ?:  |(?=(~ lyf) ?=(~ her) ?=(~ hyf) ?=(~ cyf))
-          [~ ~]
-        ?.  =(u.lyf life.ames-state)
-          ~
-        ?~  key=(get-key-for u.her u.hyf)
-          ~
-        =/  pat=path  (open-path:crypt u.key u.cyf)
-        ?~  inn=(inner-path-to-beam our pat)
-          ~
-        ?~  res=(rof `[u.her ~ ~] /ames/chum vew.u.inn bem.u.inn)
-          ~
-        ?~  u.res
-          [~ ~]
-        =>  [key=u.key cyf=u.cyf bem=bem res=res ..crypt] :: XX rift.ames-state
-        :: ~>  %memo./ames/chum
-        :: XX rift.ames-state
-        =/  gag  [p q.q]:u.u.res
-        =/  ful  (en-beam bem)
-        =/  ser  (jam gag)
-        =/  cyr  (encrypt:crypt key cyf ser)
-        :+  ~  ~
-        message/!>([%hmac (mac:crypt key ful (root:lss (met 3 cyr)^cyr)) cyr])
-      ::  publisher-side, message-level (group encrypted namespace)
-      ::
-      ++  peek-shut
-        |=  [bem=beam tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%shut kid=@ cyf=@ ~] tyl)
-          ~
-        =/  kid  (slaw %ud kid.tyl)
-        =/  cyf  (slaw %uv cyf.tyl)
-        ?:  |(?=(~ kid) ?=(~ cyf))
-          [~ ~]
-        ?~  key=(get:key-chain server-chain.ames-state u.kid)
-          ~
-        =/  key  -.u.key
-        =/  pat  (open-path:crypt key u.cyf)
-        ::  XX check path prefix
-        ?~  inn=(inner-path-to-beam our pat)
-          ~
-        ?~  res=(rof [~ ~] /ames/shut vew.u.inn bem.u.inn)
-          ~
-        ?~  u.res
-          ~
-        ::  XX  rift.ames-state
-        =/  prv=@uxI  (end 8 (rsh 3 priv.ames-state))  :: extract ed25519 key
-        =>  [key=key cyf=u.cyf bem=bem res=res prv=prv ..crypt]
-        :: ~>  %memo./ames/shut
-        =/  gag  [p q.q]:u.u.res
-        =/  ful  (en-beam bem)
-        =/  ser  (jam gag)
-        =/  cyr  (encrypt:crypt `@uxI`key iv=cyf ser)
-        =/  sig  (sign:crypt prv ful (root:lss (met 3 cyr) cyr))
-        ``[%message !>([%sign sig cyr])]
-      ::  publisher-side, flow-level
-      ::
-      ++  peek-flow
-        |=  [lyc=gang tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?:  ?=([%flow bone=@ %cork pat=*] tyl)
-          (peek-cork lyc tyl)
-        ?.  ?=([%flow bone=@ =load =dire rcvr=@ mess=@ ~] tyl)
-          ~
-        =/  bone  (slaw %ud bone.tyl)
-        =/  rcvr  (slaw %p rcvr.tyl)
-        =/  mess  (slaw %ud mess.tyl)
-        ?:  |(?=(~ bone) ?=(~ rcvr) ?=(~ mess))
-          [~ ~]
-        ?.  &(?=(^ lyc) (~(has in u.lyc) u.rcvr))
-          ~
-        =+  per-sat=(get-per u.rcvr)
-        ?.  ?=([~ ~ %known *] per-sat)
-          ~  ::  %alien or missing
-        =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
-        =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
-        ?:  &(?=(%ack load.tyl) fo-corked:fo-core)
-            :: ~&  >>>  corked-flow-dropping/load^corked.per  :: XX remove
-            ::  if the flow is corked, block
-            ::  XX when are corked bones evicted?
-            ::
-            ~  ::  XX  [~ ~]
+      ++  na
+        |%
+        ::  publisher-side, protocol-level
         ::
-        ?~(res=(fo-peek:fo-core load.tyl u.mess) ~ ``[%message !>(u.res)])
-      ::  client/server %mesa %corks, flow-level
-      ::
-      ++  peek-cork
-        |=  [lyc=gang tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%flow bone=@ %cork =dire rcvr=@ ~] tyl)
-          ~
-        =/  bone  (slaw %ud bone.tyl)
-        =/  rcvr  (slaw %p rcvr.tyl)
-        ?:  |(?=(~ bone) ?=(~ rcvr))
-          [~ ~]
-        ?.  &(?=(^ lyc) (~(has in u.lyc) u.rcvr))
-          ~
-        =+  per-sat=(get-per u.rcvr)
-        ?.  ?=([~ ~ %known *] per-sat)
-          ~  ::  %alien or missing
-        =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
-        =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
-        ?~(res=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.res)])
-      ::  comet attestations
-      ::
-      ++  peek-pawn
-        |=  tyl=(pole knot)
-        ^-  (unit (unit cage))
-        ?.  ?=([%pawn %proof rcvr=@ life=@ ~] tyl)
-          ~
-        ::  only comets have this
-        ::
-        ?.  ?=(%pawn (clan:title our))
-          [~ ~]
-        =/  rcvr  (slaw %p rcvr.tyl)
-        =/  life  (slaw %ud life.tyl)
-        ?:  |(?=(~ life) ?=(~ rcvr))
-          [~ ~]
-        ::
-        =+  core=(ev:ames now^eny^rof ~[//attestation] ames-state)
-        =/  =open-packet
-          [pub:ex:crypto-core our life.ames-state u.rcvr u.life]
-        :+  ~  ~
-        [%message !>(proof/(sign:as:crypto-core (jam open-packet)))]
-      ::  publisher-side, weight of a noun bounded at .pat, as measured by .boq
-      ::
-      ++  peek-whey
-        |=  [lyc=gang tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%whey boq=@ her=@ pat=*] tyl)
-          ~
-        =/  boq  (slaw %ud boq.tyl)
-        =/  her  (slaw %p her.tyl)
-        ?:  |(?=(~ boq) ?=(~ her))
-          [~ ~]
-        ?~  inn=(inner-path-to-beam our pat.tyl)
-          ~
-        ::
-        ?.  &(?=(^ lyc) (~(has in u.lyc) u.her))
-          ~
-        ?~  res=(rof lyc /ames/whey vew.u.inn bem.u.inn)
-          ~
-        :^  ~  ~  %whey
-        !>([boq=u.boq (met u.boq (jam ?~(u.res ~ [p q.q]:u.u.res)))])
-      ::  receiver-side, verify packet auth
-      ::
-      ++  peek-veri
-        |=  tyl=(pole knot)
-        ^-  (unit (unit cage))
-        ?.  ?=([%veri typ=?(%sign %hmac) her=@ aut=@ rut=@ pat=*] tyl)
-          ~
-        =/  her  (slaw %p her.tyl)
-        =/  aut  (slaw %uv aut.tyl)
-        =/  rut  (slaw %uv rut.tyl)
-        ?:  |(?=(~ her) ?=(~ aut) ?=(~ rut))
-          [~ ~]
-        =/  ful  (en-beam [[u.her %$ ud+1] pat.tyl])
-        :^  ~  ~  %flag  !>  :: XX is this right?
-        ?-  typ.tyl
-          %sign  (verify-sig:crypt (get-path-key pat.tyl u.her) u.aut ful u.rut)
-          %hmac  (verify-mac:crypt (get-path-key pat.tyl u.her) u.aut ful u.rut)
-        ==
-      ::  metadata query; XX only flow information supported
-      ::
-      ++  peek-meta
-        |=  [lyc=gang tyl=(pole knot)]
-        ^-  (unit (unit cage))
-        ?.  ?=([%meta pat=*] tyl)
-          ~
-        =/  [ship=(unit ship) bone=(unit bone) =dire]
-          ?+    pat.tyl  [~ ~ *dire]
-              [ship=@ %flow bone=@ =dire *]
-            :+  (slaw %p ship.pat.tyl)
-              (slaw %ud bone.pat.tyl)
-            dire.pat.tyl
-          ==
-        ?:  |(?=(~ ship) ?=(~ bone))
-          [~ ~]
-        ?.  &(?=(^ lyc) (~(has in u.lyc) u.ship))
-          ~
-        =+  per-sat=(get-per u.ship)
-        ?.  ?=([~ ~ %known *] per-sat)
-          ~  ::  %alien or missing
-        ?>  ?=([ship=@ %flow bone=@ dire:ames qery=*] pat.tyl)
-        =+  ev-core=(ev-foco:ev u.ship +.u.u.per-sat)
-        =/  =side  [u.bone dire]
-        =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side)
-        ?.  (~(has by flows.per.fo-core) side)
-          ~
-        =,  state:fo-core
-        ?+    qery.pat.tyl  ~
-            ~          ``message/!>(sate/state:fo-core)
-            [%clos ~]  ``message/!>(clos/closing)
-            [%cork ~]  ?~(r=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.r)])
-            [%line ~]  ``message/!>(line/line)
-            [%lods ~]  ``message/!>(lods/(wyt:fo-mop:fo-core loads.snd))
-            [%next ~]  ``message/!>(next/next.snd)
-            [%last ~]  ``message/!>(last/last-acked.rcv)
-          ::
-            [%whey boq=@ ~]  :: XX rewrite in terms of %whey namespace
-          ?~  boq=(slaw %ud boq.qery.pat.tyl)
+        ++  peek-mess
+          |=  [bem=beam tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%mess ryf=@ res=*] tyl)
             ~
-          :^  ~  ~  %message  !>
-          whey/[u.boq (met u.boq (jam state:fo-core))]
+          =/  ryf  (slaw %ud ryf.tyl)
+          ?~  ryf  [~ ~]
+          ?.  =(rift.ames-state u.ryf)      ::  XX unauthenticated
+            ~
+          =*  rif  u.ryf
+          =/  nex
+            =>  |%  +$  typ  ?(%auth %data)
+                    +$  ser  ?(%etch %pure)
+                --
+            ::
+            ^-  $@  ~
+                $:  pat=path
+                    $=  pac       ::  XX control packet serialization
+                    $@  ~
+                    $:  boq=bloq
+                        ser=?
+                        wan=$@(~ [=typ fag=@ud])
+                ==  ==
+            ?+    res.tyl  ~
+                [%$ pat=*]  [pat.res.tyl ~]
+            ::
+                [%pact boq=@ =ser %init pat=*]
+              ?~  boq=(slaw %ud boq.res.tyl)
+                ~
+              [pat.res.tyl u.boq ?=(%etch ser.res.tyl) ~]
+            ::
+                [%pact boq=@ =ser =typ fag=@ pat=*]
+              =/  boq  (slaw %ud boq.res.tyl)
+              =/  fag  (slaw %ud fag.res.tyl)
+              ?:  |(?=(~ boq) ?=(~ fag))
+                ~
+              [pat.res.tyl u.boq ?=(%etch ser.res.tyl) typ.res.tyl u.fag]
+            ==
           ::
-            [%mess mess=@ m-qery=*]
-          =/  mess=(unit @ud)  (slaw %ud mess.qery.pat.tyl)
-          ?:  ?=(~ mess)
+          ?~  nex
             [~ ~]
-          ?+  m-qery.qery.pat.tyl  ~
-              [%naxp ~]
-            ``message/!>(naxp/(~(has by nax.rcv) u.mess))
-          ==
-        ==
-      ::
-      ++  peek
-        ^-  roon
-        |=  [lyc=gang pov=path car=term bem=beam]
-        ^-  (unit (unit cage))
-        ?:  ?&  =(our p.bem)
-                =(%$ q.bem)
-                =([%ud 1] r.bem)
-                =(%x car)
-            ==
-          =/  tyl=(pole knot)  s.bem
-          ?+    tyl  ~
-            ::  message-level public namespaces
-            ::
-              [%publ lyf=@ pat=*]                (peek-publ bem tyl)
-              [%chum lyf=@ her=@ hyf=@ cyf=@ ~]  (peek-chum bem tyl)
-              [%shut kid=@ cyf=@ ~]              (peek-shut bem tyl)
-              [%pawn %proof rcvr=@ life=@ ~]     (peek-pawn tyl)
-            ::  message-level private namespaces
-            ::
-              $%([%flow *] [%meta *] [%whey *])
-            ?:  =(~ lyc)  ~
-            ?-  tyl
-              [%meta *]  (peek-meta lyc tyl)
-              [%flow *]  (peek-flow lyc tyl)
-              [%whey *]  (peek-whey lyc tyl)
-            ==
-            ::  client-side, protocol-level (authentication namespace)
-            ::
-              [%veri ?(%sign %hmac) her=@ aut=@ rut=@ *]  (peek-veri tyl)
-            ::  publisher-side, protocol-level
-            ::
-              [%mess ryf=@ res=*]
-            =/  ryf  (slaw %ud ryf.tyl)
-            ?~  ryf  [~ ~]
-            ?.  =(rift.ames-state u.ryf)      ::  XX unauthenticated
-              ~
-            =*  rif  u.ryf
-            =/  nex
-              =>  |%  +$  typ  ?(%auth %data)
-                      +$  ser  ?(%etch %pure)
-                  --
-              ::
-              ^-  $@  ~
-                  $:  pat=path
-                      $=  pac       ::  XX control packet serialization
-                      $@  ~
-                      $:  boq=bloq
-                          ser=?
-                          wan=$@(~ [=typ fag=@ud])
-                  ==  ==
-              ?+    res.tyl  ~
-                  [%$ pat=*]  [pat.res.tyl ~]
-              ::
-                  [%pact boq=@ =ser %init pat=*]
-                ?~  boq=(slaw %ud boq.res.tyl)
-                  ~
-                [pat.res.tyl u.boq ?=(%etch ser.res.tyl) ~]
-              ::
-                  [%pact boq=@ =ser =typ fag=@ pat=*]
-                =/  boq  (slaw %ud boq.res.tyl)
-                =/  fag  (slaw %ud fag.res.tyl)
-                ?:  |(?=(~ boq) ?=(~ fag))
-                  ~
-                [pat.res.tyl u.boq ?=(%etch ser.res.tyl) typ.res.tyl u.fag]
+          =*  pat  pat.nex
+          =/  res  (peek lyc=~ pov=/ames/message car=%x bem(s pat))
+          ?.  ?&  ?=([~ ~ %message *] res)
+            :: ...validate that it's really a message
+            :: =>  [%message tag=?(sig hmac) ser=@]
               ==
-            ::
-            ?~  nex
+            ~
+          ?~  pac.nex  res
+          ::
+          ::  packets
+          ::
+          =*  boq  boq.pac.nex
+          :: ?.  ?=(%13 boq)
+          ::   ~ :: non-standard fragments for later
+          =/  msg  ;;([typ=?(%sign %hmac) aut=@ ser=@] q.q.u.u.res)
+          =/  mes=auth:mess  ?:(?=(%sign typ.msg) &+aut.msg |+aut.msg)
+          =*  ser  ser.msg
+          =/  wid  (met boq ser)
+          =/  tob  (met 3 ser)
+          ?<  ?=(%0 wid)  :: XX is this true?
+          =/  nit=?  |    :: XX refactor
+          |-  ^-  (unit (unit cage))
+          ?~  wan.pac.nex
+            $(nit &, wan.pac.nex [?:((gth wid 1) %auth %data) 0])
+          ::
+          =*  fag  fag.wan.pac.nex
+          ?.  (gth wid fag)
+            [~ ~]
+          ?:  ?&  ?=(%auth typ.wan.pac.nex)
+                  !=(0 fag)
+              ==
+            ~  :: non-standard proofs for later
+          =;  [=pact:pact pairs=(list (unit [@ux @ux])) pof=@ux]
+            ?>  ?=(%page +<.pact)
+            ?:  (gth fag (div (add tob.data.pact 1.023) 1.024))
               [~ ~]
-            =*  pat  pat.nex
-            =/  res
-              $(lyc ~, pov /ames/message, s.bem pat)
-            ?.  ?&  ?=([~ ~ %message *] res)
-              :: ...validate that it's really a message
-              :: =>  [%message tag=?(sig hmac) ser=@]
-                ==
-              ~
-            ?~  pac.nex  res
+            ?.  ser.pac.nex
+              ``[%packet !>([pact pairs])]
+            =;  airs=(list @ux)
+              ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
+            %+  turn  pairs
+            |=  p=(unit [l=@ux r=@ux])
+            ?~  p  0x0
+            (rep 8 ~[l.u.p r.u.p])
+          ::
+          ?-    typ.wan.pac.nex
+              %auth
+            =/  nam  [[our rif] [boq ?:(nit ~ [%auth fag])] pat]
+            ::  NB: root excluded as it can be recalculated by the client
             ::
-            ::  packets
-            ::
-            =*  boq  boq.pac.nex
-            :: ?.  ?=(%13 boq)
-            ::   ~ :: non-standard fragments for later
-            =/  msg  ;;([typ=?(%sign %hmac) aut=@ ser=@] q.q.u.u.res)
-            =/  mes=auth:mess  ?:(?=(%sign typ.msg) &+aut.msg |+aut.msg)
-            =*  ser  ser.msg
-            =/  wid  (met boq ser)
-            =/  tob  (met 3 ser)
-            ?<  ?=(%0 wid)  :: XX is this true?
-            =/  nit=?  |    :: XX refactor
-            |-  ^-  (unit (unit cage))
-            ?~  wan.pac.nex
-              $(nit &, wan.pac.nex [?:((gth wid 1) %auth %data) 0])
-            ::
-            =*  fag  fag.wan.pac.nex
-            ?.  (gth wid fag)
-              [~ ~]
-            ?:  ?&  ?=(%auth typ.wan.pac.nex)
-                    !=(0 fag)
-                ==
-              ~  :: non-standard proofs for later
-            =;  [=pact:pact pairs=(list (unit [@ux @ux])) pof=@ux]
-              ?>  ?=(%page +<.pact)
-              ?:  (gth fag (div (add tob.data.pact 1.023) 1.024))
-                [~ ~]
-              ?.  ser.pac.nex
-                ``[%packet !>([pact pairs])]
-              =;  airs=(list @ux)
-                ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
-              %+  turn  pairs
-              |=  p=(unit [l=@ux r=@ux])
-              ?~  p  0x0
-              (rep 8 ~[l.u.p r.u.p])
-            ::
-            ?-    typ.wan.pac.nex
-                %auth
-              =/  nam  [[our rif] [boq ?:(nit ~ [%auth fag])] pat]
-              ::  NB: root excluded as it can be recalculated by the client
+            =/  lss-proof
+              =>  [ser=ser ..lss]
+              :: ~>  %memo./ames/lss-auth
+              (build:lss (met 3 ser)^ser)
+            =/  pof=@ux  (rep 8 proof.lss-proof)
+            =/  dat  [tob [%& mes] (rep 8 proof.lss-proof)]  :: XX types
+            [[hop=0 %page nam dat ~] ~ pof]
+          ::
+              %data
+            =/  lss-proof
+              =>  [ser=ser ..lss]
+              :: ~>  %memo./ames/lss-data
+              (build:lss (met 3 ser)^ser)
+            =/  nam  [[our rif] [boq ?:(nit ~ [%data fag])] pat]
+            =/  aut
+              ?:  =(wid 1)
+                [%& mes]  :: single-fragment special case
+              [%| (snag fag pairs.lss-proof)]
+            =/  dat  [tob aut (cut boq [fag 1] ser)]
+            =/  pairs
+              =/  per  (bex (sub boq 13))  ::  XX  unguarded
+              (swag [(mul per fag) (dec per)] pairs.lss-proof)
+            [[hop=0 %page nam dat ~] pairs (rep 8 proof.lss-proof)]
+          ==
+        ::  publisher-side, message-level (public namespace)
+        ::
+        ++  peek-publ
+          |=  [bem=beam tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%publ lyf=@ pat=*] tyl)
+            ~
+          =/  lyf  (slaw %ud lyf.tyl)
+          ?~  lyf  [~ ~]
+          ?.  =(u.lyf life.ames-state)
+            ~
+          ?~  inn=(inner-path-to-beam our pat.tyl)
+            [~ ~]
+          =/  view  ?@(vew.u.inn vew.u.inn (cat 3 [way car]:vew.u.inn))
+          ?~  res=(rof ~ /ames/publ view bem.u.inn)
+            ~
+          ?~  u.res
+            [~ ~]
+          =/  priv=@uxI  (end 8 (rsh 3 priv.ames-state))  :: extract ed25519 key
+          ::  XX  rift.ames-state
+          =>  [bem=bem res=res priv=priv ..crypt]
+          :: ~>  %memo./ames/publ
+          =/  gag  [p q.q]:u.u.res  :: XX how does receiver distinguish these?
+          =/  ful  (en-beam bem)
+          =/  ser  (jam gag)  :: unencrypted
+          =/  sig  (sign:crypt priv ful (root:lss (met 3 ser)^ser))
+          :^  ~  ~  %message
+          !>([%sign sig ser])
+        ::  publisher-side, message-level (two-party encrypted namespace)
+        ::
+        ++  peek-chum
+          |=  [bem=beam tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%chum lyf=@ her=@ hyf=@ cyf=@ ~] tyl)
+            ~
+          =/  lyf  (slaw %ud lyf.tyl)
+          =/  her  (slaw %p her.tyl)
+          =/  hyf  (slaw %ud hyf.tyl)
+          =/  cyf  (slaw %uv cyf.tyl)
+          ?:  |(?=(~ lyf) ?=(~ her) ?=(~ hyf) ?=(~ cyf))
+            [~ ~]
+          ~&  [u.lyf life.ames-state]
+          ?.  =(u.lyf life.ames-state)
+            ~
+          ?~  key=(get-key-for u.her u.hyf)
+            ~
+          =/  pat=path  (open-path:crypt u.key u.cyf)
+          ?~  inn=(inner-path-to-beam our pat)
+            ~
+          ?~  res=(rof `[u.her ~ ~] /ames/chum vew.u.inn bem.u.inn)
+            ~
+          ?~  u.res
+            [~ ~]
+          =>  [key=u.key cyf=u.cyf bem=bem res=res ..crypt] :: XX rift.ames-state
+          :: ~>  %memo./ames/chum
+          :: XX rift.ames-state
+          =/  gag  [p q.q]:u.u.res
+          =/  ful  (en-beam bem)
+          =/  ser  (jam gag)
+          =/  cyr  (encrypt:crypt key cyf ser)
+          :+  ~  ~
+          message/!>([%hmac (mac:crypt key ful (root:lss (met 3 cyr)^cyr)) cyr])
+        ::  publisher-side, message-level (group encrypted namespace)
+        ::
+        ++  peek-shut
+          |=  [bem=beam tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%shut kid=@ cyf=@ ~] tyl)
+            ~
+          =/  kid  (slaw %ud kid.tyl)
+          =/  cyf  (slaw %uv cyf.tyl)
+          ?:  |(?=(~ kid) ?=(~ cyf))
+            [~ ~]
+          ?~  key=(get:key-chain server-chain.ames-state u.kid)
+            ~
+          =/  key  -.u.key
+          =/  pat  (open-path:crypt key u.cyf)
+          ::  XX check path prefix
+          ?~  inn=(inner-path-to-beam our pat)
+            ~
+          ?~  res=(rof [~ ~] /ames/shut vew.u.inn bem.u.inn)
+            ~
+          ?~  u.res
+            ~
+          ::  XX  rift.ames-state
+          =/  prv=@uxI  (end 8 (rsh 3 priv.ames-state))  :: extract ed25519 key
+          =>  [key=key cyf=u.cyf bem=bem res=res prv=prv ..crypt]
+          :: ~>  %memo./ames/shut
+          =/  gag  [p q.q]:u.u.res
+          =/  ful  (en-beam bem)
+          =/  ser  (jam gag)
+          =/  cyr  (encrypt:crypt `@uxI`key iv=cyf ser)
+          =/  sig  (sign:crypt prv ful (root:lss (met 3 cyr) cyr))
+          ``[%message !>([%sign sig cyr])]
+        ::  publisher-side, flow-level
+        ::
+        ++  peek-flow
+          |=  [lyc=gang tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?:  ?=([%flow bone=@ %cork pat=*] tyl)
+            (peek-cork lyc tyl)
+          ?.  ?=([%flow bone=@ =load =dire rcvr=@ mess=@ ~] tyl)
+            ~
+          =/  bone  (slaw %ud bone.tyl)
+          =/  rcvr  (slaw %p rcvr.tyl)
+          =/  mess  (slaw %ud mess.tyl)
+          ?:  |(?=(~ bone) ?=(~ rcvr) ?=(~ mess))
+            [~ ~]
+          ?.  &(?=(^ lyc) (~(has in u.lyc) u.rcvr))
+            ~
+          =+  per-sat=(get-per u.rcvr)
+          ?.  ?=([~ ~ %known *] per-sat)
+            ~  ::  %alien or missing
+          =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
+          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
+          ?:  &(?=(%ack load.tyl) fo-corked:fo-core)
+              :: ~&  >>>  corked-flow-dropping/load^corked.per  :: XX remove
+              ::  if the flow is corked, block
+              ::  XX when are corked bones evicted?
               ::
-              =/  lss-proof
-                =>  [ser=ser ..lss]
-                :: ~>  %memo./ames/lss-auth
-                (build:lss (met 3 ser)^ser)
-              =/  pof=@ux  (rep 8 proof.lss-proof)
-              =/  dat  [tob [%& mes] (rep 8 proof.lss-proof)]  :: XX types
-              [[hop=0 %page nam dat ~] ~ pof]
+              ~  ::  XX  [~ ~]
+          ::
+          ?~(res=(fo-peek:fo-core load.tyl u.mess) ~ ``[%message !>(u.res)])
+        ::  client/server %mesa %corks, flow-level
+        ::
+        ++  peek-cork
+          |=  [lyc=gang tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%flow bone=@ %cork =dire rcvr=@ ~] tyl)
+            ~
+          =/  bone  (slaw %ud bone.tyl)
+          =/  rcvr  (slaw %p rcvr.tyl)
+          ?:  |(?=(~ bone) ?=(~ rcvr))
+            [~ ~]
+          ?.  &(?=(^ lyc) (~(has in u.lyc) u.rcvr))
+            ~
+          =+  per-sat=(get-per u.rcvr)
+          ?.  ?=([~ ~ %known *] per-sat)
+            ~  ::  %alien or missing
+          =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
+          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
+          ?~(res=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.res)])
+        ::  comet attestations
+        ::
+        ++  peek-pawn
+          |=  tyl=(pole knot)
+          ^-  (unit (unit cage))
+          ?.  ?=([%pawn %proof rcvr=@ life=@ ~] tyl)
+            ~
+          ::  only comets have this
+          ::
+          ?.  ?=(%pawn (clan:title our))
+            [~ ~]
+          =/  rcvr  (slaw %p rcvr.tyl)
+          =/  life  (slaw %ud life.tyl)
+          ?:  |(?=(~ life) ?=(~ rcvr))
+            [~ ~]
+          ::
+          =+  core=(ev:ames now^eny^rof ~[//attestation] ames-state)
+          =/  =open-packet
+            [pub:ex:crypto-core our life.ames-state u.rcvr u.life]
+          :+  ~  ~
+          [%message !>(proof/(sign:as:crypto-core (jam open-packet)))]
+        ::  publisher-side, weight of a noun at .pat, as measured by .boq
+        ::
+        ++  peek-whey
+          |=  [lyc=gang tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%whey boq=@ her=@ pat=*] tyl)
+            ~
+          =/  boq  (slaw %ud boq.tyl)
+          =/  her  (slaw %p her.tyl)
+          ?:  |(?=(~ boq) ?=(~ her))
+            [~ ~]
+          ?~  inn=(inner-path-to-beam our pat.tyl)
+            ~
+          ::
+          ?.  &(?=(^ lyc) (~(has in u.lyc) u.her))
+            ~
+          ?~  res=(rof lyc /ames/whey vew.u.inn bem.u.inn)
+            ~
+          :^  ~  ~  %whey
+          !>([boq=u.boq (met u.boq (jam ?~(u.res ~ [p q.q]:u.u.res)))])
+        ::  receiver-side, verify packet auth
+        ::
+        ++  peek-veri
+          |=  tyl=(pole knot)
+          ^-  (unit (unit cage))
+          ?.  ?=([%veri typ=?(%sign %hmac) her=@ aut=@ rut=@ pat=*] tyl)
+            ~
+          =/  her  (slaw %p her.tyl)
+          =/  aut  (slaw %uv aut.tyl)
+          =/  rut  (slaw %uv rut.tyl)
+          ?:  |(?=(~ her) ?=(~ aut) ?=(~ rut))
+            [~ ~]
+          =/  ful  (en-beam [[u.her %$ ud+1] pat.tyl])
+          :^  ~  ~  %flag  !>  :: XX is this right?
+          %.  [(get-path-key pat.tyl u.her) u.aut ful u.rut]
+          ?-  typ.tyl
+            %sign  verify-sig:crypt
+            %hmac  verify-mac:crypt
+          ==
+        ::  metadata query; XX only flow information supported
+        ::
+        ++  peek-meta
+          |=  [lyc=gang tyl=(pole knot)]
+          ^-  (unit (unit cage))
+          ?.  ?=([%meta pat=*] tyl)
+            ~
+          =/  [ship=(unit ship) bone=(unit bone) =dire]
+            ?+    pat.tyl  [~ ~ *dire]
+                [ship=@ %flow bone=@ =dire *]
+              :+  (slaw %p ship.pat.tyl)
+                (slaw %ud bone.pat.tyl)
+              dire.pat.tyl
+            ==
+          ?:  |(?=(~ ship) ?=(~ bone))
+            [~ ~]
+          ?.  &(?=(^ lyc) (~(has in u.lyc) u.ship))
+            ~
+          =+  per-sat=(get-per u.ship)
+          ?.  ?=([~ ~ %known *] per-sat)
+            ~  ::  %alien or missing
+          ?>  ?=([ship=@ %flow bone=@ dire:ames qery=*] pat.tyl)
+          =+  ev-core=(ev-foco:ev u.ship +.u.u.per-sat)
+          =/  =side  [u.bone dire]
+          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side)
+          ?.  (~(has by flows.per.fo-core) side)
+            ~
+          =,  state:fo-core
+          ?+    qery.pat.tyl  ~
+              ~          ``message/!>(sate/state:fo-core)
+              [%clos ~]  ``message/!>(clos/closing)
+              [%cork ~]  ?~(r=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.r)])
+              [%line ~]  ``message/!>(line/line)
+              [%lods ~]  ``message/!>(lods/(wyt:fo-mop:fo-core loads.snd))
+              [%next ~]  ``message/!>(next/next.snd)
+              [%last ~]  ``message/!>(last/last-acked.rcv)
             ::
-                %data
-              =/  lss-proof
-                =>  [ser=ser ..lss]
-                :: ~>  %memo./ames/lss-data
-                (build:lss (met 3 ser)^ser)
-              =/  nam  [[our rif] [boq ?:(nit ~ [%data fag])] pat]
-              =/  aut
-                ?:  =(wid 1)
-                  [%& mes]  :: single-fragment special case
-                [%| (snag fag pairs.lss-proof)]
-              =/  dat  [tob aut (cut boq [fag 1] ser)]
-              =/  pairs
-                =/  per  (bex (sub boq 13))  ::  XX  unguarded
-                (swag [(mul per fag) (dec per)] pairs.lss-proof)
-              [[hop=0 %page nam dat ~] pairs (rep 8 proof.lss-proof)]
+              [%whey boq=@ ~]  :: XX rewrite in terms of %whey namespace
+            ?~  boq=(slaw %ud boq.qery.pat.tyl)
+              ~
+            :^  ~  ~  %message  !>
+            whey/[u.boq (met u.boq (jam state:fo-core))]
+            ::
+              [%mess mess=@ m-qery=*]
+            =/  mess=(unit @ud)  (slaw %ud mess.qery.pat.tyl)
+            ?:  ?=(~ mess)
+              [~ ~]
+            ?+  m-qery.qery.pat.tyl  ~
+                [%naxp ~]
+              ``message/!>(naxp/(~(has by nax.rcv) u.mess))
             ==
-          ::  XX need a single namespace entrypoint to validate
-          ::     generically any authentication tag for a message
-          ::
-          ::  /ax/[$ship]//1/validate-message/[auth-string]/[blake3-hash]/[path]
-          ::
-          ==
-        ::  only respond for the local identity, %$ desk, current timestamp
-        ::
-        ?.  ?&  =(our p.bem)
-                =([%da now] r.bem)
-                =(%$ q.bem)
-            ==
-          ~
-        ::
-        ::  /ax/corked/[ship]/[?(%for %bak)]           (set side)
-        ::  /ax/corked/[ship]/[?(%for %bak)]/[bone]    ?(%.y %.n)
-        ::  /ax/closing/[ship]/[?(%for %bak)]          (set side)
-        ::  /ax/closing/[ship]/[?(%for %bak)]/[bone]   ?(%.y %.n)
-        ::  /ax/closing/[ship]/lanes           $@(gal=@ux $%([%if ... [%is))
-        ::  /ax/chums/[ship]                   chum-state
-        ::  /ax/chums/[ship]/lanes             $@(gal=@ux $%([%if ... [%is))
-        ::  /ax/ahoyed/[ship]                  ?(%.y %.n)
-        ::
-        ?.  ?=(%x car)  ~
-        =/  tyl=(pole knot)  s.bem
-        ::  private endpoints
-        ::
-        ?.  =([~ ~] lyc)  ~
-        ?+    tyl  ~
-            [%corked her=@ =dire req=*]
-          =/  who  (slaw %p her.tyl)
-          ?~  who  [~ ~]
-          =/  per  (~(get by chums.ames-state) u.who)
-          ?.  ?=([~ %known *] per)
-            ~
-          ?+  req.tyl  ~
-              ~
-            ``noun+!>(corked.u.per)
-          ::
-              [bone=@ ~]
-            ?~  bone=(slaw %ud bone.req.tyl)
-              [~ ~]
-            ``atom+!>((~(has in corked.u.per) u.bone dire.tyl))
           ==
         ::
-            [%closing her=@ =dire req=*]
-          =/  who  (slaw %p her.tyl)
-          ?~  who  [~ ~]
-          =/  per  (~(get by chums.ames-state) u.who)
-          ?.  ?=([~ %known *] per)
-            ~
-          ?+    req.tyl  ~
-              ~
-            :^  ~  ~  %noun  !>
-            %-  ~(rep by flows.u.per)
-            |=  [[=side flow=flow-state] clo=(set side)]
-            ?.(closing.flow clo (~(put in clo) side))
-          ::
-              [bone=@ ~]
-            ?~  bone=(slaw %ud bone.req.tyl)
-              [~ ~]
-            =+  ev-core=(ev-foco:ev u.who +.u.per)
-            =+  fo-core=(fo-abed:fo:ev-core ~[//scry] u.bone dire.tyl)
-            ``atom+!>(closing.state.fo-core)
-          ==
-        ::
-            [%chums req=*]
-          ?-    req.tyl
-              ~
-            :^  ~  ~  %noun
-            !>  ^-  (map ship ?(%alien %known))
-            (~(run by chums.ames-state) ^head)
-          ::
-              [%all ~]
-            :^  ~  ~  %noun
-            =|  out=(map ship [?(%peer %chum) ?(%alien %known)])
-            !>  ^+  out
-            =/  chums=_out
-              (~(run by chums.ames-state) |=(chum-state chum/+<-))
-            =/  peers=_out
-              (~(run by peers.ames-state) |=(ship-state peer/+<-))
-            %-  ~(gas by *_out)
-            (weld ~(tap by chums) ~(tap by peers))
-          ::
-              [her=@ req=*]
-            =/  who  (slaw %p her.req.tyl)
-            ?~  who
-              [~ ~]
-            =/  chum  (~(get by chums.ames-state) u.who)
-            =/  peer  (~(get by peers.ames-state) u.who)
-            ?+    req.req.tyl  ~
-                ~
-              ?~  chum
-                ~&  (~(get by peers.ames-state) u.who)
+        ++  peek
+          ^-  roon
+          |=  [lyc=gang pov=path car=term bem=beam]
+          ^-  (unit (unit cage))
+          ?:  ?&  =(our p.bem)
+                  =(%$ q.bem)
+                  =([%ud 1] r.bem)
+                  =(%x car)
+              ==
+            =/  tyl=(pole knot)  s.bem
+            ?+    tyl
+                ::  XX need a single namespace entrypoint to validate
+                ::     generically any authentication tag for a message
                 ::
-                [~ ~]
-              ``noun+!>(u.chum)
-              ::
-                [%lanes ~]
-              ::  this duplicates the routing hack from +send-blob:event-core so
-              ::  long as neither the peer nor the peer's sponsoring galaxy is
-              ::  us, and the peer has been reached recently:
-              ::
-              ::  - no route to the peer, or peer has not been reached recently:
-              ::    send to the peer's sponsoring galaxy
-              ::  - direct route to the peer: use that
-              ::  - indirect route to the peer: send to both that route and the
-              ::    the peer's sponsoring galaxy
-              ::
-              ?:  =(our u.who)
+                ::  :+  %ax  $ship
+                ::  //1/validate-message/[auth-string]/[blake3-hash]/[path]
+                ::
                 ~
-              =/  sax
-                (rof [~ ~] /ames j/`beam`[[our %saxo %da now] /(scot %p u.who)])
-              =/  gal=(unit @p)
-                ?.  ?=([~ ~ *] sax)
-                  ~
-                `(rear ;;((list ship) q.q.u.u.sax))
-              ?~  gal
+              ::  publisher-side, protocol-level
+              ::
+                [%mess ryf=@ res=*]                (peek-mess bem tyl)
+              ::  client-side, protocol-level (authentication namespace)
+              ::
+                [%veri ?(%sign %hmac) @ @ @ *]     (peek-veri tyl)
+              ::  message-level public namespaces
+              ::
+                [%publ lyf=@ pat=*]                (peek-publ bem tyl)
+                [%chum lyf=@ her=@ hyf=@ cyf=@ ~]  (peek-chum bem tyl)
+                [%shut kid=@ cyf=@ ~]              (peek-shut bem tyl)
+                [%pawn %proof rcvr=@ life=@ ~]     (peek-pawn tyl)
+              ::  message-level private namespaces
+              ::
+                $%([%flow *] [%meta *] [%whey *])
+              ?:  =(~ lyc)  ~
+              ?-  tyl
+                [%meta *]  (peek-meta lyc tyl)
+                [%flow *]  (peek-flow lyc tyl)
+                [%whey *]  (peek-whey lyc tyl)
+              ==
+            ==
+          ::  only respond for the local identity, %$ desk, current timestamp
+          ::
+          ?.  ?&  =(our p.bem)
+                  =([%da now] r.bem)
+                  =(%$ q.bem)
+              ==
+            ~
+          ::
+          ::  /ax/corked/[ship]/[?(%for %bak)]           (set side)
+          ::  /ax/corked/[ship]/[?(%for %bak)]/[bone]    ?(%.y %.n)
+          ::  /ax/closing/[ship]/[?(%for %bak)]          (set side)
+          ::  /ax/closing/[ship]/[?(%for %bak)]/[bone]   ?(%.y %.n)
+          ::  /ax/closing/[ship]/lanes           $@(gal=@ux $%([%if ... [%is))
+          ::  /ax/chums/[ship]                   chum-state
+          ::  /ax/chums/[ship]/lanes             $@(gal=@ux $%([%if ... [%is))
+          ::  /ax/ahoyed/[ship]                  ?(%.y %.n)
+          ::
+          ?.  ?=(%x car)  ~
+          =/  tyl=(pole knot)  s.bem
+          ::  private endpoints
+          ::
+          ?.  =([~ ~] lyc)  ~
+          ?+    tyl  ~
+              [%corked her=@ =dire req=*]
+            =/  who  (slaw %p her.tyl)
+            ?~  who  [~ ~]
+            =/  per  (~(get by chums.ames-state) u.who)
+            ?.  ?=([~ %known *] per)
+              ~
+            ?+  req.tyl  ~
+                ~
+              ``noun+!>(corked.u.per)
+            ::
+                [bone=@ ~]
+              ?~  bone=(slaw %ud bone.req.tyl)
+                [~ ~]
+              ``atom+!>((~(has in corked.u.per) u.bone dire.tyl))
+            ==
+          ::
+              [%closing her=@ =dire req=*]
+            =/  who  (slaw %p her.tyl)
+            ?~  who  [~ ~]
+            =/  per  (~(get by chums.ames-state) u.who)
+            ?.  ?=([~ %known *] per)
+              ~
+            ?+    req.tyl  ~
+                ~
+              :^  ~  ~  %noun  !>
+              %-  ~(rep by flows.u.per)
+              |=  [[=side flow=flow-state] clo=(set side)]
+              ?.(closing.flow clo (~(put in clo) side))
+            ::
+                [bone=@ ~]
+              ?~  bone=(slaw %ud bone.req.tyl)
+                [~ ~]
+              =+  ev-core=(ev-foco:ev u.who +.u.per)
+              =+  fo-core=(fo-abed:fo:ev-core ~[//scry] u.bone dire.tyl)
+              ``atom+!>(closing.state.fo-core)
+            ==
+          ::
+              [%chums req=*]
+            ?-    req.tyl
                 ~
               :^  ~  ~  %noun
-              !>  ^-  [sponsor=@p (list lane:pact)]
-              :-  u.gal
-              ?:  ?=([~ %known *] chum)
-                (get-forward-lanes-mesa our +.u.chum chums.ames-state)
-              ?.  ?=([~ %known *] peer)
-                %-  %+  %*(ev-tace ev-core:ev her u.who)  odd.veb.bug.ames-state
-                    |.("alien peek for lanes")
-                ::
-                ?:(=(our u.gal) ~ [`@ux`u.gal]~)
-              %+  turn  (get-forward-lanes our +.u.peer peers.ames-state)
-              |=  lane=(each @p address)
-              ?-    -.lane
-                  %&  `@ux`p.lane
-              ::
-                  %|
-                :+    %if
-                  ip=`@if`(end [0 32] p.lane)
-                pt=`@ud`(cut 0 [32 16] p.lane)
-              ==
+              !>  ^-  (map ship ?(%alien %known))
+              (~(run by chums.ames-state) ^head)
             ::
+                [%all ~]
+              :^  ~  ~  %noun
+              =|  out=(map ship [?(%peer %chum) ?(%alien %known)])
+              !>  ^+  out
+              =/  chums=_out
+                (~(run by chums.ames-state) |=(chum-state chum/+<-))
+              =/  peers=_out
+                (~(run by peers.ames-state) |=(ship-state peer/+<-))
+              %-  ~(gas by *_out)
+              (weld ~(tap by chums) ~(tap by peers))
+            ::
+                [her=@ req=*]
+              =/  who  (slaw %p her.req.tyl)
+              ?~  who
+                [~ ~]
+              =/  chum  (~(get by chums.ames-state) u.who)
+              =/  peer  (~(get by peers.ames-state) u.who)
+              ?+    req.req.tyl  ~
+                  ~
+                ?~  chum
+                  ~&  (~(get by peers.ames-state) u.who)
+                  ::
+                  [~ ~]
+                ``noun+!>(u.chum)
+                ::
+                  [%lanes ~]
+                ::  this duplicates the routing hack from +send-blob:ev-core
+                ::  so long as neither the peer nor the peer's sponsoring
+                ::  galaxy is  us, and the peer has been reached recently:
+                ::
+                ::  - no route to the peer, or not been reached recently:
+                ::    send to the peer's sponsoring galaxy
+                ::  - direct route to the peer: use that
+                ::  - indirect route to the peer: send to both route and the
+                ::    the peer's sponsoring galaxy
+                ::
+                ?:  =(our u.who)
+                  ~
+                =/  sax
+                  %^  rof  [~ ~]  /ames
+                  j/`beam`[[our %saxo %da now] /(scot %p u.who)]
+                =/  gal=(unit @p)
+                  ?.  ?=([~ ~ *] sax)
+                    ~
+                  `(rear ;;((list ship) q.q.u.u.sax))
+                ?~  gal
+                  ~
+                :^  ~  ~  %noun
+                !>  ^-  [sponsor=@p (list lane:pact)]
+                :-  u.gal
+                ?:  ?=([~ %known *] chum)
+                  (get-forward-lanes-mesa our +.u.chum chums.ames-state)
+                ?.  ?=([~ %known *] peer)
+                  %-  %+  %*(ev-tace ev-core:ev her u.who)
+                        odd.veb.bug.ames-state
+                      |.("alien peek for lanes")
+                  ::
+                  ?:(=(our u.gal) ~ [`@ux`u.gal]~)
+                %+  turn  (get-forward-lanes our +.u.peer peers.ames-state)
+                |=  lane=(each @p address)
+                ?-    -.lane
+                    %&  `@ux`p.lane
+                ::
+                    %|
+                  :+    %if
+                    ip=`@if`(end [0 32] p.lane)
+                  pt=`@ud`(cut 0 [32 16] p.lane)
+                ==
+              ::
+              ==
             ==
+          ::
+              [%ahoyed her=@ ~]
+            =/  who  (slaw %p her.tyl)
+            ?~  who  [~ ~]
+            ``atom+!>((~(has by chums.ames-state) u.who))
           ==
         ::
-            [%ahoyed her=@ ~]
-          =/  who  (slaw %p her.tyl)
-          ?~  who  [~ ~]
-          ``atom+!>((~(has by chums.ames-state) u.who))
-        ==
-      ::
+        --
       +|  %helpers
       ::
       ++  push-pact  :: XX forwarding?
@@ -11747,7 +11763,7 @@
                 |=  [lyc=gang pov=path vis=view bem=beam]
                 ^-  (unit (unit cage))
                 ?:  =(s.bem (pout ack))
-                   (peek-flow:me-core lyc (pout ack))
+                   (peek-flow:na:me-core lyc (pout ack))
                 (rof lyc pov vis bem)
               ::
               =<  moves

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11742,6 +11742,7 @@
               %*  ev-core  (ev-abed:ev:(mesa now eny rof) hen)
                 chums.ames-state  (~(put by chums.ames-state) her-pok known/per)
               ==
+            =.  ev-core  (ev-foco:ev-core her-pok^per)
             ::  XX refactor; same as hear-poke:ev-pact:ev:mesa
             ::
             =/  [=space cyf=(unit @) =inner-poke=path]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7933,7 +7933,7 @@
             ?:  ?=(%none -.space)
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
-                      " ack={<pat.ack.pact>}; skip"
+                      " ack={<pat.pok.pact>}; skip"
               ev-core
             ::
             =/  [pok=(pole iota) ack=(pole iota)]
@@ -11751,7 +11751,7 @@
             ::
             ?:  ?=(%none -.space)
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
-                  |.("weird poke life={<life.per>} ack={<pat.ack.pact>}; skip")
+                  |.("weird poke life={<life.per>} ack={<pat.pok.pact>}; skip")
               `ames-state
             =/  [pok=(pole iota) ack=(pole iota)]
               ::  path validation/decryption

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9471,9 +9471,13 @@
               :^  %chum  ~  %known
               (rederive-mesa-pit ship +.u.peer life symmetric-key)
             ::
-            =?  peer  ?=([%ship ~ %known *] peer)
-              :^  %ship  ~  %known
-              (rederive-mesa-keens ship +.u.peer life symmetric-key)
+            =^  keens-moves  peer
+              ?.  ?=([%ship ~ %known *] peer)
+                `peer
+              =/  [moves=(list move) peer=peer-state]
+                %-  rederive-mesa-keens
+                [ship +.u.peer our=life.ames-state her=life symmetric-key]
+              [moves %ship ~ %known peer]
             ::  update values
             ::
             =.  symmetric-key.+.u.peer  symmetric-key
@@ -9484,7 +9488,7 @@
               (~(put by chums.ames-state) ship u.peer)
             =?  peers.ames-state  ?=(%ship -.peer)
               (~(put by peers.ames-state) ship u.peer)
-            sy-core
+            (sy-emil keens-moves)
           ::  +on-publ-sponsor: handle new or lost sponsor for peer
           ::
           ::    TODO: really handle sponsor loss
@@ -9763,24 +9767,26 @@
             ::
             known/fren-state(symmetric-key symmetric-key)
           ::
-          =.  peers.ames-state
-            %-  ~(urn by peers.ames-state)
-            |=  [=ship =ship-state]
-            ^+  ship-state
-            ::
+          =/  [moves=(list move) peers=_peers.ames-state]
+            %-  ~(rep by peers.ames-state)
+            |=  [[=ship =ship-state] moves=(list move) peers=_peers.ames-state]
             ?.  ?=(%known -.ship-state)
-              ship-state
+              moves^peers
             ::
             =/  =peer-state  +.ship-state
-            =/  =symmetric-key
+            =/  new-key=symmetric-key
               (derive-symmetric-key public-key.+.ship-state sec:ex:crypto-core)
             ::
-            =.  peer-state
-              (rederive-mesa-keens ship peer-state life symmetric-key)
-            known/peer-state(symmetric-key symmetric-key)
-          =.  priv.ames-state  private-key
-          =.  life.ames-state  life
-          sy-core
+            =^  keens-moves  peer-state
+              %-  rederive-mesa-keens
+              [ship peer-state our=life life.peer-state new-key]
+            :-  (weld moves keens-moves)
+            %+  ~(put by peers)  ship
+            known/peer-state(symmetric-key new-key)
+          =.  peers.ames-state  peers
+          =.  priv.ames-state   private-key
+          =.  life.ames-state   life
+          (sy-emil moves)
         ::
         ++  sy-prod
           |=  ships=(list @p)
@@ -9920,7 +9926,6 @@
             =.  route.+.u.peer  ~
             (~(put by peers.ames-state) ship u.peer)
           (sy-emit unix-duct %give %nail ship ~)
-        ::
         ::  +sy-sift: handle request to filter debug output by ship
         ::
         ++  sy-sift
@@ -10150,7 +10155,6 @@
             ==
           ::
           --
-        ::
         ::  +sy-trim: handle request to free memory
         ::
         ::    (%ruin comets not seen for six months)
@@ -11136,6 +11140,7 @@
           ==
         ::
         --
+      ::
       +|  %helpers
       ::
       ++  push-pact  :: XX forwarding?
@@ -11312,47 +11317,54 @@
         (~(put ju tip) user-path for path)
       ::
       ++  rederive-mesa-keens
-        |=  [=ship peer=peer-state =life new-key=symmetric-key]
-        =;  [keens=_keens.peer tip=_tip.peer]
-          peer(keens keens, tip tip)
+        |=  [=ship peer=peer-state =our=life =her=life new-key=symmetric-key]
+        ^-  (quip move _peer)
+        =+  event-core=(ev:ames now^eny^rof ~[//ames] ames-state)
+        =;  core=_event-core
+          =/  [moves=(list move) state=axle]  abet:core
+          :-  moves
+          ~|  %freaky-alien-rederive-mesa-keens^ship
+          =-  ?>(?=(%known -<) ->)
+          (~(got by peers.state) ship)
         %-  ~(rep by keens.peer)
-        |=  $:  [=path keen=keen-state]
-                keens=_keens.peer  ::  init accumulator(s) with current state
-                tip=_tip.peer
-            ==
+        |=  [[=path keen=keen-state] core=_event-core]
         =>  .(path `(pole knot)`path)
           ~|  make-peeks-crashed/path
           ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
             :: XX validate van, car, cas, desk ?
             ::
-            ~&  skip-weird-path/path  keens^tip
+            ~&  skip-weird-path/path
+            core
         ?.  ?=([%chum her=@ lyf=@ cyf=@ ~] pat.path)
-          keens^tip
+          core
         %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
             |.("re-deriving new keens entry {<(spud path)>}")
         ::
-        =/  [user-path=^path new-path=^path]
-          =/  cyf=@      (slav %uv cyf.pat.path)
-          =/  pax=^path  (rash `@t`(dy:crub:crypto symmetric-key.peer cyf) stap)
-          =.  cyf
-            (scot %uv (en:crub:crypto new-key (spat pax)))
-          :-  pax
-          /a/x/1//chum/[her.pat.path]/(scot %ud life)/[cyf]
-        =|  new-keen=keen-state
-        =.  new-keen
-          new-keen(listeners listeners.keen, next-wake next-wake.keen)
-        ::  delete previous %chum entry with old path
+        =/  user-path=^path
+          =/  cyf=@  (slav %uv cyf.pat.path)
+          (rash `@t`(dy:crub:crypto symmetric-key.peer cyf) stap)
+        =.  peers.ames-state.core
+          =.  life.peer           her-life
+          =.  symmetric-key.peer  new-key
+          ::  delete previous %chum entry with old path
+          ::
+          =.  keens.peer
+            (~(del by keens.peer) (pout path))
+          ::  remove previous .tip entry; will be readded
+          ::
+          =.  tip.peer
+            %-  ~(rep by ~(key by listeners.keen))
+            |=  [for=duct tip=_tip.peer]
+            (~(del ju tip) user-path for path)
+          ::
+          (~(put by peers.ames-state.core) ship known/peer)
+        =.  life.ames-state.core  our-life
         ::
-        =.  keens  (~(del by keens) (pout path))
-        ::  update %chum entry with new-path
-        ::
-        :-  (~(put by keens) new-path new-keen)   :: XX drop any partial state
         %-  ~(rep by ~(key by listeners.keen))
-        |=  [for=duct tip=_tip]
-        ?.  (~(has by tip) user-path)
-          ~&  >>>  %missing-tip-entry
-          tip
-        (~(put ju tip) user-path for path)
+        |=  [for=duct c=_core]
+        =?  for  ?=([[%ames %chum ~] *] for)
+          t.for  ::  on-chum is re-entrant; remove /chum wire will be readded
+        (on-chum:c(duct for) ship user-path)
       ::
       +|  %tests
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11277,53 +11277,57 @@
                 pit=_pit.peer
                 tip=_tip.peer
             ==
-        =+  old-path=path
-        =/  [=space user-path=^path]
-          [space inner]:(ev-decrypt-path:ev path ship)
-        ?.  ?=(?(%publ %chum) -.space)
+        ?.  ?=([?(%chum %publ) *] path)
           pit^tip
+        =+  old-path=path
+        =/  [user-path=^path =space]
+          =>  .(path `(pole knot)`path)
+          ::  update lifes and keys in %publ and %chum namespaces
+          ::
+          ?+    path  ~|(path !!)
+              [%publ *]
+            [path [%publ her-life]]
+            ::
+              [%chum lyf=@ her=@ hyf=@ cyf=@ ~]
+            :: ?.  =([ship her-life] [her.path life.path])
+            ::   !!  :: XX log?
+            =/  cyf=@  (slav %uv cyf.path)
+            =*  key    symmetric-key.peer
+            :-  (open-path:crypt `@`key cyf)
+            :-  %chum  ::  XX +chum-to-our
+            [server=her-life client=our our-life new-key]
+          ==
         %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
             |.("re-deriving new pit entry {<(spud path)>}")
         ::
-        =.  space
-          ::  update life/keys in the space
-          ::
-          ?-    -.space
-              %publ
-            space(life her-life)
-          ::
-              %chum
-            space(client-life our-life, key new-key, server-life her-life)
-          ==
-        =.  path  (make-space-path space user-path)
+        =/  new-path=^path  (make-space-path space user-path)
         ::  only recalculate poke paths if there's an associated payload
         ::
         =?  pay.req  ?=(^ pay.req)
-          =/  [=^space poke=^path]
-            [space inner]:(ev-decrypt-path:ev u.pay.req ship)
-          ::  for poke paths, update the server life
-          ::
-          =.  space
-            ?+    -.space  space
-                %publ
-              space(life our-life)
-              ::
-                %chum
-             space(server-life our-life, key new-key, client-life her-life)
-            ==
-          `(make-space-path space poke)
+          =/  payload=(pole knot)  u.pay.req
+          ?.  ?=([%chum lyf=@ her=@ hyf=@ cyf=@ ~] payload)
+            ::  XX weird, log?
+            ::
+            pay.req
+          =/  cyf=@  (slav %uv cyf.payload)
+          =*  key    symmetric-key.peer
+          =;  [poke=^path =^space]
+            `(make-space-path space poke)
+          :-  (open-path:crypt `@`key cyf)
+          :-  %chum  ::  XX +chum-to-her
+          [server=our-life client=ship her-life new-key]
         ::  delete previous pit entry with old path
         ::
         =.  pit  (~(del by pit) old-path)
         ::  update pit entry with new-path
         ::
-        :-  (~(put by pit) path req(ps ~))   :: XX drop any partial state
+        :-  (~(put by pit) new-path req(ps ~))   :: XX drop any partial state
         %-  ~(rep by ~(key by for.req))
         |=  [for=duct tip=_tip]
         ?.  (~(has by tip) user-path)
           ~&  >>>  %missing-tip-entry
           tip
-        (~(put ju tip) user-path for path)
+        (~(put ju tip) user-path for new-path)
       ::
       ++  rederive-mesa-keens
         |=  [=ship peer=peer-state =our=life =her=life new-key=symmetric-key]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10737,7 +10737,6 @@
           =/  cyf  (slaw %uv cyf.tyl)
           ?:  |(?=(~ lyf) ?=(~ her) ?=(~ hyf) ?=(~ cyf))
             [~ ~]
-          ~&  [u.lyf life.ames-state]
           ?.  =(u.lyf life.ames-state)
             ~
           ?~  key=(get-key-for u.her u.hyf)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7796,9 +7796,8 @@
             :: ?>  ?=(%known -.per)  :: XX wat if %alien?
             :: ?.  =(u.hyf life.per)   !!  :: XX handle?
             =*  key  `@uxI`symmetric-key.sat
-            :+  [%chum server=life.ames-state client=her life.sat key]
-              cyf
-            (open-path:crypt key u.cyf)
+            =/  =space  [%chum server=life.ames-state client=her life.sat key]
+            [space cyf (open-path:crypt key u.cyf)]
           ::
               [%shut kid=@ pat=[cyf=@ ~]]  :: encrypted with group key
             =/  kid  (slaw %ud kid.tyl)
@@ -7808,9 +7807,7 @@
             :: ?>  ?=(%known -.per)  :: XX wat if %alien?
             ?~  key=(get:key-chain client-chain.sat u.kid)
               !!  :: XX handle
-            :+  [%shut u.kid -.u.key]
-              cyf
-            (open-path:crypt -.u.key u.cyf)
+            [space=[%shut u.kid -.u.key] cyf (open-path:crypt -.u.key u.cyf)]
           ==
         ::
         +|  %request-flow
@@ -9453,6 +9450,9 @@
             ^+  sy-core
             ?:  =(our ship)  sy-core
             ::
+            %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
+                |.("hear new key at life={<life>}")
+            ::
             =/  peer  (sy-find-peer ship)
             ?.  ?=([?(%ship %chum) ~ %known *] peer)
               =|  =point:jael
@@ -9462,48 +9462,21 @@
               ::
               (on-publ-full (my [ship point]~))
             ::
-            =/  old-key       symmetric-key.+.u.peer
-            =/  =private-key  sec:ex:crypto-core
-            =/  new-key       (derive-symmetric-key public-key private-key)
-            ::  recalculate paths in the .pit using the new key
+            =/  old-key         symmetric-key.+.u.peer
+            =/  =private-key    sec:ex:crypto-core
+            =/  =symmetric-key  (derive-symmetric-key public-key private-key)
+            ::  recalculate paths in .pit/.keens using the new key
             ::
             =?  peer  ?=([%chum ~ %known *] peer)
-              =;  [pit=_pit.u.peer tip=_tip.u.peer]
-                peer(pit.u pit, tip.u tip)
-              %-  ~(rep by pit.u.peer)
-              |=  $:  [=path req=request-state]
-                      pit=(map path request-state)
-                      tip=(jug =user=path [duct =ames=path])
-                  ==
-              =/  [=space user-path=^path]
-                [space inner]:(ev-decrypt-path:ev path ship)
-              =.  space
-                ::  update life/keys in the space; for acks, update the client
-                ::
-                ?+  -.space  space
-                  %publ  space(life life)
-                  %chum  space(client-life life, key new-key)
-                ==
-              =.  path  (make-space-path space user-path)
-              ::  only recalculate poke paths if there's an associated payload
-              ::
-              =?  pay.req  ?=(^ pay.req)
-                =/  [=^space poke=^path]
-                  [space inner]:(ev-decrypt-path:ev u.pay.req ship)
-                ::  for poke paths, update the server life
-                ::
-                =.  space
-                  ?+  -.space  space  :: for %publ, our life hansn't changed
-                    %chum  space(server-life life, key new-key)
-                  ==
-                `(make-space-path space poke)
-              :-  (~(put by pit) path req(ps ~))   :: XX drop any partial state
-              %-  ~(rep by ~(key by for.req))
-              |=  [for=duct tip=_tip]
-              (~(put ju tip) user-path for path)
+              :^  %chum  ~  %known
+              (rederive-mesa-pit ship +.u.peer life symmetric-key)
+            ::
+            =?  peer  ?=([%ship ~ %known *] peer)
+              :^  %ship  ~  %known
+              (rederive-mesa-keens ship +.u.peer life symmetric-key)
             ::  update values
             ::
-            =.  symmetric-key.+.u.peer  new-key
+            =.  symmetric-key.+.u.peer  symmetric-key
             =.  life.+.u.peer           life
             =.  public-key.+.u.peer     public-key
             ::
@@ -9519,6 +9492,9 @@
           ++  on-publ-sponsor
             |=  [=ship sponsor=(unit ship)]
             ^+  sy-core
+            ::
+            %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
+                |.("hear new sponsor={<sponsor>}")
             ::
             ?:  =(our ship)
               (sy-emit unix-duct %give %saxo sy-get-sponsors)
@@ -9671,6 +9647,9 @@
           ++  on-publ-rift
             |=  [=ship =rift]
             ^+  sy-core
+            %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
+                |.("hear new rift={<life>}")
+            ::
             =?  rift.ames-state  =(our ship)
               rift
             =/  peer  (sy-find-peer ship)
@@ -9760,37 +9739,47 @@
           |=  [=life vein=(map life private-key)]
           ^+  sy-core
           ::
-          =.  priv.ames-state  (~(got by vein) life)
-          =.  life.ames-state  life
-          =/  crypto-core      (nol:nu:crub:crypto priv.ames-state)
+          %-  %+  %*(ev-tace ev her our)  sun.veb.bug.ames-state
+              |.("hear new private key for life={<life>}")
+          ::
+          =/  =private-key  (~(got by vein) life)
+          =/  crypto-core   (nol:nu:crub:crypto private-key)
           ::  recalculate each peer's symmetric key
           ::
           =.  chums.ames-state
-            %-  ~(run by chums.ames-state)
-            |=  =chum-state
+            %-  ~(urn by chums.ames-state)
+            |=  [=ship =chum-state]
             ^+  chum-state
             ::
             ?.  ?=(%known -.chum-state)
               chum-state
             =/  =fren-state  +.chum-state
-            =.  symmetric-key.fren-state
+            =/  =symmetric-key
               (derive-symmetric-key public-key.fren-state sec:ex:crypto-core)
+            ::  recalculate paths in .pit/.keens using the new key
             ::
-            known/fren-state
+            =.  fren-state
+              (rederive-mesa-pit ship fren-state life symmetric-key)
+            ::
+            known/fren-state(symmetric-key symmetric-key)
           ::
           =.  peers.ames-state
-            %-  ~(run by peers.ames-state)
-            |=  =ship-state
+            %-  ~(urn by peers.ames-state)
+            |=  [=ship =ship-state]
             ^+  ship-state
             ::
             ?.  ?=(%known -.ship-state)
               ship-state
             ::
             =/  =peer-state  +.ship-state
-            =.  symmetric-key.peer-state
+            =/  =symmetric-key
               (derive-symmetric-key public-key.+.ship-state sec:ex:crypto-core)
             ::
-            known/peer-state
+            =.  peer-state
+              (rederive-mesa-keens ship peer-state life symmetric-key)
+            known/peer-state(symmetric-key symmetric-key)
+          =.  priv.ames-state  private-key
+          =.  life.ames-state  life
           sy-core
         ::
         ++  sy-prod
@@ -11189,6 +11178,8 @@
         ?:  =(our gal)
           ~  :: XX log
         [~ `@ux`gal]
+      ::
+      +|  %keys
       ::  +get-key-for : eddh with our key
       ::
       ++  get-key-for
@@ -11254,6 +11245,101 @@
       ++  crypto-core
         =>  [priv=priv.ames-state ..crypto]
         ~>(%memo./mesa/crypto-core (nol:nu:crub:crypto priv))
+      ::
+      ++  rederive-mesa-pit
+        |=  [=ship peer=fren-state =life new-key=symmetric-key]
+        =;  [pit=_pit.peer tip=_tip.peer]
+          peer(pit pit, tip tip)
+        %-  ~(rep by pit.peer)
+        |=  $:  [=path req=request-state]
+                pit=_pit.peer
+                tip=_tip.peer
+            ==
+        =+  old-path=path
+        =/  [=space user-path=^path]
+          [space inner]:(ev-decrypt-path:ev path ship)
+        ?.  ?=(?(%publ %chum) -.space)
+          pit^tip
+        %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
+            |.("re-deriving new pit entry {<(spud path)>}")
+        ::
+        =.  space
+          ::  update life/keys in the space; for acks, update the client
+          ::
+          ?-  -.space
+            %publ  space(life life)
+            %chum  space(client-life life, key new-key)
+          ==
+        =.  path  (make-space-path space user-path)
+        ::  only recalculate poke paths if there's an associated payload
+        ::
+        =?  pay.req  ?=(^ pay.req)
+          =/  [=^space poke=^path]
+            [space inner]:(ev-decrypt-path:ev u.pay.req ship)
+          ::  for poke paths, update the server life
+          ::
+          =.  space
+            ?+  -.space  space  :: for %publ, our life hansn't changed
+              %chum  space(server-life life, key new-key)
+            ==
+          `(make-space-path space poke)
+        ::  delete previous pit entry with old path
+        ::
+        =.  pit  (~(del by pit) old-path)
+        ::  update pit entry with new-path
+        ::
+        :-  (~(put by pit) path req(ps ~))   :: XX drop any partial state
+        %-  ~(rep by ~(key by for.req))
+        |=  [for=duct tip=_tip]
+        ?.  (~(has by tip) user-path)
+          ~&  >>>  %missing-tip-entry
+          tip
+        (~(put ju tip) user-path for path)
+      ::
+      ++  rederive-mesa-keens
+        |=  [=ship peer=peer-state =life new-key=symmetric-key]
+        =;  [keens=_keens.peer tip=_tip.peer]
+          peer(keens keens, tip tip)
+        %-  ~(rep by keens.peer)
+        |=  $:  [=path keen=keen-state]
+                keens=_keens.peer  ::  init accumulator(s) with current state
+                tip=_tip.peer
+            ==
+        =>  .(path `(pole knot)`path)
+          ~|  make-peeks-crashed/path
+          ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
+            :: XX validate van, car, cas, desk ?
+            ::
+            ~&  skip-weird-path/path  keens^tip
+        ?.  ?=([%chum her=@ lyf=@ cyf=@ ~] pat.path)
+          keens^tip
+        %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
+            |.("re-deriving new keens entry {<(spud path)>}")
+        ::
+        =/  [user-path=^path new-path=^path]
+          =/  cyf=@      (slav %uv cyf.pat.path)
+          =/  pax=^path  (rash `@t`(dy:crub:crypto symmetric-key.peer cyf) stap)
+          =.  cyf
+            (scot %uv (en:crub:crypto new-key (spat pax)))
+          :-  pax
+          /a/x/1//chum/[her.pat.path]/(scot %ud life)/[cyf]
+        =|  new-keen=keen-state
+        =.  new-keen
+          new-keen(listeners listeners.keen, next-wake next-wake.keen)
+        ::  delete previous %chum entry with old path
+        ::
+        =.  keens  (~(del by keens) (pout path))
+        ::  update %chum entry with new-path
+        ::
+        :-  (~(put by keens) new-path new-keen)   :: XX drop any partial state
+        %-  ~(rep by ~(key by listeners.keen))
+        |=  [for=duct tip=_tip]
+        ?.  (~(has by tip) user-path)
+          ~&  >>>  %missing-tip-entry
+          tip
+        (~(put ju tip) user-path for path)
+      ::
+      +|  %tests
       ::
       ++  regression-test
         |=  her=ship

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4289,8 +4289,9 @@
             =/  state=(unit peer-state)  (get-peer-state her.u.res)
             ?~  state
               %.  event-core
+              =+  [wat=- who=her]:u.res
               %+  slog
-                leaf/"ames: got timer for strange ship: {<her.u.res>}, ignoring"
+                leaf/"ames: got {<wat>} timer for strange ship: {<who>}; skip"
               ~
             ::
             =/  peer-core  (abed-peer:pe her.u.res u.state)
@@ -5412,7 +5413,6 @@
               ^+  mesa-co-core
               %-  ~(rep by keens.per)
               |=  [[=path keen=keen-state] core=_mesa-co-core]
-              =|  req=request-state
               =>  .(path `(pole knot)`path)
               ~|  make-peeks-crashed/path
               ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
@@ -5420,12 +5420,15 @@
                 ::
                 ~&  skip-weird-path/path  core
               =;  [pax=^path =space]
+                =?  core  ?=(^ next-wake.keen)
+                  =/  =wire  (welp /fine/behn/wake/(scot %p her) (pout path))
+                  (co-emit:core unix-duct %pass wire %b %rest u.next-wake.keen)
                 %-  ~(rep by listeners.keen)
                 |=  [[=^duct ints=(set ints)] core=_core]
                 ::  if the scry was created by the |fine core, %ames becomes the
                 ::  listener to the encrypted %tune (which will be transformed
                 ::  into a %near, and given to the original listener). %ames
-                ::  uses  the /ames/[?(%chum %fine %shut ...)] wire to tell arvo
+                ::  uses the /ames/[?(%chum %fine %shut ...)] wire to tell arvo
                 ::  to make it re-entrant into itself, so we neeed to remove
                 ::  that wire since co-make-peek is going to add a /mesa wire
                 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9469,7 +9469,8 @@
             ::
             =?  peer  ?=([%chum ~ %known *] peer)
               :^  %chum  ~  %known
-              (rederive-mesa-pit ship +.u.peer life symmetric-key)
+              %-  rederive-mesa-pit
+              [ship +.u.peer our=life.ames-state her=life symmetric-key]
             ::
             =^  keens-moves  peer
               ?.  ?=([%ship ~ %known *] peer)
@@ -9763,7 +9764,8 @@
             ::  recalculate paths in .pit/.keens using the new key
             ::
             =.  fren-state
-              (rederive-mesa-pit ship fren-state life symmetric-key)
+              %-  rederive-mesa-pit
+              [ship fren-state our=life her=life.fren-state symmetric-key]
             ::
             known/fren-state(symmetric-key symmetric-key)
           ::
@@ -11267,7 +11269,7 @@
         ~>(%memo./mesa/crypto-core (nol:nu:crub:crypto priv))
       ::
       ++  rederive-mesa-pit
-        |=  [=ship peer=fren-state =life new-key=symmetric-key]
+        |=  [=ship peer=fren-state =our=life =her=life new-key=symmetric-key]
         =;  [pit=_pit.peer tip=_tip.peer]
           peer(pit pit, tip tip)
         %-  ~(rep by pit.peer)
@@ -11284,11 +11286,14 @@
             |.("re-deriving new pit entry {<(spud path)>}")
         ::
         =.  space
-          ::  update life/keys in the space; for acks, update the client
+          ::  update life/keys in the space
           ::
-          ?-  -.space
-            %publ  space(life life)
-            %chum  space(client-life life, key new-key)
+          ?-    -.space
+              %publ
+            space(life her-life)
+          ::
+              %chum
+            space(client-life our-life, key new-key, server-life her-life)
           ==
         =.  path  (make-space-path space user-path)
         ::  only recalculate poke paths if there's an associated payload
@@ -11299,8 +11304,12 @@
           ::  for poke paths, update the server life
           ::
           =.  space
-            ?+  -.space  space  :: for %publ, our life hansn't changed
-              %chum  space(server-life life, key new-key)
+            ?+    -.space  space
+                %publ
+              space(life our-life)
+              ::
+                %chum
+             space(server-life our-life, key new-key, client-life her-life)
             ==
           `(make-space-path space poke)
         ::  delete previous pit entry with old path
@@ -11363,7 +11372,7 @@
         %-  ~(rep by ~(key by listeners.keen))
         |=  [for=duct c=_core]
         =?  for  ?=([[%ames %chum ~] *] for)
-          t.for  ::  on-chum is re-entrant; remove /chum wire will be readded
+          t.for  ::  on-chum is re-entrant; remove /chum wire, it'll  be readded
         (on-chum:c(duct for) ship user-path)
       ::
       +|  %tests

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9776,15 +9776,15 @@
               moves^peers
             ::
             =/  =peer-state  +.ship-state
-            =/  new-key=symmetric-key
+            =/  =symmetric-key
               (derive-symmetric-key public-key.+.ship-state sec:ex:crypto-core)
             ::
             =^  keens-moves  peer-state
               %-  rederive-mesa-keens
-              [ship peer-state our=life life.peer-state new-key]
+              [ship peer-state our=life life.peer-state symmetric-key]
             :-  (weld moves keens-moves)
             %+  ~(put by peers)  ship
-            known/peer-state(symmetric-key new-key)
+            known/peer-state(symmetric-key symmetric-key)
           =.  peers.ames-state  peers
           =.  priv.ames-state   private-key
           =.  life.ames-state   life
@@ -10467,7 +10467,7 @@
             (make-space-path space poke-path)
           ::
           %-  %^  co-tace  snd.veb.bug.ames-state  ship.ack-spar
-              |.("send %poke for payload={(spud poke-path)}")
+              |.("send %poke for ack={(spud path.ack-spar)}")
           ::  ack and poke paths are already encrypted at this point
           ::
           (co-make-mess ack-spar `poke-path)
@@ -11338,12 +11338,12 @@
         %-  ~(rep by keens.peer)
         |=  [[=path keen=keen-state] core=_event-core]
         =>  .(path `(pole knot)`path)
-          ~|  make-peeks-crashed/path
-          ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
-            :: XX validate van, car, cas, desk ?
-            ::
-            ~&  skip-weird-path/path
-            core
+        ~|  rederive-mesa-keens/path
+        ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
+          :: XX validate van, car, cas, desk ?
+          ::
+          ~&  skip-weird-path/path
+          core
         ?.  ?=([%chum her=@ lyf=@ cyf=@ ~] pat.path)
           core
         %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state


### PR DESCRIPTION
- %fine does not re-derive the paths in .keens (coming from the usage of the %chum task) after hearing new keys for our peers, or our own private key.
- %mesa does not re-derive the paths in .pit for the /publ and /chum namespaces after hearing a new private key
- if there were live .keens right before migrating a peer with |ahoy, the timer was not being reset, resulting in a benign but annoying "timer for strange ship" print.