### PR TITLE
pill: choose %ames core protocol in pill creation

### DIFF
--- a/bin/mesa-multi.pill
+++ b/bin/mesa-multi.pill
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12a1e457108f812fd70cc4e88a92cea46a23bd1ccfb7208c9843f0674f65c6cf
+size 11412654

--- a/bin/mesa.pill
+++ b/bin/mesa.pill
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67143794b92980dc268b84db4005a618dc60a809e4178df00943d0925f119bda
-size 11808719
+oid sha256:b42318d7daac713901fd6766efa893acecf8af8c0ad13901231fa9fe620bb6c0
+size 9367859

--- a/pkg/arvo/gen/pill/brass.hoon
+++ b/pkg/arvo/gen/pill/brass.hoon
@@ -25,6 +25,7 @@
         ==
       ::
         prime=_|
+        ames-core=_`?(%ames %mesa)`%ames
         exc=(list spur)
     ==
 :-  %pill
@@ -46,4 +47,4 @@
   |=  =desk
   [desk /(scot %p p.bec)/[desk]/(scot %da now)]
 ::
-(brass:pill sys dez prime exc)
+(brass:pill sys dez prime ames-core exc)

--- a/pkg/arvo/gen/pill/solid.hoon
+++ b/pkg/arvo/gen/pill/solid.hoon
@@ -29,6 +29,7 @@
       ::
         dub=_|
         prime=_|
+        ames-core=_`?(%ames %mesa)`%ames
         exc=(list spur)
     ==
 :-  %pill
@@ -47,4 +48,4 @@
   |=  =desk
   [desk /(scot %p p.bec)/[desk]/(scot %da now)]
 ::
-(solid:pill sys dez dub now prime exc)
+(solid:pill sys dez dub now prime ames-core exc)

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -4537,9 +4537,9 @@
       ::  %dill: reset terminal configuration
       ::
       $>(%hail task:dill)
-      ::  %ames: hear packet
+      ::  %ames: hear packet; load network protocol core
       ::
-      $>(?(%hear %heer) task:ames)
+      $>(?(%hear %heer %load) task:ames)
       ::  %clay: external edit
       ::
       $>(%into task:clay)

--- a/pkg/base-dev/lib/pill.hoon
+++ b/pkg/base-dev/lib/pill.hoon
@@ -154,7 +154,14 @@
   ::  dez: secondary desks and their root paths
   ::  exc: list of desk folders to exclude
   ::
-  |=  [sys=path dez=(list [desk path]) dub=? now=@da prime=? exc=(list spur)]
+  |=  $:  sys=path
+          dez=(list [desk path])
+          dub=?
+          now=@da
+          prime=?
+          ames-core=?(%ames %mesa)
+          exc=(list spur)
+      ==
   ^-  pill
   =/  bas=path       (scag 3 sys)
   =/  compiler-path  (weld sys /hoon)
@@ -246,6 +253,11 @@
     |=  [dek=desk *]
     ^-  unix-event
     [/c/essential/[dek] %esse dek %.y]
+  ::
+    ?:  ?=(%ames ames-core)  ~
+    ^-  (list unix-event)
+    [/a/load %load %mesa]~
+  ::
   ==
 ::
 ++  brass
@@ -253,7 +265,12 @@
   ::  dez: secondary desks and their root paths
   ::  exc: list of desk folders to exclude
   ::
-  |=  [sys=path dez=(list [desk path]) prime=? exc=(list spur)]
+  |=  $:  sys=path
+          dez=(list [desk path])
+          prime=?
+          ames-core=?(%ames %mesa)
+          exc=(list spur)
+      ==
   ^-  pill
   =/  bas=path  (scag 3 sys)
   ::  compiler-source: hoon source file producing compiler, `sys/hoon`
@@ -293,12 +310,24 @@
         (file-ovum2 [bas exc])
     ==
   =.  dez  (snoc dez [%base bas])
-  %+  weld
+  ;:  weld
     %+  turn  dez
     |=  [dek=desk bas=path]
     (file-ovum [dek bas exc])
-  ?.  prime  ~
-  [(prep-ovum (turn dez tail))]~
+  ::
+    ?.  prime  ~
+    [(prep-ovum (turn dez tail))]~
+  ::
+    %+  turn  dez
+    |=  [dek=desk *]
+    ^-  unix-event
+    [/c/essential/[dek] %esse dek %.y]
+  ::
+    ?:  ?=(%ames ames-core)  ~
+    ^-  (list unix-event)
+    [/a/load %load %mesa]~
+  ::
+  ==
 ::
 ++  ivory
   |=  sys=path


### PR DESCRIPTION
A pill created using e.g. this:

.mesa/pill +pill/solid %base, =ames-core %mesa

will load the |mesa core as the protocol to handle outgoing messages (TODO: update +pe-hear to handle %ames packets when |mesa is loaded)