### PR TITLE
hoon: make +rest take unary arg instead of list

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -10822,22 +10822,19 @@
       [%core *]   [%cell %noun p.sut]
       [%face *]   q.sut
       [%hint *]   q.sut
-      [%hold *]   (rest [[p.sut q.sut] ~])
+      [%hold *]   (rest +.sut)
       %noun       (fork [%atom %$ ~] [%cell %noun %noun] ~)
       *           ~>(%mean.'repo-fltt' !!)
     ==
   ::
   ++  rest
     ~/  %rest
-    |=  leg=(list [p=type q=hoon])
+    |=  leg=[p=type q=hoon]
     ^-  type
-    ?:  (lien leg |=([p=type q=hoon] (~(has in fan) [p q])))
+    ?:  (~(has in fan) leg)
       ~>(%mean.'rest-loop' !!)
-    =>  .(fan (~(gas in fan) leg))
-    %-  fork
-    %~  tap  in
-    %-  ~(gas in *(set type))
-    (turn leg |=([p=type q=hoon] (play(sut p) q)))
+    =.  fan  (~(put in fan) leg)
+    (play(sut p.leg) q.leg)
   ::
   ++  sink
     ~/  %sink


### PR DESCRIPTION
+rest accepted a list of type-hoon pairs, but was only ever called with a single item (in +repo).

Here, we update it and its callsite to only accept and pass the single argument. This lets us simplify and modernize the code slightly, and avoids some call overhead.

In practice, the performance gains from this are negligible. It may be _very slightly_ faster, certainly not any slower. Even without performance gains, the legibility gains here seem worth the change.

Should probably target a next-hoon release staging branch.