### PR TITLE
hoon: fix typed path parser

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5981,11 +5981,11 @@
     %+  sear  (soft iota)
     %-  stew
     ^.  stet  ^.  limo
-    :~  :-  'a'^'z'  (stag %tas sym)
+    :~  :-  'a'^'z'  sym
         :-  '$'      (cold [%tas %$] buc)
         :-  '0'^'9'  bisk:so
         :-  '-'      tash:so
-        :-  '.'      zust:so
+        :-  '.'      ;~(pfix dot zust:so)
         :-  '~'      ;~(pfix sig ;~(pose crub:so (easy [%n ~])))
         :-  '\''     (stag %t qut)
     ==


### PR DESCRIPTION
there are 2 bugs in +stip
- symbols are parsed into [%tas symbol] but iota does not allow %tas (symbols are the atom case)
- segments starting with `.` are always skipped because +zust:so expects the `.` to be stripped already