### PR TITLE
mesa: bug fixes

### DIFF
--- a/pkg/arvo/lib/test/ames-gall.hoon
+++ b/pkg/arvo/lib/test/ames-gall.hoon
@@ -196,7 +196,7 @@
   ^-  @
   =/  sample     [now=~1111.1.1 eny=`@`0xdead.beef *roof]
   =/  ames-core  (ames-gate sample)
-  ?~  pact=(co-make-pact:co:(mesa:ames-core sample) spar `path per-rift)
+  ?~  pact=(co-make-pact:co:mesa:ames-core spar `path per-rift)
     !!
   p:(fax:plot (en:pact:ames u.pact))
 ::

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -168,8 +168,7 @@
   ^-  @
   =/  sample     [now=~1111.1.1 eny=`@`0xdead.beef poke-roof]
   =/  ames-core  (ames-gate sample)
-  =/  mesa-core  (mesa:ames-core sample)
-  ?~  pact=(co-make-pact:co:mesa-core spar `path per-rift)
+  ?~  pact=(co-make-pact:co:mesa:ames-core spar `path per-rift)
     !!
   p:(fax:plot (en:pact:ames u.pact))
 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9408,20 +9408,32 @@
               (sy-emit hen %pass /qos %d %flog %text u.text)
             ::  a peer breached; drop all peer state other than pki data
             ::
-            =?  chums.ames-state  ?=(%chum -.peer)
+            =?  ames-state  ?=(%chum -.peer)
               =.  +>.u.peer  +:*fren-state
               ::  XX  reinitialize galaxy route if applicable
               ::
               =?  lane.+.u.peer  =(%czar (clan:title ship))
                 (some [hop=0 `@ux`ship])
-              (~(put by chums.ames-state) ship u.peer)
-            =?  peers.ames-state  ?=(%ship -.peer)
+              ::  if %ames is the default core, remove the ship from .chums
+              ::  and add it to .peers
+              ::
+              =?  peers.ames-state  ?=(%ames core.ames-state)
+                =|  =peer-state
+                (~(put by peers.ames-state) ship known/peer-state(- +<.u.peer))
+              =?  chums.ames-state  ?=(%ames core.ames-state)
+                (~(del by chums.ames-state) ship)
+              ::  XX TODO %mesa as default core
+              ::
+              ames-state
+            =?  ames-state  ?=(%ship -.peer)
               =.  +>.u.peer  +:*peer-state
               ::  XX  reinitialize galaxy route if applicable
               ::
               =?  route.+.u.peer  =(%czar (clan:title ship))
                 `[direct=%.y %& ship]
-              (~(put by peers.ames-state) ship u.peer)
+              ::  XX TODO %mesa as default core; if a peer is regressed back
+              ::
+              ames-state(peers (~(put by peers.ames-state) ship u.peer))
             ::  cancel all timers related to .ship
             ::
             =?  sy-core    ?=(%ship -.peer)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4844,10 +4844,16 @@
             event-core
           %-  (ev-trace snd.veb sndr.shot |.("send migrated ahoy ack"))
           ::
-          =/  ok=?  ;;(? +.u.res)
+          =+  ;;(error=? +.u.res)
+          ?:  error
+            ::  XX don't nack, otherwise the peer will wait for the naxplanation
+            ::
+            %-  %+  ev-trace  snd.veb sndr.shot
+                |.("ahoy got nacked {<bone.u.shut-packet>} seq={<message-num>}")
+            ev-core
           =/  ack-packet=^shut-packet
-            :-  (mix 1 bone.u.shut-packet)
-            [message-num.u.shut-packet %| %| ok lag=*@dr]
+            :-  (mix 0b1 bone.u.shut-packet)
+            [message-num.u.shut-packet %| %| !error lag=*@dr]
           %:  send-blob  for=|  sndr.shot
             %-  etch-shot
             %:  etch-shut-packet:ames

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11927,7 +11927,9 @@
             %poke
           =*  data     data.pact
           =*  our-ack  her.ack.pact
+          =*  rif-ack  rif.ack.pact
           =*  her-pok  her.pok.pact
+          =*  rif-pok  rif.pok.pact
           ::
           ?:  .=  =(%deny form.snub.ames-state)
               (~(has in ships.snub.ames-state) her-pok)
@@ -12018,6 +12020,7 @@
           ::
           %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
               |.("hear poke for regressed")
+          ::  XX  call hear-poke:ev-pact:ev:mesa-core instead?
           ::
           =|  per=fren-state
           =.  -.per  azimuth-state=+<.u.chum-state
@@ -12047,13 +12050,19 @@
             inner:(decrypt-path:mesa-core [pat.ack her.pok]:pact)
           ::
           ?>  &(?=(flow-pith ack) ?=(flow-pith pok))
-          ?.  =(our-ack our)  ::  do we need to respond to this ack?
+          ?.  ?&  =(our our-ack)       ::  do we need to respond to this ack?
+                  =(our-rift rif-ack)  ::  at the current rift
+              ==
             %-  %+  ev-tace:ev-core  odd.veb.bug.ames-state
-                |.("not our ack rcvr={<our-ack>}; skip")
+                =+  rifs=[our=our-rift pac=rif-ack]
+                |.("not our ack rcvr={<our-ack>} rifs={<rifs>}; skip")
             `ames-state
-          ?.  =(rcvr.pok our)  ::  are we the receiver of the poke?
+          ?.  ?&  =(our rcvr.pok)      ::  are we the receiver of the poke?
+                  =(rift.per rif-pok)  ::  at their current rift
+              ==
+            =+  rifs=[her=rift.per pac=rif-pok]
             %-  %+  ev-tace:ev-core  odd.veb.bug.ames-state
-                |.("poke for {<rcvr.pok>} not us  ; skip")
+                |.("poke for {<rcvr.pok>} at rifts={<rifs>}; skip")
             `ames-state
           ?.  =(her-pok rcvr.ack)  ::  do ack and pokes match?
             %-  %+  ev-tace:ev-core  odd.veb.bug.ames-state
@@ -12098,7 +12107,7 @@
               |=  [lyc=gang pov=path vis=view bem=beam]
               ^-  (unit (unit cage))
               ?:  =(s.bem (pout ack))
-                  (peek-flow:na:me-core lyc (pout ack))
+                (peek-flow:na:me-core lyc (pout ack))
               (rof lyc pov vis bem)
             ::
             =<  moves

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4566,7 +4566,7 @@
           ::  check that chums has in fact the flow in chums for the
           ::  corresponding bone in the shut-packet
           ::
-          =+  ev-core=(ev-foco:ev:(mesa now eny rof) sndr.shot +.chum-state)
+          =+  ev-core=(ev-abed:ev:(mesa now eny rof) ~ sndr.shot +.chum-state)
           =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[(mix 1 bone) %bak])
           ?~  res=(fo-peek:fo-core %ack message-num)
             %.  event-core
@@ -5439,7 +5439,7 @@
               ^-  (quip move axle)
               =+  mesa-core=(mesa now eny rof)
               =/  mesa-ev-core
-               (%*(ev-foco ev:mesa-core ames-state ames-state) her fren)
+               (%*(ev-abed ev:mesa-core ames-state ames-state) ~ her fren)
               =.  chums.ames-state  (~(put by chums.ames-state) her known/fren)
               =+  mesa-co-core=%*(co-core co:mesa-core ames-state ames-state)
               =*  per  peer-state
@@ -7592,7 +7592,6 @@
             |=  [hen=duct dud=(unit goof) wrapped-task=(hobo task)]
             ^-  [(list move) _vane-gate]
             =/  =task  ((harden task) wrapped-task)
-            =+  ev-core=(ev-abed:ev hen)
             =+  sy-core=~(sy-core sy hen)
             =+  co-core=(co-abed:co hen)
             ::
@@ -7690,7 +7689,6 @@
             ?^  dud
               ~|(%mesa-take-dud (mean tang.u.dud))
             ::
-            =+  ev-core=(ev-abed:ev hen)
             =^  moves  ames-state
               ?:  ?=([%gall %unto *] sign)  :: XX from poking %ping app
                 `ames-state
@@ -7709,19 +7707,26 @@
               ::  vane gifts
               ::
                   ?([%gall %flub ~] [@ %done *] [@ %boon *] [@ %noon *])
-                ev-abet:(ev-take:ev-core wire +.sign)
+                =+  ev-core=ev-core:ev
+                =^  side  ev-core  (ev-peel:ev wire +.sign)
+                =+  side
+                ?~  side  `ames-state
+                ev-abet:(ev-take:ev-core bone.u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
               ::
                 [%ames %sage *]
+                =+  ev-core=ev-core:ev
+                =^  side-were  ev-core  (ev-peel:ev wire +.sign)
+                =+  side-were
+                ?~  side  `ames-state
+                ?~  were  `ames-state
                 =<  ev-abet
                 =/  response-pith  `(pole iota)`(mesa-pave:ev-core wire)
-                %.  [wire +.sign]
                 ?+    response-pith   ~|  %mesa-evil-response-wire^wire  !!
-                    ?([%keen ~] ev-flow-wire:ev-core)
-                  ::ev-take-sage:ev-core
-                  ev-take:ev-core
+                    ?([%keen ~] ev-flow-wire:ev-core:ev)
+                  (ev-take-sage:ev-core u.were u.side +>.sign)
                 ==
               ::
               ==
@@ -7744,13 +7749,12 @@
         +|  %helpers
         ::
         ++  ev-core  .
+        ++  ev-abed  |=([d=duct h=ship p=_per] ev-core(hen d, her h, per p))
         ++  ev-abet
           :-  moves
           ?:  skip-abet  ames-state
           ames-state(chums (~(put by chums.ames-state) her %known per))
         ::
-        ++  ev-abed  |=(=duct ev-core(hen duct))
-        ++  ev-foco  |=([her=ship per=_per] ev-core(her her, per per))
         ++  ev-emit  |=(=move ev-core(moves [move moves]))
         ++  ev-emil  |=(mos=(list move) ev-core(moves (weld mos moves)))
         ++  ev-tace
@@ -8214,27 +8218,28 @@
           --
         ::
         +|  %take-responses
+        ::  +ev-peel: abed the ev-core based on the wire; skip=& if bad wire
         ::
-        ++  ev-take
+        ++  ev-peel
           |=  $:  =wire
                   $=  sign
                   $~  flub/~
                   $%([%flub ~] $>(?(%noon %boon %done %sage) gift))
               ==
-          ^+  ev-core
+          ^-  [[side=(unit side) were=(unit were)] _ev-core]
           ?^  flow-wire=(ev-parse-flow-wire wire)
             =.  her  her.u.flow-wire
             =.  per  (got-per her)
-            ?:  (lth rift.u.flow-wire rift.per)
-              %-  %+  ev-tace  odd.veb.bug.ames-state
-                    |.("ignore {<(trip -.sign)>} for old rift")
-              ev-core
-            ?>  ?=(%sage -.sign)
-             (ev-take-sage +.sign [were bone dire]:u.flow-wire)
+            ?.  (lth rift.u.flow-wire rift.per)
+              :_  ev-core
+              [`[bone dire]:u.flow-wire `were.u.flow-wire]
+            %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.("ignore {<(trip -.sign)>} for old rift")
+            [~ ~]^ev-core
           ?~  bone-wire=(parse-bone-wire wire)
             %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("weird wire on {<(trip -.sign)>} {(spud wire)}")
-            ev-core(skip-abet %.y)
+            [~ ~]^ev-core
           ?>  ?=([@ her=ship *] u.bone-wire)
           =.  her  her.u.bone-wire
           =.  per  (got-per her)
@@ -8243,23 +8248,33 @@
               ==
             %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("ignore {<(trip -.sign)>} for old rift")
-            ev-core
+            [~ ~]^ev-core
           =+  ?.  =(%old -.u.bone-wire)  ~
               %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("parsing old wire: {(spud wire)}")
               ~
           =/  =bone
             ?-(u.bone-wire [%new *] bone.u.bone-wire, [%old *] bone.u.bone-wire)
-          ::  after %sage, all signs happen on backward flows
-          ::
           =?  bone  =(%1 (mod bone 2))
             (mix 0b1 bone)
+          ::  after %sage, all signs happen on backward flows
+          ::
+          [[`[bone %bak] ~] ev-core]
+        ::
+        ++  ev-take
+          |=  $:  =bone
+                  $=  sign
+                  $~  flub/~
+                  $%([%flub ~] $>(?(%noon %boon %done) gift))
+              ==
+          ^+  ev-core
           =+  fo-core=(fo-abed:fo hen bone dire=%bak)
-          ?+  -.sign  !!  :: %sage shouldn't use bone wires
+          ?-  -.sign
             ::  XX for %done, we ack one message at at time, seq is not needed?
             ::  XX use it as an assurance check?
             ::
-            ?(%flub %done)  fo-abet:(fo-take:fo-core %van sign)
+              ?(%flub %done)
+            fo-abet:(fo-take:fo-core %van sign)
           ::
               ?(%boon %noon)
             %+  ev-req-boon  bone
@@ -8269,7 +8284,7 @@
         ::  +ev-take-sage: receive remote responses
         ::
         ++  ev-take-sage
-          |=  [=sage:mess =were =side]
+          |=  [=were =side =sage:mess]
           ^+  ev-core
           ::
           =/  message-path=(pole iota)  (validate-path path.p.sage)
@@ -9635,7 +9650,7 @@
               ::  init ev-core with provided chum-state
               ::
               =+  per=ship^+.chum-state
-              =+  ev-core=(ev-foco:ev-core:ev per)
+              =+  ev-core=(ev-abed:ev ~[//meet-chum] per)
               ::
               =.  ev-core
                 ::  apply outgoing messages
@@ -9644,7 +9659,7 @@
                 |=  [[=duct mess=mesa-message] c=_ev-core]
                 ?+    -.mess  !!  :: XX log alien peer %boon?
                     %plea
-                  (ev-req-plea:(ev-abed:c duct) +.mess)
+                  (ev-req-plea:c(hen duct) +.mess)
                 ==
               ::
               =.  ev-core
@@ -9654,7 +9669,7 @@
                 |=  [[[=path =ints] ducts=(set duct)] core=_ev-core]
                 %-  ~(rep in ducts)
                 |=  [=duct c=_core]
-                (ev-req-peek:(ev-abed:c duct) publ/life.+.per path)
+                (ev-req-peek:c(hen duct) publ/life.+.per path)
               ::
               =.  ev-core
                 ::  apply (two-party) remote scry requests
@@ -9663,7 +9678,7 @@
                 |=  [[[=path =ints] ducts=(set duct)] core=_ev-core]
                 %-  ~(rep in ducts)
                 |=  [=duct c=_core]
-                (ev-req-peek:(ev-abed:c duct) space=chum-to-our:c path)
+                (ev-req-peek:c(hen duct) space=chum-to-our:c path)
               ::
               =^  moves  ames-state  ev-abet:ev-core
               (sy-emil moves)
@@ -9841,7 +9856,7 @@
                 moves:(~(al-read-proof al ~[/ames]) ship `@ux`spon)
               ~&  retrieving-keys-again/ship
               :_  moves
-              [[//keys]~ %pass /public-keys %j %public-keys ship ~ ~]
+              [~[//keys] %pass /public-keys %j %public-keys ship ~ ~]
             ::
             =+  core=~(ev-core ev(ames-state state) hen ship +.per-sat)
             ::
@@ -10039,7 +10054,7 @@
             =+  peer-core=(abed-peer:pe:event-core her peer)
             =;  core=_peer-core
               abet:abet:core
-            =+  ev-core=(ev-foco:ev her fren)
+            =+  ev-core=(ev-abed:ev ~[//regress] her fren)
             %-  ~(rep by flows.fren)
             |=  [[side state=flow-state] core=_peer-core]
             =+  fo-core=~(. fo:ev-core hen^bone^dire state)
@@ -10848,7 +10863,7 @@
           =+  per-sat=(get-per u.rcvr)
           ?.  ?=([~ ~ %known *] per-sat)
             ~  ::  %alien or missing
-          =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
+          =+  ev-core=(ev-abed:ev ~[//scry] u.rcvr +.u.u.per-sat)
           =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
           ?:  &(?=(%ack load.tyl) fo-corked:fo-core)
               :: ~&  >>>  corked-flow-dropping/load^corked.per  :: XX remove
@@ -10874,7 +10889,7 @@
           =+  per-sat=(get-per u.rcvr)
           ?.  ?=([~ ~ %known *] per-sat)
             ~  ::  %alien or missing
-          =+  ev-core=(ev-foco:ev u.rcvr +.u.u.per-sat)
+          =+  ev-core=(ev-abed:ev ~[//scry] u.rcvr +.u.u.per-sat)
           =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
           ?~(res=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.res)])
         ::  comet attestations
@@ -10958,7 +10973,7 @@
           ?.  ?=([~ ~ %known *] per-sat)
             ~  ::  %alien or missing
           ?>  ?=([ship=@ %flow bone=@ dire:ames qery=*] pat.tyl)
-          =+  ev-core=(ev-foco:ev u.ship +.u.u.per-sat)
+          =+  ev-core=(ev-abed:ev ~[//scry] u.ship +.u.u.per-sat)
           =/  =side  [u.bone dire]
           =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side)
           ?.  (~(has by flows.per.fo-core) side)
@@ -11084,7 +11099,7 @@
                 [bone=@ ~]
               ?~  bone=(slaw %ud bone.req.tyl)
                 [~ ~]
-              =+  ev-core=(ev-foco:ev u.who +.u.per)
+              =+  ev-core=(ev-abed:ev ~[//scry] u.who +.u.per)
               =+  fo-core=(fo-abed:fo:ev-core ~[//scry] u.bone dire.tyl)
               ``atom+!>(closing.state.fo-core)
             ==
@@ -11530,7 +11545,7 @@
     ++  pe-core  .
     ++  me-core  (mesa now eny rof)
     ++  am-core  (ames now eny rof)
-    ++  ev-core  (ev-abed:ev:me-core hen)
+    ++  ev-core  ev-core:ev:me-core
     ++  al-core  (al-abed:al:me-core hen)
     ++  pe-abed  |=(=duct pe-core(hen duct))
     ++  pe-find-peer
@@ -11581,7 +11596,7 @@
         ?:  ?=([~ %known *] +.ship-state)
           =<  ev-abet
           %.  plea
-          ev-req-plea:(ev-foco:ev-core ship +.u.ship-state)
+          ev-req-plea:(ev-abed:ev-core hen ship +.u.ship-state)
         ::
         =<  al-abet
         %^  al-enqueue-alien-todo:al-core  ship  +.ship-state
@@ -11600,7 +11615,7 @@
         ?:  ?=([~ %known *] +.ship-state)
           =<  ev-abet
           %.  plea
-          ev-req-plea:(ev-foco:ev-core ship +.u.ship-state)
+          ev-req-plea:(ev-abed:ev-core hen ship +.u.ship-state)
         ::
         =<  al-abet
         %^  al-enqueue-alien-todo:al-core  ship  +.ship-state
@@ -11619,7 +11634,7 @@
           =*  sat     +.u.ship-state
           =/  =space  ?~(sec publ/life.sat shut/[idx key]:u.sec)
           %.  [space path]
-          ev-req-peek:(ev-foco:ev-core ship sat)
+          ev-req-peek:(ev-abed:ev-core hen ship sat)
         ::
         =<  al-abet
         :: XX: key exchange over ames forces all encrypted scries to be
@@ -11637,7 +11652,7 @@
         (call:am-core hen ~ soft+chum/ship^path)
       =^  moves  ames-state
         ?:  ?=([~ %known *] +.ship-state)
-          =+  ev-core=(ev-foco:ev-core ship +.u.ship-state)
+          =+  ev-core=(ev-abed:ev-core hen ship +.u.ship-state)
           =<  ev-abet
           (ev-req-peek:ev-core chum-to-our:ev-core path)
         ::
@@ -11659,7 +11674,7 @@
           ::  XX delete from alien agenda?
           ~&("peer still alien, skip peek cancel" ev-core)
         %.  [all path.spar]
-       ev-cancel-peek:(ev-foco:ev-core ship.spar +.u.ship-state)
+       ev-cancel-peek:(ev-abed:ev-core hen ship.spar +.u.ship-state)
       moves^vane-gate
     ::
     ++  pe-hear
@@ -11732,7 +11747,7 @@
       =^  moves  ames-state
         ?.  ?=([~ %known *] +.ship-state)
           !!  :: no %aliens allowed
-        =+  ev-core=(ev-foco:ev-core ship.spar +.u.ship-state)
+        =+  ev-core=(ev-abed:ev-core hen ship.spar +.u.ship-state)
         ?^  ms=(~(get by pit.per.ev-core) path.spar)
           ::  XX  call decrypt-path path.spar?
           ::
@@ -11762,7 +11777,7 @@
           !!  :: no %aliens allowed
         =<  ev-abet
         %.  [path.spar task freq]
-        ev-add-rate:(ev-foco:ev-core ship.spar +.u.ship-state)
+        ev-add-rate:(ev-abed:ev-core hen ship.spar +.u.ship-state)
       moves^vane-gate
     ::
     ++  pe-whey
@@ -11802,7 +11817,7 @@
           =/  =fren-state  +.u.+.chum-state
           =<  ev-abet
           %.  [dud lane hop.pact %page +>.pact]
-          hear-page:ev-pact:(ev-foco:ev-core her.name.pact fren-state)
+          hear-page:ev-pact:(ev-abed:ev-core hen her.name.pact fren-state)
         ::
             %peek
           ?~  dud
@@ -11868,7 +11883,7 @@
               =/  fren=fren-state  +.u.+.chum-state
               =<  ev-abet
               %.  [dud lane hop.pact %poke +>.pact]
-              hear-poke:ev-pact:(ev-foco:ev-core her-pok fren)
+              hear-poke:ev-pact:(ev-abed:ev-core hen her-pok fren)
             =?  chums.ames-state  ?=(~ +.chum-state)
               ::  first time: upgrade to %alien and +peek attestation proof
               ::
@@ -11901,7 +11916,7 @@
                 chums.ames-state.me-core
               (~(put by chums.ames-state.me-core) her-pok known/per)
             ==
-          =+  ev-core=(ev-foco:ev:mesa-core her-pok^per)
+          =+  ev-core=(ev-abed:ev:mesa-core hen her-pok^per)
           ::  XX refactor; same as hear-poke:ev-pact:ev:mesa
           ::
           =/  [=space cyf=(unit @) =inner-poke=path]
@@ -11998,7 +12013,7 @@
           ::  XX  this assumes that %aliens are checked in the packet layer
           ?>  ?=([~ %known *] chum)  ::  XX alien agenda?
           %.  [dud +.mess]
-          hear-poke:ev-mess:(ev-foco:ev-core ship.p.q.mess +.u.chum)
+          hear-poke:ev-mess:(ev-abed:ev-core hen ship.p.q.mess +.u.chum)
         ::
             %peek
           ?~  chum=(~(get by chums.ames-state) ship.mess)
@@ -12006,7 +12021,7 @@
           ::  XX  this assumes that %aliens are checked in the packet layer
           ?>  ?=([~ %known *] chum)  ::  XX alien agenda?
           %.  +.mess
-          hear-peek:ev-mess:(ev-foco:ev-core ship.mess +.u.chum)
+          hear-peek:ev-mess:(ev-abed:ev-core hen ship.mess +.u.chum)
         ::
             %page
           ?~  chum=(~(get by chums.ames-state) ship.p.mess)
@@ -12014,7 +12029,7 @@
           ::  XX  this assumes that %aliens are checked in the packet layer
           ?>  ?=([~ %known *] chum)  ::  XX alien agenda?
           %.  +.mess
-          hear-page:ev-mess:(ev-foco:ev-core ship.p.mess +.u.chum)
+          hear-page:ev-mess:(ev-abed:ev-core hen ship.p.mess +.u.chum)
         ::
         ==
       moves^vane-gate

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7711,7 +7711,7 @@
                 =^  side  ev-core  (ev-peel:ev wire +.sign)
                 =+  side
                 ?~  side  `ames-state
-                ev-abet:(ev-take:ev-core bone.u.side +.sign)
+                ev-abet:(ev-take:ev-core(hen hen) bone.u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
@@ -7726,7 +7726,7 @@
                 =/  response-pith  `(pole iota)`(mesa-pave:ev-core wire)
                 ?+    response-pith   ~|  %mesa-evil-response-wire^wire  !!
                     ?([%keen ~] ev-flow-wire:ev-core:ev)
-                  (ev-take-sage:ev-core u.were u.side +>.sign)
+                  (ev-take-sage:ev-core(hen hen) u.were u.side +>.sign)
                 ==
               ::
               ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11734,7 +11734,13 @@
         ?:  ?=(%mesa core.ames-state)
           ::  if %mesa is the default core (i.e. after everybody switches to
           ::  directed messaging) ames packet should be dropped until the sender
-          ::  migrates all its outstanding packets to |mesa
+          ::  migrates all its outstanding packets to |mesa.
+          ::
+          ::  XX what if the sender boots with an old pill after breaching that
+          ::  loads %ames as the default core?
+          ::
+          ::  XX move the peer from .chums to .peers, and enqueue an %ahoy $plea
+          ::  to migrate the peer?
           ::
           `vane-gate
         =.  peers.ames-state
@@ -11860,6 +11866,8 @@
             ::    %mesa packet
             ::
             =?  chum-state  ?=([%ames *] chum-state)
+              %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
+                  |.("hear mesa packet for regressed (alien/missing) peer")
               ?-    +.chum-state
                   ~
                 chum-state(- %mesa)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4567,7 +4567,7 @@
           ::  corresponding bone in the shut-packet
           ::
           =+  ev-core=(ev-abed:ev:(mesa now eny rof) ~ sndr.shot +.chum-state)
-          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[(mix 1 bone) %bak])
+          =+  fo-core=(fo-abed:fo:ev-core side=[(mix 1 bone) %bak])
           ?~  res=(fo-peek:fo-core %ack message-num)
             %.  event-core
             (ev-trace odd.veb sndr.shot |.("ack missing seq={<message-num>}"))
@@ -5146,8 +5146,8 @@
                   =?  flow  (~(has by flows) bone^dire)
                     (~(got by flows) bone^dire)
                   =.  flows.fren  (~(put by flows.fren) bone^dire flow)
-                  %.  [duct bone dire]
-                  fo-abed:fo:~(ev-core ev:mesa-core [duct her^fren])
+                  %.  side=bone^dire
+                  fo-abed:fo:~(ev-core ev:mesa-core [duct her fren])
                 ::
                 ?:  ?&  =(%for dire)
                         (~(has in closing.peer-state) original-bone)
@@ -7809,7 +7809,7 @@
               (~(put by by-duct) hen next-bone)
             (~(put by by-bone) next-bone hen)
           ::
-          =+  fo-core=(fo-abed:fo hen bone dire=%for)
+          =+  fo-core=(fo-abed:fo bone dire=%for)
           ::
           %-  %+  ev-tace  msg.veb.bug.ames-state
               =+  msg=?:(cork %cork %plea)
@@ -7835,7 +7835,7 @@
           |=  [=bone id=(unit *) load=*]
           ^+  ev-core
           ::
-          =+  fo-core=(fo-abed:fo hen bone dire=%bak)
+          =+  fo-core=(fo-abed:fo bone dire=%bak)
           %-  %+  ev-tace  msg.veb.bug.ames-state
               =*  next  next.snd.fo-core
               |.("send %boon {<[bone=bone seq=next]>}")
@@ -7958,7 +7958,7 @@
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("hear incomplete message")
               :: XX assert load is plea/boon?
-              =+  fo-core=(fo-abed:fo hen [bone dire]:ack)
+              =+  fo-core=(fo-abed:fo [bone dire]:ack)
               ?:  (fo-message-is-acked:fo-core mess.pok)
                 ::  don't peek if the message havs been already acked
                 ::
@@ -8200,7 +8200,7 @@
             :: XX assert load is plea/boon
             =/  fo-core
               %.  [%sink mess.pok gage ?=(~ dud)]
-              fo-call:(fo-abed:fo hen [bone dire]:ack)
+              fo-call:(fo-abed:fo [bone dire]:ack)
             =.  ev-core  fo-abet:fo-core
             ev-core(skip-abet delete-per.fo-core)
           ::
@@ -8268,7 +8268,7 @@
                   $%([%flub ~] $>(?(%noon %boon %done) gift))
               ==
           ^+  ev-core
-          =+  fo-core=(fo-abed:fo hen bone dire=%bak)
+          =+  fo-core=(fo-abed:fo bone dire=%bak)
           ?-  -.sign
             ::  XX for %done, we ack one message at at time, seq is not needed?
             ::  XX use it as an assurance check?
@@ -8288,7 +8288,7 @@
           ^+  ev-core
           ::
           =/  message-path=(pole iota)  (validate-path path.p.sage)
-          =+  fo-core=(fo-abed:fo hen side)
+          =+  fo-core=(fo-abed:fo side)
           ::
           ?:  =(%cor were)
             ::  validate %cork path and wire
@@ -8552,7 +8552,7 @@
           =|  can-be-corked=?(%.y %.n)
           =|  delete-per=?(%.y %.n)
           ::
-          |_  [[hen=duct =side] state=flow-state]
+          |_  [=side state=flow-state]
           +*  bone  bone.side
               dire  dire.side
               snd   snd.state
@@ -8562,10 +8562,9 @@
           ::
           ++  fo-core  .
           ++  fo-abed
-            |=  [=duct =^side]
+            |=  =^side
             ::  XX use +got in another arm to assert when the flow should exist
-            =.  state  (~(gut by flows.per) side *flow-state)
-            fo-core(hen duct, side side)
+            fo-core(side side, state (~(gut by flows.per) side *flow-state))
           ::
           ++  fo-abet
             ^+  ev-core
@@ -10057,7 +10056,7 @@
             =+  ev-core=(ev-abed:ev ~[//regress] her fren)
             %-  ~(rep by flows.fren)
             |=  [[side state=flow-state] core=_peer-core]
-            =+  fo-core=~(. fo:ev-core hen^bone^dire state)
+            =+  fo-core=~(. fo:ev-core bone^dire state)
             ::
             =?  bone  ?=(%bak dire)  (mix 0b1 bone) :: [bone=%0 %bak] -> bone=%1
             ::
@@ -10247,7 +10246,7 @@
             |=  [[side state=flow-state] c=_ev-core]
             ?:  =(%back dire)  c
             ?.  closing.state  c
-            =+  fo-core=~(fo-core fo:c [hen bone dire=%for] state)
+            =+  fo-core=~(fo-core fo:c [bone dire=%for] state)
             ::  sanity check on the flow state
             ::
             ?^  first=(pry:fo-mop:fo-core loads.snd.fo-core)  c
@@ -10864,7 +10863,7 @@
           ?.  ?=([~ ~ %known *] per-sat)
             ~  ::  %alien or missing
           =+  ev-core=(ev-abed:ev ~[//scry] u.rcvr +.u.u.per-sat)
-          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
+          =+  fo-core=(fo-abed:fo:ev-core side=[u.bone dire.tyl])
           ?:  &(?=(%ack load.tyl) fo-corked:fo-core)
               :: ~&  >>>  corked-flow-dropping/load^corked.per  :: XX remove
               ::  if the flow is corked, block
@@ -10890,7 +10889,7 @@
           ?.  ?=([~ ~ %known *] per-sat)
             ~  ::  %alien or missing
           =+  ev-core=(ev-abed:ev ~[//scry] u.rcvr +.u.u.per-sat)
-          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[u.bone dire.tyl])
+          =+  fo-core=(fo-abed:fo:ev-core side=[u.bone dire.tyl])
           ?~(res=(fo-peek:fo-core %cork 0) ~ ``[%message !>(u.res)])
         ::  comet attestations
         ::
@@ -10975,7 +10974,7 @@
           ?>  ?=([ship=@ %flow bone=@ dire:ames qery=*] pat.tyl)
           =+  ev-core=(ev-abed:ev ~[//scry] u.ship +.u.u.per-sat)
           =/  =side  [u.bone dire]
-          =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side)
+          =+  fo-core=(fo-abed:fo:ev-core side)
           ?.  (~(has by flows.per.fo-core) side)
             ~
           =,  state:fo-core
@@ -11100,7 +11099,7 @@
               ?~  bone=(slaw %ud bone.req.tyl)
                 [~ ~]
               =+  ev-core=(ev-abed:ev ~[//scry] u.who +.u.per)
-              =+  fo-core=(fo-abed:fo:ev-core ~[//scry] u.bone dire.tyl)
+              =+  fo-core=(fo-abed:fo:ev-core u.bone dire.tyl)
               ``atom+!>(closing.state.fo-core)
             ==
           ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -538,6 +538,12 @@
       ^-  move
       [duct %pass /ping %g %deal [our our /ames] %ping %poke noun+!>(poke)]
     ::
+    ++  poke-send-ahoy
+      |=  [=duct our=ship who=ship]
+      ^-  move
+      :+  duct  %pass
+      [/ahoy %g %deal [our our /ames] %hood %poke helm-send-ahoy+!>(who^test=|)]
+    ::
     +|  %atomics
     ::
     +$  private-key    @uwprivatekey
@@ -11704,7 +11710,8 @@
             |.("hear ames packet; %mesa default core")
         ::  handle %ames packet; keys will be asked and packet dropped
         ::
-        (call:am-core hen dud %soft %hear lane blob)
+        =^  moves  vane-gate  (call:am-core hen dud %soft %hear lane blob)
+        [(poke-send-ahoy hen our sndr.shot) moves]^vane-gate
           ::  [%mesa ~ %alien *]
           ::    %mesa is our default network core. we might have outstanding
           ::    poke/peeks, but the keys are missing and the peer sends an %ames
@@ -11730,9 +11737,9 @@
         ::  XX no need to call the ames-core again; +enqueue-alien-todo will say
         ::  that the publick-keys gift is still pending
         ::
-        ::  XX enqueue %ahoy $plea; poke /app/hood?
+        ::  enqueue %ahoy $plea; poke /app/hood
         ::
-        `vane-gate
+        ~[(poke-send-ahoy hen our sndr.shot)]^vane-gate
         ::  [%mesa ~ %known *]
         ::    if we can find the peer in chums, it means that they sent an %ahoy
         ::    $plea, we migrated them, but they haven't heard our %ack, and have
@@ -11749,8 +11756,9 @@
         =^  moves-ahoy  ames-state
           =<  abet
           %.(shot on-ack-ahoy:(ev:am-core now^eny^rof hen ames-state))
+        ?:  ?=(^ moves-ahoy)
+          [moves-ahoy vane-gate]
         =^  moves-peer  vane-gate
-          ?.  ?=(~ moves-ahoy)  `vane-gate
           ::  this was not an %ahoy plea, check if we can move the ship back to
           ::  .peers, if this is a first contact (e.g after a breach)
           ::
@@ -11764,7 +11772,7 @@
           ::    - the peer breached, we had communicated previously but our
           ::    default core was %mesa, so it stayed in .chums
           ::    - the peer booted after breaching with an old pill that has
-          ::    %mesa as the default core, or doesn't support zuse 410k or the
+          ::    %mesa as the default core, or doesn't support zuse 410k, or the
           ::    default core was manually changed
           ::
           ::  for all these causes we try to establish communication, moving
@@ -11778,10 +11786,11 @@
             (~(put by peers.ames-state) sndr.shot known/peer-state(- -.fren))
           =.  chums.ames-state
             (~(del by chums.ames-state) sndr.shot)
-          ::  XX enqueue %ahoy $plea; poke /app/hood?
+          ::  enqueue %ahoy $plea; poke /app/hood
           ::
-          (call:am-core hen dud %soft %hear lane blob)
-        [(weld moves-ahoy moves-peer) vane-gate]
+          =^  moves  vane-gate  (call:am-core hen dud %soft %hear lane blob)
+          [(poke-send-ahoy hen our sndr.shot)^moves vane-gate]
+        [moves-peer vane-gate]
       ==
     ::
     ++  pe-rate

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3574,7 +3574,6 @@
         %shut  (decrypt:crypt key.space (need cyf) ser)
         %chum  (decrypt:crypt key.space (need cyf) ser)
       ==
-    ::  XX move to utility core chapter since we use got-per?
     ::
     ++  decrypt-path
       |=  [=path =ship]
@@ -4090,7 +4089,7 @@
                   ^=     keys  keys
                   ^=  sponsor  `(^sein:title sndr.shot)
               ==
-            =+  sy-core=~(. sy:(mesa now^eny^rof) duct)
+            =+  sy-core=~(. sy:mesa duct)
             =^  moves  ames-state
               sy-abet:(sy-publ:sy-core / [%full (my [sndr.shot point]~)])
             (emil moves)
@@ -4766,7 +4765,7 @@
             =<  [moves ames-state]
             ~|  %regress-crashed
             %.  [`ship dry=%.n]
-            %*  sy-rege  sy:(mesa now eny rof)
+            %*  sy-rege  sy:mesa
               ames-state  ahoy-state
             ==
           ::  compare pre/post migrated states
@@ -4827,7 +4826,7 @@
           ::  check that chums has in fact the flow in chums for the
           ::  corresponding bone in the shut-packet
           ::
-          =+  ev-core=(ev-abed:ev:(mesa now eny rof) ~ sndr.shot +.chum-state)
+          =+  ev-core=(ev-abed:ev:mesa ~ sndr.shot +.chum-state)
           =+  fo-core=(fo-abed:fo:ev-core side=[(mix 1 bone) %bak])
           ?~  res=(fo-peek:fo-core %ack message-num)
             %.  event-core
@@ -5401,7 +5400,7 @@
                 =/  fo-core
                   =/  =^duct
                     (~(gut by by-bone.ossuary.peer-state) bone [/ames]~)
-                  =+  mesa-core=(mesa now eny rof)
+                  =+  mesa-core=mesa
                   :: XX check that we don't add a naxplanation .bone here?
                   ::
                   =?  flow  (~(has by flows) bone^dire)
@@ -5698,7 +5697,7 @@
             ++  make-peeks
               |=  fren=fren-state
               ^-  (quip move axle)
-              =+  mesa-core=(mesa now eny rof)
+              =+  mesa-core=mesa
               =/  mesa-ev-core
                (%*(ev-abed ev:mesa-core ames-state ames-state) ~ her fren)
               =.  chums.ames-state  (~(put by chums.ames-state) her known/fren)
@@ -7825,8 +7824,6 @@
     ::  directed M E S s A ging
     ::
     ++  mesa
-      |=  [now=@da eny=@uvJ rof=roof]
-      =.  vane-gate  vane-gate(now now, eny eny, rof rof)
       ::
       =<  ::  adult |mesa formal interface, after metamorphosis from larva
           ::
@@ -7919,9 +7916,11 @@
               ~?  >     test  %mass-rege-worked
               ~?  >>>  !test  %mass-rege-failed
               `ames-state
-            ::  from internal %ames request
+              ::  from internal %ames request; XX check -.duct?
               ::
-                ?(%meek %moke %mage)  co-abet:(co-call:co-core task)
+                ?(%meek %moke %mage)
+                ~&  duct/hen
+                co-abet:(co-call:co-core task)
               ==
               ::
             [moves vane-gate]
@@ -10384,7 +10383,7 @@
             |=  [her=^ship fren=fren-state state=axle]
             ^-  (quip move axle)
             =+  event-core=(ev:ames now^eny^rof hen state)
-            =/  mesa-core  %*(. (mesa now eny rof) ames-state state)
+            =/  mesa-core  mesa(ames-state state)
             =;  core=_event-core
               abet:core
             %-  ~(rep by pit.fren)
@@ -11547,7 +11546,7 @@
     +|  %helpers
     ::
     ++  pe-core  .
-    ++  me-core  (mesa now eny rof)
+    ++  me-core  mesa
     ++  am-core  (ames now eny rof)
     ++  ev-core  ev-core:ev:me-core
     ++  al-core  (al-abed:al:me-core hen)
@@ -12035,7 +12034,7 @@
   |=  [hen=duct dud=(unit goof) wrapped-task=(hobo task)]
   ^-  [(list move) _vane-gate]
   =*  sample  +<
-  =+  me-core=(mesa now eny rof)
+  =+  me-core=mesa
   =+  am-core=(ames now eny rof)
   =/  =task  ((harden task) wrapped-task)
   ?:  &(?=(~ unix-duct) ?=(?(%hear %heer %mess) -.task))
@@ -12090,7 +12089,7 @@
   |=  [=wire =duct dud=(unit goof) =sign]
   ^-  [(list move) _vane-gate]
   =*  sample  +<
-  =+  me-core=(mesa now eny rof)
+  =+  me-core=mesa
   =+  am-core=(ames now eny rof)
   ?^  dud
     ~|(%ames-take-dud (mean tang.u.dud))
@@ -12173,7 +12172,7 @@
   ^-  roon
   |=  [lyc=gang pov=path car=term bem=beam]
   =*  sample  +<
-  =+  me-core=(mesa now eny rof)
+  =+  me-core=mesa
   =+  am-core=(ames now eny rof)
   ?:  ?&  =(our p.bem)
           =(%$ q.bem)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8761,16 +8761,35 @@
                     |.("no op; weird %message gage {<-.gage>}")
                 fo-core
               ::
-              ?:  |(closing.state (~(has in corked.per) side))
-                %-  %+  ev-tace  odd.veb.bug.ames-state
-                    =+  ;;(mess=@tas +<.gage)
-                    ?:  closing.state
-                      |.("skip {<mess>}; flow in closing flow={<bone>}")
-                    |.("skip {<mess>}; flow is corked flow={<bone>} ")
-                fo-core
               ::  check that the message can be acked
               ::
               =+  flow-state=[bone=bone seq=seq last=last-acked.rcv]
+              ::
+              ?:  |(closing.state (~(has in corked.per) side))
+                =+  ;;(mess=@tas +<.gage)
+                ?.  closing.state
+                  %-  %+  ev-tace  odd.veb.bug.ames-state
+                      |.("skip {<mess>}; flow is corked flow={<bone>} ")
+                  fo-core
+                ::  if the flow is in closing, ack a resend of the %cork $plea
+                ::
+                =+  ;;([%plea =plea] +.gage)
+                ?.  &(?=([%cork ~] payload) ?=([%flow ~] path)):plea
+                  %-  %+  ev-tace  odd.veb.bug.ames-state
+                      |.("skip {<mess>}; flow in closing flow={<bone>}")
+                  fo-core
+                ::  if this is a %cork $plea, we need to have acked it already
+                ::
+                ?.  =(seq last-acked.rcv)
+                  %-  %+  ev-tace  odd.veb.bug.ames-state
+                      |.("skip %cork {<seq>}; flow in closing flow={<bone>}")
+                  fo-core
+                ::  send dupe ack
+                ::
+                %-  %+  ev-tace  snd.veb.bug.ames-state
+                    |.("cork [bon, seq]={<[bone seq]>} already acked")
+                ::
+                (fo-send-ack seq)
               ?:  (gth seq +(last-acked.rcv))
                 ::  no-op if future message
                 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2092,10 +2092,10 @@
                                              =(u.lane.mesa u.lane.back)
                                      ==  ==
           %+  print-check  %ossuary  =(ossuary.mesa ossuary.back)
-          :: %+  print-check  %closing  =(closing.mesa closing.back)
-          =-  ~?  !-  [mesa=corked.mesa back=corked.back]
-              -
-          %+  print-check  %corked   =(corked.mesa corked.back)
+          ::  corked.mesa could contain more bones if any %bak flow was in
+          ::  closing, which deletes it automatically
+          ::
+          %+  print-check  %corked   ?=(~ (~(dif in corked.mesa) corked.back))
           %+  print-check  %chain    =(client-chain.mesa client-chain.back)
           :: %+  print-check  %pit      =(pit.mesa pit.back)  :: XX
         ::  flows
@@ -2112,9 +2112,11 @@
           =/  test=?
             ?&  :: XX lines don't match for the ahoy flow
                 :: =(line.flow line.back-flow)
-                =-  ~?  !-  closing/[closing.flow closing.back-flow]
+                =-  ~?  !-  closing/[bone=bone closing.flow closing.back-flow]
                     -
-                =(closing.flow closing.back-flow)
+                ?|  =(%bak dire)
+                    =(closing.flow closing.back-flow)
+                ==
             ::
                 =-  ~?  !-  snd/[bone=bone mesa=snd.flow back=snd.back-flow]
                     -
@@ -10018,10 +10020,10 @@
             =.  peers.ames-state.core
               (~(put by peers.ames-state.core) ship %known peer)
             ::
-            =^  peek-moves  ames-state.core
-              (regress-peeks ship fren ames-state.core)
             =^  flow-moves  ames-state.core
               (regress-flows ship fren ames-state.core)
+            =^  peek-moves  ames-state.core
+              (regress-peeks ship fren ames-state.core)
             ::  delete ship from .chums
             ::
             =.  chums.ames-state.core  (~(del by chums.ames-state.core) ship)
@@ -10052,11 +10054,7 @@
             ::
             =.  core
               =;  [cor=_core loads=_loads.snd.state]
-                =?  closing.peer-state.cor  &(?=(%for dire) closing.state)
-                  ::  only a forward flow that is in closing gets migrated;
-                  ::  if this was a backward flow, the flow (and its peek for a
-                  ::  cork will get automatically removed in -regress-peeks)
-                  ::
+                =?  closing.peer-state.cor  closing.state
                   (~(put in closing.peer-state.cor) bone)
                 cor
               ::  init message-pump with highest acked message number
@@ -10162,7 +10160,7 @@
                 =+  flow=(~(got by flows.fren) bone %bak)
                 ?.  closing.flow  c
                 =+  pe-core=(abed-got:pe:c ship)
-                abet:(handle-cork:pe-core bone)
+                abet:(handle-cork:pe-core (mix 0b1 bone))
               c
             =/  [=space pax=^path]
               [space inner]:(decrypt-path:mesa-core path her)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4149,7 +4149,7 @@
             |=  [=ship =bone]
             ::  XX  defer migrating the peer until we can read from their
             ::  namespace that they have migrated us?
-            ::  XX  requires a namespace for migrated peers
+            ::  XX  requires a namespace for migrated peers?
             ::
             :: %-  %^  ev-trace  sun.veb  ship.deep
             ::     |.("migrating to |mesa")
@@ -4492,7 +4492,10 @@
           |=  =ship
           ^-  ?
           =/  ship-state  (~(get by peers.ames-state) ship)
-          ?.  ?=([~ %known *] ship-state)  %.n
+          ?.  ?=([~ %known *] ship-state)
+            ::  XX only known peers can be migrated; |pass [%a %load %mesa] ?
+            ::
+            %.n
           =+  peer-core=(abed-peer:pe ship +.u.ship-state)
           =/  [ahoy-moves=(list move) ahoy-state=axle]
             ~|(%migrate-crashed [moves ames-state]:on-migrate:peer-core)
@@ -4655,7 +4658,7 @@
                 ?:  ?=(%pawn (clan:title ship))
                   (try-next-sponsor (^sein:title ship))
                 ::  by default, %aliens are saved in peer.ames-state
-                ::  XX use chums.ames-state as default
+                ::  XX use chums.ames-state as default based on core.ames-state
                 ::
                 %^  enqueue-alien-todo  ship  ship-state
                 |=  todos=alien-agenda
@@ -7247,7 +7250,7 @@
             =/  bone  (slaw %ud bone.tyl)
             ?:  |(?=(~ ship) ?=(~ bone))
               [~ ~]
-            ::  XX check that ship is in .lyc
+            ::  check that ship is in .lyc
             ::
             ?.  &(?=(^ lyc) (~(has in u.lyc) u.ship))
               [~ ~]
@@ -9035,7 +9038,7 @@
               :: fo-core(cache.state (put:fo-cac cache.state seq error))
             |-  ^+  fo-core
             ?:  error
-              ::  XX  make error=(unit error), and include the naxplanation there
+              ::  XX make error=(unit error), and include the naxplanation there
               ::
               ::  if error start +peek for naxplanation
               ::
@@ -9688,6 +9691,7 @@
             =/  peer
               ::  XX if the peer doesn't previously exist we insert it
               ::  based on the chosen core in state; see find-peer
+              ::
               ?:  ?=(%ship wer)
                 :-  %ship
                 (gut-peer-state:(ev:ames now^eny^rof hen ames-state) ship)
@@ -10059,8 +10063,8 @@
             ::      do we need to send it?
             ::  XX  better to drop any peeks for %naxplanations, %corks?
             ::
-            =.  last-acked.sink      last-acked.rcv.state
-            =.  last-heard.sink      last-acked.rcv.state
+            =.  last-acked.sink  last-acked.rcv.state
+            =.  last-heard.sink  last-acked.rcv.state
             ::  naxplanations
             ::
             =/  naxp=^bone  (mix 0b10 bone)  ::  bone=%1 -> bone=%3
@@ -10177,7 +10181,7 @@
               =?  coms  ?&  (gth (sub now ~d180) last-contact.qos.c)
                             %-  ~(any by flows.c)
                             |=  f=flow-state
-                            !=(~ loads.snd.f)  ::  XX !?=([^ ^ *] loads.snd.f)
+                            !=(~ loads.snd.f)
                         ==
                 (~(put in coms) ship)
               coms
@@ -10293,6 +10297,10 @@
           |=  [comet=@p open-packet signature=@ signed=@]  :: XX to %lull
           ^+  al-core
           =/  crub  (com:nu:crub:crypto public-key)
+          ::  XX  this verification is redundant; comet proofs use the /publ
+          ::  namespace, so the signature verification has already happened in
+          ::  +al-take-proof
+          ::
           ::  verify signature
           ::
           ?>  (safe:as:crub signature signed)
@@ -10757,7 +10765,7 @@
             ~
           ?~  u.res
             [~ ~]
-          =>  [key=u.key cyf=u.cyf bem=bem res=res ..crypt] :: XX rift.ames-state
+          =>  [key=u.key cyf=u.cyf bem=bem res=res ..crypt]
           :: ~>  %memo./ames/chum
           :: XX rift.ames-state
           =/  gag  [p q.q]:u.u.res
@@ -11147,7 +11155,7 @@
       ::
       +|  %helpers
       ::
-      ++  push-pact  :: XX forwarding?
+      ++  push-pact  :: XX forwarding stuff here instad on +make-lanes?
         |=  [=pact:pact lanes=(list lane:pact)]
         ^-  move
         ?<  =(~ unix-duct)
@@ -11702,7 +11710,7 @@
               task=$@(~ ?([%chum ~] [%keen key=(unit @ud)]))
               freq=@ud
           ==
-      ::  XX also for |ames; move to common tasks
+      ::  XX also for |ames; move to common tasks when supported
       ::
       =/  ship-state  (pe-find-peer ship.spar)
       ?:  ?=(%ames -.ship-state)
@@ -11846,7 +11854,7 @@
           ::
           =|  per=fren-state
           =.  -.per  azimuth-state=+<.u.chum-state
-          =/  mesa-core
+          =/  mesa-core  ::  XX temporary core
             ::  XX  don't put the regressed peer again in chums
             ::
             %_  me-core
@@ -12060,6 +12068,8 @@
       ::
       ~>  %slog.0^leaf/"mesa: taking weird {<[[- +<]:sign]>} for {(spud wire)}"
       take:me-core
+    ::  XX refactor defered gift handling so no timer is needed if no unix-duct
+    ::
     ::  If the unix-duct is not set, we defer applying %public-keys and %turf
     ::  gifts (which can trigger other gifts to be sent to unix) by setting up
     ::  a timer that will request them again

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11709,10 +11709,27 @@
       %-  %+  %*(ev-tace ev-core her sndr.shot)  odd.veb.bug.ames-state
           |.("hear ames packet for migrated peer")
       ::
-      =^  moves  ames-state
+      =^  moves-ahoy  ames-state
         =<  abet
         %.(shot on-ack-ahoy:(ev:am-core now^eny^rof hen ames-state))
-      [moves vane-gate]
+      =^  moves-peer  vane-gate
+        ?.  ?=(~ moves-ahoy)  `vane-gate
+        ::  this was not an %ahoy plea, check if we can move the ship back to
+        ::  .peers, if this is a first contact (e.g after a breach)
+        ::
+        =/  fren=fren-state  +.u.+.ship-state
+        ?.  =(+:*fren-state +.fren)
+          `vane-gate
+        ::  if %ames is the default core, remove the ship from .chums
+        ::  and add it to .peers
+        ::
+        =?  peers.ames-state  ?=(%ames core.ames-state)
+          =|  =peer-state
+          (~(put by peers.ames-state) sndr.shot known/peer-state(- -.fren))
+        =?  chums.ames-state  ?=(%ames core.ames-state)
+          (~(del by chums.ames-state) sndr.shot)
+        (call:am-core hen dud %soft %hear lane blob)
+      [(weld moves-ahoy moves-peer) vane-gate]
     ::
     ++  pe-rate
       |=  [dud=(unit goof) =spar =rate]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7919,8 +7919,9 @@
               ::  from internal %ames request; XX check -.duct?
               ::
                 ?(%meek %moke %mage)
-                ~&  duct/hen
-                co-abet:(co-call:co-core task)
+              ?.  ?=([[%ames *] *] hen)
+                `ames-state ::  XX log
+              co-abet:(co-call:co-core task)
               ==
               ::
             [moves vane-gate]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11724,10 +11724,16 @@
         ::  if %ames is the default core, remove the ship from .chums
         ::  and add it to .peers
         ::
-        =?  peers.ames-state  ?=(%ames core.ames-state)
+        ?:  ?=(%mesa core.ames-state)
+          ::  if %mesa is the default core (i.e. after everybody switches to
+          ::  directed messaging) ames packet should be dropped until the sender
+          ::  migrates all its outstanding packets to |mesa
+          ::
+          `vane-gate
+        =.  peers.ames-state
           =|  =peer-state
           (~(put by peers.ames-state) sndr.shot known/peer-state(- -.fren))
-        =?  chums.ames-state  ?=(%ames core.ames-state)
+        =.  chums.ames-state
           (~(del by chums.ames-state) sndr.shot)
         (call:am-core hen dud %soft %hear lane blob)
       [(weld moves-ahoy moves-peer) vane-gate]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3814,6 +3814,8 @@
             event-core
           =/  =bone
             ?-(u.parsed [%new *] bone.u.parsed, [%old *] bone.u.parsed)
+          %-  %^  ev-trace  odd.veb  her
+              |.("dropping %flub: bone={<bone>} {(spud wire)}")
           abet:(on-flub:peer-core bone)
         ::  +on-take-done: handle notice from vane that it processed a message
         ::
@@ -6625,6 +6627,42 @@
                             la=last-acked.state  lh=last-heard.state
                         ==
                       "hear last in-progress {<data>}"
+                  =+  ?.  odd.veb  ~
+                      ?.  ?=(%plea (received bone.shut-packet))   ~
+                      =/  fragments=(map @ @uwfragment)
+                        ::  create default if first fragment
+                        ::
+                        ?~  existing=(~(get by live-messages.state) seq)
+                          ?.  =(0 fragment-num)
+                            ~
+                          %+  ~(put by *(map @ @uwfragment))
+                            fragment-num
+                          fragment
+                        ?>  (gth num-fragments.u.existing fragment-num)
+                        ?>  =(num-fragments.u.existing num-fragments)
+                        ::
+                        %+  ~(put by fragments.u.existing)
+                          fragment-num
+                        fragment
+                      ?~  fragments
+                        %-  %+  pe-trace  &
+                            |.  ^-  tape
+                            =/  data
+                              :*  her  seq=seq  bone=bone.shut-packet
+                                  fragment-num  num-fragments
+                                  la=last-acked.state  lh=last-heard.state
+                                  pending=~(key by pending-vane-ack.state)
+                              ==
+                            "last in-progress miss live {<data>}"
+                        ~
+                      =/  message=*
+                        (assemble-fragments num-fragments fragments)
+                      =+  ;;((soft [vane=@tas =path payload=*]) message)
+                      ?~  m=;;((soft [vane=@tas =path payload=*]) message)  ~
+                      %-  %+  pe-trace  &
+                          |.  ^-  tape  =,  u.m
+                          "last in-progress {<vane=vane>} path={<(spud path)>}"
+                      ~
                   sink
                 ::  ack all other packets
                 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4842,15 +4842,15 @@
           ?.  ?=([%ack error=@] u.res)
             %-  (ev-trace odd.veb sndr.shot |.("weird ack"))
             event-core
-          %-  (ev-trace snd.veb sndr.shot |.("send migrated ahoy ack"))
           ::
           =+  ;;(error=? +.u.res)
           ?:  error
             ::  XX don't nack, otherwise the peer will wait for the naxplanation
             ::
-            %-  %+  ev-trace  snd.veb sndr.shot
+            %-  %^  ev-trace  snd.veb  sndr.shot
                 |.("ahoy got nacked {<bone.u.shut-packet>} seq={<message-num>}")
-            ev-core
+            event-core
+          %-  (ev-trace snd.veb sndr.shot |.("send migrated ahoy ack"))
           =/  ack-packet=^shut-packet
             :-  (mix 0b1 bone.u.shut-packet)
             [message-num.u.shut-packet %| %| !error lag=*@dr]
@@ -12093,12 +12093,17 @@
             %-  %+  ev-tace:ev-core  odd.veb.bug.ames-state
                 |.("no op; ignore {(spud path.plea)} plea")
             `ames-state  :: XX ignore non %rege plea
-          ::  produce mesa ack
+          ::  check that we have the ack in peers.ames-state
           ::
-          %-  %+  ev-tace:ev-core  snd.veb.bug.ames-state
-              |.("ack %rege plea")
-          ::  XX check that we have the ack in peers.ames-state?
-          ::
+          ?~  sink=(~(get by rcv.+.u.chum-state) (mix 0b1 bone.ack))
+            %-  %+  ev-tace:ev-core  snd.veb.bug.ames-state
+                |.("missing %rege bone={<bone.ack>} from sink")
+            `ames-state
+          ?.  =(last-acked.u.sink mess.pok)
+            %-  %+  ev-tace:ev-core  snd.veb.bug.ames-state
+                |.
+                "%rege $plea is not last acked ({<mess.pok>}) bone={<bone.ack>}"
+            `ames-state
           =/  moves=(list move)
             ::  create temporary flow for ack payload
             ::
@@ -12106,7 +12111,7 @@
               =.  flows.per
                 =|  state=flow-state
                 %-  ~(put by flows.per)
-                [[bone dire]:ack state(last-acked.rcv mess.pok)]
+                [[bone dire]:ack state(last-acked.rcv last-acked.u.sink)]
               (~(put by chums.ames-state.me-core) her-pok known/per)
             =/  flow-roof
               ^-  roof
@@ -12119,6 +12124,10 @@
             =<  moves
             %.  [space=[%none ~] spar=[her-pok pat.ack.pact]]
             co-make-page:co:me-core(rof flow-roof)
+          ::  produce mesa ack
+          ::
+          %-  %+  ev-tace:ev-core  &(?=(^ moves) snd.veb.bug.ames-state)
+              |.("ack %rege plea")
           [moves ames-state]
         ::
         ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4834,7 +4834,7 @@
           ?.  ?=([%ack error=@] u.res)
             %-  (ev-trace odd.veb sndr.shot |.("weird ack"))
             event-core
-          %-  (ev-trace snd.veb sndr.shot |.("send migrated ack"))
+          %-  (ev-trace snd.veb sndr.shot |.("send migrated ahoy ack"))
           ::
           =/  ok=?  ;;(? +.u.res)
           =/  ack-packet=^shut-packet
@@ -11764,7 +11764,7 @@
           ::    - the peer breached, we had communicated previously but our
           ::    default core was %mesa, so it stayed in .chums
           ::    - the peer booted after breaching with an old pill that has
-          ::    %mesa as the default core, or doesn't support zuse 410k or the  
+          ::    %mesa as the default core, or doesn't support zuse 410k or the
           ::    default core was manually changed
           ::
           ::  for all these causes we try to establish communication, moving
@@ -11889,26 +11889,28 @@
             ::    a peer sends us a mesa packet, but %ames is our default core
             ::
             ::  [%mesa ~ %alien *]
-            ::    %mesa is our default network core. we had outstanding
+            ::    %mesa is our default network core. we could have outstanding
             ::    poke/peeks, but the keys are missing and the peer sends up a
             ::    %mesa packet
             ::
             ::  [%ames ~ %alien *]
-            ::    %ames is our default network core. we had outstanding
+            ::    %ames is our default network core. we could have outstanding
             ::    poke/peeks, but the keys are missing and the peer sends up a
-            ::    %mesa packet
+            ::    %mesa packet — if notthing outstanding, the peer has first
+            ::    sent an %ames packet, we dropped it and asked for the key,
+            ::    then the peer sent a %mesa packet
+            ::    XX log as missbeheaving peer?
             ::
-            =?  chum-state  ?=([%ames *] chum-state)
+            =^  delete  chum-state
+              ?.  ?=([%ames *] chum-state)  [| chum-state]
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.("hear mesa packet for regressed (alien/missing) peer")
               ?-    +.chum-state
                   ~
-                chum-state(- %mesa)
+                [delete=| chum-state(- %mesa)]
               ::
                   [~ %alien *]
-                ::  move alien state from %ames into %mesa
-                ::
-                :-  %mesa
+                :+  delete=&  %mesa
                 :+  ~  %alien  ^-  ovni-state
                 ::    packets are discarded since messages will be sent up to
                 ::    the sponsorship chain anyway
@@ -11917,6 +11919,14 @@
                     chums=chums.u.+.chum-state
                 (turn messages.u.+.chum-state |=([=duct =plea] duct^plea/plea))
               ==
+            ::
+            =?  ames-state  delete
+              ?.  ?=([%mesa ~ %alien *] chum-state)  ames-state  :: XX log
+              ::  move %alien peer into %mesa
+              ::
+              =.  chums.ames-state
+                (~(put by chums.ames-state) her-pok u.+.chum-state)
+              ames-state(peers (~(del by peers.ames-state) her-pok))
             ::
             ?>  ?=([%mesa *] chum-state)
             ?.  ?&  ?=(%pawn (clan:title her-pok))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9685,9 +9685,16 @@
               ::
               =?  route.+.u.peer  =(%czar (clan:title ship))
                 `[direct=%.y %& ship]
-              ::  XX TODO %mesa as default core; if a peer is regressed back
+              ::  if %mesa is the default core, remove the ship from .peers
+              ::  and add it to .chums
               ::
-              ames-state(peers (~(put by peers.ames-state) ship u.peer))
+              =?  chums.ames-state  ?=(%mesa core.ames-state)
+                =|  =fren-state
+                (~(put by chums.ames-state) ship known/fren-state(- +<.u.peer))
+              =?  peers.ames-state  ?=(%mesa core.ames-state)
+                (~(del by peers.ames-state) ship)
+              ::
+              ames-state
             ::  cancel all timers related to .ship
             ::
             =?  sy-core    ?=(%ames -.peer)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4564,8 +4564,8 @@
           =+  ev-core=(ev-foco:ev:(mesa now eny rof) sndr.shot +.chum-state)
           =+  fo-core=(fo-abed:fo:ev-core ~[//scry] side=[(mix 1 bone) %bak])
           ?~  res=(fo-peek:fo-core %ack message-num)
-            %-  (ev-trace odd.veb sndr.shot |.("ack missing seq={<message-num>}"))
-            event-core
+            %.  event-core
+            (ev-trace odd.veb sndr.shot |.("ack missing seq={<message-num>}"))
           ?.  ?=([%ack error=@] u.res)
             %-  (ev-trace odd.veb sndr.shot |.("weird ack"))
             event-core
@@ -11672,7 +11672,7 @@
       ::
       =^  moves  ames-state
         =<  abet
-        %.(shot on-ack-ahoy:(ev:(ames now eny rof) now^eny^rof hen ames-state))
+        %.(shot on-ack-ahoy:(ev:am-core now^eny^rof hen ames-state))
       [moves vane-gate]
     ::
     ++  pe-rate
@@ -11773,8 +11773,40 @@
             `ames-state
           =/  chum-state  (pe-find-peer her-pok)
           ?.  ?=([%ames ~ %known *] chum-state)
+            ::  [%mesa ~]
+            ::    only if %mesa core enabled (not by default)
+            ::
+            ::  [%ames ~]
+            ::    a peer sends us a mesa packet, but %ames is our default core
+            ::
+            ::  [%mesa ~ %alien *]
+            ::    %mesa is our default network core. we had outstanding
+            ::    poke/peeks, but the keys are missing and the peer sends up a
+            ::    %mesa packet
+            ::
+            ::  [%ames ~ %alien *]
+            ::    %ames is our default network core. we had outstanding
+            ::    poke/peeks, but the keys are missing and the peer sends up a
+            ::    %mesa packet
+            ::
             =?  chum-state  ?=([%ames *] chum-state)
-              [%mesa *(unit ^chum-state)]
+              ?-    +.chum-state
+                  ~
+                chum-state(- %mesa)
+              ::
+                  [~ %alien *]
+                ::  move alien state from %ames into %mesa
+                ::
+                :-  %mesa
+                :+  ~  %alien  ^-  ovni-state
+                ::    packets are discarded since messages will be sent up to
+                ::    the sponsorship chain anyway
+                ::
+                :_  :-  peeks=keens.u.+.chum-state
+                    chums=chums.u.+.chum-state
+                (turn messages.u.+.chum-state |=([=duct =plea] duct^plea/plea))
+              ==
+            ::
             ?>  ?=([%mesa *] chum-state)
             ?.  ?&  ?=(%pawn (clan:title her-pok))
                     |(?=(~ +.chum-state) ?=([~ %alien *] +.chum-state))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -6657,7 +6657,6 @@
                         ~
                       =/  message=*
                         (assemble-fragments num-fragments fragments)
-                      =+  ;;((soft [vane=@tas =path payload=*]) message)
                       ?~  m=;;((soft [vane=@tas =path payload=*]) message)  ~
                       %-  %+  pe-trace  &
                           |.  ^-  tape  =,  u.m

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -214,6 +214,13 @@
   =/  =spar:ames   &7:move
   [space spar |7:move]
 ::
+++  move-to-plea
+  |=  =move:ames
+  ^-  [ship plea:ames]
+  ::
+  ?>  ?=([%pass ^ %g %plea *] card.move)
+  |5:move
+::
 ++  move-to-ahoy
   |=  =move:ames
   ^-  cage
@@ -242,6 +249,11 @@
   ^-  ?
   ?=([%pass [%ahoy ~] %g %deal ^ %hood %poke %helm-send-ahoy *] card.move)
 ::
+++  is-move-plea
+  |=  =move:ames
+  ^-  ?
+  ?=([%pass ^ %g %plea *] card.move)
+::
 ++  snag-packet
   |=  [index=@ud moves=(list move:ames)]
   ^-  [=lane:ames =blob:ames]
@@ -265,6 +277,14 @@
   %-  move-to-ahoy
   %+  snag  index
   (skim moves is-move-ahoy)
+::
+++  snag-plea
+  |=  [index=@ud moves=(list move:ames)]
+  ^-  [ship plea:ames]
+  ::
+  %-  move-to-plea
+  %+  snag  index
+  (skim moves is-move-plea)
 ::
 ++  snag-push
   |=  [index=@ud moves=(list move:ames)]
@@ -904,6 +924,7 @@
   ::  load %mesa core into the comet
   ::
   =^  moves1  bud  (call bud ~[/hood] %load %mesa)
+  =.  peers.ames-state.comet  (~(del by peers.ames-state.bud) our-comet)
   =.  chums.ames-state.bud
     %+  ~(put by chums.ames-state.bud)  our-comet
     [%alien *ovni-state:ames]
@@ -935,5 +956,66 @@
   %+  expect-eq
     !>  &
     !>  (~(has by peers.ames-state.bud) our-comet)
+::  XX this wouldn't happen for comets since they don't breach
 ::
+++  test-comet-bunt-sends-ames
+  ::  turn on for verbosity
+  ::
+  =^  moves0  bud
+    (call bud ~[/g/hood] %spew ~[%fin %for %ges %kay %msg %odd %rcv %rot %snd %sun])
+  ::  load %mesa core into the comet
+  ::
+  =^  moves1  bud  (call bud ~[/hood] %load %mesa)
+  =.  peers.ames-state.comet  (~(del by peers.ames-state.bud) our-comet)
+  =/  crypto-core
+    %-  nol:nu:crub:crypto
+    0w9N.5uIvA.Jg0cx.NCD2R.o~MtZ.uEQOB.9uTbp.6LHvg.0yYTP.
+    3q3td.T4UF0.d5sDL.JGpZq.S3A92.QUuWg.IHdw7.izyny.j9W92
+  =/  comet-pub   pub:ex:crypto-core
+  =.  chums.ames-state.bud
+    %+  ~(put by chums.ames-state.bud)  our-comet
+    :+  %known
+      :*  symmetric-key=bud-comet-sym
+          life=1
+          rift=0
+          public-key=comet-pub
+          sponsor=~bud
+      ==
+    +:*fren-state:ames
+  =.  chums.ames-state.comet  (~(del by chums.ames-state.comet) ~bud)
+  =.  peers.ames-state.comet
+    %+  ~(put by peers.ames-state.comet)  ~bud
+    =|  =peer-state:ames
+    =.  -.peer-state
+      :*  symmetric-key=bud-comet-sym
+          life=3
+          rift=0
+          public-key=bud-pub
+          sponsor=~bud
+      ==
+    =.  route.peer-state  `[direct=%.y `lane:ames`[%& `@`~bud]]
+    [%known peer-state]
+  ::  send a %ames packet to bud that has %mesa as the default core
+  ::
+  =/  poke-plea  [%g /talk [%get %post]]
+  =^  moves1  comet  (call comet ~[/g/talk] %plea ~bud poke-plea)
+  ::  inject plea packet, move .chum to .peer, and enqueue %ahoy $plea
+  ::
+  =^  moves2  bud    (call bud ~[//unix] %hear (snag-packet 0 moves1))
+  =/  ahoy-plea  helm-send-ahoy/!>(our-comet^test=|)
+  =/  gall-plea  [our-comet poke-plea]
+  ;:  weld
+    %+  expect-eq
+      +:ahoy-plea
+    +:(snag-ahoy 0 moves2)
+  ::
+    %+  expect-eq
+      !>  gall-plea
+    !>  (snag-plea 0 moves2)
+  ::
+    %+  expect-eq
+      !>  &
+      !>  (~(has by peers.ames-state.bud) our-comet)
+  ::
+  ==
 --

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -214,6 +214,14 @@
   =/  =spar:ames   &7:move
   [space spar |7:move]
 ::
+++  move-to-ahoy
+  |=  =move:ames
+  ^-  cage
+  ::
+  ?>  ?=([%pass [%ahoy ~] %g %deal ^ %hood %poke %helm-send-ahoy *] +.move)
+  ~!  |8:move
+  |8:move
+::
 ++  is-move-send
   |=  =move:ames
   ^-  ?
@@ -228,6 +236,11 @@
   |=  =move:ames
   ^-  ?
   ?=([%pass wire=^ %a %moke *] card.move)
+::
+++  is-move-ahoy
+  |=  =move:ames
+  ^-  ?
+  ?=([%pass [%ahoy ~] %g %deal ^ %hood %poke %helm-send-ahoy *] card.move)
 ::
 ++  snag-packet
   |=  [index=@ud moves=(list move:ames)]
@@ -244,6 +257,14 @@
   %-  move-to-moke
   %+  snag  index
   (skim moves is-move-moke)
+::
+++  snag-ahoy
+  |=  [index=@ud moves=(list move:ames)]
+  ^-  cage
+  ::
+  %-  move-to-ahoy
+  %+  snag  index
+  (skim moves is-move-ahoy)
 ::
 ++  snag-push
   |=  [index=@ud moves=(list move:ames)]
@@ -873,5 +894,46 @@
   %+  expect-eq
     !>  pact
     !>  (parse-packet:bud blob)  :: %pass %peek for the attestation
+::
+::
+++  test-comet-sends-ames
+  ::  turn on for verbosity
+  ::
+  =^  moves0  bud
+    (call bud ~[/g/hood] %spew ~[%fin %for %ges %kay %msg %odd %rcv %rot %snd %sun])
+  ::  load %mesa core into the comet
+  ::
+  =^  moves1  bud  (call bud ~[/hood] %load %mesa)
+  =.  chums.ames-state.bud
+    %+  ~(put by chums.ames-state.bud)  our-comet
+    [%alien *ovni-state:ames]
+  =.  chums.ames-state.comet  (~(del by chums.ames-state.comet) ~bud)
+  =.  peers.ames-state.comet
+    %+  ~(put by peers.ames-state.comet)  ~bud
+    =|  =peer-state:ames
+    =.  -.peer-state
+      :*  symmetric-key=bud-comet-sym
+          life=3
+          rift=0
+          public-key=bud-pub
+          sponsor=~bud
+      ==
+    =.  route.peer-state  `[direct=%.y `lane:ames`[%& `@`~bud]]
+    [%known peer-state]
+  ::  send a %ames packet to bud that has %mesa as the default core
+  ::
+  =/  poke-plea  [%g /talk [%get %post]]
+  =^  moves1  comet  (call comet ~[/g/talk] %plea ~bud poke-plea)
+  ::  drop packet, move .chum to .peer, and enqueue %ahoy $plea
+  ::
+  =^  moves2  bud    (call bud ~[//unix] %hear (snag-packet 0 moves1))
+  =/  ahoy-plea  helm-send-ahoy/!>(our-comet^test=|)
+  %+  weld
+    %+  expect-eq
+      +:ahoy-plea
+    +:(snag-ahoy 0 moves2)
+  %+  expect-eq
+    !>  &
+    !>  (~(has by peers.ames-state.bud) our-comet)
 ::
 --

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -96,7 +96,7 @@
         public-key=marbud-pub
         sponsor=~bud
     ==
-  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`0xffff.7f00.0001]]
   [%known peer-state]
 ::
 =.  peers.ames-state.bud
@@ -109,7 +109,7 @@
         public-key=nec-pub
         sponsor=~nec
     ==
-  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`0xffff.7f00.0001]]
   [%known peer-state]
 ::
 =.  peers.ames-state.comet
@@ -122,7 +122,7 @@
         public-key=marbud-pub
         sponsor=~bud
     ==
-  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`0xffff.7f00.0001]]
   [%known peer-state]
 =.  peers.ames-state.comet
   %+  ~(put by peers.ames-state.comet)  ~bud
@@ -134,7 +134,7 @@
         public-key=bud-pub
         sponsor=~bud
     ==
-  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`0xffff.7f00.0001]]
   [%known peer-state]
 =.  peers.ames-state.comet2
   %+  ~(put by peers.ames-state.comet2)  ~marbud
@@ -146,7 +146,7 @@
         public-key=marbud-pub
         sponsor=~bud
     ==
-  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
+  =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`0xffff.7f00.0001]]
   [%known peer-state]
 =.  peers.ames-state.comet2
   %+  ~(put by peers.ames-state.comet2)  ~bud
@@ -177,10 +177,38 @@
   ?>  ?=([%give %send *] +.move)
   [lane blob]:+>+.move
 ::
+++  move-to-push
+  |=  =move:ames
+  ^-  [lane:pact:ames =blob:ames]
+  ::
+  =;  [l=(list lane:pact:ames) =blob:ames]
+    (snag 0 l)^blob
+  ?>  ?=([%give %push *] +.move)
+  [p q]:+>+.move
+::
+++  move-to-moke
+  |=  =move:ames
+  ^-  [space:ames spar:ames path]
+  ::
+  ?>  ?=([%pass wire=^ %a %moke *] +.move)
+  =/  =space:ames  &6:move
+  =/  =spar:ames   &7:move
+  [space spar |7:move]
+::
 ++  is-move-send
   |=  =move:ames
   ^-  ?
   ?=([%give %send *] card.move)
+::
+++  is-move-push
+  |=  =move:ames
+  ^-  ?
+  ?=([%give %push *] card.move)
+::
+++  is-move-moke
+  |=  =move:ames
+  ^-  ?
+  ?=([%pass wire=^ %a %moke *] card.move)
 ::
 ++  snag-packet
   |=  [index=@ud moves=(list move:ames)]
@@ -190,6 +218,30 @@
   %+  snag  index
   (skim moves is-move-send)
 ::
+++  snag-moke
+  |=  [index=@ud moves=(list move:ames)]
+  ^-  [space:ames spar:ames path]
+  ::
+  %-  move-to-moke
+  %+  snag  index
+  (skim moves is-move-moke)
+::
+++  snag-push
+  |=  [index=@ud moves=(list move:ames)]
+  ^-  [=lane:pact:ames =blob:ames]
+  ::
+  %-  move-to-push
+  %+  snag  index
+  (skim moves is-move-push)
+::
+++  make-roof
+  |=  [pax=path val=cage]
+  ^-  roof
+  |=  [lyc=gang pov=path vis=view bem=beam]
+  ^-  (unit (unit cage))
+  ?.  &(=(s.bem pax) |(=(vis %x) =(vis [%$ %x]) =(vis [%g %x]) =(vis [%a %x])))
+    [~ ~]
+  ``val
 ++  n-frags
   |=  n=@
   ^-  @ux
@@ -724,5 +776,38 @@
         ship=~nec
       path=/a/x/1//fine/shut/1/0v1.vvaek.7boon.0tp04.21q1h.be1i0.494an.qimof.e2fku.ern01
   ==
+::
+::  %ahoy tests
+::
+++  test-old-ames-wire-mesa  ^-  tang
+  ::  turn on for verbosity
+  :: =^  moves0  bud
+  ::   (call bud ~[/g/hood] %spew ~[%fin %for %ges %kay %msg %odd %rcv %rot %snd %sun])
+  =/  poke-plea    [%g /talk [%get %post]]
+  =^  moves1       nec  (call nec ~[/g/talk] %plea ~bud poke-plea)
+  =^  move-ahoy-1  nec  (call nec ~[/g/ahoy] %plea ~bud %$ /mesa %ahoy ~)
+  =^  move-ahoy-2  bud  (call bud ~[//unix] %hear (snag-packet 0 move-ahoy-1))
+  ?>  ?=([* [^ %pass *] *] move-ahoy-2)
+  =^  ack-ahoy  bud
+    (call bud `duct`[/bone/~nec/0/5 //unix ~] %deep %ahoy ship=~nec bone=5)
+  =^  move-ahoy-4  nec  (call nec ~[//unix] %hear (snag-packet 0 ack-ahoy))
+  ::  XX assert move-ahoy-4 == [duct=[i=/g/ahoy t=~] %give p=[%done error=~]]
+  ::
+  =^  move-ahoy-5  nec  (call nec ~[/g/hood] %mate `~bud dry=|)
+  =/  poke-roof
+    (make-roof /flow/0/poke/for/~bud/1 message+!>(plea/poke-plea))
+  =^  move-ahoy-6  nec
+    %+  call  nec(rof poke-roof)
+    :+  :+  :-  %ames  ::  added by %arvo when passing a move to %a
+            /mesa/flow/ack/for/~bud/0/0
+          //unix
+        ~
+      %moke
+    (snag-moke 0 move-ahoy-5)
+  =^  moves2  bud  (call bud ~[//unix] %heer (snag-push 0 move-ahoy-6))
+  =^  moves3  bud  (take bud /bone/~nec/1 ~[//unix] %g %done ~)
+  %+  expect-eq
+    !>  1
+    !>  (lent `(list move:ames)`moves3)  :: %pass %mage for the ack
 ::
 --

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -70,6 +70,7 @@
 =/  marbud-sym  (derive-symmetric-key:ames marbud-pub priv.ames-state.comet)
 =/  marbud2-sym  (derive-symmetric-key:ames marbud-pub priv.ames-state.comet2)
 =/  bud-marbud-sym  (derive-symmetric-key:ames bud-pub priv.ames-state.marbud)
+=/  bud-comet-sym  (derive-symmetric-key:ames nec-pub priv.ames-state.comet)
 ::
 =/  comet-sym  (derive-symmetric-key:ames bud-pub priv.ames-state.comet)
 ::
@@ -160,6 +161,24 @@
     ==
   =.  route.peer-state  `[direct=%.y `lane:ames`[%| `@`%lane-bar]]
   [%known peer-state]
+::  alien peers
+::
+=.  peers.ames-state.bud
+  %+  ~(put by peers.ames-state.bud)  our-comet
+  [%alien *alien-agenda:ames]
+::
+=.  chums.ames-state.comet
+  %+  ~(put by chums.ames-state.comet)  ~bud
+  =|  =fren-state:ames
+  =.  -.fren-state
+    :*  symmetric-key=bud-comet-sym
+        life=3
+        rift=0
+        public-key=bud-pub
+        sponsor=~bud
+    ==
+  =.  lane.fren-state  `[hop=0 `lane:pact:ames``@`~bud]
+  [%known fren-state]
 ::  metamorphose
 ::
 =>  .(nec +:(call:(nec) ~[//unix] ~ %born ~))
@@ -239,9 +258,17 @@
   ^-  roof
   |=  [lyc=gang pov=path vis=view bem=beam]
   ^-  (unit (unit cage))
-  ?.  &(=(s.bem pax) |(=(vis %x) =(vis [%$ %x]) =(vis [%g %x]) =(vis [%a %x])))
+  ?.  ?&  =(s.bem pax)
+          ?|  =(vis %x)
+              =(vis [%$ %x])
+              =(vis [%g %x])
+              =(vis [%a %x])
+              ?&  =(vis %j)
+                  =(%saxo q.bem)
+      ==  ==  ==
     [~ ~]
   ``val
+::
 ++  n-frags
   |=  n=@
   ^-  @ux
@@ -809,5 +836,42 @@
   %+  expect-eq
     !>  1
     !>  (lent `(list move:ames)`moves3)  :: %pass %mage for the ack
+::
+++  test-comet-sends-mesa
+  ::  turn on for verbosity
+  ::
+  :: =^  moves0  bud
+  ::   (call bud ~[/g/hood] %spew ~[%fin %for %ges %kay %msg %odd %rcv %rot %snd %sun])
+  ::  load %mesa core into the comet
+  ::
+  =^  moves1  comet  (call comet ~[/hood] %load %mesa)
+  ::  send a %mesa packet to bud that has %ames as the default core
+  ::
+  =/  poke-plea  [%g /talk [%get %post]]
+  =^  moves1  comet  (call comet ~[/g/talk] %plea ~bud poke-plea)
+  =/  poke-roof
+    (make-roof /flow/0/poke/for/~bud/1 message+!>(plea/poke-plea))
+  =^  moves2  comet
+    %+  call  comet(rof poke-roof)
+    :+  :+  :-  %ames  ::  added by %arvo when passing a move to %a
+            /mesa/flow/ack/for/~bud/0/0
+          //unix
+        ~
+      %moke
+    (snag-moke 0 moves1)
+  =/  comet-roof
+    (make-roof /(scot %p our-comet) noun+!>(~[0]))
+  =^  moves2  bud
+    (call bud(rof comet-roof) ~[//unix] %heer (snag-push 0 moves2))
+  =/  [=lane:pact:ames blob=@]  (snag-push 0 moves2)
+  =/  =pact:pact:ames
+    :-  hop=0
+    :-  %peek
+    :+  [her=~bosrym-podwyl-magnes-dacrys--pander-hablep-masrym-marbud rif=0]
+      [boq=13 wan=~]
+    pat=/publ/1/a/x/1//pawn/proof/~bud/3
+  %+  expect-eq
+    !>  pact
+    !>  (parse-packet:bud blob)  :: %pass %peek for the attestation
 ::
 --

--- a/tests/sys/vane/mesa/boon.hoon
+++ b/tests/sys/vane/mesa/boon.hoon
@@ -124,7 +124,7 @@
     %:    ames-check-call:v  bud
         [~1111.1.1 0xdead.beef bon-roof]
     ::
-      [~[ack-wire /poke] moke]
+      [~[[%ames ack-wire] /poke] moke]
     ::
       =/  blob=@
         %:   ames-make-pact:v  bud

--- a/tests/sys/vane/mesa/nax.hoon
+++ b/tests/sys/vane/mesa/nax.hoon
@@ -54,7 +54,7 @@
     (ames-call:v nec [~[/poke] [%plea ~bud poke-plea] *roof])
   ::
   =^  *  nec
-    (ames-call:v nec ~[ack-wire /poke] moke poke-roof)
+    (ames-call:v nec ~[[%ames ack-wire] /poke] moke poke-roof)
   ::
   =/  message=mess:ames
     [%poke [~bud ack-path] [~nec poke-path] page=[%message plea/poke-plea]]
@@ -101,7 +101,7 @@
   ~?  >  dbug  '~nec starts %peeking for the naxplanation on ~bud'
   ::
   =^  moves-x  nec
-    (ames-call:v nec [~[nax-wire /poke] meek nax-roof])
+    (ames-call:v nec [~[[%ames nax-wire] /poke] meek nax-roof])
   ~?  >  dbug  '~bud gives ~nec the first fragment'
   =^  moves-y  bud     (ames-reply:v bud ~[/unix-pact] moves-x nax-roof)
   ~?  >  dbug  '~nec hears complete message'
@@ -112,8 +112,11 @@
   =^  moves-3  nec
     %:    ames-check-take:v  nec
         [~1111.1.1 0xdead.beef *roof]
-      ?>  ?=([[^ [%give %sage *]] *] moves-page)
-      [wire=i.duct duct=t.duct %ames p.card]:i.moves-page
+      ?>  ?=([[[[%ames *] *] [%give %sage *]] *] moves-page)
+      ::  remove reentrant %ames wire; this would be done by %arvo to route it
+      ::  to the %ames vane
+      ::
+      [wire=t.i.duct duct=t.duct %ames p.card]:i.moves-page
     ::
       :~  :-  ~[/poke]
           [%give %done `*error:ames]

--- a/tests/sys/vane/mesa/plea.hoon
+++ b/tests/sys/vane/mesa/plea.hoon
@@ -73,7 +73,7 @@
     %:    ames-check-call:v  nec
         [~1111.1.1 0xdead.beef poke-roof]
     ::
-      [~[ack-wire /poke] moke]
+      [~[[%ames ack-wire] /poke] moke]
     ::
       =/  blob=@
         %:   ames-make-pact:v  nec


### PR DESCRIPTION
- Breached peers that had been ahoyed lost communication: Previously, the breached peer would remain in .chums, ignoring the default core (%ames as the time of writing), making that all packets from the breached peer after booting would be dropped.

  (note: this doesn't handle the case for people that migrated anybody, that then after breached. this would need to be done in a state migration, or as soon as a peer hears an %ames packet for a peer that only has azimuth-state, but nothing else—probably also confirming that the default core is %ames, so we prevent weird any weird behavior when the default core changes)

- If the %ack for a %cork $plea got lost, the receiver of the resend would no-op since the flow was in closing.

- The handling of migrated/regressed peers has been refactored to account for receiving %mesa packets when the peer is an %alien

- TODO: test
