### PR TITLE
ames: retry dead flows once a day with some jitter

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5991,6 +5991,10 @@
                 ::  tell congestion control a packet timed out
                 ::
                 =.  metrics.state  on-timeout:gauge
+                =?  metrics.state  (lth 100.000 tries:-:+:-:(pop:packet-queue live.state))
+                  =/  jitter=@da  (mul ~s1 (~(rad og eny) 43.200))
+                  metrics.state(rto (add ~d1 jitter))
+                ::
                 =|  acc=(unit static-fragment)
                 ::  re-send first packet and update its state in-place
                 ::


### PR DESCRIPTION
The randomly generated jitter is up to 12 hours with one second resolution. This is to avoid potential thundering herd problems. A dead flow is defined as a flow we've retried 100.000 times which'll amount to around two months.