### PR TITLE
mesa: client handling of %sage 

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -394,6 +394,7 @@
         =/  sig=@  (full path data)
         ?~  data  sig
         (mix sig (lsh 9 (jam data)))
+      ::
       ++  etch-open
         |=  [=path =hunk data=$@(~ (cask))]
         (etch path hunk (etch-data path data))
@@ -413,6 +414,7 @@
           =-  (flop - res)
           (etch-meow (make-meow path mes num))
         $(num +(num), res :_(res (etch-meow (make-meow path mes num))))
+      ::
       --
     ::  +etch-open-packet: convert $open-packet attestation to $shot
     ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3558,7 +3558,9 @@
         ?>  ?=(^ kid)
         ?~  key=(get:key-chain client-chain:(got-per ship) u.kid)
           !!  :: XX handle
-        ?>  (lte (met 3 -.u.key) 32)
+        ?>  ?|  (lte (met 3 -.u.key) 64)  :: XX support old key reservation
+                (lte (met 3 -.u.key) 32)
+            ==
         pub
       ::
           [%chum lyf=@ her=@ hyf=@ pat=[cyf=@ ~]]

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -31,7 +31,7 @@
 ::  +sign: private response from another vane to eyre
 ::
 +$  sign
-  $%  [%ames $>(?(%done %boon %lost %tune) gift:ames)]
+  $%  [%ames $>(?(%done %boon %lost %tune %sage) gift:ames)]
       [%behn $>(%wake gift:behn)]
       [%gall gift:gall]
       [%clay gift:clay]
@@ -4096,12 +4096,23 @@
           on-fail:server:eauth:authentication:(per-server-event args)
         [moz http-server-gate]
       ::
-      ?>  ?=([%ames %tune *] sign)
-      ?>  =(client ship.sign)
+      ?>  ?|  ?&  ?=([%ames %tune *] sign)
+                  =(client ship.sign)
+              ==
+              ?&  ?=([%ames %sage *] sign)
+                  =(client ship.p.sage.sign)
+          ==  ==
       =/  url=(unit @t)
-        ?~  roar.sign  ~
-        ?~  q.dat.u.roar.sign  ~
-        ;;((unit @t) q.u.q.dat.u.roar.sign)
+        ?+    +<.sign  ~
+            %tune
+          ?~  roar.sign  ~
+          ?~  q.dat.u.roar.sign  ~
+          ;;((unit @t) q.u.q.dat.u.roar.sign)
+        ::
+            %sage
+          ?~  q.sage.sign  ~
+          ;;((unit @t) q.q.sage.sign)
+        ==
       =^  moz  server-state.ax
         ?~  url
           %.  [client nonce]

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1438,7 +1438,7 @@
         (~(put by gem.yoke) coop ~)
       =/  =wire  (welp /key/[agent-name]/[run-nonce.yoke]/pug coop)
       ::  XX %plug reserves keys in %ames using (shaz eny) of length 64
-      :: use %gulp that reserves keys og length 32?
+      :: use %gulp that reserves keys of length 32?
       ::
       (ap-move [hen %pass wire %a %plug [%g %x agent-name %$ '1' coop]]~)
     ::
@@ -1891,6 +1891,7 @@
         ?+  sign-arvo  ken.yoke
           [%ames %tune spar=* *]  (~(del ju ken.yoke) spar.sign-arvo wire)
           [%ames %sage spar=* *]  (~(del ju ken.yoke) p.sage.sign-arvo wire)
+          [%ames %near spar=* *]  (~(del ju ken.yoke) spar.sign-arvo wire)
         ==
       ?^  maybe-tang
         (ap-error %arvo-response u.maybe-tang)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -835,6 +835,7 @@
       =.  mo-core  (mo-give %unto %kick ~)
       mo-core
     ==
+  ::
   ++  mo-handle-key
     ~/  %mo-handle-stub
     |=  [=(pole knot) syn=sign-arvo]
@@ -1296,8 +1297,9 @@
         [leaf+"gall: {<agent-name>}: brood request {<pole>} invalid, dropping"]~
       =.  pen.yoke  (~(put ju pen.yoke) [ship pole] wire)
       =/  =fine-request  [%0 rest.pole]
-      =/  =plea:ames  [%g /gk/[app.pole] fine-request]
-      =/  out=^wire   (welp /key/[agent-name]/[run-nonce.yoke]/bod/(scot %p ship) pole)
+      =/  =plea:ames     [%g /gk/[app.pole] fine-request]
+      =/  out=^wire
+        (welp /key/[agent-name]/[run-nonce.yoke]/bod/(scot %p ship) pole)
       (ap-move [hen %pass out %a %plea ship plea]~)
     ::
     ++  ap-take-brood
@@ -1317,7 +1319,8 @@
         ?~  bod.bud
           =.  ap-core  (ap-generic-take i.wis %ames %near [ship t.wire] ~)
           $(wis t.wis)
-        =.  ap-core  (ap-pass i.wis %arvo %a %keen `[idx key]:hutch.u.bod.bud ship t.wire)
+        =.  ap-core
+          (ap-pass i.wis %arvo %a %keen `[idx key]:hutch.u.bod.bud ship t.wire)
         $(wis t.wis)
       ::
           [%ames %done *]
@@ -1881,8 +1884,11 @@
       =^  maybe-tang  ap-core
         %+  ap-ingest  ~  |.
         (on-arvo:ap-agent-core wire sign-arvo)
-      =?  ken.yoke  ?=([%ames %tune spar=* *] sign-arvo)
-        (~(del ju ken.yoke) spar.sign-arvo wire)
+      =.  ken.yoke
+        ?+  sign-arvo  ken.yoke
+          [%ames %tune spar=* *]  (~(del ju ken.yoke) spar.sign-arvo wire)
+          [%ames %sage spar=* *]  (~(del ju ken.yoke) p.sage.sign-arvo wire)
+        ==
       ?^  maybe-tang
         (ap-error %arvo-response u.maybe-tang)
       ap-core

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1437,6 +1437,9 @@
       =?  gem.yoke  &(!exists ?=(~ pen))
         (~(put by gem.yoke) coop ~)
       =/  =wire  (welp /key/[agent-name]/[run-nonce.yoke]/pug coop)
+      ::  XX %plug reserves keys in %ames using (shaz eny) of length 64
+      :: use %gulp that reserves keys og length 32?
+      ::
       (ap-move [hen %pass wire %a %plug [%g %x agent-name %$ '1' coop]]~)
     ::
     ++  ap-stub

--- a/pkg/arvo/ted/peek.hoon
+++ b/pkg/arvo/ted/peek.hoon
@@ -3,7 +3,7 @@
 =,  strand=strand:spider
 ^-  thread:spider
 =>  |%  +$  out  $%  [%sage =sage:mess:ames]
-                     [%tune (pair spar:ames (unit roar:ames))]
+                     [%roar (pair spar:ames (unit roar:ames))]
                      [%page (pair spar:ames (unit (unit page)))]
                  ==
     --
@@ -23,7 +23,7 @@
 =/  =sage:mess:ames
   ?-  -.out
     %sage  sage.out
-    %tune  :-  p.+.out
+    %roar  :-  p.+.out
            ?~  q.+.out  ~
            ?~  q.dat.u.q.+.out  ~
            u.q.dat.u.q.+.out

--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -232,7 +232,7 @@
 ::
 ++  take-message
   =>  |%  +$  out  $%  [%sage sage:mess:ames]
-                       [%tune spar:ames (unit roar:ames)]
+                       [%roar spar:ames (unit roar:ames)]
                        [%page spar:ames (unit (unit page))]
                    ==
       --
@@ -251,7 +251,7 @@
       [~ %sign * %ames %tune ^ *]
     ?.  =(wire wire.u.in.tin)
       `[%skip ~]
-    `[%done %tune +>.sign-arvo.u.in.tin]
+    `[%done %roar +>.sign-arvo.u.in.tin]
     ::
       [~ %sign * %ames %near ^ *]
     ?.  =(wire wire.u.in.tin)


### PR DESCRIPTION
fixes:
  - eauth scries were broken for migrated peers
  - there was a space leak in %gall in which we were not removin outstanding %keens when hearing a %near or a %sage
  - %shut (multi-party remote scry) payloads, encrypted with keys created using 64 bytes of entropy would crash on the receiver if it had been migrated to |mesa, because we were asserting that the key was of length 32 (see %gulp task in %ames; currently not used by %gall)

- this opens the question of how to unify the three types of gifts that you might get using remote scry:
  - %tune, for public data via %fine
  - %near, for two (%chum) and multi-party (%shut) encrypted remote scry, via %fine
  - %sage, for any type of namespace +peek, via %mesa 

%sage and %near are identical, a spar and maybe a page of data. %tune adds (using the $roar type) signature information at a specific life, but this information is not used by any of the client vanes (%clay, %gall).

- options:
  - unifying all these gifts as one thing (e.g. a %near so we don't introduce new types)
    - %gall stills injects a %near with an empty response into an agent if there's been an error, or the plea asking for the encryption keys got nacked, so that suggest that %near might be a good candidate for unification
  - support %near/%tune for backwards compatibility, but favoring %sage for 409k? 
  -  ?? 