### PR TITLE
ames: add %tune to $sign to not break old queued-events

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -127,7 +127,7 @@
     |%
     +$  sign
       $~  [%behn %wake ~]
-      $%  [%ames $>(%sage gift)]
+      $%  [%ames $>(?(%tune %sage) gift)]
           [%behn $>(%wake gift:behn)]
           [%gall $>(?(%flub %unto) gift:gall)]
           [%jael $>(?(%private-keys %public-keys %turf) gift:jael)]
@@ -7991,7 +7991,7 @@
               ?:  ?=([%gall %unto *] sign)  :: XX from poking %ping app
                 `ames-state
               ::
-              ?-  sign
+              ?+  sign  `ames-state  :: XX %tune; not used
                 [%behn %wake *]  sy-abet:(~(sy-wake sy hen) wire error.sign)
               ::
                   [%jael %private-keys *]


### PR DESCRIPTION
the last queued events up to state %22 had a %tune $sign that was replaced with a %sage but need to be re-added so old and new types nest—this is easier than migrating the queued %tune event into a %sage