### PR TITLE
ames, gall: handle dead flows to non-running agents

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -898,6 +898,7 @@
         [%whey =spar boq=@ud]       :: weight of noun bounded at .path.spar
                                     :: as measured by .boq
         [%gulp path]                :: like %plug, but for |mesa
+        [%rock =ship =bone]         :: inmediately cork a forward flow
     ==
   ::
   ::  $gift: effect from ames
@@ -1044,6 +1045,7 @@
         [%kill =ship =bone]
         [%ahoy =ship =bone]  :: XX remove bone; it's just next-bone.ossuary
         [%prun =ship =user=path =duct =ames=path]
+        [%flub =ship agent=term =bone]
     ==
   ::  $stun: STUN notifications, from unix
   ::
@@ -3656,7 +3658,7 @@
     $%  [%boon payload=*]                               ::  ames response
         [%noon id=* payload=*]
         [%done error=(unit error:ames)]                 ::  ames message (n)ack
-        [%flub ~]                                       ::  not ready to handle plea
+        [%flub agent=term]                              ::  refuse to take plea
         [%unto p=unto]                                  ::
     ==                                                  ::
   +$  task                                              ::  incoming request
@@ -3671,6 +3673,7 @@
         [%doff dude=(unit dude) ship=(unit ship)]       ::  kill subscriptions
         [%rake dude=(unit dude) all=?]                  ::  reclaim old subs
         [%lave subs=(list [?(%g %a) ship dude duct])]   ::  delete stale bitt(s)
+        $>(%flub deep:ames)                             ::  send remote flub
         $>(%init vane-task)                             ::  set owner
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade
@@ -3701,9 +3704,9 @@
         [%plot p=(unit plot) q=(map @ta farm)]
     ==
   ::
-  +$  egg                                               ::  migratory agent state
-    $%  [%nuke sky=(map spur @ud) cop=(map coop hutch)] ::  see /sys/gall $yoke
-        $:  %live
+  +$  egg                                               ::  migratory agent
+    $%  [%nuke sky=(map spur @ud) cop=(map coop hutch)] ::  state; see /sys/gall
+        $:  %live                                       ::  $yoke
             control-duct=duct
             run-nonce=@t
             sub-nonce=@
@@ -3720,7 +3723,7 @@
             pen=(jug spar:ames wire)
             gem=(jug coop [path page])
     ==  ==
-  +$  egg-any  $%([%15 egg-15] [%16 egg])
+  +$  egg-any  $%([%15 egg-15] [%16 egg] [%17 egg])
   +$  egg-15
     $%  [%nuke sky=(map spur @ud)]
     $:  %live


### PR DESCRIPTION
XX add background info

- Option a) (in this PR): every %gall will open a subscription flow to any remote %gall upon first contact (similar to /sys/era, a subscription flow mediated by %jael for breach handling). This /flub flow will receive %boons from the remote %gall when it %flubs a %plea we have sent. Both %ames will cork the flow to avoid race conditions where the agent is immediately revived after sending the remote %flub—this is the reverse behavior as the "normal" %cork, the backward flow corks first, the forward flow corks after hearing the %flub %boon on the /flub subscription flow.
  -  XX TODO in |mesa: don't cork immediately, mark as closing and +peek the forward side
- Option b) Don't use a separate flow, send a boon on the same flow that's been flubbed.
- Option c) Handle %flub(s) by naking the %plea.  

- XX TODO: How do we get notified that the remote agents has installed/revived the app? +peek on a specific timer that the app has been installed