### PR TITLE
eyre: fix double boot protection bone format

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1126,7 +1126,7 @@
     =/  ship=(unit ship)  (slaw %p ship.crumbs)
     =/  bone=(unit @ud)
       ?.  ?=([bone=@t ~] req.crumbs)  ~
-      (slaw %ud bone.req.crumbs)
+      (rush bone.req.crumbs dem)
     ?:  ?|  ?=(~ ship)
             &(?=([bone=@ ~] req.crumbs) ?=(~ bone))
         ==


### PR DESCRIPTION
The runtime makes the http requests for double boot protection using the standard C `%d` format but the endpoint in eyre expects the bone to be `@ud` formatted. This causes a mismatch if the ping-bone is larger than 1000, causing double boot protection to become disabled. We address the mismatch in arvo instead of vere because this is easier to release.