### PR TITLE
hoon macro expansion

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8848,6 +8848,7 @@
           rib=*(set [type type hoon])
           vet=`?`&
       ==
+  =|  ros=(map term $-((list hoon) hoon))
   =+  sut=`type`%noun
   |%
   ++  clip
@@ -10010,12 +10011,6 @@
   ++  mint
     ~/  %mint
     |=  [gol=type gen=hoon]
-    ^-  [p=type q=nock]
-    (mimt gol gen ~)
-  ::
-  ++  mimt
-    ~/  %mimt
-    |=  [gol=type gen=hoon ros=(map term $-((list hoon) hoon))]
     ^-  [p=type q=nock]
     ::~&  %pure-mint
     |^  ^-  [p=type q=nock]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13033,7 +13033,12 @@
       :-  '\''
         (stag %sand (stag %t qut))
       :-  '('
-        (stag %cncl (ifix [pal par] (most ace wide)))
+        ;~  pose
+          (stag %cncl (ifix [pal par] (most ace wide)))
+        ::
+          %+  stag  %hxcn
+          (ifix [pal par] ;~(plug ;~(sfix sym zap ace) (most ace wide)))
+        ==
       :-  '*'
         ;~  pose
           (stag %kttr ;~(pfix tar wyde))

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6600,6 +6600,8 @@
     [%zppt p=(list wing) q=hoon r=hoon]                 ::  !@
     [%zpwt p=$@(p=@ [p=@ q=@]) q=hoon]                  ::  !?
     [%zpzp ~]                                           ::  !!
+  ::                                            ::::::  macro expansion
+    [%hxcn p=term q=(list hoon)]                        ::  #%  expand with args
   ==                                                    ::
 +$  tyre  (list [p=term q=hoon])                        ::
 +$  tyke  (list (unit hoon))                            ::
@@ -10009,6 +10011,12 @@
     ~/  %mint
     |=  [gol=type gen=hoon]
     ^-  [p=type q=nock]
+    (mimt gol gen ~)
+  ::
+  ++  mimt
+    ~/  %mimt
+    |=  [gol=type gen=hoon ros=(map term $-((list hoon) hoon))]
+    ^-  [p=type q=nock]
     ::~&  %pure-mint
     |^  ^-  [p=type q=nock]
     ?:  ?&(=(%void sut) !?=([%dbug *] gen))
@@ -10153,6 +10161,14 @@
     ::
         [%zpts *]   [(nice %noun) [%1 q:$(vet |, gen p.gen)]]
         [%zppt *]   ?:((feel p.gen) $(gen q.gen) $(gen r.gen))
+    ::
+        [%hxcn *]
+      =/  cro  ~|  %macro-lost  (~(got by ros) p.gen)
+      =/  doz  ~|  %macro-fail  (cro q.gen)
+      ?:  =(doz gen)
+        ~_  (show [%c 'hoon'] [%q gen])
+        ~>(%mean.'mint-macro-open' !!)
+      $(gen doz)
     ::
         [%zpzp ~]  [%void [%0 0]]
         *
@@ -13484,6 +13500,10 @@
                   ['?' (rune wut %zpwt hinh)]
               ==
             ==
+          :-  '#'
+            ;~  pfix  hax
+              (rune cen %hxcn expl)
+            ==
       ==
     ::
     ++  boog  !:
@@ -13765,6 +13785,7 @@
     ++  expx  |.(;~(goop ropa loaf loaf))               ::  wings and two hoons
     ++  expy  |.(loaf(bug &))                           ::  hoon with tracing
     ++  expz  |.(;~(goop loan loaf loaf loaf))          ::  spec and three hoons
+    ++  expl  |.((butt ;~(goop sym hank)))              ::  term, hoons
     ::  spec contents
     ::
     ++  exqa  |.(loan)                                  ::  one spec


### PR DESCRIPTION
An idea that should probably target next 408: macro expansion rune `#%`.

Adds a global parameter `ros` - a map from macro name `term` to a macro definition. Comes with sugar syntax `(macro! arg1 arg2 argn)`

The map should be filled before compiling code. E.g. Ford could feature Ford runes to define macros after the imports and before the actual source code.