### PR TITLE
clay: ignore bad desks in +suspend-non-essentials

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2325,9 +2325,10 @@
         =/  kel=(set weft)
           ?:  (~(has by wic.dom.dojo) sys-kel)
             [sys-kel ~ ~]
+          =/  t=(unit tako)  (~(get by hit.dom.dojo) let.dom.dojo)
+          ?~  t  [sys-kel ~ ~]
           %-  waft-to-wefts
-          %+  get-kelvin  %|
-          (tako-to-yaki:ze (~(got by hit.dom.dojo) let.dom.dojo))
+          (get-kelvin %| (tako-to-yaki:ze u.t))
         ?:  (~(has in kel) sys-kel)  l
         [[desk %held] l]
         ==


### PR DESCRIPTION
My previous PR #7178 introduced the following bug (unreleased, on develop):

If you are in the process of installing a new desk and haven't received any commits yet you would be unable to make any commits to `%base` `/sys` because of `+suspend-non-essentials` being unable to find a `/sys/kelvin` for the incoming desk. This would be especially bad if you typoed your install command and the desk didn't really exist anywhere.The only workaround for affected ships would be to mark the bad desk as essential with `|essential-desk %problem-desk %.y` and then applying a commit to fix the issue.

Here we instead no-op if we are unable to find a `/sys/kelvin` file in either a future pending commit or the current commit. Note that earlier in `+suspend-non-essentials` we still require `%base` to have a valid `/sys/kelvin`.