### PR TITLE
hoon: pith tests and fixes

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5979,6 +5979,7 @@
   ::
   ++  spot
     %+  sear  (soft iota)
+    =-  ;~(pose - (easy %$))
     %-  stew
     ^.  stet  ^.  limo
     :~  :-  'a'^'z'  sym
@@ -11844,7 +11845,8 @@
       ?@  iota  [%rock %tas iota]
       ?:  ?=(%hoon -.iota)  hoon.iota
       [%clhp [%rock %tas -.iota] [%sand iota]]
-    |^  %-  stew
+    |^  =-  ;~(pose - (easy %$))
+      %-  stew
       ^.  stet  ^.  limo
       :~  :-  'a'^'z'  ;~  pose
                          (spit (stag %cncl (ifix [pal par] (most ace wide))))
@@ -13213,9 +13215,15 @@
               [i (snoc t e)]
             ;~  plug
               %+  most  ;~(less ;~(plug fas tar) fas)
+              =-  ;~(pose - (easy [%leaf %tas %$]))
               %-  stew
               ^.  stet  ^.  limo
-              :~  :-  ['a' 'z']
+              :~  ::  /$
+                  ::
+                  :-  '$'
+                  (cold [%leaf %tas %$] buc)
+                ::
+                  :-  ['a' 'z']
                   ;~  pose
                     ::  /name=@aura
                     ::
@@ -13234,7 +13242,7 @@
                   ::
                     ::  /constant
                     ::
-                    (stag %leaf (stag %tas ;~(pose sym (cold %$ buc))))
+                    (stag %leaf (stag %tas sym))
                   ==
                 ::
                   ::  /@aura

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5981,8 +5981,8 @@
     %+  sear  (soft iota)
     %-  stew
     ^.  stet  ^.  limo
-    :~  :-  'a'^'z'  (stag %tas sym)
-        :-  '$'      (cold [%tas %$] buc)
+    :~  :-  'a'^'z'  sym
+        :-  '$'      (cold %$ buc)
         :-  '0'^'9'  bisk:so
         :-  '-'      tash:so
         :-  '.'      zust:so

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5986,7 +5986,7 @@
         :-  '$'      (cold %$ buc)
         :-  '0'^'9'  bisk:so
         :-  '-'      tash:so
-        :-  '.'      zust:so
+        :-  '.'      ;~(pfix dot zust:so)
         :-  '~'      ;~(pfix sig ;~(pose crub:so (easy [%n ~])))
         :-  '\''     (stag %t qut)
     ==

--- a/tests/sys/hoon/pith.hoon
+++ b/tests/sys/hoon/pith.hoon
@@ -4,28 +4,28 @@
 |%
 ++  test-literal-syntax
   %+  expect-eq
-    !>(`pith`~[%$ %$ %a ud+1 p+~zod t+'BAZ!'])
-  !>(`pith`#/$//a/1/~zod/'BAZ!')
+    !>(`pith`~[%$ %$ %a ud+1 p+~zod q+.~binnec t+'BAZ!'])
+  !>(`pith`#/$//a/1/~zod/.~binnec/'BAZ!')
 ::
 ++  test-pattern-syntax
-  =/  pith=(pole iota)  #/$//a/1/~zod/'BAZ!'
-  ?>  ?=(#/$//a/x=@ud/y=@p/@t pith)
+  =/  pith=(pole iota)  #/$//a/1/~zod/.~binnec/'BAZ!'
+  ?>  ?=(#/$//a/x=@ud/y=@p/@q/@t pith)
   %+  weld
     (expect-eq !>(1) !>(x.pith))
   (expect-eq !>(~zod) !>(y.pith))
 ::
 ++  test-stip
   %+  expect-eq
-    !>(#/$//a/1/~zod/'BAZ!')
-  !>((rash '/$//a/1/~zod/\'BAZ!\'' stip))
+    !>(#/$//a/1/~zod/.~binnec/'BAZ!')
+  !>((rash '/$//a/1/~zod/.~binnec/\'BAZ!\'' stip))
 ::
 ++  test-pout
   %+  expect-eq
-    !>(/$//a/1/~zod/~~~42.~41.~5a.~21.)
-  !>((pout #/$//a/1/~zod/'BAZ!'))
+    !>(/$//a/1/~zod/.~binnec/~~~42.~41.~5a.~21.)
+  !>((pout #/$//a/1/~zod/.~binnec/'BAZ!'))
 ::
 ++  test-pave
   %+  expect-eq
-    !>(#/$//a/1/~zod/'BAZ!')
-  !>((pave /$//a/1/~zod/~~~42.~41.~5a.~21.))
+    !>(#/$//a/1/~zod/.~binnec/'BAZ!')
+  !>((pave /$//a/1/~zod/.~binnec/~~~42.~41.~5a.~21.))
 --

--- a/tests/sys/hoon/pith.hoon
+++ b/tests/sys/hoon/pith.hoon
@@ -1,0 +1,31 @@
+::  tests for $pith, $iota, their literal and pattern syntaxes, and utils
+::
+/+  *test
+|%
+++  test-literal-syntax
+  %+  expect-eq
+    !>(`pith`~[%$ %$ %a ud+1 p+~zod t+'BAZ!'])
+  !>(`pith`#/$//a/1/~zod/'BAZ!')
+::
+++  test-pattern-syntax
+  =/  pith=(pole iota)  #/$//a/1/~zod/'BAZ!'
+  ?>  ?=(#/$//a/x=@ud/y=@p/@t pith)
+  %+  weld
+    (expect-eq !>(1) !>(x.pith))
+  (expect-eq !>(~zod) !>(y.pith))
+::
+++  test-stip
+  %+  expect-eq
+    !>(#/$//a/1/~zod/'BAZ!')
+  !>((rash '/$//a/1/~zod/\'BAZ!\'' stip))
+::
+++  test-pout
+  %+  expect-eq
+    !>(/$//a/1/~zod/~~~42.~41.~5a.~21.)
+  !>((pout #/$//a/1/~zod/'BAZ!'))
+::
+++  test-pave
+  %+  expect-eq
+    !>(#/$//a/1/~zod/'BAZ!')
+  !>((pave /$//a/1/~zod/~~~42.~41.~5a.~21.))
+--


### PR DESCRIPTION
#5887 added `$pith`, a type for "typed paths". This addition came with language-level support for both literals and patterns, as well as some stdlib utilities.

Turns out I had been negligent in my testing of those additions. This PRs addresses two problems, in the stdlib utils and syntax support respectively.

- Primarily, the `$iota` parser `+spot:stip` and the `+pave` utility that depends on it were broken. For constant symbol elements (ie, `#/foo`) the parser would produce `[%tas %foo]`. The final parse step `+soft`s the parse result into the `$iota` type, but for `@tas` that type omits the label and expects the symbol as-is. Parsing would fail. `+pave` would make this silently fall back to `[%ta ~.foo]`.  
  We patch the parser to correctly produce a `@tas` for those cases. (42c8dcf)
  - @yosoyubik ames uses its own implementation of `+pave` (`+mesa-pave`), presumably to work around the broken behavior. It still calls out to `+spot:stip` though. I _think_ the change here won't affect its behavior, but please review for impact carefully.

- Secondarily, the pattern parser didn't support writing `$` to indicate an empty path segment (a la `%$`), and none of the parsers (`+stip`, literal or pattern syntax) supported empty segments in the way that `$path` syntax does.  
  We patch the parsers to support the empty segment cases consistently. (7fff467)

We also add tests for (what I imagine should be) the expected behavior. (e43e902) The original PR should not have been merged without such tests.