### PR TITLE
fix muk jet

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1034,9 +1034,10 @@
 +|  %insecure-hashing
 ::
 ++  muk                                                 ::  standard murmur3
-  ~%  %muk  ..muk  ~
-  =+  ~(. fe 5)
+  ~/  %muk
   |=  [syd=@ len=@ key=@]
+  =+  ~(. fe 5)
+  |^  ^-  @
   =.  syd      (end 5 syd)
   =/  pad      (sub len (met 3 key))
   =/  data     (weld (rip 3 key) (reap pad 0))
@@ -1047,7 +1048,7 @@
   =/  i  nblocks
   =.  h1  =/  hi  h1  |-
     ?:  =(0 i)  hi
-    =/  k1  (snag (sub nblocks i) blocks)  ::  negative array index
+    =/  k1  (snug (sub nblocks i) blocks)  ::  negative array index
     =.  k1  (sit (mul k1 c1))
     =.  k1  (rol 0 15 k1)
     =.  k1  (sit (mul k1 c2))
@@ -1080,7 +1081,7 @@
           (mix h1 k1)
     ==
   =.  h1  (mix h1 (end 5 len))
-  |^  (fmix32 h1)
+  (fmix32 h1)
   ++  fmix32
     |=  h=@
     =.  h  (mix h (rsh [0 16] h))
@@ -1089,6 +1090,12 @@
     =.  h  (sit (mul h 0xc2b2.ae35))
     =.  h  (mix h (rsh [0 16] h))
     h
+  ::
+  ++  snug
+    |=  [a=@ b=(list @)]
+    ^-  @
+    ?:  (gte a (lent b))  0
+    (snag a b)
   --
 ::
 ++  mug                                                 ::  mug with murmur3


### PR DESCRIPTION
There are two issues with hoon version of `+muk`: `+fe` core is pinned outside of the definition of the jetted battery, leading to potential jet mismatches if `+fe` core in the head of the context of the gate is manipulated.

The second is an actual mismatch: if the length `len` of `key`, divided by four, is greater than the length of `nblocks` list, then Nock version would crash due to the lack of padding in `nblocks`. This is fixed by adding implicit padding in form of `+snug` gate.

This commit changes the registration for `+muk`, so it depends on vere PR.