### PR TITLE
dojo: prevent binding to %help

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -570,7 +570,7 @@
       =+  cay=(~(got by rez) p.q.mad)
       ?-    -.p.mad
           %verb
-        ?:  ?=(?(%eny %now %our) p.p.mad)
+        ?:  ?=(?(%eny %now %our %help) p.p.mad)
           (dy-rash %tan (cat 3 p.p.mad ' is immutable') ~)
         =.  var  (~(put by var) p.p.mad cay)
         ~|  bad-set+[p.p.mad p.q.cay]


### PR DESCRIPTION
### Description

Resolves #7199.

This fixes an inconsistency where the %help variable could be bound to but not unbound from in Dojo. The issue was that %help was missing from the immutable variable check in the %verb (binding) case on line 573, while it was correctly present in the %brev (unbinding) case on line 563.
