### PR TITLE
hoon: simpler ~? desugaring

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -8607,10 +8607,10 @@
     ::
         [%sgts *]  [%sggr [%germ p.gen] q.gen]
         [%sgwt *]
-      :+  %tsls  [%wtdt q.gen [%bust %null] [[%bust %null] r.gen]]
-      :^  %wtsg  [%& 2]~
-        [%tsgr [%$ 3] s.gen]
-      [%sgpm p.gen [%$ 5] [%tsgr [%$ 3] s.gen]]
+      :+  %tsls
+        :^  %wtcl  q.gen  [%sgpm p.gen r.gen %bust %null]
+        [%bust %null]
+      [%tsgr $+3 s.gen]
     ::
         [%mcts *]
       |-


### PR DESCRIPTION
Simpler `~?` desugaring, which, most importantly, uses only one branching rune, which would help in a more broad effort of branch elimination in e.g. print statements that check verbosity flags.

