### PR TITLE
iris: implement redirect following

### DIFF
--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -189,7 +189,7 @@
           `response-header:http-event
         ::
         [duct in-progress-http-request]
-      =/  status-code=@ud  status-code.response-header.http-event
+      =*  status-code=@ud  status-code.response-header.http-event
       ?:  ?|  =(307 status-code)
               =(303 status-code)
               =(301 status-code)
@@ -242,12 +242,11 @@
       |=  [duct=^duct =in-progress-http-request]
       :-  duct
       %=  in-progress-http-request
-        remaining-redirects
-      (dec remaining-redirects.in-progress-http-request)
+          remaining-redirects
+        (dec remaining-redirects.in-progress-http-request)
       ==
     :_  state
-    :_  ~
-    [outbound-duct.state %give %request id request(url u.loc)]
+    [outbound-duct.state %give %request id request(url u.loc)]~
   ::  +record-and-send-progress: save incoming data and send progress report
   ::
   ++  record-and-send-progress


### PR DESCRIPTION
Iris has had the `outbound-config` as a parameter for as long as the vane has existed, but the redirect and retry parameters have always been ignored and no retrying or redirect following has ever been done. Tlon recently implemented link previews and it turns out that if you share a link that causes an infinite redirect loop iris will just keep chugging along until the event gets manually interrupted.

Here we implement basic redirect following for HTTP status codes 301, 303, and 307. Notably when we upgrade to this new regime in `+load`, we set `redirects` for any outstanding requests to 0 because we cannot follow them without storing the original request.

We don't do any of the stuff that browsers do such as changing the request from POST to GET on certain status codes and not others. We will simply redirect the original request.

Retries are a somewhat tricky. As far as I can tell the `cttp.c` driver never sends `%cancel` events so the only time Iris requests get canceled is when vere starts up and passes a `%born`. This means that retrying could be risky, since it could very well be that the handling of the previous Iris request caused vere to shut down in the first place. A default retry count of 3 should hardly mean crash 3 times and then continue! We will deal with retries another day, so for now we'll just continue to ignore the parameter and pass the `%cancel` to the caller.

I also took the opportunity to clean up all the old references to `%light`.