### PR TITLE
ames: refactor +emil usage

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2962,7 +2962,7 @@
         $(cached-state `25+(state-24-to-25 +.old))
       ?:  ?=(%25 -.old)
         $(cached-state `26+(state-25-to-26 +.old))
-      ?>  ?=(%26 -.old) 
+      ?>  ?=(%26 -.old)
       ~>  %slog.0^leaf/"ames: re-fetching our public keys"
       %_    $
           -.u.cached-state  %27
@@ -4120,11 +4120,11 @@
               %-  ~(put in acc)
               [u.tim `^duct`~[ames+(make-pump-timer-wire who b) /ames]]
             =.  want
-              %-  ~(gas in want) 
+              %-  ~(gas in want)
               :~  ?:  ?=(~ +.cork.dead.ames-state)            ::  nacked corks
                     [(add now ~d1) ~[/ames/recork /ames]]     ::  (init if unset)
                   [date ames/wire duct]:u.cork.dead.ames-state
-              ::    
+              ::
                   ?:  ?=(~ +.chum.dead.ames-state)            ::  mesa retries
                     [(add now ~m2) ~[/ames/mesa/retry /ames]] ::  (init if unset)
                   [date ames/wire duct]:u.chum.dead.ames-state
@@ -4164,7 +4164,7 @@
               |=  [[wen=@da hen=^duct] this=_event-core]
               ?.  ?=([[%ames %mesa %ask %public-keys @ *] *] hen)
                 this
-              %+  emit:this  hen 
+              %+  emit:this  hen
               [%pass /public-keys %j %public-keys [n=(slav %p &5.i.hen) ~ ~]]
             ::  set timers for flows that should have one set but don't
             ::
@@ -4311,12 +4311,12 @@
                   ^=  sponsor  `(^sein:title sndr.shot)
               ==
             =+  sy-core=~(. sy:mesa duct)
-            =^  moves  ames-state
+            =^  publ-moves  ames-state
               ::  XX skip abet, only +ev-abet will flop these moves
               ::
               =<  [moves ames-state]
-              (sy-publ:sy-core / [%full (my [sndr.shot point]~)])
-            event-core(moves moves)
+              (~(sy-publ sy:mesa duct) / [%full (my [sndr.shot point]~)])
+            event-core(moves (weld publ-moves moves))
           ::  manually add the lane to the peer state
           ::
           =/  =peer-state  (gut-peer-state sndr.shot)
@@ -8302,7 +8302,7 @@
                 %init  sy-abet:sy-init:sy-core
                 %born  sy-abet:sy-born:sy-core
                 %cong  sy-abet:sy-cong:sy-core
-                %prod  (sy-prod:sy-core ships.task)
+                %prod  sy-abet:(sy-prod:sy-core ships.task)
                 %snub  sy-abet:(sy-snub:sy-core [form ships]:task)
                 %stun  sy-abet:(sy-stun:sy-core stun.task)
                 %dear  sy-abet:(sy-dear:sy-core +.task)
@@ -8317,30 +8317,30 @@
               ::  regression
               ::
                   %rege
-              ?.  dry.task  sy-abet:(sy-rege:sy-core +.task)
-              ?^  +<.task
-                ~|  %dry-regression-failed
-                ?>  (regression-test u.+<.task)
-                ~&  >  %dry-regression-worked
+                ?.  dry.task  sy-abet:(sy-rege:sy-core +.task)
+                ?^  +<.task
+                  ~|  %dry-regression-failed
+                  ?>  (regression-test u.+<.task)
+                  ~&  >  %dry-regression-worked
+                  `ames-state
+                ~&  >>  "regressing of {<~(wyt by chums.ames-state)>} chums"
+                =/  test=?
+                  ~>  %bout.[1 %make-mass-rege]
+                  %-  ~(rep by chums.ames-state)
+                  |=  [[=ship *] test=?]
+                  =/  works=?  (regression-test ship)
+                  ~?  >     works  rege-worked/ship
+                  ~?  >>   !works  rege-failed/ship
+                  &(test works)
+                ~?  >     test  %mass-rege-worked
+                ~?  >>>  !test  %mass-rege-failed
                 `ames-state
-              ~&  >>  "test regression of {<~(wyt by chums.ames-state)>} chums"
-              =/  test=?
-                ~>  %bout.[1 %make-mass-rege]
-                %-  ~(rep by chums.ames-state)
-                |=  [[=ship *] test=?]
-                =/  works=?  (regression-test ship)
-                ~?  >     works  rege-worked/ship
-                ~?  >>   !works  rege-failed/ship
-                &(test works)
-              ~?  >     test  %mass-rege-worked
-              ~?  >>>  !test  %mass-rege-failed
-              `ames-state
-              ::  from internal %ames request; XX check -.duct?
-              ::
-                ?(%meek %moke %mage)
-              ?.  ?=([[%ames *] *] hen)
-                `ames-state ::  XX log
-              co-abet:(co-call:co-core task)
+                ::  from internal %ames request; XX check -.duct?
+                ::
+                  ?(%meek %moke %mage)
+                ?.  ?=([[%ames *] *] hen)
+                  `ames-state ::  XX log
+                co-abet:(co-call:co-core task)
               ==
               ::
             [moves vane-gate]
@@ -8538,7 +8538,7 @@
         +|  %packet-entry-points
         ::
         ++  ev-pact
-          |%  
+          |%
           ++  hear-poke
             |=  [dud=(unit goof) =lane:pact =pact:pact]
             ^+  ev-core
@@ -10102,8 +10102,7 @@
           =?  sy-core  ?=(~ error)
             ::  if there's been an error, reset the timer and skip %proding
             ::
-            =^  prod-moves  ames-state  (sy-prod ~)
-            sy-core(moves (weld prod-moves moves))
+            (sy-prod ~)
           (sy-emit ~[/ames] %pass /mesa/retry %b %wait `@da`(add now ~m2))
         ::
         ++  sy-publ
@@ -10385,7 +10384,7 @@
                 (send-blob:c for=| ship b (~(get by peers.ames-state) ship))
               ::  apply remote scry requests
               ::
-              =^  moves  ames-state
+              =^  scry-moves  ames-state
                 =+  peer-core=(abed:pe:ames-core ship)
                 ::  XX skip abet, only +sy-abet will flop these moves
                 ::
@@ -10404,7 +10403,7 @@
                 ::  treated as %sage(s)
                 (~(rep in ducts) |=([=duct c=_cor] (on-chum:c ship^path)))
               ::
-              sy-core(moves moves)
+              sy-core(moves (weld scry-moves moves))
             ::
             ++  meet-alien-chum
               |=  [=ship =point:jael todos=ovni-state =chum-state]
@@ -10599,40 +10598,46 @@
         ::
         ++  sy-prod
           |=  ships=(list @p)
-          |^  ^-  (quip move axle)
+          |^  ^+  sy-core
           ?:  =(~ ships)
             (~(rep by chums.ames-state) prod-peer)
-          =|  moves=(list move)
-          |-
-          ?~  ships  [moves ames-state]
-          =^  new-moves  ames-state
+          |-  ^+  sy-core
+          ?~  ships  sy-core
+          =.  sy-core
             ?~  peer=(~(get by chums.ames-state) i.ships)
-              `ames-state
-            (prod-peer [i.ships u.peer] moves ames-state)
-          $(ships t.ships, moves (weld moves new-moves))
+              sy-core
+            (prod-peer [i.ships u.peer] sy-core)
+          $(ships t.ships)
           ::
           ++  prod-peer
-            |=  [[=ship per-sat=chum-state] moves=(list move) state=_ames-state]
+            |=  [[=ship per-sat=chum-state] core=_sy-core]
             ?.  ?=([%known *] per-sat)
-              :_  state
               ::  XX  this shouldn't be needed
               ::  XX  only if %alien
               ?:  ?=(%pawn (clan:title ship))
                 ::  XX resend attestation request?
                 ::
                 =/  spon=@p  (^sein:title ship)
-                ?:  =(our spon)  moves  ::  XX  don't send to ourselves
-                moves:(~(al-read-proof al ~[/ames]) ship `@ux`spon)
+                =.  moves.core
+                  %+  weld
+                    ?:  =(our spon)  ~  ::  XX  don't send to ourselves
+                    =<  moves
+                    %.  [ship `@ux`spon]
+                    ~(al-read-proof al(ames-state ames-state.core) ~[/ames])
+                  moves.core
+                core
               ~&  retrieving-keys-again/ship
-              :_  moves
+              %-  sy-emit:core
               [~[//keys] %pass /public-keys %j %public-keys ship ~ ~]
             ::
-            =+  core=~(ev-core ev(ames-state state) hen ship +.per-sat)
+            =+  ^=  ev-core
+              ~(ev-core ev(ames-state ames-state.core) hen ship +.per-sat)
             ::
-            =^  resend-moves  state
-              =;  c=_core  ev-abet:c
-              %-  ~(rep by pit.per.core)
-              |=  [[=path req=request-state] core=_core]
+            =^  resend-moves  ames-state.core
+              =;  c=_ev-core
+                [moves ames-state]:c
+              %-  ~(rep by pit.per.ev-core)
+              |=  [[=path req=request-state] core=_ev-core]
               ::  update and print connection status
               ::
               =?  core  (is-peer-dead:core now [her qos.per]:core)
@@ -10640,6 +10645,7 @@
               ::  if =(~ pay.req); %naxplanation, %cork or external (i.e. not
               ::  coming from %ames) $peek request
               ::
+              =/  co  co(ames-state ames-state.core)
               ?~  pact=(co-make-pact:co [her.core path] pay.req rift.per.core)
                 ::  XX don't crash since we are going to block the queue
                 ev-core:core
@@ -10648,8 +10654,7 @@
                 (slog leaf+"ames: unix-duct pending; retry %push" ~)
               %-  ev-emit:core
               (push-pact u.pact (make-lanes [her [lane qos]:per]:core))
-            :_  state
-            (weld moves resend-moves)
+            core(moves (weld resend-moves moves))
           ::
           --
         ::  +sy-snub: handle request to change ship blacklist
@@ -11296,7 +11301,7 @@
                     peeks=~(wyt by peeks.u.ship-state)
                   chums=~(wyt by chums.u.ship-state)
               |.("todos: {<pokes=pokes>} {<peeks=peeks>} {<chums=chums>}")
-          =^  moves  ames-state
+          =^  publ-moves  ames-state
             ::  XX skip sy-abet, only +al-abet will flop these moves
             ::
             =<  [moves ames-state]
@@ -11305,7 +11310,7 @@
             =|  =point:jael
             point(rift 0, life 1, keys keys, sponsor `(^sein:title comet))
           ::
-          al-core(moves moves)
+          al-core(moves (weld publ-moves moves))
         ::
         ++  al-read-proof
           |=  [comet=ship =lane:pact]


### PR DESCRIPTION
There were some awkward patterns around using the internal |mesa cores inside other cores. The general rule is "one +abet to rule them all", in each case this is the top-level +abet of the core that is calling the other cores. to append the moves that the inner core could have added we just extract them using `=<` and weld them on top of the global (in the core) `$moves`