### PR TITLE
mink: crash silently if no scry handler

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6132,11 +6132,11 @@
         [11 [tag.formula 1 product.clue] 1 product.next]
       ::
           [%12 ref=* path=*]
-        ?~  scry  !!
         =/  ref  $(formula ref.formula)
         ?.  ?=(%0 -.ref)  ref
         =/  path  $(formula path.formula)
         ?.  ?=(%0 -.path)  path
+        ?~  scry  [%2 trace]
         =/  result  (scry product.ref product.path)
         ?~  result
           [%1 product.path]

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6136,9 +6136,8 @@
         ?.  ?=(%0 -.ref)  ref
         =/  path  $(formula path.formula)
         ?.  ?=(%0 -.path)  path
-        =/  result
-          ?~  scry  ~
-          (scry product.ref product.path)
+        ?~  scry  [%2 trace]
+        =/  result  (scry product.ref product.path)
         ?~  result
           [%1 product.path]
         ?~  u.result

--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -6132,11 +6132,11 @@
         [11 [tag.formula 1 product.clue] 1 product.next]
       ::
           [%12 ref=* path=*]
+        ?~  scry  !!
         =/  ref  $(formula ref.formula)
         ?.  ?=(%0 -.ref)  ref
         =/  path  $(formula path.formula)
         ?.  ?=(%0 -.path)  path
-        ?~  scry  [%2 trace]
         =/  result  (scry product.ref product.path)
         ?~  result
           [%1 product.path]


### PR DESCRIPTION
Adresses https://github.com/urbit/vere/pull/865#discussion_r2310656852

Removes jet mismatch: currently the runtime exits from the inner road with no additional trace if %12 is executed with scry gate being `~`