### PR TITLE
tiny: copy +muk fix from hoon.hoon

### DIFF
--- a/pkg/arvo/lib/tiny.hoon
+++ b/pkg/arvo/lib/tiny.hoon
@@ -330,20 +330,18 @@
 ::  Hashes
 ::
 ++  muk                                                 ::  standard murmur3
-  ~%  %muk  ..muk  ~
-  =+  ~(. fe 5)
+  ~/  %muk
   |=  [syd=@ len=@ key=@]
+  ^-  @
+  =+  ~(. fe 5)
   =.  syd      (end 5 syd)
-  =/  pad      (sub len (met 3 key))
-  =/  data     (welp (rip 3 key) (reap pad 0))
   =/  nblocks  (div len 4)  ::  intentionally off-by-one
   =/  h1  syd
   =+  [c1=0xcc9e.2d51 c2=0x1b87.3593]
-  =/  blocks  (rip 5 key)
   =/  i  nblocks
   =.  h1  =/  hi  h1  |-
     ?:  =(0 i)  hi
-    =/  k1  (snag (sub nblocks i) blocks)  ::  negative array index
+    =/  k1  (cut 5 [(sub nblocks i) 1] key)  ::  negative array index
     =.  k1  (sit (mul k1 c1))
     =.  k1  (rol 0 15 k1)
     =.  k1  (sit (mul k1 c2))
@@ -351,31 +349,31 @@
     =.  hi  (rol 0 13 hi)
     =.  hi  (sum (sit (mul hi 5)) 0xe654.6b64)
     $(i (dec i))
-  =/  tail  (slag (mul 4 nblocks) data)
+  =/  tail  (rsh [3 (mul 4 nblocks)] key)
   =/  k1    0
   =/  tlen  (dis len 3)
   =.  h1
     ?+  tlen  h1  ::  fallthrough switch
-      %3  =.  k1  (mix k1 (lsh [0 16] (snag 2 tail)))
-          =.  k1  (mix k1 (lsh [0 8] (snag 1 tail)))
-          =.  k1  (mix k1 (snag 0 tail))
+      %3  =.  k1  (mix k1 (lsh [0 16] (cut 3 [2 1] tail)))
+          =.  k1  (mix k1 (lsh [0 8] (cut 3 [1 1] tail)))
+          =.  k1  (mix k1 (cut 3 [0 1] tail))
           =.  k1  (sit (mul k1 c1))
           =.  k1  (rol 0 15 k1)
           =.  k1  (sit (mul k1 c2))
           (mix h1 k1)
-      %2  =.  k1  (mix k1 (lsh [0 8] (snag 1 tail)))
-          =.  k1  (mix k1 (snag 0 tail))
+      %2  =.  k1  (mix k1 (lsh [0 8] (cut 3 [1 1] tail)))
+          =.  k1  (mix k1 (cut 3 [0 1] tail))
           =.  k1  (sit (mul k1 c1))
           =.  k1  (rol 0 15 k1)
           =.  k1  (sit (mul k1 c2))
           (mix h1 k1)
-      %1  =.  k1  (mix k1 (snag 0 tail))
+      %1  =.  k1  (mix k1 (cut 3 [0 1] tail))
           =.  k1  (sit (mul k1 c1))
           =.  k1  (rol 0 15 k1)
           =.  k1  (sit (mul k1 c2))
           (mix h1 k1)
     ==
-  =.  h1  (mix h1 len)
+  =.  h1  (mix h1 (end 5 len))
   |^  (fmix32 h1)
   ++  fmix32
     |=  h=@


### PR DESCRIPTION
`+muk` definition in /lib/tiny diverged from the one in /sys/hoon/hoon due to commits ab329e1 and cd34230, even though it uses the same jet. This PR syncs the definitions.