### PR TITLE
ames: handle hearing a %boon when flow is in closing

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9449,8 +9449,10 @@
               ::
               ?:  |(closing.state (~(has in corked.per) side))
                 =+  ;;(mess=@tas +<.gage)
-                =+  ;;([%plea =plea] +.gage)
+                
                 =/  is-cork-plea=?
+                  ?:  ?=(%boon mess)  |
+                  =+  ;;  =plea  +>.gage
                   &(?=([%cork ~] payload) ?=([%flow ~] path)):plea
                 ?.  closing.state
                   ?:  is-cork-plea


### PR DESCRIPTION
When we send a %cork $plea we mark the flow as "closing" dropping any incoming message, except resends of the original %cork. But, the %bak $side could still sends us %boons and in that case we were `;;` anything as a %plea, and crashing for every resend of the %boon, until the cork handshake gets handled on both sides, and messages stopped being transmitted.

(seeing in the wild on ~norsyr-torryn)