### PR TITLE
jael: interpret life in /=puby= scry as @ud

### DIFF
--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -1345,7 +1345,7 @@
     ?.  =([%& our] why)
       [~ ~]
     =/  who  (slaw %p i.tyl)
-    =/  lif  (slaw %p i.t.tyl)
+    =/  lif  (slaw %ud i.t.tyl)
     ?~  who  [~ ~]
     ?~  lif  [~ ~]
     =/  pos  (~(get by pos.zim.pki.lex) u.who)


### PR DESCRIPTION
currently, to get ~zod's public key (life=6), you do something like:
```
.^((unit [@ pass]) %j /=puby=/~zod/(scot %p 6))
```

i assume this is incorrect, and should be
```
.^((unit [@ pass]) %j /=puby=/~zod/6)
```