### PR TITLE
iris: handle requests when we don't yet have a duct

### DIFF
--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -127,6 +127,10 @@
     ::
     =.  connection-by-duct.state
       (~(put by connection-by-duct.state) duct id)
+    :: if we don't have a duct yet just ignore the request, %born will
+    :: cancel it soon. this is not ideal to say the least.
+    ::
+    ?~  outbound-duct.state  [~ state]
     ::  start the download
     ::
     ::  the original eyre keeps track of the duct on %born and then sends a
@@ -149,7 +153,8 @@
       ~&  %iris-invalid-cancel
       [~ state]
     ::
-    :-  [outbound-duct.state %give %cancel-request u.cancel-id]~
+    :-  ?~  outbound-duct.state  ~
+      [outbound-duct.state %give %cancel-request u.cancel-id]~
     (cleanup-connection u.cancel-id)
   ::  +receive: receives a response to an http-request we made
   ::


### PR DESCRIPTION
Recently the %groups desk started doing http requests to posthog during +on-init. This works fine when upgrading %groups but fails miserably when booting from a pill, crashing in arvo and bringing the ship down with %give-no-duct.

To ameliorate the issue we modify %iris to not give anything if the duct is still empty. In practice this results in the caller getting a %cancel every time if the http request happens early during the bootstrap process, since all outstanding http requests get canceled when the %born event comes in later from vere. This is obviously not good but it's better than a broken pill and a canceled http request will not matter in this specific instance for the posthog request.