### PR TITLE
mesa: fix resends of the %rege $plea

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10929,7 +10929,13 @@
               ::  XX find the bone for the flow inspecting the duct and checking
               ::  if the flow is halted; add state to .req to track halt?
               ::
-              ?:  ?|  ?=(^ pay.req)
+              ?:  ?&  ?=(^ pay.req)  ::  only pokes can be halted
+                      ::  currently pokes are only associated with one listener
+                      ::  therefore the ~(rep by for.req) is not necessary but we
+                      ::  leave it here for future consideration, asserting only
+                      ::  one listener as of the current implementation
+                      ::
+                      ?>  =(1 ~(wyt by for.req))
                       %-  ~(rep by for.req)
                       |=  [[hen=duct *] found=?(%.y %.n)]
                       ?.  ?=([[%ames %mesa %flow *] *] hen)


### PR DESCRIPTION
%rege $pleas are handled differently since we delete the peer from .chums and move it to .peers before we handle sending the $ack. when this happens the peer is gone, so we need to wait for the (from our point of view) regressed %mesa poke $plea to be re-sent again.

A couple of things were wrong here:

- in the case of galaxies we were not transferring the lane, crashing in a later assertion that guarantees that galaxies need to have lanes.
- when proding the resends of the %rege $plea, we were incorrectly dropping the %push effect, and also not handling the halted flows properly, making it such that _every_ poke would be halted.