### PR TITLE
hoon: remove sigbars from +dish

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -11099,6 +11099,7 @@
   ::
   ++  dish  !:
     |=  [ham=cape lum=*]  ^-  tank
+    ~|  [%dish-h ?@(q.ham q.ham -.q.ham)]
     %-  need
     =|  gil=(set [@ud *])
     |-  ^-  (unit tank)


### PR DESCRIPTION
A very common scenario when messing around in the dojo is that you print something extremely large by mistake. Realizing that you try to ctrl-c to interrupt the event, but most of the time this does not work and you end up having to kill the process through ctrl-z. The easiest way to reproduce this is to run `(bex (bex 26))` in the dojo.

It turns out that this is caused by the fact that sometimes these sigbars try to render absolutely massive nouns. We manage to interrupt the original print, but get stuck trying to render the stacktrace because of these sigbars!

The simplest solution is to get rid of the sigbars entirely. This will increase the reliability of ctrl-c by a significant margin.