### PR TITLE
gall: on %flub check if system flow is established

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1327,6 +1327,9 @@
         ::  only add the app if we have received the /gf $plea
         ::
         (~(put ju halts.state) agent-name ship hen)
+      ::  before flubbing, check if system flow is established
+      ::
+      =.  mo-core  (mo-track-flubs ship)
       %+  mo-give  %flub
       ::  if we are waiting to hear the /gf $plea, only %flub the flow in %ames
       ::  and skip sending the %flub $boon
@@ -1352,6 +1355,9 @@
   ++  mo-handle-flub-plea
     |=  =ship
     =.  flub-ducts.state  (~(put by flub-ducts.state) ship hen)
+    ::  before acking the %flub $plea, check if the system flow is established
+    ::
+    =.  mo-core  (mo-track-flubs ship)
     (mo-give %done error=~)
   ::  +mo-spew: handle request to set verbosity toggles on debug output
   ::


### PR DESCRIPTION
If we have a situation where a ship has "dead-flows" that are consistently being flubbed, but no "new" flow is created, (or a new %plea that reuses a %flow) the system flow won't be established, and the receiving ship will never give the %boon with the remote flub that will

In this PR we fix that by, on receving a $plea that is going to be flubbed, cheeck if we have establish the system %flub flow and if not, send the %flub $plea. Upon receiving a %flub $plea (by the %flub offender) it will check if we have established the system %flub flow, and if not, send it, achieving the two-sided system flow.

For pre-release ships that are already running 409, they will still need to actively send a plea to establish the system %flub flow.