### PR TITLE
ames: fix typo in ames migration message

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3540,7 +3540,7 @@
       ++  state-27-to-28
         |=  old=axle-26-27
         ^-  axle
-        ~>  %slog.0^leaf/"ames: migrating from state %27 to %26"
+        ~>  %slog.0^leaf/"ames: migrating from state %27 to %28"
         %=    old
             peers
           %-  ~(run by peers.old)


### PR DESCRIPTION
Booted %409 and saw a typo in the ames migration message. This PR fixes it.