### PR TITLE
gall: emit %raw-fact in %unto ova

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1737,6 +1737,8 @@
           [duct %give %unto %kick ~]
         ::
         ?.  ?=(%fact -.gift)
+          ?:  &(?=(^ duct) ?=([%$ *] i.duct))
+            [duct %give %unto %raw-fact p.cage.gift q.q.cage.gift]~
           [agent-duct %give %unto gift]~
         ::
         =/  ducts=(list duct)  (ap-ducts-from-paths paths.gift ~)


### PR DESCRIPTION
When an %unto gift is emitted by gall, no care is taken to detect whether the gift will turn into an effect. This makes it impossible to receive facts externally, such as when using aqua, because they carry a vase. Type for a vase with a type containing a %hold usually can not be verified efficiently, and thus one can't receive a fact at all, as molding nouns of such type will require a long time to compute. (This is caused by a %hold carrying a type of the subject present at the creation of the vase.)

To fix this, we detect in gall whether a fact is about to be transferred to the outside. If so, we convert the %fact into a %raw-fact, which does not carry a vase.

Together with @yosoyubik we have discussed alternative approaches. It seems the only other solution here (apart from fixing the compiler), would be for gall to have a mode where it would additionally emit %raw-facts alongside normal %facts on a dedicated duct.