### PR TITLE
gall: proper accounting of dummy 16-to-17 wire

### DIFF
--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -3013,14 +3013,14 @@
     :-  %19
     %_    old
         blocked
-      %-  ~(urn by blocked.old)
-      |=  [=term q=(qeu blocked-move)]
+      %-  ~(run by blocked.old)
+      |=  q=(qeu blocked-move)
       ^+  q
-      %-  ~(rep by q)
-      |=  [=blocked-move r=(qeu blocked-move)]
+      %-  ~(run to `(qeu blocked-move)`q)
+      |=  =blocked-move
       =?  duct.blocked-move  ?=([[%gall-use-wire *] *] duct.blocked-move)
         t.duct.blocked-move
-      (~(put to r) blocked-move)
+      blocked-move
     ==
   ::
   --


### PR DESCRIPTION
The 16-to-17 migration in gall added a dummy wire for subscription updates (%facts) that were not properly constructed when the receiving agent was not running.

This migration added the dummy wire for every blocked $deal, both local and remote ones, but local ones didn't have the wrongly constructed duct so if we poked or subscribed to a local agent we will never get the poke/watch ack, and if giving a fact we would be using the system duct.

~~Here we restore the original duct if the originating ship is .our by dropping the dummy wire if present.~~

+spore-16-to-17 added a dummy wire (/gall-use-wire) to blocked $deals. this looks to have been a misreading of the way blocked moves are enqueued, while trying to fix a wrongly-constructed wire for $untos.

The fix then was to add the wire while enqueueing %facts ($untos) to non-running agents, and the migration also added this dummy wire to blocked $deals, but those already had their duct properly added, so no /dummy wire was needed.

Instead of keeping code around forever to deal with this already-fixed bug, we just add a state migration to remove this wire from blocked $deals