### PR TITLE
hoon: lightly improve parser performance

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13630,21 +13630,24 @@
     |.  ~+
     %+  (slug |=([a=limb b=wing] [a b]))
       dot
-    ;~  pose
-      (cold [%| 0 ~] com)
-      %+  cook
-        |=([a=(list) b=term] ?~(a b [%| (lent a) `b]))
-      ;~(plug (star ket) ;~(pose sym (cold %$ buc)))
+    %-  stew
+    ^.  stet  ^.  limo
+    :~  :-  ['a' 'z']  sym
+        :-  '$'  (cold %$ buc)
+        :-  ','  (cold [%| 0 ~] com)
+        :-  '^'  %+  cook
+                   |=([a=(list) b=term] ?~(a b [%| (lent a) `b]))
+                 ;~(plug (plus ket) ;~(pose sym (cold %$ buc)))
     ::
-      %+  cook
-        |=(a=axis [%& a])
-      ;~  pose
-        ;~(pfix lus dim:ag)
-        ;~(pfix pam (cook |=(a=@ (sub (bex +(a)) 2)) dim:ag))
-        ;~(pfix bar (cook |=(a=@ (sub (bex +(a)) 1)) dim:ag))
-        ven
-        (cold 1 dot)
-      ==
+        :-  '+'  %+  cook  (lead %&)
+                 ;~  pose
+                   ;~(pfix lus dim:ag)
+                   ven
+                 ==
+        :-  '-'  (cook (lead %&) ven)
+        :-  '&'  ;~(pfix pam (cook |=(a=@ &+(sub (bex +(a)) 2)) dim:ag))
+        :-  '|'  ;~(pfix bar (cook |=(a=@ &+(sub (bex +(a)) 1)) dim:ag))
+        :-  '.'  (cold &+1 dot)
     ==
   ::
   ++  wise


### PR DESCRIPTION
d5af20f rewrites `+inde` (indentation block parser, used for multi-line strings). Previously, +inde would reparse all contiguous parts of the input that had the same (or deeper) indentation level, even after the block's closing.

Here, we make it take the opening and closing parse rules as explicit arguments, automatically include the leading and trailing newlines in the implementation, and reparse only up to the block's closing.

Parsing `hoon.hoon` becomes negligibly faster.

Parsing a degenerate version of `hoon.hoon`, where the first arm is a `'''` block-cord without any indentation, becomes ~25% faster.

Parsing [`/lib/language-server/rune-snippet`](https://github.com/urbit/urbit/blob/c767abc8f5010684c17dc7a48a93b75359d143e7/pkg/base-dev/lib/language-server/rune-snippet.hoon), which contains many `"""` block-tapes at the same indentation level, becomes ~45% faster.

This also turns `+iny`, whose implementation was a one-to-one copy of `+inde`, into an alias for `+inde`.

---

d9c3d7b wraps the parsers in `+rope`'s `pose` (the wing parsers) inside a `+stew` instead. Nearly all of its different cases are distinguishable by its first character, making it a good candidate for this.

This improves the performance of parsing `hoon.hoon` by ~10%.

---

No tests specifically for the multi-line string parsing, but did catch (and patch) some accidental breakage when building tests and other files. I expect it to have parity.
