### PR TITLE
hoon: fix how rend:co handles an empty %many $coin

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -5461,11 +5461,14 @@
         ?:  ?=(%blob -.lot)
           ['~' '0' ((v-co 1) (jam p.lot))]
         ?:  ?=(%many -.lot)
-          :-  '.'
+          :-  '._'
           |-  ^-  tape
           ?~   p.lot
             ['_' '_' rep]
-          ['_' (weld (trip (wack rent(lot i.p.lot))) $(p.lot t.p.lot))]
+          %+  weld
+            (trip (wack rent(lot i.p.lot)))
+          ?~  t.p.lot  $(p.lot t.p.lot)
+          ['_' $(p.lot t.p.lot)]
         =+  [yed=(end 3 p.p.lot) hay=(cut 3 [1 1] p.p.lot)]
         |-  ^-  tape
         ?+    yed  (z-co q.p.lot)


### PR DESCRIPTION
the +so parser expects an empty %many $coin to be rendered as `.___` (3 cabs):
```
> (rush '.___' nuck:so)
[~ [%many p=~]]
```

but the current implementation of +co prints it with only 2 cabs:
```
> ~(rend co [%many ~])
".__"
```

this change fixes the +co renderer so that a full-roundtrip is possible.