### PR TITLE
hoon: fix dig:by comment

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1491,7 +1491,7 @@
       d(r $(d r.d))
     e(l $(e l.e))
   ::
-  ++  dig                                               ::  axis of b key
+  ++  dig                                               ::  axis of [key=b val]
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)


### PR DESCRIPTION
Closes #7276.

`dig:by` comment says that it produces an axis of a given key. However, it actually produces the axis of a key-value pair where the key in the pair is equal to the given noun.