### PR TITLE
strandio: fix +await-thread to stop using +sleep

### DIFF
--- a/pkg/base-dev/lib/strandio.hoon
+++ b/pkg/base-dev/lib/strandio.hoon
@@ -912,7 +912,6 @@
   =/  poke-vase  !>(`start-args:spider`[`tid.bowl `tid byk.bowl file args])
   ;<  ~      bind:m  (watch-our /awaiting/[tid] %spider /thread-result/[tid])
   ;<  ~      bind:m  (poke-our %spider %spider-start poke-vase)
-  ;<  ~      bind:m  (sleep ~s0)  ::  wait for thread to start
   ;<  =cage  bind:m  (take-fact /awaiting/[tid])
   ;<  ~      bind:m  (take-kick /awaiting/[tid])
   ?+  p.cage  ~|([%strange-thread-result p.cage file tid] !!)


### PR DESCRIPTION
`+await-thread` `+sleep`s for 0 seconds (this presumably copied over from +start-thread-with-args) right after starting a thread. While at the surface this looks correct: we want to transfer control back to spider, so that it can start running the newly created thread, this does not work in practice, as it assumes the spawned thread will do some io during its execution, which is not guaranteed.

A trace of the sleep strand, used in `+await-thread`, reveals the following inputs:
1. It firsts receives a null input. This is expected, and causes the control to transfer back to spider.
2. The spider now runs the thread. Crucially, if the thread *runs continuously* (as the `-test` thread does, for instance), it will complete, producing a result without transferring control back to spider until its execution finished.
3. The sleep strand now receives the thread result fact and a kick from spider, and skips them, because it is awaiting a wake sign from behn.
4. `+await-thread` strand now hangs at `+take-fact`, waiting in vain for the thread result fact which was already consumed in the previous step.

Unlike in `+start-thread-with-args`, there is no need to artificially transfer control in `+await-thread`. The `+take-fact` strand following the `+poke-our` call to spider is enough for that.