### PR TITLE
hoon: expose old +co behavior for `@da` backcompat

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13901,12 +13901,37 @@
 ::
 ++  h135  .
 ++  h136
+  =,  h135
+  |%
+  ::  hoon 136 omitted leading zeroes from @da's date rendering. these helpers
+  ::  are provided to make rendering in the old style easier.
+  ::
+  ++  scot  |=(mol=dime ~(rent co %$ mol))
+  ++  scow  |=(mol=dime ~(rend co %$ mol))
+  ++  co
+    =>  [+>:co:h135 .]
+    |_  lot=coin
+    +*  co135  ~(. co:h135 lot)
+    ++  rear  rear:co135
+    ++  rent  ~+  `@ta`(rap 3 rend)
+    ++  rend
+      ^-  tape
+      ?.  ?=([%$ %da @] lot)  rend:co135
+      =+  yod=(yore q.p.lot)
+      =?  rep  ?=(^ f.t.yod)  ['.' (s-co f.t.yod)]
+      =?  rep  !&(?=(~ f) =(0 h) =(0 m) =(0 s)):t.yod
+        =.  rep  ['.' (y-co s.t.yod)]
+        =.  rep  ['.' (y-co m.t.yod)]
+        ['.' '.' (y-co h.t.yod)]
+      =.  rep  ['.' (a-co d.t.yod)]
+      =.  rep  ['.' (a-co m.yod)]
+      =?  rep  !a.yod  ['-' rep]
+      ['~' (a-co y.yod)]
+    --
   ::  hoon 136 had doccords, in $spec's %gist, $skin's and $note's %help,
   ::  and in $tome. dropped types replaced with * below for brevity.
   ::  migration helpers at the end of this core.
   ::
-  =,  h135
-  |%
   +$  abel  typo                                          ::  original sin: type
   +$  alas  (list (pair term hoon))                       ::  alias list
   +$  woof  $@(@ [~ p=hoon])                              ::  simple embed

--- a/tests/sys/hoon/auras.hoon
+++ b/tests/sys/hoon/auras.hoon
@@ -166,6 +166,11 @@
       !>  (scot %da ~2000.12.12)
   ==
 ::
+++  test-render-da-136
+  %+  expect-eq
+    !>  ~.~2000.1.1
+    !>  (scot:h136 %da ~2000.01.01)
+::
 ++  test-sane
   %-  expect
   !>(((sane %t) '🤔'))


### PR DESCRIPTION
PR #7257 changed atom rendering to include leading zeroes for `@da` in the date segments. While it also changed the parser to accept both formats (with and without leading zeroes), it is not always guaranteed that the recipient of a `@da` string has a new, lenient parser.

Here, we add a `+co` implementation into `+h136` which retains the old rendering behavior, making it easier for codebases to stay with old-style `@da` rendering wherever they need to.