### PR TITLE
ames:  refactor |ahoy flow

### DIFF
--- a/pkg/arvo/gen/hood/mate.hoon
+++ b/pkg/arvo/gen/hood/mate.hoon
@@ -7,4 +7,4 @@
   ::
 /?    310
 :-  %say
-|=([^ [who=(unit ship) ~] dry=_& ~] helm-mass-mate/who^dry)
+|=([^ [who=(unit ship) ~] ~] helm-mass-mate/who)

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -193,27 +193,33 @@
       %helm-hi  !>(mes)
   ==
 ::
-++  poke-send-ahoy
-  |=  [her=ship test=? force=?]  =<  abet
+++  poke-start-ahoy
+  |=  [her=ship test=? force-test=?]  =<  abet
   =/  =wire
     :+  %helm  %ahoy
     ?.(test /(scot %p her) /test/(scot %p her))
   =/  =path  ?:(test /test/mesa-1 /mesa-1)
   ::  before migrating, test if we can migrate, regress, and check that there
-  ::  are not flows in a weird state. if we don't crash, send the %ahoy $plea
+  ::  are not flows in a weird state. if we get a [%done ~], send the %ahoy $plea
   ::
-  =^  mate-moves  sat  
-    ?.  force  `sat  
-    (poke-mass-mate `her test=%.y)
-  =^  ahoy-moves  sat  abet:(emit %pass wire %arvo %a %plea her %$ path %ahoy ~)
-  (emil (weld mate-moves ahoy-moves))
+  ?.  force-test
+    ::  skip test, ahoy right away; only for certain cases in ames.hoon
+    ::
+    (emit %pass wire %arvo %a %plea her %$ path %ahoy ~)
+  ::  wait for the %done of the local %mate
+  ::
+  =^  mate-moves  sat  %*($ poke-mass-mate dry test, +< `her)
+  (emil mate-moves)
 ::
 ++  poke-mass-mate
-  |=  [ship=(unit ship) dry=?]
+  =|  dry=?
+  |=  ship=(unit ship)
   =/  =wire
     :+  %helm  %mate
-    ?.(dry ~ /test)
-  abet:(emit %pass wire %arvo %a %mate ship dry)
+    ?~  ship  /test
+    ?:  dry   /test/(scot %p u.ship)
+    /(scot %p u.ship)
+  abet:(emit %pass wire %arvo %a %mate ship dry=%.y)
 ::
 ++  poke-mass-rege
   |=  [ship=(unit ship) dry=?]
@@ -222,19 +228,33 @@
     ?.(dry ~ /test)
   abet:(emit %pass wire %arvo %a %rege ship dry)
 ::
+++  take-test-mate
+  |=  [way=wire error=(unit error:ames)]
+  =/  =path
+    ?:(?=([%test her=@ ~] way) /test/mesa-1 /mesa-1)
+  =/  her=@p
+    ?:  ?=([%test her=@ ~] way)
+      (slav %p i.t.way)
+    ?>  ?=([her=@ ~] way)
+    (slav %p i.way)
+  ?^  error
+    ~&  >   %local-migration-failed
+    abet
+  ~&  >   %local-migration-worked
+  abet:(emit %pass [%helm %ahoy way] %arvo %a %plea her %$ path %ahoy ~)
+::
 ++  take-ahoy
   |=  [way=wire error=(unit error:ames)]
   ?:  ?=([%test @ *] way)
     ?~  error
       ~&  >   %migration-test-worked
-      ~&  >>  %test-local-migration
-      abet:(emit %pass /helm/migrate %arvo %a %mate (slaw %p i.t.way) dry=%.y)
+      abet
     %-  (slog %take-ahoy-test-failed u.error)
     abet
   ?>  ?=([@ ~] way)
   ?~  error
       ~&  >   %remote-migration-worked
-      ~&  >>  %try-local-migration
+      ~&  >>  %do-local-migration
     abet:(emit %pass /helm/migrate %arvo %a %mate (slaw %p i.way) dry=%.n)
   ~&  >>>  %ahoy-crash
   ::  XX retry?
@@ -247,7 +267,7 @@
   |=  [way=wire error=(unit tang)]
   ?>  ?=([@ ~] way)
   ?~  error
-    (poke-send-ahoy (slav %p i.way) | force=&)
+    (poke-start-ahoy (slav %p i.way) | force=&)
   ~&  >>>  %ahoy-wake-crash
   ::  XX retry?
   ::
@@ -683,7 +703,7 @@
     %helm-pass             =;(f (f !<(_+<.f vase)) poke-pass)
     %helm-rekey            =;(f (f !<(_+<.f vase)) poke-rekey)
     %helm-send-hi          =;(f (f !<(_+<.f vase)) poke-send-hi)
-    %helm-send-ahoy        =;(f (f !<(_+<.f vase)) poke-send-ahoy)
+    %helm-send-ahoy        =;(f (f !<(_+<.f vase)) poke-start-ahoy)
     %helm-mass-mate        =;(f (f !<(_+<.f vase)) poke-mass-mate)
     %helm-send-rege        =;(f (f !<(_+<.f vase)) poke-send-rege)
     %helm-mass-rege        =;(f (f !<(_+<.f vase)) poke-mass-rege)
@@ -718,6 +738,8 @@
     [%moon-breach *]  %+  take-wake-moon-breach  t.wire
                       ?>(?=(%wake +<.sign-arvo) +>.sign-arvo)
     [%ahoy *]         %+  take-ahoy  t.wire
+                      ?>(?=(%done +<.sign-arvo) +>.sign-arvo)
+    [%mate *]         %+  take-test-mate  t.wire
                       ?>(?=(%done +<.sign-arvo) +>.sign-arvo)
     [%rege *]         %+  take-rege  t.wire
                       ?>(?=(%done +<.sign-arvo) +>.sign-arvo)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4821,9 +4821,8 @@
             ::  namespace that they have migrated us?
             ::  XX  requires a namespace for migrated peers?
             ::
-            :: %-  %^  ev-trace  sun.veb  ship.deep
-            ::     |.("migrating to |mesa")
-            ~&  >>  "migrating to |mesa"
+            %-  %^  ev-trace  sun.veb  ship.deep
+                |.("migrating to |mesa")
             ::  before migrating check that we can migrate this peer without
             ::  crashing. if so, we will nack the %ahoy $plea.
             ::
@@ -5176,11 +5175,7 @@
           |=  [ship=(unit ship) dry=?]
           |^  ^+  event-core
           =;  updated-core=_event-core
-            ?:  dry
-              ~&  >  test-local-migration-worked/ship
-              event-core
-            ~&  >  local-migration-worked/ship
-            updated-core
+            ?:(dry event-core updated-core)
           ::
           ?~  ship
             (~(rep by peers.ames-state) migrate-peer)
@@ -5812,7 +5807,6 @@
               ==
             =^  poke-moves  fren        (make-flows fren)
             =^  peek-moves  ames-state  (make-peeks fren)
-            ~&  >  %migration-done^her
             ::  XX  needed?  peek/poke-moves will have %send moves already
             ::
             ::  enqueue a %prod to start sending unsent messages, after
@@ -5861,8 +5855,7 @@
                 ::
                 ?:  =(%2 (mod bone 4))
                   ::  XX this shouldn't exist
-                  ~?  >>>  odd.veb.bug.ames-state
-                    weird-naxp-ack-bone/bone=bone
+                  ~&  >>>  weird-naxp-ack-bone/bone=bone
                   moves^fren
                 =/  naxp-bone=?    =(%3 (mod bone 4))
                 =/  original-bone  bone
@@ -6048,7 +6041,7 @@
                   ::  naxplanation of this message to increase current,
                   ::
                   ::  XX this assertion exists to catch any possible flow in a
-                  ::  weird state that we have not found a explanation and will
+                  ::  weird state that we have not found an explanation and will
                   ::  requiere further inspecting
                   ::
                   ?>  ?&  (~(has by queued-message-acks.pump) +(current.pump))
@@ -6083,7 +6076,7 @@
                 ::
                 ::  live packets in packet-pump-state are reconstructed; the
                 ::  receiver will droppped any partially received fragments
-                ::  so the full message will need to be resent.
+                ::  so the full message will need to be resend.
                 ::
                 =/  live=(list [=message-num message])
                   =+  queue=((on ,@ud message-blob) lte)
@@ -7452,9 +7445,8 @@
                     ::
                     ?>  (on-mate-test her)
                     ::
-                    :: %-  %^  ev-trace  sun.veb  her
-                    ::     |.("migrating {<her>} test succeded")
-                    ~&  >  "testing dry migration {<her>} succeded"
+                    %-  %^  ev-trace  sun.veb  her
+                        |.("migrating {<her>} test succeded")
                     ::
                     (done ok=%.y)
                 =.  peer-core
@@ -12647,6 +12639,7 @@
       =/  ship-state  (find-peer ship.spar)
       ::
       ?:  ?=(%ames -.ship-state)
+        ~&  %ames
         (call:am-core hen ~ %soft ?:(all %wham %yawn) spar)
       =^  moves  ames-state
         =<  ev-abet
@@ -13234,6 +13227,10 @@
 ++  load
   |=  state=axle
   ~>  %spin.['load/ames']
+  :: =.  peers.state
+  ::   (~(del by peers.state) ~nec)
+  :: =.  chums.state
+  ::   (~(del by chums.state) ~nec)
   vane-gate(ames-state state)
 ::  +scry: dereference namespace
 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11136,11 +11136,7 @@
           |=  [ship=(unit ship) dry=?]
           |^  ^+  sy-core
           =;  updated-core=_sy-core
-              ?:  dry
-                ~&  >  test-local-regression-worked/ship
-                sy-core
-              ~&  >  local-regression-worked/ship
-              updated-core
+              ?:(dry sy-core updated-core)
           ::
           ?~  ship
             (~(rep by chums.ames-state) regress-chum)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4001,10 +4001,11 @@
               ::
                 %mate  ?.  dry.task  (on-mate:event-core +.task)
                        ?^  +<.task
-                         ~|  %dry-migration-failed^u.+<.task
-                         ?>  (on-mate-test:event-core u.+<.task)
-                         ~&  >  %dry-migration-worked^u.+<.task
-                         event-core
+                         %-  emit:event-core
+                         :^  duct  %give  %done
+                         ?:  (on-mate-test:event-core u.+<.task)
+                           ~
+                         [~ %dry-migration-failed ~]
                        ~&  >>
                         "test migration of {<~(wyt by peers.ames-state)>} peers"
                        =/  [failed=@ test=?]


### PR DESCRIPTION
In preparation for the mass-ahoy event of %408, the ahoy flow is refactor. Instead of crashing if the local %mate fails, we just give a `done/error=[dry-migration-failed ~]` to abort sending the %ahoy $plea.