### PR TITLE
hoon: make +chip test through ?!

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9763,6 +9763,8 @@
       |-(?~(p.gen sut $(p.gen t.p.gen, sut ^$(gen i.p.gen))))
     ?:  ?&(!how ?=([%wtbr *] gen))
       |-(?~(p.gen sut $(p.gen t.p.gen, sut ^$(gen i.p.gen))))
+    ?:  ?=([%wtzp *] gen)
+      $(how !how, gen p.gen)
     =+  neg=~(open ap gen)
     ?:(=(neg gen) sut $(gen neg))
   ::

--- a/tests/sys/hoon/chip.hoon
+++ b/tests/sys/hoon/chip.hoon
@@ -1,0 +1,64 @@
+/+  *test
+|%
+++  test-negated-wuttis
+  %-  expect-fail  |.
+  %+  ride  %noun
+  '''
+  =/  u=(unit)  ~
+  ?.  !?=(~ u)  %blah
+  ?-(u ~ %empty, ^ %value)
+  '''
+::
+++  test-negated-wuttis-2
+  %-  expect-success  |.
+  %+  ride  %noun
+  '''
+  =/  u=$@(~ [~ u=*])  [~ 123]
+  ?>(!?=(~ u) u.u)
+  '''
+::
+++  test-wutpam-specialization
+  %-  expect-success  |.
+  %+  ride  %noun
+  '''
+  =/  n=[p=* q=* r=*]  [[1 2] [3 4] [5 6]]
+  ?>  ?&(?=([p=* *] p.n) ?=([p=* *] q.n) ?=([p=* *] r.n))
+  [p.p.n p.q.n p.r.n]
+  '''
+::
+++  test-wutbar-no-specialization
+  %-  expect-success  |.
+  %+  ride  %noun
+  '''
+  =/  n=[p=* q=* r=*]  [[1 2] [3 4] [5 6]]
+  ?>  ?|(?=([p=* *] p.n) ?=([p=* *] q.n) ?=([p=* *] r.n))
+  [p.n q.n r.n]
+  '''
+::
+++  test-wutbar-no-specialization-demorgan
+  %-  expect-success  |.
+  %+  ride  %noun
+  '''
+  =/  n=[p=* q=* r=*]  [[1 2] [3 4] [5 6]]
+  ?>  !?&(!?=([p=* *] p.n) !?=([p=* *] q.n) !?=([p=* *] r.n))
+  [p.n q.n r.n]
+  '''
+::
+++  test-sequential-narrowing
+  %-  expect-success  |.
+  %+  ride  -:!>(unit=unit)
+  '''
+  =/  c=[o=(unit (unit @)) d=(unit (unit @))]  [``1 ~]
+  ?>  ?&(?=(^ o.c) ?=(^ u.o.c) ?=(~ d.c))
+  [u.u.o.c `~`d.c]
+  '''
+::
+++  test-sequential-narrowing-demorgan
+  %-  expect-success  |.
+  %+  ride  -:!>(unit=unit)
+  '''
+  =/  c=[o=(unit (unit @)) d=(unit (unit @))]  [``1 ~]
+  ?>  !?|(!?=(^ o.c) !?=(^ u.o.c) !?=(~ d.c))
+  [u.u.o.c `~`d.c]
+  '''
+--


### PR DESCRIPTION
Previously, adding wutzap negation to a type-checking conditional would prevent type information from propagating into the resulting branches.

For example, the following would compile, instead of giving a mint-vain:

```hoon
=/  u=(unit)  ~
?>  !?=(^ u)
?-(u ~ %empty, ^ %value)
```

Here, we make sure `+chip` reads "into" negations, flipping the polarity whenever we pass one. The existing `+chip` logic takes care of the rest.

We also add some tests for the affected and other type checking cases.

Because this introduces type information in branches where there was none previously, this could in rare cases break existing code.