### PR TITLE
eyre: +tap:by the map, not +tap:in

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -4021,7 +4021,7 @@
     =*  sessions  sessions.auth.server-state.ax
     =.  sessions.auth.server-state.ax
       %-  ~(gas by *(map @uv session))
-      %+  skip  ~(tap in sessions)
+      %+  skip  ~(tap by sessions)
       |=  [cookie=@uv session]
       (lth expiry-time now)
     ::  if there's any cookies left, set a timer for the next expected expiry


### PR DESCRIPTION
`sessions.auth.server-state` is a map, not a set, so we should use the corresponding utilities.

Probably didn't matter in practice in this particular case, but an oversight is an oversight and should be corrected.

To be honest: untested. But: Your Honor, just look at him!