### PR TITLE
Fall through to cookie if Auth header fails

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1542,10 +1542,13 @@
     ++  session-id-from-request
       |=  =request:http
       ^-  (unit @uv)
-      ::  is there an authorization header?
+      ::  is there an authorization header with a valid session token?
       ::
-      ?^  auth=(get-header:http 'authorization' header-list.request)
+      =/  from-header=(unit @uv)
+        ?~  auth=(get-header:http 'authorization' header-list.request)
+          ~
         (rush u.auth ;~(pfix (jest 'Bearer 0v') viz:ag))
+      ?^  from-header  from-header
       ::  are there cookies passed with this request?
       ::
       =/  cookie-header=@t

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1542,7 +1542,7 @@
     ++  session-id-from-request
       |=  =request:http
       ^-  (unit @uv)
-      ::  is there an authorization header with a valid session token?
+      ::  is there an authorization header with a legible session token?
       ::
       =/  from-header=(unit @uv)
         ?~  auth=(get-header:http 'authorization' header-list.request)

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -1470,6 +1470,26 @@
   ::
   ;<  tt=@t  bind:m  get-token
   (try (expect-eq !>(t) !>(tt)))
+::  +test-header-auth-fallback-to-cookie: invalid auth header should not
+::  prevent cookie-based authentication
+::
+++  test-header-auth-fallback-to-cookie
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  perform-init-wo-timer
+  ;<  ~  bind:m  perform-born
+  ;<  ~  bind:m  perform-authentication-2
+  ::  request our name while passing an invalid authorization header.
+  ::  the valid session cookie should still be used for authentication.
+  ::
+  ;<  name=@p  bind:m
+    =/  m  (mare ,@p)
+    ^-  form:m
+    ;<  mos=(list move)  bind:m  (get '/~/name' ['authorization' 'Basic foo']~)
+    ?>  ?=([[* %give %response %start * * %.y] ~] mos)
+    (pure:m (slav %p q:(need data.http-event.p.card.i.mos)))
+  (try (expect-eq !>(~nul) !>(name)))
 ::  +perform-authentication: goes through the authentication flow
 ::
 ++  perform-authentication-2


### PR DESCRIPTION
To implement the S3 protocol on urbit we need the auth headers. if eyre sees an auth header it will automatically assume its eyre's this pr allows eyre to fall through to the cookie if the header fails