### PR TITLE
Reintroduce +crub

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -946,6 +946,32 @@
     ==
   ::
   ::::                                                  ::  (1a2)
+    ::
+  ++  acru  $_  ^?                                      ::  asym cryptosuite
+    |%                                                  ::  opaque object
+    ++  as  ^?                                          ::  asym ops
+      |%  ++  seal  |~([a=pass b=@] *@)                 ::  encrypt to a
+          ++  sign  |~(a=@ *@)                          ::  certify as us
+          ++  sigh  |~(a=@ *@)                          ::  certification only
+          ++  sure  |~(a=@ *(unit @))                   ::  authenticate from us
+          ++  safe  |~([a=@ b=@] *?)                    ::  authentication only
+          ++  tear  |~([a=pass b=@] *(unit @))          ::  accept from a
+      --  ::as                                          ::
+    ++  de  |~([a=@ b=@] *(unit @))                     ::  symmetric de, soft
+    ++  dy  |~([a=@ b=@] *@)                            ::  symmetric de, hard
+    ++  en  |~([a=@ b=@] *@)                            ::  symmetric en
+    ++  ex  ^?                                          ::  export
+      |%  ++  fig  *@uvH                                ::  fingerprint
+          ++  pac  *@uvG                                ::  default passcode
+          ++  pub  *pass                                ::  public key
+          ++  sec  *ring                                ::  private key
+      --  ::ex                                          ::
+    ++  nu  ^?                                          ::  reconstructors
+      |%  ++  pit  |~([a=@ b=@] ^?(..nu))               ::  from [width seed]
+          ++  nol  |~(a=ring ^?(..nu))                  ::  from ring
+          ++  com  |~(a=pass ^?(..nu))                  ::  from pass
+      --  ::nu                                          ::
+    --  ::acru                                          :::::                                                  ::  (1a2)
   ::  +protocol-version: current version of the ames wire protocol
   ::
   ++  protocol-version  `?(%0 %1 %2 %3 %4 %5 %6 %7)`%0

--- a/pkg/arvo/sys/zuse.hoon
+++ b/pkg/arvo/sys/zuse.hoon
@@ -1659,8 +1659,128 @@
         ^-  @
         (jam (~(en sivc:aes (shaz key) ~) msg))
       --
+    --  ::cric
+  ::                                                    ::
+  ::::                    ++crub:crypto                 ::  (2b4) suite B, Ed
+    ::                                                  ::::
+  ++  crub  !:
+    ^-  acru
+    =|  [pub=[cry=@ sgn=@] sek=(unit [cry=@ sgn=@])]
+    |%
+    ::                                                  ::  ++as:crub:crypto
+    ++  as                                              ::
+      |%
+      ::                                                ::  ++sign:as:crub:
+      ++  sign                                          ::
+        |=  msg=@
+        ^-  @ux
+        (jam [(sigh msg) msg])
+      ::                                                ::  ++sigh:as:crub:
+      ++  sigh                                          ::
+        |=  msg=@
+        ^-  @ux
+        ?~  sek  ~|  %pubkey-only  !!
+        (sign:ed msg sgn.u.sek)
+      ::                                                ::  ++sure:as:crub:
+      ++  sure                                          ::
+        |=  txt=@
+        ^-  (unit @ux)
+        =+  ;;([sig=@ msg=@] (cue txt))
+        ?.  (safe sig msg)  ~
+        (some msg)
+      ::                                                ::  ++safe:as:crub:
+      ++  safe
+        |=  [sig=@ msg=@]
+        ^-  ?
+        (veri:ed sig msg sgn.pub)
+      ::                                                ::  ++seal:as:crub:
+      ++  seal                                          ::
+        |=  [bpk=pass msg=@]
+        ^-  @ux
+        ?~  sek  ~|  %pubkey-only  !!
+        ?>  =('b' (end 3 bpk))
+        =+  pk=(rsh 8 (rsh 3 bpk))
+        =+  shar=(shax (shar:ed pk cry.u.sek))
+        =+  smsg=(sign msg)
+        (jam (~(en siva:aes shar ~) smsg))
+      ::                                                ::  ++tear:as:crub:
+      ++  tear                                          ::
+        |=  [bpk=pass txt=@]
+        ^-  (unit @ux)
+        ?~  sek  ~|  %pubkey-only  !!
+        ?>  =('b' (end 3 bpk))
+        =+  pk=(rsh 8 (rsh 3 bpk))
+        =+  shar=(shax (shar:ed pk cry.u.sek))
+        =+  ;;([iv=@ len=@ cph=@] (cue txt))
+        =+  try=(~(de siva:aes shar ~) iv len cph)
+        ?~  try  ~
+        (sure:as:(com:nu:crub bpk) u.try)
+      --  ::as
+    ::                                                  ::  ++de:crub:crypto
+    ++  de                                              ::  decrypt
+      |=  [key=@J txt=@]
+      ^-  (unit @ux)
+      =+  ;;([iv=@ len=@ cph=@] (cue txt))
+      %^    ~(de sivc:aes (shaz key) ~)
+          iv
+        len
+      cph
+    ::                                                  ::  ++dy:crub:crypto
+    ++  dy                                              ::  need decrypt
+      |=  [key=@J cph=@]
+      (need (de key cph))
+    ::                                                  ::  ++en:crub:crypto
+    ++  en                                              ::  encrypt
+      |=  [key=@J msg=@]
+      ^-  @ux
+      (jam (~(en sivc:aes (shaz key) ~) msg))
+    ::                                                  ::  ++ex:crub:crypto
+    ++  ex                                              ::  extract
+      |%
+      ::                                                ::  ++fig:ex:crub:crypto
+      ++  fig                                           ::  fingerprint
+        ^-  @uvH
+        (shaf %bfig pub)
+      ::                                                ::  ++pac:ex:crub:crypto
+      ++  pac                                           ::  private fingerprint
+        ^-  @uvG
+        ?~  sek  ~|  %pubkey-only  !!
+        (end 6 (shaf %bcod sec))
+      ::                                                ::  ++pub:ex:crub:crypto
+      ++  pub                                           ::  public key
+        ^-  pass
+        (cat 3 'b' (cat 8 sgn.^pub cry.^pub))
+      ::                                                ::  ++sec:ex:crub:crypto
+      ++  sec                                           ::  private key
+        ^-  ring
+        ?~  sek  ~|  %pubkey-only  !!
+        (cat 3 'B' (cat 8 sgn.u.sek cry.u.sek))
+      --  ::ex
+    ::                                                  ::  ++nu:crub:crypto
+    ++  nu                                              ::
+      |%
+      ::                                                ::  ++pit:nu:crub:crypto
+      ++  pit                                           ::  create keypair
+        |=  [w=@ seed=@]
+        =+  wid=(add (div w 8) ?:(=((mod w 8) 0) 0 1))
+        =+  bits=(shal wid seed)
+        =+  [c=(rsh 8 bits) s=(end 8 bits)]
+        ..nu(pub [cry=(puck:ed c) sgn=(puck:ed s)], sek `[cry=c sgn=s])
+      ::                                                ::  ++nol:nu:crub:crypto
+      ++  nol                                           ::  activate secret
+        |=  a=ring
+        =+  [mag=(end 3 a) bod=(rsh 3 a)]
+        ~|  %not-crub-seckey  ?>  =('B' mag)
+        =+  [c=(rsh 8 bod) s=(end 8 bod)]
+        ..nu(pub [cry=(puck:ed c) sgn=(puck:ed s)], sek `[cry=c sgn=s])
+      ::                                                ::  ++com:nu:crub:crypto
+      ++  com                                           ::  activate public
+        |=  a=pass
+        =+  [mag=(end 3 a) bod=(rsh 3 a)]
+        ~|  %not-crub-pubkey  ?>  =('b' mag)
+        ..nu(pub [cry=(rsh 8 bod) sgn=(end 8 bod)], sek ~)
+      --  ::nu
     --  ::crub
-  ++  crub  !!
   ::                                                    ::
   ::::                    ++crua:crypto                 ::  (2b5) suite B, RSA
     ::                                                  ::::

--- a/tests/lib/vere/dawn.hoon
+++ b/tests/lib/vere/dawn.hoon
@@ -48,8 +48,14 @@
     !>  |+[%not-keyed ~]
     !>  (veri:dawn ~zod fed =>(pot .(net ~)) ~)
 ::
-++  test-veri-wrong-key
+++  test-veri-wrong-key-cric
   =/  fed  [~zod 1 sec:ex:(pit:nu:cric:crypto 24 %foo %b ~) ~]
+  %+  expect-eq
+    !>  |+[%key-mismatch ~]
+    !>  (veri:dawn ~zod fed pot ~)
+::
+++  test-veri-wrong-key-crub
+  =/  fed  [~zod 1 sec:ex:(pit:nu:crub:crypto 24 %foo) ~]
   %+  expect-eq
     !>  |+[%key-mismatch ~]
     !>  (veri:dawn ~zod fed pot ~)
@@ -60,11 +66,22 @@
     !>  |+[%life-mismatch ~]
     !>  (veri:dawn ~zod fed pot ~)
 ::
-++  test-veri-bad-multikey
+++  test-veri-bad-multikey-cric
   =/  fed=feed:jael
     :-  [%1 ~]
     :-  ~zod
     :~  [1 sec:ex:(pit:nu:cric:crypto 24 %foo %b ~)]
+        [2 sec]
+    ==
+  %+  expect-eq
+    !>  |+[%key-mismatch %life-mismatch ~]
+    !>  (veri:dawn ~zod fed pot ~)
+::
+++  test-veri-bad-multikey-crub
+  =/  fed=feed:jael
+    :-  [%1 ~]
+    :-  ~zod
+    :~  [1 sec:ex:(pit:nu:crub:crypto 24 %foo)]
         [2 sec]
     ==
   %+  expect-eq
@@ -88,7 +105,7 @@
       !>  (veri:dawn ~zod fed pot `[2 &])
   ==
 ::
-++  test-veri-earl-good
+++  test-veri-earl-good-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who  ~simtel-mithet-dozzod-dozzod
   =/  fed
@@ -101,7 +118,19 @@
     !>  &+fed
     !>  (veri:dawn who fed pot ~)
 ::
-++  test-veri-earl-parent-not-keyed
+++  test-veri-earl-good-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who  ~simtel-mithet-dozzod-dozzod
+  =/  fed
+    =/  sig
+      %-  sign:as:(nol:nu:crub:crypto sec)
+      (shaf %earl (sham who 1 pub:ex:cub))
+    [[%2 ~] who 0 [1 sec:ex:cub]~]
+  %+  expect-eq
+    !>  &+fed
+    !>  (veri:dawn who fed pot ~)
+::
+++  test-veri-earl-parent-not-keyed-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who  ~simtel-mithet-dozzod-dozzod
   =/  fed
@@ -114,7 +143,19 @@
     !>  &+fed
     !>  (veri:dawn who fed =>(pot .(net ~)) ~)
 ::
-++  test-veri-pawn-good
+++  test-veri-earl-parent-not-keyed-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who  ~simtel-mithet-dozzod-dozzod
+  =/  fed
+    =/  sig
+      %-  sign:as:(nol:nu:crub:crypto sec)
+      (shaf %earl (sham who 1 pub:ex:cub))
+    [[%2 ~] who 0 [1 sec:ex:cub]~]
+  %+  expect-eq
+    !>  &+fed
+    !>  (veri:dawn who fed =>(pot .(net ~)) ~)
+::
+++  test-veri-pawn-good-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who=ship  `@`fig:ex:cic
   =/  fed  [who 1 sec:ex:cic ~]
@@ -122,7 +163,15 @@
     !>  &+[[%2 ~] who 0 [1 sec:ex:cic]~]
     !>  (veri:dawn who fed *point:azimuth-types ~)
 ::
-++  test-veri-pawn-key-mismatch
+++  test-veri-pawn-good-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who=ship  `@`fig:ex:cub
+  =/  fed  [who 1 sec:ex:cub ~]
+  %+  expect-eq
+    !>  &+[[%2 ~] who 0 [1 sec:ex:cub]~]
+    !>  (veri:dawn who fed *point:azimuth-types ~)
+::
+++  test-veri-pawn-key-mismatch-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who=ship  `@`fig:ex:cic
   =/  sed  [who 1 sec:ex:(pit:nu:cric:crypto 24 %bar %b ~) ~]
@@ -130,7 +179,15 @@
     !>  |+[%key-mismatch ~]
     !>  (veri:dawn who sed *point:azimuth-types ~)
 ::
-++  test-veri-pawn-invalid-life
+++  test-veri-pawn-key-mismatch-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who=ship  `@`fig:ex:cub
+  =/  sed  [who 1 sec:ex:(pit:nu:crub:crypto 24 %bar) ~]
+  %+  expect-eq
+    !>  |+[%key-mismatch ~]
+    !>  (veri:dawn who sed *point:azimuth-types ~)
+::
+++  test-veri-pawn-invalid-life-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who=ship  `@`fig:ex:cic
   =/  sed  [who 2 sec:ex:cic ~]
@@ -138,10 +195,26 @@
     !>  |+[%invalid-life ~]
     !>  (veri:dawn who sed *point:azimuth-types ~)
 ::
-++  test-veri-pawn-already-booted
+++  test-veri-pawn-invalid-life-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who=ship  `@`fig:ex:cub
+  =/  sed  [who 2 sec:ex:cub ~]
+  %+  expect-eq
+    !>  |+[%invalid-life ~]
+    !>  (veri:dawn who sed *point:azimuth-types ~)
+::
+++  test-veri-pawn-already-booted-cric
   =/  cic  (pit:nu:cric:crypto 24 %foo %b ~)
   =/  who=ship  `@`fig:ex:cic
   =/  sed  [who 1 sec:ex:cic ~]
+  %+  expect-eq
+    !>  |+[%already-booted ~]
+    !>  (veri:dawn who sed *point:azimuth-types `[1 |])
+::
+++  test-veri-pawn-already-booted-crub
+  =/  cub  (pit:nu:crub:crypto 24 %foo)
+  =/  who=ship  `@`fig:ex:cub
+  =/  sed  [who 1 sec:ex:cub ~]
   %+  expect-eq
     !>  |+[%already-booted ~]
     !>  (veri:dawn who sed *point:azimuth-types `[1 |])


### PR DESCRIPTION
Reintroduces `+crub`, which was removed in #7292, and the unit tests for it alongside the new `+cric` tests.

This is to turn a breaking change into a non-breaking change in advance of the initial 408k prerelease. As discussed in today's Core Architecture meeting, the ideal way to handle having multiple crypto cores might be a core called something like `+crux` or `+cruz` that can automatically route to the core corresponding to the key's format.