### PR TITLE
jael/ames: fix errors in +sign:as replacement logic

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12394,11 +12394,12 @@
           ::
           =/  =open-packet
             [pass.ames-state our life.ames-state u.rcvr u.life]
-          =/  sig
-            %+  sign-raw:ed:crypto  (jam open-packet)
-            [sgn.pub sgn.sek]:saf.ames-state
+          =/  ded
+            =/  msg  (jam open-packet)
+            =/  sig  (sign-raw:ed:crypto msg [sgn.pub sgn.sek]:saf.ames-state)
+            (jam sig msg)
           :+  ~  ~
-          [%message !>(proof/sig)]
+          [%message !>(proof/ded)]
         ::  publisher-side, weight of a noun at .pat, as measured by .boq
         ::
         ++  peek-whey

--- a/pkg/arvo/sys/vane/jael.hoon
+++ b/pkg/arvo/sys/vane/jael.hoon
@@ -1269,12 +1269,12 @@
         [~ ~]
       =/  sec  (~(got by jaw.own.pki.lex) u.lyf)
       =/  cic  (nol:nu:cric:crypto sec)
-      =/  sig
-        %+  sign-raw:ed:crypto
-          (shaf %self (sham [u.who 1 pub:ex:cic]))
-        [sgn.pub sgn.sek]:saf:ex:cic
+      =/  ded
+        =/  msg  (shaf %self (sham [u.who 1 pub:ex:cic]))
+        =/  sig  (sign-raw:ed:crypto msg [sgn.pub sgn.sek]:saf:ex:cic)
+        (jam sig msg)
       :^  ~  ~  %noun
-      !>  [1 pub:ex:cic `sig]
+      !>  [1 pub:ex:cic `ded]
     ::
     =/  pub  (~(get by pos.zim.pki.lex) u.who)
     ?~  pub


### PR DESCRIPTION
In 3 places where `+sign:as` had been replaced with a `+sign-raw:ed` invocation, it was returning `signature` rather than `(jam signature message)`.