### PR TITLE
dojo: fix poke perm check for dojo linking

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1759,7 +1759,9 @@
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card:agent:gall _..on-init)
-  ?>  (team:title [our src]:hid)
+  ?>  ?|  (team:title [our src]:hid)
+          (~(has in acl) src.hid)
+      ==
   =^  moves  state
     ^-  (quip card:agent:gall house)
     ?+  mark  ~|([%dojo-poke-bad-mark mark] !!)


### PR DESCRIPTION
linking to a remote dojo and typing crashed on a permissions check. 
we now also check the acl.

``` hoon
drum: link [~bus %dojo]
> |dojo/link ~bus %dojo
>=
[linked to [p=~bus q=%dojo]]
[unlinked from [p=~bus q=%dojo]]
/sys/vane/gall/hoon:<[2.061 9].[2.061 37]>
/app/dojo/hoon:<[1.761 3].[1.808 20]>
/app/dojo/hoon:<[1.762 3].[1.808 20]>
poke-ack
[%drum-coup-fail ~bus p=~bus q=%dojo]
```