### PR TITLE
clay: make mark bushes optional in %tube

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -768,7 +768,7 @@
             =/  old=(unit vase)  (bind bush.a bush-to-vase)
             ?:  &(?=(^ old) (has-arm %grow mark.b u.old))
               :: %-  (trace 4 |.("+grow:{(trip mark.a)}"))
-              %+  slap  (with-faces cor+u.old ~)
+              %+  slub  (with-faces cor+u.old ~)
               :+  %brcl  !,(*hoon v=+<.cor)
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grow-{<mark.a>}->{<mark.b>}")] ~]
@@ -780,7 +780,7 @@
               =;  v=vase
                 ?^  q.v  v
                 ~_('clay: @ product of +grab not supported' !!)
-              %+  slap  u.new
+              %+  slub  u.new
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grab-{<mark.a>}->{<mark.b>}")] ~]
               tsgl/[limb/mark.a limb/%grab]

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -459,11 +459,9 @@
 ++  has-arm
   |=  [arm=@tas =mark core=vase]
   ^-  ?
-  =/  rib  (mule |.((slub core [%wing ~[arm]])))
-  ?:  ?=(%| -.rib)  %.n
-  =/  lab  (mule |.((slob mark p.p.rib)))
-  ?:  ?=(%| -.lab)  %.n
-  p.lab
+  ?.  (slob arm p.core)  |
+  ?~  rib=(mole |.((slub core [%wing ~[arm]])))  |
+  (slob mark p.u.rib)
 ::
 ++  rave-to-rove
   |=  rav=rave
@@ -634,8 +632,11 @@
               [%hoon text=@t deps=(list (pair (unit term) bush)) =path]
               [%arch =spec files=(map @ta bush) =path]
               [%mark grad=(unit (trel bush bush bush)) cor=vase =mark]
-              [%tube p=$@(?(%same %mime) [a=[=mark =bush] b=[=mark =bush]])]  ::  identity/mime -> hoon
-          ==
+              $:  %tube
+                  $=  p
+                  $@  ?(%same %mime)  ::  identity / (mime -> hoon)
+                  [a=[=mark bush=(unit bush)] b=[=mark bush=(unit bush)]]
+          ==  ==
         ::
         +$  bush-node
           $%  [%hoon =path]
@@ -764,17 +765,17 @@
             =/  a  a.p.bush
             =/  b  b.p.bush
             :: %-  (trace 1 |.("make: tube: %{(trip mark.a)} -> %{(trip mark.b)}"))
-            =/  old  (bush-to-vase bush.a)
-            ?:  (has-arm %grow mark.b old)
+            =/  old=(unit vase)  (bind bush.a bush-to-vase)
+            ?:  &(?=(^ old) (has-arm %grow mark.b u.old))
               :: %-  (trace 4 |.("+grow:{(trip mark.a)}"))
-              %+  slub  (with-faces cor+old ~)
+              %+  slub  (with-faces cor+u.old ~)
               ^-  hoon
               :+  %brcl  !,(*hoon v=+<.cor)
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grow-{<mark.a>}->{<mark.b>}")] ~]
               :+  %tsgl  limb/mark.b
               !,(*hoon ~(grow cor v))
-            =/  new  (bush-to-vase bush.b)
+            =/  new=vase  (bush-to-vase (need bush.b))
             =/  arm=?  (has-arm %grab mark.a new)
             =/  rab
               %-  mule  |.
@@ -944,8 +945,10 @@
         ?:  =(a.mars.nod b.mars.nod)  tube+%same
         ?:  =([%mime %hoon] [a.mars.nod b.mars.nod])  tube+%mime
         :+  %tube
-          [a.mars.nod bush-loop(nod hoon+(fit-path %mar a.mars.nod))]
-        [b.mars.nod bush-loop(nod hoon+(fit-path %mar b.mars.nod))]
+          =/  pax=(unit path)  (try-fit-path %mar a.mars.nod)
+          [a.mars.nod ?~(pax ~ `bush-loop(nod hoon+u.pax))]
+        =/  pax=(unit path)  (try-fit-path %mar b.mars.nod)
+        [b.mars.nod ?~(pax ~ `bush-loop(nod hoon+u.pax))]
       ::
           %arch
         =/  fiz=(list @ta)
@@ -1130,13 +1133,19 @@
     ++  fit-path
       |=  [pre=@tas pax=@tas]
       ^-  path
+      ~_  leaf/"clay: no files match /{(trip pre)}/{(trip pax)}/hoon"
+      (need (try-fit-path pre pax))
+    ::
+    ::
+    ++  try-fit-path
+      |=  [pre=@tas pax=@tas]
+      ^-  (unit path)
       =/  paz  (segments pax)
-      |-  ^-  path
-      ?~  paz
-        ~_(leaf/"clay: no files match /{(trip pre)}/{(trip pax)}/hoon" !!)
+      |-  ^-  (unit path)
+      ?~  paz  ~
       =/  pux=path  pre^(snoc i.paz %hoon)
       ?:  (~(has by files) pux)
-        pux
+        `pux
       $(paz t.paz)
     ::
     ++  trace

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -781,11 +781,9 @@
                 ?^  q.v  v
                 ~_('clay: @ product of +grab not supported' !!)
               %+  slub  u.new
-              :^  %tsfs  %tub  tsgl+[limb+mark.a limb+%grab]
-              :+  %brcl  tsgl+[$+6 limb+%tub]
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grab-{<mark.a>}->{<mark.b>}")] ~]
-              [%cnhp limb+%tub $+6]
+              tsgl/[limb/mark.a limb/%grab]
             ?:  ?=(%noun mark.b)
               :: %-  (trace 4 |.("default"))
               same.bud

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -781,9 +781,11 @@
                 ?^  q.v  v
                 ~_('clay: @ product of +grab not supported' !!)
               %+  slub  u.new
+              :^  %tsfs  %tub  tsgl+[limb+mark.a limb+%grab]
+              :+  %brcl  tsgl+[$+6 limb+%tub]
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grab-{<mark.a>}->{<mark.b>}")] ~]
-              tsgl/[limb/mark.a limb/%grab]
+              [%cnhp limb+%tub $+6]
             ?:  ?=(%noun mark.b)
               :: %-  (trace 4 |.("default"))
               same.bud

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -768,30 +768,26 @@
             =/  old=(unit vase)  (bind bush.a bush-to-vase)
             ?:  &(?=(^ old) (has-arm %grow mark.b u.old))
               :: %-  (trace 4 |.("+grow:{(trip mark.a)}"))
-              %+  slub  (with-faces cor+u.old ~)
-              ^-  hoon
+              %+  slap  (with-faces cor+u.old ~)
               :+  %brcl  !,(*hoon v=+<.cor)
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grow-{<mark.a>}->{<mark.b>}")] ~]
               :+  %tsgl  limb/mark.b
               !,(*hoon ~(grow cor v))
-            =/  new=vase  (bush-to-vase (need bush.b))
-            =/  arm=?  (has-arm %grab mark.a new)
-            =/  rab
-              %-  mule  |.
-              %+  slap  new
-              ^-  hoon
+            =/  new=(unit vase)  (bind bush.b bush-to-vase)
+            ?:  &(?=(^ new) (has-arm %grab mark.a u.new))
+              :: %-  (trace 4 |.("+grab:{(trip mark.b)}"))
+              =;  v=vase
+                ?^  q.v  v
+                ~_('clay: @ product of +grab not supported' !!)
+              %+  slap  u.new
               :+  %sggr
                 [%spin %cltr [%sand %t (crip "grab-{<mark.a>}->{<mark.b>}")] ~]
               tsgl/[limb/mark.a limb/%grab]
-            ::
-            ?:  &(arm ?=(%& -.rab) ?=(^ q.p.rab))
-              :: %-  (trace 4 |.("+grab:{(trip mark.b)}"))
-              p.rab
             ?:  ?=(%noun mark.b)
               :: %-  (trace 4 |.("default"))
               same.bud
-            ~|(no-cast-between+[mark.a mark.b] !!)  ::  XX +jump arm, +grab with @tas product
+            ~|(no-cast-between+[mark.a mark.b] !!)  ::  XX +jump arm
           ::
           ==
         --


### PR DESCRIPTION
@bonbud-macryg noticed that mounting a fresh desk created with `|new-desk` no longer worked.

It turns out that dependency graph construction for mark conversion gates was too strict: it required files for both marks to exist, even though only one mark core is actually needed (for either `+grow` or `+grab` contents of the first or the seconds marks respectively). This led to a crash during `%hoon -> %mime` conversion gate construction, as `/mar/mime/hoon` does not exist in a fresh desk.

This PR makes marks' bushes optional in `%tube` case of `$bush`, so it makes both the bush construction and the bush-to-vase computations more robust.

~Note that I removed `arm` calculation that checked for `+grab` existence: it seems to me unnecessary since for `rab` to be succesfull `+grab` at least needs to exist.~ I realized the mistake with that: we want to check the top-level battery only and not the entire namespace of a vase. This prompted me to add another arm existence check with `+slob` in `+has-arm`.

Tested this by trying to reproduce the bug encountered by @bonbud-macryg, a new desk mounted fine.