### PR TITLE
Add Dojo API support.

### DIFF
--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1859,8 +1859,14 @@
   [~ ..on-init]
 ::
 ++  on-peek
-  |=  path
-  *(unit (unit cage))
+  |=  =path
+  ^-  (unit (unit cage))
+  ::  /x/sole/sessions: JSON array of active session names (@ta cords)
+  ?.  =(/x/sole/sessions path)  ~
+  =/  names=(list json)
+    %+  turn  ~(tap in ~(key by hoc))
+    |=([who=@p ses=@ta] s+ses)
+  ``json+!>([%a names])
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]

--- a/pkg/arvo/app/dojo.hoon
+++ b/pkg/arvo/app/dojo.hoon
@@ -1368,6 +1368,29 @@
       ==
     ==
   ::
+  ::  +he-eval: programmatic eval — like +he-done but without terminal echo
+  ::
+  ::    Parses src as a full Dojo command (supports =x bindings, generators,
+  ::    threads, etc.) and executes it against the session's subject.  Results
+  ::    are emitted as %sole-effect %tan facts on the /sole subscription; a
+  ::    trailing %sole-effect %pro signals completion.  Does not touch the
+  ::    sole-share cursor state, so terminal sessions are unaffected.
+  ::
+  ++  he-eval
+    |=  src=tape
+    ^+  +>
+    =+  doy=(he-duke src)
+    ?-    -.doy
+        %|  he-pine:(he-errd ~ p.doy)
+        %&
+      ?~  p.doy
+        he-pine:(he-errd ~ (lent src))
+      ?-  -.u.p.doy
+        %&  (he-plan(buf ~) p.u.p.doy)
+        %|  he-prom(buf p.u.p.doy)
+      ==
+    ==
+  ::
   ++  he-tab
     |=  pos=@ud
     ^+  +>
@@ -1779,6 +1802,11 @@
       =+  !<(=id vase)
       =/  ses=session  (~(got by hoc) id)
       he-abet:(~(he-done he hid id ~ ses) (tufa buf.say.ses))
+    ::
+        %eval-command
+      =+  !<([ses=@ta src=tape] vase)
+      =/  =id  [our.hid ses]
+      he-abet:(~(he-eval he hid id ~ (~(got by hoc) id)) src)
     ::
         %allow-remote-login
       =/  who  !<(@p vase)

--- a/pkg/arvo/mar/eval-command.hoon
+++ b/pkg/arvo/mar/eval-command.hoon
@@ -1,0 +1,29 @@
+::  %eval-command mark
+::
+::    Payload for the %dojo %eval-command poke.
+::
+::    ses: the @ta session name used when subscribing to /sole/[ship]/[ses]
+::    src: full Dojo command tape (same syntax as the terminal REPL)
+::
+::    The caller must already hold a subscription to /sole/[ship]/[ses]
+::    (which creates and anchors the Dojo session).  Results arrive as
+::    %sole-effect %tan facts on that subscription; %sole-effect %pro
+::    signals that the command has finished executing.
+::
+|_  [ses=@ta src=tape]
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  [ses src]
+  --
+++  grab
+  |%
+  ++  noun  ,[ses=@ta src=tape]
+  ++  json
+    |=  jon=^json
+    ^-  [ses=@ta src=tape]
+    =,  dejs:format
+    =/  res  ((ot ses+so src+so ~) jon)
+    [`@ta`-.res (trip +.res)]
+  --
+--

--- a/pkg/arvo/mar/eval-command.hoon
+++ b/pkg/arvo/mar/eval-command.hoon
@@ -1,13 +1,13 @@
 ::  %eval-command mark
 ::
-::    Payload for the %dojo %eval-command poke.
+::    Payload for an %eval-command poke on any %sole/%shoe agent.
 ::
 ::    ses: the @ta session name used when subscribing to /sole/[ship]/[ses]
-::    src: full Dojo command tape (same syntax as the terminal REPL)
+::    src: raw input tape (same syntax as the agent's interactive REPL)
 ::
 ::    The caller must already hold a subscription to /sole/[ship]/[ses]
-::    (which creates and anchors the Dojo session).  Results arrive as
-::    %sole-effect %tan facts on that subscription; %sole-effect %pro
+::    (which creates and anchors the session).  Results arrive as
+::    %sole-effect facts on that subscription; %sole-effect %pro
 ::    signals that the command has finished executing.
 ::
 |_  [ses=@ta src=tape]

--- a/pkg/base-dev/lib/shoe.hoon
+++ b/pkg/base-dev/lib/shoe.hoon
@@ -235,6 +235,27 @@
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card:agent:gall agent:gall)
+    ::  %eval-command: programmatic execution, bypasses keystroke buffer
+    ::
+    ::    The caller must already hold a subscription to /sole/[ship]/[ses]
+    ::    (which registers the session).  Results arrive as %sole-effect
+    ::    facts on that subscription; %sole-effect %pro signals completion.
+    ::
+    ?:  ?=(%eval-command mark)
+      =+  !<([ses=@ta src=tape] vase)
+      =/  =sole-id  [our.bowl ses]
+      ?>  (~(has by soles) sole-id)
+      =/  res=(unit [? cmd=command-type])
+        %+  rust  src
+        (command-parser:og sole-id)
+      ?~  res
+        :_  this
+        (deal ~[[%shoe [sole-id]~ %sole %bel ~]])
+      =^  cards  shoe  (on-command:og sole-id cmd.u.res)
+      =/  pro=card  [%shoe [sole-id]~ %sole %pro & dap.bowl "> "]
+      :_  this
+      (deal (snoc cards pro))
+    ::  pass non-%sole-action pokes to the inner app
     ?.  ?=(%sole-action mark)
       =^  cards  shoe  (on-poke:og mark vase)
       [(deal cards) this]
@@ -374,6 +395,12 @@
   ++  on-peek
     |=  =path
     ^-  (unit (unit cage))
+    ::  /x/sole/sessions: JSON array of active session names (@ta cords)
+    ?:  =(/x/sole/sessions path)
+      =/  names=(list json)
+        %+  turn  ~(tap in ~(key by soles))
+        |=([who=@p ses=@ta] s+ses)
+      ``json+!>([%a names])
     ?.  =(/x/dbug/state path)  (on-peek:og path)
     ``noun+(slop on-save:og !>(shoe=state))
   ::


### PR DESCRIPTION
This introduces an API for Dojo via authenticated Eyre SSE so that external web tools (like the [Jupytur kernel](https://github.com/sigilante/jupytur)) can interface with Dojo.