### PR TITLE
dbug: allow passing pokes to "deeper" dbugs

### DIFF
--- a/pkg/arvo/gen/dbug.hoon
+++ b/pkg/arvo/gen/dbug.hoon
@@ -27,9 +27,12 @@
         args=?(~ [what=?(%bowl %state) ~] [=poke ~])
         ::  named arguments
         ::
-        ~
+        depth=@ud
     ==
 :-  %dbug
+=;  =poke
+  ?:  =(0 depth)  poke
+  [%skip depth poke]
 ?-  args
   ~          [%state '']
   [@ ~]      ?-(what.args %bowl [%bowl ~], %state [%state ''])

--- a/pkg/base-dev/lib/dbug.hoon
+++ b/pkg/base-dev/lib/dbug.hoon
@@ -4,7 +4,8 @@
 ::
 |%
 +$  poke
-  $%  [%bowl ~]
+  $%  [%skip depth=@ud =poke]
+      [%bowl ~]
       [%state grab=cord]
       [%incoming =about]
       [%outgoing =about]
@@ -32,8 +33,13 @@
     ?.  ?=(%dbug mark)
       =^  cards  agent  (on-poke:ag mark vase)
       [cards this]
-    =/  dbug
-      !<(poke vase)
+    =/  dbug  !<(poke vase)
+    =?  dbug  ?=([%skip %0 *] dbug)  poke.dbug
+    ?:  ?=(%skip -.dbug)
+      =^  cards  agent
+        %+  on-poke:ag  %dbug
+        !>(`poke`dbug(depth (dec depth.dbug)))
+      [cards this]
     =;  =tang
       ((%*(. slog pri 1) tang) [~ this])
     ?-  -.dbug


### PR DESCRIPTION
As agent wrappers got more complicated, they started maintaining their own state and making their own changes to the bowl before presenting it to the inner agent. (See, in particular, Tlon's /lib/negotiate.) Developers had to choose between debugging the wrapper's state, or the inner agent's, by wrapping /lib/dbug around one or the other.

Here, we add a `%skip` case to the dbug poke, which the library detects and handles by decrementing the skip count, or unpacking it into the actual poke once that count reaches zero.

This way, developers get more and easier control over what "level" to inspect agent state/bowl at. It lets them wrap the dbug library around different layers of their agent without running into horrible usability problems.