### PR TITLE
hoon: ensure +del:by and +del:in are type-safe

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -1251,9 +1251,10 @@
     ?>  ?=(^ c)
     c(l a(r l.c))
   ::
-  ++  del                                               ::  b without any a
+  ++  del                                               ::  a without any b
     ~/  %del
     |*  b=*
+    =>  .(b `_?>(?=(^ a) n.a)`b)
     |-  ^+  a
     ?~  a
       ~
@@ -1460,6 +1461,7 @@
   ++  del                                               ::  delete at key b
     ~/  %del
     |*  b=*
+    =>  .(b `_?>(?=(^ a) p.n.a)`b)
     |-  ^+  a
     ?~  a
       ~

--- a/tests/sys/hoon/set.hoon
+++ b/tests/sys/hoon/set.hoon
@@ -189,7 +189,7 @@
     ::
     %+  expect-eq
       !>  ~
-      !>  (~(del in ~) 1)
+      !>  (~(del in *(set @)) 1)
     ::  Checks deleting non-existing element
     ::
     %+  expect-eq


### PR DESCRIPTION
Most function in `+by` make use of `+get:by`, which casts the argument to ensure it is a key of the correct type. `+del:by` however does not do this, letting you compile code that deletes keys which can never exist according to the type of the map.

`+del:in` suffers from the same problem. `+has:in` uses a more elaborate patch (from b75c19e), but here we re-use the simpler pattern used in most `+by` arms and elsewhere.

Before:

```hoon
> =m *(map @ud @ud)
> (~(del by m) 1 2)
~

> =s *(set @ud)
> (~(del in s) 1 2)
~
```

After:

```hoon
> =m *(map @ud @ud)
> (~(del by m) 1 2)
-need.@ud
-have.[@ud @ud]
nest-fail

> =s *(set @ud)
> (~(del in s) 1 2)
-need.@ud
-have.[@ud @ud]
nest-fail
```

This is, obviously, a breaking change: code that compiled previously may no longer compile. Up to you @pkova whether this can go out with 408 or wants to await the next hoon kelvin change.