### PR TITLE
mesa: revert double signing in %pawn namespace

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -4,8 +4,8 @@
     ahoy=hood-ahoy
 |%
 +$  state
-  $~  [%29 *state:drum *state:helm *state:kiln *state:ahoy]
-  $>(%29 any-state)
+  $~  [%30 *state:drum *state:helm *state:kiln *state:ahoy]
+  $>(%30 any-state)
 ::
 +$  any-state
   $%  [ver=?(%1 %2 %3 %4 %5 %6) lac=(map @tas fin-any-state)]
@@ -36,6 +36,12 @@
           helm=state-2:helm
           kiln=state-11:kiln
           ahoy=state-0:ahoy
+      ==
+      $:  %30
+          drum=state-6:drum
+          helm=state-2:helm
+          kiln=state-11:kiln
+          ahoy=state-1:ahoy
   ==  ==
 ::
 +$  any-state-tuple
@@ -90,7 +96,7 @@
   ?:  ?=(%27 -.old)
     $(old old(- %28), cards (eyre-clean:load [our now]:bowl))
   =/  tup=any-state-tuple
-    ?:  ?=(%29 -.old)
+    ?:  ?=(?(%29 %30) -.old)
       +.old
     ?+    -.old  +.old(kiln [kiln.old *any-state:ahoy])
         ?(%1 %2 %3 %4 %5 %6)

--- a/pkg/arvo/lib/hood/ahoy.hoon
+++ b/pkg/arvo/lib/hood/ahoy.hoon
@@ -39,13 +39,15 @@
 /+  strandio
 =*  card  card:agent:gall
 |%
-+$  state  state-0
++$  state  state-1
 +$  any-state
  $~  *state
  $%  state-0
+     state-1
  ==
-+$  state-0
-  $:  %0
++$  state-0  [%0 _+:*state-1]
++$  state-1
+  $:  %1
       ::  peers not responding, as of last attempt
       ::
       no-response=(map ship attempt=@da)
@@ -142,7 +144,12 @@
 ::
 ++  on-load
   |=  [hood-version=@ud old=any-state]  =<  abet
-  ?>  ?=(%0 -.old)
+  |-  ^-  this
+  ?:  ?=(%0 -.old)
+    ::  disable %mesa as the default core for new peers
+    ::
+    $(old old(- %1), this (emit %pass /ames %arvo %a %load %ames))
+  ?>  ?=(%1 -.old)
   this(sat old)
 ::  handle ahoy actions:
 ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12141,9 +12141,12 @@
           ?>  ?&  =(1 (div (add tob.data 1.023) 1.024))
                   ?=(%& -.aut.data)
               ==
-          =+  ;;(proof=gage:mess (cue dat.data))
+          ::
+          =+  ;;  proof=gage:mess         (cue dat.data)
           ?>  ?=([%message %proof *] proof)
-          =+  ;;(=open-packet (cue ;;(@ +>.proof)))
+          =+  ;;  [signature=@ signed=@]  (cue ;;(@ +>.proof))
+          =+  ;;  =open-packet            (cue signed)
+          ::
           ?>  %-  verify-sig:crypt
               :^    (end 8 (rsh 3 pass.open-packet))
                   p.p.aut.data
@@ -12635,9 +12638,13 @@
           ?:  |(?=(~ life) ?=(~ rcvr))
             [~ ~]
           ::
-          =;  =open-packet
-            ``[%message !>(proof/(jam open-packet))]
-          [pass.ames-state our life.ames-state u.rcvr u.life]
+          =/  =open-packet
+            [pass.ames-state our life.ames-state u.rcvr u.life]
+          =/  sig
+            %+  sign-raw:ed:crypto  (jam open-packet)
+            [sgn.pub sgn.sek]:saf.ames-state
+          :+  ~  ~
+          [%message !>(proof/sig)]
         ::  publisher-side, weight of a noun at .pat, as measured by .boq
         ::
         ++  peek-whey


### PR DESCRIPTION
This would break referential transparency for comets that were booted on 410. Also, we enable %ames as the default network core for first-contact communication for live peers—this was done in %lull but only applies to ships that are newly booted