### PR TITLE
clay: build all marks when a desk is loaded

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -315,7 +315,6 @@
     =^  cards  state
       ?+  wire  (on-arvo:def wire sign-arvo)
         [%thread @ *]  (handle-sign:sc i.t.wire t.t.wire sign-arvo)
-        [%mark ~]      `state
         [%build @ ~]   (handle-build:sc i.t.wire sign-arvo)
         [%bind ~]      `state
       ==
@@ -384,9 +383,7 @@
     ==
   =/  boc  bec
   =/  =start-args:spider  [~ `tid boc(q desk, r da+now.bowl) thread input]
-  =^  start-cards  state  (handle-start-thread start-args)
-  :_  state
-  [(build-mark give input-mark desk bowl) start-cards]
+  (handle-start-thread start-args)
 ::
 ++  on-poke-input
   |=  input
@@ -626,11 +623,6 @@
   :_  state(serving (~(del by serving.state) tid))
   ?~  request
     ~
-  ::
-  =;  cards=(list card)
-    ?.  ?=(%json take.u.request)
-      cards
-    [(build-mark %tang %json desk bowl) cards]
   %+  give-simple-payload:app:server  rid.u.request
   ^-  simple-payload:http
   ?.  ?=(http-error:spider term)
@@ -679,7 +671,6 @@
       %json
     =/  tube  (convert-tube output %json desk bowl)
     :_  state(serving (~(del by serving.state) tid))
-    :-  (build-mark output %json desk bowl)
     %+  give-simple-payload:app:server  rid.u.request
     (json-response:gen:server !<(json (tube vase)))
   ::
@@ -784,12 +775,4 @@
     %cc
     /(scot %p our.bowl)/[desk]/(scot %da now.bowl)/[from]/[to]
   ==
-::
-++  build-mark
-  |=  [from=mark to=mark =desk =bowl:gall]
-  ^-  card
-  :*  %pass  /mark  %arvo
-      [%c %warp our.bowl desk ~ %sing %c da+now.bowl /[from]/[to]]
-  ==
-::
 --

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4488,9 +4488,8 @@
         |=  [=desk =bill]
         leaf+"goad: output: {<desk>}: {<bill>}"
     =/  agents  (build-agents sat)
-    ::  TODO: enable if we can reduce memory usage
     ::
-    ::  =+  (build-marks (turn (skip sat |=([desk =bill] =(bill ~))) head))
+    =+  (build-marks (turn (skip sat |=([desk =bill] =(bill ~))) head))
     ::
     =.  ..abet  tare                                    ::  [tare] >
     (emit hen %pass /lu/load %g %load agents)

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1240,7 +1240,7 @@
         (rsh 3 (spat p.mime))  q.mime
     ::  attempt to find conversion gate to mime
     ::
-    =/  tub=(unit [tub=tube:clay mov=move])
+    =/  tub=(unit tub=tube:clay)
       (find-tube i.site.req mark %mime)
     ?~  tub  (error-response 500 "no tube from {(trip mark)} to mime")
     ::  attempt conversion, then send results
@@ -1253,11 +1253,11 @@
         %&  %+  return-static-data-on-duct  200
             [(rsh 3 (spat p.p.mym)) q.p.mym]
       ==
-    [[mov.u.tub cards] state]
+    [cards state]
     ::
     ++  find-tube
       |=  [dap=term from=mark to=mark]
-      ^-  (unit [tube:clay move])
+      ^-  (unit tube:clay)
       =/  des=(unit (unit cage))
         (do-scry %gd dap /$)
       ?.  ?=([~ ~ *] des)  ~
@@ -1266,9 +1266,7 @@
         (do-scry %cc desk /[from]/[to])
       ?.  ?=([~ ~ %tube *] tub)  ~
       :-  ~
-      :-  !<(tube:clay q.u.u.tub)
-      :^  duct  %pass  /conversion-cache/[from]
-      [%c %warp our desk `[%sing %c da+now /[from]/[to]]]
+      !<(tube:clay q.u.u.tub)
     ::
     ++  do-scry
       |=  [care=term =desk =path]
@@ -2483,7 +2481,7 @@
         =/  said
           (channel-event-to-cord channel request-id channel-event)
         ?~  said  $
-        $(events [(event-cord-to-event-stream id +.u.said) events])
+        $(events [(event-cord-to-event-stream id u.said) events])
       ?:  exit  [moves state]
       ::  send the start event to the client
       ::
@@ -2808,10 +2806,8 @@
         (sign-to-channel-event sign u.channel request-id)
       ?~  maybe-channel-event  [~ state]
       =/  =channel-event  u.maybe-channel-event
-      =/  said=(unit (quip move cord))
+      =/  said=(unit cord)
         (channel-event-to-cord u.channel request-id channel-event)
-      =?  moves  ?=(^ said)
-        (weld moves -.u.said)
       =*  sending  &(?=([%| *] state.u.channel) ?=(^ said))
       ::
       =/  next-id  next-id.u.channel
@@ -2834,7 +2830,7 @@
             ^=  data
             :-  ~
             %-  as-octs:mimes:html
-            (event-cord-to-event-stream next-id +:(need said))
+            (event-cord-to-event-stream next-id (need said))
         ::
             complete=%.n
         ==
@@ -2898,7 +2894,7 @@
             :-  ~
             %-  as-octs:mimes:html
             %+  event-cord-to-event-stream  next-id
-            +:(need (channel-event-to-cord u.channel request-id %kick ~))
+            (need (channel-event-to-cord u.channel request-id %kick ~))
         ::
             complete=%.n
         ==
@@ -2936,11 +2932,11 @@
     ::
     ++  channel-event-to-cord
       |=  [=channel request-id=@ud =channel-event]
-      ^-  (unit (quip move cord))
+      ^-  (unit cord)
       ?-  mode.channel
         %json  %+  bind  (channel-event-to-json channel request-id channel-event)
-               |=((quip move json) [+<- (en:json:html +<+)])
-        %jam   =-  `[~ (scot %uw (jam -))]
+               |=(j=json (en:json:html j))
+        %jam   =-  `(scot %uw (jam -))
                [request-id channel-event]
       ==
     ::  +channel-event-to-json: render channel event as json channel event
@@ -2948,7 +2944,7 @@
     ++  channel-event-to-json
       ~%  %eyre-channel-event-to-json  ..part  ~
       |=  [=channel request-id=@ud event=channel-event]
-      ^-  (unit (quip move json))
+      ^-  (unit json)
       ::  for facts, we try to convert the result to json
       ::
       =/  [from=(unit [=desk =mark]) jsyn=(unit sign:agent:gall)]
@@ -2973,10 +2969,6 @@
         [`[desk.event have] `[%fact %json (slym u.convert noun.event)]]
       ?~  jsyn  ~
       %-  some
-      :-  ?~  from  ~
-          :_  ~
-          :^  duct  %pass  /conversion-cache/[mark.u.from]
-          [%c %warp our desk.u.from `[%sing %f da+now /[mark.u.from]/json]]
       =*  sign  u.jsyn
       =,  enjs:format
       %-  pairs


### PR DESCRIPTION
Lazy building of marks has generally been problematic, mainly because it causes surprising performance characteristics for operations that use a given mark for the first time. To get around these problems some apps have resorted to "mark warmers" which are library files that import all the relevant marks just to have them pre-built in the ford cache. It is next to impossible to keep these mark warmers up to date, causing many performance headaches over the years.

Once upon a time the memory usage of eager mark building was unacceptable. With 408 we have ditched the hand written caches in ford and rely on the persistent caching in vere. The memory impact building all the marks on 408 ships with ford lightning is minimal.

We also get rid of the mark warming in eyre and spider.