### PR TITLE
aqua: fix aqua ames thread comet packet filtering

### DIFF
--- a/pkg/arvo/ted/aqua/ames.hoon
+++ b/pkg/arvo/ted/aqua/ames.hoon
@@ -48,8 +48,8 @@
     =+  peer=(~(get by u.peers) sndr)
     ?.  ?=(^ peer)  |
     =(%known u.peer)
-  ?:  ?&  =-  ~?  -  %is-pawn
-              -
+  ?:  ?&  :: =-  ~?  -  %is-pawn
+          ::     -
           ?|  ?=(%pawn (clan:title sndr))
               ?=(%pawn (clan:title sndr.shot))
           ==
@@ -66,7 +66,7 @@
                   !is-known
               ==
               ?&  ?=(^ out)
-                  ?=(^ ;;((soft open-packet:ames-raw) (cue signed:(need (need out)))))
+                  ?=(^ ;;((soft [~ open-packet:ames-raw]) (mole |.((cue signed:(need (need out)))))))
                   ::  if this is an attestation packet, check if the rcvr has the comet
                   ::  as %known -- this is a workaround to prevent a bail:evil that will
                   ::  end up blocking the queue of the %aqua host, when it tries to decrypt

--- a/pkg/arvo/ted/ph/hi-comet-az.hoon
+++ b/pkg/arvo/ted/ph/hi-comet-az.hoon
@@ -12,13 +12,12 @@
 ;<  ~  bind:m  (spawn ~marbud)
 ;<  ~  bind:m  (init-ship ~marbud |)
 ;<  ~  bind:m  (init-comet comet)
-:: ;<  ~  bind:m  (send-hi comet ~bud) ::  XX this crashes, sending the |hi before the attestation
-                                       ::  and we endup blocking the queue
+;<  ~  bind:m  (send-hi comet ~bud)
 ;<  ~  bind:m  (send-hi ~bud comet)
 ;<  ~  bind:m  (spawn ~linnup-torsyx)
 ;<  ~  bind:m  (init-ship ~linnup-torsyx |)
 ::
-:: ;<  ~  bind:m  (send-hi comet ~linnup-torsyx)  :: XX same as above
+;<  ~  bind:m  (send-hi comet ~linnup-torsyx)
 ;<  ~  bind:m  (send-hi ~linnup-torsyx comet)
 :: ::
 ;<  ~  bind:m  end


### PR DESCRIPTION
`(cue <random garbage>)` often doesn't fail and quite frequently produces `[0 0]` which nests in `[signature=@ signed=@]`. This results in the next unvirtualised `cue` silently crashing and killing the whole thread. I have virtualised the 2nd cue to avoid this scenario.