### PR TITLE
arvo: adds `jam-shax` jet for blobs

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -3317,6 +3317,10 @@
   =/  len  (max 32 (met 3 sal))
   (shay len (mix sal (shax ruz)))
 ::
+++  jam-shax                                            ::  sha-256 of jam
+  ~/  %jam-shax
+  |=(* (shax (jam +<)))
+::
 ++  shax                                                ::  sha-256
   ~/  %shax
   |=  ruz=@  ^-  @

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2726,7 +2726,7 @@
   ::
   ::  +page-to-lobe: hash a page to get a lobe.
   ::
-  ++  page-to-lobe  |=(page (shax (jam +<)))
+  ++  page-to-lobe  |=(page (jam-shax +<))
   ::
   ++  cord-to-waft
     |=  =cord


### PR DESCRIPTION
In Hoon now for ease of development, but consensus is it should go into Zuse. I have yet to determine how to register such a placement in `tree.c` of Vere.