### PR TITLE
ahoy: add support for set of hashes as migration triggers

### DIFF
--- a/pkg/arvo/app/hood.hoon
+++ b/pkg/arvo/app/hood.hoon
@@ -4,8 +4,8 @@
     ahoy=hood-ahoy
 |%
 +$  state
-  $~  [%30 *state:drum *state:helm *state:kiln *state:ahoy]
-  $>(%30 any-state)
+  $~  [%31 *state:drum *state:helm *state:kiln *state:ahoy]
+  $>(%31 any-state)
 ::
 +$  any-state
   $%  [ver=?(%1 %2 %3 %4 %5 %6) lac=(map @tas fin-any-state)]
@@ -42,6 +42,12 @@
           helm=state-2:helm
           kiln=state-11:kiln
           ahoy=state-1:ahoy
+      ==
+      $:  %31
+          drum=state-6:drum
+          helm=state-2:helm
+          kiln=state-11:kiln
+          ahoy=state-2:ahoy
   ==  ==
 ::
 +$  any-state-tuple
@@ -96,7 +102,7 @@
   ?:  ?=(%27 -.old)
     $(old old(- %28), cards (eyre-clean:load [our now]:bowl))
   =/  tup=any-state-tuple
-    ?:  ?=(?(%29 %30) -.old)
+    ?:  ?=(?(%29 %30 %31) -.old)
       +.old
     ?+    -.old  +.old(kiln [kiln.old *any-state:ahoy])
         ?(%1 %2 %3 %4 %5 %6)

--- a/pkg/arvo/lib/hood/ahoy.hoon
+++ b/pkg/arvo/lib/hood/ahoy.hoon
@@ -1,12 +1,14 @@
 ::  ahoy: migrate peers to %mesa
 ::
-::  flow:
+::  flows:
 ::
 :: %comb poke
 ::   -> gather all peers in peers.ames-state
 ::   -> pass pending peers and last known cases to -comb
 ::
-::  -comb thread:
+:: %prob poke for .ship
+::
+::  -prob thread:
 ::
 :: on-arvo %keen response (handle-sage):
 ::   -> parse kelvin from response
@@ -163,7 +165,14 @@
     ::
     $(old old(- %1), this (emit %pass /ames %arvo %a %load %ames))
   ?:  ?=(%1 -.old)
+    ::  enable %mesa as the default first-contact network core
+    ::
+    =.  this  (emit %pass /ames %arvo %a %load %mesa)
     ::  add migration hashes from 409k-2 until XX 408k
+    ::
+    ::  XX this is needed for ships that are on the pre-release moon
+    ::  ~binnec, for anybody else we should just read the contents of
+    ::  sys.kelvin and check for 408k
     ::
     =|  sat-2=state-2
     =.  sat-2

--- a/pkg/arvo/lib/hood/ahoy.hoon
+++ b/pkg/arvo/lib/hood/ahoy.hoon
@@ -10,8 +10,8 @@
 ::
 :: on-arvo %keen response (handle-sage):
 ::   -> parse kelvin from response
-::   -> if hash != last-hash: peek next case for same peer
-::   -> if hash == last-hash: will send dry %mate (test-mate)
+::   -> if hash not in trigs.sat: peek next case for same peer
+::   -> if hash     in trigs.sat: will send dry %mate (test-mate)
 ::   -> try next peer in pending queue
 ::
 :: on-arvo timer fire:
@@ -20,7 +20,7 @@
 ::
 ::  when all peers are done, give back result to agent
 ::
-::  for all peers which hash == last-hash, ahoy (dry mode supported)
+::  for all peers which hash in trigs.sat, ahoy (dry mode supported)
 ::
 :: on-arvo %mate done (take-mate):
 ::   -> if error: mark broken
@@ -39,20 +39,20 @@
 /+  strandio
 =*  card  card:agent:gall
 |%
-+$  state  state-1
++$  state  state-2
 +$  any-state
  $~  *state
  $%  state-0
      state-1
+     state-2
  ==
-+$  state-0  [%0 _+:*state-1]
-+$  state-1
-  $:  %1
+
++$  state-2
+  $:  %2
       ::  peers not responding, as of last attempt
       ::
       no-response=(map ship attempt=@da)
       ::  last known kids hash and case per peer, timestamped
-      ::
       ::
       hashes=(map ship [num=@ud has=@uvi when=@da])
       ::  timeout duration to cancel +peek
@@ -61,10 +61,9 @@
       ::  peers we can't migrate
       ::
       broken=(map ship attempt=@da)  :: XX add offending flows?
-      ::  hash to trigger migration
+      ::  hashes to trigger migration (from 409k-2)
       ::
-      last-hash=_0v1l.j5i77.ga13o.okjjk.tv6m9.c9pg4.
-                      7i10l.9mgpp.shtut.q530n.41il8  :: 409k-2
+      trigs=(set @uvi)
       ::  ships with an %ahoy flow in flight
       ::
       pending-ahoy=(set ship)
@@ -72,6 +71,17 @@
       ::
       veb=_|
   ==
++$  state-1
+  $:  %1
+      no-response=(map ship attempt=@da)
+      hashes=(map ship [num=@ud has=@uvi when=@da])
+      timeout=_~s12
+      broken=(map ship attempt=@da)
+      last-hash=@uvi
+      pending-ahoy=(set ship)
+      veb=_|
+  ==
++$  state-0  [%0 _+:*state-1]
 ::
 --
 =>  |%  ++  dispatch-thread
@@ -136,8 +146,11 @@
 ::
 ++  on-init  =<  abet
   %_    this
-      last-hash.sat
-    0v1l.j5i77.ga13o.okjjk.tv6m9.c9pg4.7i10l.9mgpp.shtut.q530n.41il8  :: 409k-2
+      trigs.sat
+    %-  ~(gas in *(set @uvi))
+    :~  0v1l.j5i77.ga13o.okjjk.tv6m9.c9pg4.7i10l.9mgpp.shtut.q530n.41il8  :: 409k-2
+        ::  ...
+    ==
   ==
 ::
 ++  on-peek  abet
@@ -149,7 +162,26 @@
     ::  disable %mesa as the default core for new peers
     ::
     $(old old(- %1), this (emit %pass /ames %arvo %a %load %ames))
-  ?>  ?=(%1 -.old)
+  ?:  ?=(%1 -.old)
+    ::  add migration hashes from 409k-2 until XX 408k
+    ::
+    =|  sat-2=state-2
+    =.  sat-2
+      %_  sat-2
+        no-response   no-response.old
+        hashes        hashes.old
+        timeout       timeout.old
+        broken        broken.old
+        trigs         %-  ~(gas in *(set @uvi))
+                      :~  0v1l.j5i77.ga13o.okjjk.tv6m9.c9pg4.7i10l.9mgpp.shtut.q530n.41il8  :: 409k-2
+                          ::  ...
+                      ==
+      ::
+        pending-ahoy  pending-ahoy.old
+        veb           veb.old
+      ==
+    $(old sat-2)
+  ?>  ?=(%2 -.old)
   this(sat old)
 ::  handle ahoy actions:
 ::
@@ -210,12 +242,12 @@
         p
       who^p
     ::
-    =/  data=^vase  !>([~ timeout.sat hashes.sat pend last-hash.sat veb])
+    =/  data=^vase  !>([~ timeout.sat hashes.sat pend trigs.sat veb])
     %+  emit  %pass
     [(dispatch-thread %comb dry ~) %arvo %k %fard q.byk.bowl %comb %noun data]
   ::
   ++  time       |=(tim=@dr this(timeout.sat tim))
-  ++  hash       |=(has=@uvi this(last-hash.sat has))
+  ++  hash       |=(has=@uvi this(trigs.sat (~(put in trigs.sat) has)))
   ++  verb       this(veb.sat !veb.sat)
   ++  wipe       |=  who=(unit @p)  ^+  this
                  ?^(who (wipe-ship u.who^** this) (~(rep by broken.sat) wipe-ship))
@@ -244,7 +276,7 @@
           [1 0v0 now.bowl]
         u.case
       ::
-      [~ timeout.sat num^has^wen ship last-hash.sat veb.sat]
+      [~ timeout.sat num^has^wen ship trigs.sat veb.sat]
     =.  pending-ahoy.sat  (~(put in pending-ahoy.sat) ship)
     %^  emit  %pass
       (dispatch-thread %prob force `ship)
@@ -341,9 +373,9 @@
     =+  .^  chums=(map ship ?(%known %alien))  %ax
           /(scot %p our.bowl)//(scot %da now.bowl)/chums
         ==
-    ::  ahoy the peer if on last-hash, not yet migrated, and not pending
+    ::  ahoy the peer if on any of the trigs.sat, not yet migrated, and not pending
     ::
-    ?:  ?|  !=(last-hash.sat has)
+    ?:  ?|  !(~(has in trigs.sat) has)
             (~(has by chums) who)
         ==
       ::  delete the peer from pending and try again on next %prob

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -13195,8 +13195,8 @@
           ::
           ?.  =(+>:*fren-state +>.fren)
             %-  %+  %*(ev-tace ev-core her sndr.shot)  odd.veb.bug.ames-state
-                |.("hear ames packet for migrated %known peer")
-            `vane-gate
+                |.("%ames packet with outstanding %mesa flows; spot regression")
+            (call:me-core ~[/spot-rege] dud %rege `sndr.shot dry=%.n)
           ::  if the peer sends us an %ames packets, but we have %known state in
           ::  .chums. this could be caused by:
           ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12996,7 +12996,10 @@
       ?+  -.task  !!
       ::  common tasks
       ::
-        %load  `vane-gate(ames-state ames-state(core +.task))
+          %load
+        ~>  %slog.2^leaf/"mesa: turning on {<+.task>} for first contact"
+        `vane-gate(ames-state ames-state(core +.task))
+      ::
         %plea  (pe-plea +.task)
         %cork  (pe-cork +.task)
         %keen  (pe-keen +.task)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5651,7 +5651,7 @@
           =/  =bone         bone.u.shut-packet
           =/  =message-num  message-num.u.shut-packet
           ?.  ?=(%& -.meat.u.shut-packet)
-            %-  (ev-trace odd.veb sndr.shot |.("ignoring ack"))
+            %-  (ev-trace odd.veb sndr.shot |.("ignoring ack on migrated %ahoy ack"))
             ::  ignore acks
             ::
             event-core
@@ -5707,6 +5707,52 @@
             ==
           ::
             ship-state=~  :: send-blob finds the migrated peer in chums
+          ==
+        ::
+        ++  on-spot-rege
+          |=  =shot
+          ^-  ?
+          ?.  sam.shot
+            %-  (ev-trace odd.veb sndr.shot |.("weird no ames"))
+            %.n
+          =/  =chum-state  (~(got by chums.ames-state) sndr.shot)
+          ?>  ?=([%known *] chum-state)
+          =/  =channel    [[our sndr.shot] now channel-state +<.chum-state]
+          =/  shut-packet=(unit shut-packet)
+            (sift-shut-packet shot [symmetric-key.hers life.hers our-life]:channel)
+          ?~  shut-packet
+            %-  (ev-trace odd.veb sndr.shot |.("weird shut-packet"))
+            %.n
+          =/  =bone         bone.u.shut-packet
+          =/  =message-num  message-num.u.shut-packet
+          ::  when doing a spot regression we assume the following:
+          ::
+          ::    - sndr.shot booted with an old pill or is not on 408k
+          ::    - both our and sndr.shot communicated at the same time
+          ::    - every flow needs to be outstanding
+          ::    - any new packet would create a new flow (ignore boons, and acks)
+          ::    - every outstanding flow needs to have migration line = 0
+          ::
+          ?.  ?=(%& -.meat.u.shut-packet)
+            %-  (ev-trace odd.veb sndr.shot |.("spot rege; ignoring ack"))
+            %.n
+          ?.  =(1 (end 0 bone))
+            %-  (ev-trace odd.veb sndr.shot |.("spot rege; ignore non-plea"))
+            %.n
+          =+  ev-core=(ev-abed:ev:mesa ~ sndr.shot +.chum-state)
+          ?^  fo-core=(~(get by flows.per.ev-core) side=[(mix 1 bone) %bak])
+            %-  (ev-trace odd.veb sndr.shot |.("spot rege; ignore existing flow"))
+            %.n
+          ::  this plea will create a new flow;
+          ::  check if: all %for flows are all outstanding
+          ::             no %bak flows exist
+          ::
+          %-  ~(rep by flows.per.ev-core)
+          |=  [[side state=flow-state] regress=_&]
+          ?&  regress
+              =(%for dire)
+              =(0 line.state)
+              ?=(^ loads.snd.state)
           ==
         ::
         +|  %implementation
@@ -13194,20 +13240,27 @@
           ::  skip route in comparison; galaxies have it hardcoded
           ::
           ?.  =(+>:*fren-state +>.fren)
+            ::  if we have outstanding %mesa flows and we hear %ames packets
+            ::  we need to make sure that we have not communicated previously.
+            ::  if that holds we will do a spot regression to %ames, handling
+            ::  the packet and enqueuing an %ahoy $plea
+            ::
             %-  %+  %*(ev-tace ev-core her sndr.shot)  odd.veb.bug.ames-state
                 |.("%ames packet with outstanding %mesa flows; spot regression")
+            ?.  (on-spot-rege:(ev:am-core now^eny^rof hen ames-state) shot)
+              `vane-gate
             (call:me-core ~[/spot-rege] dud %rege `sndr.shot dry=%.n)
           ::  if the peer sends us an %ames packets, but we have %known state in
-          ::  .chums. this could be caused by:
+          ::  .chums. with no flows, this could be caused by:
           ::
           ::    - the peer breached, we had communicated previously but our
-          ::    default core was %mesa, so it stayed in .chums
+          ::    default core was %mesa, so it stayed in .chums (pre 408k)
           ::
           ::    - the peer booted after breaching with an old pill that has
-          ::    %mesa as the default core, or doesn't support zuse 410k, or the
+          ::    %ames as the default core, or doesn't support zuse 410k, or the
           ::    default core was manually changed
           ::
-          ::  for all these causes we try to establish communication, moving
+          ::  for all these cases we try to establish communication, moving
           ::  back the peer into .peers, and enqueue an %ahoy $plea to migrate
           ::  the peer as soon as it can handle %mesa packets.
           ::

--- a/pkg/arvo/ted/prob.hoon
+++ b/pkg/arvo/ted/prob.hoon
@@ -17,7 +17,7 @@
             timeout=@dr
             [case=@ud has=@uvi wen=@da]
             who=ship
-            wait-hash=@uvi
+            trigs=(set @uvi)
             veb=?
         ==
     arg
@@ -121,17 +121,17 @@
   ::
   $(case +(case))
 ::
-~?  >>  &(veb !=(wait-hash u.kids-hash))
+~?  >>  &(veb !(~(has in trigs) u.kids-hash))
   "ahoy-prob: {<who>} kids hash is {<u.kids-hash>}"
 =:  has  u.kids-hash
     wen  now.bowl
   ==
 ::
-?.  =(wait-hash has)
+?.  (~(has in trigs) has)
   ::  not last-hash; try next case
   ::
   $(case +(case))
-::  found wait-hash; done with .who
+::  found hash; done with .who
 ::
 ~?  >  veb  "ahoy-prob: done with {<who>}"
 ;<  =bowl:spider  bind:m  get-bowl:strandio


### PR DESCRIPTION
On 408k, `%mesa` becomes the default protocol for first-contact communication. If there is no prior state for a ship, `core.ames-state` determines which protocol to use when sending the first packets.

For ships that reach 410k, if a `%mesa` packet arrives with no prior state, the ship is stored in `chums.ames-state`.

---

### Handling a `%mesa` packet on 408k

| Peer state | Behavior |
|---|---|
| `[%mesa ~]` | No prior state — handle normally |
| `[%ames ~]` | Impossible; only applies to pre-408k ships |
| `[%mesa ~ %alien *]` | `%mesa` is the default; outstanding pokes/peeks exist but keys are missing — drop |
| `[%ames ~ %alien *]` | `%ames` was the default when we first tried to contact this ship, keys are still missing, but the peer now sends a `%mesa` packet. If nothing is outstanding, the peer previously sent an `%ames` packet (which we dropped after requesting keys), then sent a `%mesa` packet — this implies a breach, since alien breaches are not handled |
| `[%ames ~ %known *]` | We have `%known` state for this ship under `%ames`. Three scenarios: **(a)** the ship breached just before the 408k OTA while `%ames` was our default; it stays in `.peers.ames-state` (post-408k breaches move the peer to `.chums` as `%known`); **(b)** if we have no flow state, we attempt to move the ship back to `.peers.ames-state` (only for ships past 409k-2, otherwise no-op); **(c)** if we do have flow state, only handle a resend of the `%mesa %rege $plea` |

---

### Handling an `%ames` packet on 408k

| Peer state | Behavior |
|---|---|
| `[%mesa ~]` | Peer sends an `%ames` packet, but `%mesa` is our default and we have no prior contact — handle the `%ames` packet, request keys and drop |
| `[%mesa ~ %alien *]` | `%mesa` is our default; we may have outstanding pokes/peeks but keys are missing, and the peer sends an `%ames` packet. If nothing is outstanding, the peer first sent a `%mesa` packet (we dropped it and requested keys), then sent an `%ames` packet — this implies a breach and a boot with an old pill. (In general this can happen if the peer boots with an old pill that has `%ames` as its default protocol.) In this case: move the peer back to `%ames`, handle the packet, and enqueue an `%ahoy $plea` |
| `[%mesa ~ %known *]` | Three scenarios: **(a)** if the peer is in `.chums`, they sent an `%ahoy $plea` and we migrated them, but they have not received our `%ack` and have not yet migrated us — they may still be resending the plea; just ack it if it is indeed an `%ahoy`; **(b)** if it is not an `%ahoy` plea, check whether the ship can be moved back to `.peers` (e.g. first contact after a breach using an old pill); **(c)** if flow state exists, only handle a resend of a migrated `%ahoy $plea` |

---

### Issues

**Minor:** Communicating with a pre-408k peer after a breach, when we are on 408k and use `%mesa` as the default to initiate contact (the reverse direction would work fine). This issue resolves itself if both ships are on 408k.

**Major:** The core problem comes when both ships have flow state (`%known`, with keys, having already initiated communication) but are using *different* protocols — e.g. one has `%ames` state and the other has `%mesa` state. 

This can happen in these scenarios:

- `~zod` breaches before 408k; `~nec` keeps `~zod` in `.peers`
- `~nec` upgrades to 408k; `~zod` stays in `.peers`
- `~zod` boots on the 408k pill
- Both try to communicate simultaneously, each with `%known` flow state in different protocols

(this could be fixed by simply migrating peers in .chums with no flow state directly to .chums when getting the 408K OTA, but this could be problematic for ships that booted after a breach but have not communicated with us and are behind on OTAs)

Or:

- On 408k, `~zod` breaches; `~nec` moves `~zod` to `.chums`
- `~zod` boots on the 409k pill
- Both try to communicate simultaneously, each with `%known` flow state in different protocols


### Proposed general solution

Before any flow state is established, run a protocol handshake that advertises which protocol each ship speaks — using the same flowless pattern as `%mesa` comet attestations. Once a response is received, both ships use the highest mutually supported protocol (this adds latency to every first contact)

Key consideration: pre-408k ships do not perform this handshake and will immediately send stateful packets using their default protocol. A 408k ship must account for this: while a handshake is pending, if an `%ames` packet arrives from the peer, accept it and treat it the same as the `[%mesa ~ %alien *]` case.

### In-place protocol regression

When a ship with `%mesa` flow state for a peer receives an `%ames` packet from that peer, it assumes that the peer has breached and rebooted with an old pill. The 408k ship will migrate all existing flow state in-place to %ames, handle the incoming packet, and enqueue an `%ahoy` `$plea` — one issue with this would be resends of pre-breach outstanding messages that come out of order, or by letting the ship run (e.g. a moon after the parent breached it)

