### PR TITLE
clay/mice fixes

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -95,6 +95,18 @@
       mime=(slap zuse !,(*hoon mime))
       cass=(slap zuse !,(*hoon cass:clay))
   ==
+::  virtualization gates without access to namespace
+::
+=/  mule  ~(mule vi |)
+=/  mole  ~(mole vi |)
+=/  road
+  |*  =(trap *)
+  ^+  $:trap
+  =/  res  (mule trap)
+  ?-  -.res
+    %&  p.res
+    %|  (mean p.res)
+  ==
 ::
 |=  our=ship
 =,  clay

--- a/pkg/base-dev/lib/pill.hoon
+++ b/pkg/base-dev/lib/pill.hoon
@@ -572,7 +572,7 @@
           =^  ton  memo  $(formula next.formula)
           ?.  ?=(%0 -.ton)
             [ton memo]
-          ?:  ?=([%clay %ford *] product.clue)
+          ?:  ?=(?(@ [%clay %ford *]) product.clue)
             [ton memo]
           [ton (~(put by memo) [subject next.formula] product.ton)]
         =^  next  memo


### PR DESCRIPTION
Two commits here:
  - `+mice` implementation only blacklisted `clay/ford` %memo hints, even though the runtime implementation `clay/ford` and transient caches (atomic values of the hint-formula);
  - clay is now using virtualization gates that explicitly disable scrying, enabling runtime fix https://github.com/urbit/vere/pull/1005