### PR TITLE
Autoprop: Fix args for brass pill

### DIFF
--- a/pkg/autoprop/app/autoprop.hoon
+++ b/pkg/autoprop/app/autoprop.hoon
@@ -207,7 +207,7 @@
             |=(d=desk [d (bek d)])
           ?-  -.task
             %solid  (solid:libpill (sys base) dez | now.bowl & ~)
-            %brass  (brass:libpill (sys base) dez & ~)
+            %brass  (brass:libpill (sys base) dez & & | ~)
           ==
         ::
             %desk


### PR DESCRIPTION
The autoprop desk was broken due to missing the new `prime` arg