### PR TITLE
%meld options

### DIFF
--- a/pkg/arvo/gen/hood/meld.hoon
+++ b/pkg/arvo/gen/hood/meld.hoon
@@ -8,6 +8,6 @@
   ::
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
-        [arg=~ ~]
+        [arg=~ memo=_| ford=_| ~]
     ==
-[%helm-meld ~]
+[%helm-meld memo ford]

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -155,8 +155,8 @@
   abet:(emit %pass way.mass-timer.sat %arvo %b %rest nex.mass-timer.sat)
 ::
 ++  poke-meld
-  |=  ~  =<  abet
-  (emit %pass /pack %arvo %d %flog %meld ~)
+  |=  [memo=? ford=?]  =<  abet
+  (emit %pass /pack %arvo %d %flog %meld memo ford ~)
 ::
 ++  poke-pack
   |=  ~  =<  abet

--- a/pkg/arvo/lib/hood/helm.hoon
+++ b/pkg/arvo/lib/hood/helm.hoon
@@ -156,7 +156,7 @@
 ::
 ++  poke-meld
   |=  [memo=? ford=?]  =<  abet
-  (emit %pass /pack %arvo %d %flog %meld memo ford ~)
+  (emit %pass /pack %arvo %d %flog %meld memo ford)
 ::
 ++  poke-pack
   |=  ~  =<  abet

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2861,7 +2861,7 @@
   +$  gift                                              ::  out result <-$
     $%  [%blit p=(list blit)]                           ::  terminal output
         [%logo ~]                                       ::  logout
-        [%meld ~]                                       ::  unify memory
+        [%meld $@(~ [memo=? ford=?])]                   ::  unify memory
         [%pack ~]                                       ::  compact memory
         [%trim p=@ud]                                   ::  trim kernel state
         [%logs =told]                                   ::  system output
@@ -2879,7 +2879,7 @@
         [%logs p=(unit ~)]                              ::  watch system output
         [%mass ~]                                       ::  run memory report
         [%quac p=(list quac)]                           ::  memory runtime
-        [%meld ~]                                       ::  unify memory
+        [%meld $@(~ [memo=? ford=?])]                   ::  unify memory
         [%pack ~]                                       ::  compact memory
         [%seat =desk]                                   ::  install desk
         [%shot ses=@tas task=session-task]              ::  task for session
@@ -2952,7 +2952,7 @@
     $%  [%crop p=@ud]                                   ::  trim kernel state
         $>(%crud told)                                  ::
         [%heft ~]                                       ::
-        [%meld ~]                                       ::  unify memory
+        [%meld $@(~ [memo=? ford=?])]                   ::  unify memory
         [%pack ~]                                       ::  compact memory
         $>(%text told)                                  ::
         [%verb ~]                                       ::  verbose mode


### PR DESCRIPTION
Adds optional arguments to `%meld` task/gift and adds optional arguments to `|meld` (default is not to free the appropriate buckets)