### PR TITLE
mesa: fix read comet attestation

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12681,11 +12681,10 @@
           ::
           =/  =open-packet
             [pass.ames-state our life.ames-state u.rcvr u.life]
-          =/  sig
-            %+  sign-raw:ed:crypto  (jam open-packet)
-            [sgn.pub sgn.sek]:saf.ames-state
+          =/  msg  (jam open-packet)
+          =/  sig  (sign-raw:ed:crypto msg [sgn.pub sgn.sek]:saf.ames-state)
           :+  ~  ~
-          [%message !>(proof/sig)]
+          [%message !>(proof/(jam sig msg))]
         ::  publisher-side, weight of a noun at .pat, as measured by .boq
         ::
         ++  peek-whey


### PR DESCRIPTION
this was fixed in https://github.com/urbit/urbit/pull/7316 but a revert of another fix missed it