### PR TITLE
clay: %drop hint in clay.hoon

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -85,6 +85,9 @@
 ::  defined in lull.
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::  Rebuilding Clay for any reason discards build caches
+::
+~>  %drop
 =/  bud
   ^~
   =/  zuse  !>(..zuse)


### PR DESCRIPTION
If Clay gets rebuilt for any reason (a change in hoon/arvo/lull/zuse/clay), `%drop` hint will be emitted, hinting to the runtime that we [should discard build caches](https://github.com/urbit/vere/pull/1010).

This should prevent ford cache table from growing on each change to the sys files, a problem that seems to be especially dire on ships that have a lot of desks and are on latest arvo (cc. @pkova @midden-fabler)