### PR TITLE
eyre: use extension in range scries

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -4436,7 +4436,8 @@
     =/  end=(unit @ud)  (slaw %ud i.t.t.tyl)
     =*  vew   i.t.t.t.tyl
     =*  rest  t.t.t.t.tyl
-    =/  mym  (scry-mime now rof lyc ~ [%$ vew (en-beam -.bem rest)])
+    =/  =pork  (deft:de-purl:html rest)
+    =/  mym  (scry-mime now rof lyc p.pork [%$ vew (en-beam -.bem q.pork)])
     ?:  ?=(%| -.mym)  ~
     =*  mime  p.mym
     ?~  range=(get-range [beg end] p.q.mime)


### PR DESCRIPTION
TIL that in `_~_` HTTP scries we can provide a file extension to convert the file being scried to %mime via the extension mark...

Or so I thought. Turns out all `_~_` scries go through `%range` endpoint which didn't do that.

This PR achieves parity between two endpoints.