### PR TITLE
marks: fix hoon->hymn conversion

### DIFF
--- a/pkg/base-dev/mar/hoon.hoon
+++ b/pkg/base-dev/mar/hoon.hoon
@@ -5,7 +5,19 @@
   ++  mime  `^mime`[/text/x-hoon (as-octs:mimes:html own)] ::  convert to %mime
   ++  hymn
     ^-  manx
-    =/  count=@ud  (lent (to-wain:format own))
+    =/  to-wall
+      |=  =tape
+      ^-  wall
+      %+  roll  (flop tape)
+      |=  [char=@tD =wall]
+      ?~  wall
+        [[char ~] ~]
+      ?:  =('\0a' char)
+        [~ wall]
+      [[char i.wall] t.wall]
+    ::
+    =/  src=tape  (trip own)
+    =/  count=@ud  (lent (to-wall src))
     =;  [style=tape script=tape]
       ;html
         ;head
@@ -24,7 +36,7 @@
               ;pre.gutter(id "gutter");
               ;div.code-body
                 ;div(id "hl");
-                ;pre.code-pre(id "code"): {~[own]}
+                ;pre.code-pre(id "code"): {src}
               ==
             ==
           ==
@@ -33,9 +45,9 @@
       ==
     ::
     :-
-      ^=  style
+      ^~  ^=  style
       ^-  tape
-      :_  ~
+      %-  trip
       '''
       :root {
         --bg:        #fbfbf9;
@@ -47,7 +59,7 @@
         --sel:       #fff7d6;
         --sel-edge:  #f1e4a8;
         --accent:    #4a6da7;
-        --lh:        1.55;
+        --lh:        20px;
         --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
                 "Liberation Mono", "Courier New", monospace;
       }
@@ -156,9 +168,9 @@
       #code { position: relative; z-index: 1; }   /* text above the bar */
       :focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
       '''
-    ^=  code
+    ^~  ^=  code
     ^-  tape
-    :_  ~
+    %-  trip
     '''
     (function () {
       "use strict";

--- a/pkg/base-dev/mar/hoon.hoon
+++ b/pkg/base-dev/mar/hoon.hoon
@@ -178,7 +178,6 @@
       const code = document.getElementById("code");
       const gutter = document.getElementById("gutter");
       const hl = document.getElementById("hl");
-      // const copyBtn = document.getElementById("copy-link");
       if (!panel || !code || !gutter || !hl) return;
       const text = code.textContent;
       let lineCount = text.length ? text.split("\n").length : 1;
@@ -211,13 +210,11 @@
         selLo = lo;
         selHi = hi;
         positionHighlight();
-        if (copyBtn) copyBtn.hidden = false;
       }
       function deselect() {
         selLo = selHi = 0;
         anchor = null;
         positionHighlight();
-        if (copyBtn) copyBtn.hidden = true;
         history.replaceState(null, "", location.pathname + location.search);
       }
       function parseHash(hash) {
@@ -281,18 +278,6 @@
       document.addEventListener("keydown", function (e) {
         if (e.key === "Escape") deselect();
       });
-      if (copyBtn) {
-        copyBtn.addEventListener("click", async function () {
-          const label = copyBtn.textContent;
-          try {
-            await navigator.clipboard.writeText(location.href);
-            copyBtn.textContent = "copied ✓";
-          } catch (err) {
-            copyBtn.textContent = "copy failed";
-          }
-          setTimeout(function () { copyBtn.textContent = label; }, 1200);
-        });
-      }
       window.addEventListener("hashchange", function () {
         if (!selectFromHash(true)) deselect();
       });

--- a/pkg/base-dev/mar/hoon.hoon
+++ b/pkg/base-dev/mar/hoon.hoon
@@ -28,10 +28,10 @@
         ==
         ;body
           ;div.viewer
-            ;div.viewer-bar
-              ;span.viewer-name: {(scow %ud count)} lines
-              ;button.copy-link(id "copy-link", hidden ""): copy link
-            ==
+            :: ;div.viewer-bar
+            ::   ;span.viewer-name: {(scow %ud count)} lines
+            ::   ;button.copy-link(id "copy-link", hidden ""): copy link
+            :: ==
             ;div.code
               ;pre.gutter(id "gutter");
               ;div.code-body
@@ -178,7 +178,7 @@
       const code = document.getElementById("code");
       const gutter = document.getElementById("gutter");
       const hl = document.getElementById("hl");
-      const copyBtn = document.getElementById("copy-link");
+      // const copyBtn = document.getElementById("copy-link");
       if (!panel || !code || !gutter || !hl) return;
       const text = code.textContent;
       let lineCount = text.length ? text.split("\n").length : 1;

--- a/pkg/base-dev/mar/hoon.hoon
+++ b/pkg/base-dev/mar/hoon.hoon
@@ -1,28 +1,298 @@
-::::  /hoon/hoon/mar
-  ::
-/?    310
-::
-=,  eyre
 |_  own=@t
 ::
 ++  grow                                                ::  convert to
   |%
   ++  mime  `^mime`[/text/x-hoon (as-octs:mimes:html own)] ::  convert to %mime
   ++  hymn
-    ;html
-      ;head
-        ;title:"Source"
-        ;script@"//cdnjs.cloudflare.com/ajax/libs/codemirror/4.3.0/codemirror.js";
-        ;script@"/lib/syntax/hoon.js";
-        ;link(rel "stylesheet", href "//cdnjs.cloudflare.com/ajax/libs/".
-          "codemirror/4.3.0/codemirror.min.css");
-        ;link/"/lib/syntax/codemirror.css"(rel "stylesheet");
+    ^-  manx
+    =/  count=@ud  (lent (to-wain:format own))
+    =;  [style=tape script=tape]
+      ;html
+        ;head
+          ;title: source
+          ;meta(charset "utf-8");
+          ;meta(name "viewport", content "width=device-width, initial-scale=1");
+          ;style: {style}
+        ==
+        ;body
+          ;div.viewer
+            ;div.viewer-bar
+              ;span.viewer-name: {(scow %ud count)} lines
+              ;button.copy-link(id "copy-link", hidden ""): copy link
+            ==
+            ;div.code
+              ;pre.gutter(id "gutter");
+              ;div.code-body
+                ;div(id "hl");
+                ;pre.code-pre(id "code"): {~[own]}
+              ==
+            ==
+          ==
+          ;script: {script}
+        ==
       ==
-      ;body
-        ;textarea#src:"{(trip own)}"
-        ;script:'CodeMirror.fromTextArea(src, {lineNumbers:true, readOnly:true})'
-      ==
-    ==
+    ::
+    :-
+      ^=  style
+      ^-  tape
+      :_  ~
+      '''
+      :root {
+        --bg:        #fbfbf9;
+        --panel:     #ffffff;
+        --gutter-bg: #f3f3ef;
+        --line:      #e4e4dd;
+        --fg:        #2b2b2b;
+        --fg-dim:    #9a9a90;
+        --sel:       #fff7d6;
+        --sel-edge:  #f1e4a8;
+        --accent:    #4a6da7;
+        --lh:        1.55;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                "Liberation Mono", "Courier New", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        height: 100%;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--mono);
+        -webkit-font-smoothing: antialiased;
+      }
+      .viewer {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        padding: 16px;
+        gap: 12px;
+      }
+      .viewer-bar {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 13px;
+        color: var(--fg-dim);
+      }
+      .viewer-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--fg);
+      }
+      .copy-link {
+        flex: 0 0 auto;
+        padding: 4px 12px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--panel);
+        color: var(--fg-dim);
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+        transition: color .12s, border-color .12s;
+      }
+      .copy-link:hover { color: var(--accent); border-color: var(--accent); }
+      .copy-link[hidden] { display: none; }
+      .code {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        align-items: flex-start;
+        overflow: auto;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+      }
+      .code-body {
+        position: relative;
+        flex: 1 1 auto;
+        min-width: 0;
+        width: max-content;
+      }
+      #gutter, #code {
+        margin: 0;
+        padding: 14px 0;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: var(--lh);
+        white-space: pre;
+        tab-size: 2;
+      }
+      #gutter {
+        position: sticky;
+        left: 0;
+        z-index: 2;
+        flex: 0 0 auto;
+        padding-left: 16px;
+        padding-right: 12px;
+        text-align: right;
+        color: var(--fg-dim);
+        background: var(--gutter-bg);
+        border-right: 1px solid var(--line);
+        user-select: none;
+        -webkit-user-select: none;
+        cursor: pointer;
+      }
+      #code {
+        display: block;
+        padding-left: 14px;
+        padding-right: 18px;
+        color: var(--fg);
+      }
+      #hl {
+        position: absolute;
+        left: 0;
+        right: 0;
+        z-index: 0;                     /* under the text */
+        display: none;
+        background: var(--sel);
+        box-shadow: inset 2px 0 0 var(--sel-edge);
+        pointer-events: none;
+      }
+      #code { position: relative; z-index: 1; }   /* text above the bar */
+      :focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+      '''
+    ^=  code
+    ^-  tape
+    :_  ~
+    '''
+    (function () {
+      "use strict";
+      const panel = document.querySelector(".code"); // the scroll container
+      const code = document.getElementById("code");
+      const gutter = document.getElementById("gutter");
+      const hl = document.getElementById("hl");
+      const copyBtn = document.getElementById("copy-link");
+      if (!panel || !code || !gutter || !hl) return;
+      const text = code.textContent;
+      let lineCount = text.length ? text.split("\n").length : 1;
+      if (text.endsWith("\n")) lineCount -= 1;
+      if (lineCount < 1) lineCount = 1;
+      (function fillGutter() {
+        let s = "";
+        for (let i = 1; i <= lineCount; i++) s += i + "\n";
+        gutter.textContent = s;
+      })();
+      let lineH = 0;
+      let codeTop = 0; // code's content-box top padding, the y-origin of line 1
+      function measure() {
+        const cs = getComputedStyle(code);
+        const lh = parseFloat(cs.lineHeight);
+        lineH = isNaN(lh) ? parseFloat(cs.fontSize) * 1.55 : lh;
+        codeTop = parseFloat(cs.paddingTop) || 0;
+        positionHighlight(); // keep the bar correct after a re-measure
+      }
+      let anchor = null;
+      let selLo = 0;
+      let selHi = 0;
+      function positionHighlight() {
+        if (!selLo) { hl.style.display = "none"; return; }
+        hl.style.display = "block";
+        hl.style.top = (codeTop + (selLo - 1) * lineH) + "px";
+        hl.style.height = ((selHi - selLo + 1) * lineH) + "px";
+      }
+      function applySel(lo, hi) {
+        selLo = lo;
+        selHi = hi;
+        positionHighlight();
+        if (copyBtn) copyBtn.hidden = false;
+      }
+      function deselect() {
+        selLo = selHi = 0;
+        anchor = null;
+        positionHighlight();
+        if (copyBtn) copyBtn.hidden = true;
+        history.replaceState(null, "", location.pathname + location.search);
+      }
+      function parseHash(hash) {
+        const m = /^#L(\d+)(?:-L(\d+))?$/.exec(hash || "");
+        if (!m) return null;
+        let lo = parseInt(m[1], 10);
+        let hi = m[2] ? parseInt(m[2], 10) : lo;
+        if (hi < lo) { const t = lo; lo = hi; hi = t; }
+        lo = Math.max(1, Math.min(lo, lineCount));
+        hi = Math.max(1, Math.min(hi, lineCount));
+        return [lo, hi];
+      }
+      function setHash(lo, hi) {
+        const frag = lo === hi ? "L" + lo : "L" + lo + "-L" + hi;
+        history.replaceState(null, "", "#" + frag);
+      }
+      function scrollToLine(n) {
+        const y = codeTop + (n - 1) * lineH;
+        if (y < panel.scrollTop || y > panel.scrollTop + panel.clientHeight) {
+          panel.scrollTop = Math.max(0, y - panel.clientHeight / 2);
+        }
+      }
+      function selectFromHash(scroll) {
+        const r = parseHash(location.hash);
+        if (!r) return false;
+        anchor = r[0];
+        applySel(r[0], r[1]);
+        if (scroll) scrollToLine(r[0]);
+        return true;
+      }
+      function lineFromEvent(e) {
+        // y within the code content: pointer relative to the code pre's rendered
+        // top, which already accounts for scroll since getBoundingClientRect is
+        // viewport-relative and the pre moves as the panel scrolls.
+        const rect = code.getBoundingClientRect();
+        const y = e.clientY - rect.top - codeTop;
+        let n = Math.floor(y / lineH) + 1;
+        if (n < 1) n = 1;
+        if (n > lineCount) n = lineCount;
+        return n;
+      }
+      function onClick(e) {
+        const inGutter = e.target === gutter;
+        if (!inGutter && !e.shiftKey) return; // normal text interaction in code
+        const n = lineFromEvent(e);
+        if (!e.shiftKey && selLo === n && selHi === n) {
+          deselect();
+          return;
+        }
+        if (e.shiftKey && anchor !== null) {
+          applySel(Math.min(anchor, n), Math.max(anchor, n));
+          setHash(selLo, selHi);
+        } else {
+          anchor = n;
+          applySel(n, n);
+          setHash(n, n);
+        }
+      }
+      gutter.addEventListener("click", onClick);
+      code.addEventListener("click", onClick);
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape") deselect();
+      });
+      if (copyBtn) {
+        copyBtn.addEventListener("click", async function () {
+          const label = copyBtn.textContent;
+          try {
+            await navigator.clipboard.writeText(location.href);
+            copyBtn.textContent = "copied ✓";
+          } catch (err) {
+            copyBtn.textContent = "copy failed";
+          }
+          setTimeout(function () { copyBtn.textContent = label; }, 1200);
+        });
+      }
+      window.addEventListener("hashchange", function () {
+        if (!selectFromHash(true)) deselect();
+      });
+      let rz = null;
+      window.addEventListener("resize", function () {
+        clearTimeout(rz);
+        rz = setTimeout(measure, 100);
+      });
+      measure();
+      selectFromHash(true);
+    })();
+    '''
   ++  txt
     (to-wain:format own)
   --


### PR DESCRIPTION
Following my findings in #7355 I noticed that `%hoon -> %hymn` conversion leads to a rather ugly rendering:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2ecfe3e3-8e8b-4c7b-b115-b3287eec08ef" />

Seems like some remote endpoints for code distribution got broken?

Anyway, I think having some prettier rendering + links to lines for Hoon code would be nice. So I decided to vendor all the CSS and JS into the mark for robustness.

I'll be the first to admit that I have poor taste in graphics design. I would really appreciate some feedback on that front.

You can try running a fakeship on this branch together with the one from #7355, and opening `http://localhost:8080/_~_/===/cx/sys/hoon/hoon.hymn`.