### PR TITLE
test: adds empty-message test fixtures for aes-cbc

### DIFF
--- a/tests/sys/zuse/crypto/aes.hoon
+++ b/tests/sys/zuse/crypto/aes.hoon
@@ -112,6 +112,12 @@
 ++  test-aes-cbca
   %+  do-test-vectors-cbc  cbca
   :~
+    ::  empty message: encrypted as a single zero block (= ecb of the iv)
+    :^    0x0
+        0x1
+      0x0
+    0x58e2.fcce.fa7e.3061.367f.1d57.a4e7.455a
+  ::
     :^    0x0
         0x1
       0x2
@@ -131,6 +137,12 @@
 ++  test-aes-cbcb
   %+  do-test-vectors-cbc  cbcb
   :~
+    ::  empty message: encrypted as a single zero block (= ecb of the iv)
+    :^    0x0
+        0x1
+      0x0
+    0xcd33.b28a.c773.f74b.a00e.d1f3.1257.2435
+  ::
     :^    0x0
         0x1
       0x2
@@ -151,6 +163,12 @@
 ++  test-aes-cbcc
   %+  do-test-vectors-cbc  cbcc
   :~
+    ::  empty message: encrypted as a single zero block (= ecb of the iv)
+    :^    0x0
+        0x1
+      0x0
+    0x530f.8afb.c745.36b9.a963.b4f1.c4cb.738b
+  ::
     :^    0x0
         0x1
       0x2


### PR DESCRIPTION
This PR adds (currently failing) test cases for empty inputs. The hoon is correct, a fix for the jet is in urbit/vere#1024.