### PR TITLE
mesa: replace %data packet with %auth if over MTU

### DIFF
--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -24,8 +24,8 @@
       ++  zod      (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
       ++  comet-a  (nol:nu:cric:crypto comet-a-ring)
       ++  comet-b  (nol:nu:cric:crypto comet-b-ring)
-      ++  moon-a   (pit:nu:cric:crypto 32 (can 5 [1 ^moon-a] [1 lyfe=1] ~) %b ~)
-      ++  moon-b   (pit:nu:cric:crypto 32 (can 5 [1 ^moon-b] [1 lyfe=1] ~) %b ~)
+      ++  moon-a   (pit:nu:cric:crypto 32 (shaz ^moon-a) %b ~)
+      ++  moon-b   (pit:nu:cric:crypto 32 (shaz ^moon-b) %b ~)
       ++  sign
         |=  [=ship data=@ux]
         ?:  =(ship ~nec)
@@ -109,6 +109,9 @@
   [nec=nec bud=bud]
 ::
 ++  ames-comets-moons
+  |=  $:  life=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud]
+          rift=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud]
+      ==
   ::  comets
   ::
   ::  create comet-a
@@ -116,8 +119,8 @@
   =/  comet-a  (ames-raw ~dacrum-tordyt-dassel-mogred--sabnyx-malbes-mogdef-litzod)
   =.  now.comet-a  ~1111.1.1
   =.  eny.comet-a  0v3f.arfnf
-  =.  life.ames-state.comet-a  1
-  =.  rift.ames-state.comet-a  0
+  =.  life.ames-state.comet-a  comet-a.life
+  =.  rift.ames-state.comet-a  comet-a.rift
   =.  rof.comet-a  |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.comet-a  sec:ex:comet-a:crypto-core
   =.  pass.ames-state.comet-a  pub:ex:comet-a:crypto-core
@@ -127,8 +130,8 @@
   =/  comet-b  (ames-raw ~lopdur-lopsyl-tagted-lidbet--podlud-sicnux-tidlev-marzod)
   =.  now.comet-b  ~1111.1.1
   =.  eny.comet-b  0v3f.arfnf
-  =.  life.ames-state.comet-b  1
-  =.  rift.ames-state.comet-b  0
+  =.  life.ames-state.comet-a  comet-b.life
+  =.  rift.ames-state.comet-a  comet-b.rift
   =.  rof.comet-b  |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.comet-b  sec:ex:comet-b:crypto-core
   =.  pass.ames-state.comet-b  pub:ex:comet-b:crypto-core
@@ -174,8 +177,8 @@
   =/  moon-a  (ames-raw moon-a)
   =.  now.moon-a  ~1111.1.1
   =.  eny.moon-a  0v3f.arfnf
-  =.  life.ames-state.moon-a  1
-  =.  rift.ames-state.moon-a  0
+  =.  life.ames-state.moon-a  moon-a.life
+  =.  rift.ames-state.moon-a  moon-a.rift
   =.  rof.moon-a  |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.moon-a  sec:ex:moon-a:crypto-core
   =.  pass.ames-state.moon-a  pub:ex:moon-a:crypto-core
@@ -185,8 +188,8 @@
   =/  moon-b  (ames-raw moon-b)
   =.  now.moon-b  ~1111.1.1
   =.  eny.moon-b  0v3f.arfnf
-  =.  life.ames-state.moon-b  1
-  =.  rift.ames-state.moon-b  0
+  =.  life.ames-state.moon-b  moon-b.life
+  =.  rift.ames-state.moon-b  moon-b.rift
   =.  rof.moon-b  |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.moon-b  sec:ex:moon-b:crypto-core
   =.  pass.ames-state.moon-b  pub:ex:moon-b:crypto-core
@@ -203,8 +206,8 @@
     =|  =fren-state:ames
     =.  -.fren-state
       :*  symmetric-key=moon-b-sym
-          life=1
-          rift=0
+          moon-a.life
+          moon-a.rift
           [public-keys=pub.saf pass=pass]:ames-state.moon-a
           sponsor=~bud
       ==
@@ -217,8 +220,8 @@
     =|  =fren-state:ames
     =.  -.fren-state
       :*  symmetric-key=moon-a-sym
-          life=1
-          rift=0
+          moon-b.life
+          moon-b.rift
           [public-keys=pub.saf pass=pass]:ames-state.moon-b
           sponsor=~bud
       ==
@@ -231,6 +234,10 @@
     (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.comet-a)
   =/  moon-b-comet-b-sym
     (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.comet-b)
+  =/  moon-a-comet-b-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.comet-b)
+  =/  moon-b-comet-a-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.comet-a)
   ::
   ::  tell ~comet-a about ~moon-a
   ::
@@ -239,8 +246,8 @@
     =|  =fren-state:ames
     =.  -.fren-state
       :*  symmetric-key=moon-a-comet-a-sym
-          life=1
-          rift=0
+          moon-a.life
+          moon-a.rift
           [public-keys=pub.saf pass=pass]:ames-state.moon-a
           sponsor=~bud
       ==
@@ -253,8 +260,8 @@
     =|  =fren-state:ames
     =.  -.fren-state
       :*  symmetric-key=moon-a-comet-a-sym
-          life=1
-          rift=0
+          comet-a.life
+          comet-a.rift
           [public-keys=pub.saf pass=pass]:ames-state.moon-a
           sponsor=~bud
       ==
@@ -267,9 +274,79 @@
     =|  =fren-state:ames
     =.  -.fren-state
       :*  symmetric-key=moon-b-comet-b-sym
-          life=1
-          rift=0
+          comet-b.life
+          comet-b.rift
           [public-keys=pub.saf pass=pass]:ames-state.comet-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~comet-b about ~moon-b
+  ::
+  =.  chums.ames-state.comet-b
+    %+  ~(put by chums.ames-state.comet-b)  our.moon-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-b-comet-b-sym
+          moon-b.life
+          moon-b.rift
+          [public-keys=pub.saf pass=pass]:ames-state.moon-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~moon-b about ~comet-a
+  ::
+  =.  chums.ames-state.moon-b
+    %+  ~(put by chums.ames-state.moon-b)  our.comet-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-b-comet-a-sym
+          comet-a.life
+          comet-a.rift
+          [public-keys=pub.saf pass=pass]:ames-state.comet-a
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~comet-a about ~moon-b
+  ::
+  =.  chums.ames-state.comet-a
+    %+  ~(put by chums.ames-state.comet-a)  our.moon-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-b-comet-a-sym
+          moon-b.life
+          moon-b.rift
+          [public-keys=pub.saf pass=pass]:ames-state.moon-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~moon-a about ~comet-b
+  ::
+  =.  chums.ames-state.moon-a
+    %+  ~(put by chums.ames-state.moon-a)  our.comet-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-a-comet-b-sym
+          comet-b.life
+          comet-b.rift
+          [public-keys=pub.saf pass=pass]:ames-state.comet-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~comet-b about ~moon-a
+  ::
+  =.  chums.ames-state.comet-b
+    %+  ~(put by chums.ames-state.comet-b)  our.moon-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-a-comet-b-sym
+          moon-a.life
+          moon-a.rift
+          [public-keys=pub.saf pass=pass]:ames-state.moon-a
           sponsor=~bud
       ==
     =.  lane.fren-state  `[0 *lane:pact:ames]

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -7,10 +7,20 @@
 ::  basic helpers
 ::
 |%
+++  comet-a-ring
+  0wfm.lBEWM.08gfy.AxYjy.8-tBQ.uq-aa.LZt9c.CVQqd.XBJIs.
+  CoG90.BNNGV.1ZmVi.ZbAhY.LuhwC.idNnU.lCVkt.Z4qug.7iY92
+::
+++  comet-b-ring
+  0w3-.kl6Hg.mLISf.pDTQQ.LymxF.q4Isr.AGUAv.uJvkf.DOjeU.
+  U8OPv.XO9T2.Hfhe~.zFwpO.Q1tn5.BeBSQ.o4MTS.lTWAh.TcOJ2
+::
 ++  crypto-core
-  |%  ++  nec  (pit:nu:cric:crypto 512 (shaz 'nec') %b ~)
-      ++  bud  (pit:nu:cric:crypto 512 (shaz 'bud') %b ~)
-      ++  zod  (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
+  |%  ++  nec      (pit:nu:cric:crypto 512 (shaz 'nec') %b ~)
+      ++  bud      (pit:nu:cric:crypto 512 (shaz 'bud') %b ~)
+      ++  zod      (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
+      ++  comet-a  (nol:nu:cric:crypto comet-a-ring)
+      ++  comet-b  (nol:nu:cric:crypto comet-b-ring)
       ++  sign
         |=  [=ship data=@ux]
         ?:  =(ship ~nec)
@@ -91,6 +101,73 @@
   =>  .(bud +:(call:(bud) ~[//unix] ~ %born ~))
   ::
   [nec=nec bud=bud]
+::
+++  ames-comets-moons
+  ::  create comet-a
+  ::
+  =/  comet-a  (ames-raw ~dacrum-tordyt-dassel-mogred--sabnyx-malbes-mogdef-litzod)
+  =.  now.comet-a  ~1111.1.1
+  =.  eny.comet-a  0v3f.arfnf
+  =.  life.ames-state.comet-a  1
+  =.  rift.ames-state.comet-a  0
+  =.  rof.comet-a  |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.comet-a  sec:ex:comet-a:crypto-core
+  =.  pass.ames-state.comet-a  pub:ex:comet-a:crypto-core
+  =.  saf.ames-state.comet-a   saf:ex:comet-a:crypto-core
+  ::  create comet-b
+  ::
+  =/  comet-b  (ames-raw ~lopdur-lopsyl-tagted-lidbet--podlud-sicnux-tidlev-marzod)
+  =.  now.comet-b  ~1111.1.1
+  =.  eny.comet-b  0v3f.arfnf
+  =.  life.ames-state.comet-b  1
+  =.  rift.ames-state.comet-b  0
+  =.  rof.comet-b  |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.comet-b  sec:ex:comet-b:crypto-core
+  =.  pass.ames-state.comet-b  pub:ex:comet-b:crypto-core
+  =.  saf.ames-state.comet-b   saf:ex:comet-b:crypto-core
+  ::
+  =/  comet-a-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.comet-a sek.saf.ames-state.comet-b)
+  =/  comet-b-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.comet-b sek.saf.ames-state.comet-a)
+  ?>  =(comet-b-sym comet-a-sym)
+  ::  tell ~comet-b about ~comet-a
+  ::
+  =.  chums.ames-state.comet-b
+    %+  ~(put by chums.ames-state.comet-b)  our.comet-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=comet-b-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.comet-a
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~comet-a about ~comet-b
+  ::
+  =.  chums.ames-state.comet-a
+    %+  ~(put by chums.ames-state.comet-a)  our.comet-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=comet-a-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.comet-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  metamorphose
+  ::
+  =>  .(comet-b +:(call:(comet-b) ~[//unix] ~ %born ~))
+  =>  .(comet-a +:(call:(comet-a) ~[//unix] ~ %born ~))
+  ::
+  ::  XX TODO moons
+  ::
+  [comet-b=comet-b comet-a=comet-a]
+::
 --
 ::  forward-declare to avoid repeated metamorphoses
 ::

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -17,15 +17,19 @@
 ::
 ++  moon-a  ~mister-dister-norsyr-torryn
 ++  moon-b  ~mister-roller-norsyr-torryn
+++  planet-a  ~norsyr-torryn
+++  planet-b  ~torryn-norsyr
 ::
 ++  crypto-core
-  |%  ++  nec      (pit:nu:cric:crypto 512 (shaz 'nec') %b ~)
-      ++  bud      (pit:nu:cric:crypto 512 (shaz 'bud') %b ~)
-      ++  zod      (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
-      ++  comet-a  (nol:nu:cric:crypto comet-a-ring)
-      ++  comet-b  (nol:nu:cric:crypto comet-b-ring)
-      ++  moon-a   (pit:nu:cric:crypto 32 (shaz ^moon-a) %b ~)
-      ++  moon-b   (pit:nu:cric:crypto 32 (shaz ^moon-b) %b ~)
+  |%  ++  nec        (pit:nu:cric:crypto 512 (shaz 'nec') %b ~)
+      ++  bud        (pit:nu:cric:crypto 512 (shaz 'bud') %b ~)
+      ++  zod        (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
+      ++  comet-a    (nol:nu:cric:crypto comet-a-ring)
+      ++  comet-b    (nol:nu:cric:crypto comet-b-ring)
+      ++  moon-a     (pit:nu:cric:crypto 32 (shaz ^moon-a) %b ~)
+      ++  moon-b     (pit:nu:cric:crypto 32 (shaz ^moon-b) %b ~)
+      ++  planet-a   (pit:nu:cric:crypto 32 (shaz ^planet-a) %b ~)
+      ++  planet-b   (pit:nu:cric:crypto 32 (shaz ^planet-b) %b ~)
       ++  sign
         |=  [=ship data=@ux]
         ?:  =(ship ~nec)
@@ -108,257 +112,163 @@
   ::
   [nec=nec bud=bud]
 ::
-++  ames-comets-moons
-  |=  $:  life=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud]
-          rift=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud]
+++  ames-comets-moons-planets-galaxies
+  |=  $:  life=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud planet-a=@ud planet-b=@ud galaxy-a=@ud galaxy-b=@ud]
+          rift=[comet-a=@ud comet-b=@ud moon-a=@ud moon-b=@ud planet-a=@ud planet-b=@ud galaxy-a=@ud galaxy-b=@ud]
       ==
-  ::  comets
-  ::
-  ::  create comet-a
+  ::  create each ship: set now, eny, life, rift, rof, and crypto keys
   ::
   =/  comet-a  (ames-raw ~dacrum-tordyt-dassel-mogred--sabnyx-malbes-mogdef-litzod)
-  =.  now.comet-a  ~1111.1.1
-  =.  eny.comet-a  0v3f.arfnf
+  =.  now.comet-a   ~1111.1.1
+  =.  eny.comet-a   0v3f.arfnf
   =.  life.ames-state.comet-a  comet-a.life
   =.  rift.ames-state.comet-a  comet-a.rift
-  =.  rof.comet-a  |=(* ``[%noun !>(*(list turf))])
+  =.  rof.comet-a   |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.comet-a  sec:ex:comet-a:crypto-core
   =.  pass.ames-state.comet-a  pub:ex:comet-a:crypto-core
   =.  saf.ames-state.comet-a   saf:ex:comet-a:crypto-core
-  ::  create comet-b
   ::
   =/  comet-b  (ames-raw ~lopdur-lopsyl-tagted-lidbet--podlud-sicnux-tidlev-marzod)
-  =.  now.comet-b  ~1111.1.1
-  =.  eny.comet-b  0v3f.arfnf
-  =.  life.ames-state.comet-a  comet-b.life
-  =.  rift.ames-state.comet-a  comet-b.rift
-  =.  rof.comet-b  |=(* ``[%noun !>(*(list turf))])
+  =.  now.comet-b   ~1111.1.1
+  =.  eny.comet-b   0v3f.arfnf
+  =.  life.ames-state.comet-b  comet-b.life
+  =.  rift.ames-state.comet-b  comet-b.rift
+  =.  rof.comet-b   |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.comet-b  sec:ex:comet-b:crypto-core
   =.  pass.ames-state.comet-b  pub:ex:comet-b:crypto-core
   =.  saf.ames-state.comet-b   saf:ex:comet-b:crypto-core
   ::
-  =/  comet-a-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.comet-a sek.saf.ames-state.comet-b)
-  =/  comet-b-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.comet-b sek.saf.ames-state.comet-a)
-  ?>  =(comet-b-sym comet-a-sym)
-  ::  tell ~comet-b about ~comet-a
-  ::
-  =.  chums.ames-state.comet-b
-    %+  ~(put by chums.ames-state.comet-b)  our.comet-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=comet-b-sym
-          life=1
-          rift=0
-          [public-keys=pub.saf pass=pass]:ames-state.comet-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~comet-a about ~comet-b
-  ::
-  =.  chums.ames-state.comet-a
-    %+  ~(put by chums.ames-state.comet-a)  our.comet-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=comet-a-sym
-          life=1
-          rift=0
-          [public-keys=pub.saf pass=pass]:ames-state.comet-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  moons
-  ::
-  ::  create moon-a
-  ::
   =/  moon-a  (ames-raw moon-a)
-  =.  now.moon-a  ~1111.1.1
-  =.  eny.moon-a  0v3f.arfnf
+  =.  now.moon-a   ~1111.1.1
+  =.  eny.moon-a   0v3f.arfnf
   =.  life.ames-state.moon-a  moon-a.life
   =.  rift.ames-state.moon-a  moon-a.rift
-  =.  rof.moon-a  |=(* ``[%noun !>(*(list turf))])
+  =.  rof.moon-a   |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.moon-a  sec:ex:moon-a:crypto-core
   =.  pass.ames-state.moon-a  pub:ex:moon-a:crypto-core
   =.  saf.ames-state.moon-a   saf:ex:moon-a:crypto-core
-  ::  create moon-b
   ::
   =/  moon-b  (ames-raw moon-b)
-  =.  now.moon-b  ~1111.1.1
-  =.  eny.moon-b  0v3f.arfnf
+  =.  now.moon-b   ~1111.1.1
+  =.  eny.moon-b   0v3f.arfnf
   =.  life.ames-state.moon-b  moon-b.life
   =.  rift.ames-state.moon-b  moon-b.rift
-  =.  rof.moon-b  |=(* ``[%noun !>(*(list turf))])
+  =.  rof.moon-b   |=(* ``[%noun !>(*(list turf))])
   =.  ring.ames-state.moon-b  sec:ex:moon-b:crypto-core
   =.  pass.ames-state.moon-b  pub:ex:moon-b:crypto-core
   =.  saf.ames-state.moon-b   saf:ex:moon-b:crypto-core
-  =/  moon-a-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.moon-b)
-  =/  moon-b-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.moon-a)
   ::
-  ::  tell ~moon-b about ~moon-a
+  =/  planet-a  (ames-raw planet-a)
+  =.  now.planet-a   ~1111.1.1
+  =.  eny.planet-a   0v3f.arfnf
+  =.  life.ames-state.planet-a  planet-a.life
+  =.  rift.ames-state.planet-a  planet-a.rift
+  =.  rof.planet-a   |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.planet-a  sec:ex:planet-a:crypto-core
+  =.  pass.ames-state.planet-a  pub:ex:planet-a:crypto-core
+  =.  saf.ames-state.planet-a   saf:ex:planet-a:crypto-core
   ::
-  =.  chums.ames-state.moon-b
-    %+  ~(put by chums.ames-state.moon-b)  our.moon-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-b-sym
-          moon-a.life
-          moon-a.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~moon-a about ~moon-b
+  =/  planet-b  (ames-raw planet-b)
+  =.  now.planet-b   ~1111.1.1
+  =.  eny.planet-b   0v3f.arfnf
+  =.  life.ames-state.planet-b  planet-b.life
+  =.  rift.ames-state.planet-b  planet-b.rift
+  =.  rof.planet-b   |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.planet-b  sec:ex:planet-b:crypto-core
+  =.  pass.ames-state.planet-b  pub:ex:planet-b:crypto-core
+  =.  saf.ames-state.planet-b   saf:ex:planet-b:crypto-core
   ::
-  =.  chums.ames-state.moon-a
-    %+  ~(put by chums.ames-state.moon-a)  our.moon-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-a-sym
-          moon-b.life
-          moon-b.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
+  =/  galaxy-a  (ames-raw ~nec)
+  =.  now.galaxy-a   ~1111.1.1
+  =.  eny.galaxy-a   0v3f.arfnf
+  =.  life.ames-state.galaxy-a  galaxy-a.life
+  =.  rift.ames-state.galaxy-a  galaxy-a.rift
+  =.  rof.galaxy-a   |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.galaxy-a  sec:ex:nec:crypto-core
+  =.  pass.ames-state.galaxy-a  pub:ex:nec:crypto-core
+  =.  saf.ames-state.galaxy-a   saf:ex:nec:crypto-core
   ::
-  ::  comet to moon
+  =/  galaxy-b  (ames-raw ~bud)
+  =.  now.galaxy-b   ~1111.1.1
+  =.  eny.galaxy-b   0v3f.arfnf
+  =.  life.ames-state.galaxy-b  galaxy-b.life
+  =.  rift.ames-state.galaxy-b  galaxy-b.rift
+  =.  rof.galaxy-b   |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.galaxy-b  sec:ex:bud:crypto-core
+  =.  pass.ames-state.galaxy-b  pub:ex:bud:crypto-core
+  =.  saf.ames-state.galaxy-b   saf:ex:bud:crypto-core
   ::
-  =/  moon-a-comet-a-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.comet-a)
-  =/  moon-b-comet-b-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.comet-b)
-  =/  moon-a-comet-b-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.comet-b)
-  =/  moon-b-comet-a-sym
-    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.comet-a)
+  ::  connect-all: for each ship A, register every other ship B in A's chums.
+  ::  iterates all ordered pairs (A,B) with A≠B; derives shared key from
+  ::  A's sek and B's pub (ECDH), then writes B into A's chums map.
   ::
-  ::  tell ~comet-a about ~moon-a
+  =/  connect-all
+    |=  ss=(list [g=_ames-bunt lif=@ud rif=@ud])
+    ^+  ss
+    %+  turn  ss
+    |=  a=[g=_ames-bunt lif=@ud rif=@ud]
+    ^+  a
+    =/  others  ss
+    |-  ^+  a
+    ?~  others
+      a
+    =/  b  i.others
+    ?:  =(our.g.b our.g.a)
+      $(others t.others)
+    =/  sym
+      (derive-symmetric-key:ames-raw pub.saf.ames-state.g.b sek.saf.ames-state.g.a)
+    =.  g.a
+      =.  chums.ames-state.g.a
+        %+  ~(put by chums.ames-state.g.a)  our.g.b
+        =|  =fren-state:ames
+        =.  -.fren-state
+          :*  symmetric-key=sym
+              lif.b
+              rif.b
+              [public-keys=pub.saf pass=pass]:ames-state.g.b
+              sponsor=~bud
+          ==
+        =.  lane.fren-state  `[0 *lane:pact:ames]
+        [%known fren-state]
+      g.a
+    $(others t.others)
   ::
-  =.  chums.ames-state.comet-a
-    %+  ~(put by chums.ames-state.comet-a)  our.moon-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-a-comet-a-sym
-          moon-a.life
-          moon-a.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~moon-a about ~comet-a
+  =/  ships
+    %:  connect-all
+        :~  [comet-a comet-a.life comet-a.rift]
+            [comet-b comet-b.life comet-b.rift]
+            [moon-a moon-a.life moon-a.rift]
+            [moon-b moon-b.life moon-b.rift]
+            [planet-a planet-a.life planet-a.rift]
+            [planet-b planet-b.life planet-b.rift]
+            [galaxy-a galaxy-a.life galaxy-a.rift]
+            [galaxy-b galaxy-b.life galaxy-b.rift]
+    ==  ==
   ::
-  =.  chums.ames-state.moon-a
-    %+  ~(put by chums.ames-state.moon-a)  our.comet-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-a-comet-a-sym
-          comet-a.life
-          comet-a.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~moon-b about ~comet-b
-  ::
-  =.  chums.ames-state.moon-b
-    %+  ~(put by chums.ames-state.moon-b)  our.comet-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-b-comet-b-sym
-          comet-b.life
-          comet-b.rift
-          [public-keys=pub.saf pass=pass]:ames-state.comet-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~comet-b about ~moon-b
-  ::
-  =.  chums.ames-state.comet-b
-    %+  ~(put by chums.ames-state.comet-b)  our.moon-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-b-comet-b-sym
-          moon-b.life
-          moon-b.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~moon-b about ~comet-a
-  ::
-  =.  chums.ames-state.moon-b
-    %+  ~(put by chums.ames-state.moon-b)  our.comet-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-b-comet-a-sym
-          comet-a.life
-          comet-a.rift
-          [public-keys=pub.saf pass=pass]:ames-state.comet-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~comet-a about ~moon-b
-  ::
-  =.  chums.ames-state.comet-a
-    %+  ~(put by chums.ames-state.comet-a)  our.moon-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-b-comet-a-sym
-          moon-b.life
-          moon-b.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~moon-a about ~comet-b
-  ::
-  =.  chums.ames-state.moon-a
-    %+  ~(put by chums.ames-state.moon-a)  our.comet-b
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-a-comet-b-sym
-          comet-b.life
-          comet-b.rift
-          [public-keys=pub.saf pass=pass]:ames-state.comet-b
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
-  ::  tell ~comet-b about ~moon-a
-  ::
-  =.  chums.ames-state.comet-b
-    %+  ~(put by chums.ames-state.comet-b)  our.moon-a
-    =|  =fren-state:ames
-    =.  -.fren-state
-      :*  symmetric-key=moon-a-comet-b-sym
-          moon-a.life
-          moon-a.rift
-          [public-keys=pub.saf pass=pass]:ames-state.moon-a
-          sponsor=~bud
-      ==
-    =.  lane.fren-state  `[0 *lane:pact:ames]
-    [%known fren-state]
+  =/  comet-a   g:(snag 0 ships)
+  =/  comet-b   g:(snag 1 ships)
+  =/  moon-a    g:(snag 2 ships)
+  =/  moon-b    g:(snag 3 ships)
+  =/  planet-a  g:(snag 4 ships)
+  =/  planet-b  g:(snag 5 ships)
+  =/  galaxy-a  g:(snag 6 ships)
+  =/  galaxy-b  g:(snag 7 ships)
   ::  metamorphose
   ::
-  =>  .(comet-b +:(call:(comet-b) ~[//unix] ~ %born ~))
   =>  .(comet-a +:(call:(comet-a) ~[//unix] ~ %born ~))
-  =>  .(moon-b +:(call:(moon-b) ~[//unix] ~ %born ~))
+  =>  .(comet-b +:(call:(comet-b) ~[//unix] ~ %born ~))
   =>  .(moon-a +:(call:(moon-a) ~[//unix] ~ %born ~))
+  =>  .(moon-b +:(call:(moon-b) ~[//unix] ~ %born ~))
+  =>  .(planet-a +:(call:(planet-a) ~[//unix] ~ %born ~))
+  =>  .(planet-b +:(call:(planet-b) ~[//unix] ~ %born ~))
+  =>  .(galaxy-a +:(call:(galaxy-a) ~[//unix] ~ %born ~))
+  =>  .(galaxy-b +:(call:(galaxy-b) ~[//unix] ~ %born ~))
   ::
-  [comet-b=comet-b comet-a=comet-a moon-a=moon-a moon-b=moon-b]
+  :*  comet-a=comet-a    comet-b=comet-b
+      moon-a=moon-a      moon-b=moon-b
+      planet-a=planet-a  planet-b=planet-b
+      galaxy-a=galaxy-a  galaxy-b=galaxy-b
+  ==
 ::
 --
 ::  forward-declare to avoid repeated metamorphoses

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -15,12 +15,17 @@
   0w3-.kl6Hg.mLISf.pDTQQ.LymxF.q4Isr.AGUAv.uJvkf.DOjeU.
   U8OPv.XO9T2.Hfhe~.zFwpO.Q1tn5.BeBSQ.o4MTS.lTWAh.TcOJ2
 ::
+++  moon-a  ~mister-dister-norsyr-torryn
+++  moon-b  ~mister-roller-norsyr-torryn
+::
 ++  crypto-core
   |%  ++  nec      (pit:nu:cric:crypto 512 (shaz 'nec') %b ~)
       ++  bud      (pit:nu:cric:crypto 512 (shaz 'bud') %b ~)
       ++  zod      (pit:nu:cric:crypto 512 (shaz 'zod') %b ~)
       ++  comet-a  (nol:nu:cric:crypto comet-a-ring)
       ++  comet-b  (nol:nu:cric:crypto comet-b-ring)
+      ++  moon-a   (pit:nu:cric:crypto 32 (can 5 [1 ^moon-a] [1 lyfe=1] ~) %b ~)
+      ++  moon-b   (pit:nu:cric:crypto 32 (can 5 [1 ^moon-b] [1 lyfe=1] ~) %b ~)
       ++  sign
         |=  [=ship data=@ux]
         ?:  =(ship ~nec)
@@ -28,6 +33,7 @@
         ?:  =(ship ~zod)
           (sign:ed:crypto data sgn:ven:ex:zod)
         (sign:ed:crypto data sgn:ven:ex:bud)
+  ::
   --
 ::
 ++  make-gall
@@ -103,6 +109,8 @@
   [nec=nec bud=bud]
 ::
 ++  ames-comets-moons
+  ::  comets
+  ::
   ::  create comet-a
   ::
   =/  comet-a  (ames-raw ~dacrum-tordyt-dassel-mogred--sabnyx-malbes-mogdef-litzod)
@@ -159,14 +167,121 @@
       ==
     =.  lane.fren-state  `[0 *lane:pact:ames]
     [%known fren-state]
+  ::  moons
+  ::
+  ::  create moon-a
+  ::
+  =/  moon-a  (ames-raw moon-a)
+  =.  now.moon-a  ~1111.1.1
+  =.  eny.moon-a  0v3f.arfnf
+  =.  life.ames-state.moon-a  1
+  =.  rift.ames-state.moon-a  0
+  =.  rof.moon-a  |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.moon-a  sec:ex:moon-a:crypto-core
+  =.  pass.ames-state.moon-a  pub:ex:moon-a:crypto-core
+  =.  saf.ames-state.moon-a   saf:ex:moon-a:crypto-core
+  ::  create moon-b
+  ::
+  =/  moon-b  (ames-raw moon-b)
+  =.  now.moon-b  ~1111.1.1
+  =.  eny.moon-b  0v3f.arfnf
+  =.  life.ames-state.moon-b  1
+  =.  rift.ames-state.moon-b  0
+  =.  rof.moon-b  |=(* ``[%noun !>(*(list turf))])
+  =.  ring.ames-state.moon-b  sec:ex:moon-b:crypto-core
+  =.  pass.ames-state.moon-b  pub:ex:moon-b:crypto-core
+  =.  saf.ames-state.moon-b   saf:ex:moon-b:crypto-core
+  =/  moon-a-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.moon-b)
+  =/  moon-b-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.moon-a)
+  ::
+  ::  tell ~moon-b about ~moon-a
+  ::
+  =.  chums.ames-state.moon-b
+    %+  ~(put by chums.ames-state.moon-b)  our.moon-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-b-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.moon-a
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~moon-a about ~moon-b
+  ::
+  =.  chums.ames-state.moon-a
+    %+  ~(put by chums.ames-state.moon-a)  our.moon-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-a-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.moon-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::
+  ::  comet to moon
+  ::
+  =/  moon-a-comet-a-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-a sek.saf.ames-state.comet-a)
+  =/  moon-b-comet-b-sym
+    (derive-symmetric-key:ames-raw pub.saf.ames-state.moon-b sek.saf.ames-state.comet-b)
+  ::
+  ::  tell ~comet-a about ~moon-a
+  ::
+  =.  chums.ames-state.comet-a
+    %+  ~(put by chums.ames-state.comet-a)  our.moon-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-a-comet-a-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.moon-a
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~moon-a about ~comet-a
+  ::
+  =.  chums.ames-state.moon-a
+    %+  ~(put by chums.ames-state.moon-a)  our.comet-a
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-a-comet-a-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.moon-a
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
+  ::  tell ~moon-b about ~comet-b
+  ::
+  =.  chums.ames-state.moon-b
+    %+  ~(put by chums.ames-state.moon-b)  our.comet-b
+    =|  =fren-state:ames
+    =.  -.fren-state
+      :*  symmetric-key=moon-b-comet-b-sym
+          life=1
+          rift=0
+          [public-keys=pub.saf pass=pass]:ames-state.comet-b
+          sponsor=~bud
+      ==
+    =.  lane.fren-state  `[0 *lane:pact:ames]
+    [%known fren-state]
   ::  metamorphose
   ::
   =>  .(comet-b +:(call:(comet-b) ~[//unix] ~ %born ~))
   =>  .(comet-a +:(call:(comet-a) ~[//unix] ~ %born ~))
+  =>  .(moon-b +:(call:(moon-b) ~[//unix] ~ %born ~))
+  =>  .(moon-a +:(call:(moon-a) ~[//unix] ~ %born ~))
   ::
-  ::  XX TODO moons
-  ::
-  [comet-b=comet-b comet-a=comet-a]
+  [comet-b=comet-b comet-a=comet-a moon-a=moon-a moon-b=moon-b]
 ::
 --
 ::  forward-declare to avoid repeated metamorphoses

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12379,10 +12379,10 @@
             ~&  [%no-page man=man]
             ~
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
-          =/  ser  p:(fax:plot (en:pact poke))
-          ?.  (gth (met 3 ser) 1.472)
+          =/  [=bloq =step]  (met:plot (en:pact poke))
+          ?>  =(3 bloq)
+          ?.  (gth step 1.472)
             `poke
-          ::
           ::
           ~&  >>  page-above-mtu/man(wan [%auth 0])
           ?~  page=(co-get-page man(wan [%auth 0]))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -82,9 +82,11 @@
 =,  ames
 =*  point               point:jael
 =*  public-keys-result  public-keys-result:jael
-=/  packet-size  13
-=/  retry-timer  ~m2    ::  only used in /mesa/retry and /dead-flow timers
-=/  ahoy-on=?    %.y
+=/  packet-size      13
+=/  retry-timer      ~m2    ::  only used in /mesa/retry and /dead-flow timers
+=/  ahoy-on=?        %.y
+=/  comet-threshold  886
+=/  moon-threshold   978
 ::
 =>  ::  common helpers
     ~%  %ames  ..part  ~
@@ -12488,6 +12490,22 @@
               [~ ~]
             ?.  ser.pac.nex
               ``[%packet !>([pact pairs])]
+            ::
+            ?.  ser.pac.nex
+              ``[%packet !>([pact pairs])]
+            ?:  ?&  =(wid 1)
+                    ::  XX nit ?
+                    =+  dat-size=(met 3 dat.data.pact)
+                    ?|  ?&  ?=(%pawn (clan:title our))
+                            (gte dat-size comet-threshold)
+                        ==
+                        ?&  ?=(%earl (clan:title our))
+                            (gte dat-size moon-threshold)
+                ==  ==  ==
+              ::  if wid <= 1 but dat.data.page is bigger than the threshold
+              ::  for comets and moons, replace the %data packet with an %auth
+              ::
+              $(wan.pac.nex [%auth fag=0])
             =;  airs=(list @ux)
               ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
             %+  turn  pairs

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -86,7 +86,6 @@
 =/  retry-timer      ~m2    ::  only used in /mesa/retry and /dead-flow timers
 =/  ahoy-on=?        %.y
 =/  comet-threshold  886
-=/  moon-threshold   978
 ::
 =>  ::  common helpers
     ~%  %ames  ..part  ~
@@ -12496,14 +12495,11 @@
             ?:  ?&  =(wid 1)
                     ::  XX nit ?
                     =+  dat-size=(met 3 dat.data.pact)
-                    ?|  ?&  ?=(%pawn (clan:title our))
-                            (gte dat-size comet-threshold)
-                        ==
-                        ?&  ?=(%earl (clan:title our))
-                            (gte dat-size moon-threshold)
-                ==  ==  ==
+                    ?&  ?=(%pawn (clan:title our))
+                        (gte dat-size comet-threshold)
+                ==  ==
               ::  if wid <= 1 but dat.data.page is bigger than the threshold
-              ::  for comets and moons, replace the %data packet with an %auth
+              ::  for comets, replace the %data packet with an %auth
               ::
               $(wan.pac.nex [%auth fag=0])
             =;  airs=(list @ux)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12511,9 +12511,6 @@
               [~ ~]
             ?.  ser.pac.nex
               ``[%packet !>([pact pairs])]
-            ::
-            ?.  ser.pac.nex
-              ``[%packet !>([pact pairs])]
             =;  airs=(list @ux)
               ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
             %+  turn  pairs

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12541,7 +12541,7 @@
           ?-    typ.wan.pac.nex
               %auth
             =/  nam  [[our rif] [boq ?:(nit ~ [%auth fag])] pat]
-            ::  NB: root excluded as it can be recalculated by the client
+            ::  NB: root included for special one-fragment message %auth
             ::
             =/  lss-proof
               =>  [ser=ser ..lss]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9485,9 +9485,10 @@
                 ev-core
               =/  proof=(list @ux)  (rip 8 dat.data)
               ?>  %-  authenticate
-                  [(recover-root:verifier:lss proof) aut.data name]
-              =/  state    (init:verifier:lss tof proof)
-              =.  pit.per  (~(put by pit.per) sealed-path u.res(ps `[state ~]))
+                  [?:(=(1 tof) dat.data (recover-root:verifier:lss proof)) aut.data name]
+              =?  pit.per  !=(1 tof)
+                =/  state    (init:verifier:lss tof proof)
+                (~(put by pit.per) sealed-path u.res(ps `[state ~]))
               ::
               %-  (ev-tace snd.veb.bug.ames-state |.("request frag={<fag>}"))
               ::  request next fragment
@@ -12504,8 +12505,8 @@
               =>  [ser=ser ..lss]
               :: ~>  %memo./ames/lss-auth
               (build:lss (met 3 ser)^ser)
-            =/  pof=@ux  (rep 8 proof.lss-proof)
-            =/  dat  [tob [%& mes] (rep 8 proof.lss-proof)]  :: XX types
+            =/  pof=@ux  ?:(=(1 wid) root.lss-proof (rep 8 proof.lss-proof))
+            =/  dat  [tob [%& mes] pof]  :: XX types
             [[hop=0 %page nam dat ~] ~ pof]
           ::
               %data

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12370,22 +12370,26 @@
           =/  nam  [[ship.p per-rift] [13 ~] path.p]
           ?~  q
             `[hop=0 %peek nam]
-          ::  XX assert that the serializes path fits in the MTU
-          ::  XX if path will be too long, put in [tmp] and use that path
-          ::  %-  mess:plot:d
-          ::  (en:name:d [[her=~nec rif=40] [boq=0 wan=~] pat=['c~_h' ~]]))
-          ::  [bloq=q=3 step=r=12]
-          ::  =/  has  (shax u.u.res)
-          ::  =.  tmp-chums.ames-state
-          ::    %+  ~(put by tmp-chums.ames-state)  has
-          ::    [%some-envelope original-path u.u.res])
-          ::  //ax/[$ship]//1/temp/[hash]
           ::
           =/  man=name:pact  [[our rift.ames-state] [13 ~] u.q]
           ::
           ?~  page=(co-get-page man)
             ::  XX
-            ~&  [%no-page man=man]  ~
+            ~&  [%no-page man=man]
+            ~
+          =/  poke=pact:pact  [hop=0 %poke nam man u.page]
+          =/  ser  p:(fax:plot (en:pact poke))
+          ?.  (gth (met 3 ser) 1.472)
+            `poke
+          ::
+          ::
+          ~&  >>  page-above-mtu/man(wan [%auth 0])
+          ?~  page=(co-get-page man(wan [%auth 0]))
+            ::  XX
+            ~&  [%no-auth-page man=man]
+            ~
+          ::  XX  man(wan [%auth 0])
+          ::
           `[hop=0 %poke nam man u.page]
         ::
         ++  co-get-page
@@ -12492,16 +12496,40 @@
             ::
             ?.  ser.pac.nex
               ``[%packet !>([pact pairs])]
-            ?:  ?&  =(wid 1)
-                    ::  XX nit ?
-                    =+  dat-size=(met 3 dat.data.pact)
-                    ?&  ?=(%pawn (clan:title our))
-                        (gte dat-size comet-threshold)
-                ==  ==
-              ::  if wid <= 1 but dat.data.page is bigger than the threshold
-              ::  for comets, replace the %data packet with an %auth
-              ::
-              $(wan.pac.nex [%auth fag=0])
+            ::  rewrite %data packet as %auth if bigget than MTU
+            ::
+            ::  option a) assume worst case (i.e. biggest path) and adjust basued on page size
+            ::
+            :: ?:  ?&  =(wid 1)
+            ::         ::  XX nit ?
+            ::         =+  dat-size=(met 3 dat.data.pact)
+            ::         ?&  ?=(%pawn (clan:title our))
+            ::             (gte dat-size comet-threshold)
+            ::     ==  ==
+            ::   ::  if wid <= 1 but dat.data.page is bigger than the threshold
+            ::   ::  for comets, replace the %data packet with an %auth
+            ::   ::
+            ::   $(wan.pac.nex [%auth fag=0])
+            ::
+            ::  make a synthetic %poke packet and measure it exactly
+            ::
+            :: ?:  ?&  =(wid 1)
+            ::         ::?=([%chum lyf=@ who=@ *] pat)  :: XX
+            ::         ::  construct synthetic pact
+            ::         ::
+            ::         =/  poke=pact:^pact
+            ::           :*  hop=0  %poke
+            ::               ack=name.pact  :: XX  assumes ack = pok
+            ::               pok=name.pact(wan ~)
+            ::               data.pact
+            ::           ==
+            ::         =/  ser  p:(fax:plot (en:^pact poke))
+            ::         (gte pac-size=(met 3 ser) 1.472)
+            ::     ==
+            ::   ::  if wid <= 1 but dat.data.page is bigger than the threshold
+            ::   ::  for comets and moons, replace the %data packet with an %auth
+            ::   ::
+            ::   $(wan.pac.nex [%auth fag=0])
             =;  airs=(list @ux)
               ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
             %+  turn  pairs
@@ -12518,8 +12546,10 @@
               =>  [ser=ser ..lss]
               :: ~>  %memo./ames/lss-auth
               (build:lss (met 3 ser)^ser)
+            ::  if ser is less than two fragments, no proof and no pairs
+            ::
             =/  pof=@ux  (rep 8 proof.lss-proof)
-            =/  dat  [tob [%& mes] (rep 8 proof.lss-proof)]  :: XX types
+            =/  dat  [tob [%& mes] pof]  :: XX types
             [[hop=0 %page nam dat ~] ~ pof]
           ::
               %data

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -85,7 +85,7 @@
 =/  packet-size      13
 =/  retry-timer      ~m2    ::  only used in /mesa/retry and /dead-flow timers
 =/  ahoy-on=?        %.y
-=/  comet-threshold  886
+=/  max-mtu=@ud      1.472  :: boq=3
 ::
 =>  ::  common helpers
     ~%  %ames  ..part  ~
@@ -9385,11 +9385,19 @@
             ::
             =?  ev-core  ?=(~ lane.per)  (ev-update-qos %dead last-contact=now)
             ::
-            ?.  =(1 (div (add tob.data.pact 1.023) 1.024))
+            =+  fo-core=(fo-abed:fo [bone dire]:ack)
+            ::  how many 1.024-byte fragments does tob require?
+            ::    e.g. boq=13 (frag=1.024); if tob=1.025 => 2 fragments
+            ::
+            =+  boq=13
+            =+  frag=(div (bex boq) 8) ::  fragment size in bytes (1.024 for boq=13)
+            ::  tob.data.pact is (met 3 dat.data.pact) in bytes
+            ::
+            ?:  (gth (div (add tob.data.pact (dec frag)) frag) 1)
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("hear incomplete message")
               :: XX assert load is plea/boon?
-              =+  fo-core=(fo-abed:fo [bone dire]:ack)
+              ::
               ?:  (fo-message-is-acked:fo-core mess.pok)
                 ::  don't peek if the message havs been already acked
                 ::
@@ -9408,6 +9416,20 @@
               %^  ev-emit  hen  %pass
               [(fo-wire:fo-core %pok) %a %meek [none/~ [her pat]:pok.pact]]
             ::  authenticate one-fragment message
+            ::
+            ::  if this is a one-fragment %data pact, tob would equal the size of
+            ::  dat but if it's an over-MTU %auth poke,
+            ::  (dat.data.pact = lss-root = 32B)
+            ::  and tob > 32B to create the over-MTU %auth packet
+            ::
+            ?:  !=(tob.data.pact (met 3 dat.data.pact))
+              ?>  %-  authenticate
+                  [dat.data aut.data pok.pact]
+              %-  %+  ev-tace  fin.veb.bug.ames-state
+                  |.("peek for n=1 over-mtu poke payload {<[flow=bone seq=mess]:pok>}")
+              %^  ev-emit  hen  %pass
+              [(fo-wire:fo-core %pok) %a %meek [none/~ [her pat]:pok.pact]]
+            ::  direct single-fragment: dat is full message; inject
             ::
             ?>  %-  authenticate
                 [(root:lss (met 3 dat.data)^dat.data) aut.data pok.pact]
@@ -12375,22 +12397,17 @@
           =/  man=name:pact  [[our rift.ames-state] [13 ~] u.q]
           ::
           ?~  page=(co-get-page man)
-            ::  XX
-            ~&  [%no-page man=man]
-            ~
+            ~&([%no-page man=man] ~)  :: XX
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
-          =/  [=bloq =step]  (met:plot (en:pact poke))
+          =/  [=bloq =step]   (met:plot (en:pact poke))
           ?>  =(3 bloq)
-          ?.  (gth step 1.472)
+          ?.  (gth step max-mtu)
             `poke
           ::
-          ~&  >>  page-above-mtu/man(wan [%auth 0])
+          %-  %^  co-tace  odd.veb.bug.ames-state  ship.p
+              |.("pact over-mtu page={<(met 3 dat.u.page)>}B; send %auth pact")
           ?~  page=(co-get-page man(wan [%auth 0]))
-            ::  XX
-            ~&  [%no-auth-page man=man]
-            ~
-          ::  XX  man(wan [%auth 0])
-          ::
+            ~&([%no-auth-page man=man] ~)  :: XX
           `[hop=0 %poke nam man u.page]
         ::
         ++  co-get-page
@@ -12497,40 +12514,6 @@
             ::
             ?.  ser.pac.nex
               ``[%packet !>([pact pairs])]
-            ::  rewrite %data packet as %auth if bigget than MTU
-            ::
-            ::  option a) assume worst case (i.e. biggest path) and adjust basued on page size
-            ::
-            :: ?:  ?&  =(wid 1)
-            ::         ::  XX nit ?
-            ::         =+  dat-size=(met 3 dat.data.pact)
-            ::         ?&  ?=(%pawn (clan:title our))
-            ::             (gte dat-size comet-threshold)
-            ::     ==  ==
-            ::   ::  if wid <= 1 but dat.data.page is bigger than the threshold
-            ::   ::  for comets, replace the %data packet with an %auth
-            ::   ::
-            ::   $(wan.pac.nex [%auth fag=0])
-            ::
-            ::  make a synthetic %poke packet and measure it exactly
-            ::
-            :: ?:  ?&  =(wid 1)
-            ::         ::?=([%chum lyf=@ who=@ *] pat)  :: XX
-            ::         ::  construct synthetic pact
-            ::         ::
-            ::         =/  poke=pact:^pact
-            ::           :*  hop=0  %poke
-            ::               ack=name.pact  :: XX  assumes ack = pok
-            ::               pok=name.pact(wan ~)
-            ::               data.pact
-            ::           ==
-            ::         =/  ser  p:(fax:plot (en:^pact poke))
-            ::         (gte pac-size=(met 3 ser) 1.472)
-            ::     ==
-            ::   ::  if wid <= 1 but dat.data.page is bigger than the threshold
-            ::   ::  for comets and moons, replace the %data packet with an %auth
-            ::   ::
-            ::   $(wan.pac.nex [%auth fag=0])
             =;  airs=(list @ux)
               ``[%atom !>([p:(fax:plot (en:^pact pact)) airs pof])]
             %+  turn  pairs

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -2,11 +2,13 @@
 ::
 /+  *test, v=test-mesa-gall
 ::
+=+  thres=32
+::
 =/  [life=@ud rift=@ud bone=@ud msg=@ud]
-  [(dec (bex 32)) (dec (bex 32)) (dec (bex 32)) (dec (bex 32))]
-=+  lifes=[comet-a=1 comet-b=1 moon-a=life moon-b=life]
-=+  rifts=[comet-a=0 comet-b=0 moon-a=rift moon-b=rift]
-=+  (ames-comets-moons:v lifes rifts)
+  [(dec (bex thres)) (dec (bex thres)) (dec (bex thres)) (dec (bex thres))]
+=+  lifes=[comet-a=life comet-b=life moon-a=life moon-b=life planet-a=life planet-b=life galaxy-a=1 galaxy-b=1]
+=+  rifts=[comet-a=rift comet-b=rift moon-a=rift moon-b=rift planet-a=rift planet-b=rift galaxy-a=0 galaxy-b=0]
+=+  (ames-comets-moons-planets-galaxies:v lifes rifts)
 ::
 =>  |%
     ++  dbug  `?`&
@@ -60,10 +62,20 @@
   =/  vane-wire
     /bone/(scot %p our:sender)/(scot %ud bone)/(scot %ud msg)
   =/  ack-full=path
-    (make-space-path.sender ack-space %a %x '1' %$ ack-path)
+    %+  make-space-path.sender  ack-space
+      :: :*  %publ
+      ::     receiver-life
+      :: ==
+    [%a %x '1' %$ ack-path]
   =/  pok-full=path
-    (make-space-path.receiver pok-space %a %x '1' %$ pok-path)
-  =|  over-mtus=(list @ud)
+    %+  make-space-path.receiver  pok-space
+      :: :*  %publ
+      ::     sender-life
+      :: ==
+    [%a %x '1' %$ pok-path]
+  ~&  ack-path^pok-path
+  ~&  ack-full^pok-full
+  =|  over-mtus=(list [page=@ud pact=@ud i=@ud])
   =;  mts=_over-mtus
     %+  expect-eq
       !>  ~
@@ -96,46 +108,162 @@
   =/  poke=pact:pact:sender
     :*  hop=0
         %poke
-        ack=[[our:receiver 0] [13 ~] ack-full]
-        pok=[[our:sender 0] [13 ~] pok-full]
+        ack=[[our:receiver sender-rift] [13 ~] ack-full]
+        pok=[[our:sender receiver-rift] [13 ~] pok-full]
         data.page
     ==
   =/  ser  p:(fax:plot (en:pact:ames poke))
-  ?.  (gth (met 3 ser) 1.472)
-    $(iters t.iters)
   =+  dat-size=(met 3 dat.data.page)
+  ?.  (gth (met 3 ser) 1.472)
+    :: ?>  ?=(%poke +<.poke)
+    :: ~&  :*  %+  met  3  p:(fax:plot (en:^name:pact:sender ack.poke))
+    ::         %+  met  3  p:(fax:plot (en:^name:pact:sender pok.poke))
+    ::         %+  met  3  p:(fax:plot (en:^data:pact:sender data.poke))
+    ::     ==
+    :: ~&  >  ser/(met 3 ser)^dat/dat-size
+    $(iters t.iters)
+
   ?.  (lth dat-size 1.024)
-    ~&  >  %done-2
+    :: ~&  >  %done-2
     over-mtus
   :: ~&  >>  ser/(met 3 ser)^dat/dat-size
-  $(iters t.iters, over-mtus [dat-size over-mtus])
+  =/  res
+    %-  scry:(sender ~1111.1.10 `@`0xdead.beef bex-roof)
+    =-  [~ / %x [[our:sender %$ ud+1] -]]
+    (weld /mess/(scot %ud sender-rift)/pact/13/etch/auth/0 pok-full)
+  ?~  res
+    ~&  >>>  %nope-1
+    ~
+  ?~  u.res
+    ~&  >>>  %nope-2
+    ~
+  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
+  ~&  >  proof/proof
+  =/  page=pact:pact:sender  (parse-packet:sender blob)
+  ?>  ?=(%page +<.page)
+  =/  poke=pact:pact:sender
+    :*  hop=0
+        %poke
+        ack=[[our:receiver sender-rift] [13 ~] ack-full]
+        pok=[[our:sender receiver-rift] [13 ~] pok-full]
+        data.page
+    ==
+  =/  ser  p:(fax:plot (en:pact:ames poke))
+  =+  dat-size=(met 3 dat.data.page)
+  :: ~&  page^(met 3 ser)
+  ::$(iters t.iters, over-mtus [[dat-size (met 3 ser) i.iters] over-mtus])
+  $(iters t.iters)
 ::
-++  test-mesa-ns-comet-moon
-  %:  check-mesa-ns
-      comet-a  moon-a
-      comet-a.lifes  moon-a.lifes
-      comet-a.rifts  moon-a.rifts
-  ==
-::
-++  test-mesa-ns-moon-comet
-  %:  check-mesa-ns
-      moon-a  comet-a
-      moon-a.lifes  comet-a.lifes
-      moon-a.rifts  comet-a.rifts
-  ==
-::
+:: ++  test-mesa-ns-comet-moon
+::   %:  check-mesa-ns
+::       comet-a  moon-a
+::       comet-a.lifes  moon-a.lifes
+::       comet-a.rifts  moon-a.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-moon-comet
+::   %:  check-mesa-ns
+::       moon-a  comet-a
+::       moon-a.lifes  comet-a.lifes
+::       moon-a.rifts  comet-a.rifts
+::   ==
+:: ::
 ++  test-mesa-ns-comet-comet
   %:  check-mesa-ns
       comet-a  comet-b
       comet-a.lifes  comet-b.lifes
       comet-a.rifts  comet-b.rifts
   ==
-::
-++  test-mesa-ns-moon-moon
-  %:  check-mesa-ns
-      moon-a  moon-b
-      moon-a.lifes  moon-b.lifes
-      moon-a.rifts  moon-b.rifts
-  ==
-::
+:: ::
+:: ++  test-mesa-ns-moon-moon
+::   %:  check-mesa-ns
+::       moon-a  moon-b
+::       moon-a.lifes  moon-b.lifes
+::       moon-a.rifts  moon-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-planet-comet
+::   %:  check-mesa-ns
+::       planet-a  comet-b
+::       planet-a.lifes  comet-b.lifes
+::       planet-a.rifts  comet-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-galaxy-comet
+::   %:  check-mesa-ns
+::       galaxy-a  comet-b
+::       galaxy-a.lifes  comet-b.lifes
+::       galaxy-a.rifts  comet-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-planet-planet
+::   %:  check-mesa-ns
+::       planet-a  planet-b
+::       planet-a.lifes  planet-b.lifes
+::       planet-a.rifts  planet-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-galaxy-galaxy
+::   %:  check-mesa-ns
+::       galaxy-a  galaxy-b
+::       galaxy-a.lifes  galaxy-b.lifes
+::       galaxy-a.rifts  galaxy-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-galaxy-planet
+::   %:  check-mesa-ns
+::       galaxy-a  planet-b
+::       galaxy-a.lifes  planet-b.lifes
+::       galaxy-a.rifts  planet-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-galaxy-moon
+::   %:  check-mesa-ns
+::       galaxy-a  moon-b
+::       galaxy-a.lifes  moon-b.lifes
+::       galaxy-a.rifts  moon-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-planet-galaxy
+::   %:  check-mesa-ns
+::       planet-a  galaxy-b
+::       planet-a.lifes  galaxy-b.lifes
+::       planet-a.rifts  galaxy-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-planet-moon
+::   %:  check-mesa-ns
+::       planet-a  moon-b
+::       planet-a.lifes  moon-b.lifes
+::       planet-a.rifts  moon-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-moon-galaxy
+::   %:  check-mesa-ns
+::       moon-a  galaxy-b
+::       moon-a.lifes  galaxy-b.lifes
+::       moon-a.rifts  galaxy-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-moon-planet
+::   %:  check-mesa-ns
+::       moon-a  planet-b
+::       moon-a.lifes  planet-b.lifes
+::       moon-a.rifts  planet-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-comet-galaxy
+::   %:  check-mesa-ns
+::       comet-a  galaxy-b
+::       comet-a.lifes  galaxy-b.lifes
+::       comet-a.rifts  galaxy-b.rifts
+::   ==
+:: ::
+:: ++  test-mesa-ns-comet-planet
+::   %:  check-mesa-ns
+::       comet-a  planet-b
+::       comet-a.lifes  planet-b.lifes
+::       comet-a.rifts  planet-b.rifts
+::   ==
+:: ::
 --

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -1,0 +1,176 @@
+::  test %pact
+::
+/+  *test, v=test-mesa-gall
+::
+=+  ames-comets-moons:v
+::
+=>  |%
+    ++  dbug  `?`&
+    ++  make-roof
+      |=  [pax=path val=cage]
+      ^-  roof
+      |=  [lyc=gang pov=path vis=view bem=beam]
+      ^-  (unit (unit cage))
+      ?.  ?&(=(s.bem pax) |(=(vis %x) =(vis [%g %x]) =(vis [%a %x]) =(vis %gx) =(vis %ax)))
+        [~ ~]
+      ``val
+    ::
+    --
+|%
+++  test-mesa-ns-comets
+  =|  iters=_1.000
+  ::  comet-a -- %poke --> comet-b
+  ::  pok-path            ack-path
+  ::
+  =/  ack-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            comet-a
+            [~1111.1.10 0xdead.beef *roof]
+            [our:comet-a our:comet-b]
+        ==
+    [%chum server-life=1 client=our:comet-a client-life=1 key]
+  =/  pok-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            comet-b
+            [~1111.1.10 0xdead.beef *roof]
+            [our:comet-b our:comet-a]
+        ==
+    [%chum server-life=1 client=our:comet-b client-life=1 key]
+  =/  pok-path=path
+    ::  in comet-a namespace, for comet-b
+    ::
+    /flow/0/poke/for/(scot %p our:comet-b)/1
+  =/  ack-path=path
+    ::  in comet-b namespace, for comet-a
+    ::
+    /flow/0/ack/bak/(scot %p our:comet-a)/1
+  ::
+  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:comet-b)/0/0
+  =/  vane-wire  /bone/(scot %p our:comet-a)/0/1
+  =/  ack-full=path
+    (make-space-path.comet-a ack-space %a %x '1' %$ ack-path)
+  =/  pok-full=path
+    (make-space-path.comet-b pok-space %a %x '1' %$ pok-path)
+  ~&  ack-full^pok-full
+  =/  iters=(list @ud)  (gulf 1 1.500)
+  |-  ^-  tang
+  ?~  iters
+    ~
+  =/  bex-roof
+    %-  make-roof
+    :-  pok-path  ^-  cage
+    :-  %atom  !>
+    :*  vane=%g
+        path=/ge/hood
+        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
+    ==
+  =/  res
+    %-  scry:(comet-a ~1111.1.10 `@`0xdead.beef bex-roof)
+    =-  [~ / %x [[our:comet-a %$ ud+1] -]]
+    ::  XX  /mess/0/pact/13/pure/init
+    (weld /mess/0/pact/13/etch/init pok-full)
+  ?~  res
+    ~
+  ?~  u.res
+    ~
+  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
+ ::  %page packet containing the %auth or data, based on payload size
+ ::
+  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
+  ?>  ?=(%page +<.page)
+  =/  poke=pact:pact:comet-a
+    :*  hop=0
+        %poke
+        ack=[[our:comet-b 0] [13 ~] ack-full]
+        pok=[[our:comet-a 0] [13 ~] pok-full]
+        data.page
+    ==
+  =/  ser  p:(fax:plot (en:pact:ames poke))
+  ?.  (gth (met 3 ser) 1.472)
+    $(iters t.iters)
+  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)^iter/i.iters
+  $(iters t.iters)
+::
+++  test-mesa-ns-moons
+  =|  iters=_1.000
+  ::  comet-a -- %poke --> comet-b
+  ::  pok-path            ack-path
+  ::
+  =/  ack-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            comet-a
+            [~1111.1.10 0xdead.beef *roof]
+            [our:comet-a our:comet-b]
+        ==
+    [%chum server-life=1 client=our:comet-a client-life=1 key]
+  =/  pok-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            comet-b
+            [~1111.1.10 0xdead.beef *roof]
+            [our:comet-b our:comet-a]
+        ==
+    [%chum server-life=1 client=our:comet-b client-life=1 key]
+  =/  pok-path=path
+    ::  in comet-a namespace, for comet-b
+    ::
+    /flow/0/poke/for/(scot %p our:comet-b)/1
+  =/  ack-path=path
+    ::  in comet-b namespace, for comet-a
+    ::
+    /flow/0/ack/bak/(scot %p our:comet-a)/1
+  ::
+  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:comet-b)/0/0
+  =/  vane-wire  /bone/(scot %p our:comet-a)/0/1
+  =/  ack-full=path
+    (make-space-path.comet-a ack-space %a %x '1' %$ ack-path)
+  =/  pok-full=path
+    (make-space-path.comet-b pok-space %a %x '1' %$ pok-path)
+  ~&  ack-full^pok-full
+  =/  iters=(list @ud)  (gulf 1 1.500)
+  |-  ^-  tang
+  ?~  iters
+    ~
+  =/  bex-roof
+    %-  make-roof
+    :-  pok-path  ^-  cage
+    :-  %atom  !>
+    :*  vane=%g
+        path=/ge/hood
+        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
+    ==
+  =/  res
+    %-  scry:(comet-a ~1111.1.10 `@`0xdead.beef bex-roof)
+    =-  [~ / %x [[our:comet-a %$ ud+1] -]]
+    ::  XX  /mess/0/pact/13/pure/init
+    (weld /mess/0/pact/13/etch/init pok-full)
+  ?~  res
+    ~
+  ?~  u.res
+    ~
+  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
+ ::  %page packet containing the %auth or data, based on payload size
+ ::
+  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
+  ?>  ?=(%page +<.page)
+  =/  poke=pact:pact:comet-a
+    :*  hop=0
+        %poke
+        ack=[[our:comet-b 0] [13 ~] ack-full]
+        pok=[[our:comet-a 0] [13 ~] pok-full]
+        data.page
+    ==
+  =/  ser  p:(fax:plot (en:pact:ames poke))
+  ?.  (gth (met 3 ser) 1.472)
+    $(iters t.iters)
+  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)^iter/i.iters
+  $(iters t.iters)
+::
+--

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -253,4 +253,79 @@
       comet-a.rifts  planet-b.rifts
   ==
 ::
+++  test-mesa-mtu-flow
+  ^-  tang
+  %.  :*  comet-a  comet-b
+          comet-a.lifes  comet-b.lifes
+          comet-a.rifts  comet-b.rifts
+      ==
+  |=  $:  sender=ames-gate:v
+          receiver=ames-gate:v
+          sender-life=@ud
+          receiver-life=@ud
+          sender-rift=@ud
+          receiver-rift=@ud
+      ==
+  =/  ack-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            sender
+            [~1111.1.10 0xdead.beef *roof]
+            [our:sender our:receiver]
+        ==
+    [%chum server-life=receiver-life client=our:sender client-life=sender-life key]
+  =/  pok-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            receiver
+            [~1111.1.10 0xdead.beef *roof]
+            [our:receiver our:sender]
+        ==
+    [%chum server-life=sender-life client=our:receiver client-life=receiver-life key]
+  =/  pok-path=path
+    /flow/(scot %ud bone)/poke/for/(scot %p our:receiver)/(scot %ud msg)
+  =/  ack-path=path
+    /flow/(scot %ud bone)/ack/bak/(scot %p our:sender)/(scot %ud msg)
+  =/  ack-wire
+    /mesa/flow/ack/for/(scot %p our:receiver)/(scot %ud receiver-rift)/(scot %ud bone)
+  =/  vane-wire
+    /bone/(scot %p our:sender)/(scot %ud bone)/(scot %ud msg)
+  =/  =noun
+    :*  vane=%g
+        path=/ge/hood
+        payload=[%0 %m %helm-hi `*`(crip "{(reap 900 'a')}")]
+    ==
+  =/  bex-roof  (make-roof pok-path atom/!>(noun))
+  :: =/  res
+  ::   %-  scry:(sender ~1111.1.10 `@`0xdead.beef bex-roof)
+  ::   =-  [~ / %x [[our:sender %$ ud+1] -]]
+  ::   (weld /mess/(scot %ud sender-rift)/pact/13/etch/init pok-full)
+  ::
+  =^  *  sender
+   (ames-call:v sender ~[/none] [%spew ~[%msg %snd %rcv %odd %rot %fin]] *roof)
+  =^  *  receiver
+   (ames-call:v receiver ~[/none] [%spew ~[%msg %snd %rcv %odd %rot %fin]] *roof)
+  =^  moves-1  sender
+    %-  ames-call:v
+    :*  sender
+        ~[/ames /test]
+      ::
+        :^    %moke
+            ack-space
+          `spar:ames`[our:receiver `path`[%a %x '1' %$ ack-path]]
+        `path`[%a %x '1' %$ pok-path]
+      ::
+        bex-roof
+    ==
+  =^  moves-2  receiver  (ames-reply:v receiver ~[//unix] moves-1 bex-roof) :: "ok, here is the %auth fragment"
+  =+  meek=(snag 1 moves-2)
+  ?>  ?=([duct=^ %pass wire=^ *] meek)
+  ?>  ?=([%meek *] |4.meek)
+  =^  moves-3  receiver  (ames-call:v receiver ~[/ames /test] |4.meek bex-roof)
+  =^  moves-4  sender    (ames-reply:v sender ~[//unix] moves-3 bex-roof)     :: "ok, give me the %data frag"
+  =^  moves-5  receiver  (ames-reply:v receiver ~[//unix] moves-4 bex-roof)   :: "ok, here is the %data frag"
+  (ames-expect-msg:v moves-5 noun)
+::
 --

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -298,10 +298,6 @@
         payload=[%0 %m %helm-hi `*`(crip "{(reap 900 'a')}")]
     ==
   =/  bex-roof  (make-roof pok-path atom/!>(noun))
-  :: =/  res
-  ::   %-  scry:(sender ~1111.1.10 `@`0xdead.beef bex-roof)
-  ::   =-  [~ / %x [[our:sender %$ ud+1] -]]
-  ::   (weld /mess/(scot %ud sender-rift)/pact/13/etch/init pok-full)
   ::
   =^  *  sender
    (ames-call:v sender ~[/none] [%spew ~[%msg %snd %rcv %odd %rot %fin]] *roof)
@@ -325,6 +321,95 @@
   ?>  ?=([%meek *] |4.meek)
   =^  moves-3  receiver  (ames-call:v receiver ~[/ames /test] |4.meek bex-roof)
   =^  moves-4  sender    (ames-reply:v sender ~[//unix] moves-3 bex-roof)     :: "ok, give me the %data frag"
+  =^  moves-5  receiver  (ames-reply:v receiver ~[//unix] moves-4 bex-roof)   :: "ok, here is the %data frag"
+  (ames-expect-msg:v moves-5 noun)
+::
+++  test-mesa-mtu-flow-auth-first
+  ^-  tang
+  %.  :*  comet-a  comet-b
+          comet-a.lifes  comet-b.lifes
+          comet-a.rifts  comet-b.rifts
+      ==
+  |=  $:  sender=ames-gate:v
+          receiver=ames-gate:v
+          sender-life=@ud
+          receiver-life=@ud
+          sender-rift=@ud
+          receiver-rift=@ud
+      ==
+  =/  ack-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            sender
+            [~1111.1.10 0xdead.beef *roof]
+            [our:sender our:receiver]
+        ==
+    [%chum server-life=receiver-life client=our:sender client-life=sender-life key]
+  =/  pok-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            receiver
+            [~1111.1.10 0xdead.beef *roof]
+            [our:receiver our:sender]
+        ==
+    [%chum server-life=sender-life client=our:receiver client-life=receiver-life key]
+  =/  pok-path=path
+    /flow/(scot %ud bone)/poke/for/(scot %p our:receiver)/(scot %ud msg)
+  =/  ack-path=path
+    /flow/(scot %ud bone)/ack/bak/(scot %p our:sender)/(scot %ud msg)
+  =/  ack-wire
+    /mesa/flow/ack/for/(scot %p our:receiver)/(scot %ud receiver-rift)/(scot %ud bone)
+  =/  vane-wire
+    /bone/(scot %p our:sender)/(scot %ud bone)/(scot %ud msg)
+  =/  pok-full=path
+      %+  make-space-path.receiver  pok-space
+        :: :*  %publ
+        ::     sender-life
+        :: ==
+      [%a %x '1' %$ pok-path]
+
+  =/  =noun
+    :*  vane=%g
+        path=/ge/hood
+        payload=[%0 %m %helm-hi `*`(crip "{(reap 900 'a')}")]
+    ==
+  =/  bex-roof  (make-roof pok-path atom/!>(noun))
+  ::
+  =^  *  sender
+   (ames-call:v sender ~[/none] [%spew ~[%msg %snd %rcv %odd %rot %fin]] *roof)
+  =^  *  receiver
+   (ames-call:v receiver ~[/none] [%spew ~[%msg %snd %rcv %odd %rot %fin]] *roof)
+  =^  moves-1  receiver
+    %-  ames-call:v
+    :*  receiver
+        ~[/ames /test]
+      ::
+        :+  %meek
+          none/~
+        :-  our:sender
+        ^-  path
+        :: (weld /mess/(scot %ud sender-rift)/pact/13/etch/auth/0 pok-full)
+        pok-full
+      ::
+        bex-roof
+    ==
+  =.  moves-1
+    %+  skim  moves-1
+    |=  =move:sender
+    ?=([* [%give [%push *]]] move)
+  ?>  ?=([[* [%give [%push *]]] *] moves-1)
+  =/  peek=pact:pact:sender
+    (parse-packet:sender q.p.card.i.moves-1)
+  ~|  peek/peek
+  ?>  ?=(%peek +<.peek)
+  =.  wan.name.peek  [%auth 0]
+  =+  blob=p:(fax:plot (en:pact:ames peek))
+  =^  moves-2  sender
+    (ames-call:v sender ~[//unix] [%heer *lane:pact:ames blob] bex-roof)     :: "ok, give me the %auth fragment"
+  =^  moves-3  receiver  (ames-reply:v receiver ~[//unix] moves-2 bex-roof)   :: "ok, here is the %auth frag"
+  =^  moves-4  sender  (ames-reply:v sender ~[//unix] moves-3 bex-roof)        :: "ok, give me the %data frag"
   =^  moves-5  receiver  (ames-reply:v receiver ~[//unix] moves-4 bex-roof)   :: "ok, here is the %data frag"
   (ames-expect-msg:v moves-5 noun)
 ::

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -2,7 +2,11 @@
 ::
 /+  *test, v=test-mesa-gall
 ::
-=+  ames-comets-moons:v
+=/  [life=@ud rift=@ud bone=@ud msg=@ud]
+  [(dec (bex 32)) (dec (bex 32)) (dec (bex 32)) (dec (bex 32))]
+=+  lifes=[comet-a=1 comet-b=1 moon-a=life moon-b=life]
+=+  rifts=[comet-a=0 comet-b=0 moon-a=rift moon-b=rift]
+=+  (ames-comets-moons:v lifes rifts)
 ::
 =>  |%
     ++  dbug  `?`&
@@ -17,253 +21,121 @@
     ::
     --
 |%
-++  test-mesa-ns-comets
-  ::  comet-a -- %poke --> comet-b
-  ::  pok-path            ack-path
-  ::
-  =/  ack-space=space:ames
-    =/  key  =<  symmetric-key
-        ^-  fren-state:ames
-        %:  ames-scry-peer:v
-            comet-a
-            [~1111.1.10 0xdead.beef *roof]
-            [our:comet-a our:comet-b]
-        ==
-    [%chum server-life=1 client=our:comet-a client-life=1 key]
-  =/  pok-space=space:ames
-    =/  key  =<  symmetric-key
-        ^-  fren-state:ames
-        %:  ames-scry-peer:v
-            comet-b
-            [~1111.1.10 0xdead.beef *roof]
-            [our:comet-b our:comet-a]
-        ==
-    [%chum server-life=1 client=our:comet-b client-life=1 key]
-  =/  pok-path=path
-    ::  in comet-a namespace, for comet-b
-    ::
-    /flow/0/poke/for/(scot %p our:comet-b)/1
-  =/  ack-path=path
-    ::  in comet-b namespace, for comet-a
-    ::
-    /flow/0/ack/bak/(scot %p our:comet-a)/1
-  ::
-  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:comet-b)/0/0
-  =/  vane-wire  /bone/(scot %p our:comet-a)/0/1
-  =/  ack-full=path
-    (make-space-path.comet-a ack-space %a %x '1' %$ ack-path)
-  =/  pok-full=path
-    (make-space-path.comet-b pok-space %a %x '1' %$ pok-path)
-  ~&  ack-full^pok-full
-  =/  iters=(list @ud)  (gulf 1 1.500)
-  |-  ^-  tang
-  ?~  iters
-    ~
-  =/  bex-roof
-    %-  make-roof
-    :-  pok-path  ^-  cage
-    :-  %atom  !>
-    :*  vane=%g
-        path=/ge/hood
-        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
-    ==
-  =/  res
-    %-  scry:(comet-a ~1111.1.10 `@`0xdead.beef bex-roof)
-    =-  [~ / %x [[our:comet-a %$ ud+1] -]]
-    ::  XX  /mess/0/pact/13/pure/init
-    (weld /mess/0/pact/13/etch/init pok-full)
-  ?~  res
-    ~
-  ?~  u.res
-    ~
-  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
- ::  %page packet containing the %auth or data, based on payload size
- ::
-  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
-  ?>  ?=(%page +<.page)
-  =/  poke=pact:pact:comet-a
-    :*  hop=0
-        %poke
-        ack=[[our:comet-b 0] [13 ~] ack-full]
-        pok=[[our:comet-a 0] [13 ~] pok-full]
-        data.page
-    ==
-  =/  ser  p:(fax:plot (en:pact:ames poke))
-  ?.  (gth (met 3 ser) 1.472)
-    $(iters t.iters)
-  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)^iter/i.iters
-  $(iters t.iters)
+::  +check-mesa-ns: verify poke packet size for arbitrary sender/receiver rank pair
 ::
-++  test-mesa-ns-moons
- =/  iters=(list @ud)  (gulf 1 1.500)
-  ::  moon-a -- %poke --> moon-b
-  ::  pok-path            ack-path
-  ::
+++  check-mesa-ns
+  |=  $:  sender=ames-gate:v
+          receiver=ames-gate:v
+          sender-life=@ud
+          receiver-life=@ud
+          sender-rift=@ud
+          receiver-rift=@ud
+      ==
+  ^-  tang
+  =/  iters=(list @ud)  (gulf 1 1.500)
   =/  ack-space=space:ames
     =/  key  =<  symmetric-key
         ^-  fren-state:ames
         %:  ames-scry-peer:v
-            moon-a
+            sender
             [~1111.1.10 0xdead.beef *roof]
-            [our:moon-a our:moon-b]
+            [our:sender our:receiver]
         ==
-    [%chum server-life=1 client=our:moon-a client-life=1 key]
+    [%chum server-life=receiver-life client=our:sender client-life=sender-life key]
   =/  pok-space=space:ames
     =/  key  =<  symmetric-key
         ^-  fren-state:ames
         %:  ames-scry-peer:v
-            moon-b
+            receiver
             [~1111.1.10 0xdead.beef *roof]
-            [our:moon-b our:moon-a]
+            [our:receiver our:sender]
         ==
-    [%chum server-life=1 client=our:moon-b client-life=1 key]
+    [%chum server-life=sender-life client=our:receiver client-life=receiver-life key]
   =/  pok-path=path
-    ::  in moon-a namespace, for comet-b
-    ::
-    /flow/0/poke/for/(scot %p our:moon-b)/1
+    /flow/(scot %ud bone)/poke/for/(scot %p our:receiver)/(scot %ud msg)
   =/  ack-path=path
-    ::  in moon-b namespace, for moon-a
-    ::
-    /flow/0/ack/bak/(scot %p our:moon-a)/1
-  ::
-  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:moon-b)/0/0
-  =/  vane-wire  /bone/(scot %p our:moon-a)/0/1
+    /flow/(scot %ud bone)/ack/bak/(scot %p our:sender)/(scot %ud msg)
+  =/  ack-wire
+    /mesa/flow/ack/for/(scot %p our:receiver)/(scot %ud receiver-rift)/(scot %ud bone)
+  =/  vane-wire
+    /bone/(scot %p our:sender)/(scot %ud bone)/(scot %ud msg)
   =/  ack-full=path
-    (make-space-path.moon-a ack-space %a %x '1' %$ ack-path)
+    (make-space-path.sender ack-space %a %x '1' %$ ack-path)
   =/  pok-full=path
-    (make-space-path.moon-b pok-space %a %x '1' %$ pok-path)
-  ~&  ack-full^pok-full
-  =|  i=@
-  |-  ^-  tang
+    (make-space-path.receiver pok-space %a %x '1' %$ pok-path)
+  =|  over-mtus=(list @ud)
+  =;  mts=_over-mtus
+    %+  expect-eq
+      !>  ~
+      !>  mts
+  |-  ^+  over-mtus
   ?~  iters
     ~&  >  %done-1
-    ~
+    over-mtus
   =/  bex-roof
     %-  make-roof
     :-  pok-path  ^-  cage
     :-  %atom  !>
     :*  vane=%g
         path=/ge/hood
-        ::payload=[%0 %m %helm-hi `*`i]
         payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
     ==
   =/  res
-    %-  scry:(moon-a ~1111.1.10 `@`0xdead.beef bex-roof)
-    =-  [~ / %x [[our:moon-a %$ ud+1] -]]
-    ::  XX  /mess/0/pact/13/pure/init
-    (weld /mess/0/pact/13/etch/init pok-full)
+    %-  scry:(sender ~1111.1.10 `@`0xdead.beef bex-roof)
+    =-  [~ / %x [[our:sender %$ ud+1] -]]
+    (weld /mess/(scot %ud sender-rift)/pact/13/etch/init pok-full)
   ?~  res
+    ~&  >>>  %nope-1
     ~
   ?~  u.res
+    ~&  >>>  %nope-2
     ~
   =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
- ::  %page packet containing the %auth or data, based on payload size
- ::
-  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
-  :: ?:  :: if this page is %auth we are done
-  ::     ::
-  ::     XX
+  =/  page=pact:pact:sender  (parse-packet:sender blob)
   ?>  ?=(%page +<.page)
-  =/  poke=pact:pact:comet-a
+  =/  poke=pact:pact:sender
     :*  hop=0
         %poke
-        ack=[[our:comet-b 0] [13 ~] ack-full]
-        pok=[[our:comet-a 0] [13 ~] pok-full]
+        ack=[[our:receiver 0] [13 ~] ack-full]
+        pok=[[our:sender 0] [13 ~] pok-full]
         data.page
     ==
   =/  ser  p:(fax:plot (en:pact:ames poke))
   ?.  (gth (met 3 ser) 1.472)
     $(iters t.iters)
-  ?.  (lth (met 3 dat.data.page) 1.024)
+  =+  dat-size=(met 3 dat.data.page)
+  ?.  (lth dat-size 1.024)
     ~&  >  %done-2
-    ~
-  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)
-  $(iters t.iters)
+    over-mtus
+  :: ~&  >>  ser/(met 3 ser)^dat/dat-size
+  $(iters t.iters, over-mtus [dat-size over-mtus])
 ::
 ++  test-mesa-ns-comet-moon
- =/  iters=(list @ud)  (gulf 1 1.500)
-  ::  comet-a -- %poke --> moon-a
-  ::  pok-path            ack-path
-  ::
-  =/  ack-space=space:ames
-    =/  key  =<  symmetric-key
-        ^-  fren-state:ames
-        %:  ames-scry-peer:v
-            comet-a
-            [~1111.1.10 0xdead.beef *roof]
-            [our:comet-a our:moon-a]
-        ==
-    [%chum server-life=1 client=our:comet-a client-life=1 key]
-  =/  pok-space=space:ames
-    =/  key  =<  symmetric-key
-        ^-  fren-state:ames
-        %:  ames-scry-peer:v
-            moon-a
-            [~1111.1.10 0xdead.beef *roof]
-            [our:moon-a our:comet-a]
-        ==
-    [%chum server-life=1 client=our:moon-a client-life=1 key]
-  =/  pok-path=path
-    ::  in comet-a namespace, for comet-b
-    ::
-    /flow/0/poke/for/(scot %p our:moon-a)/1
-  =/  ack-path=path
-    ::  in moon-b namespace, for comet-a
-    ::
-    /flow/0/ack/bak/(scot %p our:comet-a)/1
-  ::
-  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:moon-a)/0/0
-  =/  vane-wire  /bone/(scot %p our:comet-a)/0/1
-  =/  ack-full=path
-    (make-space-path.comet-a ack-space %a %x '1' %$ ack-path)
-  =/  pok-full=path
-    (make-space-path.moon-a pok-space %a %x '1' %$ pok-path)
-  ~&  ack-full^pok-full
-  =|  i=@
-  |-  ^-  tang
-  ?~  iters
-    ~&  >  %done-1
-    ~
-  =/  bex-roof
-    %-  make-roof
-    :-  pok-path  ^-  cage
-    :-  %atom  !>
-    :*  vane=%g
-        path=/ge/hood
-        ::payload=[%0 %m %helm-hi `*`i]
-        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
-    ==
-  =/  res
-    %-  scry:(comet-a ~1111.1.10 `@`0xdead.beef bex-roof)
-    =-  [~ / %x [[our:comet-a %$ ud+1] -]]
-    ::  XX  /mess/0/pact/13/pure/init
-    (weld /mess/0/pact/13/etch/init pok-full)
-  ?~  res
-    ~
-  ?~  u.res
-    ~
-  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
- ::  %page packet containing the %auth or data, based on payload size
- ::
-  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
-  :: ?:  :: if this page is %auth we are done
-  ::     ::
-  ::     XX
-  ?>  ?=(%page +<.page)
-  =/  poke=pact:pact:comet-a
-    :*  hop=0
-        %poke
-        ack=[[our:moon-a 0] [13 ~] ack-full]
-        pok=[[our:comet-a 0] [13 ~] pok-full]
-        data.page
-    ==
-  =/  ser  p:(fax:plot (en:pact:ames poke))
-  ?.  (gth (met 3 ser) 1.472)
-    $(iters t.iters)
-  ?.  (lth (met 3 dat.data.page) 1.024)
-    ~&  >  %done-2
-    ~
-  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)
-  $(iters t.iters)
+  %:  check-mesa-ns
+      comet-a  moon-a
+      comet-a.lifes  moon-a.lifes
+      comet-a.rifts  moon-a.rifts
+  ==
+::
+++  test-mesa-ns-moon-comet
+  %:  check-mesa-ns
+      moon-a  comet-a
+      moon-a.lifes  comet-a.lifes
+      moon-a.rifts  comet-a.rifts
+  ==
+::
+++  test-mesa-ns-comet-comet
+  %:  check-mesa-ns
+      comet-a  comet-b
+      comet-a.lifes  comet-b.lifes
+      comet-a.rifts  comet-b.rifts
+  ==
+::
+++  test-mesa-ns-moon-moon
+  %:  check-mesa-ns
+      moon-a  moon-b
+      moon-a.lifes  moon-b.lifes
+      moon-a.rifts  moon-b.rifts
+  ==
 ::
 --

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -73,8 +73,6 @@
       ::     sender-life
       :: ==
     [%a %x '1' %$ pok-path]
-  ~&  ack-path^pok-path
-  ~&  ack-full^pok-full
   =|  over-mtus=(list [page=@ud pact=@ud i=@ud])
   =;  mts=_over-mtus
     %+  expect-eq
@@ -82,7 +80,6 @@
       !>  mts
   |-  ^+  over-mtus
   ?~  iters
-    ~&  >  %done-1
     over-mtus
   =/  bex-roof
     %-  make-roof
@@ -112,20 +109,11 @@
         pok=[[our:sender receiver-rift] [13 ~] pok-full]
         data.page
     ==
-  =/  ser  p:(fax:plot (en:pact:ames poke))
+  =/  [=bloq =step]  (met:plot (en:pact:ames poke))
+  ?>  =(3 bloq)
   =+  dat-size=(met 3 dat.data.page)
-  ?.  (gth (met 3 ser) 1.472)
-    :: ?>  ?=(%poke +<.poke)
-    :: ~&  :*  %+  met  3  p:(fax:plot (en:^name:pact:sender ack.poke))
-    ::         %+  met  3  p:(fax:plot (en:^name:pact:sender pok.poke))
-    ::         %+  met  3  p:(fax:plot (en:^data:pact:sender data.poke))
-    ::     ==
-    :: ~&  >  ser/(met 3 ser)^dat/dat-size
+  ?.  (gth step 1.472)
     $(iters t.iters)
-
-  ?.  (lth dat-size 1.024)
-    :: ~&  >  %done-2
-    over-mtus
   ::  if we go over the MTU, scry again for the %auth fragment
   ::
   =/  res
@@ -139,7 +127,6 @@
     ~&  >>>  %nope-2
     ~
   =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
-  ~&  >  proof/proof
   =/  page=pact:pact:sender  (parse-packet:sender blob)
   ?>  ?=(%page +<.page)
   =/  poke=pact:pact:sender
@@ -149,122 +136,121 @@
         pok=[[our:sender receiver-rift] [13 [%auth 0]] pok-full]
         data.page
     ==
-  =/  ser  p:(fax:plot (en:pact:ames poke))
-  =+  dat-size=(met 3 dat.data.page)
-  :: ~&  page^(met 3 ser)
-  ::$(iters t.iters, over-mtus [[dat-size (met 3 ser) i.iters] over-mtus])
+  =/  [=^bloq =^step]  (met:plot (en:pact:ames poke))
+  =?  over-mtus  (gth step 1.472)
+    [[dat-size step i.iters] over-mtus]
   $(iters t.iters)
 ::
-:: ++  test-mesa-ns-comet-moon
-::   %:  check-mesa-ns
-::       comet-a  moon-a
-::       comet-a.lifes  moon-a.lifes
-::       comet-a.rifts  moon-a.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-moon-comet
-::   %:  check-mesa-ns
-::       moon-a  comet-a
-::       moon-a.lifes  comet-a.lifes
-::       moon-a.rifts  comet-a.rifts
-::   ==
-:: ::
+++  test-mesa-ns-comet-moon
+  %:  check-mesa-ns
+      comet-a  moon-a
+      comet-a.lifes  moon-a.lifes
+      comet-a.rifts  moon-a.rifts
+  ==
+::
+++  test-mesa-ns-moon-comet
+  %:  check-mesa-ns
+      moon-a  comet-a
+      moon-a.lifes  comet-a.lifes
+      moon-a.rifts  comet-a.rifts
+  ==
+::
 ++  test-mesa-ns-comet-comet
   %:  check-mesa-ns
       comet-a  comet-b
       comet-a.lifes  comet-b.lifes
       comet-a.rifts  comet-b.rifts
   ==
-:: ::
-:: ++  test-mesa-ns-moon-moon
-::   %:  check-mesa-ns
-::       moon-a  moon-b
-::       moon-a.lifes  moon-b.lifes
-::       moon-a.rifts  moon-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-planet-comet
-::   %:  check-mesa-ns
-::       planet-a  comet-b
-::       planet-a.lifes  comet-b.lifes
-::       planet-a.rifts  comet-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-galaxy-comet
-::   %:  check-mesa-ns
-::       galaxy-a  comet-b
-::       galaxy-a.lifes  comet-b.lifes
-::       galaxy-a.rifts  comet-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-planet-planet
-::   %:  check-mesa-ns
-::       planet-a  planet-b
-::       planet-a.lifes  planet-b.lifes
-::       planet-a.rifts  planet-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-galaxy-galaxy
-::   %:  check-mesa-ns
-::       galaxy-a  galaxy-b
-::       galaxy-a.lifes  galaxy-b.lifes
-::       galaxy-a.rifts  galaxy-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-galaxy-planet
-::   %:  check-mesa-ns
-::       galaxy-a  planet-b
-::       galaxy-a.lifes  planet-b.lifes
-::       galaxy-a.rifts  planet-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-galaxy-moon
-::   %:  check-mesa-ns
-::       galaxy-a  moon-b
-::       galaxy-a.lifes  moon-b.lifes
-::       galaxy-a.rifts  moon-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-planet-galaxy
-::   %:  check-mesa-ns
-::       planet-a  galaxy-b
-::       planet-a.lifes  galaxy-b.lifes
-::       planet-a.rifts  galaxy-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-planet-moon
-::   %:  check-mesa-ns
-::       planet-a  moon-b
-::       planet-a.lifes  moon-b.lifes
-::       planet-a.rifts  moon-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-moon-galaxy
-::   %:  check-mesa-ns
-::       moon-a  galaxy-b
-::       moon-a.lifes  galaxy-b.lifes
-::       moon-a.rifts  galaxy-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-moon-planet
-::   %:  check-mesa-ns
-::       moon-a  planet-b
-::       moon-a.lifes  planet-b.lifes
-::       moon-a.rifts  planet-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-comet-galaxy
-::   %:  check-mesa-ns
-::       comet-a  galaxy-b
-::       comet-a.lifes  galaxy-b.lifes
-::       comet-a.rifts  galaxy-b.rifts
-::   ==
-:: ::
-:: ++  test-mesa-ns-comet-planet
-::   %:  check-mesa-ns
-::       comet-a  planet-b
-::       comet-a.lifes  planet-b.lifes
-::       comet-a.rifts  planet-b.rifts
-::   ==
-:: ::
+::
+++  test-mesa-ns-moon-moon
+  %:  check-mesa-ns
+      moon-a  moon-b
+      moon-a.lifes  moon-b.lifes
+      moon-a.rifts  moon-b.rifts
+  ==
+::
+++  test-mesa-ns-planet-comet
+  %:  check-mesa-ns
+      planet-a  comet-b
+      planet-a.lifes  comet-b.lifes
+      planet-a.rifts  comet-b.rifts
+  ==
+::
+++  test-mesa-ns-galaxy-comet
+  %:  check-mesa-ns
+      galaxy-a  comet-b
+      galaxy-a.lifes  comet-b.lifes
+      galaxy-a.rifts  comet-b.rifts
+  ==
+::
+++  test-mesa-ns-planet-planet
+  %:  check-mesa-ns
+      planet-a  planet-b
+      planet-a.lifes  planet-b.lifes
+      planet-a.rifts  planet-b.rifts
+  ==
+::
+++  test-mesa-ns-galaxy-galaxy
+  %:  check-mesa-ns
+      galaxy-a  galaxy-b
+      galaxy-a.lifes  galaxy-b.lifes
+      galaxy-a.rifts  galaxy-b.rifts
+  ==
+::
+++  test-mesa-ns-galaxy-planet
+  %:  check-mesa-ns
+      galaxy-a  planet-b
+      galaxy-a.lifes  planet-b.lifes
+      galaxy-a.rifts  planet-b.rifts
+  ==
+::
+++  test-mesa-ns-galaxy-moon
+  %:  check-mesa-ns
+      galaxy-a  moon-b
+      galaxy-a.lifes  moon-b.lifes
+      galaxy-a.rifts  moon-b.rifts
+  ==
+::
+++  test-mesa-ns-planet-galaxy
+  %:  check-mesa-ns
+      planet-a  galaxy-b
+      planet-a.lifes  galaxy-b.lifes
+      planet-a.rifts  galaxy-b.rifts
+  ==
+::
+++  test-mesa-ns-planet-moon
+  %:  check-mesa-ns
+      planet-a  moon-b
+      planet-a.lifes  moon-b.lifes
+      planet-a.rifts  moon-b.rifts
+  ==
+::
+++  test-mesa-ns-moon-galaxy
+  %:  check-mesa-ns
+      moon-a  galaxy-b
+      moon-a.lifes  galaxy-b.lifes
+      moon-a.rifts  galaxy-b.rifts
+  ==
+::
+++  test-mesa-ns-moon-planet
+  %:  check-mesa-ns
+      moon-a  planet-b
+      moon-a.lifes  planet-b.lifes
+      moon-a.rifts  planet-b.rifts
+  ==
+::
+++  test-mesa-ns-comet-galaxy
+  %:  check-mesa-ns
+      comet-a  galaxy-b
+      comet-a.lifes  galaxy-b.lifes
+      comet-a.rifts  galaxy-b.rifts
+  ==
+::
+++  test-mesa-ns-comet-planet
+  %:  check-mesa-ns
+      comet-a  planet-b
+      comet-a.lifes  planet-b.lifes
+      comet-a.rifts  planet-b.rifts
+  ==
+::
 --

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -126,7 +126,8 @@
   ?.  (lth dat-size 1.024)
     :: ~&  >  %done-2
     over-mtus
-  :: ~&  >>  ser/(met 3 ser)^dat/dat-size
+  ::  if we go over the MTU, scry again for the %auth fragment
+  ::
   =/  res
     %-  scry:(sender ~1111.1.10 `@`0xdead.beef bex-roof)
     =-  [~ / %x [[our:sender %$ ud+1] -]]
@@ -145,7 +146,7 @@
     :*  hop=0
         %poke
         ack=[[our:receiver sender-rift] [13 ~] ack-full]
-        pok=[[our:sender receiver-rift] [13 ~] pok-full]
+        pok=[[our:sender receiver-rift] [13 [%auth 0]] pok-full]
         data.page
     ==
   =/  ser  p:(fax:plot (en:pact:ames poke))

--- a/tests/sys/vane/mesa/mtu.hoon
+++ b/tests/sys/vane/mesa/mtu.hoon
@@ -18,7 +18,6 @@
     --
 |%
 ++  test-mesa-ns-comets
-  =|  iters=_1.000
   ::  comet-a -- %poke --> comet-b
   ::  pok-path            ack-path
   ::
@@ -96,8 +95,94 @@
   $(iters t.iters)
 ::
 ++  test-mesa-ns-moons
-  =|  iters=_1.000
-  ::  comet-a -- %poke --> comet-b
+ =/  iters=(list @ud)  (gulf 1 1.500)
+  ::  moon-a -- %poke --> moon-b
+  ::  pok-path            ack-path
+  ::
+  =/  ack-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            moon-a
+            [~1111.1.10 0xdead.beef *roof]
+            [our:moon-a our:moon-b]
+        ==
+    [%chum server-life=1 client=our:moon-a client-life=1 key]
+  =/  pok-space=space:ames
+    =/  key  =<  symmetric-key
+        ^-  fren-state:ames
+        %:  ames-scry-peer:v
+            moon-b
+            [~1111.1.10 0xdead.beef *roof]
+            [our:moon-b our:moon-a]
+        ==
+    [%chum server-life=1 client=our:moon-b client-life=1 key]
+  =/  pok-path=path
+    ::  in moon-a namespace, for comet-b
+    ::
+    /flow/0/poke/for/(scot %p our:moon-b)/1
+  =/  ack-path=path
+    ::  in moon-b namespace, for moon-a
+    ::
+    /flow/0/ack/bak/(scot %p our:moon-a)/1
+  ::
+  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:moon-b)/0/0
+  =/  vane-wire  /bone/(scot %p our:moon-a)/0/1
+  =/  ack-full=path
+    (make-space-path.moon-a ack-space %a %x '1' %$ ack-path)
+  =/  pok-full=path
+    (make-space-path.moon-b pok-space %a %x '1' %$ pok-path)
+  ~&  ack-full^pok-full
+  =|  i=@
+  |-  ^-  tang
+  ?~  iters
+    ~&  >  %done-1
+    ~
+  =/  bex-roof
+    %-  make-roof
+    :-  pok-path  ^-  cage
+    :-  %atom  !>
+    :*  vane=%g
+        path=/ge/hood
+        ::payload=[%0 %m %helm-hi `*`i]
+        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
+    ==
+  =/  res
+    %-  scry:(moon-a ~1111.1.10 `@`0xdead.beef bex-roof)
+    =-  [~ / %x [[our:moon-a %$ ud+1] -]]
+    ::  XX  /mess/0/pact/13/pure/init
+    (weld /mess/0/pact/13/etch/init pok-full)
+  ?~  res
+    ~
+  ?~  u.res
+    ~
+  =+  !<([blob=@ pairs=(list @ux) proof=@ux] q.u.u.res)
+ ::  %page packet containing the %auth or data, based on payload size
+ ::
+  =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
+  :: ?:  :: if this page is %auth we are done
+  ::     ::
+  ::     XX
+  ?>  ?=(%page +<.page)
+  =/  poke=pact:pact:comet-a
+    :*  hop=0
+        %poke
+        ack=[[our:comet-b 0] [13 ~] ack-full]
+        pok=[[our:comet-a 0] [13 ~] pok-full]
+        data.page
+    ==
+  =/  ser  p:(fax:plot (en:pact:ames poke))
+  ?.  (gth (met 3 ser) 1.472)
+    $(iters t.iters)
+  ?.  (lth (met 3 dat.data.page) 1.024)
+    ~&  >  %done-2
+    ~
+  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)
+  $(iters t.iters)
+::
+++  test-mesa-ns-comet-moon
+ =/  iters=(list @ud)  (gulf 1 1.500)
+  ::  comet-a -- %poke --> moon-a
   ::  pok-path            ack-path
   ::
   =/  ack-space=space:ames
@@ -106,37 +191,38 @@
         %:  ames-scry-peer:v
             comet-a
             [~1111.1.10 0xdead.beef *roof]
-            [our:comet-a our:comet-b]
+            [our:comet-a our:moon-a]
         ==
     [%chum server-life=1 client=our:comet-a client-life=1 key]
   =/  pok-space=space:ames
     =/  key  =<  symmetric-key
         ^-  fren-state:ames
         %:  ames-scry-peer:v
-            comet-b
+            moon-a
             [~1111.1.10 0xdead.beef *roof]
-            [our:comet-b our:comet-a]
+            [our:moon-a our:comet-a]
         ==
-    [%chum server-life=1 client=our:comet-b client-life=1 key]
+    [%chum server-life=1 client=our:moon-a client-life=1 key]
   =/  pok-path=path
     ::  in comet-a namespace, for comet-b
     ::
-    /flow/0/poke/for/(scot %p our:comet-b)/1
+    /flow/0/poke/for/(scot %p our:moon-a)/1
   =/  ack-path=path
-    ::  in comet-b namespace, for comet-a
+    ::  in moon-b namespace, for comet-a
     ::
     /flow/0/ack/bak/(scot %p our:comet-a)/1
   ::
-  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:comet-b)/0/0
+  =/  ack-wire   /mesa/flow/ack/for/(scot %p our:moon-a)/0/0
   =/  vane-wire  /bone/(scot %p our:comet-a)/0/1
   =/  ack-full=path
     (make-space-path.comet-a ack-space %a %x '1' %$ ack-path)
   =/  pok-full=path
-    (make-space-path.comet-b pok-space %a %x '1' %$ pok-path)
+    (make-space-path.moon-a pok-space %a %x '1' %$ pok-path)
   ~&  ack-full^pok-full
-  =/  iters=(list @ud)  (gulf 1 1.500)
+  =|  i=@
   |-  ^-  tang
   ?~  iters
+    ~&  >  %done-1
     ~
   =/  bex-roof
     %-  make-roof
@@ -144,6 +230,7 @@
     :-  %atom  !>
     :*  vane=%g
         path=/ge/hood
+        ::payload=[%0 %m %helm-hi `*`i]
         payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
     ==
   =/  res
@@ -159,18 +246,24 @@
  ::  %page packet containing the %auth or data, based on payload size
  ::
   =/  page=pact:pact:comet-a  (parse-packet:comet-a blob)
+  :: ?:  :: if this page is %auth we are done
+  ::     ::
+  ::     XX
   ?>  ?=(%page +<.page)
   =/  poke=pact:pact:comet-a
     :*  hop=0
         %poke
-        ack=[[our:comet-b 0] [13 ~] ack-full]
+        ack=[[our:moon-a 0] [13 ~] ack-full]
         pok=[[our:comet-a 0] [13 ~] pok-full]
         data.page
     ==
   =/  ser  p:(fax:plot (en:pact:ames poke))
   ?.  (gth (met 3 ser) 1.472)
     $(iters t.iters)
-  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)^iter/i.iters
+  ?.  (lth (met 3 dat.data.page) 1.024)
+    ~&  >  %done-2
+    ~
+  ~&  >>  ser/(met 3 ser)^dat/(met 3 dat.data.page)
   $(iters t.iters)
 ::
 --


### PR DESCRIPTION
for a %poke from ~comet-a to ~comet-b of a plea of the following format, using the %chum namespace:

```hoon
    :*  vane=%g
        path=/ge/hood
        payload=[%0 %m %helm-hi `*`(crip "{(reap i.iters 'a')}")]
    ==
```

the range that make a one fragment %data payload in a %poke to go over the MTU of (1.470 bytes) is from 

`[886-1.024]` -> packet size: `[1.473-1.611]`

comet-threshold: `886`

range of 'a's in the |hi payload [853-991]

(note: we also get the same results by just `payload=[%0 %m %helm-hi (gulf 0 ...)]`

beyond that the message turns into a multi-fragment packet, and the first fragment becomes an %auth payload

- ~comet to ~moon / ~moon to ~comet presents the same problem:

`[978-1.023]` -> packet size: `[1.473-1.518]`

for this we also use the same comet-threshold: `886`

- ~moon to ~moon and doesn't seem to go over the MTU, for normal paths
