### PR TITLE
mesa: handle multi jumbo-frame pages

### DIFF
--- a/pkg/arvo/lib/test/ames-gall.hoon
+++ b/pkg/arvo/lib/test/ames-gall.hoon
@@ -199,7 +199,7 @@
   ^-  @
   =/  sample     [now=~1111.1.1 eny=`@`0xdead.beef *roof]
   =/  ames-core  (ames-gate sample)
-  ?~  pact=(co-make-pact:co:mesa:ames-core spar `path per-rift)
+  ?~  pact=(ma-pact:ma:mesa:ames-core spar `path per-rift)
     !!
   p:(fax:plot (en:pact:ames u.pact))
 ::

--- a/pkg/arvo/lib/test/ames-gall.hoon
+++ b/pkg/arvo/lib/test/ames-gall.hoon
@@ -201,7 +201,8 @@
   =/  ames-core  (ames-gate sample)
   ?~  pact=(ma-pact:ma:mesa:ames-core spar `path per-rift)
     !!
-  p:(fax:plot (en:pact:ames u.pact))
+  ?>  ?=([%| *] pact)
+  p:(fax:plot (en:pact:ames +.pact))
 ::
 ++  ames-scry-payload
   |=  [=ames-gate =ship =path]

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -358,7 +358,7 @@
   ^-  @
   =/  sample     [now=~1111.1.1 eny=`@`0xdead.beef poke-roof]
   =/  ames-core  (ames-gate sample)
-  ?~  pact=(co-make-pact:co:mesa:ames-core spar `path per-rift)
+  ?~  pact=(ma-pact:ma:mesa:ames-core spar `path per-rift)
     !!
   p:(fax:plot (en:pact:ames u.pact))
 ::

--- a/pkg/arvo/lib/test/mesa-gall.hoon
+++ b/pkg/arvo/lib/test/mesa-gall.hoon
@@ -360,7 +360,8 @@
   =/  ames-core  (ames-gate sample)
   ?~  pact=(ma-pact:ma:mesa:ames-core spar `path per-rift)
     !!
-  p:(fax:plot (en:pact:ames u.pact))
+  ?>  ?=([%| *] pact)
+  p:(fax:plot (en:pact:ames +.pact))
 ::
 ++  ames-scry-payload
   |=  [=ames-gate her=ship our=ship =path]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9141,10 +9141,7 @@
                 =^  side  ev-core  (ev-peel:ev wire +.sign)
                 =+  side
                 ?~  side  `ames-state
-                =<  ev-abet
-                ?.  ?=([%ames %done *] sign)
-                  (ev-take:ev-core(hen hen) bone.u.side +.sign)
-                (ev-early-done:ev-core(hen hen) u.side +.sign)
+                ev-abet:(ev-take:ev-core(hen hen) bone.u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
@@ -9806,18 +9803,6 @@
               |.("hear cork ack; delete {<bone=bone.side>}")
           ::
           fo-abel:fo-core
-        ::
-        ++  ev-early-done
-          |=  [side sign=$~(done/~ $>(%done gift:gall))]
-          ^+  ev-core
-          ::  XX  call fo-abel to delete the flow?
-          ::
-          ?:  =(%bak dire)
-            ~>  %slog.3^leaf/"ames: $boon exceeds single jumbo frame"
-            ::  for %boons, don't give anything to the vane; implicit ack
-            ::
-            ev-core
-          fo-abet:(fo-clean:(fo-abed:fo bone dire=%for) (need error.sign))
         ::
         +|  %peek-subscribers
         ::
@@ -10810,25 +10795,6 @@
             ::  produce ack or naxplanation
             ::
             [key.u.cack ?:(?=(%ok -.val.u.cack) ~ `+.val.u.cack)]
-          ::  +fo-clean: forget oldest outstanding payload
-          ::
-          ++  fo-clean
-            |=  =error
-            ^+  fo-core
-            ?~  first=(pry:fo-mop loads.snd)
-              %-  %+  ev-tace  odd.veb.bug.ames-state
-                  |.("no outstanding payload to clean {<bone=bone>}")
-              fo-core
-            %-  %+  ev-tace  odd.veb.bug.ames-state
-                |.("cleaning over jumbo-frame %poke {<bone=bone>}")
-            ::  remove oldest payload
-            ::
-            =^  m  loads.snd  (del:fo-mop loads.snd key.u.first)
-            =.  send-window.snd  +(send-window.snd)
-            ::
-            =~  (fo-emit (ev-got-duct bone) %give %done `error)
-                fo-send  ::  send next messages if any
-            ==
           ::
           --
         ::
@@ -12412,16 +12378,7 @@
             ~|  [remote=remote payload=payload rift=rift.per]
             !!
           ?:  ?=(%& -.pact)
-            ::  if we can't make this poke, give early [poke-ack error]
-            ::  (if =(dire %for); for %boons acks are implicit so it will no-op)
-            ::
-            %-  %^  ma-tace  snd.veb.bug.ames-state  who
-                |.("payload exceeds single jumbo frame; skip")
-            %-  ma-emit
-            :*  hen  %give  %done
-                :+  ~  %over-frame
-                [leaf/"ames: payload exceeds single jumbo frame"]~
-            ==
+            !! :: XX not implemented
           =|  new=request-state
           =.  for.new  (~(put ju for.new) hen %sage)
           =.  pay.new  payload
@@ -12451,10 +12408,6 @@
           ::
           ?~  page=(ma-get-page man)
             ~&([%no-page man=man] ~)   :: XX
-          ?:  (gth tob.u.page max-jum)
-            ::  XX should not happen for boq 32 in vere-32
-            ::
-            &+%over-jumbo-frame
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))
           ?>  =(3 bloq)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12415,6 +12415,8 @@
             ::  if we can't make this poke, give early [poke-ack error]
             ::  (if =(dire %for); for %boons acks are implicit so it will no-op)
             ::
+            %-  %^  ma-tace  snd.veb.bug.ames-state  who
+                |.("payload exceeds single jumbo frame; skip")
             %-  ma-emit
             :*  hen  %give  %done
                 :+  ~  %over-frame
@@ -12449,7 +12451,9 @@
           ::
           ?~  page=(ma-get-page man)
             ~&([%no-page man=man] ~)   :: XX
-          ?:  (gth tob.u.page max-jum) :: boq = 32
+          ?:  (gth tob.u.page max-jum)
+            ::  XX should not happen for boq 32 in vere-32
+            ::
             &+%over-jumbo-frame
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -85,7 +85,9 @@
 =/  packet-size      13
 =/  retry-timer      ~m2    ::  only used in /mesa/retry and /dead-flow timers
 =/  ahoy-on=?        %.y
-=/  max-mtu=@ud      1.472  :: boq=3
+=/  max-mtu=@ud      1.472  :: boq=3; bytes
+=/  jumbo=@ud        32     :: frame of (bex 32) = 2^32; bits
+=/  max-jum=@ud      (bex (sub jumbo boq=3))
 ::
 =>  ::  common helpers
     ~%  %ames  ..part  ~
@@ -12422,7 +12424,7 @@
         ::
         ++  co-make-pact
           |=  [p=spar q=(unit path) =per=rift]
-          ^-  (unit pact:pact)
+          ^-  (unit pact:pact)  ::  XX  $@(~ each ...)
           =/  nam  [[ship.p per-rift] [13 ~] path.p]
           ?~  q
             `[hop=0 %peek nam]
@@ -12430,8 +12432,8 @@
           =/  man=name:pact  [[our rift.ames-state] [13 ~] u.q]
           ::
           ?~  page=(co-get-page man)
-            ~&([%no-page man=man] ~)  :: XX
-          ?:  (gte tob.u.page 268.435.457)  :: XX (wid > 1) boq=31
+            ~&([%no-page man=man] ~)   :: XX
+          ?:  (gte tob.u.page max-jum) :: boq = 32
             ~
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10812,18 +10812,18 @@
             ^+  fo-core
             ?~  first=(pry:fo-mop loads.snd)
               %-  %+  ev-tace  odd.veb.bug.ames-state
-                  |.("no outstanding payload {<bone=bone>}")
+                  |.("no outstanding payload to clean {<bone=bone>}")
               fo-core
-            ::  remove oldest paylod
+            %-  %+  ev-tace  odd.veb.bug.ames-state
+                |.("cleaning over jumbo-frame %poke {<bone=bone>}")
+            ::  remove oldest payload
             ::
             =^  m  loads.snd  (del:fo-mop loads.snd key.u.first)
             =.  send-window.snd  +(send-window.snd)
-            ::  send next messages
             ::
-            =.  fo-core  fo-send
-            ::  XX give meaningful error here?
-            ::
-            (fo-emit (ev-got-duct bone) %give %done `error)
+            =~  (fo-emit (ev-got-duct bone) %give %done `error)
+                fo-send  ::  send next messages if any
+            ==
           ::
           --
         ::
@@ -12399,12 +12399,16 @@
           ::
           ?~  pact=(co-make-pact remote payload rift.per)
             ~|  [remote=remote payload=payload rift=rift.per]
-            ?^  payload
-              ::  if we can't make this poke, give early [poke-ack error]
-              ::  without modifying the state
-              ::
-              (co-emit hen %give %done `*error)  :: XX real error
-            !!
+            ?~  payload
+              !!
+            ::  if we can't make this poke, give early [poke-ack error]
+            ::  (if =(dire %for), for %boons acks are implicit so will no-op)
+            ::
+            %-  co-emit
+            :*  hen  %give  %done
+                :+  ~  %over-frame
+                [leaf/"ames: payload exceeds single jumbo frame"]~
+            ==
           =|  new=request-state
           =.  for.new  (~(put ju for.new) hen %sage)
           =.  pay.new  payload

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12433,7 +12433,7 @@
           ::
           ?~  page=(co-get-page man)
             ~&([%no-page man=man] ~)   :: XX
-          ?:  (gte tob.u.page max-jum) :: boq = 32
+          ?:  (gth tob.u.page max-jum) :: boq = 32
             ~
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9144,7 +9144,7 @@
                 =<  ev-abet
                 ?.  ?=([%ames %done *] sign)
                   (ev-take:ev-core(hen hen) bone.u.side +.sign)
-                (ev-early-done:ev-core(hen hen) bone.u.side +.sign)
+                (ev-early-done:ev-core(hen hen) u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
@@ -9808,10 +9808,15 @@
           fo-abel:fo-core
         ::
         ++  ev-early-done
-          |=  [=bone sign=$~(done/~ $>(%done gift:gall))]
+          |=  [side sign=$~(done/~ $>(%done gift:gall))]
           ^+  ev-core
           ::  XX  call fo-abel to delete the flow?
           ::
+          ?:  =(%bak dire)
+            ~>  %slog.3^leaf/"ames: $boon exceeds single jumbo frame"
+            ::  for %boons, don't give anything to the vane; implicit ack
+            ::
+            ev-core
           fo-abet:(fo-clean:(fo-abed:fo bone dire=%for) (need error.sign))
         ::
         +|  %peek-subscribers

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11388,11 +11388,14 @@
               ?~  pact=(co-make-pact:co [her.core path] pay.req rift.per.core)
                 ::  XX don't crash since we are going to block the queue
                 ev-core:core
+              ?:  ?=([%& *] pact)
+                ::  XX log
+                ev-core:core
               ?:  =(~ unix-duct)
                 %.  ev-core:core
                 (slog leaf+"ames: unix-duct pending; retry %push" ~)
               %-  ev-emit:core
-              (give-push ship u.pact (make-lanes [her [lane qos]:per]:core))
+              (give-push ship +.pact (make-lanes [her [lane qos]:per]:core))
             (sy-emil:core resend-moves)
           ::
           --
@@ -12217,9 +12220,12 @@
             %-  %^  al-tace  odd.veb.bug.ames-state  comet
                 |.("peek for comet attestation failed")
             al-core
+          ?:  ?=([%& *] pact)
+            ::  XX log
+            al-core
           %-  %^  al-tace  fin.veb.bug.ames-state  comet
               |.("peek for comet attestation proof")
-          (al-emit (give-push comet u.pact (make-lanes comet `[0 lane] *qos)))
+          (al-emit (give-push comet +.pact (make-lanes comet `[0 lane] *qos)))
         ::
         ++  al-take-proof
           |=  [=lane:pact hop=@ud =name:pact =data:pact =next:pact]
@@ -12404,10 +12410,10 @@
           ::
           ?~  pact=(co-make-pact remote payload rift.per)
             ~|  [remote=remote payload=payload rift=rift.per]
-            ?~  payload
-              !!
+            !!
+          ?:  ?=(%& -.pact)
             ::  if we can't make this poke, give early [poke-ack error]
-            ::  (if =(dire %for), for %boons acks are implicit so will no-op)
+            ::  (if =(dire %for); for %boons acks are implicit so it will no-op)
             ::
             %-  co-emit
             :*  hen  %give  %done
@@ -12428,34 +12434,34 @@
           ?:  =(~ unix-duct)
             %.  co-core
             (slog leaf+"ames: unix-duct pending; will retry %push" ~)
-          (co-emit (give-push who u.pact (make-lanes who [lane qos]:per)))
+          (co-emit (give-push who +.pact (make-lanes who [lane qos]:per)))
         ::
         +|  %internals
         ::
         ++  co-make-pact
           |=  [p=spar q=(unit path) =per=rift]
-          ^-  (unit pact:pact)  ::  XX  $@(~ each ...)
+          ^-  $@(~ (each term pact:pact))
           =/  nam  [[ship.p per-rift] [13 ~] path.p]
           ?~  q
-            `[hop=0 %peek nam]
+            |+[hop=0 %peek nam]
           ::
           =/  man=name:pact  [[our rift.ames-state] [13 ~] u.q]
           ::
           ?~  page=(co-get-page man)
             ~&([%no-page man=man] ~)   :: XX
           ?:  (gth tob.u.page max-jum) :: boq = 32
-            ~
+            &+%over-jumbo-frame
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))
           ?>  =(3 bloq)
           ?.  (gth step max-mtu)
-            `poke
+            |+poke
           ::
           %-  %^  co-tace  odd.veb.bug.ames-state  ship.p
               |.("pact over-mtu page={<(met 3 dat.u.page)>}B; send %auth pact")
           ?~  page=(co-get-page man(wan [%auth 0]))
             ~&([%no-auth-page man=man] ~)  :: XX
-          `[hop=0 %poke nam man u.page]
+          |+[hop=0 %poke nam man u.page]
         ::
         ++  co-get-page
           |=  =name:pact

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -86,7 +86,7 @@
 =/  retry-timer      ~m2    ::  only used in /mesa/retry and /dead-flow timers
 =/  ahoy-on=?        %.y
 =/  max-mtu=@ud      1.472  :: boq=3; bytes
-=/  jumbo=@ud        32     :: frame of (bex 32) = 2^32; bits
+=/  jumbo=@ud        31     :: frame of (bex 31) = 2^31; bits
 =/  max-jum=@ud      (bex (sub jumbo boq=3))
 ::
 =>  ::  common helpers

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -6792,12 +6792,12 @@
               =/  mesa-ev-core
                (%*(ev-abed ev:mesa-core ames-state ames-state) ~ her fren)
               =.  chums.ames-state  (~(put by chums.ames-state) her known/fren)
-              =+  mesa-co-core=%*(co-core co:mesa-core ames-state ames-state)
+              =+  mesa-ma-core=%*(ma-core ma:mesa-core ames-state ames-state)
               =*  per  peer-state
-              =<  co-abet
-              ^+  mesa-co-core
+              =<  ma-abet
+              ^+  mesa-ma-core
               %-  ~(rep by keens.per)
-              |=  [[=path keen=keen-state] core=_mesa-co-core]
+              |=  [[=path keen=keen-state] core=_mesa-ma-core]
               =>  .(path `(pole knot)`path)
               ~|  make-peeks-crashed/path
               ?.  ?=([van=@ car=@ cas=@ desk=@ pat=*] path)
@@ -6809,7 +6809,7 @@
                 ::
                 =?  core  ?=(^ next-wake.keen)
                   =/  =wire  (welp /fine/behn/wake/(scot %p her) (pout path))
-                  (co-emit:core unix-duct %pass wire %b %rest u.next-wake.keen)
+                  (ma-emit:core unix-duct %pass wire %b %rest u.next-wake.keen)
                 %-  ~(rep by listeners.keen)
                 |=  [[=^duct ints=(set ints)] core=_core]
                 ::  if the scry was created by the |fine core, %ames becomes the
@@ -6817,12 +6817,12 @@
                 ::  into a %near, and given to the original listener). %ames
                 ::  uses the /ames/[?(%chum %fine %shut ...)] wire to tell arvo
                 ::  to make it re-entrant into itself, so we neeed to remove
-                ::  that wire since co-make-peek is going to add a /mesa wire
+                ::  that wire since ma-peek is going to add a /mesa wire
                 ::
                 =?  duct  ?=([[%ames ?(%chum %fine) *] *] duct)  t.duct
                 ::  XX  call the rate task
                 ::
-                (co-make-peek:core(hen duct) space her pax)
+                (ma-peek:core(hen duct) space her pax)
               ::  XX unitize this and no-op if failure to convert
               ::
               ?+    pat.path  [path [%publ life.per]]
@@ -9024,7 +9024,7 @@
             ^-  [(list move) _vane-gate]
             =/  =task  ((harden task) wrapped-task)
             =+  sy-core=~(sy-core sy hen)
-            =+  co-core=(co-abed:co hen)
+            =+  ma-core=(ma-abed:ma hen)
             ::
             =^  moves  ames-state
               ::  handle error notifications
@@ -9112,7 +9112,7 @@
                   ?(%meek %moke %mage)
                 ?.  ?=([[%ames *] *] hen)
                   `ames-state ::  XX log
-                co-abet:(co-call:co-core task)
+                ma-abet:(ma-call:ma-core task)
               ==
               ::
             [moves vane-gate]
@@ -9304,7 +9304,7 @@
           ::
           =.  chums.ames-state  (~(put by chums.ames-state) her %known per)
           =^  moves-peek  ames-state
-            co-abet:(co-make-peek:(co-abed:co hen) space her path)
+            ma-abet:(ma-peek:(ma-abed:ma hen) space her path)
           ::  update per in the door's sample with the updated value from
           ::  ames-state; removing this will discard the last change when doing
           ::  +ev-abet
@@ -9996,7 +9996,7 @@
           =/  lane=tape
             ?@  i.next
               "from {<`@p`i.next>}"
-            "lane={(scow %if p.i.next)}:{((d-co:^co 1) q.i.next)}"
+            "lane={(scow %if p.i.next)}:{((d-co:co 1) q.i.next)}"
           %-  %+  ev-tace  rcv.veb.bug.ames-state
               |.("hear indirect packet hop={<hop>} {lane}")
           %_    per
@@ -11384,8 +11384,8 @@
               ::  if =(~ pay.req); %naxplanation, %cork or external (i.e. not
               ::  coming from %ames) $peek request
               ::
-              =/  co  co(ames-state ames-state.core)
-              ?~  pact=(co-make-pact:co [her.core path] pay.req rift.per.core)
+              =/  ma  ma(ames-state ames-state.core)
+              ?~  pact=(ma-pact:ma [her.core path] pay.req rift.per.core)
                 ::  XX don't crash since we are going to block the queue
                 ev-core:core
               ?:  ?=([%& *] pact)
@@ -11421,7 +11421,7 @@
                 =,  lane.stun
                 =/  ip=@if  (end [0 32] p)
                 =/  pt=@ud  (cut 0 [32 16] p)
-                "lane {(scow %if ip)}:{((d-co:^co 1) pt)} ({(scow %ux p)})"
+                "lane {(scow %if ip)}:{((d-co:co 1) pt)} ({(scow %ux p)})"
               |.("inject %stun {<-.stun>} {lane}")
           ::
           %-  sy-emit
@@ -12216,7 +12216,7 @@
           ::  we call the arm directly instead of sending a %meek task
           ::  so we can set up the comet lane which is not in state
           ::
-          ?~  pact=(co-make-pact:co `spar`comet^path ~ rift=0)
+          ?~  pact=(ma-pact:ma `spar`comet^path ~ rift=0)
             %-  %^  al-tace  odd.veb.bug.ames-state  comet
                 |.("peek for comet attestation failed")
             al-core
@@ -12277,51 +12277,51 @@
         ::
         --
       ::
-      +|  %packet-constructors
+      +|  %packet-makers
       ::
-      ++  co
+      ++  ma
         =|  moves=(list move)
         ::
         |_  [hen=duct pax=path]  ::  .hen listens to +peek .pax
         ::
         +|  %helpers
         ::
-        ++  co-core  .
-        ++  co-abet  [(flop moves) ames-state]
-        ++  co-abed  |=(=duct co-core(hen duct))
-        ++  co-emit  |=(=move co-core(moves [move moves]))
-        ++  co-tace
+        ++  ma-core  .
+        ++  ma-abet  [(flop moves) ames-state]
+        ++  ma-abed  |=(=duct ma-core(hen duct))
+        ++  ma-emit  |=(=move ma-core(moves [move moves]))
+        ++  ma-tace
           |=  [verb=? her=ship print=(trap tape)]
           ^+  same
           (trace %mesa verb her ships.bug.ames-state print)
         ::
         +|  %entry-points
         ::
-        ++  co-call
+        ++  ma-call
           |=  =task
-          ^+  co-core
+          ^+  ma-core
           ?+  -.task  ~|(-.task !!)
-            %mage  (co-make-page +.task)
-            %meek  (co-make-peek +.task)
-            %moke  (co-make-poke +.task)
+            %mage  (ma-page +.task)
+            %meek  (ma-peek +.task)
+            %moke  (ma-poke +.task)
           ==
         ::
         +|  %packet-entry-points
         ::
         ::  XX remove all spaces from the task, and make the paths at callsite?
         ::
-        ++  co-make-peek
+        ++  ma-peek
           |=  [=space =spar]
           =.  pax
             ?+  -.space  path.spar  :: XX skip adding flow paths to the .tip?
               %none  inner:(decrypt-path [path ship]:spar)
             ==
-          %-  %^  co-tace  fin.veb.bug.ames-state  ship.spar
+          %-  %^  ma-tace  fin.veb.bug.ames-state  ship.spar
               |.("send %peek for page={(spud path.spar)}")
           ::
-          (co-push-pact spar(path (make-space-path space path.spar)) ~)
+          (ma-push-pact spar(path (make-space-path space path.spar)) ~)
         ::
-        ++  co-make-poke
+        ++  ma-poke
           |=  [=space =ack=spar =poke=path]
           ::  XX  make all paths when the %moke task is sent?
           ::
@@ -12344,54 +12344,54 @@
               ==
             (make-space-path space poke-path)
           ::
-          %-  %^  co-tace  snd.veb.bug.ames-state  ship.ack-spar
+          %-  %^  ma-tace  snd.veb.bug.ames-state  ship.ack-spar
               |.("send %poke for ack={(spud path.ack-spar)}")
           ::  ack and poke paths are already encrypted at this point
           ::
-          (co-push-pact ack-spar `poke-path)
+          (ma-push-pact ack-spar `poke-path)
         ::
-        ++  co-make-page
+        ++  ma-page
           |=  [=space spar]
-          ^+  co-core
+          ^+  ma-core
           =+  per=(get-per:ev ship)
           ?.  ?=([~ ~ %known *] per)
-            %-  %^  co-tace  odd.veb.bug.ames-state  ship
+            %-  %^  ma-tace  odd.veb.bug.ames-state  ship
                 |.("missing peer for page={(spud path)}")
-            co-core  ::  %alien or missing
+            ma-core  ::  %alien or missing
           =*  sat  +.u.u.per
           =/  space-path=^path  (make-space-path space path)
           =/  =name:pact
             [[our rift.ames-state] [13 ~] space-path]
-          ?~  page=(co-get-page name)
-            %-  %^  co-tace  odd.veb.bug.ames-state  ship
+          ?~  page=(ma-get-page name)
+            %-  %^  ma-tace  odd.veb.bug.ames-state  ship
                 |.("missing page={(spud space-path)}")
-            co-core
+            ma-core
           ::  XX the use case for sending pages are acks, that fit in one
           ::  (bloq=13) fragment. no-op if bigger than that?
           ::
           ::  XX only allow %ames to send %mage task? (inspecting the duct?)
           ::
           ?:  =(~ unix-duct)
-            %.  co-core
+            %.  ma-core
             (slog leaf+"ames: unix-duct pending; will retry %push" ~)
           ::  vere should ignores any lanes attach to a %page, and use the one
           ::  it has stored in the pit to avoid breaking symmetric routing
           ::    (we add the lane here as a hack to avoid having to deal with
           ::     %aqua's lane management)
           ::
-          %-  co-emit
+          %-  ma-emit
           %^  give-push  ship
             [hop=0 %page name u.page next=~]
           (make-lanes ship lane.sat qos.sat)
         ::
-        ++  co-push-pact
+        ++  ma-push-pact
           |=  [remote=spar payload=(unit path)]
-          ^+  co-core
+          ^+  ma-core
           =*  who  ship.remote
           ?~  her=(~(get by chums.ames-state) who)
-            %-  %^  co-tace  odd.veb.bug.ames-state  who
+            %-  %^  ma-tace  odd.veb.bug.ames-state  who
                 |.("missing chum on {<[ship path]:remote>}")
-            co-core
+            ma-core
           ?>  ?=([%known *] u.her)
           =/  per=fren-state  +.u.her
           ?^  res=(~(get by pit.per) path.remote)
@@ -12403,19 +12403,19 @@
             ?>  ?=(^ pax)
             =.  tip.per  (~(put ju tip.per) pax [hen path.remote])
             ~|  [user-pax=pax ames-pax=path.remote pit.per]
-            %_  co-core
+            %_  ma-core
                 chums.ames-state
               (~(put by chums.ames-state) ship.remote known/per)
             ==
           ::
-          ?~  pact=(co-make-pact remote payload rift.per)
+          ?~  pact=(ma-pact remote payload rift.per)
             ~|  [remote=remote payload=payload rift=rift.per]
             !!
           ?:  ?=(%& -.pact)
             ::  if we can't make this poke, give early [poke-ack error]
             ::  (if =(dire %for); for %boons acks are implicit so it will no-op)
             ::
-            %-  co-emit
+            %-  ma-emit
             :*  hen  %give  %done
                 :+  ~  %over-frame
                 [leaf/"ames: payload exceeds single jumbo frame"]~
@@ -12426,19 +12426,19 @@
           =.  pit.per  (~(put by pit.per) path.remote new)
           ?>  ?=(^ pax)
           =.  tip.per  (~(put ju tip.per) pax [hen path.remote])
-          %-  %^  co-tace  fin.veb.bug.ames-state  who
+          %-  %^  ma-tace  fin.veb.bug.ames-state  who
               |.("add {<(spud pax)>} to .pit")
           =.  chums.ames-state
             (~(put by chums.ames-state) who known/per)
           ::
           ?:  =(~ unix-duct)
-            %.  co-core
+            %.  ma-core
             (slog leaf+"ames: unix-duct pending; will retry %push" ~)
-          (co-emit (give-push who +.pact (make-lanes who [lane qos]:per)))
+          (ma-emit (give-push who +.pact (make-lanes who [lane qos]:per)))
         ::
         +|  %internals
         ::
-        ++  co-make-pact
+        ++  ma-pact
           |=  [p=spar q=(unit path) =per=rift]
           ^-  $@(~ (each term pact:pact))
           =/  nam  [[ship.p per-rift] [13 ~] path.p]
@@ -12447,7 +12447,7 @@
           ::
           =/  man=name:pact  [[our rift.ames-state] [13 ~] u.q]
           ::
-          ?~  page=(co-get-page man)
+          ?~  page=(ma-get-page man)
             ~&([%no-page man=man] ~)   :: XX
           ?:  (gth tob.u.page max-jum) :: boq = 32
             &+%over-jumbo-frame
@@ -12457,13 +12457,13 @@
           ?.  (gth step max-mtu)
             |+poke
           ::
-          %-  %^  co-tace  odd.veb.bug.ames-state  ship.p
+          %-  %^  ma-tace  odd.veb.bug.ames-state  ship.p
               |.("pact over-mtu page={<(met 3 dat.u.page)>}B; send %auth pact")
-          ?~  page=(co-get-page man(wan [%auth 0]))
+          ?~  page=(ma-get-page man(wan [%auth 0]))
             ~&([%no-auth-page man=man] ~)  :: XX
           |+[hop=0 %poke nam man u.page]
         ::
-        ++  co-get-page
+        ++  ma-get-page
           |=  =name:pact
           ^-  (unit data:pact)
           =/  res=(unit (unit cage))
@@ -13638,7 +13638,7 @@
             ::
             =<  moves
             %.  [space=[%none ~] spar=[her-pok pat.ack.pact]]
-            co-make-page:co:me-core(rof flow-roof)
+            ma-page:ma:me-core(rof flow-roof)
           ::  produce mesa ack
           ::
           %-  %+  ev-tace:ev-core  &(?=(^ moves) snd.veb.bug.ames-state)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -7924,7 +7924,7 @@
                     ==
                     ?>  ?=([%test %mesa-2 *] path.plea)  ::  only %mesa-2 supported
                     ::  check that we can migrate this peer, without
-                    ::  modifying the state
+                    ::  modifying the .pit state (flow cleanup still necessary)
                     ::
                     ?>  (on-mate-test her)
                     ::
@@ -9139,7 +9139,10 @@
                 =^  side  ev-core  (ev-peel:ev wire +.sign)
                 =+  side
                 ?~  side  `ames-state
-                ev-abet:(ev-take:ev-core(hen hen) bone.u.side +.sign)
+                =<  ev-abet
+                ?:  ?=([%ames %done *] sign)
+                  (ev-early-done:ev-core(hen hen) bone.u.side)
+                (ev-take:ev-core(hen hen) bone.u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
@@ -9801,6 +9804,13 @@
               |.("hear cork ack; delete {<bone=bone.side>}")
           ::
           fo-abel:fo-core
+        ::
+        ++  ev-early-done
+          |=  =bone
+          ^+  ev-core
+          ::  XX  call fo-abel to delete the flow?
+          ::
+          fo-abet:fo-clean:(fo-abed:fo bone dire=%for)
         ::
         +|  %peek-subscribers
         ::
@@ -10793,6 +10803,24 @@
             ::  produce ack or naxplanation
             ::
             [key.u.cack ?:(?=(%ok -.val.u.cack) ~ `+.val.u.cack)]
+          ::  +fo-clean: forget oldest outstanding payload
+          ::
+          ++  fo-clean
+            ^+  fo-core
+            ?~  first=(pry:fo-mop loads.snd)
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.("no outstanding payload {<bone=bone>}")
+              fo-core
+            ::  remove oldest paylod
+            ::
+            =^  m  loads.snd  (del:fo-mop loads.snd key.u.first)
+            =.  send-window.snd  +(send-window.snd)
+            ::  send next messages
+            ::
+            =.  fo-core  fo-send
+            ::  XX give meaningful error here?
+            ::
+            (fo-emit (ev-got-duct bone) %give %done `*error)
           ::
           --
         ::
@@ -12368,6 +12396,11 @@
           ::
           ?~  pact=(co-make-pact remote payload rift.per)
             ~|  [remote=remote payload=payload rift=rift.per]
+            ?^  payload
+              ::  if we can't make this poke, give early [poke-ack error]
+              ::  without modifying the state
+              ::
+              (co-emit hen %give %done `*error)  :: XX real error
             !!
           =|  new=request-state
           =.  for.new  (~(put ju for.new) hen %sage)
@@ -12398,6 +12431,8 @@
           ::
           ?~  page=(co-get-page man)
             ~&([%no-page man=man] ~)  :: XX
+          ?:  (gte tob.u.page 268.435.457)  :: XX (wid > 1) boq=31
+            ~
           =/  poke=pact:pact  [hop=0 %poke nam man u.page]
           =/  [=bloq =step]   (met:plot (en:pact poke))
           ?>  =(3 bloq)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9142,9 +9142,9 @@
                 =+  side
                 ?~  side  `ames-state
                 =<  ev-abet
-                ?:  ?=([%ames %done *] sign)
-                  (ev-early-done:ev-core(hen hen) bone.u.side)
-                (ev-take:ev-core(hen hen) bone.u.side +.sign)
+                ?.  ?=([%ames %done *] sign)
+                  (ev-take:ev-core(hen hen) bone.u.side +.sign)
+                (ev-early-done:ev-core(hen hen) bone.u.side +.sign)
               ::
               ::  remote responses: acks/poke/cork/naxplanation payloads
               ::    reentrant from %ames (from either message or packet layer)
@@ -9808,11 +9808,11 @@
           fo-abel:fo-core
         ::
         ++  ev-early-done
-          |=  =bone
+          |=  [=bone sign=$~(done/~ $>(%done gift:gall))]
           ^+  ev-core
           ::  XX  call fo-abel to delete the flow?
           ::
-          fo-abet:fo-clean:(fo-abed:fo bone dire=%for)
+          fo-abet:(fo-clean:(fo-abed:fo bone dire=%for) (need error.sign))
         ::
         +|  %peek-subscribers
         ::
@@ -10808,6 +10808,7 @@
           ::  +fo-clean: forget oldest outstanding payload
           ::
           ++  fo-clean
+            |=  =error
             ^+  fo-core
             ?~  first=(pry:fo-mop loads.snd)
               %-  %+  ev-tace  odd.veb.bug.ames-state
@@ -10822,7 +10823,7 @@
             =.  fo-core  fo-send
             ::  XX give meaningful error here?
             ::
-            (fo-emit (ev-got-duct bone) %give %done `*error)
+            (fo-emit (ev-got-duct bone) %give %done `error)
           ::
           --
         ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9392,10 +9392,19 @@
             ::    e.g. boq=13 (frag=1.024); if tob=1.025 => 2 fragments
             ::
             =+  boq=13
-            =+  frag=(div (bex boq) 8) ::  fragment size in bytes (1.024 for boq=13)
-            ::  tob.data.pact is (met 3 dat.data.pact) in bytes
+            =*  tob  tob.data.pact
+            =+  frag=(bex (sub boq 3)) ::  fragment size in bytes (1.024 for boq=13)
             ::
-            ?:  (gth (div (add tob.data.pact (dec frag)) frag) 1)
+            ?:  (gth (div (add tob (dec frag)) frag) 1)
+                ::  if error, inject message and send %nack
+                ::
+                ?^  dud
+                  %:  hear-poke:ev-mess
+                    dud
+                    [her.ack.pact (pout ack)]
+                    [her.pok.pact (pout pok)]
+                    message/?-(dire.ack %bak plea/~, %for boon/~)
+                  ==
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("hear incomplete message")
               :: XX assert load is plea/boon?
@@ -9415,6 +9424,11 @@
               %-  %+  ev-tace  fin.veb.bug.ames-state
                   |.("peek for poke payload {<[flow=bone seq=mess]:pok>}")
               ::
+              ::  if the %page we need to +peek is bigger than max-jum, %nack
+              ::
+              ~|  "page exceeds jumbo-frame={<tob>}B; crash"
+              ?>  (lte tob max-jum)
+              ::
               %^  ev-emit  hen  %pass
               [(fo-wire:fo-core %pok) %a %meek [none/~ [her pat]:pok.pact]]
             ::  authenticate one-fragment message
@@ -9424,7 +9438,7 @@
             ::  (dat.data.pact = lss-root = 32B)
             ::  and tob > 32B to create the over-MTU %auth packet
             ::
-            ?:  !=(tob.data.pact (met 3 dat.data.pact))
+            ?:  !=(tob (met 3 dat.data.pact))
               ?>  %-  authenticate
                   [dat.data aut.data pok.pact]
               %-  %+  ev-tace  fin.veb.bug.ames-state
@@ -10406,7 +10420,9 @@
             =.  last-acked.rcv  +(last-acked.rcv)
             %-  %+  ev-tace  msg.veb.bug.ames-state
                 |.
-                "hear complete %boon {<[bone=bone seq=last-acked.rcv]>}; ack"
+                ?:  ok
+                  "sink %boon {<[bone=bone seq=last-acked.rcv]>}; ack"
+                "crashed on sink boon {<[bone=bone seq=last-acked.rcv]>}"
             (fo-send-ack last-acked.rcv)
           ::
           ++  fo-sink-plea
@@ -10436,7 +10452,7 @@
             =.  pending-ack.rcv  %.y
             ::
             %-  %+  ev-tace  msg.veb.bug.ames-state
-                |.("hear complete %plea {<[bone=bone seq=+(last-acked.rcv)]>}")
+                |.("sink %plea {<[bone=bone seq=+(last-acked.rcv)]>}")
             ::
             ?:  &(=(vane %$) ?=([%ahoy ~] payload)):plea
               ::  migrated %ahoy pleas are always acked


### PR DESCRIPTION
WIP

Option a)

The sender blocks any %poke %plea/ %poke %boon that tries to send a %page that doesn't fit in 1 jumbo (boq=31) frame.

- [x] confirm no other reentrant `[%ames %done]` can use ev-clean
  - [x] seems safe (also for %boons)
- [ ] ~~make +fo-clean use the actual seq number? (XX not in the wire)~~
  - XX this could be a problem is the send-window becomes > 1
- [x] refactor +co-make-pact to distinguish legitimate multi-jumbo %pokes, rather than any generic "we can't make this pact now"
- [x] give a real `error:ames`
- [ ] the %boon is dropped and the subscriber %kicked (i.e. enqueues a %kick to be sent instead of the original %boon (equivalent to the %clog machinery)
  - [ ] at the point where we know this goes over the number of jumbo frames we can handle (e.g. 1 if boq 31), the %clog id has been lost


Option b)

- [ ] Instead og blocking the sender, nack when the receiver gets a poke with `bytes > jumbo-max`.
  - XX problem for %boons since those are assumed to always be acked
  - [ ] we crash while handling the %boon, then %give %lost to %gall to %leave the subscription
  
 TODO
 
 - implement option b)