### PR TITLE
clay: %wath task for per-file desk auto-sync

### DIFF
--- a/pkg/arvo/gen/hood/autosync.hoon
+++ b/pkg/arvo/gen/hood/autosync.hoon
@@ -1,0 +1,1 @@
+clay/autosync.hoon

--- a/pkg/arvo/gen/hood/cancel-autosync.hoon
+++ b/pkg/arvo/gen/hood/cancel-autosync.hoon
@@ -1,0 +1,1 @@
+clay/cancel-autosync.hoon

--- a/pkg/arvo/gen/hood/clay/autosync.hoon
+++ b/pkg/arvo/gen/hood/clay/autosync.hoon
@@ -1,0 +1,15 @@
+::  Kiln: mark a mount point for auto-sync
+::
+::::  /hoon/autosync/hood/gen
+  ::
+/?    310
+::
+::::
+  ::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [mon=term ~]
+        ~
+    ==
+:-  %kiln-autosync
+[mon &]

--- a/pkg/arvo/gen/hood/clay/cancel-autosync.hoon
+++ b/pkg/arvo/gen/hood/clay/cancel-autosync.hoon
@@ -1,0 +1,15 @@
+::  Kiln: unmark a mount point for auto-sync
+::
+::::  /hoon/cancel-autosync/hood/gen
+  ::
+/?    310
+::
+::::
+  ::
+:-  %say
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [mon=term ~]
+        ~
+    ==
+:-  %kiln-autosync
+[mon |]

--- a/pkg/arvo/lib/hood/kiln.hoon
+++ b/pkg/arvo/lib/hood/kiln.hoon
@@ -568,6 +568,7 @@
   ?+  mark  ~|([%poke-kiln-bad-mark mark] !!)
     %kiln-approve-merge      =;(f (f !<(_+<.f vase)) poke-approve-merge)
     %kiln-autocommit         =;(f (f !<(_+<.f vase)) poke-autocommit)
+    %kiln-autosync           =;(f (f !<(_+<.f vase)) poke-autosync)
     %kiln-bump               =;(f (f !<(_+<.f vase)) poke-bump)
     %kiln-cancel             =;(f (f !<(_+<.f vase)) poke-cancel)
     %kiln-cancel-autocommit  =;(f (f !<(_+<.f vase)) poke-cancel-autocommit)
@@ -626,6 +627,11 @@
   =.  commit-timer
     [/kiln/autocommit (add now recur) recur mon]
   (emit %pass way.commit-timer %arvo %b [%wait nex.commit-timer])
+::
+++  poke-autosync
+  |=  [mon=term on=?]
+  =<  abet
+  (emit %pass /autosync %arvo %c [%wath mon on])
 ::
 ++  poke-bump
   |=  ~

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -2436,6 +2436,8 @@
         [%ogre p=@tas]                                  ::  delete mount point
         [%rule red=dict wit=dict]                       ::  node r+w permissions
         [%tire p=(each rock:tire wave:tire)]            ::  app state
+        [%wath p=@tas]                                  ::  watch mount point
+        [%wend p=@tas]                                  ::  unwatch mount point
         [%writ p=riot]                                  ::  response
         [%wris p=[%da p=@da] q=(set (pair care path))]  ::  many changes
     ==                                                  ::
@@ -2474,6 +2476,7 @@
         $>(%trim vane-task)                             ::  trim state
         $>(%vega vane-task)                             ::  report upgrade
         [%warp wer=ship rif=riff]                       ::  internal file req
+        [%wath pot=term on=?]                           ::  (un)mark auto-sync
         [%werp who=ship wer=ship rif=riff-any]          ::  external file req
         [%wick ~]                                       ::  try upgrade
         [%zeal lit=(list [=desk =zest])]                ::  batch zest

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2963,13 +2963,7 @@
     =/  for-yon  ?:(=(let.dom u.yon) 0 u.yon)
     =.  mon                                             ::  [ergo]
       (~(put by mon) pot [her syd ud+for-yon] spur)
-    =/  =yaki  (~(got by hut.ran) (~(got by hit.dom) u.yon))
-    =/  files  (~(run by q.yaki) |=(=lobe |+lobe))
-    =/  =args:ford:fusion  [files lat.ran veb.bug]
-    =^  mim  args
-      (checkout-mime args ~ ~(key by files))
-    =.  mim.dom  (apply-changes-to-mim mim.dom mim)
-    (ergo for-yon mim)
+    (mirror pot)
   ::
   ::  Unmount a beam
   ::

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -210,6 +210,8 @@
 ::  --  `ran` is the object store.
 ::  --  `mon` is a collection of mount points (mount point name to urbit
 ::      location).
+::  --  `syn` is the set of mount points marked for auto-sync, watched by
+::      the runtime for filesystem events.
 ::  --  `hez` is the unix duct that %ergo's should be sent to.
 ::  --  `cez` is a collection of named permission groups.
 ::  --  `pud` is an update that's waiting on a kernel upgrade
@@ -219,6 +221,7 @@
       hoy=(map ship rung)                               ::  foreign
       ran=rang                                          ::  hashes
       mon=(map term beam)                               ::  mount points
+      syn=(set term)                                    ::  auto-sync mounts
       hez=(unit duct)                                   ::  sync duct
       cez=(map @ta crew)                                ::  permission groups
       tyr=(set duct)                                    ::  app subs
@@ -2975,6 +2978,7 @@
     ^+  ..unmount
     ?>  ?=(^ hez.ruf)
     =.  mon  (~(del by mon) pot)                        ::  [ergo]
+    =.  syn  (~(del in syn) pot)
     =?  mim.dom  !(want-mime 0)  ~
     (emit u.hez.ruf %give %ogre pot)
   ::
@@ -4665,7 +4669,7 @@
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =|                                                    ::  instrument state
-    $:  ver=%16                                       ::  vane version
+    $:  ver=%17                                       ::  vane version
         ruf=raft                                      ::  revision tree
     ==                                                ::
 |=  [now=@da eny=@uvJ rof=roof]                       ::  current invocation
@@ -4690,7 +4694,11 @@
   ?-    -.req
       %boat
     :_  ..^$
-    [hen %give %hill (turn ~(tap by mon.ruf) head)]~
+    ^-  (list move)
+    :-  [hen %give %hill (turn ~(tap by mon.ruf) head)]
+    %+  turn  ~(tap in syn.ruf)
+    |=  pot=term
+    [hen %give %wath pot]
   ::
       %cred
     =.  cez.ruf
@@ -4829,6 +4837,18 @@
       ~&  [%not-mounted pot.req]
       [~ ..^$]
     [~[[u.hez.ruf %give %dirk pot.req]] ..^$]
+  ::
+      %wath
+    ?.  (~(has by mon.ruf) pot.req)
+      ~|([%wath-not-mounted pot.req] !!)
+    ?>  ?=(^ hez.ruf)
+    =.  syn.ruf
+      ?:  on.req  (~(put in syn.ruf) pot.req)
+      (~(del in syn.ruf) pot.req)
+    :_  ..^$
+    ?:  on.req
+      [u.hez.ruf %give %wath pot.req]~
+    [u.hez.ruf %give %wend pot.req]~
   ::
       %ogre
     ?:  =(~ hez.ruf)
@@ -5022,7 +5042,8 @@
   ::
   =>  |%
       +$  raft-any
-        $%  [%16 raft-16]
+        $%  [%17 raft-17]
+            [%16 raft-16]
             [%15 raft-15]
             [%14 raft-14]
             [%13 raft-13]
@@ -5034,7 +5055,22 @@
             [%7 raft-7]
             [%6 raft-6]
         ==
-      +$  raft-16  raft
+      +$  raft-17  raft
+      ::
+      +$  raft-16
+        $+  raft-16
+        $:  rom=room
+            hoy=(map ship rung)
+            ran=rang
+            mon=(map term beam)
+            hez=(unit duct)
+            cez=(map @ta crew)
+            tyr=(set duct)
+            tur=rock:tire
+            pud=(unit [=desk =yoki])
+            sad=(map ship @da)
+            bug=[veb=@ mas=@]
+        ==
       ::
       +$  flow  (map leak [refs=@ud =soak])
       +$  leak
@@ -5507,7 +5543,8 @@
   =?  old  ?=(%13 -.old)  14+(raft-13-to-14 +.old)
   =?  old  ?=(%14 -.old)  15+(raft-14-to-15 +.old)
   =?  old  ?=(%15 -.old)  16+(raft-15-to-16 +.old)
-  ?>  ?=(%16 -.old)
+  =?  old  ?=(%16 -.old)  17+(raft-16-to-17 +.old)
+  ?>  ?=(%17 -.old)
   ..^^$(ruf +.old)
   ::
   ::  +raft-6-to-7: delete stale ford caches (they could all be invalid)
@@ -5865,6 +5902,14 @@
       ?.  ?=([~ ~ *] c)  c
       ``(next-cage:a235 u.u.c)
     --
+  ::  +raft-16-to-17: add syn, the set of auto-synced mount points
+  ::
+  ++  raft-16-to-17
+    |=  raf=raft-16
+    ^-  raft-17
+    :*  rom.raf  hoy.raf  ran.raf  mon.raf  syn=~
+        hez.raf  cez.raf  tyr.raf  tur.raf  pud.raf  sad.raf  bug.raf
+    ==
   --
 ::
 ++  scry                                              ::  inspect
@@ -6005,7 +6050,7 @@
 ++  stay
   ^-  raft-any:load
   :-  ver
-  ^-  raft-16:load
+  ^-  raft-17:load
   ruf
 ::
 ++  take                                              ::  accept response

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -2982,6 +2982,30 @@
     =?  mim.dom  !(want-mime 0)  ~
     (emit u.hez.ruf %give %ogre pot)
   ::
+  ::  Mirror a mount point's full contents out to unix
+  ::
+  ::  Used at auto-sync reconciliation: the runtime restores files
+  ::  that are missing on disk, skips files that match, and leaves
+  ::  locally-edited files for the inbound sync.  Mars is the ground
+  ::  truth for existence; earth is believed for live edits.
+  ::
+  ++  mirror
+    |=  pot=term
+    ^+  ..mirror
+    =/  bem=beam  (~(got by mon) pot)
+    ?>  ?=(%ud -.r.bem)
+    =/  for-yon  p.r.bem
+    ?:  &(=(0 for-yon) =(0 let.dom))
+      ..mirror
+    =/  yon  ?:(=(0 for-yon) let.dom for-yon)
+    =/  =yaki  (~(got by hut.ran) (~(got by hit.dom) yon))
+    =/  files  (~(run by q.yaki) |=(=lobe |+lobe))
+    =/  =args:ford:fusion  [files lat.ran veb.bug]
+    =^  mim  args
+      (checkout-mime args ~ ~(key by files))
+    =.  mim.dom  (apply-changes-to-mim mim.dom mim)
+    (ergo for-yon mim)
+  ::
   ::  Set permissions for a node.
   ::
   ++  perm
@@ -4693,12 +4717,24 @@
   ::
   ?-    -.req
       %boat
-    :_  ..^$
-    ^-  (list move)
-    :-  [hen %give %hill (turn ~(tap by mon.ruf) head)]
-    %+  turn  ~(tap in syn.ruf)
-    |=  pot=term
-    [hen %give %wath pot]
+    =/  pots  ~(tap in syn.ruf)
+    =/  mos=(list move)
+      :-  [hen %give %hill (turn ~(tap by mon.ruf) head)]
+      %+  turn  pots
+      |=  pot=term
+      [hen %give %wath pot]
+    ::  re-mirror auto-synced mounts, restoring any files that went
+    ::  missing while we were down (after the %wath reconciliation
+    ::  scan has captured offline edits)
+    ::
+    |-  ^-  [(list move) _..^^$]
+    ?~  pots
+      [mos ..^^$]
+    =/  bem  (~(got by mon.ruf) i.pots)
+    =^  mor  ruf
+      =/  den  ((de now rof hen ruf) p.bem q.bem)
+      abet:(mirror:den i.pots)
+    $(pots t.pots, mos (weld mos mor))
   ::
       %cred
     =.  cez.ruf
@@ -4841,14 +4877,21 @@
       %wath
     ?.  (~(has by mon.ruf) pot.req)
       ~|([%wath-not-mounted pot.req] !!)
-    ?>  ?=(^ hez.ruf)
+    =/  dut=duct  (need hez.ruf)
     =.  syn.ruf
       ?:  on.req  (~(put in syn.ruf) pot.req)
       (~(del in syn.ruf) pot.req)
-    :_  ..^$
-    ?:  on.req
-      [u.hez.ruf %give %wath pot.req]~
-    [u.hez.ruf %give %wend pot.req]~
+    ?.  on.req
+      [[dut %give %wend pot.req]~ ..^$]
+    ::  mirror the mount after the %wath gift: the runtime arms its
+    ::  watchers and scans first, then the mirror restores anything
+    ::  missing on disk
+    ::
+    =/  bem  (~(got by mon.ruf) pot.req)
+    =^  mos  ruf
+      =/  den  ((de now rof hen ruf) p.bem q.bem)
+      abet:(mirror:den pot.req)
+    [[[dut %give %wath pot.req] mos] ..^$]
   ::
       %ogre
     ?:  =(~ hez.ruf)


### PR DESCRIPTION
Implements the Arvo side of per-file desk auto-sync — runtime side in urbit/vere#1031, UIP draft to follow in urbit/UIPs.

Adds `[%wath pot=term on=?]` to clay's tasks and `[%wath p=@tas]`/`[%wend p=@tas]` gifts on the unix duct. A mount point marked for auto-sync is watched by the runtime via filesystem events; the runtime injects per-file `%into` events instead of relying on polled `%dirk` commits, and clay's existing per-file commit path needs no changes.

Reconciliation makes auto-synced mounts self-healing: after the `%wath` gift (on enable and at `%boat` after every restart), clay mirrors the mount's full contents back out as `%ergo`. Combined with the runtime's write rules, files missing on disk are restored from the desk, unchanged files are untouched, and files edited on disk are left for the inbound sync — the desk is the ground truth for existence, the disk is believed for live edits. Gifts aren't persisted, so the mirror adds nothing to the event log.

- lull: new task and gifts
- clay: `syn=(set term)` in the raft (state 16→17), `%wath` handling, `+mirror` (also deduplicates `+mount`'s checkout tail), re-arm + mirror at `%boat`, cleanup at unmount
- kiln: `%kiln-autosync` poke; `|autosync` / `|cancel-autosync` generators

Tested end-to-end on a fake ship against the vere branch: live create/modify/delete sync per-file in ~200ms on a non-live desk; offline edits sync inward while offline deletions are restored; watchers re-arm across restarts.