### PR TITLE
mesa: on %cork, remove any %peek for $boon

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4272,8 +4272,8 @@
           ::
           =.  chums.old
             ^-  (map ship chum-state)
-            %-  ~(run by chums.old)
-            |=  c=chum-state
+            %-  ~(urn by chums.old)
+            |=  [=ship c=chum-state]
             ^-  chum-state
             ?:  ?=(%alien -.c)  c
             ^-  chum-state
@@ -4296,6 +4296,11 @@
               =/  =dire  ?:(?=(%for dir.user-path) %bak %for)
               ?.  (~(has in corked.c) u.bone dire)
                 tip
+              %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                    ships.bug.old
+                    |.  %+  weld  "corked flow {<[u.bone dire]>}; remove "
+                        "{(spud `path`user-path)} from .tip"
+                  ==
               (~(del by tip) user-path)
             ==
           ::  last pass; .pit clean-up
@@ -4303,8 +4308,8 @@
           %=    old
               chums
             ^-  (map ship chum-state)
-            %-  ~(run by chums.old)
-            |=  c=chum-state
+            %-  ~(urn by chums.old)
+            |=  [=ship c=chum-state]
             ^-  chum-state
             ?:  ?=(%alien -.c)  c
             ^-  chum-state
@@ -4327,13 +4332,18 @@
                 p
               ?~  bone=(slaw %ud bone.i.hen)
                 p
-              ~?  >>>  ?=(^ pay.req)
-                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
               ::  flow wires carry our side's dire;
               ::  use it directly to find the flow in .corked
               ::
               ?.  (~(has in corked.c) u.bone dir.i.hen)
                 p
+              ~?  >>>  ?=(^ pay.req)
+                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
+              %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                    ships.bug.old
+                    |.  %+  weld  "corked flow {<[u.bone dir.i.hen]>}; remove "
+                        "{(spud ames-path)} from .pit"
+                  ==
               (~(del by p) ames-path)
             ==
           ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2697,7 +2697,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%35 larva/ames-state]
+    ++  stay  [%35 %larva state=axle cache=_cached-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2883,9 +2883,12 @@
                   state=axle
               ==
               $:  %35                            :: clean up corked peeks
-                  ?(%adult %larva)               :: for $boons
-                  state=axle
-          ==  ==
+              $%  $:  %larva                     :: for $boons.
+                      state=axle                 ::
+                      cache=_cached-state        :: give cached-state in +stay
+                  ==                             ::
+                  [%adult state=axle]
+          ==  ==  ==
       |^  ?-  old
           [%4 %adult *]
         =.  cached-state  `[%4 state.old]
@@ -3204,11 +3207,13 @@
         ~>  %slog.1^leaf/"ames: larva %34 reload"
         larval-gate
       ::
-          [%35 *]
-        ?-  +<.old
-          %larva  larval-gate
-          %adult  (load:adult-core state.old)
-        ==
+          [%35 %adult *]
+        (load:adult-core state.old)
+      ::
+          [%35 %larva *]
+        ::  larva doesn't use or update ames-state
+        ::
+        larval-gate(cached-state cache.old)
       ::
       ==
       ::
@@ -3392,7 +3397,7 @@
       ?:  ?=(%33 -.old)
         =^  moz-34  +.old  (state-33-to-34 +.old)
         $(u.cached-state old(- %34), moz (weld moz moz-34))
-      ?>  ?=(%33 -.old)
+      ?>  ?=(%34 -.old)
       $(cached-state `35+(state-34-to-35 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
@@ -4172,8 +4177,8 @@
               ~&  >>>  missing-ossuary-state-33-to-34/[ship bone dire]
               moz
             %+  weld  moz
-            =/  =space    chum-to-our:fo-core
-            =/  =wire     (fo-wire:fo-core %ack)
+            =/  =space  chum-to-our:fo-core
+            =/  =wire   (fo-wire:fo-core %ack)
             moves:(fo-emit:fo-core u.hen %pass wire %a moke/[space ack poke])
         ::  second pass to fix .tip entries with wrong rift in duct
         ::
@@ -4301,9 +4306,10 @@
               ::
               %-  ~(rep by pit.c)
               |=  [[=ames=path req=request-state] pit=_pit.c]
-              ?:  ?=(^ pay.req)  pit
-              ::  skip poke acks
-              ::
+              ?:  ?=(^ pay.req)
+                ::  skip +peek for poke acks
+                ::
+                pit
               %-  ~(rep by for.req)
               |=  [[hen=duct *] p=_pit]
               ::  inspect the duct to find %mesa wires for %pokes
@@ -10396,10 +10402,6 @@
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
                       |.("remove %peek for %boon from .tip {<side>}")
-                  ~&  >>  :*  boon-path
-                              `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
-                              ames-boon
-                          ==
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4284,9 +4284,17 @@
               %-  ~(rep by tip.c)
               |=  [[=user=path *] tip=_tip.c]
               =>  .(user-path `(pole knot)`user-path)
-              ?.  ?=([%a %x %'1' %$ %flow bone=@ *] user-path)
+              ?.  ?=([%a %x %'1' %$ %flow bone=@ lod=@ dir=@ *] user-path)
                 tip
-              ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
+              ?.  ?=(?(%for %bak) dir.user-path)
+                tip
+              ?~  bone=(slaw %ud bone.user-path)
+                tip
+              ::  flow paths carry the dire of the other side; flip it
+              ::  to find our side of the flow in .corked
+              ::
+              =/  =dire  ?:(?=(%for dir.user-path) %bak %for)
+              ?.  (~(has in corked.c) u.bone dire)
                 tip
               (~(del by tip) user-path)
             ==
@@ -4306,22 +4314,25 @@
               ::
               %-  ~(rep by pit.c)
               |=  [[=ames=path req=request-state] pit=_pit.c]
-              ?:  ?=(^ pay.req)
-                ::  skip +peek for poke acks
-                ::
-                pit
               %-  ~(rep by for.req)
               |=  [[hen=duct *] p=_pit]
-              ::  inspect the duct to find %mesa wires for %pokes
+              ::  inspect the duct to find %mesa wires
               ::
               ?.  ?=([[%ames %mesa %flow *] *] hen)
                 p
               =>  .(i.hen `(pole knot)`i.hen)
-              ?.  ?=([@ @ @ %pok %for h=@ r=@ bone=@ ~] i.hen)
+              ?.  ?=([@ @ @ wer=@ dir=@ h=@ r=@ bone=@ ~] i.hen)
+                p
+              ?.  ?=(?(%for %bak) dir.i.hen)
                 p
               ?~  bone=(slaw %ud bone.i.hen)
                 p
-              ?.  (~(has in corked.c) u.bone %for)
+              ~?  >>>  ?=(^ pay.req)
+                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
+              ::  flow wires carry our side's dire;
+              ::  use it directly to find the flow in .corked
+              ::
+              ?.  (~(has in corked.c) u.bone dir.i.hen)
                 p
               (~(del by p) ames-path)
             ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2618,6 +2618,7 @@
             [%30 axle-30]
             [%31 axle]
             [%32 axle]
+            [%33 axle]
         ==
     ::
     ::
@@ -2692,7 +2693,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%32 larva/ames-state]
+    ++  stay  [%33 larva/ames-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2868,6 +2869,10 @@
               $:  %32                            :: use %ames as default core.
                   ?(%adult %larva)               :: migrate attestation flows
                   state=axle                     :: clean up corked peeks
+              ==
+              $:  %33                            :: clean up multi-frag peeks
+                  ?(%adult %larva)               ::
+                  state=axle
           ==  ==
       |^  ?-  old
           [%4 %adult *]
@@ -3173,10 +3178,16 @@
         larval-gate
       ::
           [%32 *]
+        =.  cached-state  `[%32 state.old]
+        ~>  %slog.1^leaf/"ames: larva %32 reload"
+        larval-gate
+      ::
+          [%33 *]
         ?-  +<.old
           %larva  larval-gate
           %adult  (load:adult-core state.old)
         ==
+      ::
       ==
       ::
       ++  event-9-til-11-to-12
@@ -3251,7 +3262,7 @@
       |^  ^+  [moz larval-core]
       ?~  cached-state  [~ larval-core]
       =*  old  u.cached-state
-      ?:  ?=(%32 -.old)
+      ?:  ?=(%33 -.old)
         ::  no state migrations left; update state, clear cache, and exit
         ::
         [(flop moz) larval-core(ames-state.adult-gate +.old, cached-state ~)]
@@ -3352,8 +3363,10 @@
         $(cached-state `30+(state-29-to-30 +.old))
       ?:  ?=(%30 -.old)
         $(cached-state `31+(state-30-to-31 +.old))
-      ?>  ?=(%31 -.old)
-      $(cached-state `32+(state-31-to-32 +.old))
+      ?:  ?=(%31 -.old)
+        $(cached-state `32+(state-31-to-32 +.old))
+      ?>  ?=(%32 -.old)
+      $(cached-state `33+(state-32-to-33 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
       ++  state-4-to-5
@@ -4022,6 +4035,68 @@
             ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
               tip
             (~(del by tip) user-path)
+          ==
+        ==
+      ::
+      ++  state-32-to-33
+        |=  old=axle
+        ^-  axle
+        ~>  %slog.0^leaf/"ames: migrating from state %32 to %33"
+        ::  first pass to clean the .tip
+        ::
+        =.  chums.old
+          ^-  (map ship chum-state)
+          %-  ~(run by chums.old)
+          |=  c=chum-state
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          %_    c
+              tip
+            ::  remove entries for corked flows
+            ::
+            %-  ~(rep by tip.c)
+            |=  [[=user=path *] tip=_tip.c]
+            =>  .(user-path `(pole knot)`user-path)
+            ?.  ?=([%a %x %'1' %$ %flow bone=@ *] user-path)
+              tip
+            ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
+              tip
+            (~(del by tip) user-path)
+          ==
+        ::  last pass; .pit clean-up
+        ::
+        %=    old
+            chums
+          ^-  (map ship chum-state)
+          %-  ~(run by chums.old)
+          |=  c=chum-state
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          %_    c
+              pit
+            ::  remove entries for corked flows
+            ::
+            %-  ~(rep by pit.c)
+            |=  [[=ames=path req=request-state] pit=_pit.c]
+            ?:  ?=(^ pay.req)  pit
+            ::  skip poke acks
+            ::
+            %-  ~(rep by for.req)
+            |=  [[hen=duct *] p=_pit]
+            ::  inspect the duct to find %mesa wires for %pokes
+            ::
+            ?.  ?=([[%ames %mesa %flow *] *] hen)
+              p
+            =>  .(i.hen `(pole knot)`i.hen)
+            ?.  ?=([@ @ @ %pok %for h=@ r=@ bone=@ ~] i.hen)
+              p
+            ?~  bone=(slaw %ud bone.i.hen)
+              p
+            ?.  (~(has in corked.c) u.bone %for)
+              p
+            (~(del by pit) ames-path)
           ==
         ==
       ::
@@ -13797,7 +13872,7 @@
   take:am-core
 ::  +stay: extract state before reload
 ::
-++  stay  [%32 adult/ames-state]
+++  stay  [%33 adult/ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9333,7 +9333,7 @@
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (decrypt-path [pat her]:pok.pact)
             ::
-            ?:  ?=(%none -.space)
+            ?:  ?=(?(%publ %none) -.space)
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
                       " pok={<pat.pok.pact>}; skip"

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9333,10 +9333,12 @@
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (decrypt-path [pat her]:pok.pact)
             ::
-            ?:  ?=(?(%publ %none) -.space)
+            ?.  ?=(%chum -.space)
+              ::  XX
+              ::
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
-                      " pok={<pat.pok.pact>}; skip"
+                      " pok={<pat.pok.pact>} using {<-.space>}; skip"
               ev-core
             ::
             =/  [pok=(pole iota) ack=(pole iota)]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10747,14 +10747,6 @@
             =/  =space   chum-to-our
             (fo-emit hen [%pass wire %a meek/[space her (fo-nax-path seq our)]])
           ::
-          ++  fo-send-ack
-            |=  seq=@ud
-            ^+  fo-core
-            ::  emit (n)ack to unix; see +fo-peek where the (n)ack is produced
-            ::
-            =/  =path  (%*(fo-ack-path fo-core dire.side fo-flip-dire) seq her)
-            (fo-emit [/ames]~ %pass /make-page %a mage/[chum-to-her her^path])
-          ::
           ++  fo-peek-cork
             %-  %+  ev-tace  fin.veb.bug.ames-state
                 |.("peek for %cork {<bone=bone>}")
@@ -10774,6 +10766,14 @@
             ::  for-cor-path will produce a path for the %cork on the other side
             ::
             [(fo-wire %fub) %a meek/[chum-to-our her (fo-cor-path seq=0 our)]]
+          ::
+          ++  fo-send-ack
+            |=  seq=@ud
+            ^+  fo-core
+            ::  emit (n)ack to unix; see +fo-peek where the (n)ack is produced
+            ::
+            =/  =path  (%*(fo-ack-path fo-core dire.side fo-flip-dire) seq her)
+            (fo-emit [/ames]~ %pass /make-page %a mage/[chum-to-her her^path])
           ::
           ++  fo-handle-miss-ack
             |=  seq=message-num

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9404,25 +9404,7 @@
                   :+  (recover-root:verifier:lss (rip 8 dat.data))
                     aut.data
                   pok.pact
-              :: XX assert load is plea/boon?
-              ::
-              ?:  (fo-message-is-acked:fo-core mess.pok)
-                ::  don't peek if the message havs been already acked
-                ::
-                ?:  (gte (sub last-acked.rcv:fo-core mess.pok) 10)
-                  %-  %+  ev-tace  odd.veb.bug.ames-state
-                      |.("poke [bon, seq]={<[bone mess]:pok>} outside of window")
-                  ev-core
-                %-  %+  ev-tace  rcv.veb.bug.ames-state
-                    |.("poke [bon, seq]={<[bone mess]:pok>} already acked")
-                ::
-                fo-abet:(fo-send-ack:fo-core mess.pok)
-              ::
-              %-  %+  ev-tace  fin.veb.bug.ames-state
-                  |.("peek for poke payload {<[flow=bone seq=mess]:pok>}")
-              ::
-              %^  ev-emit  hen  %pass
-              [(fo-wire:fo-core %pok) %a %meek [none/~ [her pat]:pok.pact]]
+              fo-abet:(fo-peek-poke:fo-core seq=mess.pok pat.pok.pact)
             ::  authenticate one-fragment message
             ::
             ::  if this is a one-fragment %data pact, tob would equal the size of
@@ -10735,7 +10717,7 @@
                 ==
             fo-core
           ::
-          +|  %internals
+          +|  %peeks
           ::
           ++  fo-peek-naxplanation
             |=  seq=@ud
@@ -10766,6 +10748,30 @@
             ::  for-cor-path will produce a path for the %cork on the other side
             ::
             [(fo-wire %fub) %a meek/[chum-to-our her (fo-cor-path seq=0 our)]]
+          ::
+          ++  fo-peek-poke
+            |=  [seq=@ud =poke=path]
+            :: XX assert load is plea/boon?
+            ::
+            ?:  (fo-message-is-acked seq)
+              ::  don't peek if the message havs been already acked
+              ::
+              ?:  (gte (sub last-acked.rcv seq) 10)
+                %-  %+  ev-tace  odd.veb.bug.ames-state
+                    |.("poke [bon, seq]={<[bone seq]>} outside of window")
+                fo-core
+              %-  %+  ev-tace  rcv.veb.bug.ames-state
+                  |.("poke [bon, seq]={<[bone seq]>} already acked")
+              ::
+              (fo-send-ack:fo-core seq)
+            ::
+            %-  %+  ev-tace  fin.veb.bug.ames-state
+                |.("peek for poke payload {<[flow=bone seq=seq]>}")
+            ::
+            %^  fo-emit  hen  %pass
+            [(fo-wire %pok) %a %meek [none/~ her poke-path]]
+          ::
+          +|  %internals
           ::
           ++  fo-send-ack
             |=  seq=@ud

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2697,7 +2697,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%35 %larva state=axle cache=_cached-state]
+    ++  stay  [%35 %larva state=ames-state cache=cached-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10060,6 +10060,14 @@
           ++  fo-abel
             ^+  ev-core
             ::
+            =/  cork-path  (fo-cor-path seq=0 our)
+            ::  this assumes that the sender has only one outstanding $boon
+            ::    (snd-window = 1)
+            ::
+            =/  boon-path  (fo-pok-path seq=+(last-acked.rcv) our)
+            =/  ames-cork  (make-space-path chum-to-our cork-path)
+            =/  ames-boon  (make-space-path chum-to-our boon-path)
+            ::
             =:   flows.per  (~(del by flows.per) bone^dire)
                 corked.per  (~(put in corked.per) bone^dire)
             ::
@@ -10072,8 +10080,6 @@
               (~(del by by-duct.ossuary.per) (ev-got-duct bone))
             ::
                 tip.per
-              =/  cork-path  (fo-cor-path seq=0 our)
-              =/  ames-cork  (make-space-path chum-to-our cork-path)
               =+  ?.  (~(has by tip.per) cork-path)  ~
                   %.  ~
                   %+  ev-tace  fin.veb.bug.ames-state
@@ -10084,7 +10090,12 @@
                       """
               =;  [tip=_tip.per *]
                 ::  once all %acks are deleted we can delete the peek for the cork
+                ::    (and any possible %peek for $boon)
                 ::
+                =?  tip  ?=(%for dire) :: XX necessary?
+                  %^  ~(del ju tip)  boon-path
+                    `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
+                  ames-boon
                 %^  ~(del ju tip)  cork-path
                   `duct`[`wire`[%ames (fo-wire %cor)] duct=hen]
                 ames-cork
@@ -10101,15 +10112,21 @@
             ::
                 pit.per
                   =;  [pit=_pit.per *]
-                    ::  a forward flow can be deleted when we hear an %ack for a
-                    ::  %cork $plea, or a %gone $page for a corked flow +peek.
+                    ::  a forward flow can be deleted when we hear an %ack for
+                    ::  a %cork $plea, or a %gone $page for a corked flow +peek
                     ::
                     ::  for the %ack, there could be a path in the .pit to read
                     ::  if the flow has been corked, so we can just derive it
                     ::  based on the flow-state, and attempt to delete it.
                     ::
-                    %-  ~(del by pit)
-                    (make-space-path chum-to-our (fo-cor-path seq=0 our))
+                    ::  if we are the %bak side, we could be peeking for a
+                    ::  multi-fragment $boon. If we leave the subscription
+                    ::  before the $boon completes, and then %cork the flow
+                    ::
+                    ::
+                    =?  pit  ?=(%bak dire) :: XX necessary?
+                      (~(del by pit) ames-boon)
+                    (~(del by pit) ames-cork)
                   ::
                   %^  (dip:fo-mop _pit.per)  loads.snd
                     pit.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10075,6 +10075,14 @@
                 ::    (and any possible %peek for $boon)
                 ::
                 =?  tip  ?=(%for dire) :: XX necessary?
+                  =+  ?.  (~(has by tip.per) boon-path)  ~
+                      %.  ~
+                      %+  ev-tace  fin.veb.bug.ames-state
+                      |.  """
+                          remove {(spud boon-path)} from .tip {<side=side>}
+                          {<[%ames (fo-wire %pok) duct=hen]>}
+                          ames-path={(spud ames-boon)}
+                          """
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10106,7 +10114,15 @@
                     ::  before the $boon completes, and then %cork the flow
                     ::
                     ::
-                    =?  pit  ?=(%bak dire) :: XX necessary?
+                    =?  pit  ?=(%for dire) :: XX necessary?
+                      =+  ?.  (~(has by tip.per) boon-path)  ~
+                          %.  ~
+                          %+  ev-tace  fin.veb.bug.ames-state
+                          |.  """
+                              remove {(spud boon-path)} from .pit {<side=side>}
+                              {<[%ames (fo-wire %pok) duct=hen]>}
+                              ames-path={(spud ames-boon)}
+                              """
                       (~(del by pit) ames-boon)
                     (~(del by pit) ames-cork)
                   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9467,6 +9467,14 @@
             ::
             =.  ev-core  (ev-update-qos %live last-contact=now)
             ::
+            =/  tof  (div (add tob.data 1.023) 1.024)
+            =/  [typ=?(%auth %data) fag=@ud]
+              ?~  wan.name
+                [?:((gth tof 1) %auth %data) 0]
+              [typ fag]:wan.name
+            %-  %+  ev-tace  rcv.veb.bug.ames-state
+                |.("hear page packet {<[tof=tof typ=typ fag=fag]>}")
+            ::
             ::  check for pending request (peek|poke)
             ::
             ?~  res=(~(get by pit.per) sealed-path)
@@ -9474,20 +9482,11 @@
               %+  ev-tace  odd.veb.bug.ames-state
               |.("missing page from pit {(spud inner-path)}")
             ::
-            %-  (ev-tace rcv.veb.bug.ames-state |.("hear page packet"))
-            ::
             ?.  =(rift.per rif.name)
               %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("wrong rift {<[rift.per rif.name]>}; skip")
               ev-core
             ::
-            ::
-            =/  tof  (div (add tob.data 1.023) 1.024)
-            ::
-            =/  [typ=?(%auth %data) fag=@ud]
-              ?~  wan.name
-                [?:((gth tof 1) %auth %data) 0]
-              [typ fag]:wan.name
             ::
             ?-    typ
                 %auth
@@ -10065,11 +10064,7 @@
               =+  ?.  (~(has by tip.per) cork-path)  ~
                   %.  ~
                   %+  ev-tace  fin.veb.bug.ames-state
-                  |.  """
-                      remove {(spud cork-path)} from .tip {<side=side>}
-                      {<[%ames (fo-wire %cor) duct=hen]>}
-                      ames-path={(spud ames-cork)}
-                      """
+                  |.("remove %peek for %cork from .tip {<side>}")
               =;  [tip=_tip.per *]
                 ::  once all %acks are deleted we can delete the peek for the cork
                 ::    (and any possible %peek for $boon)
@@ -10078,11 +10073,7 @@
                   =+  ?.  (~(has by tip.per) boon-path)  ~
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
-                      |.  """
-                          remove {(spud boon-path)} from .tip {<side=side>}
-                          {<[%ames (fo-wire %pok) duct=hen]>}
-                          ames-path={(spud ames-boon)}
-                          """
+                      |.("remove %peek for %boon from .tip {<side>}")
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10118,11 +10109,7 @@
                       =+  ?.  (~(has by tip.per) boon-path)  ~
                           %.  ~
                           %+  ev-tace  fin.veb.bug.ames-state
-                          |.  """
-                              remove {(spud boon-path)} from .pit {<side=side>}
-                              {<[%ames (fo-wire %pok) duct=hen]>}
-                              ames-path={(spud ames-boon)}
-                              """
+                          |.("remove %peek for %boon from .pit {<side>}")
                       (~(del by pit) ames-boon)
                     (~(del by pit) ames-cork)
                   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4096,7 +4096,7 @@
               p
             ?.  (~(has in corked.c) u.bone %for)
               p
-            (~(del by pit) ames-path)
+            (~(del by p) ames-path)
           ==
         ==
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9396,6 +9396,14 @@
             ?:  (gth (div (add tob.data.pact (dec frag)) frag) 1)
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("hear incomplete message")
+              ::  authenticate the first (%auth) fragment before peeking for
+              ::  the rest of the payload: dat is the serialized lss proof, so
+              ::  recover the root and verify the sender's signature/mac over it
+              ::
+              ?>  %-  authenticate
+                  :+  (recover-root:verifier:lss (rip 8 dat.data))
+                    aut.data
+                  pok.pact
               :: XX assert load is plea/boon?
               ::
               ?:  (fo-message-is-acked:fo-core mess.pok)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10076,6 +10076,10 @@
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
                       |.("remove %peek for %boon from .tip {<side>}")
+                  ~&  >>  :*  boon-path
+                              `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
+                              ames-boon
+                          ==
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10108,7 +10112,7 @@
                     ::
                     ::
                     =?  pit  ?=(%for dire) :: XX necessary?
-                      =+  ?.  (~(has by tip.per) boon-path)  ~
+                      =+  ?.  (~(has by pit.per) ames-boon)  ~
                           %.  ~
                           %+  ev-tace  fin.veb.bug.ames-state
                           |.("remove %peek for %boon from .pit {<side>}")
@@ -10781,10 +10785,18 @@
               ::
               (fo-send-ack:fo-core seq)
             ::
+
             %-  %+  ev-tace  fin.veb.bug.ames-state
-                |.("peek for poke payload {<[flow=bone seq=seq]>}")
+                |.  %+  weld  "peek for {<?:(?=(%for dire) %plea %boon)>} "
+                    "payload {<[flow=bone seq=seq]>}"
             ::
-            %^  fo-emit  hen  %pass
+
+            %^    fo-emit
+                ?.  ?=(%for dire)  hen
+                ::  if peeking for a %boon, use the right listener
+                ::
+                (~(got by by-bone.ossuary.per) bone)
+              %pass
             [(fo-wire %pok) %a %meek [none/~ her poke-path]]
           ::
           +|  %internals

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11111,7 +11111,7 @@
             ::
 
             %-  %+  ev-tace  fin.veb.bug.ames-state
-                |.  %+  weld  "peek for {<?:(?=(%for dire) %plea %boon)>} "
+                |.  %+  weld  "peek for {<?:(?=(%for dire) %boon %plea)>} "
                     "payload {<[flow=bone seq=seq]>}"
             ::
             ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10767,6 +10767,17 @@
           ::
           ++  fo-peek-poke
             |=  [seq=@ud =poke=path]
+            ::  if flow is corked, no-op
+            ::
+            ?:  |(halt.state closing.state (~(has in corked.per) side))
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.
+                  ?:  halt.state
+                    "flow {<[side]>} is halted; skip peek"
+                  ?:  closing.state
+                    "flow {<[side]>} in closing; skip peek"
+                  "flow {<[side]>} is corked; skip peek"
+              fo-core
             :: XX assert load is plea/boon?
             ::
             ?:  (fo-message-is-acked seq)


### PR DESCRIPTION
If we left a subscription in the middle of peeking for a multi-fragmemnt $boon, and the %cork $ack came before the $boon page was delivered, we would create a space leak in the .pit by not removing the payload peek.

I reorder the code a bit here and also to move the logic for peeking for multifragment payloads into the flow layer.

Also, I (re)add the authentication for the %auth fragment in a %poke, that was somehow not pushed?(probably due to some merge conflicts).

This is the first(!!) PR that gives the cached-state if we somehow end up in the larval stage (either because we crash ++molt, or because nothing has been passed/given to %ames) and we reload the vane.

If this happens (or has happened for any of the many ames migration) we are going to throw away ALL ames state from the previous version.

Here (as of ames %35) ++stay produces together with the axle, the cached-state. if ++load gets passed a larva noun, we are going to populate the cached-state with the previous version, making us remember everything needed for a successful migration.

This also adds extra checks to harden poke sinking and handling of corks (e.g. a cork sent with seq=1 should be ignored)