### PR TITLE
ahoy: wip peek for sys/kelvin to trigger %mesa migration

### DIFF
--- a/pkg/arvo/lib/hood/ahoy.hoon
+++ b/pkg/arvo/lib/hood/ahoy.hoon
@@ -313,19 +313,22 @@
       ::
       =.  pending-ahoy.sat  (~(del in pending-ahoy.sat) who)
       (flog %crud [mote tang]:p.p.sign-arvo)
-    =+  !<  [[num=@ud has=@uvi wen=@da] no-response=?]
+    =+  !<  [[num=@ud out=[kel=@ud has=(unit @uvi)] wen=@da] no-response=?]
             q.p.p.sign-arvo
     ::
     =?  hashes.sat  !no-response  :: only update hashes if we did get a response
+      ::  maybe we did get a response, but the kids hash %keen timeout
+      ::
+      ?~  has.out  hashes.sat
       ?.  (~(has by hashes.sat) who)
-        (~(put by hashes.sat) who num^has^wen)
+        (~(put by hashes.sat) who num^u.has.out^wen)
       ::  the ship exists; update only if this
       ::  case is higher than previous
       ::
       %+  ~(jab by hashes.sat)  who
       |=  old=[num=@ud has=@uvi wen=@da]
       ?.  (gte num num.old)  old
-      [num has wen]
+      [num u.has.out wen]
     ::
     =.  no-response.sat
       ::  if none of these thread's attempts give a response
@@ -343,7 +346,8 @@
         ==
     ::  ahoy the peer if on last-hash, not yet migrated, and not pending
     ::
-    ?:  ?|  !=(last-hash.sat has)
+    ?:  ?|  ::  !=(last-hash.sat has.out) XX
+            !=(408 kel.out)
             (~(has by chums) who)
         ==
       ::  delete the peer from pending and try again on next %prob

--- a/pkg/arvo/ted/prob.hoon
+++ b/pkg/arvo/ted/prob.hoon
@@ -9,6 +9,114 @@
 =,  strand=strand:spider
 ^-  thread:spider
 ::
+=>  |%
+    ++  peek-for-kelvin
+      |=  [=bowl:spider =keen=wire =timer=wire timeout-time=@da =spar:ames]
+      :: XX
+      ::   ^-  form:m-race
+      ::   %+  (map-err ,~)  |=(* [%offline *tang])
+      ::   %+  (set-timeout ,~)  timeout-time
+      =/  m-race  (strand ,[timeout=? result=vase])
+      ^-  form:m-race
+      |=  tin=strand-input:strand
+      ^-  output:m-race
+      ?+    in.tin  `[%skip ~]
+          ~  `[%wait ~]
+      ::
+      ::  sage response: give kids hash
+      ::
+          [~ %sign * %ames %sage *]
+        ?.  =(keen-wire wire.u.in.tin)
+          `[%skip ~]
+        =/  =sage:mess:ames  sage.sign-arvo.u.in.tin
+        :^    [%pass timer-wire %arvo %b %rest timeout-time]~
+            %done
+          %.n
+        ::
+        !>
+        ?~  q.sage  ~
+        =+  .^  =dais:clay  %cb
+              /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[p.q.sage]
+            ==
+        =/  res  (mule |.((vale.dais q.q.sage)))
+        ?:  ?=(%| -.res)
+          ~
+        ::  try to extract kelvin data
+        ::
+        =/  kelvin-data=(list weft)
+          =+  !<(=waft:clay p.res)
+          ?.  ?=([[%1 ~] *] waft)
+            ^-  (list weft)  [waft]~
+          ~(tap in p.waft)
+        ?:  =(~ kelvin-data)
+          ~
+        =/  arvo-kelvin=(unit @ud)
+          |-  ^-  (unit @ud)
+          ?~  kelvin-data  ~
+          ?:  =(lal.i.kelvin-data %zuse)
+            `num.i.kelvin-data
+          ~!  kelvin-data
+          $(kelvin-data t.kelvin-data)
+        ?~  arvo-kelvin
+          ~
+        `u.arvo-kelvin
+      ::
+      ::  timer: peer timed out
+      ::
+          [~ %sign * %behn %wake *]
+        ?.  =(timer-wire wire.u.in.tin)
+          `[%skip ~]
+        ?^  error.sign-arvo.u.in.tin
+          `[%fail %timer-error u.error.sign-arvo.u.in.tin]
+        ~&  >>  yawn/keen-wire^spar
+        :-  [%pass keen-wire %arvo %a %yawn spar]~
+        [%done [%.y !>(~)]]
+      ==
+    ::
+    ++  peek-for-hash
+      |=  [=bowl:spider =keen=wire =timer=wire timeout-time=@da =spar:ames]
+      =/  m-race  (strand ,[timeout=? result=vase])
+      :: XX
+      ::   ^-  form:m-race
+      ::   %+  (map-err ,~)  |=(* [%offline *tang])
+      ::   %+  (set-timeout ,~)  timeout-time
+      ~&  peek-for-hash/keen-wire^timer-wire
+      ^-  form:m-race
+      |=  tin=strand-input:strand
+      ^-  output:m-race
+      ?+    in.tin  `[%skip ~]
+          ~  `[%wait ~]
+      ::
+      ::  sage response: give kids hash
+      ::
+          [~ %sign * %ames %sage *]
+        ?.  =(keen-wire wire.u.in.tin)
+          `[%skip ~]
+        =/  =sage:mess:ames  sage.sign-arvo.u.in.tin
+        :^    [%pass timer-wire %arvo %b %rest timeout-time]~
+            %done
+          %.n
+        ::
+        ?:  ?|  ?=(~ q.sage)
+                !=(%uvi p.q.sage)
+            ==
+          !>(*(unit @uvi))
+        !>([~ ;;(hash=@uvi q.q.sage)])
+      ::
+      ::  timer: peer timed out
+      ::
+          [~ %sign * %behn %wake *]
+        ?.  =(timer-wire wire.u.in.tin)
+          `[%skip ~]
+        ?^  error.sign-arvo.u.in.tin
+          `[%fail %timer-error u.error.sign-arvo.u.in.tin]
+        ~&  >>>  yawn/keen-wire^ship^path
+        :-  [%pass keen-wire %arvo %a %yawn spar]~
+        [%done [%.y !>(*(unit @uvi))]]
+      ==
+    ::
+    --
+::
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
@@ -17,7 +125,7 @@
             timeout=@dr
             [case=@ud has=@uvi wen=@da]
             who=ship
-            wait-hash=@uvi
+            kel=@ud
             veb=?
         ==
     arg
@@ -35,10 +143,11 @@
 =/  start=@da  now.bowl
 ~?  >  veb  "ahoy-prob: start {<who>} {<now.bowl>}"
 =|  no-response=?
+=|  remote-kel=@ud
 ::
 |-
 ;<  =bowl:spider  bind:m  get-bowl:strandio  ::  refresh bowl
-=/  scry-path=path  /c/z/(scot %ud case)/kids
+=/  scry-path=path  /c/x/(scot %ud case)/kids/sys/kelvin
 =/  =spar:ames      [who scry-path]
 =/  wire-keen       /keen
 =/  timeout-time    (add now.bowl timeout)
@@ -52,49 +161,12 @@
 ::
 ::  race sage vs timer
 ::
-=/  m-race  (strand ,[timeout=? result=vase])
-;<  [timeout=? result=vase]  bind:m
-:: XX
-::   ^-  form:m-race
-::   %+  (map-err ,~)  |=(* [%offline *tang])
-::   %+  (set-timeout ,~)  timeout-time
-  ^-  form:m-race
-  |=  tin=strand-input:strand
-  ^-  output:m-race
-  ?+    in.tin  `[%skip ~]
-      ~  `[%wait ~]
-  ::
-  ::  sage response: give kids hash
-  ::
-      [~ %sign * %ames %sage *]
-    ?.  =(wire-keen wire.u.in.tin)
-      `[%skip ~]
-    =/  =sage:mess:ames  sage.sign-arvo.u.in.tin
-    :^    [%pass wire-timer %arvo %b %rest timeout-time]~
-        %done
-      %.n
-    ::
-    ?:  ?|  ?=(~ q.sage)
-            !=(%uvi p.q.sage)
-        ==
-      !>(*(unit @uvi))
-    !>([~ ;;(hash=@uvi q.q.sage)])
-  ::
-  ::  timer: peer timed out
-  ::
-      [~ %sign * %behn %wake *]
-    ?.  =(wire-timer wire.u.in.tin)
-      `[%skip ~]
-    ?^  error.sign-arvo.u.in.tin
-      `[%fail %timer-error u.error.sign-arvo.u.in.tin]
-    :-  [%pass wire-keen %arvo %a %yawn spar]~
-    [%done [%.y !>(*(unit @uvi))]]
-  ==
+;<  [did-timeout=? result=vase]  bind:m
+  (peek-for-kelvin bowl wire-keen wire-timer timeout-time spar)
 ::
 ::  process result
 ::
-?:  timeout
-  ;<  =bowl:spider  bind:m  get-bowl:strandio
+?:  did-timeout
   ::  timed out; flag as no-responsive if no previous attempt worked
   ::
   ;<  =bowl:spider  bind:m  get-bowl:strandio
@@ -110,25 +182,48 @@
     ::
     (dec case)
   :_  no-response
-  [case has ?:(no-response now.bowl wen)]
+  [case [remote-kel ~] ?:(no-response now.bowl wen)]
 ::
 ::  sage responded; check kelvin
 ::
 =.  no-response  %.n
-=+  !<(kids-hash=(unit @uvi) result)
-?~  kids-hash
-  ::  %kids desk doesn't exist?; try next case
+=+  !<(kelvin=(unit @ud) result)
+?~  kelvin
+  ::  sys/kelvin desk doesn't exist?; try next case
   ::
   $(case +(case))
 ::
-~?  >>  &(veb !=(wait-hash u.kids-hash))
-  "ahoy-prob: {<who>} kids hash is {<u.kids-hash>}"
-=:  has  u.kids-hash
-    wen  now.bowl
-  ==
+=.  remote-kel  u.kelvin
+~?  >>  &(veb !=(kel u.kelvin))
+  "ahoy-prob: {<who>} kelvin is {<u.kelvin>}"
+::  we have sys/kelvin; scry for kids desk hash
 ::
-?.  =(wait-hash has)
-  ::  not last-hash; try next case
+::  send %keen and set timer
+::
+=/  wire-keen     /kids
+=/  =spar:ames    [who /c/z/(scot %ud case)/kids]
+;<  =bowl:spider  bind:m  get-bowl:strandio
+~&  >  `@s`now.bowl
+=/  timeout-time  (add now.bowl timeout)
+~&  timeout-time/`@da`timeout-time
+=/  wire-timer    /wait/(scot %da timeout-time)
+;<  ~  bind:m  (keen:strandio wire-keen spar sec=~)
+;<  ~  bind:m
+  (send-raw-card:strandio %pass wire-timer %arvo %b %wait timeout-time)
+;<  [did-timeout=? result=vase]  bind:m
+  (peek-for-hash bowl wire-keen wire-timer timeout-time spar)
+::
+::  XX ignore possible timeout?
+::
+~|  result
+=+  !<(kids-hash=(unit @uvi) result)
+~&  >>>  kids-hash
+=.  wen  now.bowl
+?~  kids-hash  $(case +(case))
+=.  has  u.kids-hash  :: if sys/kelvin exist it should have a hash
+::
+?.  =(kel u.kelvin)
+  ::  not the kelvin we want; try next case
   ::
   $(case +(case))
 ::  found wait-hash; done with .who
@@ -136,4 +231,4 @@
 ~?  >  veb  "ahoy-prob: done with {<who>}"
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ~?  >  veb  end/`@dr`(sub now.bowl start)
-(pure:m !>([[case has wen] no-response]))
+(pure:m !>([[case [remote-kel `has] wen] no-response]))


### PR DESCRIPTION
Instead of trying to match a specific hash (that could have been skipped for ships migrating directly from an old version to 408), we peek for the contents of `sys/kelvin` in the %kids desk. 