### PR TITLE
ames: emit %saxo in +on-publ-sponsor on any change in saxo chain

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11146,10 +11146,11 @@
             %-  %+  %*(ev-tace ev her ship)  sun.veb.bug.ames-state
                 |.("hear new sponsor={<sponsor>}")
             ::
-            =?  sy-core  =(our ship)
+            =/  our-saxo=(list @p)  sy-get-sponsors
+            =?  sy-core  ?=(^ (find ~[ship] our-saxo))
               ?~  unix-duct
                 sy-core
-              (sy-emit unix-duct %give %saxo sy-get-sponsors)
+              (sy-emit unix-duct %give %saxo our-saxo)
             ?~  sponsor
               %-  (slog leaf+"ames: {(scow %p ship)} lost sponsor, ignoring" ~)
               sy-core


### PR DESCRIPTION
Currently `+on-publ-sponsor` only emits a `%saxo` to the runtime when our immediate sponsor changes. It doesn't emit one when our sponsor's sponsor changes (or sponsor's sponsor's sponsor, etc). This means vere can be wrong about which galaxy is routing for our ship, and consequently use the wrong STUN server.

This PR makes it check if the ship whose sponsor has changed is anywhere in our saxo chain, and emits a new %saxo if so.