### PR TITLE
hoon: parse %ktcb as ^_ instead of ^#

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -13210,7 +13210,7 @@
                   ['?' (rune wut %ktwt expa)]
                   ['*' (rune tar %kttr exqa)]
                   [':' (rune col %ktcl exqa)]
-                  ['#' (rune hax %ktcb expb)]
+                  ['_' (rune cab %ktcb expb)]
               ==
             ==
           :-  '~'


### PR DESCRIPTION
#7297 added `%ktcb`, but contained the in-development parser code, which parses the rune as `^#` instead of `^_`.

Here, we update the parser. The rune was only used in code-generation, so updating the parser is "free".

@pkova this could be a hot-patch for 408 before release, but that's up to you!