### PR TITLE
ames, azimuth: fix wrong rift in %ames

### DIFF
--- a/pkg/arvo/app/azimuth.hoon
+++ b/pkg/arvo/app/azimuth.hoon
@@ -446,9 +446,9 @@
   =/  =pass
     (pass-from-eth:azimuth [32^crypt 32^auth suite]:keys.net)
   ^-  (list [@p udiff:point])
-  :*  [ship id %keys [life.keys.net suite.keys.net pass] %.y]
-      [ship id %rift rift.net %.y]
+  :*  [ship id %rift rift.net %.y]
       [ship id %spon ?:(has.sponsor.net `who.sponsor.net ~)]
+      [ship id %keys [life.keys.net suite.keys.net pass] %.y]
       udiffs
   ==
 ::

--- a/pkg/arvo/gen/ames/keys.hoon
+++ b/pkg/arvo/gen/ames/keys.hoon
@@ -1,11 +1,58 @@
-::  Print keys for a ship, as stored in %ames
+::  Print keys for a (list of) ship, as stored in %ames, compared to %jael
+::
+::    (miss = %.y) only prints missmatches
 ::
 :-  %say
-|=  [[now=time @ our=ship ^] [=ship ~] ~]
-=+  .^  =ship-state:ames
-        %ax  /(scot %p our)//(scot %da now)/peers/(scot %p ship)
-    ==
+|=  [[now=time @ bec=beak] arg=$@(~ [=ship ~]) miss=_| ~]
+=/  peers=(list @p)
+  ?^  arg
+    [ship.arg ~]
+  ::  XX also look at /chums
+  ::
+  =+  .^  ships=(map ship ?(%alien %known))
+        %ax  /(scot %p p.bec)//(scot %da now)/peers
+      ==
+  %-  ~(rep by ships)
+  |=  [[=ship val=?(%alien %known)] out=(list @p)]
+  ?:  =(ship p.bec)
+    out  ::  this is weird, but we saw it
+  ?-  val
+    %alien  out
+    %known  ship^out
+  ==
+~&  peers=(lent peers)
+
+=|  out=(list [who=@p (pair jael=[(unit life=@) rift=(unit @)] ames=[life=(unit @) rift=(unit @)])])
 :-  %noun
-?.  ?=(%known -.ship-state)
-  %ship-still-alien
-[life=life rift=rift]:+.ship-state
+ =;  o=_out
+   o^total=(lent o)
+|-  ^+  out
+?~  peers  out
+=*  ship  i.peers
+=+  .^  =ship-state:ames
+        %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
+    ==
+?>  ?=([%known *] ship-state)
+::  for each peer scry into %jael and %ames
+::
+=/  our  (scot %p p.bec)
+=/  now  (scot %da now)
+=/  her  (scot %p ship)
+=+  life=.^((unit @ud) %j /[our]/lyfe/[now]/[her])
+=+  rift=.^((unit @ud) %j /[our]/ryft/[now]/[her])
+=+  jael=[jael-life=life jael-rift=rift]
+=+  ames=[ames-life=`life ames-rift=`rift]:+.ship-state
+%_    $
+    peers  t.peers
+    out
+  ?:  ?&  miss
+          =(jael ames)
+      ==
+    out
+  ?:  ?=(%pawn (clan:title ship))
+    ::  jael has no info about comets
+    ::
+    ?:  =([`1 `0] ames)  out
+    [ship [`1 `0] ames]^out
+  [ship jael ames]^out
+==

--- a/pkg/arvo/gen/ames/keys.hoon
+++ b/pkg/arvo/gen/ames/keys.hoon
@@ -3,16 +3,21 @@
 ::    (miss = %.y) only prints missmatches
 ::
 :-  %say
-|=  [[now=time @ bec=beak] arg=$@(~ [=ship ~]) miss=_| ~]
+|=  [[now=time @ bec=beak] arg=$@(~ [=ship ~]) miss=_| core=?(%mesa %ames) ~]
 =/  peers=(list @p)
   ?^  arg
     [ship.arg ~]
   ::  XX also look at /chums
   ::
-  =+  .^  ships=(map ship ?(%alien %known))
-        %ax  /(scot %p p.bec)//(scot %da now)/peers
+  =+  ^=  peers
+      ?:  ?=(%ames core)
+        .^  (map ship ?(%alien %known))
+          %ax  /(scot %p p.bec)//(scot %da now)/peers
+        ==
+      .^  (map ship ?(%alien %known))
+        %ax  /(scot %p p.bec)//(scot %da now)/chums
       ==
-  %-  ~(rep by ships)
+  %-  ~(rep by peers)
   |=  [[=ship val=?(%alien %known)] out=(list @p)]
   ?:  =(ship p.bec)
     out  ::  this is weird, but we saw it
@@ -21,18 +26,25 @@
     %known  ship^out
   ==
 ~&  peers=(lent peers)
-
 =|  out=(list [who=@p (pair jael=[(unit life=@) rift=(unit @)] ames=[life=(unit @) rift=(unit @)])])
 :-  %noun
  =;  o=_out
-   o^total=(lent o)
+   :_  total=(lent o)
+   (turn o |*([=ship r=*] [core^ship r]))
 |-  ^+  out
 ?~  peers  out
 =*  ship  i.peers
-=+  .^  =ship-state:ames
+=/  [ames-life=(unit @ud) ames-rift=(unit @ud)]
+    =-  ?>  ?=([%known *] -)
+        [ames-life=`life ames-rift=`rift]:->
+    ?:  ?=(%ames core)
+      .^  =ship-state:ames
         %ax  /(scot %p p.bec)//(scot %da now)/peers/(scot %p ship)
+      ==
+    .^  =chum-state:ames
+      %ax  /(scot %p p.bec)//(scot %da now)/chums/(scot %p ship)
     ==
-?>  ?=([%known *] ship-state)
+
 ::  for each peer scry into %jael and %ames
 ::
 =/  our  (scot %p p.bec)
@@ -41,7 +53,7 @@
 =+  life=.^((unit @ud) %j /[our]/lyfe/[now]/[her])
 =+  rift=.^((unit @ud) %j /[our]/ryft/[now]/[her])
 =+  jael=[jael-life=life jael-rift=rift]
-=+  ames=[ames-life=`life ames-rift=`rift]:+.ship-state
+=+  ames=[ames-life=ames-life ames-rift=ames-rift]
 %_    $
     peers  t.peers
     out

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11098,6 +11098,12 @@
               ::
               sy-core
             ?.  ?=([?(%ames %mesa) ~ %known *] peer)
+              ::  XX if this is the first time we contact this ship, the
+              ::  %keys diff should be the first to be given to %ames, then
+              ::  %rift, then %spon. a different order would end up with the
+              ::  .rift.peer beeing dropped by the bunt in the point we pass
+              ::  to on-publ-full
+              ::
               =|  =point:jael
               =.  life.point     life
               =.  keys.point     (my [life crypto-suite pass]~)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2620,6 +2620,7 @@
             [%30 axle-30]
             [%31 axle]
             [%32 axle]
+            [%33 axle]
         ==
     ::
     ::
@@ -2694,7 +2695,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%32 larva/ames-state]
+    ++  stay  [%33 larva/ames-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2870,6 +2871,10 @@
               $:  %32                            :: use %ames as default core.
                   ?(%adult %larva)               :: migrate attestation flows
                   state=axle                     :: clean up corked peeks
+              ==
+              $:  %33                            :: fix broken rifts
+                  ?(%adult %larva)               ::
+                  state=axle
           ==  ==
       |^  ?-  old
           [%4 %adult *]
@@ -3175,10 +3180,16 @@
         larval-gate
       ::
           [%32 *]
+        =.  cached-state  `[%32 state.old]
+        ~>  %slog.1^leaf/"ames: larva %32 reload"
+        larval-gate
+      ::
+          [%33 *]
         ?-  +<.old
           %larva  larval-gate
           %adult  (load:adult-core state.old)
         ==
+      ::
       ==
       ::
       ++  event-9-til-11-to-12
@@ -3253,7 +3264,7 @@
       |^  ^+  [moz larval-core]
       ?~  cached-state  [~ larval-core]
       =*  old  u.cached-state
-      ?:  ?=(%32 -.old)
+      ?:  ?=(%33 -.old)
         ::  no state migrations left; update state, clear cache, and exit
         ::
         [(flop moz) larval-core(ames-state.adult-gate +.old, cached-state ~)]
@@ -3354,8 +3365,10 @@
         $(cached-state `30+(state-29-to-30 +.old))
       ?:  ?=(%30 -.old)
         $(cached-state `31+(state-30-to-31 +.old))
-      ?>  ?=(%31 -.old)
-      $(cached-state `32+(state-31-to-32 +.old))
+      ?:  ?=(%31 -.old)
+        $(cached-state `32+(state-31-to-32 +.old))
+      ?>  ?=(%32 -.old)
+      $(cached-state `33+(state-32-to-33 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
       ++  state-4-to-5
@@ -4024,6 +4037,61 @@
             ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
               tip
             (~(del by tip) user-path)
+          ==
+        ==
+      ::
+      ++  state-32-to-33
+        |=  old=axle
+        ^-  axle
+        ~>  %slog.0^leaf/"ames: migrating from state %32 to %33"
+        ::  first pass to fix rifts in .chums
+        ::
+        =.  chums.old
+          ^-  (map ship chum-state)
+          %-  ~(urn by chums.old)
+          |=  [=ship c=chum-state]
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          %_    c
+              rift
+            =;  rift=@ud
+              =+  ?:  =(rift rift.c)  ~
+                  %.  ~
+                  %:  trace   %mesa   odd.veb.bug.old   ship
+                      ships.bug.ames-state
+                      |.("fixing rift from {<rift.c>} to {<rift>}")
+                  ==
+              rift
+            ?:  ?=(%pawn (clan:title ship))  0
+            ;;  @ud
+            =<  q.q  %-  need  %-  need
+            (rof [~ ~] /ames %j `beam`[[our %rift %da now] /(scot %p ship)])
+          ==
+        ::  last pass to fix rifts in .peers
+        ::
+        %=    old
+            peers
+          ^-  (map ship ship-state)
+          %-  ~(urn by peers.old)
+          |=  [=ship s=ship-state]
+          ^-  ship-state
+          ?:  ?=(%alien -.s)  s
+          ^-  ship-state
+          %_    s
+              rift
+            =;  rift=@ud
+              =+  ?:  =(rift rift.s)  ~
+                  %.  ~
+                  %:  trace   %ames   odd.veb.bug.old   ship
+                      ships.bug.ames-state
+                      |.("fixing rift from {<rift.s>} to {<rift>}")
+                  ==
+              rift
+            ?:  ?=(%pawn (clan:title ship))  0
+            ;;  @ud
+            =<  q.q  %-  need  %-  need
+            (rof [~ ~] /ames %j `beam`[[our %rift %da now] /(scot %p ship)])
           ==
         ==
       ::
@@ -13788,7 +13856,7 @@
   take:am-core
 ::  +stay: extract state before reload
 ::
-++  stay  [%32 adult/ames-state]
+++  stay  [%33 adult/ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load


### PR DESCRIPTION
Four years ago, when L2 was launched, a subtle bug was introduced in /app/azimuth that would give %diffs (a ship sponsor, it's rift and keys) to %jael in a pathological order that in certain circumstances would case the rift stored in %ames to be bunted.

%ames did not use rifts so this problem was never apparent. only %fine would use them in the path used for peeking, but if this timedout, we would fallback to %ames so communication would always be restored.

If a peer never breached, its rift is 0 anyway, so nothing would happen. 
If we contacted the ship after the azimuth snapshot was loaded,. on initial subscription we would get a %full gift from %jael, instead of individual %diffs. With the pathological order, and contacting the peer before %jael has any state, would just give a %full with no point information in it, and %ames would just drop that gift. When the snapshot gets loaded into %jael, diffs would be given (turning the first of those into a %full), and we need to guarantee that the first of those is the %keys diff.

Besides adding a state migration to scry for the correct rift (XX pass a %public-keys task to %jael instead), /app/azimuth will now give the %keys %diff first, that turns into a %full gift from %jael. When the keys for this ship exist in %ames, the %spon and %rift diffs won't be dropped (as is the case now when they are first given)

This problem will become evident if we migrate to %mesa since rifts are actively checked in every path. If you have the wrong rift about a peer, they will drop all your packets, and you will as well, losing any communication.

(I've added a generator to test this in some of my ships and have also found some ships where there is also a missmatch between ames and jael. It can be installed, without applying this PR, which will fix the problem by doing:)

```hoon
|install ~dister-norsyr-torryn %diagnose
+diagnose!keys, =miss %.y, =core %mesa
+diagnose!keys, =miss %.y, =core %ames
```