### PR TITLE
eyre: use old encoding for eauth scry

### DIFF
--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1927,7 +1927,7 @@
           ::
           =/  =wire       /eauth/keen/(scot %p ship)/(scot %uv nonce)
           =.   time       (sub time (mod time eauth-cache-rounding))
-          =/  =spar:ames  [ship /e/x/(scot %da time)//eauth/url]
+          =/  =spar:ames  [ship /e/x/(scot:h136 %da time)//eauth/url]
           [duct %pass wire %a ?-(kind %keen keen+[~ spar], %yawn yawn+spar)]
         ::
         ++  send-boon

--- a/tests/sys/vane/eyre.hoon
+++ b/tests/sys/vane/eyre.hoon
@@ -1550,13 +1550,13 @@
       %+  ex  ~[/http-blah]
       ::TODO  want to access eauth-cache-rounding:eyre-gate here but can't..?
       =.  time  (sub time (mod time ~m5))
-      [%pass wire %a %keen ~ ~sampel /e/x/(scot %da time)//eauth/url]
+      [%pass wire %a %keen ~ ~sampel /e/x/(scot:h136 %da time)//eauth/url]
     ::
     ++  ex-yawn
       |=  =time
       %+  ex  ~[/http-blah]
       =.  time  (sub time (mod time ~h1))
-      [%pass wire %a %yawn ~sampel /e/x/(scot %da time)//eauth/url]
+      [%pass wire %a %yawn ~sampel /e/x/(scot:h136 %da time)//eauth/url]
     ::
     ++  ex-done
       (ex ~[/http-blah] %give %done ~)


### PR DESCRIPTION
Change in `@da` encoding broke eauth flow between 408 and 409 ships: a 408 ship would scry with leading zeros in the date segment of the path, and the receiving 409 ship would fail parsing that.

This PR uses `+scot:h136` encoder to enable backwards compatibility.