### PR TITLE
arvo: two's-complement integer library (lib/twoc)

### DIFF
--- a/pkg/arvo/lib/twoc.hoon
+++ b/pkg/arvo/lib/twoc.hoon
@@ -1,0 +1,134 @@
+|%
+::  Two's-complement signed integers, MODULAR (operations wrap mod 2^width
+::  rather than crashing on overflow -- a deliberate divergence from a
+::  checked-overflow type, matching hardware two's-complement and Lagoon's
+::  %uint wrapping).  Two doors share one implementation:
+::
+::  - +twid: keyed on a raw bit-WIDTH (any @), for callers like /lib/fixed
+::    whose widths are not powers of two (N = a + b + 1).
+::  - +twoc: keyed on a `bloq` (width = 2^bloq), for callers like /lib/unum
+::    and Lagoon that work in bloq-sized lanes.  It delegates to +twid at
+::    width (bex bloq), so the logic is defined once in +twid.
+::
+++  twid
+  |_  wid=@
+  ::  +len: bit width.  +len-mod: the modulus 2^width.
+  ++  len  wid
+  ++  len-mod  (bex wid)
+  ::  +msb: the sign bit (1 if the width-1 bit is set).
+  ++  msb
+    |=  a=@
+    ?:  (^lth (xeb a) len)
+      0
+    1
+  ++  ones  (dec len)
+  ::  +s-to-twoc: hoon signed integer (@s) -> width-bit two's-complement.
+  ::  Wraps modularly for out-of-range inputs.
+  ::    > (~(s-to-twoc twid 8) -14)
+  ::      242
+  ++  s-to-twoc
+    |=  a=@s
+    ^-  @
+    =+  [sn mg]=(old:si a)
+    ?:  sn  (mod mg len-mod)
+    (neg mg)
+  ::  +twoc-to-s: width-bit two's-complement -> hoon signed integer (@s).
+  ++  twoc-to-s
+    |=  a=@
+    ^-  @s
+    ?:  =(1 (msb a))  (new:si | (abs a))
+    (new:si & (mod a len-mod))
+  ::
+  ::  Arithmetic.  Because the low `len` bits of a sum/product are independent
+  ::  of sign, the same bit-level add and multiply serve signed and unsigned.
+  ::
+  ++  add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
+  ::  +neg: two's-complement negation, ~a + 1 (flip the len bits, add one).
+  ::  neg(min) = min (wraps).
+  ++  neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
+  ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
+  ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
+  ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
+  ++  abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))
+  ::  +overflow: would a + b overflow a CHECKED signed add?  Retained for
+  ::  callers that want to detect rather than wrap; +add no longer uses it.
+  ++  overflow
+    |=  [a=@ b=@ c=@]
+    ?|  &(=(0 (msb c)) =(1 (msb a)) =(1 (msb b)))
+        &(=(1 (msb c)) =(0 (msb a)) =(0 (msb b)))
+    ==
+  ::  +div: signed division, truncating toward zero (C / Hoon `div` style).
+  ::  Division by zero crashes (as `div` does).  div(min, -1) wraps to min.
+  ++  div
+    |=  [a=@ b=@]
+    ^-  @
+    =/  sa  (msb a)
+    =/  sb  (msb b)
+    =/  q   (^div (abs a) (abs b))
+    ?:  =(sa sb)  (mod q len-mod)
+    (neg q)
+  ::  +rem: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
+  ::  a == (add (mul (div a b) b) (rem a b)).
+  ++  rem
+    |=  [a=@ b=@]
+    ^-  @
+    =/  r  (mod (abs a) (abs b))
+    ?:  =(0 (msb a))  (mod r len-mod)
+    (neg r)
+  ::  +pow: a to a NON-NEGATIVE integer power n (raw @), by modular squaring.
+  ++  pow
+    |=  [a=@ n=@]
+    ^-  @
+    =/  base  (mod a len-mod)
+    =/  acc   (mod 1 len-mod)
+    |-  ^-  @
+    ?:  =(0 n)  acc
+    =?  acc  =(1 (dis n 1))  (mul acc base)
+    $(n (rsh 0 n), base (mul base base))
+  ::  +extend: sign-extension fill (all-ones if negative, else zero).
+  ++  extend
+    |=  a=@
+    ^-  @
+    ?:  =((msb a) 0)
+      0
+    (dec (bex len))
+  ::  Comparisons, by two's-complement order (negatives below non-negatives).
+  ++  gth
+    |=  [a=@ b=@]
+    ?:  =(1 (mix (msb a) (msb b)))
+      =(0 (msb a))
+    (^gth a b)
+  ++  lth  |=([a=@ b=@] (gth b a))
+  ++  lte  |=([a=@ b=@] !(gth a b))
+  ++  gte  |=([a=@ b=@] !(gth b a))
+  --
+::
+::  +twoc: bloq-keyed facade over +twid (width = 2^bloq).  Logic lives in
+::  +twid; these arms just re-export it at the delegated width, so existing
+::  callers `~(add twoc:twoc bloq)` keep working unchanged.
+::
+++  twoc
+  |_  =bloq
+  +*  w  ~(. twid (bex bloq))
+  ++  len        len:w
+  ++  len-mod    len-mod:w
+  ++  msb        msb:w
+  ++  ones       ones:w
+  ++  s-to-twoc  s-to-twoc:w
+  ++  twoc-to-s  twoc-to-s:w
+  ++  add        add:w
+  ++  neg        neg:w
+  ++  sub        sub:w
+  ++  mul        mul:w
+  ++  abs        abs:w
+  ++  overflow   overflow:w
+  ++  div        div:w
+  ++  rem        rem:w
+  ++  pow        pow:w
+  ++  extend     extend:w
+  ++  gth        gth:w
+  ++  lth        lth:w
+  ++  lte        lte:w
+  ++  gte        gte:w
+  --
+--

--- a/pkg/arvo/lib/twoc.hoon
+++ b/pkg/arvo/lib/twoc.hoon
@@ -47,6 +47,7 @@
   ::  neg(min) = min (wraps).
   ++  neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
   ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
+  ::  low-order bits of a product are sign-independent, so modular unsigned mul is also correct signed mul
   ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
   ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
   ++  abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))

--- a/tests/lib/twoc.hoon
+++ b/tests/lib/twoc.hoon
@@ -1,0 +1,142 @@
+  ::  /tests/lib/twoc
+::::
+::    Two's-complement integer arithmetic (modular).  The bulk of the
+::    arithmetic is checked at int8 (bloq 3) through the +twoc facade; the
+::    wrap boundaries are re-checked at int16/32/64.  The width-keyed +twid
+::    door is exercised directly at a non-power-of-2 width (17) -- the case
+::    /lib/fixed needs -- plus a facade/width parity check.
+::
+/+  *test,
+    twoc
+^|
+=/  t  ~(. twoc:twoc 3)            :: int8 (facade)
+=/  t16  ~(. twoc:twoc 4)          :: int16
+=/  t32  ~(. twoc:twoc 5)          :: int32
+=/  t64  ~(. twoc:twoc 6)          :: int64
+=/  w17  ~(. twid:twoc 17)         :: width-17 (q8.8 fixed N)
+=/  w8   ~(. twid:twoc 8)          :: width-8, should match the bloq-3 facade
+|%
+++  test-add  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x96)  !>((add:t 0x64 0x32))   ::  100+50 wraps -> -106
+    %+  expect-eq  !>(`@`0x0)   !>((add:t 0xff 0x1))    ::  -1+1=0
+    %+  expect-eq  !>(`@`0x7)   !>((add:t 0x5 0x2))     ::  5+2=7
+  ==
+::
+++  test-neg-sub  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xff)  !>((neg:t 0x1))         ::  -1
+    %+  expect-eq  !>(`@`0x80)  !>((neg:t 0x80))        ::  min negates to self
+    %+  expect-eq  !>(`@`0xfb)  !>((sub:t 0x5 0xa))     ::  5-10=-5
+    %+  expect-eq  !>(`@`0x0)   !>((sub:t 0x7 0x7))
+    %+  expect-eq  !>(`@`0x0)   !>((neg:t 0x0))         ::  -0=0
+  ==
+::
+++  test-mul  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1)   !>((mul:t 0xff 0xff))   ::  -1*-1=1
+    %+  expect-eq  !>(`@`0x0)   !>((mul:t 0x10 0x10))   ::  16*16=256 wraps 0
+    %+  expect-eq  !>(`@`0xf6)  !>((mul:t 0xfb 0x2))    ::  -5*2=-10
+  ==
+::
+++  test-abs  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x5)   !>((abs:t 0xfb))        ::  |-5|=5
+    %+  expect-eq  !>(`@`0x5)   !>((abs:t 0x5))
+    %+  expect-eq  !>(`@`0x80)  !>((abs:t 0x80))        ::  |min| wraps to min
+  ==
+::
+++  test-div-rem  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xfd)  !>((div:t 0xf9 0x2))    ::  -7/2 trunc=-3
+    %+  expect-eq  !>(`@`0xfd)  !>((div:t 0x7 0xfe))    ::  7/-2 trunc=-3
+    %+  expect-eq  !>(`@`0x3)   !>((div:t 0xf9 0xfe))   ::  -7/-2=3
+    %+  expect-eq  !>(`@`0xff)  !>((rem:t 0xf9 0x2))    ::  -7%2=-1
+    %+  expect-eq  !>(`@`0x1)   !>((rem:t 0x7 0xfe))    ::  7%-2=1
+  ==
+::
+++  test-pow  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xf8)  !>((pow:t 0xfe 3))      ::  -2^3=-8
+    %+  expect-eq  !>(`@`0x51)  !>((pow:t 0x3 4))       ::  3^4=81
+    %+  expect-eq  !>(`@`0x1)   !>((pow:t 0x5 0))       ::  x^0=1
+  ==
+::
+++  test-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(%.n)  !>((gth:t 0xff 0x1))        ::  -1 > 1 ? no
+    %+  expect-eq  !>(%.y)  !>((lth:t 0xff 0x1))        ::  -1 < 1 ? yes
+    %+  expect-eq  !>(%.y)  !>((gth:t 0x1 0xff))        ::  1 > -1 ? yes
+    %+  expect-eq  !>(%.y)  !>((lte:t 0x5 0x5))         ::  5 <= 5
+    %+  expect-eq  !>(%.y)  !>((gte:t 0x5 0x5))         ::  5 >= 5
+    %+  expect-eq  !>(%.n)  !>((lth:t 0x5 0x5))         ::  5 < 5 ? no
+  ==
+::
+::  round-trip identity for the division algorithm: a == div*b + rem
+++  test-div-identity  ^-  tang
+  =/  pairs=(list [@ @])  ~[[0xf9 0x2] [0x7 0xfe] [0xf9 0xfe] [0x64 0x7] [0x9c 0x5]]
+  %+  roll  pairs
+  |=  [[a=@ b=@] acc=tang]
+  =/  recon  (add:t (mul:t (div:t a b) b) (rem:t a b))
+  %+  weld  acc
+  (expect-eq !>(a) !>(recon))
+::
+::  int16 (bloq 4): wrap boundary at 0x7fff/0x8000, neg, signed mul/cmp
+++  test-int16  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x7d0)   !>((add:t16 0x3e8 0x3e8))    ::  1000+1000=2000
+    %+  expect-eq  !>(`@`0x8000)  !>((add:t16 0x7fff 0x1))     ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff)  !>((neg:t16 0x1))            ::  -1
+    %+  expect-eq  !>(`@`0x8000)  !>((neg:t16 0x8000))         ::  min self
+    %+  expect-eq  !>(`@`0xfffe)  !>((mul:t16 0xffff 0x2))     ::  -1*2=-2
+    %+  expect-eq  !>(`@`0x1)     !>((mul:t16 0xffff 0xffff))  ::  -1*-1=1
+    %+  expect-eq  !>(%.y)        !>((lth:t16 0xffff 0x1))     ::  -1 < 1
+    %+  expect-eq  !>(`@`0x5)     !>((abs:t16 0xfffb))         ::  |-5|=5
+  ==
+::
+::  int32 (bloq 5): same boundary structure at 32 bits
+++  test-int32  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x8000.0000)  !>((add:t32 0x7fff.ffff 0x1))     ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff.ffff)  !>((neg:t32 0x1))                 ::  -1
+    %+  expect-eq  !>(`@`0x1)          !>((mul:t32 0xffff.ffff 0xffff.ffff))  ::  -1*-1=1
+    %+  expect-eq  !>(`@`0xffff.fffe)  !>((mul:t32 0xffff.ffff 0x2))     ::  -1*2=-2
+    %+  expect-eq  !>(%.y)             !>((gth:t32 0x1 0xffff.ffff))     ::  1 > -1
+  ==
+::
+::  int64 (bloq 6): boundary structure at 64 bits
+++  test-int64  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x8000.0000.0000.0000)  !>((add:t64 0x7fff.ffff.ffff.ffff 0x1))  ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff.ffff.ffff.ffff)  !>((neg:t64 0x1))                         ::  -1
+    %+  expect-eq  !>(`@`0x1)                    !>((mul:t64 0xffff.ffff.ffff.ffff 0xffff.ffff.ffff.ffff))  ::  -1*-1=1
+    %+  expect-eq  !>(`@`0xffff.ffff.ffff.fffe)  !>((mul:t64 0xffff.ffff.ffff.ffff 0x2))   ::  -1*2=-2
+    %+  expect-eq  !>(%.y)                       !>((lth:t64 0xffff.ffff.ffff.ffff 0x1))   ::  -1 < 1
+  ==
+::
+::  +twid at a non-power-of-2 width (17): the case /lib/fixed needs.
+::  Sign bit is bit 16 (0x1.0000); max positive is 0xffff, min is 0x1.0000.
+++  test-twid17  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ffff)  !>((neg:w17 0x1))             ::  -1
+    %+  expect-eq  !>(`@`0x1.0000)  !>((add:w17 0xffff 0x1))      ::  maxpos+1 -> min (wrap)
+    %+  expect-eq  !>(`@`0x1.fffa)  !>((mul:w17 (neg:w17 0x3) 0x2))  ::  -3*2=-6
+    %+  expect-eq  !>(`@`0x6)       !>((mul:w17 (neg:w17 0x3) (neg:w17 0x2)))  ::  -3*-2=6
+    %+  expect-eq  !>(%.y)          !>((lth:w17 0x1.ffff 0x1))    ::  -1 < 1
+    %+  expect-eq  !>(`@`0x5)       !>((abs:w17 0x1.fffb))        ::  |-5|=5
+    %+  expect-eq  !>(`@`0x5)       !>((s-to-twoc:w17 --5))       ::  +5
+    %+  expect-eq  !>(`@`0x1.fffb)  !>((s-to-twoc:w17 -5))        ::  -5
+    %+  expect-eq  !>(`@s`-5)       !>((twoc-to-s:w17 0x1.fffb))  ::  round trip back
+    %+  expect-eq  !>(`@s`--5)      !>((twoc-to-s:w17 0x5))
+  ==
+::
+::  facade/width parity: +twoc at bloq 3 must equal +twid at width 8.
+++  test-facade-parity  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>((add:t 0x64 0x32))   !>((add:w8 0x64 0x32))
+    %+  expect-eq  !>((mul:t 0xfb 0x2))    !>((mul:w8 0xfb 0x2))
+    %+  expect-eq  !>((div:t 0xf9 0x2))    !>((div:w8 0xf9 0x2))
+    %+  expect-eq  !>((neg:t 0x1))         !>((neg:w8 0x1))
+    %+  expect-eq  !>((rem:t 0xf9 0x2))    !>((rem:w8 0xf9 0x2))
+  ==
+--


### PR DESCRIPTION
Adds `lib/twoc.hoon` — two's-complement signed-integer helpers (sign, negate,
comparison, width-aware ops). Pure Hoon, **no dependencies**. It is the shared
base for the posit (`lib/unum`) and fixed-point (`lib/fixed`) libraries, which
follow in their own PRs.

`tests/lib/twoc.hoon` included. Verified: arvo compiles and `-test
%/tests/lib/twoc` is green on a fresh %zuse-408 ship.

First of the numerics-library upstreaming series (twoc → unum → fixed → complex),
companion to the math.hoon work (urbit/urbit #7372, urbit/vere #1044/#1045).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Refreshed to numerics `main` (2026-09-21)

Commit `52a5cd7780` mirrors numerics `main`'s `lib/twoc.hoon` byte-for-byte. The change is **jet hints only** (urbit/numerics `0955657`): `~%  %non  ..part` on the library, `~/  %twid` on the door, and `~/` on `add`/`neg`/`sub`/`mul`/`abs`/`div`/`rem`/`pow`/`gth`/`lth`/`lte`/`gte`. No arm's behavior changes, and the hints are inert without registered jets — the same way #7372 and #7374 ship theirs. `tests/lib/twoc.hoon` was already identical, and the audit-fix commit is preserved.

**Re-verified** on a fresh fakezod (hoon-135/zuse-408) with the dependents built on this `twoc`: `twoc` 13, `unum` (#7374) 55, `fixed` (#7375) 13 — all green.
