### PR TITLE
arvo: posit number library (lib/unum)

### DIFF
--- a/pkg/arvo/lib/unum.hoon
+++ b/pkg/arvo/lib/unum.hoon
@@ -1,0 +1,575 @@
+/+  twoc   :: two's-complement helpers (sign, comparison) shared with numerics
+  ::
+::::  Universal numbers (unums), Type III: posits, quires, valids
+::
+::  Per the 2022 Posit Standard (Posit Working Group, John Gustafson chair):
+::  https://posithub.org/docs/posit_standard-2.pdf
+::
+::  We represent unums using Hoon auras at four bitwidths:
+::  - @rpb @rph @rps @rpd @rpq  :: posits  (byte/half/single/double/quad)
+::  - @rqb @rqh @rqs            :: quires
+::  - @rvb @rvh @rvs            :: valids  (not yet implemented)
+::
+::  STANDARD, NOT LEGACY.  The 2022 standard fixes the exponent size at
+::  es = 2 for every width (the exponent field is a 2-bit unsigned integer,
+::  0..3), so useed = 2^2^es = 16.  This differs from the 2017 draft (and
+::  SoftPosit's fast p8/p16 types) which scaled es with width.  Only posit32
+::  coincides between the two.  We target the standard.
+::
+::  A posit of precision n has, most-significant first:
+::  - sign     S  (1 bit)              s in {0,1}; implicit value 1-3s
+::  - regime   R  (k+1 bits)           run of R0 bits, terminated by ~R0;
+::                                     r = -k if R0=0, else r = k-1
+::  - exponent E  (2 bits, truncable)  e in {0,1,2,3}
+::  - fraction F  (rest, truncable)    f = F / 2^m, 0 <= f < 1
+::
+::  value:  p = ((1-3s) + f) * 2^((1-2s)*(4r + e + s))
+::
+::  Exceptions: all bits but S zero -> S=0 is posit 0, S=1 is NaR.
+::
+::  NB: this core defines posit add/sub/mul/div, which shadow the stdlib
+::  gates of the same name.  Internal integer arithmetic therefore uses the
+::  ^-prefixed forms (^add/^sub/^mul/^div) to reach the standard library.
+::
+|%
+::  G-layer (decoded) representation of a posit, mirroring the stdlib float +$fn
+::  (`[%f s=? e=@s a=@u]`):  value = (sign) a * 2^e, with a an integer
+::  significand (the hidden 1 included) and e a signed binary exponent.
+::
+::  s=%.y is non-negative (the +$si convention), so value is
+::  ?:(s +1 -1) * a * 2^e.
+::
++$  up
+  $%  [%p s=? e=@s a=@u]   :: real posit
+      [%z ~]              :: zero
+      [%n ~]              :: Not a Real (NaR)
+  ==
+::  Type III Unum Quire: a fixed-point exact accumulator of 16n bits (§3.4):
+::  sign (1) . carry guard (31) . integer (8n-16) . fraction (8n-16).
+::
++$  uq
+  $%  $:  %q
+          s=?      :: sign
+          c=@      :: carry guard, 31 bits
+          i=@      :: integer part, 8n-16 bits
+          f=@      :: fractional part, 8n-16 bits
+      ==
+      [%n ~]       :: NaR
+  ==
+::  Generic posit core, parameterized by bloq (log2 of the bitwidth).
+::
+::  Specialize with %*: posit8 is bloq=3 (n=8), posit16 bloq=4, posit32 bloq=5.
+::
+++  pp
+  |_  =bloq
+  ++  n  (bex bloq)
+  ++  es  2
+  ++  useed  16
+  ++  msk  (dec (bex n))
+  ++  zero    `@`0
+  ++  nar     (bex (dec n))
+  ++  maxpos  (dec (bex (dec n)))
+  ++  minpos  `@`1
+  ++  huge  maxpos
+  ++  tiny  minpos
+  ++  one  (bit [%p %.y --0 1])
+  ::  Mathematical constants (Q2.52 fixed-point hex of the value, rounded by
+  ::  +bit at each width).  Cross-checked vs SoftPosit (pX2) and a reference.
+  ++  pi       (bit [%p %.y -52 0x32.43f6.a888.5a31])   ::  3.14159265358979
+  ++  tau      (bit [%p %.y -52 0x64.87ed.5110.b461])   ::  6.28318530717959
+  ++  e        (bit [%p %.y -52 0x2b.7e15.1628.aed3])   ::  2.71828182845905
+  ++  phi      (bit [%p %.y -52 0x19.e377.9b97.f4a8])   ::  1.61803398874989
+  ++  sqt2     (bit [%p %.y -52 0x16.a09e.667f.3bcd])   ::  1.41421356237310
+  ++  invsqt2  (bit [%p %.y -52 0xb.504f.333f.9de6])    ::  0.70710678118655
+  ++  log2     (bit [%p %.y -52 0xb.1721.7f7d.1cf8])    ::  0.69314718055995
+  ++  invlog2  (bit [%p %.y -52 0x17.1547.652b.82fe])   ::  1.44269504088896
+  ++  log10    (bit [%p %.y -52 0x24.d763.776a.aa2b])   ::  2.30258509299405
+  ::    +sea:  @ -> $up   (decode an n-bit posit into its g-layer form)
+  ++  sea
+    |=  p=@
+    ^-  up
+    =.  p  (dis msk p)
+    ?:  =(0 p)    [%z ~]
+    ?:  =(nar p)  [%n ~]
+    =/  neg  =(1 (cut 0 [(dec n) 1] p))
+    =/  mag  ?:(neg (^sub (bex n) p) p)
+    =/  pw   (dec n)
+    =/  r0   (cut 0 [(dec pw) 1] mag)
+    =/  k=@  1
+    |-  ^-  up
+    ?:  =(k pw)
+      =/  r  ?:(=(1 r0) (sun:si (dec k)) (dif:si --0 (sun:si k)))
+      [%p !neg (pro:si r --4) 1]
+    =/  nb  (cut 0 [(^sub (dec pw) k) 1] mag)
+    ?:  =(nb r0)
+      $(k +(k))
+    =/  r       ?:(=(1 r0) (sun:si (dec k)) (dif:si --0 (sun:si k)))
+    =/  remwid  (^sub pw +(k))
+    =/  rem     (dis (dec (bex remwid)) mag)
+    =/  elo  ?:  (^gte remwid 2)
+               (rsh [0 (^sub remwid 2)] rem)
+             ?:(=(1 remwid) (^mul 2 rem) 0)
+    =/  fw    ?:((^gte remwid 2) (^sub remwid 2) 0)
+    =/  frac  (dis (dec (bex fw)) rem)
+    =/  x  (sum:si (pro:si r --4) (sun:si elo))
+    =/  a  (^add (bex fw) frac)
+    [%p !neg (dif:si x (sun:si fw)) a]
+  ::    +bit:  $up -> @   (encode, round-to-nearest-even, saturating)
+  ++  bit
+    |=  =up
+    ^-  @
+    ?:  ?=(%z -.up)  zero
+    ?:  ?=(%n -.up)  nar
+    ?>  ?=(%p -.up)
+    ?:  =(0 a.up)  zero
+    =/  neg   !s.up
+    =/  lead  (dec (met 0 a.up))
+    =/  x     (sum:si e.up (sun:si lead))
+    =/  frac  (dis (dec (bex lead)) a.up)
+    =/  rel
+      =/  ax  (abs:si x)
+      ?:  (syn:si x)
+        [(sun:si (^div ax 4)) (mod ax 4)]
+      =/  q  (^div ax 4)
+      =/  m  (mod ax 4)
+      ?:  =(0 m)
+        [(dif:si --0 (sun:si q)) 0]
+      [(dif:si --0 (sun:si +(q))) (^sub 4 m)]
+    =/  r=@s   -.rel
+    =/  elo=@  +.rel
+    ?:  (gte-s r (sun:si (^sub n 2)))    (smag neg maxpos)
+    ?:  (lte-s r (dif:si --0 (sun:si (dec n))))  (smag neg minpos)
+    =/  rmag  (abs:si r)
+    =/  rr
+      ?:  (syn:si r)
+        [(lsh [0 1] (dec (bex +(rmag)))) (^add rmag 2)]
+      [1 (^add rmag 1)]
+    =/  regval=@  -.rr
+    =/  regwid=@  +.rr
+    =/  totw  (^add (^add regwid 2) lead)
+    =/  pay   (con (lsh [0 (^add 2 lead)] regval) (con (lsh [0 lead] elo) frac))
+    =/  pw    (dec n)
+    ?:  (^lte totw pw)
+      (smag neg (lsh [0 (^sub pw totw)] pay))
+    =/  sh      (^sub totw pw)
+    =/  keep    (rsh [0 sh] pay)
+    =/  guard   (cut 0 [(dec sh) 1] pay)
+    =/  sticky  ?:(=(0 (dis (dec (bex (dec sh))) pay)) 0 1)
+    =/  lsbit   (dis 1 keep)
+    =/  roundup  &(=(1 guard) |(=(1 sticky) =(1 lsbit)))
+    =/  mag      ?:(roundup +(keep) keep)
+    =?  mag  (^gth mag maxpos)  maxpos
+    (smag neg mag)
+  ++  smag
+    |=  [neg=? mag=@]
+    ^-  @
+    ?.  neg  mag
+    (dis msk (^sub (bex n) mag))
+  ++  gte-s  |=([a=@s b=@s] ^-(? !=(-1 (cmp:si a b))))
+  ++  lte-s  |=([a=@s b=@s] ^-(? !=(--1 (cmp:si a b))))
+  ::  Comparisons (= two's-complement integer ordering of the raw bits, sec 5.3).
+  ++  gth  |=([a=@ b=@] ^-(? (~(gth twoc:twoc bloq) a b)))
+  ++  lth  |=([a=@ b=@] ^-(? (~(lth twoc:twoc bloq) a b)))
+  ++  gte  |=([a=@ b=@] ^-(? (~(gte twoc:twoc bloq) a b)))
+  ++  lte  |=([a=@ b=@] ^-(? (~(lte twoc:twoc bloq) a b)))
+  ++  equ  |=([a=@ b=@] ^-(? =(a b)))
+  ++  neq  |=([a=@ b=@] ^-(? !=(a b)))
+  ++  neg  |=(a=@ ^-(@ (dis msk (^sub (bex n) a))))
+  ++  abs  |=(a=@ ^-(@ ?:(=(1 (~(msb twoc:twoc bloq) a)) (neg a) a)))
+  ++  sgn
+    |=  a=@
+    ^-  @
+    ?:  =(zero a)  zero
+    ?:  =(nar a)   nar
+    ?:  =(1 (~(msb twoc:twoc bloq) a))  (neg one)
+    one
+  ::  Arithmetic (sec 5.4); exact g-layer combine, single round via +bit.
+  ++  mul
+    |=  [a=@ b=@]
+    ^-  @
+    =/  ua  (sea a)
+    =/  ub  (sea b)
+    ?:  |(?=(%n -.ua) ?=(%n -.ub))  nar
+    ?:  |(?=(%z -.ua) ?=(%z -.ub))  zero
+    ?>  ?=(%p -.ua)
+    ?>  ?=(%p -.ub)
+    (bit [%p =(s.ua s.ub) (sum:si e.ua e.ub) (^mul a.ua a.ub)])
+  ++  add
+    |=  [a=@ b=@]
+    ^-  @
+    =/  ua  (sea a)
+    =/  ub  (sea b)
+    ?:  |(?=(%n -.ua) ?=(%n -.ub))  nar
+    ?:  ?=(%z -.ua)  b
+    ?:  ?=(%z -.ub)  a
+    ?>  ?=(%p -.ua)
+    ?>  ?=(%p -.ub)
+    =/  emin  ?:(=(-1 (cmp:si e.ua e.ub)) e.ua e.ub)
+    =/  s1  (lsh [0 (abs:si (dif:si e.ua emin))] a.ua)
+    =/  s2  (lsh [0 (abs:si (dif:si e.ub emin))] a.ub)
+    ?:  =(s.ua s.ub)
+      (bit [%p s.ua emin (^add s1 s2)])
+    ?:  (^gth s1 s2)
+      (bit [%p s.ua emin (^sub s1 s2)])
+    ?:  (^gth s2 s1)
+      (bit [%p s.ub emin (^sub s2 s1)])
+    zero
+  ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
+  ++  div
+    |=  [a=@ b=@]
+    ^-  @
+    =/  ua  (sea a)
+    =/  ub  (sea b)
+    ?:  |(?=(%n -.ua) ?=(%n -.ub))  nar
+    ?:  ?=(%z -.ub)  nar
+    ?:  ?=(%z -.ua)  zero
+    ?>  ?=(%p -.ua)
+    ?>  ?=(%p -.ub)
+    =/  g    (^add n n)
+    =/  num  (lsh [0 g] a.ua)
+    =/  q    (^div num a.ub)
+    =/  qs   ?:(=(0 (mod num a.ub)) q (con q 1))
+    =/  eo   (dif:si (dif:si e.ua e.ub) (sun:si g))
+    (bit [%p =(s.ua s.ub) eo qs])
+  ::  Elementary and rounding ops.
+  ++  isqt
+    |=  x=@
+    ^-  @
+    ?:  =(0 x)  0
+    =/  r  (bex (^div (^add (met 0 x) 1) 2))
+    |-  ^-  @
+    =/  nr  (^div (^add r (^div x r)) 2)
+    ?:  (^gte nr r)
+      |-  ^-  @
+      ?:  (^gth (^mul r r) x)  $(r (dec r))
+      r
+    $(r nr)
+  ++  sqt
+    |=  p=@
+    ^-  @
+    =/  u  (sea p)
+    ?:  ?=(%n -.u)  nar
+    ?:  ?=(%z -.u)  zero
+    ?>  ?=(%p -.u)
+    ?.  s.u  nar
+    =/  odd  =(1 (dis 1 (abs:si e.u)))
+    =/  aa   ?:(odd (lsh [0 1] a.u) a.u)
+    =/  ee   ?:(odd (dif:si e.u --1) e.u)
+    =/  g    (^add n n)
+    =/  m    (lsh [0 (^mul 2 g)] aa)
+    =/  s    (isqt m)
+    =/  sx   ?:(=(m (^mul s s)) s (con s 1))
+    (bit [%p %.y (dif:si (fra:si ee --2) (sun:si g)) sx])
+  ++  round
+    |=  mode=?(%near %down %up)
+    |=  p=@
+    ^-  @
+    =/  u  (sea p)
+    ?.  ?=(%p -.u)  p
+    ?:  (gte-s e.u --0)  p
+    =/  sh    (abs:si e.u)
+    =/  hi    (rsh [0 sh] a.u)
+    =/  rem   (dis (dec (bex sh)) a.u)
+    =/  half  (bex (dec sh))
+    =?  hi  &(?=(%near mode) |((^gth rem half) &(=(rem half) =(1 (dis 1 hi)))))
+      +(hi)
+    =?  hi  &(?=(%down mode) !s.u !=(0 rem))  +(hi)
+    =?  hi  &(?=(%up mode) s.u !=(0 rem))     +(hi)
+    ?:  =(0 hi)  zero
+    (bit [%p s.u --0 hi])
+  ++  rnd  (round %near)
+  ++  flr  (round %down)
+  ++  cel  (round %up)
+  ++  sun  |=(v=@ ^-(@ ?:(=(0 v) zero (bit [%p %.y --0 v]))))
+  ++  san
+    |=  v=@s
+    ^-  @
+    =+  [sn mg]=(old:si v)
+    ?:  =(0 mg)  zero
+    (bit [%p sn --0 mg])
+  ++  toi
+    |=  p=@
+    ^-  (unit @s)
+    =/  u  (sea p)
+    ?:  ?=(%n -.u)  ~
+    =/  r   (rnd p)
+    =/  ur  (sea r)
+    ?:  ?=(%z -.ur)  `--0
+    ?>  ?=(%p -.ur)
+    =/  sh   (abs:si e.ur)
+    =/  mag  ?:((gte-s e.ur --0) (lsh [0 sh] a.ur) (rsh [0 sh] a.ur))
+    `(new:si s.ur mag)
+  ++  fma
+    |=  [a=@ b=@ c=@]
+    ^-  @
+    =/  ua  (sea a)
+    =/  ub  (sea b)
+    =/  uc  (sea c)
+    ?:  |(?=(%n -.ua) ?=(%n -.ub) ?=(%n -.uc))  nar
+    ?:  |(?=(%z -.ua) ?=(%z -.ub))  c
+    ?>  ?=(%p -.ua)
+    ?>  ?=(%p -.ub)
+    =/  ps  =(s.ua s.ub)
+    =/  pe  (sum:si e.ua e.ub)
+    =/  pa  (^mul a.ua a.ub)
+    ?:  ?=(%z -.uc)  (bit [%p ps pe pa])
+    ?>  ?=(%p -.uc)
+    =/  emin  ?:(=(-1 (cmp:si pe e.uc)) pe e.uc)
+    =/  s1  (lsh [0 (abs:si (dif:si pe emin))] pa)
+    =/  s2  (lsh [0 (abs:si (dif:si e.uc emin))] a.uc)
+    ?:  =(ps s.uc)    (bit [%p ps emin (^add s1 s2)])
+    ?:  (^gth s1 s2)  (bit [%p ps emin (^sub s1 s2)])
+    ?:  (^gth s2 s1)  (bit [%p s.uc emin (^sub s2 s1)])
+    zero
+  ::
+  ::  Transcendental / elementary functions, in the naive, reproducible
+  ::  Taylor-series style of /lib/math: fixed term counts, posit arithmetic
+  ::  throughout (the loop counters use ^-escaped stdlib ops).  NOT correctly
+  ::  rounded and accurate only near 0 (no range reduction), matching libmath;
+  ::  the running sums could later move to the quire for exact accumulation.
+  ::
+  ::    +exp:  @ -> @   (e^x = sum x^k/k!)
+  ++  exp
+    |=  x=@
+    ^-  @
+    =/  sum   one
+    =/  term  one
+    =/  nn=@  1
+    |-
+    ?:  (^gth nn 20)  sum
+    =.  term  (mul term (div x (sun nn)))
+    =.  sum   (add sum term)
+    $(nn +(nn))
+  ::    +sin:  @ -> @   (sum (-1)^k x^(2k+1)/(2k+1)!)
+  ++  sin
+    |=  x=@
+    ^-  @
+    =/  term  x
+    =/  sum   x
+    =/  nn=@  1
+    |-
+    ?:  (^gth nn 20)  sum
+    =/  k  (^mul 2 nn)
+    =.  term  (neg (mul term (div (mul x x) (mul (sun k) (sun +(k))))))
+    =.  sum   (add sum term)
+    $(nn +(nn))
+  ::    +cos:  @ -> @   (sum (-1)^k x^2k/(2k)!)
+  ++  cos
+    |=  x=@
+    ^-  @
+    =/  term  one
+    =/  sum   one
+    =/  nn=@  1
+    |-
+    ?:  (^gth nn 20)  sum
+    =/  k  (^mul 2 nn)
+    =.  term  (neg (mul term (div (mul x x) (mul (sun (dec k)) (sun k)))))
+    =.  sum   (add sum term)
+    $(nn +(nn))
+  ::    +tan:  @ -> @
+  ++  tan  |=(x=@ ^-(@ (div (sin x) (cos x))))
+  ::    +pow-n:  @ -> @u -> @   (integer power by repeated multiplication)
+  ++  pow-n
+    |=  [x=@ p=@u]
+    ^-  @
+    ?:  =(nar x)  nar            :: NaR propagates even when p=0
+    =/  res  one
+    |-
+    ?:  =(0 p)  res
+    $(p (dec p), res (mul res x))
+  ::    +log:  @ -> @   (ln, via 2*atanh((x-1)/(x+1)))
+  ::  Domain is x > 0; x <= 0 (which includes NaR, the most-negative
+  ::  bit pattern, and posit zero) returns NaR rather than a divergent
+  ::  series result.  Like the rest of /lib/math, accurate only near 1.
+  ++  log
+    |=  x=@
+    ^-  @
+    ?:  (lte x zero)  nar
+    =/  y     (div (sub x one) (add x one))
+    =/  y2    (mul y y)
+    =/  sum   y
+    =/  term  y
+    =/  nn=@  1
+    |-
+    ?:  (^gth nn 30)  (mul (sun 2) sum)
+    =.  term  (mul term y2)
+    =/  coef  (div one (sun +((^mul 2 nn))))
+    =.  sum   (add sum (mul coef term))
+    $(nn +(nn))
+  ::    +log-2 / +log-10:  base-2 / base-10 logarithm
+  ++  log-2   |=(x=@ ^-(@ (div (log x) log2)))
+  ++  log-10  |=(x=@ ^-(@ (div (log x) log10)))
+  ::    +pow:  @ -> @ -> @   (x^y = exp(y * log x))
+  ++  pow  |=([x=@ y=@] ^-(@ (exp (mul y (log x)))))
+  ::    +factorial:  @ -> @   (x! by repeated multiplication)
+  ::  Domain x >= 0 (NaR otherwise, and NaR propagates); for integer x this is
+  ::  exact up to the precision, halting once x <= 1.  Mirrors /lib/math.
+  ++  factorial
+    |=  x=@
+    ^-  @
+    ?:  =(nar x)  nar
+    ?:  (lth x zero)  nar
+    =/  t  one
+    |-  ^-  @
+    ?:  (lte x one)  t
+    $(x (sub x one), t (mul t x))
+  ::    +cbrt:  @ -> @   (cube root, x^(1/3) = exp(log x / 3))
+  ::  Domain x > 0 (NaR for x < 0, like the rest of the exp/log-based ops);
+  ::  cbrt(0) = 0.  Mirrors /lib/math's `cbt = (pow x .0.33...)`.
+  ++  cbrt
+    |=  x=@
+    ^-  @
+    ?:  =(nar x)  nar
+    ?:  =(zero x)  zero
+    ?:  (lth x zero)  nar
+    (pow x (div one (sun 3)))
+  ::    +atan:  @ -> @   (inverse tangent, Gauss/AGM iteration)
+  ::  arctan(x) = x / ((1+x^2)^0.5 * b), with [a b] driven to the AGM of
+  ::  (1+x^2)^-0.5 and 1.  Fixed iteration count (AGM converges quadratically).
+  ::  Odd in x, so negative arguments are handled by the carried sign.
+  ++  atan
+    |=  x=@
+    ^-  @
+    ?:  =(nar x)  nar
+    =/  x2  (add one (mul x x))
+    =/  rt  (sqt x2)
+    =/  a   (div one rt)
+    =/  b   one
+    =/  nn=@  0
+    |-  ^-  @
+    ?:  (^gth nn 40)
+      (div x (mul rt b))
+    =/  ai  (mul (div one (sun 2)) (add a b))
+    =/  bi  (sqt (mul ai b))
+    $(a ai, b bi, nn +(nn))
+  ::    +asin:  @ -> @   (inverse sine)
+  ::  arcsin(x) = atan(x / sqrt(1 - x^2)) for |x| < 1; +-pi/2 at x = +-1;
+  ::  NaR outside [-1, 1].  Mirrors /lib/math.
+  ++  asin
+    |=  x=@
+    ^-  @
+    ?:  =(nar x)  nar
+    ?:  (lth (abs x) one)
+      (atan (div x (sqt (sub one (mul x x)))))
+    ?:  (equ x one)        (mul pi (div one (sun 2)))
+    ?:  (equ x (neg one))  (neg (mul pi (div one (sun 2))))
+    nar
+  ::    +acos:  @ -> @   (inverse cosine)
+  ::  arccos(x) = atan(sqrt(1 - x^2) / x) for 0 < |x| < 1 (pi/2 at 0); 0 at
+  ::  x = 1, pi at x = -1; NaR outside [-1, 1].  Mirrors /lib/math.
+  ++  acos
+    |=  x=@
+    ^-  @
+    ?:  =(nar x)  nar
+    ?:  (lth (abs x) one)
+      ?:  (equ x zero)  (mul pi (div one (sun 2)))
+      (atan (div (sqt (sub one (mul x x))) x))
+    ?:  (equ x one)        zero
+    ?:  (equ x (neg one))  pi
+    nar
+  ::    +is-close:  @ -> @ -> @ -> ?   (|a - b| <= tol)
+  ++  is-close  |=([a=@ b=@ tol=@] ^-(? (lte (abs (sub a b)) tol)))
+  ::
+  ::  Quire (sec 3.4 / 5.11): a 16n-bit fixed-point exact accumulator, held
+  ::  as a raw two's-complement atom.  Sums of products accumulate exactly and
+  ::  round only once, via +q-to-p -- the basis of the fused dot product +fdp,
+  ::  which is why posits beat floats for linear algebra.  q-NaR is the most
+  ::  negative pattern.  Verified against SoftPosit qX2 over random vectors.
+  ::
+  ++  qbits   (^mul 16 n)
+  ++  qscale  (^sub (^mul 8 n) 16)
+  ++  qmod    (bex qbits)
+  ++  q-nar   (bex (dec qbits))
+  ++  q-zero  `@`0
+  ++  p-to-q
+    |=  p=@
+    ^-  @
+    =/  u  (sea p)
+    ?:  ?=(%n -.u)  q-nar
+    ?:  ?=(%z -.u)  q-zero
+    ?>  ?=(%p -.u)
+    =/  m  (lsh [0 (abs:si (sum:si e.u (sun:si qscale)))] a.u)
+    ?:(s.u m (^sub qmod m))
+  ++  q-to-p
+    |=  q=@
+    ^-  @
+    =.  q  (dis (dec qmod) q)
+    ?:  =(q-nar q)  nar
+    =/  neg  =(1 (cut 0 [(dec qbits) 1] q))
+    =/  acc  ?:(neg (^sub qmod q) q)
+    ?:  =(0 acc)  zero
+    (bit [%p !neg (dif:si --0 (sun:si qscale)) acc])
+  ++  q-mul-add
+    |=  [q=@ a=@ b=@]
+    ^-  @
+    ?:  =(q-nar q)  q-nar
+    =/  ua  (sea a)
+    =/  ub  (sea b)
+    ?:  |(?=(%n -.ua) ?=(%n -.ub))  q-nar
+    ?:  |(?=(%z -.ua) ?=(%z -.ub))  q
+    ?>  ?=(%p -.ua)
+    ?>  ?=(%p -.ub)
+    =/  m   (lsh [0 (abs:si :(sum:si e.ua e.ub (sun:si qscale)))] (^mul a.ua a.ub))
+    =/  qc  ?:(=(s.ua s.ub) m (^sub qmod m))
+    (mod (^add q qc) qmod)
+  ++  q-mul-sub  |=([q=@ a=@ b=@] ^-(@ (q-mul-add q a (neg b))))
+  ++  q-add-p  |=([q=@ p=@] ^-(@ (q-mul-add q p one)))
+  ++  q-sub-p  |=([q=@ p=@] ^-(@ (q-mul-add q (neg p) one)))
+  ++  q-negate  |=(q=@ ^-(@ ?:(=(q-nar q) q-nar (mod (^sub qmod q) qmod))))
+  ++  q-add-q
+    |=  [x=@ y=@]
+    ^-  @
+    ?:  |(=(q-nar x) =(q-nar y))  q-nar
+    (mod (^add x y) qmod)
+  ++  q-sub-q  |=([x=@ y=@] ^-(@ (q-add-q x (q-negate y))))
+  ::    +fdp:  (list @) -> (list @) -> @  (fused dot product, single rounding)
+  ++  fdp
+    |=  [av=(list @) bv=(list @)]
+    ^-  @
+    =|  q=@
+    |-  ^-  @
+    ?~  av  (q-to-p q)
+    ?~  bv  (q-to-p q)
+    $(q (q-mul-add q i.av i.bv), av t.av, bv t.bv)
+  ::
+  ::  IEEE-754 interop (sec 6.5).  Conversion is by VALUE, so a posit of ANY
+  ::  width converts to/from a float of ANY width -- the full matrix.  Posits
+  ::  pack more accuracy per bit (posit16 ~ float32, posit32 ~ float64), so
+  ::  same-width is NOT the meaningful correspondence.  Posit zero <-> float
+  ::  +0; posit NaR <-> float NaN; float +-inf/NaN -> NaR.  +up-to-fn/+fn-to-up
+  ::  bridge the (identical) posit g-layer +$up and the stdlib float +$fn.
+  ::
+  ++  up-to-fn
+    |=  u=up
+    ^-  fn
+    ?:  ?=(%n -.u)  [%n ~]
+    ?:  ?=(%z -.u)  [%f %.y --0 0]
+    [%f s.u e.u a.u]
+  ++  fn-to-up
+    |=  f=fn
+    ^-  up
+    ?.  ?=(%f -.f)  [%n ~]                 :: NaN / +-inf -> NaR
+    ?:  =(0 a.f)  [%z ~]
+    [%p s.f e.f a.f]
+  ::    +to-rh/rs/rd/rq:  this-width posit -> half/single/double/quad float
+  ++  to-rh  |=(p=@ ^-(@rh (bit:rh (up-to-fn (sea p)))))
+  ++  to-rs  |=(p=@ ^-(@rs (bit:rs (up-to-fn (sea p)))))
+  ++  to-rd  |=(p=@ ^-(@rd (bit:rd (up-to-fn (sea p)))))
+  ++  to-rq  |=(p=@ ^-(@rq (bit:rq (up-to-fn (sea p)))))
+  ::    +from-rh/rs/rd/rq:  half/single/double/quad float -> this-width posit
+  ++  from-rh  |=(r=@rh ^-(@ (bit (fn-to-up (sea:rh r)))))
+  ++  from-rs  |=(r=@rs ^-(@ (bit (fn-to-up (sea:rs r)))))
+  ++  from-rd  |=(r=@rd ^-(@ (bit (fn-to-up (sea:rd r)))))
+  ++  from-rq  |=(r=@rq ^-(@ (bit (fn-to-up (sea:rq r)))))
+  --
+::  posit8   ("byte"),   posit<8,2>
+++  rpb  %*(. pp bloq 3)
+::  posit16  ("half"),   posit<16,2>
+++  rph  %*(. pp bloq 4)
+::  posit32  ("single"), posit<32,2>
+++  rps  %*(. pp bloq 5)
+::  posit64  ("double"), posit<64,2>
+++  rpd  %*(. pp bloq 6)
+::  posit128 ("quad"),   posit<128,2>
+++  rpq  %*(. pp bloq 7)
+--

--- a/pkg/arvo/lib/unum.hoon
+++ b/pkg/arvo/lib/unum.hoon
@@ -10,6 +10,10 @@
 ::  - @rqb @rqh @rqs            :: quires
 ::  - @rvb @rvh @rvs            :: valids  (not yet implemented)
 ::
+::  Aura note: `@rq` is the Hoon stdlib aura for IEEE 754 binary128 (quad float).
+::  `@rpq` (posit-128) is a different format that coincidentally shares the `q`
+::  suffix.  The quire auras `@rqb`/`@rqh`/`@rqs` are likewise distinct from both.
+::
 ::  STANDARD, NOT LEGACY.  The 2022 standard fixes the exponent size at
 ::  es = 2 for every width (the exponent field is a 2-bit unsigned integer,
 ::  0..3), so useed = 2^2^es = 16.  This differs from the 2017 draft (and
@@ -168,6 +172,8 @@
   ++  gte-s  |=([a=@s b=@s] ^-(? !=(-1 (cmp:si a b))))
   ++  lte-s  |=([a=@s b=@s] ^-(? !=(--1 (cmp:si a b))))
   ::  Comparisons (= two's-complement integer ordering of the raw bits, sec 5.3).
+  ::  NaR (the most-negative bit pattern, e.g. `0x80` for posit8) compares less
+  ::  than every real posit, including negative ones (2022 Posit Standard §5.3).
   ++  gth  |=([a=@ b=@] ^-(? (~(gth twoc:twoc bloq) a b)))
   ++  lth  |=([a=@ b=@] ^-(? (~(lth twoc:twoc bloq) a b)))
   ++  gte  |=([a=@ b=@] ^-(? (~(gte twoc:twoc bloq) a b)))
@@ -499,6 +505,11 @@
     =/  acc  ?:(neg (^sub qmod q) q)
     ?:  =(0 acc)  zero
     (bit [%p !neg (dif:si --0 (sun:si qscale)) acc])
+  ::    +q-mul-add:  [quire posit posit] -> quire
+  ::
+  ::  Exact fused multiply-accumulate into the quire: returns `q + a*b` in the
+  ::  quire's `16n`-bit fixed-point representation.  No rounding; rounding only
+  ::  occurs when `++q-to-p` converts back to a posit.
   ++  q-mul-add
     |=  [q=@ a=@ b=@]
     ^-  @
@@ -512,17 +523,41 @@
     =/  m   (lsh [0 (abs:si :(sum:si e.ua e.ub (sun:si qscale)))] (^mul a.ua a.ub))
     =/  qc  ?:(=(s.ua s.ub) m (^sub qmod m))
     (mod (^add q qc) qmod)
+  ::    +q-mul-sub:  [quire posit posit] -> quire
+  ::
+  ::  Exact fused multiply-subtract: returns `q - a*b`.  No rounding.
   ++  q-mul-sub  |=([q=@ a=@ b=@] ^-(@ (q-mul-add q a (neg b))))
+  ::    +q-add-p:  [quire posit] -> quire
+  ::
+  ::  Exact posit-to-quire addition: returns `q + p`.  No rounding.
   ++  q-add-p  |=([q=@ p=@] ^-(@ (q-mul-add q p one)))
+  ::    +q-sub-p:  [quire posit] -> quire
+  ::
+  ::  Exact posit-to-quire subtraction: returns `q - p`.  No rounding.
   ++  q-sub-p  |=([q=@ p=@] ^-(@ (q-mul-add q (neg p) one)))
+  ::    +q-negate:  quire -> quire
+  ::
+  ::  Exact quire negation.  No rounding.
   ++  q-negate  |=(q=@ ^-(@ ?:(=(q-nar q) q-nar (mod (^sub qmod q) qmod))))
+  ::    +q-add-q:  [quire quire] -> quire
+  ::
+  ::  Exact quire-to-quire addition.  No rounding.
   ++  q-add-q
     |=  [x=@ y=@]
     ^-  @
     ?:  |(=(q-nar x) =(q-nar y))  q-nar
     (mod (^add x y) qmod)
+  ::    +q-sub-q:  [quire quire] -> quire
+  ::
+  ::  Exact quire-to-quire subtraction.  No rounding.
   ++  q-sub-q  |=([x=@ y=@] ^-(@ (q-add-q x (q-negate y))))
   ::    +fdp:  (list @) -> (list @) -> @  (fused dot product, single rounding)
+  ::
+  ::  Accumulates av[i]*bv[i] into the quire exactly, then rounds once via
+  ::  +q-to-p.  If the two lists differ in length, iteration stops when the
+  ::  shorter list is exhausted -- the tail of the longer list is silently
+  ::  ignored.  Callers are responsible for ensuring equal-length inputs for
+  ::  a full dot product.
   ++  fdp
     |=  [av=(list @) bv=(list @)]
     ^-  @

--- a/tests/lib/unum-core.hoon
+++ b/tests/lib/unum-core.hoon
@@ -1,0 +1,144 @@
+  ::  /tests/lib/unum-core
+::::
+::    Posits (2022 Posit Standard, es=2) -- decode/encode, constants,
+::    comparison, and core arithmetic.  Split from a single oversized file so
+::    each compiles quickly (cf. the lagoon test-by-category convention).
+::
+::  Heavy exhaustive cross-checks vs SoftPosit run once, offline, in Python
+::  (libmath/tools/posit_check.py).  The on-ship suite is lean: round-trips,
+::  a property sweep, and curated SoftPosit-verified spot values.
+::
+/+  *test,
+    unum
+^|
+|%
+++  test-round-trip-rpb  ^-  tang
+  =|  i=@
+  |-  ^-  tang
+  ?:  =(256 i)  ~
+  =/  rt  (bit:rpb:unum (sea:rpb:unum i))
+  ?:  =(i rt)  $(i +(i))
+  [(cat 3 'rpb round-trip failed at ' (scot %ux i)) $(i +(i))]
+::
+++  test-round-trip-rph  ^-  tang
+  =|  i=@
+  |-  ^-  tang
+  ?:  =(65.536 i)  ~
+  =/  rt  (bit:rph:unum (sea:rph:unum i))
+  ?:  =(i rt)  $(i +(i))
+  [(cat 3 'rph round-trip failed at ' (scot %ux i)) $(i +(i))]
+::
+++  test-values-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x0)   !>(zero:rpb:unum)
+    %+  expect-eq  !>(`@`0x80)  !>(nar:rpb:unum)
+    %+  expect-eq  !>(`@`0x40)  !>(one:rpb:unum)
+    %+  expect-eq  !>(`@`0x7f)  !>(maxpos:rpb:unum)
+    %+  expect-eq  !>(`@`0x1)   !>(minpos:rpb:unum)
+  ==
+::
+++  test-consts-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4d)  !>(pi:rpb:unum)
+    %+  expect-eq  !>(`@`0x55)  !>(tau:rpb:unum)
+    %+  expect-eq  !>(`@`0x4b)  !>(e:rpb:unum)
+    %+  expect-eq  !>(`@`0x45)  !>(phi:rpb:unum)
+    %+  expect-eq  !>(`@`0x43)  !>(sqt2:rpb:unum)
+    %+  expect-eq  !>(`@`0x3b)  !>(invsqt2:rpb:unum)
+    %+  expect-eq  !>(`@`0x3b)  !>(log2:rpb:unum)
+    %+  expect-eq  !>(`@`0x44)  !>(invlog2:rpb:unum)
+    %+  expect-eq  !>(`@`0x49)  !>(log10:rpb:unum)
+  ==
+::
+++  test-consts-rph  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4c91)  !>(pi:rph:unum)
+    %+  expect-eq  !>(`@`0x5491)  !>(tau:rph:unum)
+    %+  expect-eq  !>(`@`0x4ae0)  !>(e:rph:unum)
+    %+  expect-eq  !>(`@`0x44f2)  !>(phi:rph:unum)
+    %+  expect-eq  !>(`@`0x4350)  !>(sqt2:rph:unum)
+    %+  expect-eq  !>(`@`0x3b50)  !>(invsqt2:rph:unum)
+    %+  expect-eq  !>(`@`0x3b17)  !>(log2:rph:unum)
+    %+  expect-eq  !>(`@`0x438b)  !>(invlog2:rph:unum)
+    %+  expect-eq  !>(`@`0x4936)  !>(log10:rph:unum)
+  ==
+::
+++  test-consts-rps  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4c90.fdaa)  !>(pi:rps:unum)
+    %+  expect-eq  !>(`@`0x5490.fdaa)  !>(tau:rps:unum)
+    %+  expect-eq  !>(`@`0x4adf.8546)  !>(e:rps:unum)
+    %+  expect-eq  !>(`@`0x44f1.bbce)  !>(phi:rps:unum)
+    %+  expect-eq  !>(`@`0x4350.4f33)  !>(sqt2:rps:unum)
+    %+  expect-eq  !>(`@`0x3b50.4f33)  !>(invsqt2:rps:unum)
+    %+  expect-eq  !>(`@`0x3b17.217f)  !>(log2:rps:unum)
+    %+  expect-eq  !>(`@`0x438a.a3b3)  !>(invlog2:rps:unum)
+    %+  expect-eq  !>(`@`0x4935.d8de)  !>(log10:rps:unum)
+  ==
+::
+++  test-sea-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>([%z ~])             !>((sea:rpb:unum 0x0))
+    %+  expect-eq  !>([%n ~])             !>((sea:rpb:unum 0x80))
+    %+  expect-eq  !>([%p %.y -3 8])      !>((sea:rpb:unum 0x40))
+    %+  expect-eq  !>([%p %.y -2 8])      !>((sea:rpb:unum 0x48))
+    %+  expect-eq  !>([%p %.y -3 10])     !>((sea:rpb:unum 0x42))
+  ==
+::
+++  test-bit-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x0)   !>((bit:rpb:unum [%z ~]))
+    %+  expect-eq  !>(`@`0x80)  !>((bit:rpb:unum [%n ~]))
+    %+  expect-eq  !>(`@`0x40)  !>((bit:rpb:unum [%p %.y --0 1]))
+    %+  expect-eq  !>(`@`0x48)  !>((bit:rpb:unum [%p %.y -2 8]))
+    %+  expect-eq  !>(`@`0xc0)  !>((bit:rpb:unum [%p %.n --0 1]))
+  ==
+::
+++  test-compare-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(%.y)  !>((lth:rpb:unum 0x38 0x40))
+    %+  expect-eq  !>(%.n)  !>((lth:rpb:unum 0x40 0x38))
+    %+  expect-eq  !>(%.y)  !>((gth:rpb:unum 0x40 0xc0))
+    %+  expect-eq  !>(%.y)  !>((lth:rpb:unum 0x80 0xc0))
+    %+  expect-eq  !>(%.y)  !>((equ:rpb:unum 0x80 0x80))
+    %+  expect-eq  !>(`@`0xc0)  !>((neg:rpb:unum 0x40))
+    %+  expect-eq  !>(`@`0x40)  !>((abs:rpb:unum 0xc0))
+    %+  expect-eq  !>(`@`0xc0)  !>((sgn:rpb:unum 0xa0))
+  ==
+::
+++  test-arith-spot-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x48)  !>((add:rpb:unum 0x40 0x40))
+    %+  expect-eq  !>(`@`0x40)  !>((add:rpb:unum 0x38 0x38))
+    %+  expect-eq  !>(`@`0x4c)  !>((add:rpb:unum 0x40 0x48))
+    %+  expect-eq  !>(`@`0x48)  !>((sub:rpb:unum 0x4c 0x40))
+    %+  expect-eq  !>(`@`0x54)  !>((mul:rpb:unum 0x48 0x4c))
+    %+  expect-eq  !>(`@`0x38)  !>((div:rpb:unum 0x40 0x48))
+    %+  expect-eq  !>(`@`0x80)  !>((div:rpb:unum 0x40 0x0))
+    %+  expect-eq  !>(`@`0x80)  !>((mul:rpb:unum 0x40 0x80))
+  ==
+::
+++  test-arith-spot-rph  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4c00)  !>((add:rph:unum 0x4000 0x4800))
+    %+  expect-eq  !>(`@`0x319a)  !>((mul:rph:unum 0x4c00 0x24cd))
+  ==
+::
+++  test-arith-props-rpb  ^-  tang
+  =/  mu  mul:rpb:unum
+  =/  ad  add:rpb:unum
+  =/  ng  neg:rpb:unum
+  =/  on  one:rpb:unum
+  =/  no  (ng on)
+  =|  i=@
+  |-  ^-  tang
+  ?:  =(256 i)  ~
+  =/  a  i
+  =/  b  (mod (add (mul i 181) 67) 256)
+  =/  e1=tang  ?:(=((mu a b) (mu b a)) ~ ~[(cat 3 'mul comm at ' (scot %ux i))])
+  =/  e2=tang  ?:(=((ad a b) (ad b a)) ~ ~[(cat 3 'add comm at ' (scot %ux i))])
+  =/  e3=tang  ?:(=(a (ad a 0x0)) ~ ~[(cat 3 'a+0 at ' (scot %ux i))])
+  =/  e4=tang  ?:(=(a (mu a on)) ~ ~[(cat 3 'a*1 at ' (scot %ux i))])
+  =/  e5=tang  ?:(=((ng a) (mu a no)) ~ ~[(cat 3 'a*-1 at ' (scot %ux i))])
+  :(weld e1 e2 e3 e4 e5 $(i +(i)))
+--

--- a/tests/lib/unum-edge.hoon
+++ b/tests/lib/unum-edge.hoon
@@ -1,0 +1,59 @@
+::  /tests/lib/unum-edge -- posit (%unum) transcendental edge cases.
+::
+::  Exact identities, sign, NaR propagation, domain -> NaR, and the naive-series
+::  breakdown / saturation at large arguments.  Mostly at posit32 (rps), with a
+::  posit8 (rpb) cross-width spot.  Posits round-to-nearest-even, so there is no
+::  rounding-mode variation to sweep.
+::
+/+  *test, unum
+|%
+++  u    rps:unum
+++  b    rpb:unum
+++  nar  `@`0x8000.0000
+++  s1   (sun:rps:unum 1)
+++  s4   (sun:rps:unum 4)
+++  s5   (sun:rps:unum 5)
+++  sa   (sun:rps:unum 10)
+++  sb   (sun:rps:unum 50)
+++  sc   (sun:rps:unum 100)
+++  n1   (neg:rps:unum (sun:rps:unum 1))
+::  exact identities (correctly rounded; series accurate near 0)
+++  test-exp0    (expect-eq !>(`@`0x4000.0000) !>((exp:u 0x0)))         ::  exp 0 = 1
+++  test-cos0    (expect-eq !>(`@`0x4000.0000) !>((cos:u 0x0)))         ::  cos 0 = 1
+++  test-sin0    (expect-eq !>(`@`0x0) !>((sin:u 0x0)))                 ::  sin 0 = 0
+++  test-tan0    (expect-eq !>(`@`0x0) !>((tan:u 0x0)))
+++  test-log1    (expect-eq !>(`@`0x0) !>((log:u s1)))                  ::  log 1 = 0
+++  test-sqt0    (expect-eq !>(`@`0x0) !>((sqt:u 0x0)))
+++  test-sqt1    (expect-eq !>(`@`0x4000.0000) !>((sqt:u s1)))
+++  test-sqt4    (expect-eq !>(`@`0x4800.0000) !>((sqt:u s4)))          ::  sqrt 4 = 2
+++  test-fact0   (expect-eq !>(`@`0x4000.0000) !>((factorial:u 0x0)))   ::  0! = 1
+++  test-fact5   (expect-eq !>(`@`0x6b80.0000) !>((factorial:u s5)))    ::  5! = 120
+++  test-atan0   (expect-eq !>(`@`0x0) !>((atan:u 0x0)))
+++  test-asin0   (expect-eq !>(`@`0x0) !>((asin:u 0x0)))
+++  test-acos1   (expect-eq !>(`@`0x0) !>((acos:u s1)))                 ::  acos 1 = 0
+::  sign
+++  test-exp-n1   (expect-eq !>(`@`0x33c5.ab1c) !>((exp:u n1)))         ::  1/e
+++  test-atan-n1  (expect-eq !>(`@`0xc36f.0255) !>((atan:u n1)))        ::  -pi/4 (atan is odd)
+::  NaR propagation
+++  test-exp-nar   (expect-eq !>(`@`0x8000.0000) !>((exp:u nar)))
+++  test-sin-nar   (expect-eq !>(`@`0x8000.0000) !>((sin:u nar)))
+++  test-sqt-nar   (expect-eq !>(`@`0x8000.0000) !>((sqt:u nar)))
+++  test-fact-nar  (expect-eq !>(`@`0x8000.0000) !>((factorial:u nar)))
+::  domain -> NaR
+++  test-sqt-neg  (expect-eq !>(`@`0x8000.0000) !>((sqt:u n1)))         ::  sqrt(-1) = NaR
+::  posit8 cross-width spot: identity + NaR propagation (-1 @rpb = 0xc0)
+++  test-rpb-exp0     (expect-eq !>(`@`0x40) !>((exp:b 0x0)))           ::  exp 0 = 1
+++  test-rpb-exp-nar  (expect-eq !>(`@`0x80) !>((exp:b 0x80)))
+++  test-rpb-sqt-neg  (expect-eq !>(`@`0x80) !>((sqt:b 0xc0)))          ::  sqrt(-1) = NaR
+::  KNOWN LIMITATION: the naive Taylor series diverges far from the origin.
+::  exp(10) ~ 21991 vs true 22026; exp(50)/exp(100) saturate near maxpos rather
+::  than tracking the true value; sin(10) blows up to a huge magnitude instead
+::  of staying in [-1, 1] (no range reduction).  log (atanh form) holds up
+::  better -- log(100) ~ 4.605.  Locked as regression, NOT correctness; #18's
+::  Chebyshev rewrite (range reduction) would fix these.
+++  test-exp10   (expect-eq !>(`@`0x7a57.9ded) !>((exp:u sa)))
+++  test-exp50   (expect-eq !>(`@`0x7ffe.1b02) !>((exp:u sb)))
+++  test-exp100  (expect-eq !>(`@`0x7fff.f02b) !>((exp:u sc)))
+++  test-sin10   (expect-eq !>(`@`0xc74b.a64a) !>((sin:u sa)))
+++  test-log100  (expect-eq !>(`@`0x50e9.b7f7) !>((log:u sc)))
+--

--- a/tests/lib/unum-fns.hoon
+++ b/tests/lib/unum-fns.hoon
@@ -1,0 +1,207 @@
+  ::  /tests/lib/unum-fns
+::::
+::    Posits (2022 Posit Standard, es=2) -- elementary functions, rounding,
+::    integer/IEEE conversions, the quire, and transcendentals.  Split from a
+::    single oversized file so each compiles quickly.
+::
+::  Note: the from-rh/rs/rd/rq gates are typed on the float aura, so their
+::  arguments must be cast (`@rs`0x..) -- a bare 0x.. literal is @ux and will
+::  not nest.  The to-* gates take a bare @, so their literals need no cast.
+::
+/+  *test,
+    unum
+^|
+|%
+++  test-sqt-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x48)  !>((sqt:rpb:unum 0x50))
+    %+  expect-eq  !>(`@`0x43)  !>((sqt:rpb:unum 0x48))
+    %+  expect-eq  !>(`@`0x80)  !>((sqt:rpb:unum 0xc0))
+    %+  expect-eq  !>(`@`0x0)   !>((sqt:rpb:unum 0x0))
+    %+  expect-eq  !>(`@`0x80)  !>((sqt:rpb:unum 0x80))
+  ==
+::
+++  test-round-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40)  !>((rnd:rpb:unum 0x42))
+    %+  expect-eq  !>(`@`0x48)  !>((rnd:rpb:unum 0x4a))
+    %+  expect-eq  !>(`@`0x0)   !>((rnd:rpb:unum 0x38))
+    %+  expect-eq  !>(`@`0x50)  !>((rnd:rpb:unum 0x4e))
+    %+  expect-eq  !>(`@`0x40)  !>((flr:rpb:unum 0x42))
+    %+  expect-eq  !>(`@`0x48)  !>((cel:rpb:unum 0x42))
+    %+  expect-eq  !>(`@`0xb8)  !>((flr:rpb:unum 0xbe))
+    %+  expect-eq  !>(`@`0xc0)  !>((cel:rpb:unum 0xbe))
+  ==
+::
+++  test-convert-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4c)  !>((sun:rpb:unum 3))
+    %+  expect-eq  !>(`@`0x0)   !>((sun:rpb:unum 0))
+    %+  expect-eq  !>(`@`0x4c)  !>((san:rpb:unum --3))
+    %+  expect-eq  !>(`@`0xb4)  !>((san:rpb:unum -3))
+    %+  expect-eq  !>(`(unit @s)`[~ --1])  !>((toi:rpb:unum 0x42))
+    %+  expect-eq  !>(`(unit @s)`[~ --4])  !>((toi:rpb:unum 0x4e))
+    %+  expect-eq  !>(`(unit @s)`~)        !>((toi:rpb:unum 0x80))
+    %+  expect-eq  !>(`(unit @s)`[~ --0])  !>((toi:rpb:unum 0x0))
+  ==
+::
+++  test-fma-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x56)  !>((fma:rpb:unum 0x48 0x4c 0x40))
+    %+  expect-eq  !>(`@`0x80)  !>((fma:rpb:unum 0x48 0x80 0x40))
+  ==
+::
+++  test-quire-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x42)  !>((q-to-p:rpb:unum (p-to-q:rpb:unum 0x42)))
+    %+  expect-eq  !>(`@`0x38)  !>((q-to-p:rpb:unum (p-to-q:rpb:unum 0x38)))
+    %+  expect-eq  !>(`@`0x4c)
+      !>((q-to-p:rpb:unum (q-add-p:rpb:unum (p-to-q:rpb:unum 0x40) 0x48)))
+    %+  expect-eq  !>(`@`0x54)
+      !>((q-to-p:rpb:unum (q-mul-add:rpb:unum q-zero:rpb:unum 0x48 0x4c)))
+  ==
+::
+++  test-fdp-rpb  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x52)  !>((fdp:rpb:unum ~[0x40 0x48] ~[0x4c 0x40]))
+    %+  expect-eq  !>(`@`0x5d)  !>((fdp:rpb:unum ~[0x48 0x4c] ~[0x48 0x4c]))
+    %+  expect-eq  !>(`@`0x40)
+      !>((fdp:rpb:unum ~[0x7f 0x40 0x81] ~[0x40 0x40 0x40]))
+  ==
+::
+::  posit32 <-> single (value-based; posit -2.0 = 0xb800.0000, NOT the
+::  single -2.0 = 0xc000.0000 -- the two formats differ at the same width).
+++  test-ieee-rps  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3f80.0000)  !>((to-rs:rps:unum 0x4000.0000))
+    %+  expect-eq  !>(`@`0xc000.0000)  !>((to-rs:rps:unum 0xb800.0000))
+    %+  expect-eq  !>(`@`0x3f00.0000)  !>((to-rs:rps:unum 0x3800.0000))
+    %+  expect-eq  !>(`@`0x4000.0000)  !>((from-rs:rps:unum `@rs`0x3f80.0000))
+    %+  expect-eq  !>(`@`0xb800.0000)  !>((from-rs:rps:unum `@rs`0xc000.0000))
+    %+  expect-eq  !>(`@`0x3800.0000)  !>((from-rs:rps:unum `@rs`0x3f00.0000))
+  ==
+::
+++  test-ieee-rph  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3c00)  !>((to-rh:rph:unum 0x4000))
+    %+  expect-eq  !>(`@`0xc000)  !>((to-rh:rph:unum 0xb800))
+    %+  expect-eq  !>(`@`0x4000)  !>((from-rh:rph:unum `@rh`0x3c00))
+    %+  expect-eq  !>(`@`0xb800)  !>((from-rh:rph:unum `@rh`0xc000))
+  ==
+::
+::  The matrix: ANY posit width <-> ANY float width (value-based).  posits
+::  pack more accuracy per bit, so cross-width is the useful correspondence.
+::
+++  test-ieee-matrix  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3f80.0000)  !>((to-rs:rph:unum 0x4000))
+    %+  expect-eq  !>(`@`0x3ff0.0000.0000.0000)  !>((to-rd:rps:unum 0x4000.0000))
+    %+  expect-eq  !>(`@`0x3f80.0000)  !>((to-rs:rpb:unum 0x40))
+    %+  expect-eq  !>(`@`0x4000)  !>((from-rs:rph:unum `@rs`0x3f80.0000))
+    %+  expect-eq  !>(`@`0x4000.0000)  !>((from-rd:rps:unum `@rd`0x3ff0.0000.0000.0000))
+  ==
+::
+::  Transcendentals (naive Taylor series, /lib/math style).  These posit8
+::  values are the series outputs, which match the SoftPosit correctly-rounded
+::  result (verified offline by a Python port of the same series).  pow-n is
+::  exact integer power.
+::
+++  test-transcendental-rpb  ^-  tang
+  =/  u  rpb:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40)  !>((exp:u 0x0))
+    %+  expect-eq  !>(`@`0x4b)  !>((exp:u 0x40))
+    %+  expect-eq  !>(`@`0x0)   !>((sin:u 0x0))
+    %+  expect-eq  !>(`@`0x3d)  !>((sin:u 0x40))
+    %+  expect-eq  !>(`@`0x40)  !>((cos:u 0x0))
+    %+  expect-eq  !>(`@`0x39)  !>((cos:u 0x40))
+    %+  expect-eq  !>(`@`0x44)  !>((tan:u 0x40))
+    %+  expect-eq  !>(`@`0x0)   !>((log:u 0x40))
+    %+  expect-eq  !>(`@`0x3b)  !>((log:u (sun:u 2)))
+    %+  expect-eq  !>(`@`0x58)  !>((pow-n:u (sun:u 2) 3))
+    %+  expect-eq  !>(`@`0x40)  !>((pow:u (sun:u 2) 0x0))
+  ==
+::
+::  Domain guards: log/pow of out-of-domain inputs return NaR (not a divergent
+::  series result), and NaR propagates through pow-n even when the exponent is 0.
+::
+++  test-domain-rpb  ^-  tang
+  =/  u  rpb:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x80)  !>((log:u 0x0))            ::  log(0)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((log:u 0xc0))           ::  log(-1)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((log:u 0x80))           ::  log(NaR)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((log:u 0xb4))           ::  log(-3)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((pow-n:u 0x80 0))       ::  NaR^0=NaR (not 1)
+    %+  expect-eq  !>(`@`0x40)  !>((pow-n:u 0x40 0))       ::  1^0=1 still
+    %+  expect-eq  !>(`@`0x80)  !>((pow:u 0x0 (sun:u 2)))  ::  pow(0,2)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((pow:u 0xc0 (sun:u 2))) ::  pow(-1,2)=NaR
+  ==
+::  New transcendentals (factorial, cbrt, atan, asin, acos) at posit8.  Expected
+::  values from tools/posit_check.py's series replica; all correctly rounded vs
+::  mpmath at posit8.  Inputs: 0x38 = .5, (sun 1) = 1, (sun 3/4) = 3/4.
+++  test-transcendental-new-rpb  ^-  tang
+  =/  u  rpb:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x54)  !>((factorial:u (sun:u 3)))   ::  3! = 6
+    %+  expect-eq  !>(`@`0x62)  !>((factorial:u (sun:u 4)))   ::  4! = 24
+    %+  expect-eq  !>(`@`0x40)  !>((cbrt:u (sun:u 1)))        ::  cbrt 1 = 1
+    %+  expect-eq  !>(`@`0x3d)  !>((atan:u (sun:u 1)))        ::  atan 1 = pi/4
+    %+  expect-eq  !>(`@`0x38)  !>((atan:u 0x38))             ::  atan .5
+    %+  expect-eq  !>(`@`0x39)  !>((asin:u 0x38))             ::  asin .5
+    %+  expect-eq  !>(`@`0x41)  !>((acos:u 0x38))             ::  acos .5
+    %+  expect-eq  !>(`@`0x45)  !>((acos:u 0x0))              ::  acos 0 = pi/2
+  ==
+::  Domain guards for the new arms: out-of-range -> NaR (unum nar convention),
+::  exact +-1 / 0 boundaries, cbrt(0)=0.
+++  test-domain-new-rpb  ^-  tang
+  =/  u  rpb:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x80)  !>((cbrt:u 0xc0))             ::  cbrt(-1)=NaR
+    %+  expect-eq  !>(`@`0x0)   !>((cbrt:u 0x0))              ::  cbrt(0)=0
+    %+  expect-eq  !>(`@`0x80)  !>((factorial:u 0xb4))        ::  factorial(-3)=NaR
+    %+  expect-eq  !>(`@`0x80)  !>((asin:u (sun:u 4)))        ::  asin(4)=NaR (|x|>1)
+    %+  expect-eq  !>(`@`0x80)  !>((acos:u (sun:u 4)))        ::  acos(4)=NaR
+    %+  expect-eq  !>(`@`0x45)  !>((asin:u (sun:u 1)))        ::  asin(1)=pi/2
+    %+  expect-eq  !>(`@`0x0)   !>((acos:u (sun:u 1)))        ::  acos(1)=0
+  ==
+::  Full transcendental set at posit16 (rph) and posit32 (rps).  Expected values
+::  from the series replica; the naive Taylor/AGM series is correctly rounded
+::  near the expansion point and within ~1 ULP elsewhere (see tools/posit_check).
+++  test-transcendental-rph  ^-  tang
+  =/  u  rph:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4531)  !>((exp:u 0x3800))          ::  exp .5
+    %+  expect-eq  !>(`@`0x3757)  !>((sin:u 0x3800))          ::  sin .5
+    %+  expect-eq  !>(`@`0x3e0b)  !>((cos:u 0x3800))          ::  cos .5
+    %+  expect-eq  !>(`@`0x38bd)  !>((tan:u 0x3800))          ::  tan .5
+    %+  expect-eq  !>(`@`0x3b18)  !>((log:u (sun:u 2)))       ::  log 2
+    %+  expect-eq  !>(`@`0x5400)  !>((factorial:u (sun:u 3))) ::  3!
+    %+  expect-eq  !>(`@`0x6200)  !>((factorial:u (sun:u 4))) ::  4!
+    %+  expect-eq  !>(`@`0x4000)  !>((cbrt:u (sun:u 1)))      ::  cbrt 1
+    %+  expect-eq  !>(`@`0x3c90)  !>((atan:u (sun:u 1)))      ::  atan 1
+    %+  expect-eq  !>(`@`0x36d5)  !>((atan:u 0x3800))         ::  atan .5
+    %+  expect-eq  !>(`@`0x3861)  !>((asin:u 0x3800))         ::  asin .5
+    %+  expect-eq  !>(`@`0x4060)  !>((acos:u 0x3800))         ::  acos .5
+    %+  expect-eq  !>(`@`0x4491)  !>((acos:u 0x0))            ::  acos 0
+    %+  expect-eq  !>(`@`0x5800)  !>((pow-n:u (sun:u 2) 3))   ::  2^3
+  ==
+++  test-transcendental-rps  ^-  tang
+  =/  u  rps:unum
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4530.94c8)  !>((exp:u 0x3800.0000))  ::  exp .5
+    %+  expect-eq  !>(`@`0x3757.743a)  !>((sin:u 0x3800.0000))  ::  sin .5
+    %+  expect-eq  !>(`@`0x3e0a.9404)  !>((cos:u 0x3800.0000))  ::  cos .5
+    %+  expect-eq  !>(`@`0x38bd.a7ad)  !>((tan:u 0x3800.0000))  ::  tan .5
+    %+  expect-eq  !>(`@`0x3b17.2180)  !>((log:u (sun:u 2)))   ::  log 2
+    %+  expect-eq  !>(`@`0x5400.0000)  !>((factorial:u (sun:u 3)))
+    %+  expect-eq  !>(`@`0x6200.0000)  !>((factorial:u (sun:u 4)))
+    %+  expect-eq  !>(`@`0x4000.0000)  !>((cbrt:u (sun:u 1)))  ::  cbrt 1
+    %+  expect-eq  !>(`@`0x3c90.fdab)  !>((atan:u (sun:u 1)))  ::  atan 1
+    %+  expect-eq  !>(`@`0x36d6.3381)  !>((atan:u 0x3800.0000)) ::  atan .5
+    %+  expect-eq  !>(`@`0x3860.a91c)  !>((asin:u 0x3800.0000)) ::  asin .5
+    %+  expect-eq  !>(`@`0x4060.a91d)  !>((acos:u 0x3800.0000)) ::  acos .5
+    %+  expect-eq  !>(`@`0x4490.fdaa)  !>((acos:u 0x0))        ::  acos 0
+    %+  expect-eq  !>(`@`0x5800.0000)  !>((pow-n:u (sun:u 2) 3))
+  ==
+--


### PR DESCRIPTION
Adds `lib/unum.hoon` — Standard-2022 posit arithmetic (es=2 uniform across
widths): encode/decode, elementary ops, transcendentals, and quire support.
Pure Hoon.

**Stacked on #7373** (`lib/twoc`) — unum uses `/+ twoc` for two's-complement
helpers. Retarget to develop once #7373 merges.

`tests/lib/unum-{core,fns,edge}.hoon` included. Verified: arvo compiles and all
three suites are green on a fresh %zuse-408 ship.

Second of the numerics-library series (twoc → **unum** → fixed → complex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Refreshed to numerics `main` (2026-09-21)

This PR was cut before two numerics changes landed. Commit `557459ee18` mirrors numerics `main`'s `lib/unum.hoon` and its tests **byte-for-byte**:

- **Correctly rounded transcendentals** (urbit/numerics#71). The previous head returned series results one ulp off — measured on a ship, `exp(0.5)`, `cos(0.5)`, `tan(0.5)` and `log(2)` at posit32 came back `…94c8`, `…9404`, `…a7ad`, `…2180`; the correctly rounded values, which the refreshed library returns, are `…94c7`, `…9403`, `…a7ae`, `…217f`. `tests/lib/unum-edge` and `unum-fns` are refreshed to match.
- **Jet hints** (urbit/numerics#65, #79), matching urbit/vere#1046's registration. #1046's SoftUnum jets are already on the same Chebyshev basis, so Hoon and jets agree bit-for-bit; without #1046 the hints are inert.

Nothing from the earlier commits is lost — every line of the audit-fix commit is present in numerics `main`. `unum` uses only `twoc` door arms that #7373 defines.

**Re-verified** on a fresh fakezod (hoon-135/zuse-408) against #7373's `lib/twoc`: `unum-core` 12, `unum-edge` 28, `unum-fns` 15 — all 55 green.
