### PR TITLE
arvo: fixed-point library (lib/fixed)

### DIFF
--- a/pkg/arvo/lib/fixed.hoon
+++ b/pkg/arvo/lib/fixed.hoon
@@ -1,0 +1,239 @@
+/+  twoc
+::::  /lib/fixed -- fixed-point arithmetic
+::::  Version ~2024.1.15 by ~lagrev-nocfep and ~mopfel-winrux
+::::  ~2026.6.1: rebuilt on /lib/twoc for correct signed mul/div/scale.
+::
+::  A fixed-point number is a two's-complement integer of N = a + b + 1 bits
+::  interpreted as value / 2^b:
+::
+::    value = 1/2^b * ( -2^(N-1) x_(N-1) + sum_{n=0}^{N-2} 2^n x_n )
+::
+::  where a = integer bits, b = fractional bits, and the leading bit is the
+::  sign.  (Yates2023, http://www.digitalsignallabs.com/downloads/fp.pdf)
+::
+::  Arithmetic is signed and MODULAR (wraps mod 2^N on overflow), delegating
+::  to the width-keyed +twid door of /lib/twoc so the sign handling is shared
+::  with the rest of numerics rather than reimplemented here.
+::
+|%
++$  prec  [a=@ b=@]   ::  fixed-point precision, a+b+1=bloq
+::  +wid: total bit width N = a + b + 1 of a precision.
+++  wid  |=(=prec ^-(@ :(^add a.prec b.prec 1)))
+::  +ng: the /lib/twoc width-keyed door at a given precision's N.
+++  ng   |=(=prec ~(. twid:twoc (wid prec)))
+::    +add: [@ prec @ prec] -> @
+::
+::  Add two fixed-point numbers of equal precision (signed, wrapping).
+::    Examples
+::      > (add 0x180 [8 8] 0x240 [8 8])   :: 1.5 + 2.25
+::      0x3c0                             :: 3.75
+::  Source
+++  add
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (add:(ng xprec) x y)
+::    +sub: [@ prec @ prec] -> @
+::
+::  Subtract two fixed-point numbers of equal precision (signed, wrapping).
+::    Examples
+::      > (sub 0x100 [8 8] 0x200 [8 8])   :: 1.0 - 2.0
+::      0x1.ff00                          :: -1.0 in N=17 bits
+::  Source
+++  sub
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (sub:(ng xprec) x y)
+::    +mul: [@ prec @ prec] -> [@ prec]
+::
+::  Multiply two fixed-point numbers (signed).  The product precision widens:
+::  integer bits a.x + a.y + 1, fractional bits b.x + b.y.
+::    Examples
+::      > (mul 0x180 [8 8] 0x200 [8 8])   :: 1.5 * 2.0
+::      [0x3.0000 17 16]                  :: 3.0 in q17.16
+::      > (mul (neg 0x180 [8 8]) [8 8] 0x200 [8 8])   :: -1.5 * 2.0
+::      [0x3.fffd.0000 17 16]             :: -3.0
+::  Source
+++  mul
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ^-  [@ prec]
+  =/  prodp=prec  [:(^add a.xprec a.yprec 1) (^add b.xprec b.yprec)]
+  ::  re-encode each operand at the product width, then signed multiply.
+  =/  px  (s-to-twoc:(ng prodp) (to-s x xprec))
+  =/  py  (s-to-twoc:(ng prodp) (to-s y yprec))
+  [(mul:(ng prodp) px py) prodp]
+::    +div: [@ prec @ prec] -> [@ prec]
+::
+::  Divide two fixed-point numbers of equal precision (signed), keeping the
+::  input precision.  Division by zero crashes.
+::    Examples
+::      > (div (neg 0x300 [8 8]) [8 8] 0x200 [8 8])   :: -3.0 / 2.0
+::      [0x1.fe80 8 8]                                :: -1.5
+::  Source
+++  div
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ^-  [@ prec]
+  ?>  ~|(%argument-precision-must-match =(xprec yprec))
+  ::  scale the dividend up by 2^b before the signed divide so the quotient
+  ::  lands back in xprec's fixed-point scale: (x * 2^b) / y.
+  =/  sx   (to-s x xprec)
+  =/  num  (new:si (syn:si sx) (lsh [0 b.xprec] (abs:si sx)))
+  =/  qa   (fra:si num (to-s y yprec))
+  [(s-to-twoc:(ng xprec) qa) xprec]
+::    +mod: [@ prec @ prec] -> @
+::
+::  Signed remainder a - b*trunc(a/b), keeping the input precision.  The sign
+::  follows the dividend (truncated division), via /lib/twoc's +rem.  Both
+::  operands share precision, so the 2^b scale cancels in the remainder.
+::    Examples
+::      > (mod 0x380 [8 8] 0x200 [8 8])   :: 3.5 mod 2.0
+::      0x180                             :: 1.5
+::  Source
+++  mod
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (rem:(ng xprec) x y)
+::    +abs: [@ prec] -> @
+::
+::  Absolute value at the number's own width (abs of the most-negative value
+::  wraps back to itself, per two's-complement).
+::    Examples
+::      > (abs (neg 0x180 [8 8]) [8 8])   :: |-1.5|
+::      0x180
+::  Source
+++  abs
+  |=  [x=@ =prec]
+  ^-  @
+  (abs:(ng prec) x)
+::    +gth/+gte/+lth/+lte/+equ/+neq: [@ prec @ prec] -> ?
+::
+::  Signed comparisons of two equal-precision fixed-point numbers.  Because
+::  both are stored at the same 2^b scale, comparing the two's-complement
+::  values (via /lib/twoc) is order-preserving on the represented reals.
+::  +equ is bit equality (two's-complement has no negative zero).
+::  Source
+++  gth
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (gth:(ng xprec) x y)
+++  gte
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (gte:(ng xprec) x y)
+++  lth
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (lth:(ng xprec) x y)
+++  lte
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (lte:(ng xprec) x y)
+++  equ
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  .=(x y)
+++  neq
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  !.=(x y)
+::    +to-s: [@ prec] -> @s
+::
+::  Decode a fixed-point bit pattern to a hoon signed integer (the stored
+::  two's-complement value, fractional bits included).
+::  Source
+++  to-s
+  |=  [x=@ =prec]
+  ^-  @s
+  (twoc-to-s:(ng prec) x)
+::    +from-s: [@s prec] -> @
+::
+::  Encode a (whole) signed integer as a fixed-point number at the given
+::  precision: stored value = n * 2^b.  Out-of-range n crashes (s-to-twoc).
+::    Examples
+::      > (from-s --3 [8 8])   :: 3.0
+::      0x300
+::      > (from-s -2 [8 8])    :: -2.0
+::      0x1.fe00
+::  Source
+++  from-s
+  |=  [n=@s =prec]
+  ^-  @
+  (s-to-twoc:(ng prec) (new:si (syn:si n) (lsh [0 b.prec] (abs:si n))))
+::    +from-rs: [@rs prec] -> @
+::
+::  Quantize a single-precision IEEE float to fixed-point, rounding the
+::  scaled value f * 2^b to the nearest integer (ties to even).  Out-of-range
+::  results wrap (s-to-twoc).  Use this to construct fractional constants.
+::    Examples
+::      > (from-rs .1.5 [8 8])
+::      0x180
+::  Source
+++  from-rs
+  |=  [f=@rs =prec]
+  ^-  @
+  =/  i=@s  (need (~(toi rs %n) (~(mul rs %n) f (~(sun rs %n) (bex b.prec)))))
+  (s-to-twoc:(ng prec) i)
+::    +to-rs: [@ prec] -> @rs
+::
+::  Decode a fixed-point number to a single-precision IEEE float: value =
+::  stored / 2^b.  Rounded to nearest (ties to even) where not exact.
+::    Examples
+::      > (to-rs 0x180 [8 8])
+::      .1.5
+::  Source
+++  to-rs
+  |=  [x=@ =prec]
+  ^-  @rs
+  =/  s=@s  (to-s x prec)
+  =/  fs=@rs
+    ?:  (syn:si s)
+      (~(sun rs %n) (abs:si s))
+    (~(mul rs %n) .-1 (~(sun rs %n) (abs:si s)))
+  (~(div rs %n) fs (~(sun rs %n) (bex b.prec)))
+::    +neg: [@ prec] -> @
+::
+::  Two's-complement negation of a fixed-point number at its own width.
+::  (Renamed from the old +twoc, which shadowed the /lib/twoc import face
+::  and duplicated a name; behavior unchanged: -x.)
+::    Examples
+::      > (neg 0x100 [8 8])   :: -(1.0)
+::      0x1.ff00
+::  Source
+++  neg
+  |=  [x=@ =prec]
+  ^-  @
+  (neg:(ng prec) x)
+::    +hi: [@ prec @] -> @   (high n bits)
+::  Source
+++  hi
+  |=  [x=@ =prec n=@]
+  ?>  (^lte n (wid prec))
+  (rsh [0 (^sub (wid prec) n)] x)
+::    +lo: [@ prec @] -> @   (low n bits)
+::  Source
+++  lo
+  |=  [x=@ =prec n=@]
+  ?>  (^lte n (wid prec))
+  (dis x (dec (bex n)))
+::    +scale: [@ prec prec] -> @
+::
+::  Re-quantize x from xprec to yprec (signed): shift the fractional part to
+::  the new b, then re-encode at the new width.  Saturation/rounding are not
+::  applied; high bits beyond yprec's range are dropped (wrap).
+::    Examples
+::      > (scale 0x10 [4 4] [8 8])   :: 1.0 in q4.4 -> q8.8
+::      0x100
+::      > (scale 0x100 [8 8] [4 4])  :: 1.0 in q8.8 -> q4.4
+::      0x10
+::  Source
+++  scale
+  |=  [x=@ xprec=prec yprec=prec]
+  ^-  @
+  ::  decode to the signed value, rescale the fractional precision, re-encode.
+  =/  sx  (to-s x xprec)
+  =/  sg  (syn:si sx)
+  =/  mg  (abs:si sx)
+  =/  mg2  ?:  (^gth b.yprec b.xprec)
+             (lsh [0 (^sub b.yprec b.xprec)] mg)
+           (rsh [0 (^sub b.xprec b.yprec)] mg)
+  (s-to-twoc:(ng yprec) (new:si sg mg2))
+--

--- a/tests/lib/fixed.hoon
+++ b/tests/lib/fixed.hoon
@@ -1,0 +1,109 @@
+  ::  /tests/lib/fixed
+::::
+::    Fixed-point arithmetic (signed, modular), built on /lib/twoc.
+::    q8.8 = prec [8 8], N = 17.  Negative operands are the cases the old
+::    unsigned mul/div/scale got wrong; the scale crash is also covered.
+::
+/+  *test,
+    fixed
+^|
+=/  q88=prec:fixed  [8 8]
+=/  n1-5  (neg:fixed 0x180 q88)   :: -1.5 in q8.8 = 0x1.fe80
+=/  n3    (neg:fixed 0x300 q88)   :: -3.0 in q8.8 = 0x1.fd00
+|%
+++  test-add  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3c0)     !>((add:fixed 0x180 q88 0x240 q88))  ::  1.5+2.25=3.75
+    %+  expect-eq  !>(`@`0x200)     !>((add:fixed 0x100 q88 0x100 q88))  ::  1+1=2
+    %+  expect-eq  !>(`@`0x1.ff80)  !>((add:fixed 0x100 q88 n1-5 q88))   ::  1+(-1.5)=-0.5
+  ==
+::
+++  test-sub  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ff00)  !>((sub:fixed 0x100 q88 0x200 q88))  ::  1-2=-1
+    %+  expect-eq  !>(`@`0x100)     !>((sub:fixed 0x200 q88 0x100 q88))  ::  2-1=1
+  ==
+::
+++  test-neg  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ff00)  !>((neg:fixed 0x100 q88))   ::  -(1.0)
+    %+  expect-eq  !>(`@`0x1.fe80)  !>((neg:fixed 0x180 q88))   ::  -(1.5)
+    %+  expect-eq  !>(`@`0x100)     !>((neg:fixed (neg:fixed 0x100 q88) q88))  ::  --1=1
+  ==
+::
+::  mul widens precision to [17 16] (N=34).  Negative cases the old unsigned
+::  mul returned garbage for.  -3.0 in q17.16 is 0x3.fffd.0000.
+++  test-mul  ^-  tang
+  =/  prodp=prec:fixed  [17 16]
+  ;:  weld
+    %+  expect-eq  !>([0x3.0000 prodp])       !>((mul:fixed 0x180 q88 0x200 q88))
+    %+  expect-eq  !>([0x3.fffd.0000 prodp])  !>((mul:fixed n1-5 q88 0x200 q88))
+    %+  expect-eq  !>([0x3.0000 prodp])       !>((mul:fixed n1-5 q88 (neg:fixed 0x200 q88) q88))
+  ==
+::
+::  div keeps precision [8 8].  Negative cases the old unsigned div got wrong.
+++  test-div  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>([0x1.fe80 q88])  !>((div:fixed n3 q88 0x200 q88))   ::  -3/2=-1.5
+    %+  expect-eq  !>([0x180 q88])     !>((div:fixed 0x300 q88 0x200 q88))  ::  3/2=1.5
+    %+  expect-eq  !>([0x180 q88])     !>((div:fixed n3 q88 (neg:fixed 0x200 q88) q88))  ::  -3/-2=1.5
+  ==
+::
+::  scale (the old version crashed on widen via a bad lsh; now correct).
+::  -1.5 in q4.4 (N=9) is 0x1e8.
+++  test-scale  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x100)  !>((scale:fixed 0x10 [4 4] [8 8]))   ::  1.0 q4.4 -> q8.8
+    %+  expect-eq  !>(`@`0x10)   !>((scale:fixed 0x100 [8 8] [4 4]))  ::  1.0 q8.8 -> q4.4
+    %+  expect-eq  !>(`@`0x1e8)  !>((scale:fixed n1-5 [8 8] [4 4]))   ::  -1.5 q8.8 -> q4.4
+  ==
+::
+::  round-trip: (3.0/2.0) then *2.0 = 3.0 (exact here).
+++  test-div-roundtrip  ^-  tang
+  =/  q  (div:fixed 0x300 q88 0x200 q88)        ::  3.0/2.0 = 1.5 in q8.8
+  =/  back  (mul:fixed -.q q88 0x200 q88)       ::  1.5*2.0 = 3.0 in q17.16
+  %+  expect-eq  !>(`@`0x3.0000)  !>(-.back)
+::
+++  test-abs  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)  !>((abs:fixed n1-5 q88))     ::  |-1.5| = 1.5
+    %+  expect-eq  !>(`@`0x180)  !>((abs:fixed 0x180 q88))    ::  |1.5|  = 1.5
+  ==
+::
+++  test-mod  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)     !>((mod:fixed 0x380 q88 0x200 q88))  ::  3.5 mod 2 = 1.5
+    %+  expect-eq  !>(`@`0x1.fe80)  !>((mod:fixed (neg:fixed 0x380 q88) q88 0x200 q88))  ::  -3.5 mod 2 = -1.5
+  ==
+::
+::  comparisons (signed, equal precision) return loobeans
+++  test-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`?`%.y)  !>((gth:fixed 0x180 q88 0x100 q88))  ::  1.5 > 1.0
+    %+  expect-eq  !>(`?`%.n)  !>((gth:fixed n1-5 q88 0x100 q88))   ::  -1.5 > 1.0 -> no
+    %+  expect-eq  !>(`?`%.y)  !>((lth:fixed n1-5 q88 0x100 q88))   ::  -1.5 < 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((gte:fixed 0x100 q88 0x100 q88))  ::  1.0 >= 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((lte:fixed 0x100 q88 0x100 q88))  ::  1.0 <= 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((equ:fixed 0x100 q88 0x100 q88))  ::  1.0 == 1.0
+    %+  expect-eq  !>(`?`%.n)  !>((equ:fixed 0x100 q88 0x180 q88))  ::  1.0 == 1.5 -> no
+    %+  expect-eq  !>(`?`%.y)  !>((neq:fixed 0x100 q88 0x180 q88))  ::  1.0 != 1.5
+  ==
+::
+::  constructors: integer and float -> fixed
+++  test-from-s  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x300)     !>((from-s:fixed --3 q88))   ::  3.0
+    %+  expect-eq  !>(`@`0x1.fe00)  !>((from-s:fixed -2 q88))    ::  -2.0
+    %+  expect-eq  !>(`@`0x0)       !>((from-s:fixed --0 q88))   ::  0
+  ==
+::
+::  float bridge: from-rs / to-rs (1.5, -1.5, 2.25 are exact in both)
+++  test-rs-bridge  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)     !>((from-rs:fixed .1.5 q88))    ::  1.5
+    %+  expect-eq  !>(`@`0x1.fdc0)  !>((from-rs:fixed .-2.25 q88))  ::  -2.25
+    %+  expect-eq  !>(`@rs`.1.5)    !>((to-rs:fixed 0x180 q88))     ::  1.5
+    %+  expect-eq  !>(`@rs`.-1.5)   !>((to-rs:fixed n1-5 q88))      ::  -1.5
+    %+  expect-eq  !>(`@`0x180)     !>((from-rs:fixed (to-rs:fixed 0x180 q88) q88))  ::  round-trip
+  ==
+--


### PR DESCRIPTION
Adds `lib/fixed.hoon` — power-of-two-width fixed-point arithmetic with
configurable fractional precision. Pure Hoon.

**Stacked on #7373** (`lib/twoc`) — uses `/+ twoc`. Retarget to develop once
#7373 merges. (Independent of #7374/unum.)

`tests/lib/fixed.hoon` included. Verified: arvo compiles and `-test
%/tests/lib/fixed` is green on a fresh %zuse-408 ship.

Third of the numerics-library series (twoc → unum → **fixed** → complex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Refreshed to numerics `main` (2026-09-21)

Commit `086d1c7e02` mirrors numerics `main`'s `lib/fixed.hoon` and `tests/lib/fixed.hoon` byte-for-byte. The change is **purely additive** (urbit/numerics `d56ca72`): a new `+from-rd`, which quantizes a double-precision float to fixed point exactly as `+from-rs` does at single precision (round to nearest, ties to even; out-of-range wraps). It was added for `/lib/i754rand`'s distribution-to-fixed-point composition. Its test, `test-rd-bridge`, comes with it. No existing arm changes.

**Re-verified** on a fresh fakezod (hoon-135/zuse-408) against the refreshed `twoc` of #7373: `fixed` 13 — all green.
