### PR TITLE
ames: always %ack ahoy on the lane it just arrived on

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5694,7 +5694,7 @@
           ==
         ::
         ++  on-ack-ahoy
-          |=  =shot
+          |=  [=lane =shot]
           ^+  event-core
           ?.  sam.shot
             %-  (ev-trace odd.veb sndr.shot |.("weird no ames"))
@@ -5768,7 +5768,7 @@
           =/  ack-packet=^shut-packet
             :-  (mix 0b1 bone.u.shut-packet)
             [message-num.u.shut-packet %| %| !error lag=*@dr]
-          %:  send-blob  for=|  sndr.shot
+          =/  b=^blob
             %-  etch-shot
             %:  etch-shut-packet:ames
               ack-packet
@@ -5776,9 +5776,16 @@
               our               sndr.shot
               our-life.channel  life.hers.channel
             ==
+          ::  ack on the lane it came from, also send to galaxy just in case
           ::
-            ship-state=~  :: send-blob finds the migrated peer in chums
-          ==
+          =?  event-core  ?=(^ unix-duct)
+            (emit unix-duct %give %send lane b)
+          ?:  ?=(%& -.lane)
+            event-core
+          =/  gal=(unit @ux)  (get-sponsor sndr.shot)
+          ?:  |(?=(~ gal) ?=(~ unix-duct))
+            event-core
+          (emit unix-duct %give %send [%& `@pC`u.gal] b)
         ::
         +|  %implementation
         ::  +enqueue-alien-todo: helper to enqueue a pending request
@@ -13321,7 +13328,7 @@
           [~ %known *]
         =^  moves-ahoy  ames-state
           =<  abet
-          %.(shot on-ack-ahoy:(ev:am-core now^eny^rof hen ames-state))
+          %.([lane shot] on-ack-ahoy:(ev:am-core now^eny^rof hen ames-state))
         ?:  ?=(^ moves-ahoy)
           [moves-ahoy vane-gate]
         =^  moves-peer  vane-gate


### PR DESCRIPTION
Busy ships such %groups and %landscape distribution ships have recently migrated to 408. This caused them to immediately start migrating all of their peers to directed messaging, which for these ships is basically every ship on the network.

Some of these migrations got stuck in the following way.

1. Ship A sends an %ahoy %plea to begin the migration.
2. Ship B processes the %ahoy, runs self-test checks, executes the migration and sends an ack.
3. The ack got lost
4. Ship A proceeds to resend the %ahoy plea using old ames, but it is extremely busy so the resend takes a while to happen.
5. Another %ahoy plea arrives at ship B, but the response get's sent on the lane that was recorded in step 2, nat pinhole long gone.

When this happens the ships will keep looping steps 4 and 5 forever.

This PR sends the ack back on the lane it came from, which may or may not be the galaxy lane. This is robust against all NAT configurations as far as I can tell. I also send the ack back to the galaxy in case our ship is very busy and the nat pinhole has already closed.

There is a separate question of %mesa routes not falling back to %indirect like we do in %ames, @yosoyubik we will need to look at that.