### PR TITLE
mesa: clean _synthetic_ %for flows that have reused a %bak flow

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4272,8 +4272,8 @@
           ::
           =.  chums.old
             ^-  (map ship chum-state)
-            %-  ~(run by chums.old)
-            |=  c=chum-state
+            %-  ~(urn by chums.old)
+            |=  [=ship c=chum-state]
             ^-  chum-state
             ?:  ?=(%alien -.c)  c
             ^-  chum-state
@@ -4296,6 +4296,11 @@
               =/  =dire  ?:(?=(%for dir.user-path) %bak %for)
               ?.  (~(has in corked.c) u.bone dire)
                 tip
+              %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                    ships.bug.old
+                    |.  %+  weld  "corked flow {<[u.bone dire]>}; remove "
+                        "{(spud `path`user-path)} from .tip"
+                  ==
               (~(del by tip) user-path)
             ==
           ::  last pass; .pit clean-up
@@ -4303,8 +4308,8 @@
           %=    old
               chums
             ^-  (map ship chum-state)
-            %-  ~(run by chums.old)
-            |=  c=chum-state
+            %-  ~(urn by chums.old)
+            |=  [=ship c=chum-state]
             ^-  chum-state
             ?:  ?=(%alien -.c)  c
             ^-  chum-state
@@ -4327,13 +4332,18 @@
                 p
               ?~  bone=(slaw %ud bone.i.hen)
                 p
-              ~?  >>>  ?=(^ pay.req)
-                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
               ::  flow wires carry our side's dire;
               ::  use it directly to find the flow in .corked
               ::
               ?.  (~(has in corked.c) u.bone dir.i.hen)
                 p
+              ~?  >>>  ?=(^ pay.req)
+                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
+              %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                    ships.bug.old
+                    |.  %+  weld  "corked flow {<[u.bone dir.i.hen]>}; remove "
+                        "{(spud ames-path)} from .pit"
+                  ==
               (~(del by p) ames-path)
             ==
           ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11019,7 +11019,9 @@
             ?:  =(0 last-acked.rcv)
               %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("%cork $plea is first message {<side>}; drop")
-              fo-core
+              ::  drop pending-ack so we skip this bone in fo-abet
+              ::
+              fo-core(pending-ack.rcv %.n)
             ::  publisher receives %cork
             ::  mark flow as closing
             ::  publish %cork %ack (in +hear-poke:ev-mess) in corked.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10857,6 +10857,13 @@
                 %poke  ?~(v=(get:fo-mop loads.snd seq) ~ `u.v)
             ::
                 %ack
+              ::  XX only for send-window=1:
+              ::  if the flow is corked this can only be the %cork $plea
+              ::  so we always ack it (if we are the publisher in a
+              ::  subscription flow)
+              ::
+              ?:  &(fo-corked ?=(%bak dire))
+                `ack/error=%.n
               ::  always ack messages on a forward flow
               ::  (i.e. %boons are always acked)
               ::
@@ -13299,12 +13306,7 @@
             ~  ::  %alien or missing
           =+  ev-core=(ev-abed:ev ~[//scry] u.rcvr +.u.u.per-sat)
           =+  fo-core=(fo-abed:fo:ev-core side=[u.bone dire.tyl])
-          ?:  &(?=(%ack load.tyl) fo-corked:fo-core)
-              :: ~&  >>>  corked-flow-dropping/load^corked.per  :: XX remove
-              ::  if the flow is corked, block
-              ::  XX when are corked bones evicted?
-              ::
-              ~  ::  XX  [~ ~]
+          ::  corked flows are handled in +fo-peek
           ::
           ?~(res=(fo-peek:fo-core load.tyl u.mess) ~ ``[%message !>(u.res)])
         ::  client/server %mesa %corks, flow-level

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10578,7 +10578,7 @@
                       %+  ev-tace  fin.veb.bug.ames-state
                       |.("remove %peek for %boon from .tip {<side>}")
                   %^  ~(del ju tip)  boon-path
-                    `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
+                    `duct`[`wire`[%ames (fo-wire %pok)] (ev-got-duct bone)]
                   ames-boon
                 %^  ~(del ju tip)  cork-path
                   `duct`[`wire`[%ames (fo-wire %cor)] duct=hen]
@@ -12353,7 +12353,11 @@
             ::
             ?:  ?=(%bak dire)  c
             ?.  closing.state  c
-            =+  fo-core=~(fo-core fo:c [bone dire] state)
+            ?~  hun=(~(get by by-bone.ossuary.per.c) bone)
+              ::  don't crash, we could queue-block
+              ::
+              c  ::  XX log; bone not in ossuary
+            =+  fo-core=~(fo-core fo:c(hen u.hun) [bone dire] state)
             ::  sanity check on the flow state
             ::
             ?^  first=(pry:fo-mop:fo-core loads.snd.fo-core)  c

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2623,6 +2623,7 @@
             [%33 axle]
             [%34 axle]
             [%35 axle]
+            [%36 axle]
         ==
     ::
     ::
@@ -2697,7 +2698,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%35 %larva state=ames-state cache=cached-state]
+    ++  stay  [%36 %larva state=ames-state cache=cached-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2887,6 +2888,13 @@
                       state=axle                 ::
                       cache=_cached-state        :: give cached-state in +stay
                   ==                             ::
+                  [%adult state=axle]
+              ==  ==
+              $:  %36                            :: remove stale %for flows
+              $%  $:  %larva                     :: created by the %clos %stir
+                      state=axle                 ::
+                      cache=_cached-state
+                  ==
                   [%adult state=axle]
           ==  ==  ==
       |^  ?-  old
@@ -3208,9 +3216,19 @@
         larval-gate
       ::
           [%35 %adult *]
-        (load:adult-core state.old)
+        =.  cached-state  `[%35 state.old]
+        ~>  %slog.1^leaf/"ames: larva %35 reload"
+        larval-gate
       ::
           [%35 %larva *]
+        ::  larva doesn't use or update ames-state
+        ::
+        larval-gate(cached-state cache.old)
+      ::
+          [%36 %adult *]
+        (load:adult-core state.old)
+      ::
+          [%36 %larva *]
         ::  larva doesn't use or update ames-state
         ::
         larval-gate(cached-state cache.old)
@@ -3289,7 +3307,7 @@
       |^  ^+  [moz larval-core]
       ?~  cached-state  [~ larval-core]
       =*  old  u.cached-state
-      ?:  ?=(%35 -.old)
+      ?:  ?=(%36 -.old)
         ::  no state migrations left; update state, clear cache, and exit
         ::
         [(flop moz) larval-core(ames-state.adult-gate +.old, cached-state ~)]
@@ -3397,8 +3415,10 @@
       ?:  ?=(%33 -.old)
         =^  moz-34  +.old  (state-33-to-34 +.old)
         $(u.cached-state old(- %34), moz (weld moz moz-34))
-      ?>  ?=(%34 -.old)
-      $(cached-state `35+(state-34-to-35 +.old))
+      ?:  ?=(%34 -.old)
+        $(cached-state `35+(state-34-to-35 +.old))
+      ?>  ?=(%35 -.old)
+      $(cached-state `36+(state-35-to-36 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
       ++  state-4-to-5
@@ -4174,6 +4194,8 @@
                 %bak  ``duct`[//ames]~
               ==
             ?~  hen
+              ::  this entries will be fixed in the next migration
+              ::
               ~&  >>>  missing-ossuary-state-33-to-34/[ship bone dire]
               moz
             %+  weld  moz
@@ -4348,6 +4370,95 @@
             ==
           ==
         ::
+      ++  state-35-to-36
+        |=  old=axle
+        ^-  axle
+        ~>  %slog.0^leaf/"ames: migrating from state %35 to %36"
+        %=    old
+            chums
+          ^-  (map ship chum-state)
+          %-  ~(urn by chums.old)
+          |=  [=ship c=chum-state]
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          ::  remove stales %for flows created by +do-clos:sy-stir, which
+          ::  used %bak flows in closing and made them as %for and queued
+          ::  a %cork $plea to be sent
+          ::
+          ::  a forward flow's bone always useds .next-bone.ossuary, so a
+          ::  %for flow where ( bone >= next-bone ) is stale
+          ::
+          =/  bones=(set bone)
+            %-  ~(rep in ~(key by flows.c))
+            |=  [=side bones=(set bone)]
+            ?.  &(?=(%for dire.side) (gte bone.side next-bone.ossuary.c))
+              bones
+            (~(put in bones) bone.side)
+          ?:  =(~ bones)  c
+          %_    c
+              flows
+            %-  ~(rep in bones)
+            |=  [=bone flows=_flows.c]
+            %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                  ships.bug.old
+                  |.("stale %for flow {<[bone %for]>}; remove")
+                ==
+            (~(del by flows) bone %for)
+          ::
+              tip
+            ::  remove peeks for stale flows (e.g. %acks for
+            ::  their %cork $pleas); by definition this would
+            ::  have used dire=%bak in the path
+            ::
+            %-  ~(rep by tip.c)
+            |=  [[=user=path *] tip=_tip.c]
+            =>  .(user-path `(pole knot)`user-path)
+            ?.  ?=([%a %x %'1' %$ %flow bone=@ lod=@ dir=@ *] user-path)
+              tip
+            ?.  ?=(%bak dir.user-path)
+              tip
+            ?~  bone=(slaw %ud bone.user-path)
+              tip
+            ::  confirm that this was a stale flow
+            ::
+            ?.  (~(has in bones) u.bone)
+              tip
+            %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                  ships.bug.old
+                  |.  %+  weld  "stale flow [{<u.bone>} %for]; remove "
+                      "{(spud `path`user-path)} from .tip"
+                ==
+            (~(del by tip) user-path)
+          ::
+              pit
+            ::  flow wires carry our side's dire; stale entries use %for
+            ::
+            %-  ~(rep by pit.c)
+            |=  [[=ames=path req=request-state] pit=_pit.c]
+            %-  ~(rep by for.req)
+            |=  [[hen=duct *] p=_pit]
+            ?.  ?=([[%ames %mesa %flow *] *] hen)
+              p
+            =>  .(i.hen `(pole knot)`i.hen)
+            ?.  ?=([@ @ @ wer=@ dir=@ h=@ r=@ bone=@ ~] i.hen)
+              p
+            ?.  ?=(%for dir.i.hen)
+              p
+            ?~  bone=(slaw %ud bone.i.hen)
+              p
+            ::  confirm that this was a stale flow
+            ::
+            ?.  (~(has in bones) u.bone)
+              p
+            %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                  ships.bug.old
+                  |.  %+  weld  "stale flow [{<u.bone>} %for]; remove "
+                      "{(spud ames-path)} from .pit"
+                ==
+            (~(del by p) ames-path)
+          ==
+        ==
       --
     ::
     --
@@ -14195,7 +14306,7 @@
   take:am-core
 ::  +stay: extract state before reload
 ::
-++  stay  [%35 adult/ames-state]
+++  stay  [%36 adult/ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -3995,6 +3995,7 @@
         %*  fo-peek-cork  fo-core
                       her  ship
                     -.per  (azimuth-state-29-to-30 +<.per-sat)
+                     side  u.bone^%for
            bug.ames-state  bug.state
           life.ames-state  life.state
         ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11023,7 +11023,8 @@
                   |.("%cork $plea is first message {<side>}; drop")
               ::  drop pending-ack so we skip this bone in fo-abet
               ::
-              fo-core(pending-ack.rcv %.n)
+              =.  pending-ack.rcv  %.n
+              fo-core
             ::  publisher receives %cork
             ::  mark flow as closing
             ::  publish %cork %ack (in +hear-poke:ev-mess) in corked.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2697,7 +2697,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%35 larva/ames-state]
+    ++  stay  [%35 %larva state=axle cache=_cached-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2883,9 +2883,12 @@
                   state=axle
               ==
               $:  %35                            :: clean up corked peeks
-                  ?(%adult %larva)               :: for $boons
-                  state=axle
-          ==  ==
+              $%  $:  %larva                     :: for $boons.
+                      state=axle                 ::
+                      cache=_cached-state        :: give cached-state in +stay
+                  ==                             ::
+                  [%adult state=axle]
+          ==  ==  ==
       |^  ?-  old
           [%4 %adult *]
         =.  cached-state  `[%4 state.old]
@@ -3204,11 +3207,13 @@
         ~>  %slog.1^leaf/"ames: larva %34 reload"
         larval-gate
       ::
-          [%35 *]
-        ?-  +<.old
-          %larva  larval-gate
-          %adult  (load:adult-core state.old)
-        ==
+          [%35 %adult *]
+        (load:adult-core state.old)
+      ::
+          [%35 %larva *]
+        ::  larva doesn't use or update ames-state
+        ::
+        larval-gate(cached-state cache.old)
       ::
       ==
       ::
@@ -3392,7 +3397,7 @@
       ?:  ?=(%33 -.old)
         =^  moz-34  +.old  (state-33-to-34 +.old)
         $(u.cached-state old(- %34), moz (weld moz moz-34))
-      ?>  ?=(%33 -.old)
+      ?>  ?=(%34 -.old)
       $(cached-state `35+(state-34-to-35 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
@@ -4172,8 +4177,8 @@
               ~&  >>>  missing-ossuary-state-33-to-34/[ship bone dire]
               moz
             %+  weld  moz
-            =/  =space    chum-to-our:fo-core
-            =/  =wire     (fo-wire:fo-core %ack)
+            =/  =space  chum-to-our:fo-core
+            =/  =wire   (fo-wire:fo-core %ack)
             moves:(fo-emit:fo-core u.hen %pass wire %a moke/[space ack poke])
         ::  second pass to fix .tip entries with wrong rift in duct
         ::
@@ -4301,9 +4306,10 @@
               ::
               %-  ~(rep by pit.c)
               |=  [[=ames=path req=request-state] pit=_pit.c]
-              ?:  ?=(^ pay.req)  pit
-              ::  skip poke acks
-              ::
+              ?:  ?=(^ pay.req)
+                ::  skip +peek for poke acks
+                ::
+                pit
               %-  ~(rep by for.req)
               |=  [[hen=duct *] p=_pit]
               ::  inspect the duct to find %mesa wires for %pokes
@@ -10396,10 +10402,6 @@
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
                       |.("remove %peek for %boon from .tip {<side>}")
-                  ~&  >>  :*  boon-path
-                              `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
-                              ames-boon
-                          ==
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4284,9 +4284,17 @@
               %-  ~(rep by tip.c)
               |=  [[=user=path *] tip=_tip.c]
               =>  .(user-path `(pole knot)`user-path)
-              ?.  ?=([%a %x %'1' %$ %flow bone=@ *] user-path)
+              ?.  ?=([%a %x %'1' %$ %flow bone=@ lod=@ dir=@ *] user-path)
                 tip
-              ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
+              ?.  ?=(?(%for %bak) dir.user-path)
+                tip
+              ?~  bone=(slaw %ud bone.user-path)
+                tip
+              ::  flow paths carry the dire of the other side; flip it
+              ::  to find our side of the flow in .corked
+              ::
+              =/  =dire  ?:(?=(%for dir.user-path) %bak %for)
+              ?.  (~(has in corked.c) u.bone dire)
                 tip
               (~(del by tip) user-path)
             ==
@@ -4306,22 +4314,25 @@
               ::
               %-  ~(rep by pit.c)
               |=  [[=ames=path req=request-state] pit=_pit.c]
-              ?:  ?=(^ pay.req)
-                ::  skip +peek for poke acks
-                ::
-                pit
               %-  ~(rep by for.req)
               |=  [[hen=duct *] p=_pit]
-              ::  inspect the duct to find %mesa wires for %pokes
+              ::  inspect the duct to find %mesa wires
               ::
               ?.  ?=([[%ames %mesa %flow *] *] hen)
                 p
               =>  .(i.hen `(pole knot)`i.hen)
-              ?.  ?=([@ @ @ %pok %for h=@ r=@ bone=@ ~] i.hen)
+              ?.  ?=([@ @ @ wer=@ dir=@ h=@ r=@ bone=@ ~] i.hen)
+                p
+              ?.  ?=(?(%for %bak) dir.i.hen)
                 p
               ?~  bone=(slaw %ud bone.i.hen)
                 p
-              ?.  (~(has in corked.c) u.bone %for)
+              ~?  >>>  ?=(^ pay.req)
+                flow-corked-with-pit-entry/bone=u.bone^dire=dir.i.hen
+              ::  flow wires carry our side's dire;
+              ::  use it directly to find the flow in .corked
+              ::
+              ?.  (~(has in corked.c) u.bone dir.i.hen)
                 p
               (~(del by p) ames-path)
             ==

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2618,6 +2618,7 @@
             [%30 axle-30]
             [%31 axle]
             [%32 axle]
+            [%33 axle]
         ==
     ::
     ::
@@ -2692,7 +2693,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%32 larva/ames-state]
+    ++  stay  [%33 larva/ames-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old
@@ -2868,6 +2869,10 @@
               $:  %32                            :: use %ames as default core.
                   ?(%adult %larva)               :: migrate attestation flows
                   state=axle                     :: clean up corked peeks
+              ==
+              $:  %33                            :: clean up multi-frag peeks
+                  ?(%adult %larva)               ::
+                  state=axle
           ==  ==
       |^  ?-  old
           [%4 %adult *]
@@ -3173,10 +3178,16 @@
         larval-gate
       ::
           [%32 *]
+        =.  cached-state  `[%32 state.old]
+        ~>  %slog.1^leaf/"ames: larva %32 reload"
+        larval-gate
+      ::
+          [%33 *]
         ?-  +<.old
           %larva  larval-gate
           %adult  (load:adult-core state.old)
         ==
+      ::
       ==
       ::
       ++  event-9-til-11-to-12
@@ -3251,7 +3262,7 @@
       |^  ^+  [moz larval-core]
       ?~  cached-state  [~ larval-core]
       =*  old  u.cached-state
-      ?:  ?=(%32 -.old)
+      ?:  ?=(%33 -.old)
         ::  no state migrations left; update state, clear cache, and exit
         ::
         [(flop moz) larval-core(ames-state.adult-gate +.old, cached-state ~)]
@@ -3352,8 +3363,10 @@
         $(cached-state `30+(state-29-to-30 +.old))
       ?:  ?=(%30 -.old)
         $(cached-state `31+(state-30-to-31 +.old))
-      ?>  ?=(%31 -.old)
-      $(cached-state `32+(state-31-to-32 +.old))
+      ?:  ?=(%31 -.old)
+        $(cached-state `32+(state-31-to-32 +.old))
+      ?>  ?=(%32 -.old)
+      $(cached-state `33+(state-32-to-33 +.old))
       ::
       ++  our-beam  `beam`[[our %rift %da now] /(scot %p our)]
       ++  state-4-to-5
@@ -4022,6 +4035,68 @@
             ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
               tip
             (~(del by tip) user-path)
+          ==
+        ==
+      ::
+      ++  state-32-to-33
+        |=  old=axle
+        ^-  axle
+        ~>  %slog.0^leaf/"ames: migrating from state %32 to %33"
+        ::  first pass to clean the .tip
+        ::
+        =.  chums.old
+          ^-  (map ship chum-state)
+          %-  ~(run by chums.old)
+          |=  c=chum-state
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          %_    c
+              tip
+            ::  remove entries for corked flows
+            ::
+            %-  ~(rep by tip.c)
+            |=  [[=user=path *] tip=_tip.c]
+            =>  .(user-path `(pole knot)`user-path)
+            ?.  ?=([%a %x %'1' %$ %flow bone=@ *] user-path)
+              tip
+            ?.  (~(has in corked.c) (slav %ud bone.user-path) %for)
+              tip
+            (~(del by tip) user-path)
+          ==
+        ::  last pass; .pit clean-up
+        ::
+        %=    old
+            chums
+          ^-  (map ship chum-state)
+          %-  ~(run by chums.old)
+          |=  c=chum-state
+          ^-  chum-state
+          ?:  ?=(%alien -.c)  c
+          ^-  chum-state
+          %_    c
+              pit
+            ::  remove entries for corked flows
+            ::
+            %-  ~(rep by pit.c)
+            |=  [[=ames=path req=request-state] pit=_pit.c]
+            ?:  ?=(^ pay.req)  pit
+            ::  skip poke acks
+            ::
+            %-  ~(rep by for.req)
+            |=  [[hen=duct *] p=_pit]
+            ::  inspect the duct to find %mesa wires for %pokes
+            ::
+            ?.  ?=([[%ames %mesa %flow *] *] hen)
+              p
+            =>  .(i.hen `(pole knot)`i.hen)
+            ?.  ?=([@ @ @ %pok %for h=@ r=@ bone=@ ~] i.hen)
+              p
+            ?~  bone=(slaw %ud bone.i.hen)
+              p
+            ?.  (~(has in corked.c) u.bone %for)
+              p
+            (~(del by pit) ames-path)
           ==
         ==
       ::
@@ -13797,7 +13872,7 @@
   take:am-core
 ::  +stay: extract state before reload
 ::
-++  stay  [%32 adult/ames-state]
+++  stay  [%33 adult/ames-state]
 ::  +load: load in old state after reload
 ::
 ++  load

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9333,7 +9333,7 @@
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (decrypt-path [pat her]:pok.pact)
             ::
-            ?:  ?=(%none -.space)
+            ?:  ?=(?(%publ %none) -.space)
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
                       " pok={<pat.pok.pact>}; skip"

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12351,7 +12351,7 @@
             ::  only the %for side sends %cork $pleas; %bak flows in
             ::  closing only +peek for the %gone page
             ::
-            ?:  =(%bak dire)  c
+            ?:  ?=(%bak dire)  c
             ?.  closing.state  c
             =+  fo-core=~(fo-core fo:c [bone dire] state)
             ::  sanity check on the flow state

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2670,7 +2670,7 @@
       ::
       =^  call-moves  adult-gate  (call:adult-core duct dud task)
       ~>  %slog.0^leaf/"ames: metamorphosis on %call"
-      [:(weld queu-moves call-moves molt-moves) adult-gate]
+      [:(weld molt-moves queu-moves call-moves) adult-gate]
     ::
     ++  take
       |=  [=wire =duct dud=(unit goof) =sign]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9333,10 +9333,12 @@
               ~|  inner-path/[pat.ack^pat.pok]:pact
               (decrypt-path [pat her]:pok.pact)
             ::
-            ?:  ?=(?(%publ %none) -.space)
+            ?.  ?=(%chum -.space)
+              ::  XX
+              ::
               %-  %+  %*(ev-tace ev-core her her-pok)  odd.veb.bug.ames-state
                   |.  %+  weld  "weird poke lifes={<life.per^life.ames-state>}"
-                      " pok={<pat.pok.pact>}; skip"
+                      " pok={<pat.pok.pact>} using {<-.space>}; skip"
               ev-core
             ::
             =/  [pok=(pole iota) ack=(pole iota)]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10747,14 +10747,6 @@
             =/  =space   chum-to-our
             (fo-emit hen [%pass wire %a meek/[space her (fo-nax-path seq our)]])
           ::
-          ++  fo-send-ack
-            |=  seq=@ud
-            ^+  fo-core
-            ::  emit (n)ack to unix; see +fo-peek where the (n)ack is produced
-            ::
-            =/  =path  (%*(fo-ack-path fo-core dire.side fo-flip-dire) seq her)
-            (fo-emit [/ames]~ %pass /make-page %a mage/[chum-to-her her^path])
-          ::
           ++  fo-peek-cork
             %-  %+  ev-tace  fin.veb.bug.ames-state
                 |.("peek for %cork {<bone=bone>}")
@@ -10774,6 +10766,14 @@
             ::  for-cor-path will produce a path for the %cork on the other side
             ::
             [(fo-wire %fub) %a meek/[chum-to-our her (fo-cor-path seq=0 our)]]
+          ::
+          ++  fo-send-ack
+            |=  seq=@ud
+            ^+  fo-core
+            ::  emit (n)ack to unix; see +fo-peek where the (n)ack is produced
+            ::
+            =/  =path  (%*(fo-ack-path fo-core dire.side fo-flip-dire) seq her)
+            (fo-emit [/ames]~ %pass /make-page %a mage/[chum-to-her her^path])
           ::
           ++  fo-handle-miss-ack
             |=  seq=message-num

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10212,6 +10212,8 @@
                         &(=(%bak dire.message-path) =(%for dire.side))
                 ==  ==
             ?:  =(%fub were)
+              ::  XX not used
+              ::
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("%cork %flub received; delete {<side>}")
               fo-abel:(fo-take-fub:fo-core sage)
@@ -10242,6 +10244,18 @@
                 ack-path=our^(pout message-path(load %ack, dire dire.side))
               her^(pout message-path)
             q.sage
+          ?.  =(%ack were)
+            %-  %+  ev-tace  odd.veb.bug.ames-state
+                |.("weird {<were>}; skip")
+            ev-core
+          ::  %acks should be given to existing non-corked flows
+          ::
+          ?.  ?|  (~(has by flows.per) side)
+                  (~(has in corked.per) side)
+              ==
+            %-  %+  ev-tace  odd.veb.bug.ames-state
+                |.("%ack for missing flow {<side>}; skip")
+            ev-core
           ::  wires are tagged ?(%ack %nax) so we can diferentiate if we are
           ::  proessing an ack or a naxplanation payload
           ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10821,9 +10821,13 @@
             ::
                 %ack
               ::  always ack messages on a forward flow
-              ::  (i.e. produce %ack for a %boon)
+              ::  (i.e. %boons are always acked)
               ::
               ?:  ?=(%for dire)
+                ?.  (lte seq last-acked.rcv)
+                  ::  skip future %boons
+                  ::
+                  ~
                 `ack/error=%.n
               ?:  (~(has by nax.rcv) seq)
                 ::  if we have naxplanation state for this message—even

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9404,25 +9404,7 @@
                   :+  (recover-root:verifier:lss (rip 8 dat.data))
                     aut.data
                   pok.pact
-              :: XX assert load is plea/boon?
-              ::
-              ?:  (fo-message-is-acked:fo-core mess.pok)
-                ::  don't peek if the message havs been already acked
-                ::
-                ?:  (gte (sub last-acked.rcv:fo-core mess.pok) 10)
-                  %-  %+  ev-tace  odd.veb.bug.ames-state
-                      |.("poke [bon, seq]={<[bone mess]:pok>} outside of window")
-                  ev-core
-                %-  %+  ev-tace  rcv.veb.bug.ames-state
-                    |.("poke [bon, seq]={<[bone mess]:pok>} already acked")
-                ::
-                fo-abet:(fo-send-ack:fo-core mess.pok)
-              ::
-              %-  %+  ev-tace  fin.veb.bug.ames-state
-                  |.("peek for poke payload {<[flow=bone seq=mess]:pok>}")
-              ::
-              %^  ev-emit  hen  %pass
-              [(fo-wire:fo-core %pok) %a %meek [none/~ [her pat]:pok.pact]]
+              fo-abet:(fo-peek-poke:fo-core seq=mess.pok pat.pok.pact)
             ::  authenticate one-fragment message
             ::
             ::  if this is a one-fragment %data pact, tob would equal the size of
@@ -10735,7 +10717,7 @@
                 ==
             fo-core
           ::
-          +|  %internals
+          +|  %peeks
           ::
           ++  fo-peek-naxplanation
             |=  seq=@ud
@@ -10766,6 +10748,30 @@
             ::  for-cor-path will produce a path for the %cork on the other side
             ::
             [(fo-wire %fub) %a meek/[chum-to-our her (fo-cor-path seq=0 our)]]
+          ::
+          ++  fo-peek-poke
+            |=  [seq=@ud =poke=path]
+            :: XX assert load is plea/boon?
+            ::
+            ?:  (fo-message-is-acked seq)
+              ::  don't peek if the message havs been already acked
+              ::
+              ?:  (gte (sub last-acked.rcv seq) 10)
+                %-  %+  ev-tace  odd.veb.bug.ames-state
+                    |.("poke [bon, seq]={<[bone seq]>} outside of window")
+                fo-core
+              %-  %+  ev-tace  rcv.veb.bug.ames-state
+                  |.("poke [bon, seq]={<[bone seq]>} already acked")
+              ::
+              (fo-send-ack:fo-core seq)
+            ::
+            %-  %+  ev-tace  fin.veb.bug.ames-state
+                |.("peek for poke payload {<[flow=bone seq=seq]>}")
+            ::
+            %^  fo-emit  hen  %pass
+            [(fo-wire %pok) %a %meek [none/~ her poke-path]]
+          ::
+          +|  %internals
           ::
           ++  fo-send-ack
             |=  seq=@ud

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4371,6 +4371,7 @@
             ==
           ==
         ::
+      ::
       ++  state-35-to-36
         |=  old=axle
         ^-  axle
@@ -4494,6 +4495,7 @@
             (~(del by p) ames-path)
           ==
         ==
+      ::
       --
     ::
     --
@@ -11323,12 +11325,19 @@
                 |.  %+  weld  "peek for {<?:(?=(%for dire) %boon %plea)>} "
                     "payload {<[flow=bone seq=seq]>}"
             ::
-            ::
-            %^    fo-emit
-                ?.  ?=(%for dire)  hen
-                ::  if peeking for a %boon, use the right listener
-                ::
-                (~(got by by-bone.ossuary.per) bone)
+            =/  hun=(unit duct)
+              ?.  ?=(%for dire)  `hen
+              ::  if peeking for a %boon, use the right listener
+              ::
+              (~(get by by-bone.ossuary.per) bone)
+            ?~  hun
+              ::  a %for flow with no ossuary duct can't deliver the
+              ::  $boon (+fo-sink-boon would crash); don't peek for it
+              ::
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.("flow {<side>} not in ossuary; skip peek")
+              fo-core
+            %^    fo-emit  u.hun
               %pass
             [(fo-wire %pok) %a %meek [none/~ her poke-path]]
           ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4382,11 +4382,11 @@
           ^-  chum-state
           ?:  ?=(%alien -.c)  c
           ^-  chum-state
-          ::  remove stales %for flows created by +do-clos:sy-stir, which
-          ::  used %bak flows in closing and made them as %for and queued
-          ::  a %cork $plea to be sent
+          ::  remove stale %for flows created by +do-clos:sy-stir, which
+          ::  used %bak flows in closing and turn them into a %for flow
+          ::  with a queued %cork $plea to be sent
           ::
-          ::  a forward flow's bone always useds .next-bone.ossuary, so a
+          ::  a forward flow's bone always uses .next-bone.ossuary, so a
           ::  %for flow where ( bone >= next-bone ) is stale
           ::
           =/  bones=(set bone)
@@ -10244,7 +10244,10 @@
                 ack-path=our^(pout message-path(load %ack, dire dire.side))
               her^(pout message-path)
             q.sage
-          ?.  =(%ack were)
+          ::  wires are tagged ?(%ack %nax) so we can diferentiate if we are
+          ::  proessing an ack or a naxplanation payload
+          ::
+          ?.  ?=(?(%ack %nax) were)
             %-  %+  ev-tace  odd.veb.bug.ames-state
                 |.("weird {<were>}; skip")
             ev-core
@@ -10254,11 +10257,8 @@
                   (~(has in corked.per) side)
               ==
             %-  %+  ev-tace  odd.veb.bug.ames-state
-                |.("%ack for missing flow {<side>}; skip")
+                |.("{<were>} for missing flow {<side>}; skip")
             ev-core
-          ::  wires are tagged ?(%ack %nax) so we can diferentiate if we are
-          ::  proessing an ack or a naxplanation payload
-          ::
           =.  fo-core
             ::  XX parse $ack payload in here, and call task instead?
             (fo-take:fo-core were sage/[mess.message-path sage])

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -2697,7 +2697,7 @@
       ~>  %slog.0^leaf/"ames: metamorphosis on %take"
       [:(weld molt-moves queu-moves take-moves) adult-gate]
     ::
-    ++  stay  [%35 %larva state=axle cache=_cached-state]
+    ++  stay  [%35 %larva state=ames-state cache=cached-state]
     ++  scry  scry:adult-core
     ++  load
       |=  $=  old

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10060,6 +10060,14 @@
           ++  fo-abel
             ^+  ev-core
             ::
+            =/  cork-path  (fo-cor-path seq=0 our)
+            ::  this assumes that the sender has only one outstanding $boon
+            ::    (snd-window = 1)
+            ::
+            =/  boon-path  (fo-pok-path seq=+(last-acked.rcv) our)
+            =/  ames-cork  (make-space-path chum-to-our cork-path)
+            =/  ames-boon  (make-space-path chum-to-our boon-path)
+            ::
             =:   flows.per  (~(del by flows.per) bone^dire)
                 corked.per  (~(put in corked.per) bone^dire)
             ::
@@ -10072,8 +10080,6 @@
               (~(del by by-duct.ossuary.per) (ev-got-duct bone))
             ::
                 tip.per
-              =/  cork-path  (fo-cor-path seq=0 our)
-              =/  ames-cork  (make-space-path chum-to-our cork-path)
               =+  ?.  (~(has by tip.per) cork-path)  ~
                   %.  ~
                   %+  ev-tace  fin.veb.bug.ames-state
@@ -10084,7 +10090,12 @@
                       """
               =;  [tip=_tip.per *]
                 ::  once all %acks are deleted we can delete the peek for the cork
+                ::    (and any possible %peek for $boon)
                 ::
+                =?  tip  ?=(%for dire) :: XX necessary?
+                  %^  ~(del ju tip)  boon-path
+                    `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
+                  ames-boon
                 %^  ~(del ju tip)  cork-path
                   `duct`[`wire`[%ames (fo-wire %cor)] duct=hen]
                 ames-cork
@@ -10101,15 +10112,21 @@
             ::
                 pit.per
                   =;  [pit=_pit.per *]
-                    ::  a forward flow can be deleted when we hear an %ack for a
-                    ::  %cork $plea, or a %gone $page for a corked flow +peek.
+                    ::  a forward flow can be deleted when we hear an %ack for
+                    ::  a %cork $plea, or a %gone $page for a corked flow +peek
                     ::
                     ::  for the %ack, there could be a path in the .pit to read
                     ::  if the flow has been corked, so we can just derive it
                     ::  based on the flow-state, and attempt to delete it.
                     ::
-                    %-  ~(del by pit)
-                    (make-space-path chum-to-our (fo-cor-path seq=0 our))
+                    ::  if we are the %bak side, we could be peeking for a
+                    ::  multi-fragment $boon. If we leave the subscription
+                    ::  before the $boon completes, and then %cork the flow
+                    ::
+                    ::
+                    =?  pit  ?=(%bak dire) :: XX necessary?
+                      (~(del by pit) ames-boon)
+                    (~(del by pit) ames-cork)
                   ::
                   %^  (dip:fo-mop _pit.per)  loads.snd
                     pit.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10075,6 +10075,14 @@
                 ::    (and any possible %peek for $boon)
                 ::
                 =?  tip  ?=(%for dire) :: XX necessary?
+                  =+  ?.  (~(has by tip.per) boon-path)  ~
+                      %.  ~
+                      %+  ev-tace  fin.veb.bug.ames-state
+                      |.  """
+                          remove {(spud boon-path)} from .tip {<side=side>}
+                          {<[%ames (fo-wire %pok) duct=hen]>}
+                          ames-path={(spud ames-boon)}
+                          """
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10106,7 +10114,15 @@
                     ::  before the $boon completes, and then %cork the flow
                     ::
                     ::
-                    =?  pit  ?=(%bak dire) :: XX necessary?
+                    =?  pit  ?=(%for dire) :: XX necessary?
+                      =+  ?.  (~(has by tip.per) boon-path)  ~
+                          %.  ~
+                          %+  ev-tace  fin.veb.bug.ames-state
+                          |.  """
+                              remove {(spud boon-path)} from .pit {<side=side>}
+                              {<[%ames (fo-wire %pok) duct=hen]>}
+                              ames-path={(spud ames-boon)}
+                              """
                       (~(del by pit) ames-boon)
                     (~(del by pit) ames-cork)
                   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -12186,9 +12186,12 @@
               (sy-emil clos-moves)
             %-  ~(rep by flows.per.ev-core)
             |=  [[side state=flow-state] c=_ev-core]
-            ?:  =(%back dire)  c
+            ::  only the %for side sends %cork $pleas; %bak flows in
+            ::  closing only +peek for the %gone page
+            ::
+            ?:  =(%bak dire)  c
             ?.  closing.state  c
-            =+  fo-core=~(fo-core fo:c [bone dire=%for] state)
+            =+  fo-core=~(fo-core fo:c [bone dire] state)
             ::  sanity check on the flow state
             ::
             ?^  first=(pry:fo-mop:fo-core loads.snd.fo-core)  c

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9467,6 +9467,14 @@
             ::
             =.  ev-core  (ev-update-qos %live last-contact=now)
             ::
+            =/  tof  (div (add tob.data 1.023) 1.024)
+            =/  [typ=?(%auth %data) fag=@ud]
+              ?~  wan.name
+                [?:((gth tof 1) %auth %data) 0]
+              [typ fag]:wan.name
+            %-  %+  ev-tace  rcv.veb.bug.ames-state
+                |.("hear page packet {<[tof=tof typ=typ fag=fag]>}")
+            ::
             ::  check for pending request (peek|poke)
             ::
             ?~  res=(~(get by pit.per) sealed-path)
@@ -9474,20 +9482,11 @@
               %+  ev-tace  odd.veb.bug.ames-state
               |.("missing page from pit {(spud inner-path)}")
             ::
-            %-  (ev-tace rcv.veb.bug.ames-state |.("hear page packet"))
-            ::
             ?.  =(rift.per rif.name)
               %-  %+  ev-tace  odd.veb.bug.ames-state
                   |.("wrong rift {<[rift.per rif.name]>}; skip")
               ev-core
             ::
-            ::
-            =/  tof  (div (add tob.data 1.023) 1.024)
-            ::
-            =/  [typ=?(%auth %data) fag=@ud]
-              ?~  wan.name
-                [?:((gth tof 1) %auth %data) 0]
-              [typ fag]:wan.name
             ::
             ?-    typ
                 %auth
@@ -10065,11 +10064,7 @@
               =+  ?.  (~(has by tip.per) cork-path)  ~
                   %.  ~
                   %+  ev-tace  fin.veb.bug.ames-state
-                  |.  """
-                      remove {(spud cork-path)} from .tip {<side=side>}
-                      {<[%ames (fo-wire %cor) duct=hen]>}
-                      ames-path={(spud ames-cork)}
-                      """
+                  |.("remove %peek for %cork from .tip {<side>}")
               =;  [tip=_tip.per *]
                 ::  once all %acks are deleted we can delete the peek for the cork
                 ::    (and any possible %peek for $boon)
@@ -10078,11 +10073,7 @@
                   =+  ?.  (~(has by tip.per) boon-path)  ~
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
-                      |.  """
-                          remove {(spud boon-path)} from .tip {<side=side>}
-                          {<[%ames (fo-wire %pok) duct=hen]>}
-                          ames-path={(spud ames-boon)}
-                          """
+                      |.("remove %peek for %boon from .tip {<side>}")
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10118,11 +10109,7 @@
                       =+  ?.  (~(has by tip.per) boon-path)  ~
                           %.  ~
                           %+  ev-tace  fin.veb.bug.ames-state
-                          |.  """
-                              remove {(spud boon-path)} from .pit {<side=side>}
-                              {<[%ames (fo-wire %pok) duct=hen]>}
-                              ames-path={(spud ames-boon)}
-                              """
+                          |.("remove %peek for %boon from .pit {<side>}")
                       (~(del by pit) ames-boon)
                     (~(del by pit) ames-cork)
                   ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4383,6 +4383,23 @@
           ^-  chum-state
           ?:  ?=(%alien -.c)  c
           ^-  chum-state
+          ::  clear pending acks on flows in closing. this would prevent
+          ::  a flow that was either a product of the buggy +do-clos, or
+          ::  its counterpart to be corked properly since for both the
+          ::  %ack for the %cork $plea or the %gone $page would crash on
+          ::  the sanity of the corked flow check
+          ::
+          =.  flows.c
+            %-  ~(urn by flows.c)
+            |=  [=side state=flow-state]
+            ^-  flow-state
+            ?.  &(closing.state pending-ack.rcv.state)
+              state
+            %-  %:  trace   %mesa   odd.veb.bug.old   ship
+                  ships.bug.old
+                  |.("clear pending ack on closing flow {<side>}")
+                ==
+            state(pending-ack.rcv %.n)
           ::  remove stale %for flows created by +do-clos:sy-stir, which
           ::  used %bak flows in closing and turn them into a %for flow
           ::  with a queued %cork $plea to be sent

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4410,6 +4410,20 @@
                 ==
             (~(del by flows) bone %for)
           ::
+              corked
+            ::  to prevent the other side to  be stuck in  closing,
+            ::  and +peeking for the %gone page of these flows, we add
+            ::  these flows to the %cork set and move next-bone
+            ::  past them so we don't allocate new flows born corked
+            ::
+            %-  ~(rep in bones)
+            |=  [=bone corked=_corked.c]
+            (~(put in corked) bone %for)
+          ::
+              next-bone.ossuary
+            %+  max  next-bone.ossuary.c
+            (add 4 (~(rep in bones) max))
+          ::
               tip
             ::  remove peeks for stale flows (e.g. %acks for
             ::  their %cork $pleas); by definition this would

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4096,7 +4096,7 @@
               p
             ?.  (~(has in corked.c) u.bone %for)
               p
-            (~(del by pit) ames-path)
+            (~(del by p) ames-path)
           ==
         ==
       ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9396,6 +9396,14 @@
             ?:  (gth (div (add tob.data.pact (dec frag)) frag) 1)
               %-  %+  ev-tace  msg.veb.bug.ames-state
                   |.("hear incomplete message")
+              ::  authenticate the first (%auth) fragment before peeking for
+              ::  the rest of the payload: dat is the serialized lss proof, so
+              ::  recover the root and verify the sender's signature/mac over it
+              ::
+              ?>  %-  authenticate
+                  :+  (recover-root:verifier:lss (rip 8 dat.data))
+                    aut.data
+                  pok.pact
               :: XX assert load is plea/boon?
               ::
               ?:  (fo-message-is-acked:fo-core mess.pok)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10076,6 +10076,10 @@
                       %.  ~
                       %+  ev-tace  fin.veb.bug.ames-state
                       |.("remove %peek for %boon from .tip {<side>}")
+                  ~&  >>  :*  boon-path
+                              `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
+                              ames-boon
+                          ==
                   %^  ~(del ju tip)  boon-path
                     `duct`[`wire`[%ames (fo-wire %pok)] duct=hen]
                   ames-boon
@@ -10108,7 +10112,7 @@
                     ::
                     ::
                     =?  pit  ?=(%for dire) :: XX necessary?
-                      =+  ?.  (~(has by tip.per) boon-path)  ~
+                      =+  ?.  (~(has by pit.per) ames-boon)  ~
                           %.  ~
                           %+  ev-tace  fin.veb.bug.ames-state
                           |.("remove %peek for %boon from .pit {<side>}")
@@ -10781,10 +10785,18 @@
               ::
               (fo-send-ack:fo-core seq)
             ::
+
             %-  %+  ev-tace  fin.veb.bug.ames-state
-                |.("peek for poke payload {<[flow=bone seq=seq]>}")
+                |.  %+  weld  "peek for {<?:(?=(%for dire) %plea %boon)>} "
+                    "payload {<[flow=bone seq=seq]>}"
             ::
-            %^  fo-emit  hen  %pass
+
+            %^    fo-emit
+                ?.  ?=(%for dire)  hen
+                ::  if peeking for a %boon, use the right listener
+                ::
+                (~(got by by-bone.ossuary.per) bone)
+              %pass
             [(fo-wire %pok) %a %meek [none/~ her poke-path]]
           ::
           +|  %internals

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11111,7 +11111,7 @@
             ::
 
             %-  %+  ev-tace  fin.veb.bug.ames-state
-                |.  %+  weld  "peek for {<?:(?=(%for dire) %plea %boon)>} "
+                |.  %+  weld  "peek for {<?:(?=(%for dire) %boon %plea)>} "
                     "payload {<[flow=bone seq=seq]>}"
             ::
             ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10514,7 +10514,9 @@
             ^+  ev-core
             ?:  delete-per
               ev-core(skip-abet delete-per)
-            =?  flows.per  !fo-corked
+            =?  flows.per  ?&  !fo-corked
+                               !=(*flow-state state)
+                           ==
               (~(put by flows.per) bone^dire state)
             %_    ev-core
                 ames-state
@@ -10972,6 +10974,10 @@
                 fo-core(delete-per %.y)
               ==
             ?>  &(?=([%cork ~] payload) ?=([%flow ~] path)):plea
+            ?:  =(0 last-acked.rcv)
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.("%cork $plea is first message {<side>}; drop")
+              fo-core
             ::  publisher receives %cork
             ::  mark flow as closing
             ::  publish %cork %ack (in +hear-poke:ev-mess) in corked.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4393,7 +4393,10 @@
           =/  bones=(set bone)
             %-  ~(rep in ~(key by flows.c))
             |=  [=side bones=(set bone)]
-            ?.  &(?=(%for dire.side) (gte bone.side next-bone.ossuary.c))
+            ?.  ?&  ?=(%for dire.side)
+                    ?|  (gte bone.side next-bone.ossuary.c)
+                        !(~(has by by-bone.ossuary.c) bone.side)
+                ==  ==
               bones
             (~(put in bones) bone.side)
           ?:  =(~ bones)  c

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -9808,6 +9808,15 @@
                   |.("ack {<rcvr.ack>} and poke {<her-pok>} missmatch; skip")
               ev-core
             ::
+            ?.  ?&  =(bone.ack bone.pok) :: do paths describes same flow?
+                    =(mess.ack mess.pok)
+                    !=(dire.ack dire.pok)
+                ==
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  =+  [a=[bone dire mess]:ack p=[bone dire mess]:pok]
+                  |.("ack/poke flow mismatch {<[a=a p=p]>}; skip")
+              ev-core
+            ::
             %-  (ev-tace rcv.veb.bug.ames-state |.("hear poke packet"))
             ::
             =+  old-lane=lane.per

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10767,6 +10767,17 @@
           ::
           ++  fo-peek-poke
             |=  [seq=@ud =poke=path]
+            ::  if flow is corked, no-op
+            ::
+            ?:  |(halt.state closing.state (~(has in corked.per) side))
+              %-  %+  ev-tace  odd.veb.bug.ames-state
+                  |.
+                  ?:  halt.state
+                    "flow {<[side]>} is halted; skip peek"
+                  ?:  closing.state
+                    "flow {<[side]>} in closing; skip peek"
+                  "flow {<[side]>} is corked; skip peek"
+              fo-core
             :: XX assert load is plea/boon?
             ::
             ?:  (fo-message-is-acked seq)


### PR DESCRIPTION
if a %bak flow was in closing with no outstanding pleas (i.e. the %cork $plea was corked) +do-close (if the /recork-timer happens to run at the time with a flow is in closing, but is still waiting to hear the %gone $page from +peeking the %cork) would allocate a fake/stale %for flow with the contents of the %bak flow, and reusing the bone number.

if the bone used was higher than the next-bone in the ossuary, this would just create a loop where after receiving the %ack for the %cork, we would crash, since the bone is not in the ossuary (an incoming state migration will fix this), and the %cork plea would be sent again and again.

If the bone used was from a real %for flow with state, depending on the state of the real %bak flow on the other side, the %cork plea would no-op, or be acked thinking it's a resend, or if this is the first $plea ever to be received (seq=1) it would cork the flow silently without notifying %gall.

Here we add a state migration to fix the synthetic %for flows if we can. If this ever reused any pre-existing flow number, at best we would leave a leak in ames forever, at worst we would block a subscription flow, so we would need to coordinate with %gall to remove this subscription and create a new one.

%gall has several of these de-sync already existing, and there is a %lave task to do this exact type of cleaning (check corked flows with existing gall subscriptions)

built on top of https://github.com/urbit/urbit/pull/7364 that has the correct +stay for the larval core and another migration that does even more cleanup for any entry in the .tip/.pit for corked flows