### PR TITLE
ames, gall: fix %flub handling for running agent

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8119,7 +8119,6 @@
                   sink
                 %-  %+  pe-trace  odd.veb
                         |.("%flubbing: {<bone=bone>} last={<last-heard.state>}")
-                =+  left=q:~(get to pending-vane-ack.state)
                 %_  sink
                   pending-vane-ack.state  ~                :: drop all pending
                         last-heard.state  last-acked.state :: rewind last heard

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8433,19 +8433,6 @@
             ++  done
               |=  ok=?
               ^+  sink
-              ?:  =(~ pending-vane-ack.state)
-                ::  a %done for no-pending ack means a wrongly handled %flub
-                ::  (%gall still held the $plea this %done belonged to, but
-                ::  told %ames to flub it, rewinding .last-heard and dropping
-                ::  acks) in that case we just wait for the sender to re-send
-                ::  the message
-                ::
-                ::  instead of crashing, no-op, since we would abort the
-                ::  unsuspension of the agent
-                ::
-                %-  %+  pe-trace  odd.veb
-                    |.("drop %done bone={<bone>}; missing pending")
-                sink
               =^  pending  pending-vane-ack.state
                 ~(get to pending-vane-ack.state)
               =/  =message-num  message-num.p.pending
@@ -10920,13 +10907,7 @@
               :: ack from client vane
               ::
                   %done
-                ?.  pending-ack.rcv
-                  ::  (see +done handling in %ames)
-                  ::
-                  %-  %+  ev-tace  odd.veb.bug.ames-state
-                      |.("drop %done bone={<bone>}; missing pending")
-                  fo-core
-                (fo-take-done +.sign)
+                ?>(pending-ack.rcv (fo-take-done +.sign))
               ::  halt the flow
               ::
                   %flub

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10831,12 +10831,18 @@
               ::  halt the flow
               ::
                   %flub
-                =?  halt.state   ?=([? ^] +.sign)  %.y
-                =?     fo-core   ?=([? ^] +.sign)
-                  (fo-emit hen %pass /halt %g %halt her u.dap.sign bone)
-                =?  pending-ack.rcv  &(?=([? *] +.sign) !blocked.sign)
-                  %.n  :: XX  tack.pending-ack.rcv
-                fo-core
+                ?~  +.sign
+                  ::  a running agent has recevied a /gp plea with
+                  ::  no blocked moves; remove pending
+                  ::
+                  =.  pending-ack.rcv  %.n
+                  fo-core
+                =?  pending-ack.rcv  !blocked.sign  %.n
+                ?~  dap.sign  fo-core
+                ::  if system-flow is established, halt flow and send %boon %flub
+                ::
+                =.  halt.state  %.y
+                (fo-emit hen %pass /halt %g %halt her u.dap.sign bone)
               ::  un-halt the flow
               ::
                   %spur

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8180,7 +8180,7 @@
                   ::  pending-vane-ack.state which has not been acked
                   ::  so we can attempt to redeliver the head of the pending
                   ::  queue from the payload stored there.
-
+                  ::
                   ::  note: we can't rely on the sender's pump, since we don't
                   ::  know if the sender is/will be rewound via a $boon %spur
                   ::
@@ -8433,7 +8433,19 @@
             ++  done
               |=  ok=?
               ^+  sink
-              ::
+              ?:  =(~ pending-vane-ack.state)
+                ::  a %done for no-pending ack means a wrongly handled %flub
+                ::  (%gall still held the $plea this %done belonged to, but
+                ::  told %ames to flub it, rewinding .last-heard and dropping
+                ::  acks) in that case we just wait for the sender to re-send
+                ::  the message
+                ::
+                ::  instead of crashing, no-op, since we would abort the
+                ::  unsuspension of the agent
+                ::
+                %-  %+  pe-trace  odd.veb
+                    |.("drop %done bone={<bone>}; missing pending")
+                sink
               =^  pending  pending-vane-ack.state
                 ~(get to pending-vane-ack.state)
               =/  =message-num  message-num.p.pending
@@ -10908,13 +10920,18 @@
               :: ack from client vane
               ::
                   %done
-                ?>  =(%.y pending-ack.rcv)
+                ?.  pending-ack.rcv
+                  ::  (see +done handling in %ames)
+                  ::
+                  %-  %+  ev-tace  odd.veb.bug.ames-state
+                      |.("drop %done bone={<bone>}; missing pending")
+                  fo-core
                 (fo-take-done +.sign)
               ::  halt the flow
               ::
                   %flub
                 ?~  +.sign
-                  ::  a running agent has recevied a /gp plea with
+                  ::  a running agent has received a /gp plea with
                   ::  no blocked moves; remove pending
                   ::
                   =.  pending-ack.rcv  %.n

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8108,7 +8108,20 @@
                   %drop  sink(nax.state (~(del in nax.state) message-num.task))
                   %done  (done ok.task)
                   %flub
-                ?:  ?=([%flub ~] task)  sink
+                ?:  ?=([%flub ~] task)
+                  ::  a running agent has recevied a /gp plea with
+                  ::  no blocked moves; remove pending
+                  ::
+                  ?~  next=~(top to pending-vane-ack.state)
+                    ::  XX if there is nothing in pending, rewind last-heard?
+                    ::
+                    sink
+                  ?:  &  sink
+                  ::  is this safe to do?
+                  ::
+                  %-  %+  pe-trace  odd.veb
+                      |.("redeliver pending {<message-num.u.next>} bone={<bone>}")
+                  (handle-sink message-num.u.next message.u.next ok=%.y)
                 =?  peer-core  ?=([%flub ? ^] task)
                   ::  /gf system flow established; halt the flow
                   ::
@@ -8263,8 +8276,8 @@
                       |.  ^-  tape
                       "hear last in-progress; try to %flub {<[agent data]>}"
                   %^  pe-emit  duct  %pass
-                  :-  (make-bone-wire her rift.hers.channel bone.shut-packet)
-                  [%g %plea her u.m(path /gp/[agent])]
+                    :-  (make-bone-wire her rift.hers.channel bone.shut-packet)
+                    [%g %plea her u.m(path /gp/[agent])]
                   sink
               ::  last-heard<seq<10+last-heard; packet in a live message
               ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8109,16 +8109,20 @@
                   %done  (done ok.task)
                   %flub
                 ?:  ?=([%flub ~] task)
-                  ::  a running agent has recevied a /gp plea with
-                  ::  no blocked moves; remove pending
+                  ::  a running agent has received a /gp plea with no
+                  ::  blocked moves.
+                  ::  the trigger for the /gp plea in %ames is state in
+                  ::  pending-vane-ack.state which has not been acked
+                  ::  so we can attempt to redeliver the head of the pending
+                  ::  queue from the payload stored there.
+
+                  ::  note: we can't rely on the sender's pump, since we don't
+                  ::  know if the sender is/will be rewound via a $boon %spur
                   ::
                   ?~  next=~(top to pending-vane-ack.state)
                     ::  XX if there is nothing in pending, rewind last-heard?
                     ::
                     sink
-                  ?:  &  sink
-                  ::  is this safe to do?
-                  ::
                   %-  %+  pe-trace  odd.veb
                       |.("redeliver pending {<message-num.u.next>} bone={<bone>}")
                   (handle-sink message-num.u.next message.u.next ok=%.y)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1132,7 +1132,7 @@
   ::  +mo-remote-blocked: check if .dap has a remote blocked move for .ship
   ::
   ++  mo-remote-blocked
-    |=  [=ship dap=term]
+    |=  [=duct =ship dap=term]
     ^-  ?
     ?~  waiting=(~(get by blocked.state) dap)
       %.n
@@ -1142,6 +1142,14 @@
     |=  =blocked-move
     ?&  ?=(%& -.move.blocked-move)
         =(ship ship.attributing.routes.blocked-move)
+        ::  the enqueued deal's duct is the original %ames delivery duct
+        ::  prefixed with our own /sys/req wire; match on the %ames
+        ::  bone-wire so we don't mix flows from the same ship
+        ::
+        ?&  ?=(^ duct)
+            ?=([gall-wire=* ames-wire=^ *] duct.blocked-move)
+            =(i.duct i.t.duct.blocked-move)
+        ==
     ==
   ::  +mo-do-flub: drop incoming pleas in %ames
   ::
@@ -1170,7 +1178,7 @@
     ::  if we have remote blocked moves, skip the %flub handling logic in %ames
     ::  if /gf system flow is not established, skip sending the %flub $boon
     ::
-      maybe-blocked=(mo-remote-blocked ship agent-name)
+      maybe-blocked=(mo-remote-blocked hen ship agent-name)
     ?.((~(has by flub-ducts.state) ship) ~ `agent-name)
   ::
   ++  mo-handle-flub-plea
@@ -2454,7 +2462,7 @@
     ::  %ames. if we don't have blocked remote moves tell %ames to delete
     ::  its pending-ack
     ::
-    ?:  (mo-remote-blocked:mo-core ship agent-name)
+    ?:  (mo-remote-blocked:mo-core duct ship agent-name)
       %-  %^  trace:mo-core  odd.veb.bug.state  agent-name
           &+"on {<ship>} in-progress flow; %plea enqueued; wait"
       mo-core

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1129,6 +1129,20 @@
         %u  [%leave ~]
       ==
     (mo-pass wire %g %deal [ship our /] agent-name deal)
+  ::  +mo-remote-blocked: check if .dap has a remote blocked move for .ship
+  ::
+  ++  mo-remote-blocked
+    |=  [=ship dap=term]
+    ^-  ?
+    ?~  waiting=(~(get by blocked.state) dap)
+      %.n
+    %+  lien  ~(tap to u.waiting)
+    ::  check if any of the blocked moves is attributed to .ship
+    ::
+    |=  =blocked-move
+    ?&  ?=(%& -.move.blocked-move)
+        =(ship ship.attributing.routes.blocked-move)
+    ==
   ::  +mo-do-flub: drop incoming pleas in %ames
   ::
   ::    (if the /gf system flow has been established, notify the other ship
@@ -1153,10 +1167,10 @@
     ::  currently we always halt it
     ::
     %^  mo-give  %flub
-    ::  if we have blocked moves, skip the %flub handling logic in %ames
+    ::  if we have remote blocked moves, skip the %flub handling logic in %ames
     ::  if /gf system flow is not established, skip sending the %flub $boon
     ::
-      maybe-blocked=?=(^ (~(get by blocked.state) agent-name))
+      maybe-blocked=(mo-remote-blocked ship agent-name)
     ?.((~(has by flub-ducts.state) ship) ~ `agent-name)
   ::
   ++  mo-handle-flub-plea
@@ -2434,11 +2448,19 @@
       %-  %^  trace:mo-core  &(?=([%gp @ ~] path) odd.veb.bug.state)  agent-name
           &+"on {<ship>} flubbing in-progress flow"
       (mo-do-flub:mo-core ship agent-name)
-    ?:  ?=([%gp @ ~] path)
+    ?:  ?=([%ge @ ~] path)
+      (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
+    ::  the agent is running but the flow's %plea is still pending in
+    ::  %ames. if we don't have blocked remote moves tell %ames to delete
+    ::  its pending-ack
+    ::
+    ?:  (mo-remote-blocked:mo-core ship agent-name)
       %-  %^  trace:mo-core  odd.veb.bug.state  agent-name
-          &+"on {<ship>} weird in-progress flow; running agent; skip %flub"
+          &+"on {<ship>} in-progress flow; %plea enqueued; wait"
       mo-core
-    (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
+    %-  %^  trace:mo-core  odd.veb.bug.state  agent-name
+        &+"on {<ship>} in-progress flow; running agent; redeliver"
+    (mo-give:mo-core %flub ~)
   ::
       %sear  mo-abet:(mo-filter-queue:mo-core ship.task)
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1143,6 +1143,12 @@
     ::
     =?  mo-core  ?=(%u -.ames-request)
       (mo-give %done ~)
+    ::  the /sys/req wire (and the internal /ames/bone wire in the duct),
+    ::  are patterned-matched by +mo-remote-blocked to recognize
+    ::  blocked remote %deals;
+    ::
+    ::  if we update it here, we need to updade it there
+    ::
     =/  =wire  /sys/req/(scot %p ship)/[agent-name]
     ::
     =/  =deal
@@ -1158,36 +1164,68 @@
   ++  mo-remote-blocked
     |=  [=duct =ship dap=term]
     ^-  ?
-    ?~  waiting=(~(get by blocked.state) dap)
-      %.n
-    %+  lien  ~(tap to u.waiting)
-    ::  check if any of the blocked moves is attributed to .ship
+    ::  extra safe checks so
     ::
-    |=  =blocked-move
-    ?.  ?&  ?=(%& -.move.blocked-move)
-            =(ship ship.attributing.routes.blocked-move)
-            ?=(^ duct)
-            ?=([^ ^ *] duct.blocked-move)
-        ==
-      %.n
+    |^  ?~  waiting=(~(get by blocked.state) dap)
+          %.n
+        ?.  ?=(^ duct)
+          %.n
+        ?~  hen=(parse-bone-wire i.duct)
+          %.n
+        ?.  =(ship her.u.hen)
+          %.n
+        %+  lien  ~(tap to u.waiting)
+        ::  check if any of the blocked moves is attributed to .ship
+        ::
+        |=  =blocked-move
+        ?.  ?&  ?=(%& -.move.blocked-move)
+                =(ship ship.attributing.routes.blocked-move)
+                ?=([^ ^ *] duct.blocked-move)
+            ==
+          %.n
+        =/  req=(pole knot)  i.duct.blocked-move
+        ?.  ?&  ?=([%gall %sys %req ship=@ dap=@ ~] req)
+                =(`ship (slaw %p ship.req))
+                =(dap dap.req)
+            ==
+          %.n
+        ::  match the exact flow so we don't end up mixing
+        ::  different flows
+        ::
+        ?~  del=(parse-bone-wire i.t.duct.blocked-move)
+          %.n
+        ?&  =(ship her.u.del)
+            =(bone.u.del bone.u.hen)
+            ::  ?=(~ rift...) in unlikely but this would be a move
+            ::  enqueued before rifts were included in %ames bone wires;
+            ::
+            ::  if we do have rifts from old breached peers this flow
+            ::  has been corked/removed so we report it as not-blocked
+            ::  since the %done handling in %ames would no-op anyway
+            ::
+            ?|  ?=(~ rift.u.del)
+                ?=(~ rift.u.hen)
+                =(u.rift.u.del u.rift.u.hen)
+        ==  ==
+    ::  +parse-bone-wire: (see +parse-bone-wire in %ames)
     ::
-    =/  req=(pole knot)  i.duct.blocked-move
-    =/  del=(pole knot)  i.t.duct.blocked-move
-    =/  hen=(pole knot)  i.duct
-    ::  try to match exact flow so we don't end-up mixing
-    ::  different flows
-    ::
-    ?&  ?=([%gall %sys %req ship=@ dap=@ ~] req)
-        =(`ship (slaw %p ship.req))
-        =(dap dap.req)
+    ++  parse-bone-wire
+      |=  =wire
+      ^-  (unit [her=@p rift=(unit @ud) =bone:ames])
+      =/  w=(pole knot)  wire
+      ?+    w  ~
+          [%ames %bone ship=@ bone=@ ~]
+        ?~  who=(slaw %p ship.w)   ~
+        ?~  bon=(slaw %ud bone.w)  ~
+        `[u.who ~ u.bon]
       ::
-        ?=([%ames %bone ship=@ rest=*] del)
-        ?=([%ames %bone ship=@ rest=*] hen)
-        =(`ship (slaw %p ship.del))
-        =(`ship (slaw %p ship.hen))
-        =(rest.del rest.hen)  :: XX old pre-rift wires?
-                              :: XX check if rifts match?
-    ==
+          [%ames %bone ship=@ rift=@ bone=@ ~]
+        ?~  who=(slaw %p ship.w)   ~
+        ?~  rif=(slaw %ud rift.w)  ~
+        ?~  bon=(slaw %ud bone.w)  ~
+        `[u.who `u.rif u.bon]
+      ==
+    --
   ::  +mo-do-flub: drop incoming pleas in %ames
   ::
   ::    (if the /gf system flow has been established, notify the other ship

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1140,16 +1140,29 @@
     ::  check if any of the blocked moves is attributed to .ship
     ::
     |=  =blocked-move
-    ?&  ?=(%& -.move.blocked-move)
-        =(ship ship.attributing.routes.blocked-move)
-        ::  the enqueued deal's duct is the original %ames delivery duct
-        ::  prefixed with our own /sys/req wire; match on the %ames
-        ::  bone-wire so we don't mix flows from the same ship
-        ::
-        ?&  ?=(^ duct)
-            ?=([gall-wire=* ames-wire=^ *] duct.blocked-move)
-            =(i.duct i.t.duct.blocked-move)
+    ?.  ?&  ?=(%& -.move.blocked-move)
+            =(ship ship.attributing.routes.blocked-move)
+            ?=(^ duct)
+            ?=([^ ^ *] duct.blocked-move)
         ==
+      %.n
+    ::
+    =/  req=(pole knot)  i.duct.blocked-move
+    =/  del=(pole knot)  i.t.duct.blocked-move
+    =/  hen=(pole knot)  i.duct
+    ::  try to match exact flow so we don't end-up mixing
+    ::  different flows
+    ::
+    ?&  ?=([%gall %sys %req ship=@ dap=@ ~] req)
+        =(`ship (slaw %p ship.req))
+        =(dap dap.req)
+      ::
+        ?=([%ames %bone ship=@ rest=*] del)
+        ?=([%ames %bone ship=@ rest=*] hen)
+        =(`ship (slaw %p ship.del))
+        =(`ship (slaw %p ship.hen))
+        =(rest.del rest.hen)  :: XX old pre-rift wires?
+                              :: XX check if rifts match?
     ==
   ::  +mo-do-flub: drop incoming pleas in %ames
   ::


### PR DESCRIPTION
On %flub, the logic to check if a non-running agent had blocked moves in gall's queue assumed that any move there would be from a remote ship (i.e. ames has given it to %gall, which was the normal behavior before %flub handling was introduced. if this is the case, %ames shouldn't touch any of its state and only, if the system flow has been established, tell the other party to stop spamming), but this is not true, local moves also end up here if the agent is not running.

If local moves were blocked, and we received a remote plea, we would halt the flow normally if the system flow was established, but critically, we would be telling ames "don't forget that this is pending, gall has received it already in its queue, so remember it so you don't give me the same thing twice", which is not always true.

When the agent is revived (local %goad, remote %spur) ames would still think that gall has the move, so it's expecting a %done, which will never arrive, and the incoming %plea is blocked on the pending-ack from the vane.

We have a reproduction for this in mesa that detects this exact behavior, "running agent, with nothing blocked", so upon resend of the plea, we would process it normally, unlocking this flow.

I'm uncertain about how to handle this in legacy ames until i can reproduce that first -- there is more state variations to handle there.

One historical note:

Be fore %flub was introduced, a %plea would endup in galls blocked-move queue, and skip giving a %done if the agent is not running. The sender will keep retrying this forever, and %ames will drop it since we have already heard this message.

The last version of %flub added the ability to stop the sender spamming with these pleas by using a synthetic /gp plea that would check is this agent blocked, and, more importantly, has it been stored in the queue.

If the agent is not here (because we already handle %flub) we can safely remove the pending-vane-ack from %ames, the sender will just re-deliver it.

If the agent is there %ames SHOULD NOT touch any of its state, or we risk breaking exactly-once message delivery: upon revival, the blocked move will be given, then the sender will send the same message again, and %ames will think that it's a new message, since it would have forgotten that it was given to %gall