### PR TITLE
hoon: don't include =* face in its own subject

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -9480,7 +9480,7 @@
                   $(sut q.sut, lon [~ lon], p.heg +(p.heg))
                 ?.  =(0 p.heg)
                   next(p.heg (dec p.heg))
-                =+  tor=(fund way u.u.tyr)
+                =+  tor=(fund(sut q.sut) way u.u.tyr)
                 ?-  -.tor
                   %&  [%& (weld p.p.tor `vein`[~ `axe lon]) q.p.tor]
                   %|  [%| %| p.p.tor (comb [%0 axe] q.p.tor)]

--- a/tests/sys/hoon/tistar.hoon
+++ b/tests/sys/hoon/tistar.hoon
@@ -1,0 +1,8 @@
+/+  *test
+|%
+++  test-tistar-no-self-reference
+  %-  expect-success  |.
+  =+  a=1
+  =*  a  +(a)
+  ?>(=(2 a) ~)
+--


### PR DESCRIPTION
Previously, `=*` would include itself in the subject against which it evaluates. Resolving its face inside the alias would recur infinitely.

Here we remove that property.

This is a meaningful hoon change and will require a hoon kelvin bump. So I'm targeting a fresh `next/kelvin/407` for it. But feel free to redirect as desired.