### PR TITLE
hoon: trigger unifying equality in AST migrations

### DIFF
--- a/pkg/arvo/sys/hoon.hoon
+++ b/pkg/arvo/sys/hoon.hoon
@@ -14213,11 +14213,15 @@
   ++  next-vase
     |=  a=vase
     ^-  vase:h135
+    ::  trigger unifying equality
+    ::
+    =;  b  =+(=(a b) b)
     a(p (next-type p.a))
   ::
   ++  next-type
     |=  a=type  ~+
     ^-  type:h135
+    =;  b  =+(=(a b) b)
     ?+  a  a
       [%cell *]  [%cell $(a p.a) $(a q.a)]
       [%core *]  [%core $(a p.a) (next-coil q.a)]
@@ -14231,6 +14235,7 @@
   ++  next-coil
     |=  a=coil
     ^-  coil:h135
+    =;  b  =+(=(a b) b)
     :+  p.a
       (next-type q.a)
     [p.r.a (~(run by q.r.a) next-tome)]
@@ -14238,22 +14243,26 @@
   ++  next-tome
     |=  a=tome
     ^-  tome:h135
+    =;  b  =+(=(a b) b)
     (~(run by q.a) next-hoon)
   ::
   ++  next-tune
     |=  a=tune
     ^-  tune:h135
+    =;  b  =+(=(a b) b)
     :-  (~(run by p.a) (curr bind next-hoon))
     (turn q.a next-hoon)
   ::
   ++  next-manx
     |=  a=manx:hoot
     ^-  manx:hoot:h135
+    =;  b  =+(=(a b) b)
     [(next-marx g.a) (next-marl c.a)]
   ::
   ++  next-marx
     |=  a=marx:hoot
     ^-  marx:hoot:h135
+    =;  b  =+(=(a b) b)
     :-  n.a
     %+  turn  a.a
     |=  [n=mane:hoot v=(list beer:hoot)]
@@ -14261,6 +14270,7 @@
   ::
   ++  next-marl
     |=  a=marl:hoot
+    =;  b  =+(=(a b) b)
     %+  turn  a
     |=  a=tuna:hoot
     ^-  tuna:hoot:h135
@@ -14270,6 +14280,7 @@
   ++  next-skin
     |=  a=skin
     ^-  skin:h135
+    =;  b  =+(=(a b) b)
     ?+  a  a
       [%cell *]  [%cell $(a +<.a) $(a +>.a)]
       [%dbug *]  [%dbug spot.a $(a skin.a)]
@@ -14282,6 +14293,7 @@
   ++  next-spec
     |=  a=spec  ~+
     ^-  spec:h135
+    =;  b  =+(=(a b) b)
     ?+  -.a  a
       %dbug  [%dbug p.a $(a q.a)]
       %gist  $(a q.a)  ::  drop
@@ -14315,6 +14327,7 @@
   ++  next-hoon
     |=  a=hoon  ~+
     ^-  hoon:h135
+    =;  b  =+(=(a b) b)
     ?+  a  a
       [^ *]      [$(a p.a) $(a q.a)]
     ::


### PR DESCRIPTION
Adds comparisons in `++next-*` arms to trigger unifying equality between the product of the migrating arm and the argument. Should reduce the memory pressure for ships that migrate a lot of vases.