### PR TITLE
clay: rebuild all agents if %base is involved

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -4475,6 +4475,12 @@
   ++  goad
     |=  syd=(unit desk)
     ^+  ..abet
+    ::  Hack: if %base desk is involved, the change might have caused gall
+    ::  recompilation, making it suspend all agents. In that case we rebuild
+    ::  agents from all desks to make sure they are unsuspended
+    ::
+    =?  syd  =(syd `%base)  ~
+    ::
     =^  sat=(list [=desk =bill])  ..abet
       =/  desks=(list desk)
         ?^  syd  ~[u.syd]


### PR DESCRIPTION
Relaxes a condition to rebuild the agents only from a given desk: if the given desk is %base then we rebuild all agents.

This is done because a change to the %base desk might have caused Gall recompilation, which causes suspension of all agents. To unsuspend them we rebuild all agents.

This change should automatically fix ships whose non-%base agents got suspended due to an OTA from ~binnec. Sorry!