### PR TITLE
spider: don't re-validate local facts

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -4675,6 +4675,7 @@
           ?.  ?=(%agent -.in)                  `in
           ?.  ?=(%fact -.sign.in)              `in
           ?:  ?=(%thread-done p.cage.sign.in)  `in
+          ?:  =(src our):bowl.strand-input     `in
           ::
           :-  ~
           :^  %agent  wire.in  %fact


### PR DESCRIPTION
My intention is to have spider match gall's behavior for subscriptions, which only re-vales remote facts.

See:
https://github.com/urbit/urbit/blob/0d00e56a56ed60db21911c9a2538bf656762a115/pkg/arvo/sys/vane/gall.hoon#L1917-L1918

where, if the `unto` is %raw-fact it gets revalidated, but otherwise falls through immediately.