### PR TITLE
gall: remove statefulness workarounds, don't clam local facts in spider

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -4651,6 +4651,10 @@
       ++  validate-mark
         |=  [in=* =mark =bowl]
         ^-  cage
+        ?:  =(%noun mark)
+          ::  skip validating raw nouns
+          ::
+          [%noun %noun in]
         =+  .^  =dais:clay  %cb
                 /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/[mark]
             ==
@@ -4675,6 +4679,13 @@
           ?.  ?=(%agent -.in)                  `in
           ?.  ?=(%fact -.sign.in)              `in
           ?:  ?=(%thread-done p.cage.sign.in)  `in
+          ::  if the fact has a %noun type, then it either has a %noun-like
+          ::  mark or it comes from raw-fact in Gall, whose validation got
+          ::  deferred to get the mark from the correct desk. In the former case
+          ::  the validation will no-op, and in the latter case it will fully
+          ::  validate the raw noun.
+          ::
+          ?.  ?=(%noun p.q.cage.sign.in)       `in
           ::
           :-  ~
           :^  %agent  wire.in  %fact

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1037,6 +1037,9 @@
       ::
       ?:  =(%noun mark.deal)
         (mo-apply-sure dap routes [%poke %noun %noun noun.deal])
+      ::  we do not defer noun validation if the poked agent is %spider,
+      ::  unlike with apps, because %spider may only be poked by us.
+      ::
       =/  =case  da+now
       =/  yok  (~(got by yokes.state) dap)
       =/  =desk  q.beak:?>(?=(%live -.yok) yok)  ::TODO acceptable assertion?
@@ -1052,9 +1055,6 @@
         ?:  ?=(%| -.res)
           =/  ror  "gall: raw-poke vale fail :{(trip dap)} {<mark.deal>}"
           (mo-give %unto %poke-ack `[leaf+ror p.res])
-        =.  mo-core
-          %+  mo-pass  /nowhere
-          [%c %warp our desk ~ %sing %b case /[mark.deal]]
         (mo-apply-sure dap routes [%poke mark.deal p.res])
       ==
     ::
@@ -1076,9 +1076,6 @@
         ?:  ?=(%| -.res)
           =/  ror  "gall: poke-as cast fail :{(trip dap)} {<mars>}"
           (mo-give %unto %poke-ack `[leaf+ror p.res])
-        =.  mo-core
-          %+  mo-pass  /nowhere
-          [%c %warp our desk ~ %sing %c case /[a.mars]/[b.mars]]
         (mo-apply-sure dap routes [%poke mark.deal p.res])
       ==
     ==
@@ -1603,11 +1600,7 @@
           ?:  ?=(%| -.res)
             %-  (slog leaf+"watch-as fact conversion failure" p.res)
             (ap-kill-up-slip duct)
-          :~  :*  duct  %pass  /nowhere  %c  %warp  our  q.beak.yoke  ~
-                  %sing  %c  case  mars-path
-              ==
-              [duct %give %unto %fact b.mars p.res]
-          ==
+          [duct %give %unto %fact b.mars p.res]~
         ==
       ::
           %pass
@@ -1922,7 +1915,7 @@
           [unto ap-core]
         =/  =case  da+now
         ?:  ?=(%spider agent-name)
-          :-  [%fact mark.unto !>(noun.unto)]
+          :-  [%fact mark.unto `vase`[%noun noun.unto]]
           ap-core
         =/  sky  (rof [~ ~] /gall %cb [our q.beak.yoke case] /[mark.unto])
         ?.  ?=([~ ~ *] sky)
@@ -1933,9 +1926,7 @@
         ?:  ?=(%| -.res)
           (mean leaf+"gall: ames vale fail {<mark.unto>}" p.res)
         :-  [%fact mark.unto p.res]
-        %-  ap-move  :_  ~
-        :^  hen  %pass  /nowhere
-        [%c %warp our q.beak.yoke ~ %sing %b case /[mark.unto]]
+        ap-core
       |^  ^+  ap-core
           ::  %poke-ack has no nonce; ingest directly
           ::
@@ -3201,8 +3192,6 @@
   ~>  %spin.['take/gall']
   ?^  dud
     ~&(%gall-take-dud ((slog tang.u.dud) [~ gall-payload]))
-  ?:  =(/nowhere wire)
-    [~ gall-payload]
   ?:  =(/clear-huck wire)
     =/  =gift  ?>(?=([%behn %heck %gall *] syn) +>+.syn)
     [[duct %give gift]~ gall-payload]


### PR DESCRIPTION
Replaces #7406.

Validation of remote facts in Gall was deferred to the agent if the agent is %spider, as the source desk of thread can be different from the desk of the spider agent, which is always %base. The deferral worked by just replacing the %raw-fact with a fact with a vase of a raw noun. This made threads not be able to distinguish between local and remote facts and clam all of them, affecting performance for marks with recursive types.

Currently Gall does not validate local pokes and facts, so for consistency we no longer validate facts whose types are not exactly `%noun`, as is the case for local facts. A fact with a `%noun` type is then one of these:
  - A raw remote fact, which gets validated by +validate-mark;
  - A local fact with a %noun mark, which is not validated. This is based on an assumption that a %noun mark always defines a raw noun, an assumption that is used in Clay, so I guess it is also valid to use it here
  - Rarely, it could be a local fact with a non-%noun mark that also uses `*` type, in which case it would get clammed too, which won't be too expensive.

Also removes stateful-Ford workarounds from Gall.

Sidenote: what is the purpose of virtualizing the validation if we immediately crash afterwards, just with another mean stack entry added? Would not this be better:

```
=/  res=vase
  ~|  %spider-mark-fail
  ~_  leaf+"spider: ames vale fail {<mark>}"
  (vale.dais in)
```

This does have an effect of reversing the stack trace, which raises the question of consistency of recrashing with +mean vs crashing immediately