### PR TITLE
mesa: ack %leave $plea on a corked flow

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10832,7 +10832,7 @@
                   ?:  ?|  is-cork-plea
                           is-leave-plea
                       ==
-                    %-  %+  ev-tace  snd.veb.bug.ames-state
+                    %-  %+  ev-tace  odd.veb.bug.ames-state
                         =+  load=?:(is-cork-plea "%cork" "%leave")
                         |.("ack {load} $plea for %corked flow {<data>}")
                     (fo-send-ack seq)

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10819,17 +10819,22 @@
                   %-  %+  ev-tace  odd.veb.bug.ames-state
                       |.("skip {<mess>}; flow is halted flow={<bone>} ")
                   fo-core
-                =/  is-cork-plea=?
-                  ?:  ?=(%boon mess)  |
+                =/  [is-cork-plea=? is-leave-plea=?]
+                  ?:  ?=(%boon mess)  [| |]
                   =+  ;;  =plea  +>.gage
-                  &(?=([%cork ~] payload) ?=([%flow ~] path)):plea
+                  :-  &(?=([%cork ~] payload) ?=([%flow ~] path)):plea
+                  &(=(%g vane.plea) ?=([%ge *] path.plea) =([%0 %u ~] payload.plea))
                 ?.  closing.state
-                  ?:  is-cork-plea
+                  =+  data=[bone=bone seq=seq]
+                  ?:  ?|  is-cork-plea
+                          is-leave-plea
+                      ==
                     %-  %+  ev-tace  snd.veb.bug.ames-state
-                        |.("ack %cork $plea for %corked flow")
+                        =+  load=?:(is-cork-plea "%cork" "%leave")
+                        |.("ack {load} $plea for %corked flow {<data>}")
                     (fo-send-ack seq)
                   %-  %+  ev-tace  odd.veb.bug.ames-state
-                      |.("skip {<mess>}; flow is corked flow={<bone>} ")
+                      |.("skip {<mess>}; flow is corked {<data>}")
                   fo-core
                 ::  if the flow is in closing, ack a resend of the %cork $plea
                 ::


### PR DESCRIPTION
Consider the following:

- A subscription flow that gets %kicked while having an outstanding %leave. The %kick triggers adding a %cork to %ames outstanding queue (if we don't get %kicked, the %cork will only be added when the %leave is acked... unless this is a very old flow where this invariant was not held)
- The %bak side gets both %leave and %cork and acks them (because of congestion, %ames has enough slots to send both $pleas); the flow now is corked
- Both %acks are lost, or, we migrate this peer to %mesa right before the %acks arrive (which drops them on the floor)
- Now in %mesa, the default send-window is 1 so only the leave is outstanding.
- During the migration of this flow, we also started peeking to see if our %cork went through
- The flow is indeed %corked, but when we got the %gone for it, we crash because we are not supposed to have anything outstanding that is not a %cork
- The only thing that we are sending is the %leave, which, because the floor is corked gets dropped on the floor.
- The crash continues forever every ~m2.

The fix:

- a %leave is always acked, so if a re-send of one arrives on a flow that has been corked, it's safe to send a dupe %ack. this will unblock the %cork to be sent as well which will cork the flow on the sender side (if the %gone page doesn't arrive before)

(note: the stack trace that discovered this https://gist.github.com/joemfb/6508504ea9d5c30caff49419bf353e94)