### PR TITLE
clay: filter file-store before entering ford

### DIFF
--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -660,6 +660,25 @@
           ==
         --
     =>  |%
+        ::  in file-store leaves only pages reachable from files
+        ::
+        ++  launder-args
+          |=  =args
+          ^+  args
+          =-  [files.args - verb.args]
+          ^-  (map lobe page)
+          =/  local-lobes=(set lobe)
+            %-  ~(rep by files.args)
+            |=  [[k=* v=(each page lobe)] acc=(set lobe)]
+            ?:  ?=(%& -.v)  acc
+            (~(put in acc) p.v)
+          ::
+          %-  malt
+          %-  ~(rep by file-store.args)
+          |=  [[k=lobe v=page] acc=(list [lobe page])]
+          ?.  (~(has in syd-lobes) k)  acc
+          [[k v] acc]
+        ::
         ++  bush-to-vase
           =/  only-prelude=?  |
           =|  sut=vase
@@ -806,6 +825,7 @@
         --
     ~%  %ford-gate  ..ford  ~
     |=  args
+    =.  +<  (launder-args +<)
     ~%  %ford-core  ..$  ~
     |%
     ::  Chapter for constructing $bush (dependency graph of a file) given its

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -671,7 +671,8 @@
           %-  ~(rep by files.args)
           |=  [[k=* v=(each page lobe)] acc=(list [lobe page])]
           ?:  ?=(%& -.v)  acc
-          [[p.v (~(got by file-store.args) p.v)] acc]
+          ?~  pag=(~(get by file-store.args) p.v)  acc
+          [[p.v u.pag] acc]
         ::
         ++  bush-to-vase
           =/  only-prelude=?  |

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -676,7 +676,7 @@
           %-  malt
           %-  ~(rep by file-store.args)
           |=  [[k=lobe v=page] acc=(list [lobe page])]
-          ?.  (~(has in syd-lobes) k)  acc
+          ?.  (~(has in local-lobes) k)  acc
           [[k v] acc]
         ::
         ++  bush-to-vase

--- a/pkg/arvo/sys/vane/clay.hoon
+++ b/pkg/arvo/sys/vane/clay.hoon
@@ -667,17 +667,11 @@
           ^+  args
           =-  [files.args - verb.args]
           ^-  (map lobe page)
-          =/  local-lobes=(set lobe)
-            %-  ~(rep by files.args)
-            |=  [[k=* v=(each page lobe)] acc=(set lobe)]
-            ?:  ?=(%& -.v)  acc
-            (~(put in acc) p.v)
-          ::
           %-  malt
-          %-  ~(rep by file-store.args)
-          |=  [[k=lobe v=page] acc=(list [lobe page])]
-          ?.  (~(has in local-lobes) k)  acc
-          [[k v] acc]
+          %-  ~(rep by files.args)
+          |=  [[k=* v=(each page lobe)] acc=(list [lobe page])]
+          ?:  ?=(%& -.v)  acc
+          [[p.v (~(got by file-store.args) p.v)] acc]
         ::
         ++  bush-to-vase
           =/  only-prelude=?  |


### PR DESCRIPTION
@tinnus-napbus noticed a Ford issue where commiting files to a desk seemingly rebuilt the files in other desks as well. #7353 was supposed to alleviate the symptoms, but it occured to me that this is merely a workaround: if everything were to work as intended then the dependency graph rebuilds shouldn't been happening.

I investigated and noticed that `file-store.args` was using lat.ran, which is a global map `commit-hash -> file`. This PR adds filtering of this map before Ford Lightning is entered: only files that have lobes in our `files` map are left in the file store.

Tested by applying this commit on master branch which lacks #7353 fix. With this fix a commit to %base only rebuilds the dependency graphs of %base's agents and marks, not doing anything else.