### PR TITLE
mesa: fix enqueing/flushing of %pokes for halted flows

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -11176,9 +11176,9 @@
                   ?=(~ loads.snd)  ::  nothing else is pending
                   ?=(^ m)  =([%plea %$ [%flow ~] %cork ~] u.m)
               ==
-            ::  send next messages
+            ::  send next messages if not halted
             ::
-            =.  fo-core  fo-send
+            =?  fo-core  !halt.state  fo-send
             ::  don't give %done for %boon and %cork; implicit %ack
             ::
             =?  fo-core  ?&  ?=(%for dire)
@@ -11256,7 +11256,9 @@
             ::  XX check path.spar
             ::  XX path.spar will be the full namespace path, peel off before?
             ::
-            =.  fo-core  fo-send  ::  send next messages
+            ::  send next messages if not halted
+            ::
+            =?  fo-core  !halt.state  fo-send
             ::  if the bone belongs to a closing flow and we got a
             ::  naxplanation, don't relay ack to the client vane
             ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10903,11 +10903,11 @@
                 =?  pending-ack.rcv  &(?=([? *] +.sign) !blocked.sign)
                   %.n  :: XX  tack.pending-ack.rcv
                 fo-core
-              ::  un-halt the flow
+              ::  un-halt the flow; try sending anything queued up
               ::
                   %spur
                 =.  halt.state  %.n
-                fo-core
+                fo-send
               ==
             ==
           ::

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10799,7 +10799,7 @@
               ?.  halt.state
                 fo-send
               %-  %+  ev-tace  odd.veb.bug.ames-state
-                  |.("queue {<mess>}; flow is halted flow={<bone>}")
+                  |.("queue {<-.load>}; flow is halted flow={<bone>}")
               fo-core
             ::
             ++  sink

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -10786,7 +10786,7 @@
             ::
             ++  pump
               |=  load=mesa-message
-              ?:  |((fo-to-close load) fo-corked halt.state)
+              ?:  |((fo-to-close load) fo-corked)
                 %-  %+  ev-tace  odd.veb.bug.ames-state
                     ?:  (fo-to-close load)
                       |.("skip $plea; flow {<bone>} is closing")


### PR DESCRIPTION
if a vane tried to pass a %poke ($plea or $boon) for a halted flow ames would drop them on the floor due to a buggy check on the pump handling.

also, if an ack would arrive an the time of halting the flow, we would still be sending any queued-up message, breaking the halt contract.

then, on revival of the agent, only the %for side was flushing anything that was in the loads queue, but the %bak would just sit there without triggering any %mokes that actually populate the .pit and are actually sent on /mesa-retry timers