### PR TITLE
ted: reduce eth-watcher zoom-step from 100.000 to 10.000

### DIFF
--- a/pkg/arvo/ted/eth-watcher.hoon
+++ b/pkg/arvo/ted/eth-watcher.hoon
@@ -84,7 +84,7 @@
   =/  m  (strand:strandio ,watchpup)
   ^-  form:m
   =/  zoom-margin=number:block  30
-  =/  zoom-step=number:block    100.000
+  =/  zoom-step=number:block    10.000
   ?:  (lth latest-number (add number.pup zoom-margin))
     (pure:m pup)
   =/  up-to-number=number:block


### PR DESCRIPTION
Infura recently limited eth_getLogs to disallow all block ranges larger than 10k. We try to catch up azimuth logs 100k blocks at a time, and if we're behind even a little bit we start hitting this limit. 

Ethereum has a block time of around 12 seconds nowadays. This means that we run into this limit after (12*10k)/60/60 = 33.3 hours of being offline!