### PR TITLE
ames, gall: recover pleas stuck behind running agents

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -8176,7 +8176,18 @@
                   %drop  sink(nax.state (~(del in nax.state) message-num.task))
                   %done  (done ok.task)
                   %flub
-                ?:  ?=([%flub ~] task)  sink
+                ?:  ?=([%flub ~] task)
+                  ::  Gall found a running agent with no matching blocked move.
+                  ::  Redeliver the head of the pending queue from the payload
+                  ::  saved in pending-vane-ack.state.
+                  ::
+                  ?~  next=~(top to pending-vane-ack.state)
+                    ::  XX if there is nothing pending, rewind last-heard?
+                    ::
+                    sink
+                  %-  %+  pe-trace  odd.veb
+                      |.("redeliver pending {<message-num.u.next>} bone={<bone>}")
+                  (handle-sink message-num.u.next message.u.next ok=%.y)
                 =?  peer-core  ?=([%flub ? ^] task)
                   ::  /gf system flow established; halt the flow
                   ::
@@ -8187,7 +8198,6 @@
                   sink
                 %-  %+  pe-trace  odd.veb
                         |.("%flubbing: {<bone=bone>} last={<last-heard.state>}")
-                =+  left=q:~(get to pending-vane-ack.state)
                 %_  sink
                   pending-vane-ack.state  ~                :: drop all pending
                         last-heard.state  last-acked.state :: rewind last heard
@@ -10900,17 +10910,22 @@
               :: ack from client vane
               ::
                   %done
-                ?>  =(%.y pending-ack.rcv)
-                (fo-take-done +.sign)
+                ?>(pending-ack.rcv (fo-take-done +.sign))
               ::  halt the flow
               ::
                   %flub
-                =?  halt.state   ?=([? ^] +.sign)  %.y
-                =?     fo-core   ?=([? ^] +.sign)
-                  (fo-emit hen %pass /halt %g %halt her u.dap.sign bone)
-                =?  pending-ack.rcv  &(?=([? *] +.sign) !blocked.sign)
-                  %.n  :: XX  tack.pending-ack.rcv
-                fo-core
+                ?~  +.sign
+                  ::  Gall found a running agent with no blocked move.
+                  ::  Remove pending so the redelivered plea can be accepted.
+                  ::
+                  =.  pending-ack.rcv  %.n
+                  fo-core
+                =?  pending-ack.rcv  !blocked.sign  %.n
+                ?~  dap.sign  fo-core
+                ::  if the system flow exists, halt it and send %boon %flub
+                ::
+                =.  halt.state  %.y
+                (fo-emit hen %pass /halt %g %halt her u.dap.sign bone)
               ::  un-halt the flow; try sending anything queued up
               ::
                   %spur

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1144,6 +1144,12 @@
     ::
     =?  mo-core  ?=(%u -.ames-request)
       (mo-give %done ~)
+    ::  the /sys/req wire (and the internal /ames/bone wire in the duct),
+    ::  are pattern-matched by +mo-remote-blocked to recognize
+    ::  blocked remote %deals;
+    ::
+    ::  if we update it here, we need to update it there
+    ::
     =/  =wire  /sys/req/(scot %p ship)/[agent-name]
     ::
     =/  =deal
@@ -1154,6 +1160,25 @@
         %u  [%leave ~]
       ==
     (mo-pass wire %g %deal [ship our /] agent-name deal)
+  ::  +mo-remote-blocked: check if .dap has a remote blocked move for .ship
+  ::
+  ++  mo-remote-blocked
+    |=  [=duct =ship dap=term]
+    ^-  ?
+    ?~  waiting=(~(get by blocked.state) dap)
+      %.n
+    ?.  ?=(^ duct)
+      %.n
+    %+  lien  ~(tap to u.waiting)
+    ::  Check for a remote deal attributed to .ship on this exact Ames
+    ::  flow. The blocked queue is already scoped to .dap.
+    ::
+    |=  =blocked-move
+    ?&  ?=(%& -.move.blocked-move)
+        =(ship ship.attributing.routes.blocked-move)
+        ?=(^ duct.blocked-move)
+        =(i.duct i.duct.blocked-move)
+    ==
   ::  +mo-do-flub: drop incoming pleas in %ames
   ::
   ::    (if the /gf system flow has been established, notify the other ship
@@ -1178,10 +1203,10 @@
     ::  currently we always halt it
     ::
     %^  mo-give  %flub
-    ::  if we have blocked moves, skip the %flub handling logic in %ames
+    ::  if we have blocked remote moves, skip %flub handling in %ames
     ::  if /gf system flow is not established, skip sending the %flub $boon
     ::
-      maybe-blocked=?=(^ (~(get by blocked.state) agent-name))
+      maybe-blocked=(mo-remote-blocked hen ship agent-name)
     ?.((~(has by flub-ducts.state) ship) ~ `agent-name)
   ::
   ++  mo-handle-flub-plea
@@ -2453,11 +2478,19 @@
       %-  %^  trace:mo-core  &(?=([%gp @ ~] path) odd.veb.bug.state)  agent-name
           &+"on {<ship>} flubbing in-progress flow"
       (mo-do-flub:mo-core ship agent-name)
-    ?:  ?=([%gp @ ~] path)
+    ?:  ?=([%ge @ ~] path)
+      (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
+    ::  The agent is running but the flow's %plea is still pending in Ames.
+    ::  If Gall has the exact blocked remote move, leave Ames' state alone.
+    ::  Otherwise ask Ames to redeliver its saved pending message.
+    ::
+    ?:  (mo-remote-blocked:mo-core duct ship agent-name)
       %-  %^  trace:mo-core  odd.veb.bug.state  agent-name
-          &+"on {<ship>} weird in-progress flow; running agent; skip %flub"
+          &+"on {<ship>} in-progress flow; %plea enqueued; wait"
       mo-core
-    (mo-handle-ames-request:mo-core ship agent-name +.ames-request-all)
+    %-  %^  trace:mo-core  odd.veb.bug.state  agent-name
+        &+"on {<ship>} in-progress flow; running agent; redeliver"
+    (mo-give:mo-core %flub ~)
   ::
       %sear  mo-abet:(mo-filter-queue:mo-core ship.task)
       %jolt  mo-abet:(mo-jolt:mo-core dude.task our desk.task)

--- a/pkg/arvo/ted/ph/all.hoon
+++ b/pkg/arvo/ted/ph/all.hoon
@@ -33,6 +33,7 @@
         :: %ph-hi-uncle-az
         %ph-moon-az
         %ph-peek
+        %ph-running-flub
         %ph-second-cousin-hi
         %ph-tend
     ==

--- a/pkg/arvo/ted/ph/running-flub.hoon
+++ b/pkg/arvo/ted/ph/running-flub.hoon
@@ -1,0 +1,35 @@
+/-  spider, aquarium
+/+  *ph-io
+/*  test-agent  %hoon  /tests/app/running-flub/hoon
+=,  strand=strand:spider
+^-  thread:spider
+|=  vase
+=/  m  (strand ,vase)
+;<  ~  bind:m  start-simple
+;<  ~  bind:m  (init-ship ~bud fake=&)
+;<  ~  bind:m  (dojo ~bud "|pass [%a %load %mesa]")
+;<  ~  bind:m  (init-ship ~dev fake=&)
+;<  ~  bind:m  (dojo ~dev "|pass [%a %load %mesa]")
+;<  ~  bind:m  (dojo ~bud "|mount %base")
+;<  ~  bind:m  (dojo ~dev "|mount %base")
+;<  ~  bind:m  (send-hi ~bud ~dev)
+;<  ~  bind:m  (copy-file ~bud /app/lost/hoon test-agent)
+::
+::  Queue a local move for a non-running agent, then send it a remote poke.
+::  The local move must not make Gall report the unrelated remote plea as
+::  blocked. Once the agent starts, Ames must redeliver the pending poke.
+::
+=/  =aqua-event:aquarium
+  :+  %event  ~bud
+  [/g/aqua/watch/lost %deal [~bud ~bud /] %lost %watch /http]
+;<  ~  bind:m  (send-events aqua-event ~)
+=/  =aqua-event:aquarium
+  :+  %event  ~dev
+  [/g/aqua/poke/lost %deal [~dev ~bud /] %lost %poke %noun !>(~)]
+;<  ~  bind:m  (send-events aqua-event ~)
+;<  ~  bind:m  (dojo ~bud "|start %lost")
+;<  ~  bind:m
+  %+  wait-for-output  ~bud
+  "running-flub-received"
+;<  ~  bind:m  end
+(pure:m *vase)

--- a/tests/app/running-flub.hoon
+++ b/tests/app/running-flub.hoon
@@ -1,0 +1,24 @@
+/+  default-agent, dbug
+::
+=|  state=~
+%-  agent:dbug
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+::
+++  on-poke
+  |=  [=mark =vase]
+  :_  this
+  [%pass /flog %arvo %d %flog %text "running-flub-received"]~
+::
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-init   `this
+++  on-save   !>(state)
+++  on-load   |=(old=vase `this(state !<(_state old)))
+++  on-agent  on-agent:def
+++  on-arvo   on-arvo:def
+++  on-peek   on-peek:def
+++  on-fail   on-fail:def
+--


### PR DESCRIPTION
## Summary

- recover a pending Ames `%plea` when Gall reports `%gp` for an agent that is already running but does not have the corresponding remote move blocked
- preserve the existing wait behavior when Gall really does have that exact remote deal in the agent's blocked queue
- implement the equivalent pending-ack recovery in the legacy Mesa flow path
- add an Aqua regression that reproduces the false-positive blocked-queue case with two ships

## Context

This is a refreshed follow-up to #7391, rebased and adapted for current `develop`.

We reproduced the failure on live ships as one-way Gall traffic that remained queued in Ames even though the destination agent was running. Restarting the destination agent caused the queue to drain immediately. The field evidence and queue counters are recorded in [this comment on #7391](https://github.com/urbit/urbit/pull/7391#issuecomment-5304018976).

The problematic case is:

1. a local move is blocked for a stopped Gall agent;
2. a remote `%plea` for the same agent arrives and remains pending in Ames;
3. the agent starts;
4. Gall sees *some* blocked work for the agent and treats the unrelated remote `%plea` as already enqueued;
5. Ames never redelivers it.

## Implementation

Gall now tests for an exact remote blocked move: the agent queue, attributed ship, and current outer Ames duct wire must all match. If they do not, Gall sends `%flub ~`, which asks Ames to replay the saved head of `pending-vane-ack`. The Mesa receiver similarly clears `pending-ack` so the plea can be accepted again.

The deeper inner `/sys/req` parser from the older draft caused Gall `%load` to bail on current `develop`, so this version uses the exact outer Ames wire and attribution carried by the blocked move. That intentionally does not attempt to recognize an equivalent pre-rift legacy wire.

## Verification

- booted the patched current-`develop` kernel successfully; Gall loaded with hash `0vk.q10co`
- ran the new `-ph-running-flub ~` Aqua regression using two fake ships and Mesa
- observed the local `%watch` queue while `%lost` was stopped
- started `%lost`, received the formerly pending remote poke as `running-flub-received`, and the test completed with `done`
- added `%ph-running-flub` to the default `%ph-all` set
- `git diff --check`

The `ph-all` block in `nix/test-fake-ship.nix` is currently commented out, so the regression was run manually in Aqua.
