### PR TITLE
shoe: reap sole sessions on leave, and call +on-disconnect

### DIFF
--- a/pkg/base-dev/lib/shoe.hoon
+++ b/pkg/base-dev/lib/shoe.hoon
@@ -377,7 +377,15 @@
   ++  on-leave
     |=  =path
     ^-  (quip card:agent:gall agent:gall)
-    =^  cards  shoe  (on-leave:og path)
+    ::  mirror +on-watch: sole paths belong to us, everything else to the app.
+    ::  a sole-id is single-tenant (+on-watch resets its $sole-share, so a
+    ::  second subscriber would clobber the first), so the first leave reaps.
+    ::
+    ?~  sole-id=(path-to-id:sole path)
+      =^  cards  shoe  (on-leave:og path)
+      [(deal cards) this]
+    =.  soles  (~(del by soles) u.sole-id)
+    =^  cards  shoe  (on-disconnect:og u.sole-id)
     [(deal cards) this]
   ::
   ++  on-peek


### PR DESCRIPTION
Companion to #7379, which exposes `/x/sole/sessions`.  That scry is only as useful as `soles` is accurate, and today `soles` never shrinks.

## The leak

`+on-watch` installs a `$sole-share` for the subscribed `sole-id`, but `+on-leave` never removed it.  Nothing else deletes from the map, so a shoe agent accumulates a `$sole-share` for every session ever opened, for the lifetime of the agent.  With #7379 merged, `/x/sole/sessions` reports every session ever opened rather than the live ones.

## The dead hook

`+on-disconnect` is declared in the `+shoe` interface and implemented in `+default`, but the `+agent` wrapper never called it.  A wrapped app had no way to learn that a client had gone away and drop its per-session state.  `/app/shoe.hoon` wires it up and it has simply never fired.

## The change

Make `+on-leave` mirror `+on-watch`: sole paths are handled here, everything else is passed to the wrapped app.  On a sole path, delete the session and call `+on-disconnect:og`.

A `sole-id` is single-tenant already — `+on-watch` resets its `$sole-share`, so a second subscriber to the same id would clobber the first — so the first leave reaps without refcounting.

This also makes a leave/watch pair a genuine session reset, which is what a notebook-style client needs for "restart kernel".

## Testing

On a fake ship with #7379 applied, driving a subscription to `%shoe` from a scratch agent:

| | after subscribe | after leave |
|---|---|---|
| patched | `[{"session":"myses","ship":"~sev"}]` | `[]` |
| unpatched | `[{"session":"ctrl","ship":"~sev"}]` | `[{"session":"ctrl","ship":"~sev"}]` |

## Note

This does not retroactively clean sessions orphaned before the upgrade; it only stops new ones from leaking.  An agent that has been running a while will keep whatever it has already accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjYjY3rPiTsTxdP2HFBSrF