### PR TITLE
shoe: emit %pro after +on-command as a completion signal

### DIFF
--- a/pkg/base-dev/lib/shoe.hoon
+++ b/pkg/base-dev/lib/shoe.hoon
@@ -317,7 +317,12 @@
       ::  clear buffer
       ::
       =^  clear  cli-state  (~(transmit sole cli-state) [%set ~])
-      =-  [[[- cards] cli-state] shoe]
+      ::  send the prompt after the app's cards, mirroring +on-watch.
+      ::  clients may treat %pro as a completion signal: once it arrives,
+      ::  all effects from this command have been sent.
+      ::
+      =/  pro=card  (effect %pro & dap.bowl "> ")
+      =-  [[[- (snoc cards pro)] cli-state] shoe]
       %+  effect  %mor
       :~  [%nex ~]
           [%det clear]


### PR DESCRIPTION
Resolves #7417.  Stacked on #7416 (the base branch of this PR); independent of #7379 in code, sibling in spirit.

## The gap

`+run-command` conses its `%nex`/`%det` buffer-clear ahead of `+on-command`'s cards, so a client sees the clear, then N output effects, then nothing.  Nothing marks the end of a command's output.  A human at a terminal doesn't care; a programmatic client (a Gall agent, a notebook kernel) can only guess with a wall-clock timeout, which a Gall agent cannot even do cheaply.  Details in #7417.

## The change

Emit the prompt after `+on-command`'s cards, mirroring the `%pro` already sent on connect in `+on-watch`:

```hoon
      ::  send the prompt after the app's cards, mirroring +on-watch.
      ::  clients may treat %pro as a completion signal: once it arrives,
      ::  all effects from this command have been sent.
      ::
      =/  pro=card  (effect %pro & dap.bowl "> ")
      =-  [[[- (snoc cards pro)] cli-state] shoe]
```

`%pro` already means "prompt is yours again", so this is shape 1 from #7417 — the least invasive option, and the same thing North's vendored `shoe.hoon` has been doing in the field.  Existing terminal clients redraw a prompt they were going to redraw anyway.  The effect order per command becomes: clear (`%mor %nex %det`), the app's output, `%pro`.

## Testing

On a fake zod, driving the example `/app/shoe` over Eyre channels with a jupytur-style client (subscribe to `/sole/~zod/<session>`, `%sole-action` pokes, break on `%pro` with a 500ms idle-timeout fallback):

| | completion | latency per command |
|---|---|---|
| unpatched | idle-timeout guess | 548–555ms |
| patched | `%pro` observed | ~40ms |

Two concurrent sessions each get their own `%pro` (it is sent to `[sole-id]~` only); the connect-time prompt and dojo are unaffected.

With this merged, jupytur can delete its `IDLE_TIMEOUT` fallback for shoe agents and North can drop its vendored `lib/shoe.hoon`.

## Related

- #7417 — the issue this resolves
- #7379 — `/x/sole/sessions` scry (sessions discoverable)
- #7416 — reap on leave (sessions reapable); this PR's base
- #7331 — the earlier, unwound attempt at a programmatic evaluation poke

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iZfzGidBhU7M1tNum5G5k