### PR TITLE
spider: unsubscribe from dill %logs left behind by finished threads

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -405,7 +405,15 @@
   =/  yarn  (~(get by tid.state) tid)
   ?~  yarn
     %-  (slog leaf+"spider got sign for non-existent {<tid>}" ~)
-    `state
+    ::  a finished thread left a dill %logs subscription behind
+    ::  (+thread-clean only leaves gall subscriptions). nobody can
+    ::  ever hear it, so unsubscribe on its behalf: this is the same
+    ::  wire, hence the same duct, that opened it.
+    ::
+    ?.  ?=([%dill %logs *] sign-arvo)
+      `state
+    :_  state
+    [%pass [%thread tid wire] %arvo %d %logs ~]~
   (take-input u.yarn ~ %sign wire sign-arvo)
 ::
 ++  on-agent


### PR DESCRIPTION
Trying to fix the annoying spam from urbit %mcp [tloncorp/mcp](https://github.com/tloncorp/mcp/pull/26), but seems like a good change overall. If there's a better way, let me know.

## Symptom

A ship whose threads have leaked a few dozen dill `%logs` subscriptions prints thousands of these on every `|commit`:

```
spider got sign for non-existent ~.khan-lard--0v7.qttjk.77r7h.s8roq.fr2u9.the1e
```

## Cause

`+thread-clean` only issues `%leave` for the gall subscriptions in `wex.bowl` (and `%yawn` for tracked `%keen`/`%chum`). Any other arvo request a thread made and did not cancel before finishing outlives the thread. Behn timers and clay `%next` are one-shot and clear themselves, but dill `%logs` is not: dill fans every `%text`/`%talk`/`%crud` to every duct in `ear.all`, and there is no way for anyone but that duct to remove it. Clay prints one `%text` per changed file on commit, so the flood scales with leaked-subscriptions × changed-files.

The thread that leaked them in our case was a `%lard` inline thread that subscribed to dill logs to capture `|commit` output and returned early on a timeout without unsubscribing. That is fixed on the thread side, but nothing could clear the subscriptions already sitting in dill.

## Fix

Gall passes agent cards on a fixed system duct, so a `%pass` from spider on the same `/thread/<tid>/<wire>` wire reaches dill on exactly the duct that opened the subscription. When a `%dill %logs` sign arrives for a tid spider no longer knows, pass `%logs ~` back on that wire. Each leaked subscription prints one last "non-existent" line and is removed.

This is a backstop, not a substitute for threads cancelling what they open. A fuller fix would have spider track `%d %logs` (and `%c %warp` with `%next`/`%many`/`%mult`) the way it tracks `%keen`/`%chum` in `scrying.state` and cancel them in `+thread-done`/`+thread-fail`; that needs a state change and is left for a follow-up if wanted.

## Testing

Not yet exercised on a live ship. The affected moons here are dev moons; I will commit this to `%base` on one of them and confirm the spam is gone after one further commit before taking this out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)