### PR TITLE
arvo, ted, tests: support remote scries to our own ship

### DIFF
--- a/pkg/arvo/gen/hood/clay/keen.hoon
+++ b/pkg/arvo/gen/hood/clay/keen.hoon
@@ -5,4 +5,4 @@
 =/  =path
   ?^  pax  -.pax
   /c/x/1/kids/sys/kelvin
-[%helm-pass %a %keen ship path]
+[%helm-pass %a %keen ~ ship path]

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -13807,8 +13807,42 @@
         todos(pokes [[hen^plea/plea] pokes.todos])
       moves^vane-gate
     ::
+    ::  +pe-self-peek: answer a remote scry request aimed at ourselves
+    ::
+    ::    resolve the path against the local namespace with local privilege
+    ::    and give a %sage on the requesting duct. for local scries, a blocked
+    ::    scry (~) is reported as "no value" immediately rather than retried
+    ::
+    ++  pe-self-peek
+      |=  =path
+      ^-  [(list move) _vane-gate]
+      :_  vane-gate
+      :~  :*  hen
+              %give
+              %sage
+              [our path]
+              ^-  gage:mess
+              ?~  inn=(inner-path-to-beam our path)
+                ~
+              =/  res
+                %:  rof
+                    [~ ~]
+                    /ames/self
+                    ?@  vew.u.inn
+                      vew.u.inn
+                    (cat 3 [way car]:vew.u.inn)
+                    bem.u.inn
+                ==
+              ?.  ?=([~ ~ ^] res)
+                ~
+              [p q.q]:u.u.res
+          ==
+      ==
+    ::
     ++  pe-keen
       |=  [sec=(unit [idx=@ key=@]) spar:^ames]
+      ?:  =(our ship)
+        (pe-self-peek path)
       =/  ship-state  (find-peer ship)
       ?:  ?=(%ames -.ship-state)
         (call:am-core hen ~ soft+keen/sec^ship^path)
@@ -13831,6 +13865,8 @@
     ::
     ++  pe-chum
       |=  spar:^ames
+      ?:  =(our ship)
+        (pe-self-peek path)
       =/  ship-state  (find-peer ship)
       ?:  ?=(%ames -.ship-state)
         (call:am-core hen ~ soft+chum/ship^path)
@@ -13848,6 +13884,11 @@
     ::
     ++  pe-cancel
       |=  [all=? =spar]
+      ::  requests to ourselves were answered
+      ::  synchronously; nothing is pending
+      ::
+      ?:  =(our ship.spar)
+        `vane-gate
       =/  ship-state  (find-peer ship.spar)
       ::
       ?:  ?=(%ames -.ship-state)
@@ -14021,7 +14062,7 @@
     ++  pe-whey
       |=  [dud=(unit goof) spar:^ames boq=@ud]
       =/  ship-state  (find-peer ship)
-      ?:  ?=(%mesa -.ship-state)
+      ?:  |(=(our ship) ?=(%mesa -.ship-state))
         (pe-chum ship %a %x '1' %$ %whey (scot %ud boq) (scot %p our) path)
       (call:am-core hen dud %soft %whey ship^path boq)
     ::

--- a/pkg/arvo/sys/vane/gall.hoon
+++ b/pkg/arvo/sys/vane/gall.hoon
@@ -1416,7 +1416,9 @@
     ++  ap-keen
       |=  [=wire secret=? =spar:ames]
       ^+  ap-core
-      ?:  secret
+      ::  ames answers requests to ourselves locally; no key needed
+      ::
+      ?:  &(secret !=(our ship.spar))
         (ap-request-brood wire spar)
       =.  ken.yoke  (~(put ju ken.yoke) spar wire)
       (ap-pass wire %arvo %a %keen ~ spar)

--- a/pkg/arvo/ted/comb.hoon
+++ b/pkg/arvo/ted/comb.hoon
@@ -33,6 +33,9 @@
     ==
   %+  murn  ~(tap by all)
   |=  [who=ship sta=?(%alien %known)]
+  ::  never scan ourselves: a self scry of a future case answers ~ at
+  ::  once, which would make the case loop below spin forever
+  ::
   ?:  =(our.bowl who)  ~
   ?.  ?=(%known sta)   ~
   ?:  ?=(%pawn (clan:title who))  ~

--- a/pkg/arvo/ted/ph/tend.hoon
+++ b/pkg/arvo/ted/ph/tend.hoon
@@ -12,11 +12,14 @@
   ;<  ~  bind:m  (dojo ~bud ":tend +dbug %bowl")
   (pure:m ~)
 ::
+::
+::  .who scries ~bud; ~bud scrying itself exercises the self remote-scry path
+::
 ++  keen-wait-for-result
-  |=  [cas=@ud zuse=@ud]
+  |=  [who=ship cas=@ud zuse=@ud]
   =/  m  (strand ,~)
-  ;<  ~  bind:m  (dojo ~dev ":tend [%keen ~bud {(scow %ud cas)} /foo/baz]")
-  ;<  ~  bind:m  (wait-for-output ~dev "kal=[lal=%zuse num={(scow %ud zuse)}]")
+  ;<  ~  bind:m  (dojo who ":tend [%keen ~bud {(scow %ud cas)} /foo/baz]")
+  ;<  ~  bind:m  (wait-for-output who "kal=[lal=%zuse num={(scow %ud zuse)}]")
   (pure:m ~)
 ::
 ++  setup
@@ -47,10 +50,12 @@
   ;<  ~  bind:m  (dojo ~bud ":tend [%germ /foo]")
   ;<  ~  bind:m  (sleep:strandio ~s2)
   ;<  ~  bind:m  (tend zuse)
-  ;<  ~  bind:m  (keen-wait-for-result 1 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~dev 1 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~bud 1 zuse)
   =/  zuse  (dec zuse)
   ;<  ~  bind:m  (tend zuse)
-  ;<  ~  bind:m  (keen-wait-for-result 2 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~dev 2 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~bud 2 zuse)
   ;<  ~  bind:m  end
   (pure:m ~)
 ::
@@ -61,10 +66,12 @@
   ;<  ~  bind:m  (dojo ~bud ":tend [%germ /foo]")
   ;<  ~  bind:m  (sleep:strandio ~s2)
   ;<  ~  bind:m  (tend zuse)
-  ;<  ~  bind:m  (keen-wait-for-result 1 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~dev 1 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~bud 1 zuse)
   =/  zuse  (dec zuse)
   ;<  ~  bind:m  (tend zuse)
-  ;<  ~  bind:m  (keen-wait-for-result 2 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~dev 2 zuse)
+  ;<  ~  bind:m  (keen-wait-for-result ~bud 2 zuse)
   ;<  ~  bind:m  end
   (pure:m ~)
 --

--- a/pkg/arvo/ted/prob.hoon
+++ b/pkg/arvo/ted/prob.hoon
@@ -24,7 +24,9 @@
 ::
 ;<  =bowl:spider  bind:m  get-bowl:strandio
 ::
-::  if peer not in ames, abort
+::  if peer not in ames, abort. this also excludes ourselves: a self
+::  scry of a future case answers ~ at once, so the case loop below
+::  would spin forever
 ::
 =+  .^  peers=(map ship ?(%alien %known))  %ax
     /(scot %p our.bowl)//(scot %da now.bowl)/peers

--- a/tests/app/tend.hoon
+++ b/tests/app/tend.hoon
@@ -4,10 +4,13 @@
 +$  card  card:agent:gall
 +$  coop  coop:gall
 +$  action
-  $%  [%tend =coop =path =page]
-      [%germ =coop]
-      [%snip =coop]
-      [%keen =ship case=@ud =path]
+  $%   [%cull =case =spur]
+       [%germ =coop]
+       [%grow =spur =page]
+       [%keen =ship case=@ud =path]
+       [%snip =coop]
+       [%tend =coop =path =page]
+       [%tomb =case =spur]
   ==
 --
 ::

--- a/tests/sys/fine.hoon
+++ b/tests/sys/fine.hoon
@@ -28,6 +28,34 @@
         %gx  ``atom+!>((bex (bex 14)))
       ==
     ::
+    ::  agent that sends a secret %keen to whoever pokes it
+    ::
+    ++  keen-agent
+      ^-  agent:gall
+      |_  =bowl:gall
+      ++  on-init   `..on-init
+      ++  on-save   !>(~)
+      ++  on-load   |=(vase `..on-init)
+      ++  on-poke
+        |=  [=mark =vase]
+        =+  !<(=ship vase)
+        :_  ..on-init
+        [%pass /keen %keen & ship /g/x/0/keen//1/foo]~
+      ++  on-watch  |=(path !!)
+      ++  on-leave  |=(path `..on-init)
+      ++  on-peek   |=(path ~)
+      ++  on-agent  |=([wire sign:agent:gall] !!)
+      ++  on-arvo   |=([wire sign-arvo] `..on-init)
+      ++  on-fail   |=([term tang] `..on-init)
+      --
+    ::  roof that blocks on everything
+    ::
+    ++  block-roof
+      ^-  roof
+      |=  [lyc=gang pov=path vis=view bem=beam]
+      ^-  (unit (unit cage))
+      ~
+    ::
     ++  etch-request-content
       |=  [our=@p =path num=@ud]
       ^-  @
@@ -318,4 +346,108 @@
     ==
   ::
   t4
+::
+::  remote scry of our own ship: answered locally, no packets, no peer
+::
+++  test-fine-self
+  %-  run-chain
+  |.  :-  %|
+  =+  (nec-bud-zod:v life=[nec=1 bud=1 zod=1] rift=[nec=1 bud=1 zod=1])
+  =/  scry-path=path  /c/x/1/kids/sys/kelvin
+  =/  =sage:mess:ames  [~nec^scry-path hoon/kelvin]
+  ::
+  ~?  >  dbug  'public %keen to ourselves'
+  =^  t1  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef kelvin-roof]
+      [~[/keen-duct-1] [%keen ~ ~nec scry-path]]
+      [~[/keen-duct-1] %give %sage sage]~
+    ==
+  :-  t1  |.  :-  %|
+  ~?  >  dbug  '%chum to ourselves'
+  =^  t2  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef kelvin-roof]
+      [~[/keen-duct-2] [%chum ~nec scry-path]]
+      [~[/keen-duct-2] %give %sage sage]~
+    ==
+  :-  t2  |.  :-  %|
+  ~?  >  dbug  'group-key %keen to ourselves ignores the key'
+  =^  t3  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef kelvin-roof]
+      [~[/keen-duct-3] [%keen `[1 0xdead] ~nec scry-path]]
+      [~[/keen-duct-3] %give %sage sage]~
+    ==
+  :-  t3  |.  :-  %|
+  ~?  >  dbug  'large payload is given whole'
+  =/  big-path=path  /g/x/0/dap//some/data/atom
+  =^  t4  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef bex-roof]
+      [~[/keen-duct-4] [%keen ~ ~nec big-path]]
+      [~[/keen-duct-4] %give %sage ~nec^big-path atom/(bex (bex 14))]~
+    ==
+  :-  t4  |.  :-  %|
+  ~?  >  dbug  'blocked scry gives empty %sage at once'
+  =^  t5  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef block-roof]
+      [~[/keen-duct-5] [%keen ~ ~nec scry-path]]
+      [~[/keen-duct-5] %give %sage ~nec^scry-path ~]~
+    ==
+  :-  t5  |.  :-  %|
+  ~?  >  dbug  'malformed path gives empty %sage'
+  =^  t6  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef kelvin-roof]
+      [~[/keen-duct-6] [%keen ~ ~nec /foo]]
+      [~[/keen-duct-6] %give %sage ~nec^/foo ~]~
+    ==
+  :-  t6  |.  :-  %|
+  ~?  >  dbug  '%yawn and %wham to ourselves are silent'
+  =^  t7  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef *roof]
+      [~[/keen-duct-1] [%yawn ~nec scry-path]]
+      ~
+    ==
+  :-  t7  |.  :-  %|
+  =^  t8  ames.nec
+    %:  ames-check-call:v  ames.nec
+      [~1111.1.1 0xdead.beef *roof]
+      [~[/wham-duct] [%wham ~nec scry-path]]
+      ~
+    ==
+  :-  t8  |.  :-  %&
+  ~?  >  dbug  'no peer state was created for ourselves'
+  =/  peers=(map ship ?(%alien %known))
+    !<  (map ship ?(%alien %known))
+    =<  q
+    %-  need  %-  need
+    %-  (ames-scry-gate:v [~1111.1.1 0xdead.beef *roof] ames.nec)
+    [[~ ~] / %x [[~nec %$ da+~1111.1.1] /peers]]
+  (expect-eq !>(|) !>((~(has by peers) ~nec)))
+::
+::  gall skips the group-key fetch for a secret %keen to ourselves
+::
+++  test-gall-keen-self
+  =+  (nec-bud-zod:v life=[nec=1 bud=1 zod=1] rift=[nec=1 bud=1 zod=1])
+  =.  gall.nec  (load-agent:v ~nec gall.nec %keen keen-agent)
+  =/  scry-path=path  /g/x/0/keen//1/foo
+  =/  =task:gall  [%deal [~nec ~nec /] %keen %poke noun+!>(~nec)]
+  =^  moves  gall.nec  (gall-call:v gall.nec ~[/keen] task *roof)
+  =/  passes=(list move:gall-bunt:v)
+    %+  skim  moves
+    |=  =move:gall-bunt:v
+    ?=([* %pass * %a *] move)
+  ;:  weld
+    ~?  >  dbug  'one %keen to ames, no key request'
+    (expect-eq !>(1) !>((lent passes)))
+  ::
+    ?>  ?=([[* %pass * %a *] ~] passes)
+    %+  expect-eq
+      !>(`*`[%keen ~ ~nec scry-path])
+    !>(`*`+>+.move.i.passes)
+  ==
 --

--- a/tests/sys/vane/mesa/pact.hoon
+++ b/tests/sys/vane/mesa/pact.hoon
@@ -20,7 +20,7 @@
 |%
 ++  test-mesa-peek-no-proof
   ~?  >  dbug  'test-mesa-peek-no-proof'
-  ::  tell ~nec to ask ~nec for a 1-fragment message
+  ::  tell ~nec to ask ~bud for a 1-fragment message
   ::
   =/  dat=@        'hi'
   =/  =space:ames  publ/bud-life
@@ -31,6 +31,17 @@
   =^  moves-2  ames.bud  (ames-reply:v ames.bud ~[/pact] moves-1 bex-roof) :: "ok, here is the 1st fragment"
   =^  moves-3  ames.nec  (ames-reply:v ames.nec ~[/pact] moves-2 bex-roof) :: "ok, here is the complete message"
   (ames-expect-msg:v moves-3 dat)
+::
+++  test-mesa-peek-self
+  ~?  >  dbug  'test-mesa-peek-self'
+  ::  tell ~nec to ask itself; answered locally in one call
+  ::
+  =/  dat=@        (bex (bex 14))
+  =/  pat          /g/x/0/dap//hello/atom
+  =/  bex-roof     (make-roof //hello/atom atom+!>(dat))
+  =^  moves  ames.nec
+    (ames-call:v ames.nec [~[/pact] [%keen ~ ~nec pat] bex-roof])
+  (ames-expect-msg:v moves dat)
 ::
 ++  test-mesa-peek-inline-proof
   ~?  >  dbug  'test-mesa-peek-inline-proof'


### PR DESCRIPTION
Remote scry is underutilised by userspace developers in part because they hit a snag when they can't remote scry their own ship, and have to implement two code paths depending on the ship they want information from.

This PR intercepts remote scries to ourself in Ames's `+pe` core and returns the same `$sage:ames` in any case. The only behaviour change from scrying another ship is that if a "local remote scry" returns `~`, Ames returns a `$sage` immediately rather than polling. This  supports `%keen`, `%chum`, `%yawn`, and `%wham`.

Generators, threads and tests updated accordingly. Also expands %tend's `$action` type to let users try out `%grow`ing and reading paths, which should be the basis of a revised Remote Scry page in the Urbit Docs.